### PR TITLE
test(reborn): cover projection subscription isolation

### DIFF
--- a/tests/support/reborn/test_adapter.rs
+++ b/tests/support/reborn/test_adapter.rs
@@ -5,8 +5,9 @@ use ironclaw_product_adapters::{
     ExternalConversationRef, ExternalEventId, OutboundDeliverySink, ParsedProductInbound,
     ProductAdapter, ProductAdapterCapabilities, ProductAdapterError, ProductAdapterHealth,
     ProductAdapterId, ProductInboundEnvelope, ProductInboundPayload, ProductOutboundEnvelope,
-    ProductRenderOutcome, ProductSurfaceKind, ProductTriggerReason, ProtocolAuthEvidence,
-    ProtocolAuthFailure, ProtocolHttpEgress, TrustedInboundContext, UserMessagePayload,
+    ProductRenderOutcome, ProductSurfaceKind, ProductTriggerReason, ProjectionCursor,
+    ProjectionSubscriptionPayload, ProtocolAuthEvidence, ProtocolAuthFailure, ProtocolHttpEgress,
+    TrustedInboundContext, UserMessagePayload,
 };
 use serde::{Deserialize, Serialize};
 
@@ -54,11 +55,36 @@ impl RebornTestProductAdapter {
         trigger: ProductTriggerReason,
     ) -> Result<Vec<u8>, ProductAdapterError> {
         serde_json::to_vec(&RebornTestInboundPayload {
+            kind: RebornTestInboundKind::UserMessage,
             event_id,
             user_id,
             thread_id,
-            text,
-            trigger,
+            text: Some(text),
+            trigger: Some(trigger),
+            thread_id_hint: None,
+            after_cursor: None,
+        })
+        .map_err(|error| ProductAdapterError::MalformedInboundPayload {
+            reason: ironclaw_product_adapters::RedactedString::new(error.to_string()),
+        })
+    }
+
+    pub fn subscription_payload(
+        event_id: &str,
+        user_id: &str,
+        thread_id: &str,
+        thread_id_hint: Option<&str>,
+        after_cursor: Option<ProjectionCursor>,
+    ) -> Result<Vec<u8>, ProductAdapterError> {
+        serde_json::to_vec(&RebornTestInboundPayload {
+            kind: RebornTestInboundKind::SubscriptionRequest,
+            event_id,
+            user_id,
+            thread_id,
+            text: None,
+            trigger: None,
+            thread_id_hint,
+            after_cursor,
         })
         .map_err(|error| ProductAdapterError::MalformedInboundPayload {
             reason: ironclaw_product_adapters::RedactedString::new(error.to_string()),
@@ -121,6 +147,33 @@ impl ProductAdapter for RebornTestProductAdapter {
                 },
             ));
         }
+        let inbound_payload = match payload.kind {
+            RebornTestInboundKind::UserMessage => {
+                ProductInboundPayload::UserMessage(UserMessagePayload::new(
+                    payload
+                        .text
+                        .ok_or_else(|| ProductAdapterError::MalformedInboundPayload {
+                            reason: ironclaw_product_adapters::RedactedString::new(
+                                "user message payload missing text",
+                            ),
+                        })?,
+                    Vec::new(),
+                    payload.trigger.ok_or_else(|| {
+                        ProductAdapterError::MalformedInboundPayload {
+                            reason: ironclaw_product_adapters::RedactedString::new(
+                                "user message payload missing trigger",
+                            ),
+                        }
+                    })?,
+                )?)
+            }
+            RebornTestInboundKind::SubscriptionRequest => {
+                ProductInboundPayload::SubscriptionRequest(ProjectionSubscriptionPayload::new(
+                    payload.thread_id_hint,
+                    payload.after_cursor,
+                )?)
+            }
+        };
         ParsedProductInbound::new(
             ExternalEventId::new(payload.event_id)?,
             ExternalActorRef::new(
@@ -129,11 +182,7 @@ impl ProductAdapter for RebornTestProductAdapter {
                 Some(payload.user_id),
             )?,
             ExternalConversationRef::new(None, payload.thread_id, None, None)?,
-            ProductInboundPayload::UserMessage(UserMessagePayload::new(
-                payload.text,
-                Vec::new(),
-                payload.trigger,
-            )?),
+            inbound_payload,
         )
     }
 
@@ -210,6 +259,32 @@ impl RebornTestIngress {
         ProductInboundEnvelope::from_trusted_parse(context, parsed)
     }
 
+    pub fn verified_subscription_envelope(
+        &self,
+        event_id: &str,
+        user_id: &str,
+        thread_id: &str,
+        thread_id_hint: Option<&str>,
+        after_cursor: Option<ProjectionCursor>,
+    ) -> Result<ProductInboundEnvelope, ProductAdapterError> {
+        let evidence = ProtocolAuthEvidence::test_verified(AuthRequirement::BearerToken, user_id);
+        let raw = RebornTestProductAdapter::subscription_payload(
+            event_id,
+            user_id,
+            thread_id,
+            thread_id_hint,
+            after_cursor,
+        )?;
+        let parsed = self.adapter.parse_inbound(&raw, &evidence)?;
+        let context = TrustedInboundContext::from_verified_evidence(
+            self.adapter.adapter_id().clone(),
+            self.adapter.installation_id().clone(),
+            Utc::now(),
+            &evidence,
+        )?;
+        ProductInboundEnvelope::from_trusted_parse(context, parsed)
+    }
+
     pub fn failed_auth_payload(
         &self,
         raw_payload: &[u8],
@@ -219,20 +294,42 @@ impl RebornTestIngress {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RebornTestInboundKind {
+    UserMessage,
+    SubscriptionRequest,
+}
+
+fn default_inbound_kind() -> RebornTestInboundKind {
+    RebornTestInboundKind::UserMessage
+}
+
 #[derive(Debug, Serialize)]
 struct RebornTestInboundPayload<'a> {
+    kind: RebornTestInboundKind,
     event_id: &'a str,
     user_id: &'a str,
     thread_id: &'a str,
-    text: &'a str,
-    trigger: ProductTriggerReason,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trigger: Option<ProductTriggerReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread_id_hint: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    after_cursor: Option<ProjectionCursor>,
 }
 
 #[derive(Debug, Deserialize)]
 struct OwnedRebornTestInboundPayload {
+    #[serde(default = "default_inbound_kind")]
+    kind: RebornTestInboundKind,
     event_id: String,
     user_id: String,
     thread_id: String,
-    text: String,
-    trigger: ProductTriggerReason,
+    text: Option<String>,
+    trigger: Option<ProductTriggerReason>,
+    thread_id_hint: Option<String>,
+    after_cursor: Option<ProjectionCursor>,
 }

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -378,10 +378,11 @@ mod reborn_support_tests {
         PolicyNetworkHttpEgress,
     };
     use ironclaw_product_adapters::{
-        AuthRequirement, DeliveryStatus, ExternalConversationRef, FakeProtocolHttpEgress,
-        FinalReplyView, OutboundDeliverySink, ProductAdapter, ProductAdapterError,
-        ProductInboundAck, ProductOutboundEnvelope, ProductOutboundPayload, ProductOutboundTarget,
-        ProductRenderOutcome, ProductWorkflow, ProjectionCursor, ProtocolAuthEvidence,
+        AuthRequirement, DeliveryStatus, ExternalConversationRef, FakeProjectionStream,
+        FakeProtocolHttpEgress, FinalReplyView, OutboundDeliverySink, ProductAdapter,
+        ProductAdapterError, ProductInboundAck, ProductOutboundEnvelope, ProductOutboundPayload,
+        ProductOutboundTarget, ProductProjectionItem, ProductProjectionState, ProductRenderOutcome,
+        ProductWorkflow, ProjectionCursor, ProjectionStream, ProtocolAuthEvidence,
     };
     use ironclaw_product_workflow::{
         ActionDispatchKind, ActionFingerprintKey, ConversationBindingService,
@@ -1740,6 +1741,210 @@ mod reborn_support_tests {
     }
 
     #[test]
+    fn test_adapter_rejects_subscription_actor_spoofing_against_verified_subject() {
+        let adapter = RebornTestProductAdapter::new("reborn-test", "install-1").expect("adapter");
+        let evidence = ProtocolAuthEvidence::test_verified(AuthRequirement::BearerToken, "alice");
+        let raw = RebornTestProductAdapter::subscription_payload(
+            "event-sub-1",
+            "bob",
+            "thread-1",
+            None,
+            None,
+        )
+        .expect("subscription payload");
+        let error = adapter
+            .parse_inbound(&raw, &evidence)
+            .expect_err("subscription actor mismatch should reject");
+        assert!(matches!(error, ProductAdapterError::Authentication(_)));
+    }
+
+    #[tokio::test]
+    async fn projection_subscription_resolution_and_stream_are_scope_isolated() {
+        let scope_a = resource_scope(
+            TenantId::new("tenant-projection-a").unwrap(),
+            UserId::new("host-user").unwrap(),
+            AgentId::new("agent-projection").unwrap(),
+            Some(ProjectId::new("project-projection").unwrap()),
+        );
+        let scope_b = resource_scope(
+            TenantId::new("tenant-projection-b").unwrap(),
+            UserId::new("host-user").unwrap(),
+            AgentId::new("agent-projection").unwrap(),
+            Some(ProjectId::new("project-projection").unwrap()),
+        );
+        let product_a = RebornProductWorkflowHarness::filesystem_temp(scope_a)
+            .expect("tenant A product harness");
+        let product_b = product_a
+            .with_scope(scope_b)
+            .expect("tenant B product harness");
+        let ingress = RebornTestIngress::new(
+            RebornTestProductAdapter::new("reborn-test", "install-1").expect("adapter"),
+        );
+
+        let binding_a = product_a
+            .binding_service()
+            .expect("tenant A binding service")
+            .resolve_binding(binding_request(
+                "event-projection-a",
+                "alice",
+                "room-projection",
+            ))
+            .await
+            .expect("tenant A binding");
+        let binding_b = product_b
+            .binding_service()
+            .expect("tenant B binding service")
+            .resolve_binding(binding_request(
+                "event-projection-b",
+                "alice",
+                "room-projection",
+            ))
+            .await
+            .expect("tenant B binding");
+        assert_ne!(binding_a.tenant_id, binding_b.tenant_id);
+        assert_ne!(binding_a.thread_id, binding_b.thread_id);
+
+        let workflow_a = projection_workflow(&product_a, "projection-a");
+        let workflow_b = projection_workflow(&product_b, "projection-b");
+        let envelope_a = ingress
+            .verified_subscription_envelope(
+                "event-sub-a",
+                "alice",
+                "room-projection",
+                Some(binding_a.thread_id.as_str()),
+                Some(ProjectionCursor::new("cursor:tenant-a:0").expect("cursor")),
+            )
+            .expect("tenant A subscription envelope");
+        let envelope_b = ingress
+            .verified_subscription_envelope(
+                "event-sub-b",
+                "alice",
+                "room-projection",
+                Some(binding_b.thread_id.as_str()),
+                Some(ProjectionCursor::new("cursor:tenant-b:0").expect("cursor")),
+            )
+            .expect("tenant B subscription envelope");
+
+        let subscription_a = workflow_a
+            .resolve_projection_subscription(envelope_a)
+            .await
+            .expect("tenant A subscription");
+        let subscription_b = workflow_b
+            .resolve_projection_subscription(envelope_b)
+            .await
+            .expect("tenant B subscription");
+        assert_eq!(subscription_a.scope.tenant_id, binding_a.tenant_id);
+        assert_eq!(subscription_b.scope.tenant_id, binding_b.tenant_id);
+        assert_eq!(subscription_a.scope.thread_id, binding_a.thread_id);
+        assert_eq!(subscription_b.scope.thread_id, binding_b.thread_id);
+        assert_ne!(subscription_a.scope, subscription_b.scope);
+        assert_ne!(subscription_a.actor.user_id, subscription_b.actor.user_id);
+
+        let stream = FakeProjectionStream::new();
+        let target_a = ReplyTargetBindingRef::new("reply:projection-a").unwrap();
+        let target_b = ReplyTargetBindingRef::new("reply:projection-b").unwrap();
+        stream.push_for_request(
+            subscription_a.clone(),
+            projection_update_envelope(
+                &ingress,
+                target_a,
+                binding_a.thread_id.as_str(),
+                "tenant A event",
+            ),
+        );
+        stream.push_for_request(
+            subscription_b.clone(),
+            projection_update_envelope(
+                &ingress,
+                target_b,
+                binding_b.thread_id.as_str(),
+                "tenant B event",
+            ),
+        );
+
+        let drained_a = stream
+            .drain(subscription_a.clone())
+            .await
+            .expect("drain tenant A");
+        assert_eq!(drained_a.len(), 1);
+        assert_projection_contains_only(&drained_a, "tenant A event", "tenant B event");
+
+        let empty_a_replay = stream
+            .drain(subscription_a)
+            .await
+            .expect("tenant A replay after drain");
+        assert!(empty_a_replay.is_empty());
+
+        let drained_b = stream.drain(subscription_b).await.expect("drain tenant B");
+        assert_eq!(drained_b.len(), 1);
+        assert_projection_contains_only(&drained_b, "tenant B event", "tenant A event");
+    }
+
+    #[tokio::test]
+    async fn projection_subscription_rejects_cross_thread_hint() {
+        let scope_a = resource_scope(
+            TenantId::new("tenant-projection-hint-a").unwrap(),
+            UserId::new("host-user").unwrap(),
+            AgentId::new("agent-projection").unwrap(),
+            Some(ProjectId::new("project-projection").unwrap()),
+        );
+        let scope_b = resource_scope(
+            TenantId::new("tenant-projection-hint-b").unwrap(),
+            UserId::new("host-user").unwrap(),
+            AgentId::new("agent-projection").unwrap(),
+            Some(ProjectId::new("project-projection").unwrap()),
+        );
+        let product_a = RebornProductWorkflowHarness::filesystem_temp(scope_a)
+            .expect("tenant A product harness");
+        let product_b = product_a
+            .with_scope(scope_b)
+            .expect("tenant B product harness");
+        let binding_a = product_a
+            .binding_service()
+            .expect("tenant A binding service")
+            .resolve_binding(binding_request(
+                "event-projection-hint-a",
+                "alice",
+                "room-projection-hint",
+            ))
+            .await
+            .expect("tenant A binding");
+        let binding_b = product_b
+            .binding_service()
+            .expect("tenant B binding service")
+            .resolve_binding(binding_request(
+                "event-projection-hint-b",
+                "alice",
+                "room-projection-hint",
+            ))
+            .await
+            .expect("tenant B binding");
+        let workflow_a = projection_workflow(&product_a, "projection-hint-a");
+        let ingress = RebornTestIngress::new(
+            RebornTestProductAdapter::new("reborn-test", "install-1").expect("adapter"),
+        );
+        let cross_hint = ingress
+            .verified_subscription_envelope(
+                "event-sub-cross-hint",
+                "alice",
+                "room-projection-hint",
+                Some(binding_b.thread_id.as_str()),
+                None,
+            )
+            .expect("cross hint envelope");
+
+        let error = workflow_a
+            .resolve_projection_subscription(cross_hint)
+            .await
+            .expect_err("tenant A subscription must reject tenant B thread hint");
+        assert!(matches!(
+            error,
+            ProductAdapterError::WorkflowRejected { .. }
+        ));
+        assert_ne!(binding_a.thread_id, binding_b.thread_id);
+    }
+
+    #[test]
     fn test_adapter_rejects_malformed_inbound_payload() {
         let adapter = RebornTestProductAdapter::new("reborn-test", "install-1").expect("adapter");
         let evidence = ProtocolAuthEvidence::test_verified(AuthRequirement::BearerToken, "alice");
@@ -2034,6 +2239,68 @@ mod reborn_support_tests {
             AgentId::new("agent-product").unwrap(),
             Some(ProjectId::new("project-product").unwrap()),
         )
+    }
+
+    fn projection_workflow(
+        product_harness: &RebornProductWorkflowHarness,
+        thread_label: &str,
+    ) -> DefaultProductWorkflow {
+        let binding_service: Arc<dyn ConversationBindingService> =
+            Arc::new(product_harness.binding_service().expect("binding service"));
+        let thread_harness = RebornThreadHarness::filesystem_temp(thread_scope(thread_label))
+            .expect("thread harness");
+        let inbound: Arc<dyn InboundTurnService> = Arc::new(DefaultInboundTurnService::new(
+            Arc::clone(&binding_service),
+            thread_harness.service_instance().expect("thread service"),
+            DryRunCapturingTurnCoordinator::default(),
+        ));
+        let ledger: Arc<dyn IdempotencyLedger> = Arc::new(product_harness.idempotency_ledger());
+        DefaultProductWorkflow::new(inbound, ledger, binding_service)
+    }
+
+    fn projection_update_envelope(
+        ingress: &RebornTestIngress,
+        target_ref: ReplyTargetBindingRef,
+        thread_id: &str,
+        body: &str,
+    ) -> ProductOutboundEnvelope {
+        ProductOutboundEnvelope::new(
+            ingress.adapter().adapter_id().clone(),
+            ingress.adapter().installation_id().clone(),
+            ProductOutboundTarget::new(
+                target_ref,
+                ExternalConversationRef::new(None, "room-projection", None, None)
+                    .expect("conversation ref"),
+                None,
+            ),
+            ProjectionCursor::new(format!("cursor:{thread_id}:{body}")).expect("cursor"),
+            ProductOutboundPayload::ProjectionUpdate {
+                state: ProductProjectionState::new(
+                    thread_id,
+                    vec![ProductProjectionItem::Text {
+                        id: format!("item:{thread_id}"),
+                        body: body.to_string(),
+                    }],
+                )
+                .expect("projection state"),
+            },
+        )
+    }
+
+    fn assert_projection_contains_only(
+        envelopes: &[ProductOutboundEnvelope],
+        expected: &str,
+        forbidden: &str,
+    ) {
+        let rendered = serde_json::to_string(envelopes).expect("serialize projection envelopes");
+        assert!(
+            rendered.contains(expected),
+            "projection stream should include expected event {expected:?}: {rendered}"
+        );
+        assert!(
+            !rendered.contains(forbidden),
+            "projection stream must not leak forbidden event {forbidden:?}: {rendered}"
+        );
     }
 
     fn test_envelope(


### PR DESCRIPTION
## Summary
- add subscription-request payload support to the Reborn test adapter
- reject subscription actor spoofing against verified auth subject
- add projection subscription scope isolation coverage across tenants
- assert projection stream drains only events matching the resolved subscription request
- assert cross-tenant `thread_id_hint` is rejected

## Coverage
- tenant A and tenant B resolve same external subscription shape to distinct canonical actors/scopes/threads
- tenant A projection drain returns only tenant A event
- tenant A replay after drain does not drain tenant B event
- tenant B projection drain returns only tenant B event
- subscription auth boundary matches user-message actor-spoofing behavior

## Boundary notes
- covers projection subscription resolution and stream filtering via test support stream
- does not claim HTTP SSE transport coverage; no gateway/SSE endpoint exercised here
- keeps backing storage shared where tenant isolation matters

## Validation
- `cargo test -q --features libsql --test support_unit_tests projection -- --nocapture`
- `cargo test -q --features libsql --test support_unit_tests subscription -- --nocapture`
- `cargo test -q --features libsql --test support_unit_tests test_adapter -- --nocapture`
- `cargo test -q --features libsql --test support_unit_tests -- --nocapture`
- `cargo test -q -p ironclaw_product_workflow`
- `cargo test -q -p ironclaw_outbound`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: validation still emits existing `ironclaw_llm` unused import warnings.
