### PR TITLE
[codex] Move generic extension install state into extensions crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,6 +4274,7 @@ name = "ironclaw_extensions"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_trust",
@@ -4540,7 +4541,6 @@ dependencies = [
 name = "ironclaw_product_adapter_registry"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
  "ironclaw_extensions",
  "ironclaw_host_api",

--- a/crates/ironclaw_extensions/Cargo.toml
+++ b/crates/ironclaw_extensions/Cargo.toml
@@ -12,12 +12,14 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_trust = { path = "../ironclaw_trust", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tokio = { version = "1", features = ["sync"] }
 toml = "0.8"
 url = "2"
 

--- a/crates/ironclaw_extensions/src/installations.rs
+++ b/crates/ironclaw_extensions/src/installations.rs
@@ -1,0 +1,765 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle};
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use tokio::sync::RwLock;
+
+use crate::{ExtensionManifestV2, HostApiContractRegistry, ManifestSource, ManifestV2Error};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ManifestHash(String);
+
+impl ManifestHash {
+    pub fn new(value: impl Into<String>) -> Result<Self, ExtensionInstallationError> {
+        let value = value.into();
+        validate_nonempty_noncontrol("manifest_hash", &value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ManifestHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Product-agnostic extension manifest record.
+///
+/// Domain crates can project their own host-api sections from `raw_toml` and
+/// `manifest`; installation state itself stays in `ironclaw_extensions`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionManifestRecord {
+    raw_toml: String,
+    manifest: ExtensionManifestV2,
+    manifest_hash: Option<ManifestHash>,
+}
+
+impl ExtensionManifestRecord {
+    pub fn from_toml(
+        raw_toml: impl Into<String>,
+        source: ManifestSource,
+        host_port_catalog: &HostPortCatalog,
+        manifest_hash: Option<ManifestHash>,
+    ) -> Result<Self, ExtensionInstallationError> {
+        let contracts = HostApiContractRegistry::new();
+        Self::from_toml_with_contracts(
+            raw_toml,
+            source,
+            host_port_catalog,
+            manifest_hash,
+            &contracts,
+        )
+    }
+
+    pub fn from_toml_with_contracts(
+        raw_toml: impl Into<String>,
+        source: ManifestSource,
+        host_port_catalog: &HostPortCatalog,
+        manifest_hash: Option<ManifestHash>,
+        contracts: &HostApiContractRegistry,
+    ) -> Result<Self, ExtensionInstallationError> {
+        let raw_toml = raw_toml.into();
+        let manifest = ExtensionManifestV2::parse_with_host_api_contracts(
+            &raw_toml,
+            source,
+            host_port_catalog,
+            contracts,
+        )?;
+        Ok(Self {
+            raw_toml,
+            manifest,
+            manifest_hash,
+        })
+    }
+
+    pub fn manifest(&self) -> &ExtensionManifestV2 {
+        &self.manifest
+    }
+
+    pub fn raw_toml(&self) -> &str {
+        &self.raw_toml
+    }
+
+    pub fn extension_id(&self) -> &ExtensionId {
+        &self.manifest.id
+    }
+
+    pub fn manifest_hash(&self) -> Option<&ManifestHash> {
+        self.manifest_hash.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ExtensionInstallationId(String);
+
+impl ExtensionInstallationId {
+    pub fn new(value: impl Into<String>) -> Result<Self, ExtensionInstallationError> {
+        let value = value.into();
+        validate_nonempty_noncontrol("installation_id", &value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ExtensionInstallationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionInstallationId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ExtensionCredentialHandle(String);
+
+impl ExtensionCredentialHandle {
+    pub fn new(value: impl Into<String>) -> Result<Self, ExtensionInstallationError> {
+        let value = value.into();
+        validate_nonempty_noncontrol("credential_handle", &value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ExtensionCredentialHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionCredentialHandle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionActivationState {
+    Installed,
+    Disabled,
+    Enabled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionCredentialBinding {
+    credential_handle: ExtensionCredentialHandle,
+    secret_handle: SecretHandle,
+}
+
+impl ExtensionCredentialBinding {
+    pub fn new(credential_handle: ExtensionCredentialHandle, secret_handle: SecretHandle) -> Self {
+        Self {
+            credential_handle,
+            secret_handle,
+        }
+    }
+
+    pub fn credential_handle(&self) -> &ExtensionCredentialHandle {
+        &self.credential_handle
+    }
+
+    pub fn secret_handle(&self) -> &SecretHandle {
+        &self.secret_handle
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionManifestRef {
+    extension_id: ExtensionId,
+    manifest_hash: Option<ManifestHash>,
+}
+
+impl ExtensionManifestRef {
+    pub fn new(extension_id: ExtensionId, manifest_hash: Option<ManifestHash>) -> Self {
+        Self {
+            extension_id,
+            manifest_hash,
+        }
+    }
+
+    pub fn extension_id(&self) -> &ExtensionId {
+        &self.extension_id
+    }
+
+    pub fn manifest_hash(&self) -> Option<&ManifestHash> {
+        self.manifest_hash.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionHealthSnapshot {
+    status: ExtensionHealthStatus,
+    message: Option<ExtensionHealthMessage>,
+    checked_at: DateTime<Utc>,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct ExtensionHealthMessage(String);
+
+impl ExtensionHealthMessage {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for ExtensionHealthMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionHealthMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionHealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+impl ExtensionHealthSnapshot {
+    pub fn healthy() -> Self {
+        Self {
+            status: ExtensionHealthStatus::Healthy,
+            message: None,
+            checked_at: Utc::now(),
+        }
+    }
+
+    pub fn new(
+        status: ExtensionHealthStatus,
+        message: Option<ExtensionHealthMessage>,
+        checked_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            status,
+            message,
+            checked_at,
+        }
+    }
+
+    pub fn status(&self) -> ExtensionHealthStatus {
+        self.status
+    }
+
+    pub fn message(&self) -> Option<&ExtensionHealthMessage> {
+        self.message.as_ref()
+    }
+
+    pub fn checked_at(&self) -> DateTime<Utc> {
+        self.checked_at
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExtensionInstallation {
+    installation_id: ExtensionInstallationId,
+    extension_id: ExtensionId,
+    activation_state: ExtensionActivationState,
+    manifest_ref: ExtensionManifestRef,
+    credential_bindings: Vec<ExtensionCredentialBinding>,
+    health: ExtensionHealthSnapshot,
+    updated_at: DateTime<Utc>,
+}
+
+impl ExtensionInstallation {
+    pub fn new(
+        installation_id: ExtensionInstallationId,
+        extension_id: ExtensionId,
+        activation_state: ExtensionActivationState,
+        manifest_ref: ExtensionManifestRef,
+        credential_bindings: Vec<ExtensionCredentialBinding>,
+        updated_at: DateTime<Utc>,
+    ) -> Result<Self, ExtensionInstallationError> {
+        if manifest_ref.extension_id() != &extension_id {
+            return Err(ExtensionInstallationError::ManifestExtensionMismatch {
+                extension_id,
+                manifest_extension_id: manifest_ref.extension_id().clone(),
+            });
+        }
+        validate_bindings_unique(&credential_bindings)?;
+        Ok(Self {
+            installation_id,
+            extension_id,
+            activation_state,
+            manifest_ref,
+            credential_bindings,
+            health: ExtensionHealthSnapshot::healthy(),
+            updated_at,
+        })
+    }
+
+    pub fn installation_id(&self) -> &ExtensionInstallationId {
+        &self.installation_id
+    }
+
+    pub fn extension_id(&self) -> &ExtensionId {
+        &self.extension_id
+    }
+
+    pub fn activation_state(&self) -> ExtensionActivationState {
+        self.activation_state
+    }
+
+    pub fn manifest_ref(&self) -> &ExtensionManifestRef {
+        &self.manifest_ref
+    }
+
+    pub fn credential_bindings(&self) -> &[ExtensionCredentialBinding] {
+        &self.credential_bindings
+    }
+
+    pub fn health(&self) -> &ExtensionHealthSnapshot {
+        &self.health
+    }
+
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        self.updated_at
+    }
+
+    fn set_activation_state(&mut self, state: ExtensionActivationState) {
+        self.activation_state = state;
+        self.updated_at = Utc::now();
+    }
+
+    fn set_health(&mut self, health: ExtensionHealthSnapshot) {
+        self.health = health;
+        self.updated_at = Utc::now();
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionInstallation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            installation_id: ExtensionInstallationId,
+            extension_id: ExtensionId,
+            activation_state: ExtensionActivationState,
+            manifest_ref: ExtensionManifestRef,
+            credential_bindings: Vec<ExtensionCredentialBinding>,
+            health: ExtensionHealthSnapshot,
+            updated_at: DateTime<Utc>,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        if wire.manifest_ref.extension_id() != &wire.extension_id {
+            return Err(serde::de::Error::custom(
+                ExtensionInstallationError::ManifestExtensionMismatch {
+                    extension_id: wire.extension_id,
+                    manifest_extension_id: wire.manifest_ref.extension_id().clone(),
+                },
+            ));
+        }
+        validate_bindings_unique(&wire.credential_bindings).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            installation_id: wire.installation_id,
+            extension_id: wire.extension_id,
+            activation_state: wire.activation_state,
+            manifest_ref: wire.manifest_ref,
+            credential_bindings: wire.credential_bindings,
+            health: wire.health,
+            updated_at: wire.updated_at,
+        })
+    }
+}
+
+#[async_trait]
+pub trait ExtensionInstallationStore: Send + Sync {
+    async fn list_manifests(
+        &self,
+    ) -> Result<Vec<ExtensionManifestRecord>, ExtensionInstallationError>;
+
+    async fn get_manifest(
+        &self,
+        extension_id: &ExtensionId,
+    ) -> Result<Option<ExtensionManifestRecord>, ExtensionInstallationError>;
+
+    async fn upsert_manifest(
+        &self,
+        manifest: ExtensionManifestRecord,
+    ) -> Result<(), ExtensionInstallationError>;
+
+    async fn list_installations(
+        &self,
+    ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError>;
+
+    async fn list_enabled_installations(
+        &self,
+    ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError>;
+
+    async fn get_installation(
+        &self,
+        installation_id: &ExtensionInstallationId,
+    ) -> Result<Option<ExtensionInstallation>, ExtensionInstallationError>;
+
+    async fn upsert_installation(
+        &self,
+        installation: ExtensionInstallation,
+    ) -> Result<(), ExtensionInstallationError>;
+
+    async fn set_activation_state(
+        &self,
+        installation_id: &ExtensionInstallationId,
+        state: ExtensionActivationState,
+    ) -> Result<(), ExtensionInstallationError>;
+
+    async fn update_health(
+        &self,
+        installation_id: &ExtensionInstallationId,
+        health: ExtensionHealthSnapshot,
+    ) -> Result<(), ExtensionInstallationError>;
+}
+
+#[async_trait]
+impl<T> ExtensionInstallationStore for Arc<T>
+where
+    T: ExtensionInstallationStore + ?Sized,
+{
+    async fn list_manifests(
+        &self,
+    ) -> Result<Vec<ExtensionManifestRecord>, ExtensionInstallationError> {
+        (**self).list_manifests().await
+    }
+
+    async fn get_manifest(
+        &self,
+        extension_id: &ExtensionId,
+    ) -> Result<Option<ExtensionManifestRecord>, ExtensionInstallationError> {
+        (**self).get_manifest(extension_id).await
+    }
+
+    async fn upsert_manifest(
+        &self,
+        manifest: ExtensionManifestRecord,
+    ) -> Result<(), ExtensionInstallationError> {
+        (**self).upsert_manifest(manifest).await
+    }
+
+    async fn list_installations(
+        &self,
+    ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError> {
+        (**self).list_installations().await
+    }
+
+    async fn list_enabled_installations(
+        &self,
+    ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError> {
+        (**self).list_enabled_installations().await
+    }
+
+    async fn get_installation(
+        &self,
+        installation_id: &ExtensionInstallationId,
+    ) -> Result<Option<ExtensionInstallation>, ExtensionInstallationError> {
+        (**self).get_installation(installation_id).await
+    }
+
+    async fn upsert_installation(
+        &self,
+        installation: ExtensionInstallation,
+    ) -> Result<(), ExtensionInstallationError> {
+        (**self).upsert_installation(installation).await
+    }
+
+    async fn set_activation_state(
+        &self,
+        installation_id: &ExtensionInstallationId,
+        state: ExtensionActivationState,
+    ) -> Result<(), ExtensionInstallationError> {
+        (**self).set_activation_state(installation_id, state).await
+    }
+
+    async fn update_health(
+        &self,
+        installation_id: &ExtensionInstallationId,
+        health: ExtensionHealthSnapshot,
+    ) -> Result<(), ExtensionInstallationError> {
+        (**self).update_health(installation_id, health).await
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryExtensionInstallationStore {
+    inner: Arc<RwLock<InMemoryState>>,
+}
+
+#[derive(Debug, Default)]
+struct InMemoryState {
+    manifests: HashMap<ExtensionId, ExtensionManifestRecord>,
+    installations: HashMap<ExtensionInstallationId, ExtensionInstallation>,
+}
+
+#[async_trait]
+impl ExtensionInstallationStore for InMemoryExtensionInstallationStore {
+    async fn list_manifests(
+        &self,
+    ) -> Result<Vec<ExtensionManifestRecord>, ExtensionInstallationError> {
+        let inner = self.inner.read().await;
+        let mut manifests: Vec<_> = inner.manifests.values().cloned().collect();
+        manifests.sort_by(|a, b| a.extension_id().cmp(b.extension_id()));
+        Ok(manifests)
+    }
+
+    async fn get_manifest(
+        &self,
+        extension_id: &ExtensionId,
+    ) -> Result<Option<ExtensionManifestRecord>, ExtensionInstallationError> {
+        Ok(self.inner.read().await.manifests.get(extension_id).cloned())
+    }
+
+    async fn upsert_manifest(
+        &self,
+        manifest: ExtensionManifestRecord,
+    ) -> Result<(), ExtensionInstallationError> {
+        let mut inner = self.inner.write().await;
+        for installation in inner.installations.values() {
+            if installation.extension_id() == manifest.extension_id() {
+                validate_installation_against_one_manifest(&manifest, installation)?;
+            }
+        }
+        inner
+            .manifests
+            .insert(manifest.extension_id().clone(), manifest);
+        Ok(())
+    }
+
+    async fn list_installations(
+        &self,
+    ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError> {
+        let inner = self.inner.read().await;
+        let mut installations: Vec<_> = inner.installations.values().cloned().collect();
+        installations.sort_by(|a, b| a.installation_id().cmp(b.installation_id()));
+        Ok(installations)
+    }
+
+    async fn list_enabled_installations(
+        &self,
+    ) -> Result<Vec<ExtensionInstallation>, ExtensionInstallationError> {
+        Ok(self
+            .list_installations()
+            .await?
+            .into_iter()
+            .filter(|i| i.activation_state() == ExtensionActivationState::Enabled)
+            .collect())
+    }
+
+    async fn get_installation(
+        &self,
+        installation_id: &ExtensionInstallationId,
+    ) -> Result<Option<ExtensionInstallation>, ExtensionInstallationError> {
+        Ok(self
+            .inner
+            .read()
+            .await
+            .installations
+            .get(installation_id)
+            .cloned())
+    }
+
+    async fn upsert_installation(
+        &self,
+        installation: ExtensionInstallation,
+    ) -> Result<(), ExtensionInstallationError> {
+        validate_bindings_unique(installation.credential_bindings())?;
+        let mut inner = self.inner.write().await;
+        validate_installation_against_manifest(&inner.manifests, &installation)?;
+        inner
+            .installations
+            .insert(installation.installation_id().clone(), installation);
+        Ok(())
+    }
+
+    async fn set_activation_state(
+        &self,
+        installation_id: &ExtensionInstallationId,
+        state: ExtensionActivationState,
+    ) -> Result<(), ExtensionInstallationError> {
+        let mut inner = self.inner.write().await;
+        let InMemoryState {
+            manifests,
+            installations,
+        } = &mut *inner;
+        let installation = installations.get_mut(installation_id).ok_or_else(|| {
+            ExtensionInstallationError::InstallationNotFound {
+                installation_id: installation_id.clone(),
+            }
+        })?;
+        if installation.activation_state() == state {
+            return Ok(());
+        }
+        if state == ExtensionActivationState::Enabled {
+            validate_installation_against_manifest(manifests, installation)?;
+        }
+        installation.set_activation_state(state);
+        Ok(())
+    }
+
+    async fn update_health(
+        &self,
+        installation_id: &ExtensionInstallationId,
+        health: ExtensionHealthSnapshot,
+    ) -> Result<(), ExtensionInstallationError> {
+        self.inner
+            .write()
+            .await
+            .installations
+            .get_mut(installation_id)
+            .ok_or_else(|| ExtensionInstallationError::InstallationNotFound {
+                installation_id: installation_id.clone(),
+            })?
+            .set_health(health);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ExtensionInstallationError {
+    #[error(transparent)]
+    Manifest(#[from] ManifestV2Error),
+    #[error("invalid {field}: {reason}")]
+    InvalidValue { field: &'static str, reason: String },
+    #[error("installation references unknown extension manifest {extension_id}")]
+    UnknownManifest { extension_id: ExtensionId },
+    #[error(
+        "installation extension {extension_id} does not match manifest extension {manifest_extension_id}"
+    )]
+    ManifestExtensionMismatch {
+        extension_id: ExtensionId,
+        manifest_extension_id: ExtensionId,
+    },
+    #[error(
+        "installation manifest hash does not match registered manifest hash for {extension_id}"
+    )]
+    ManifestHashMismatch { extension_id: ExtensionId },
+    #[error("installation {installation_id} was not found")]
+    InstallationNotFound {
+        installation_id: ExtensionInstallationId,
+    },
+    #[error("duplicate credential binding {handle}")]
+    DuplicateCredentialBinding { handle: ExtensionCredentialHandle },
+}
+
+fn validate_installation_against_manifest(
+    manifests: &HashMap<ExtensionId, ExtensionManifestRecord>,
+    installation: &ExtensionInstallation,
+) -> Result<(), ExtensionInstallationError> {
+    let manifest = manifests.get(installation.extension_id()).ok_or_else(|| {
+        ExtensionInstallationError::UnknownManifest {
+            extension_id: installation.extension_id().clone(),
+        }
+    })?;
+    validate_installation_against_one_manifest(manifest, installation)
+}
+
+fn validate_installation_against_one_manifest(
+    manifest: &ExtensionManifestRecord,
+    installation: &ExtensionInstallation,
+) -> Result<(), ExtensionInstallationError> {
+    if manifest.extension_id() != installation.manifest_ref().extension_id() {
+        return Err(ExtensionInstallationError::ManifestExtensionMismatch {
+            extension_id: installation.extension_id().clone(),
+            manifest_extension_id: installation.manifest_ref().extension_id().clone(),
+        });
+    }
+    match (
+        manifest.manifest_hash(),
+        installation.manifest_ref().manifest_hash(),
+    ) {
+        (Some(registered), Some(referenced)) if registered != referenced => {
+            return Err(ExtensionInstallationError::ManifestHashMismatch {
+                extension_id: installation.extension_id().clone(),
+            });
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(ExtensionInstallationError::ManifestHashMismatch {
+                extension_id: installation.extension_id().clone(),
+            });
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_bindings_unique(
+    credential_bindings: &[ExtensionCredentialBinding],
+) -> Result<(), ExtensionInstallationError> {
+    let mut seen = std::collections::BTreeSet::new();
+    for binding in credential_bindings {
+        if !seen.insert(binding.credential_handle.clone()) {
+            return Err(ExtensionInstallationError::DuplicateCredentialBinding {
+                handle: binding.credential_handle.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_nonempty_noncontrol(
+    field: &'static str,
+    value: &str,
+) -> Result<(), ExtensionInstallationError> {
+    if value.is_empty() {
+        return Err(ExtensionInstallationError::InvalidValue {
+            field,
+            reason: "must not be empty".to_string(),
+        });
+    }
+    if value.chars().any(|c| c == '\0' || c.is_control()) {
+        return Err(ExtensionInstallationError::InvalidValue {
+            field,
+            reason: "must not contain control characters".to_string(),
+        });
+    }
+    Ok(())
+}

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -327,6 +327,7 @@ impl ExtensionPackage {
 }
 
 pub mod host_api;
+mod installations;
 mod lifecycle;
 mod registry;
 pub mod v2;
@@ -344,6 +345,13 @@ pub use v2::{
 
 pub type CapabilityManifest = CapabilityDeclV2;
 
+pub use installations::{
+    ExtensionActivationState, ExtensionCredentialBinding, ExtensionCredentialHandle,
+    ExtensionHealthMessage, ExtensionHealthSnapshot, ExtensionHealthStatus, ExtensionInstallation,
+    ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationStore,
+    ExtensionManifestRecord, ExtensionManifestRef, InMemoryExtensionInstallationStore,
+    ManifestHash,
+};
 pub use lifecycle::{
     ExtensionLifecycleEvent, ExtensionLifecycleEventSink, ExtensionLifecycleService,
 };

--- a/crates/ironclaw_product_adapter_registry/AGENTS.md
+++ b/crates/ironclaw_product_adapter_registry/AGENTS.md
@@ -1,11 +1,12 @@
 # ironclaw_product_adapter_registry Agent Notes
 
-- This crate owns ProductAdapter host-api section projection + installation registry contracts for IronClaw Reborn. ProductAdapter declarations live in the single Extension Manifest v2, not a separate adapter manifest.
+- This crate owns ProductAdapter host-api section projection for IronClaw Reborn. Generic extension manifests, installation state, activation state, health, and credential bindings live in `ironclaw_extensions`.
+- ProductAdapter declarations live in the single Extension Manifest v2, not a separate adapter manifest.
 - Read `CLAUDE.md` for the full guardrail set before changing behavior.
 - Do not load WASM components, perform HTTP egress, route webhooks, or read raw secret material from this crate.
-- Do not add an env-var adapter declaration path. Registry state is authoritative.
-- Credential bindings store opaque `SecretHandle`s only; never raw secret material.
-- When mutations cross writes (manifest replaced; activation flipped), re-validate the affected installation against the current manifest before persisting or surfacing the change.
+- Do not add an env-var adapter declaration path. `ironclaw_extensions` installation state is authoritative.
+- Credential bindings are generic extension installation state; this crate only validates ProductAdapter credential handles during projection.
+- When manifests/installations are surfaced as ProductAdapter runtime entries, re-validate bindings against the current ProductAdapter sections before returning them.
 - ProductAdapter host-api section projection rejects unknown TOML fields, inline secret material, and undeclared egress credential handles. Keep those invariants and add caller-level tests when changing them.
 - Validation runs:
   - `cargo test -p ironclaw_product_adapter_registry`

--- a/crates/ironclaw_product_adapter_registry/CLAUDE.md
+++ b/crates/ironclaw_product_adapter_registry/CLAUDE.md
@@ -1,12 +1,13 @@
 # ironclaw_product_adapter_registry guardrails
 
-Owns ProductAdapter installation registry contracts for IronClaw Reborn.
+Owns ProductAdapter host-api projection contracts for IronClaw Reborn.
 
 - ProductAdapter declarations live in the single Extension Manifest v2 as
   `ironclaw.product_adapter/v1` host-api sections. This crate owns the typed
-  ProductAdapter projection plus installations, activation state,
-  credential-handle bindings, and health snapshots; it must not introduce a
-  second ProductAdapter TOML manifest format.
+  ProductAdapter projection; generic extension manifests, installation state,
+  activation state, credential-handle bindings, and health snapshots live in
+  `ironclaw_extensions`. This crate must not introduce a second ProductAdapter
+  TOML manifest format.
 - Do **not** load WASM components, perform HTTP egress, route webhooks,
   resolve secret material, or write durable database state from this crate.
 - Do **not** introduce an env-var adapter list (no `REBORN_PRODUCT_ADAPTERS`
@@ -22,21 +23,19 @@ Owns ProductAdapter installation registry contracts for IronClaw Reborn.
   - validate every egress credential handle is declared in
     `required_credentials`,
   - keep `(host, credential_handle)` pairs distinct.
-- Registry mutations must keep the cross-write invariant: every stored
-  installation must remain valid against its registered manifest. When a
-  manifest is replaced, existing installations must be re-validated; when
-  an installation is enabled, it must be re-validated against the current
-  manifest at the time of the activation transition.
-- Health updates must redact provider/runtime internals through
-  `ironclaw_product_adapters::RedactedString`.
+- ProductAdapter runtime projection must keep the cross-write invariant at
+  read time: every surfaced installation must remain valid against its
+  registered manifest and current ProductAdapter sections.
+- Health updates are generic extension installation state and use
+  `ironclaw_extensions::ExtensionHealthMessage` for redacted debug output.
 
 ## Tests
 
 - Unit tests in `src/**/mod tests {}` cover validation helpers.
-- Integration tests in `tests/registry_contract.rs` pin store invariants:
-  default-empty, explicit activation, undeclared credential binding,
-  egress pair preservation, manifest hash mismatch, redacted health, and
-  cross-write invariant maintenance.
+- Integration tests in `tests/registry_contract.rs` pin projection over the
+  generic extension store: default-empty, explicit activation, undeclared
+  ProductAdapter credential binding, egress pair preservation, manifest hash
+  mismatch, redacted health, and cross-write invariant maintenance.
 - Integration tests in `tests/manifest_ingestion.rs` cover manifest
   parsing, unknown-field rejection, inline-secret rejection, and egress
   credential validation.

--- a/crates/ironclaw_product_adapter_registry/Cargo.toml
+++ b/crates/ironclaw_product_adapter_registry/Cargo.toml
@@ -3,7 +3,7 @@ name = "ironclaw_product_adapter_registry"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.92"
-description = "ProductAdapter host-api projection and installation registry for IronClaw Reborn"
+description = "ProductAdapter host-api projection for IronClaw Reborn extension manifests"
 authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/nearai/ironclaw"
@@ -11,16 +11,14 @@ repository = "https://github.com/nearai/ironclaw"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
 ironclaw_extensions = { path = "../ironclaw_extensions", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_product_adapters = { path = "../ironclaw_product_adapters", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
-tokio = { version = "1", features = ["sync"] }
 toml = "0.8"
 
 [dev-dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/crates/ironclaw_product_adapter_registry/src/lib.rs
+++ b/crates/ironclaw_product_adapter_registry/src/lib.rs
@@ -1,12 +1,8 @@
-//! Generic extension installation registry with ProductAdapter projection.
-//!
-//! There is one store, one installation type, one manifest type. The
-//! ProductAdapter-specific path is a projection on top:
+//! ProductAdapter host-api projection over generic extension installation state.
 //!
 //! ```text
-//! ExtensionInstallationStore (generic, async, persistence-backed)
-//!   manifests    → ExtensionManifestRecord   (any ExtensionManifestV2)
-//!   installations → ExtensionInstallation    (any extension, keyed by ExtensionId)
+//! ironclaw_extensions::ExtensionInstallationStore
+//!   manifests/installations for any extension
 //!
 //! list_enabled_product_adapter_entries(store)
 //!   → filter enabled installations whose manifest carries ironclaw.product_adapter/v1
@@ -17,23 +13,27 @@
 #![forbid(unsafe_code)]
 
 use std::collections::{BTreeSet, HashMap};
-use std::fmt;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use ironclaw_extensions::{
     ExtensionManifestV2, HostApiContractRegistry, HostApiId, HostApiManifestContract,
     HostApiMultiplicity, HostApiRefV2, ManifestSectionPath, ManifestSource, ManifestV2Error,
 };
-use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle};
+use ironclaw_host_api::{ExtensionId, HostPortCatalog};
 use ironclaw_product_adapters::{
     AuthRequirement, DeclaredEgressTarget, EgressCredentialHandle, ProductAdapterCapabilities,
-    ProductAdapterId, ProductCapabilityFlag, ProductSurfaceKind, RedactedString,
+    ProductAdapterId, ProductCapabilityFlag, ProductSurfaceKind,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::Deserialize;
 use thiserror::Error;
-use tokio::sync::RwLock;
+
+pub use ironclaw_extensions::{
+    ExtensionActivationState, ExtensionCredentialBinding, ExtensionCredentialHandle,
+    ExtensionHealthMessage, ExtensionHealthSnapshot, ExtensionHealthStatus, ExtensionInstallation,
+    ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationStore,
+    ExtensionManifestRecord, ExtensionManifestRef, InMemoryExtensionInstallationStore,
+    ManifestHash,
+};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -42,615 +42,33 @@ use tokio::sync::RwLock;
 pub const PRODUCT_ADAPTER_HOST_API_ID: &str = "ironclaw.product_adapter/v1";
 pub const PRODUCT_ADAPTER_SECTION_PREFIX: &str = "product_adapter";
 
-// ---------------------------------------------------------------------------
-// Shared primitives
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
-#[serde(transparent)]
-pub struct ManifestHash(String);
-
-impl ManifestHash {
-    pub fn new(value: impl Into<String>) -> Result<Self, RegistryError> {
-        let value = value.into();
-        validate_nonempty_noncontrol("manifest_hash", &value)?;
-        Ok(Self(value))
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for ManifestHash {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Self::new(value).map_err(serde::de::Error::custom)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// ExtensionManifestRecord — single manifest type for any extension
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExtensionManifestRecord {
-    raw_toml: String,
-    manifest: ExtensionManifestV2,
-    product_adapters: Vec<ProductAdapterHostApiSection>,
+pub fn parse_product_adapter_manifest_record(
+    raw_toml: impl Into<String>,
+    source: ManifestSource,
+    host_port_catalog: &HostPortCatalog,
     manifest_hash: Option<ManifestHash>,
+) -> Result<ExtensionManifestRecord, RegistryError> {
+    let contract = Arc::new(ProductAdapterHostApiContract::new()?);
+    let mut contracts = HostApiContractRegistry::new();
+    contracts.register(contract)?;
+    ExtensionManifestRecord::from_toml_with_contracts(
+        raw_toml,
+        source,
+        host_port_catalog,
+        manifest_hash,
+        &contracts,
+    )
+    .map_err(|error| match error {
+        ExtensionInstallationError::Manifest(error) => RegistryError::Manifest(error),
+        other => RegistryError::Installation(other),
+    })
 }
 
-impl ExtensionManifestRecord {
-    /// Parse a single Extension Manifest v2 TOML document. ProductAdapter
-    /// host-api sections are projected automatically when present.
-    pub fn from_toml(
-        raw_toml: impl Into<String>,
-        source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
-        manifest_hash: Option<ManifestHash>,
-    ) -> Result<Self, RegistryError> {
-        let contract = Arc::new(ProductAdapterHostApiContract::new()?);
-        let mut contracts = HostApiContractRegistry::new();
-        contracts.register(contract)?;
-        Self::from_toml_with_contracts(
-            raw_toml,
-            source,
-            host_port_catalog,
-            manifest_hash,
-            &contracts,
-        )
-    }
-
-    /// Parse with a caller-supplied contract registry (for additional host API types).
-    pub fn from_toml_with_contracts(
-        raw_toml: impl Into<String>,
-        source: ManifestSource,
-        host_port_catalog: &HostPortCatalog,
-        manifest_hash: Option<ManifestHash>,
-        contracts: &HostApiContractRegistry,
-    ) -> Result<Self, RegistryError> {
-        let raw_toml = raw_toml.into();
-        let manifest = ExtensionManifestV2::parse_with_host_api_contracts(
-            &raw_toml,
-            source,
-            host_port_catalog,
-            contracts,
-        )?;
-        let product_adapters = project_product_adapter_sections(&raw_toml, &manifest)?;
-        Ok(Self {
-            raw_toml,
-            manifest,
-            product_adapters,
-            manifest_hash,
-        })
-    }
-
-    pub fn manifest(&self) -> &ExtensionManifestV2 {
-        &self.manifest
-    }
-
-    pub fn raw_toml(&self) -> &str {
-        &self.raw_toml
-    }
-
-    pub fn extension_id(&self) -> &ExtensionId {
-        &self.manifest.id
-    }
-
-    pub fn product_adapters(&self) -> &[ProductAdapterHostApiSection] {
-        &self.product_adapters
-    }
-
-    pub fn manifest_hash(&self) -> Option<&ManifestHash> {
-        self.manifest_hash.as_ref()
-    }
+pub fn product_adapter_sections(
+    record: &ExtensionManifestRecord,
+) -> Result<Vec<ProductAdapterHostApiSection>, RegistryError> {
+    project_product_adapter_sections(record.raw_toml(), record.manifest())
 }
-
-// ---------------------------------------------------------------------------
-// Generic extension installation state
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
-#[serde(transparent)]
-pub struct ExtensionInstallationId(String);
-
-impl ExtensionInstallationId {
-    pub fn new(value: impl Into<String>) -> Result<Self, RegistryError> {
-        let value = value.into();
-        validate_nonempty_noncontrol("installation_id", &value)?;
-        Ok(Self(value))
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl fmt::Display for ExtensionInstallationId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for ExtensionInstallationId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Self::new(value).map_err(serde::de::Error::custom)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ExtensionActivationState {
-    Installed,
-    Disabled,
-    Enabled,
-}
-
-/// Opaque credential binding: maps a manifest-declared handle name to a
-/// host secret handle. Never stores raw secret material.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExtensionCredentialBinding {
-    credential_handle: EgressCredentialHandle,
-    secret_handle: SecretHandle,
-}
-
-impl ExtensionCredentialBinding {
-    pub fn new(credential_handle: EgressCredentialHandle, secret_handle: SecretHandle) -> Self {
-        Self {
-            credential_handle,
-            secret_handle,
-        }
-    }
-
-    pub fn credential_handle(&self) -> &EgressCredentialHandle {
-        &self.credential_handle
-    }
-
-    pub fn secret_handle(&self) -> &SecretHandle {
-        &self.secret_handle
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExtensionManifestRef {
-    extension_id: ExtensionId,
-    manifest_hash: Option<ManifestHash>,
-}
-
-impl ExtensionManifestRef {
-    pub fn new(extension_id: ExtensionId, manifest_hash: Option<ManifestHash>) -> Self {
-        Self {
-            extension_id,
-            manifest_hash,
-        }
-    }
-
-    pub fn extension_id(&self) -> &ExtensionId {
-        &self.extension_id
-    }
-
-    pub fn manifest_hash(&self) -> Option<&ManifestHash> {
-        self.manifest_hash.as_ref()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExtensionHealthSnapshot {
-    status: ExtensionHealthStatus,
-    message: Option<RedactedString>,
-    checked_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ExtensionHealthStatus {
-    Healthy,
-    Degraded,
-    Unhealthy,
-}
-
-impl ExtensionHealthSnapshot {
-    pub fn healthy() -> Self {
-        Self {
-            status: ExtensionHealthStatus::Healthy,
-            message: None,
-            checked_at: Utc::now(),
-        }
-    }
-
-    pub fn new(
-        status: ExtensionHealthStatus,
-        message: Option<RedactedString>,
-        checked_at: DateTime<Utc>,
-    ) -> Self {
-        Self {
-            status,
-            message,
-            checked_at,
-        }
-    }
-
-    pub fn status(&self) -> ExtensionHealthStatus {
-        self.status
-    }
-
-    pub fn message(&self) -> Option<&RedactedString> {
-        self.message.as_ref()
-    }
-
-    pub fn checked_at(&self) -> DateTime<Utc> {
-        self.checked_at
-    }
-}
-
-/// One installed extension with activation state and opaque credential bindings.
-/// Works for any extension kind — ProductAdapter filtering is a projection.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ExtensionInstallation {
-    installation_id: ExtensionInstallationId,
-    extension_id: ExtensionId,
-    activation_state: ExtensionActivationState,
-    manifest_ref: ExtensionManifestRef,
-    credential_bindings: Vec<ExtensionCredentialBinding>,
-    health: ExtensionHealthSnapshot,
-    updated_at: DateTime<Utc>,
-}
-
-impl ExtensionInstallation {
-    pub fn new(
-        installation_id: ExtensionInstallationId,
-        extension_id: ExtensionId,
-        activation_state: ExtensionActivationState,
-        manifest_ref: ExtensionManifestRef,
-        credential_bindings: Vec<ExtensionCredentialBinding>,
-        updated_at: DateTime<Utc>,
-    ) -> Result<Self, RegistryError> {
-        if manifest_ref.extension_id() != &extension_id {
-            return Err(RegistryError::ManifestExtensionMismatch {
-                extension_id,
-                manifest_extension_id: manifest_ref.extension_id().clone(),
-            });
-        }
-        validate_bindings_unique(&credential_bindings)?;
-        Ok(Self {
-            installation_id,
-            extension_id,
-            activation_state,
-            manifest_ref,
-            credential_bindings,
-            health: ExtensionHealthSnapshot::healthy(),
-            updated_at,
-        })
-    }
-
-    pub fn installation_id(&self) -> &ExtensionInstallationId {
-        &self.installation_id
-    }
-
-    pub fn extension_id(&self) -> &ExtensionId {
-        &self.extension_id
-    }
-
-    pub fn activation_state(&self) -> ExtensionActivationState {
-        self.activation_state
-    }
-
-    pub fn manifest_ref(&self) -> &ExtensionManifestRef {
-        &self.manifest_ref
-    }
-
-    pub fn credential_bindings(&self) -> &[ExtensionCredentialBinding] {
-        &self.credential_bindings
-    }
-
-    pub fn health(&self) -> &ExtensionHealthSnapshot {
-        &self.health
-    }
-
-    pub fn updated_at(&self) -> DateTime<Utc> {
-        self.updated_at
-    }
-
-    fn set_activation_state(&mut self, state: ExtensionActivationState) {
-        self.activation_state = state;
-        self.updated_at = Utc::now();
-    }
-
-    fn set_health(&mut self, health: ExtensionHealthSnapshot) {
-        self.health = health;
-        self.updated_at = Utc::now();
-    }
-}
-
-impl<'de> Deserialize<'de> for ExtensionInstallation {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Wire {
-            installation_id: ExtensionInstallationId,
-            extension_id: ExtensionId,
-            activation_state: ExtensionActivationState,
-            manifest_ref: ExtensionManifestRef,
-            credential_bindings: Vec<ExtensionCredentialBinding>,
-            health: ExtensionHealthSnapshot,
-            updated_at: DateTime<Utc>,
-        }
-        let wire = Wire::deserialize(deserializer)?;
-        if wire.manifest_ref.extension_id() != &wire.extension_id {
-            return Err(serde::de::Error::custom(
-                RegistryError::ManifestExtensionMismatch {
-                    extension_id: wire.extension_id,
-                    manifest_extension_id: wire.manifest_ref.extension_id().clone(),
-                },
-            ));
-        }
-        validate_bindings_unique(&wire.credential_bindings).map_err(serde::de::Error::custom)?;
-        Ok(Self {
-            installation_id: wire.installation_id,
-            extension_id: wire.extension_id,
-            activation_state: wire.activation_state,
-            manifest_ref: wire.manifest_ref,
-            credential_bindings: wire.credential_bindings,
-            health: wire.health,
-            updated_at: wire.updated_at,
-        })
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Single generic store trait
-// ---------------------------------------------------------------------------
-
-#[async_trait]
-pub trait ExtensionInstallationStore: Send + Sync {
-    async fn list_manifests(&self) -> Result<Vec<ExtensionManifestRecord>, RegistryError>;
-
-    async fn get_manifest(
-        &self,
-        extension_id: &ExtensionId,
-    ) -> Result<Option<ExtensionManifestRecord>, RegistryError>;
-
-    async fn upsert_manifest(&self, manifest: ExtensionManifestRecord)
-    -> Result<(), RegistryError>;
-
-    async fn list_installations(&self) -> Result<Vec<ExtensionInstallation>, RegistryError>;
-
-    async fn list_enabled_installations(&self)
-    -> Result<Vec<ExtensionInstallation>, RegistryError>;
-
-    async fn get_installation(
-        &self,
-        installation_id: &ExtensionInstallationId,
-    ) -> Result<Option<ExtensionInstallation>, RegistryError>;
-
-    async fn upsert_installation(
-        &self,
-        installation: ExtensionInstallation,
-    ) -> Result<(), RegistryError>;
-
-    async fn set_activation_state(
-        &self,
-        installation_id: &ExtensionInstallationId,
-        state: ExtensionActivationState,
-    ) -> Result<(), RegistryError>;
-
-    /// Replace the stored health snapshot without enforcing status/message
-    /// consistency; callers may report status codes before a diagnostic exists.
-    async fn update_health(
-        &self,
-        installation_id: &ExtensionInstallationId,
-        health: ExtensionHealthSnapshot,
-    ) -> Result<(), RegistryError>;
-}
-
-#[async_trait]
-impl<T> ExtensionInstallationStore for Arc<T>
-where
-    T: ExtensionInstallationStore + ?Sized,
-{
-    async fn list_manifests(&self) -> Result<Vec<ExtensionManifestRecord>, RegistryError> {
-        (**self).list_manifests().await
-    }
-
-    async fn get_manifest(
-        &self,
-        extension_id: &ExtensionId,
-    ) -> Result<Option<ExtensionManifestRecord>, RegistryError> {
-        (**self).get_manifest(extension_id).await
-    }
-
-    async fn upsert_manifest(
-        &self,
-        manifest: ExtensionManifestRecord,
-    ) -> Result<(), RegistryError> {
-        (**self).upsert_manifest(manifest).await
-    }
-
-    async fn list_installations(&self) -> Result<Vec<ExtensionInstallation>, RegistryError> {
-        (**self).list_installations().await
-    }
-
-    async fn list_enabled_installations(
-        &self,
-    ) -> Result<Vec<ExtensionInstallation>, RegistryError> {
-        (**self).list_enabled_installations().await
-    }
-
-    async fn get_installation(
-        &self,
-        installation_id: &ExtensionInstallationId,
-    ) -> Result<Option<ExtensionInstallation>, RegistryError> {
-        (**self).get_installation(installation_id).await
-    }
-
-    async fn upsert_installation(
-        &self,
-        installation: ExtensionInstallation,
-    ) -> Result<(), RegistryError> {
-        (**self).upsert_installation(installation).await
-    }
-
-    async fn set_activation_state(
-        &self,
-        installation_id: &ExtensionInstallationId,
-        state: ExtensionActivationState,
-    ) -> Result<(), RegistryError> {
-        (**self).set_activation_state(installation_id, state).await
-    }
-
-    async fn update_health(
-        &self,
-        installation_id: &ExtensionInstallationId,
-        health: ExtensionHealthSnapshot,
-    ) -> Result<(), RegistryError> {
-        (**self).update_health(installation_id, health).await
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct InMemoryExtensionInstallationStore {
-    inner: Arc<RwLock<InMemoryState>>,
-}
-
-#[derive(Debug, Default)]
-struct InMemoryState {
-    manifests: HashMap<ExtensionId, ExtensionManifestRecord>,
-    installations: HashMap<ExtensionInstallationId, ExtensionInstallation>,
-}
-
-#[async_trait]
-impl ExtensionInstallationStore for InMemoryExtensionInstallationStore {
-    async fn list_manifests(&self) -> Result<Vec<ExtensionManifestRecord>, RegistryError> {
-        let inner = self.inner.read().await;
-        let mut manifests: Vec<_> = inner.manifests.values().cloned().collect();
-        manifests.sort_by(|a, b| a.extension_id().cmp(b.extension_id()));
-        Ok(manifests)
-    }
-
-    async fn get_manifest(
-        &self,
-        extension_id: &ExtensionId,
-    ) -> Result<Option<ExtensionManifestRecord>, RegistryError> {
-        Ok(self.inner.read().await.manifests.get(extension_id).cloned())
-    }
-
-    async fn upsert_manifest(
-        &self,
-        manifest: ExtensionManifestRecord,
-    ) -> Result<(), RegistryError> {
-        let mut inner = self.inner.write().await;
-        for installation in inner.installations.values() {
-            if installation.extension_id() == manifest.extension_id() {
-                validate_installation_against_one_manifest(&manifest, installation)?;
-            }
-        }
-        inner
-            .manifests
-            .insert(manifest.extension_id().clone(), manifest);
-        Ok(())
-    }
-
-    async fn list_installations(&self) -> Result<Vec<ExtensionInstallation>, RegistryError> {
-        let inner = self.inner.read().await;
-        let mut installations: Vec<_> = inner.installations.values().cloned().collect();
-        installations.sort_by(|a, b| a.installation_id().cmp(b.installation_id()));
-        Ok(installations)
-    }
-
-    async fn list_enabled_installations(
-        &self,
-    ) -> Result<Vec<ExtensionInstallation>, RegistryError> {
-        Ok(self
-            .list_installations()
-            .await?
-            .into_iter()
-            .filter(|i| i.activation_state() == ExtensionActivationState::Enabled)
-            .collect())
-    }
-
-    async fn get_installation(
-        &self,
-        installation_id: &ExtensionInstallationId,
-    ) -> Result<Option<ExtensionInstallation>, RegistryError> {
-        Ok(self
-            .inner
-            .read()
-            .await
-            .installations
-            .get(installation_id)
-            .cloned())
-    }
-
-    async fn upsert_installation(
-        &self,
-        installation: ExtensionInstallation,
-    ) -> Result<(), RegistryError> {
-        validate_bindings_unique(installation.credential_bindings())?;
-        let mut inner = self.inner.write().await;
-        validate_installation_against_manifest(&inner.manifests, &installation)?;
-        inner
-            .installations
-            .insert(installation.installation_id().clone(), installation);
-        Ok(())
-    }
-
-    async fn set_activation_state(
-        &self,
-        installation_id: &ExtensionInstallationId,
-        state: ExtensionActivationState,
-    ) -> Result<(), RegistryError> {
-        let mut inner = self.inner.write().await;
-        let InMemoryState {
-            manifests,
-            installations,
-        } = &mut *inner;
-        let installation = installations.get_mut(installation_id).ok_or_else(|| {
-            RegistryError::InstallationNotFound {
-                installation_id: installation_id.clone(),
-            }
-        })?;
-        if installation.activation_state() == state {
-            return Ok(());
-        }
-        if state == ExtensionActivationState::Enabled {
-            validate_installation_against_manifest(manifests, installation)?;
-        }
-        installation.set_activation_state(state);
-        Ok(())
-    }
-
-    async fn update_health(
-        &self,
-        installation_id: &ExtensionInstallationId,
-        health: ExtensionHealthSnapshot,
-    ) -> Result<(), RegistryError> {
-        self.inner
-            .write()
-            .await
-            .installations
-            .get_mut(installation_id)
-            .ok_or_else(|| RegistryError::InstallationNotFound {
-                installation_id: installation_id.clone(),
-            })?
-            .set_health(health);
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// ProductAdapter projection
-// ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProductAdapterHostApiSection {
@@ -805,12 +223,12 @@ pub async fn list_enabled_product_adapter_entries(
             .ok_or_else(|| RegistryError::UnknownManifest {
                 extension_id: installation.extension_id().clone(),
             })?;
-        validate_installation_against_one_manifest(manifest, &installation)?;
-        let adapters = manifest.product_adapters();
+        let adapters = project_product_adapter_sections(manifest.raw_toml(), manifest.manifest())?;
+        validate_installation_against_one_manifest(manifest, &installation, &adapters)?;
         if adapters.is_empty() {
             continue;
         }
-        for adapter in adapters {
+        for adapter in &adapters {
             entries.push(ProductAdapterRuntimeEntry::new(
                 installation.clone(),
                 adapter.clone(),
@@ -883,6 +301,8 @@ impl HostApiManifestContract for ProductAdapterHostApiContract {
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum RegistryError {
     #[error(transparent)]
+    Installation(#[from] ExtensionInstallationError),
+    #[error(transparent)]
     Manifest(#[from] ManifestV2Error),
     #[error("invalid {field}: {reason}")]
     InvalidValue { field: &'static str, reason: String },
@@ -926,21 +346,10 @@ pub enum RegistryError {
 // Internal validation helpers
 // ---------------------------------------------------------------------------
 
-fn validate_installation_against_manifest(
-    manifests: &HashMap<ExtensionId, ExtensionManifestRecord>,
-    installation: &ExtensionInstallation,
-) -> Result<(), RegistryError> {
-    let manifest = manifests.get(installation.extension_id()).ok_or_else(|| {
-        RegistryError::UnknownManifest {
-            extension_id: installation.extension_id().clone(),
-        }
-    })?;
-    validate_installation_against_one_manifest(manifest, installation)
-}
-
 fn validate_installation_against_one_manifest(
     manifest: &ExtensionManifestRecord,
     installation: &ExtensionInstallation,
+    product_adapters: &[ProductAdapterHostApiSection],
 ) -> Result<(), RegistryError> {
     if manifest.extension_id() != installation.manifest_ref().extension_id() {
         return Err(RegistryError::ManifestExtensionMismatch {
@@ -969,47 +378,25 @@ fn validate_installation_against_one_manifest(
     // For non-product-adapter manifests there are no declared credentials, so
     // any binding would be invalid; but installations on non-PA manifests are
     // allowed (they just must not carry bindings).
-    let declared: BTreeSet<_> = manifest
-        .product_adapters()
+    let declared: BTreeSet<_> = product_adapters
         .iter()
-        .flat_map(|pa| pa.required_credentials().iter().cloned())
+        .flat_map(|pa| {
+            pa.required_credentials()
+                .iter()
+                .map(EgressCredentialHandle::as_str)
+        })
         .collect();
     for binding in installation.credential_bindings() {
-        if !declared.contains(binding.credential_handle()) {
+        if !declared.contains(binding.credential_handle().as_str()) {
             return Err(RegistryError::UndeclaredCredentialHandle {
-                handle: binding.credential_handle().clone(),
+                handle: EgressCredentialHandle::new(binding.credential_handle().as_str()).map_err(
+                    |reason| RegistryError::InvalidValue {
+                        field: "credential_handle",
+                        reason: reason.to_string(),
+                    },
+                )?,
             });
         }
-    }
-    Ok(())
-}
-
-fn validate_bindings_unique(
-    credential_bindings: &[ExtensionCredentialBinding],
-) -> Result<(), RegistryError> {
-    let mut seen = BTreeSet::new();
-    for binding in credential_bindings {
-        if !seen.insert(binding.credential_handle.clone()) {
-            return Err(RegistryError::DuplicateCredentialBinding {
-                handle: binding.credential_handle.clone(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn validate_nonempty_noncontrol(field: &'static str, value: &str) -> Result<(), RegistryError> {
-    if value.is_empty() {
-        return Err(RegistryError::InvalidValue {
-            field,
-            reason: "must not be empty".to_string(),
-        });
-    }
-    if value.chars().any(|c| c == '\0' || c.is_control()) {
-        return Err(RegistryError::InvalidValue {
-            field,
-            reason: "must not contain control characters".to_string(),
-        });
     }
     Ok(())
 }

--- a/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/manifest_ingestion.rs
@@ -1,6 +1,9 @@
 use ironclaw_extensions::{MANIFEST_SCHEMA_VERSION, ManifestSource};
 use ironclaw_host_api::HostPortCatalog;
-use ironclaw_product_adapter_registry::{ExtensionManifestRecord, ManifestHash, RegistryError};
+use ironclaw_product_adapter_registry::{
+    ExtensionManifestRecord, ManifestHash, RegistryError, parse_product_adapter_manifest_record,
+    product_adapter_sections,
+};
 use ironclaw_product_adapters::{AuthRequirement, ProductCapabilityFlag, ProductSurfaceKind};
 
 fn manifest(extra: &str) -> String {
@@ -45,7 +48,7 @@ credential_handle = "telegram_bot_token"
 }
 
 fn parse(raw: &str) -> Result<ExtensionManifestRecord, RegistryError> {
-    ExtensionManifestRecord::from_toml(
+    parse_product_adapter_manifest_record(
         raw,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -58,8 +61,9 @@ fn parses_product_adapter_host_api_section_from_extension_manifest_v2() {
     let record = parse(&manifest("")).unwrap();
 
     assert_eq!(record.extension_id().as_str(), "telegram-v2");
-    assert_eq!(record.product_adapters().len(), 1);
-    let adapter = &record.product_adapters()[0];
+    let adapters = product_adapter_sections(&record).unwrap();
+    assert_eq!(adapters.len(), 1);
+    let adapter = &adapters[0];
     assert_eq!(adapter.adapter_id().as_str(), "telegram-v2/inbound");
     assert_eq!(adapter.surface_kind(), ProductSurfaceKind::ExternalChannel);
     assert!(matches!(

--- a/crates/ironclaw_product_adapter_registry/tests/registry_contract.rs
+++ b/crates/ironclaw_product_adapter_registry/tests/registry_contract.rs
@@ -4,12 +4,13 @@ use chrono::Utc;
 use ironclaw_extensions::{MANIFEST_SCHEMA_VERSION, ManifestSource};
 use ironclaw_host_api::{ExtensionId, HostPortCatalog, SecretHandle};
 use ironclaw_product_adapter_registry::{
-    ExtensionActivationState, ExtensionCredentialBinding, ExtensionInstallation,
-    ExtensionInstallationId, ExtensionInstallationStore, ExtensionManifestRecord,
-    ExtensionManifestRef, InMemoryExtensionInstallationStore, ManifestHash, RegistryError,
-    list_enabled_product_adapter_entries,
+    ExtensionActivationState, ExtensionCredentialBinding, ExtensionCredentialHandle,
+    ExtensionInstallation, ExtensionInstallationError, ExtensionInstallationId,
+    ExtensionInstallationStore, ExtensionManifestRecord, ExtensionManifestRef,
+    InMemoryExtensionInstallationStore, ManifestHash, RegistryError,
+    list_enabled_product_adapter_entries, parse_product_adapter_manifest_record,
+    product_adapter_sections,
 };
-use ironclaw_product_adapters::EgressCredentialHandle;
 
 fn extension_id() -> ExtensionId {
     ExtensionId::new("telegram-v2").unwrap()
@@ -19,8 +20,8 @@ fn installation_id() -> ExtensionInstallationId {
     ExtensionInstallationId::new("acme-telegram-prod").unwrap()
 }
 
-fn credential(value: &str) -> EgressCredentialHandle {
-    EgressCredentialHandle::new(value).unwrap()
+fn credential(value: &str) -> ExtensionCredentialHandle {
+    ExtensionCredentialHandle::new(value).unwrap()
 }
 
 fn manifest_hash(value: &str) -> ManifestHash {
@@ -59,7 +60,7 @@ handle = "{required_credential}"
 "#,
         schema = MANIFEST_SCHEMA_VERSION,
     );
-    ExtensionManifestRecord::from_toml(
+    parse_product_adapter_manifest_record(
         raw,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -185,7 +186,7 @@ async fn credential_binding_must_reference_declared_manifest_handle() {
     let invalid = ExtensionInstallation::new(
         installation_id(),
         extension_id(),
-        ExtensionActivationState::Installed,
+        ExtensionActivationState::Enabled,
         ExtensionManifestRef::new(extension_id(), Some(manifest_hash("sha256:abc123"))),
         vec![ExtensionCredentialBinding::new(
             credential("slack_bot_token"),
@@ -195,7 +196,10 @@ async fn credential_binding_must_reference_declared_manifest_handle() {
     )
     .unwrap();
 
-    let err = store.upsert_installation(invalid).await.unwrap_err();
+    store.upsert_installation(invalid).await.unwrap();
+    let err = list_enabled_product_adapter_entries(&store)
+        .await
+        .unwrap_err();
     assert!(matches!(
         err,
         RegistryError::UndeclaredCredentialHandle { .. }
@@ -214,7 +218,10 @@ async fn manifest_hash_mismatch_is_rejected() {
         .upsert_installation(installation(ExtensionActivationState::Installed))
         .await
         .unwrap_err();
-    assert!(matches!(err, RegistryError::ManifestHashMismatch { .. }));
+    assert!(matches!(
+        err,
+        ExtensionInstallationError::ManifestHashMismatch { .. }
+    ));
 }
 
 #[tokio::test]
@@ -229,8 +236,11 @@ async fn upsert_manifest_rejects_when_existing_installation_binding_revoked() {
         .await
         .unwrap();
 
-    let err = store
+    store
         .upsert_manifest(manifest("other_token", "sha256:abc123"))
+        .await
+        .unwrap();
+    let err = list_enabled_product_adapter_entries(&store)
         .await
         .unwrap_err();
     assert!(matches!(
@@ -280,7 +290,10 @@ fn duplicate_credential_bindings_rejected_at_construction() {
     )
     .unwrap_err();
     assert!(
-        matches!(err, RegistryError::DuplicateCredentialBinding { .. }),
+        matches!(
+            err,
+            ExtensionInstallationError::DuplicateCredentialBinding { .. }
+        ),
         "expected DuplicateCredentialBinding, got {err:?}"
     );
 }
@@ -397,7 +410,7 @@ handle = "outbound_token"
         schema = MANIFEST_SCHEMA_VERSION,
     );
     let multi_id = ExtensionId::new("multi-adapter").unwrap();
-    let multi_manifest = ExtensionManifestRecord::from_toml(
+    let multi_manifest = parse_product_adapter_manifest_record(
         raw,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
@@ -405,7 +418,7 @@ handle = "outbound_token"
     )
     .unwrap();
     assert_eq!(
-        multi_manifest.product_adapters().len(),
+        product_adapter_sections(&multi_manifest).unwrap().len(),
         2,
         "manifest should project two product adapter sections"
     );
@@ -465,8 +478,9 @@ async fn arc_store_delegation_works() {
 
 #[tokio::test]
 async fn update_health_uses_redacted_string() {
-    use ironclaw_product_adapter_registry::{ExtensionHealthSnapshot, ExtensionHealthStatus};
-    use ironclaw_product_adapters::RedactedString;
+    use ironclaw_product_adapter_registry::{
+        ExtensionHealthMessage, ExtensionHealthSnapshot, ExtensionHealthStatus,
+    };
 
     let store = InMemoryExtensionInstallationStore::default();
     store
@@ -480,7 +494,7 @@ async fn update_health_uses_redacted_string() {
 
     let health = ExtensionHealthSnapshot::new(
         ExtensionHealthStatus::Degraded,
-        Some(RedactedString::new("timeout after 5s")),
+        Some(ExtensionHealthMessage::new("timeout after 5s")),
         Utc::now(),
     );
     store
@@ -494,10 +508,10 @@ async fn update_health_uses_redacted_string() {
         .unwrap()
         .unwrap();
     assert_eq!(inst.health().status(), ExtensionHealthStatus::Degraded);
-    // RedactedString Debug impl should redact the value.
+    // ExtensionHealthMessage Debug impl should redact the value.
     let debug = format!("{:?}", inst.health().message().unwrap());
     assert!(
         !debug.contains("timeout after 5s"),
-        "RedactedString should redact the message in Debug output"
+        "ExtensionHealthMessage should redact the message in Debug output"
     );
 }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -43,7 +43,9 @@ use ironclaw_reborn::runtime::{
     build_default_planned_runtime,
 };
 use ironclaw_reborn::turn_runner::{TurnRunnerWakeSender, TurnRunnerWorkerConfig};
-use ironclaw_reborn_extensions::{FirstPartySkillsExtension, FirstPartySkillsExtensionHandles};
+use ironclaw_reborn_extensions::{
+    FirstPartySkillsExtension, FirstPartySkillsExtensionHandles, LoadedRebornFirstPartyExtensions,
+};
 use ironclaw_threads::{
     AcceptInboundMessageRequest, EnsureThreadRequest, InMemorySessionThreadService, MessageContent,
     MessageKind, MessageStatus, SessionThreadService, ThreadHistoryRequest, ThreadScope,
@@ -658,7 +660,7 @@ pub async fn build_reborn_runtime(
 fn local_dev_filesystem_skill_context_source(
     local_runtime: &crate::factory::RebornLocalRuntimeServices,
 ) -> Result<Arc<dyn HostSkillContextSource>, RebornRuntimeError> {
-    let extension = FirstPartySkillsExtension::new(
+    let skills_extension = FirstPartySkillsExtension::new(
         Arc::clone(&local_runtime.skill_filesystem),
         FirstPartySkillsExtensionHandles::reborn_default().map_err(|reason| {
             RebornRuntimeError::InvalidArgument {
@@ -666,7 +668,13 @@ fn local_dev_filesystem_skill_context_source(
             }
         })?,
     );
-    Ok(extension.host_skill_context_source())
+    let loaded_extensions = LoadedRebornFirstPartyExtensions::new().with_skills(skills_extension);
+    loaded_extensions
+        .skill_context_source()
+        .ok_or(RebornRuntimeError::InvalidArgument {
+            reason: "first-party skills extension did not expose a skill context source"
+                .to_string(),
+        })
 }
 
 struct ValidatedRuntimeIdentity {

--- a/crates/ironclaw_reborn_extensions/src/lib.rs
+++ b/crates/ironclaw_reborn_extensions/src/lib.rs
@@ -5,8 +5,10 @@
 //! export narrow ports back to Reborn composition.
 #![forbid(unsafe_code)]
 
+mod loaded;
 mod skills;
 
+pub use loaded::LoadedRebornFirstPartyExtensions;
 pub use skills::{
     FirstPartySkillsExtension, FirstPartySkillsExtensionError, FirstPartySkillsExtensionHandles,
 };

--- a/crates/ironclaw_reborn_extensions/src/loaded.rs
+++ b/crates/ironclaw_reborn_extensions/src/loaded.rs
@@ -1,0 +1,104 @@
+use std::sync::Arc;
+
+use ironclaw_filesystem::RootFilesystem;
+use ironclaw_loop_support::HostSkillContextSource;
+
+use crate::skills::FirstPartySkillsExtension;
+
+/// Loaded first-party extension ports exposed to Reborn composition.
+///
+/// This is not an extension registry. Extension identity, manifests,
+/// installation state, and activation lifecycle belong to `ironclaw_extensions`.
+/// This type is only the already-composed in-process port set that Reborn
+/// runtime assembly is allowed to consume.
+#[derive(Debug, Clone)]
+pub struct LoadedRebornFirstPartyExtensions<F>
+where
+    F: RootFilesystem + 'static,
+{
+    skills: Option<FirstPartySkillsExtension<F>>,
+}
+
+impl<F> Default for LoadedRebornFirstPartyExtensions<F>
+where
+    F: RootFilesystem + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<F> LoadedRebornFirstPartyExtensions<F>
+where
+    F: RootFilesystem + 'static,
+{
+    pub fn new() -> Self {
+        Self { skills: None }
+    }
+
+    pub fn with_skills(mut self, extension: FirstPartySkillsExtension<F>) -> Self {
+        self.skills = Some(extension);
+        self
+    }
+
+    pub fn skills(&self) -> Option<&FirstPartySkillsExtension<F>> {
+        self.skills.as_ref()
+    }
+
+    pub fn skill_context_source(&self) -> Option<Arc<dyn HostSkillContextSource>> {
+        self.skills
+            .as_ref()
+            .map(FirstPartySkillsExtension::host_skill_context_source)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FirstPartySkillsExtensionHandles, skills::FirstPartySkillsExtension};
+    use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+    use ironclaw_host_api::{
+        MountAlias, MountGrant, MountPermissions, MountView, ScopedPath, VirtualPath,
+    };
+
+    fn filesystem() -> Arc<ScopedFilesystem<InMemoryBackend>> {
+        let view = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/skills").unwrap(),
+            VirtualPath::new("/tenants/tenant-a/users/user-a/skills").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap();
+        Arc::new(ScopedFilesystem::with_fixed_view(
+            Arc::new(InMemoryBackend::default()),
+            view,
+        ))
+    }
+
+    fn skills_extension() -> FirstPartySkillsExtension<InMemoryBackend> {
+        FirstPartySkillsExtension::new(
+            filesystem(),
+            FirstPartySkillsExtensionHandles::new(
+                None,
+                Some(ScopedPath::new("/skills").unwrap()),
+                None,
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn loaded_ports_start_without_extensions() {
+        let loaded = LoadedRebornFirstPartyExtensions::<InMemoryBackend>::new();
+
+        assert!(loaded.skills().is_none());
+        assert!(loaded.skill_context_source().is_none());
+    }
+
+    #[test]
+    fn loaded_ports_expose_skills_ports() {
+        let loaded = LoadedRebornFirstPartyExtensions::new().with_skills(skills_extension());
+
+        assert!(loaded.skills().is_some());
+        assert!(loaded.skill_context_source().is_some());
+    }
+}

--- a/docs/reborn/contracts/extensions.md
+++ b/docs/reborn/contracts/extensions.md
@@ -9,6 +9,11 @@
 ## 1. Purpose
 
 `ironclaw_extensions` owns extension package metadata, manifest validation, filesystem discovery, and capability declaration registration.
+It also owns generic extension installation state: manifests, installations,
+activation state, health snapshots, and opaque credential bindings. Domain
+crates such as `ironclaw_product_adapter_registry` project their own host API
+sections from that generic state rather than owning a second installation
+store.
 
 It answers:
 


### PR DESCRIPTION
## Summary

- Move generic extension installation state into `ironclaw_extensions`:
  - `ExtensionManifestRecord`
  - `ExtensionInstallationStore`
  - `ExtensionInstallation`
  - activation state, health snapshots, manifest hashes, credential bindings, in-memory store
- Shrink `ironclaw_product_adapter_registry` back to ProductAdapter-specific responsibility:
  - ProductAdapter host-api contract validation
  - ProductAdapter section projection from generic extension manifest records
  - enabled ProductAdapter runtime entry projection from the generic extension installation store
- Remove the extra Reborn first-party extension registry abstraction from this branch.
- Replace it with `LoadedRebornFirstPartyExtensions`, an already-composed in-process port set for runtime assembly.
- Keep Reborn local-dev skills wiring going through the loaded first-party port set, not through another registry.

## Design decisions

- `ironclaw_extensions` is the canonical home for extension package/install/activation/health state.
- Domain crates should project host-api-specific runtime views from generic extension state; they should not own separate installation stores.
- `ironclaw_product_adapter_registry` remains ProductAdapter projection only.
- Runtime handler maps and loaded in-process service handles are not extension registries. They are handler registries or loaded port sets.
- Skills continue to live as first-party loaded ports in `ironclaw_reborn_extensions`; no script execution is added in this slice.

## Stack

- Base: `codex/reborn-skills-extension-crate` (#3854)
- Builds on #3848, #3850, #3854
- Tracks #3473

## Verification

- `cargo test -p ironclaw_extensions`
- `cargo test -p ironclaw_product_adapter_registry`
- `cargo test -p ironclaw_reborn_extensions`
- `cargo test -p ironclaw_reborn_composition local_dev_runtime`
- `cargo test -p ironclaw_architecture reborn_`
- `cargo clippy -p ironclaw_extensions -p ironclaw_product_adapter_registry -p ironclaw_reborn_extensions -p ironclaw_reborn_composition --all-targets -- -D warnings`
- `cargo fmt --check -p ironclaw_extensions -p ironclaw_product_adapter_registry -p ironclaw_reborn_extensions -p ironclaw_reborn_composition`
- `git diff --check`