### PR TITLE
[Draft] Subagent spawn phase 0 prerequisite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4267,6 +4267,7 @@ dependencies = [
  "ironclaw_host_api",
  "ironclaw_memory",
  "ironclaw_reborn_event_store",
+ "ironclaw_turns",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -1695,6 +1695,12 @@ fn boundary_rules() -> Vec<BoundaryRule> {
             ],
         },
         BoundaryRule {
+            // Product-facing projection reducers consume typed domain events.
+            // `ironclaw_turns` is intentionally allowed here for
+            // `TurnLifecycleEvent`-derived read models such as pending gates;
+            // projection crates must still stay below product/runtime
+            // composition and must not import root `src/` or legacy engine
+            // pending-gate types.
             crate_name: "ironclaw_event_projections",
             forbidden: vec![
                 "ironclaw",

--- a/crates/ironclaw_event_projections/CLAUDE.md
+++ b/crates/ironclaw_event_projections/CLAUDE.md
@@ -10,4 +10,14 @@ This crate is above `ironclaw_events` and below product adapters. Keep it:
 - non-mutating: projection failures must not mutate durable logs or kernel state;
 - backend-independent: do not depend on JSONL/PostgreSQL/libSQL adapter crates directly.
 
-Current first slice is replay-derived `ThreadTimeline` and `RunStatusProjection` over `DurableEventLog`. Approval/auth/resource/memory/mission projections should be added only when their source facts are stable and typed.
+Current slices:
+
+- replay-derived `ThreadTimeline` and `RunStatusProjection` over `DurableEventLog`;
+- `PendingGateProjection`, a Reborn turn-event read model over typed blocked/resume/terminal `TurnLifecycleEvent` facts.
+
+The pending-gate projection may carry stable metadata needed to key the product read model: tenant, owner, thread, run, gate kind, opaque gate ref for the resolver, and blocked timestamp. Do not add approval reasons, raw prompts, tool input, backend errors, or host paths to the projection row.
+
+Legacy root `src/gate/PendingGateStore` writers still exist for the pre-Reborn engine path. Treat them as legacy engine owners until a composition adapter maps `PendingGateProjectionSink` rows into that store; do not add new direct Reborn pending-gate writers outside the projection consumer.
+
+See `PENDING_GATE_PROJECTION.md` for the current writer audit and follow-up
+composition boundary.

--- a/crates/ironclaw_event_projections/Cargo.toml
+++ b/crates/ironclaw_event_projections/Cargo.toml
@@ -10,6 +10,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ironclaw_events = { path = "../ironclaw_events" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_memory = { path = "../ironclaw_memory" }
+ironclaw_turns = { path = "../ironclaw_turns" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 

--- a/crates/ironclaw_event_projections/PENDING_GATE_PROJECTION.md
+++ b/crates/ironclaw_event_projections/PENDING_GATE_PROJECTION.md
@@ -1,0 +1,20 @@
+# Pending Gate Projection
+
+`PendingGateProjection` materializes a Reborn pending-gate read model from
+`TurnLifecycleEvent`. It is the only Reborn path that should write derived
+pending-gate rows.
+
+The legacy root `src/gate/PendingGateStore` remains engine-owned until product
+composition adapts `PendingGateProjectionSink` into that store. Existing legacy
+writer audit:
+
+- `src/bridge/gate_controller.rs` inserts pending gates for the legacy inline
+  engine pause path.
+- `src/bridge/router.rs` requeues and removes pending gates through legacy web
+  bridge routes, including `/api/chat/gate/resolve`.
+- `src/gate/store.rs` owns the legacy `insert`, verified-resolution removal,
+  thread cleanup, and key discard helpers.
+
+Follow-up composition work must either adapt this projection into the root UI
+store or retire those legacy writers for Reborn-backed turns. Do not add a new
+direct writer for Reborn blocked turns.

--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -8,8 +8,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-mod pending_gate_projection;
-
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_events::{
@@ -29,9 +27,11 @@ use ironclaw_memory::{
     PromptWriteOperation, PromptWriteSafetyEvent, PromptWriteSafetyEventKind,
     PromptWriteSafetyEventSink,
 };
+use ironclaw_turns::EventCursor as TurnEventCursor;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+mod pending_gate_projection;
 mod runtime_projection;
 use runtime_projection::{
     RuntimeProjectionState, sort_capability_activities_for_projection, sort_runs_for_projection,
@@ -310,10 +310,43 @@ pub enum CapabilityActivityStatus {
     Killed,
 }
 
+/// Replay-tolerable projection metadata field absent from a legacy
+/// `TurnLifecycleEvent`.
+///
+/// Variants are matched structurally by replay-tolerance logic; do not add a
+/// `String` payload — match-on-string-literals is what this enum exists to
+/// replace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissingMetadataField {
+    /// `TurnLifecycleEvent.blocked_gate` was absent on a `Blocked` event.
+    BlockedGate,
+    /// `TurnLifecycleEvent.occurred_at` was absent on an event whose
+    /// projection row records the blocked timestamp.
+    OccurredAt,
+    /// `TurnLifecycleEvent.owner_user_id` was absent on an event whose
+    /// projection key requires the owner identity.
+    OwnerUserId,
+}
+
+impl MissingMetadataField {
+    pub fn as_static_str(self) -> &'static str {
+        match self {
+            Self::BlockedGate => "blocked turn event missing gate metadata",
+            Self::OccurredAt => "blocked turn event missing timestamp",
+            Self::OwnerUserId => "turn event missing owner metadata",
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ProjectionError {
     #[error("projection request rejected: {reason}")]
     InvalidRequest { reason: &'static str },
+    /// A `TurnLifecycleEvent` arrived without metadata the projection requires
+    /// to materialize or key its row. Replay tolerates this for legacy events
+    /// retained from before the metadata existed; live delivery surfaces it.
+    #[error("projection metadata missing: {}", .field.as_static_str())]
+    MissingProjectionMetadata { field: MissingMetadataField },
     #[error(
         "projection rebase required: requested runtime cursor {requested:?} cannot replay from earliest retained runtime cursor {earliest:?}"
     )]
@@ -329,8 +362,8 @@ pub enum ProjectionError {
         "turn event projection rebase required: requested turn cursor {requested:?} cannot replay from earliest retained turn cursor {earliest:?}"
     )]
     TurnEventRebaseRequired {
-        requested: ironclaw_turns::EventCursor,
-        earliest: ironclaw_turns::EventCursor,
+        requested: TurnEventCursor,
+        earliest: TurnEventCursor,
     },
     #[error("projection source failed during {operation}")]
     Source { operation: &'static str },

--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -38,8 +38,8 @@ use runtime_projection::{
 };
 
 pub use pending_gate_projection::{
-    PENDING_GATE_PROJECTION_CONSUMER_ID, PendingGateProjection, PendingGateProjectionCursorStore,
-    PendingGateProjectionGateKind, PendingGateProjectionKey, PendingGateProjectionReplay,
+    PENDING_GATE_PROJECTION_CONSUMER_ID, PendingGateKind, PendingGateProjection,
+    PendingGateProjectionCursorStore, PendingGateProjectionKey, PendingGateProjectionReplay,
     PendingGateProjectionRow, PendingGateProjectionSink,
 };
 
@@ -324,6 +324,13 @@ pub enum ProjectionError {
         // happy path. Construction sites use `Box::new(..)`.
         requested: Box<ProjectionCursor>,
         earliest: Box<ProjectionCursor>,
+    },
+    #[error(
+        "turn event projection rebase required: requested turn cursor {requested:?} cannot replay from earliest retained turn cursor {earliest:?}"
+    )]
+    TurnEventRebaseRequired {
+        requested: ironclaw_turns::EventCursor,
+        earliest: ironclaw_turns::EventCursor,
     },
     #[error("projection source failed during {operation}")]
     Source { operation: &'static str },

--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -8,6 +8,8 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+mod pending_gate_projection;
+
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_events::{
@@ -33,6 +35,12 @@ use thiserror::Error;
 mod runtime_projection;
 use runtime_projection::{
     RuntimeProjectionState, sort_capability_activities_for_projection, sort_runs_for_projection,
+};
+
+pub use pending_gate_projection::{
+    PENDING_GATE_PROJECTION_CONSUMER_ID, PendingGateProjection, PendingGateProjectionCursorStore,
+    PendingGateProjectionGateKind, PendingGateProjectionKey, PendingGateProjectionReplay,
+    PendingGateProjectionRow, PendingGateProjectionSink,
 };
 
 const STATE_REPLAY_PAGE_LIMIT: usize = 256;

--- a/crates/ironclaw_event_projections/src/pending_gate_projection.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection.rs
@@ -9,7 +9,7 @@ use ironclaw_turns::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::ProjectionError;
+use crate::{MissingMetadataField, ProjectionError};
 
 /// Stable consumer id used to persist pending-gate replay progress.
 ///
@@ -75,8 +75,12 @@ pub struct PendingGateProjectionRow {
 /// Storage boundary for projected pending gate rows.
 ///
 /// Implementations must apply the cursor ordering guard described on each
-/// method and should enforce bounded per-scope retention through row limits,
-/// TTL eviction, or an equivalent storage policy.
+/// method and must enforce bounded per-scope retention through row limits,
+/// TTL eviction, or an equivalent storage policy — a turn flood that blocks
+/// repeatedly on auth/approval gates can otherwise grow the read model
+/// without bound. The projection layer is stateless and intentionally does
+/// not duplicate this guard; the sink owns persistent state, so retention
+/// belongs with whoever durably stores the row.
 #[async_trait]
 pub trait PendingGateProjectionSink: Send + Sync {
     /// Upsert a pending-gate row only if `row.source_cursor` is not older than
@@ -218,11 +222,7 @@ impl PendingGateProjection {
         })
     }
 
-    async fn project_event(
-        &self,
-        event: TurnLifecycleEvent,
-        advance_cursor: bool,
-    ) -> Result<(), ProjectionError> {
+    async fn project_event(&self, event: TurnLifecycleEvent) -> Result<(), ProjectionError> {
         match event.kind {
             TurnEventKind::Blocked => {
                 let Some(gate_kind) = TurnBlockedGateKind::from_status(event.status) else {
@@ -243,32 +243,46 @@ impl PendingGateProjection {
             }
             _ => {}
         }
-
-        if advance_cursor {
-            self.cursor_store
-                .advance_pending_gate_cursor(self.consumer_id, &event.scope, event.cursor)
-                .await?;
-        }
         Ok(())
     }
 
     async fn project_replay_event(&self, event: TurnLifecycleEvent) -> Result<(), ProjectionError> {
-        match self.project_event(event.clone(), false).await {
+        // Keep only the kind (cheap to clone) for the error-tolerance check
+        // so the happy path does not clone the full event.
+        let kind = event.kind.clone();
+        match self.project_event(event).await {
             Ok(()) => Ok(()),
-            Err(ProjectionError::InvalidRequest { reason })
-                if is_replayable_legacy_metadata_gap(&event, reason) =>
-            {
+            Err(ProjectionError::MissingProjectionMetadata { .. }) if is_replayable_kind(&kind) => {
                 Ok(())
             }
             Err(error) => Err(error),
         }
+    }
+
+    /// Project an event and advance the durable replay cursor in one step.
+    ///
+    /// Test-only: production replay owns cursor progress in
+    /// [`Self::replay_scope`] (batch advance per page) and live delivery does
+    /// not advance the durable cursor. Exposing the combined step on the
+    /// public surface would let a future caller double-advance the cursor.
+    #[cfg(test)]
+    pub(crate) async fn project_event_and_advance_cursor(
+        &self,
+        event: TurnLifecycleEvent,
+    ) -> Result<(), ProjectionError> {
+        let cursor = event.cursor;
+        let scope = event.scope.clone();
+        self.project_event(event).await?;
+        self.cursor_store
+            .advance_pending_gate_cursor(self.consumer_id, &scope, cursor)
+            .await
     }
 }
 
 #[async_trait]
 impl TurnEventSink for PendingGateProjection {
     async fn publish(&self, event: TurnLifecycleEvent) -> Result<(), ironclaw_turns::TurnError> {
-        self.project_event(event, false)
+        self.project_event(event)
             .await
             .map_err(|error| match error {
                 ProjectionError::InvalidRequest { reason } => {
@@ -276,8 +290,27 @@ impl TurnEventSink for PendingGateProjection {
                         reason: format!("pending gate projection failed: {reason}"),
                     }
                 }
-                other => ironclaw_turns::TurnError::Unavailable {
-                    reason: format!("pending gate projection failed: {other}"),
+                ProjectionError::MissingProjectionMetadata { field } => {
+                    ironclaw_turns::TurnError::InvalidRequest {
+                        reason: format!(
+                            "pending gate projection failed: {}",
+                            field.as_static_str()
+                        ),
+                    }
+                }
+                // Avoid leaking the inner cursor values into the error reason
+                // string crossing the turn-runtime boundary.
+                ProjectionError::TurnEventRebaseRequired { .. } => {
+                    ironclaw_turns::TurnError::Unavailable {
+                        reason: "pending gate projection failed: turn event rebase required"
+                            .to_string(),
+                    }
+                }
+                ProjectionError::RebaseRequired { .. } => ironclaw_turns::TurnError::Unavailable {
+                    reason: "pending gate projection failed: runtime rebase required".to_string(),
+                },
+                ProjectionError::Source { operation } => ironclaw_turns::TurnError::Unavailable {
+                    reason: format!("pending gate projection failed: source {operation}"),
                 },
             })
     }
@@ -287,15 +320,18 @@ fn row_from_blocked_event(
     event: &TurnLifecycleEvent,
     gate_kind: TurnBlockedGateKind,
 ) -> Result<PendingGateProjectionRow, ProjectionError> {
-    let blocked_gate = event
-        .blocked_gate
-        .as_ref()
-        .ok_or(ProjectionError::InvalidRequest {
-            reason: "blocked turn event missing gate metadata",
+    let blocked_gate =
+        event
+            .blocked_gate
+            .as_ref()
+            .ok_or(ProjectionError::MissingProjectionMetadata {
+                field: MissingMetadataField::BlockedGate,
+            })?;
+    let blocked_at = event
+        .occurred_at
+        .ok_or(ProjectionError::MissingProjectionMetadata {
+            field: MissingMetadataField::OccurredAt,
         })?;
-    let blocked_at = event.occurred_at.ok_or(ProjectionError::InvalidRequest {
-        reason: "blocked turn event missing timestamp",
-    })?;
 
     Ok(PendingGateProjectionRow {
         key: key_from_lifecycle_event(event)?,
@@ -309,12 +345,13 @@ fn row_from_blocked_event(
 fn key_from_lifecycle_event(
     event: &TurnLifecycleEvent,
 ) -> Result<PendingGateProjectionKey, ProjectionError> {
-    let owner_user_id = event
-        .owner_user_id
-        .clone()
-        .ok_or(ProjectionError::InvalidRequest {
-            reason: "turn event missing owner metadata",
-        })?;
+    let owner_user_id =
+        event
+            .owner_user_id
+            .clone()
+            .ok_or(ProjectionError::MissingProjectionMetadata {
+                field: MissingMetadataField::OwnerUserId,
+            })?;
 
     Ok(PendingGateProjectionKey {
         tenant_id: event.scope.tenant_id.clone(),
@@ -326,22 +363,13 @@ fn key_from_lifecycle_event(
     })
 }
 
-fn is_replayable_legacy_metadata_gap(event: &TurnLifecycleEvent, reason: &'static str) -> bool {
-    let missing_metadata = matches!(
-        reason,
-        "blocked turn event missing gate metadata"
-            | "blocked turn event missing timestamp"
-            | "turn event missing owner metadata"
-    );
-    if !missing_metadata {
-        return false;
-    }
-
-    // Replay can encounter events retained from before pending-gate metadata
-    // existed. Those historical events could not have produced a resolvable
-    // pending-gate row, so skip them and let the replay cursor advance.
+/// `TurnLifecycleEvent` kinds that the pending-gate projection can derive a
+/// row from (or remove a row for). Other kinds are silent-skip; the
+/// replay-tolerance path uses this predicate to bound the kinds for which
+/// missing legacy metadata may be ignored.
+fn is_replayable_kind(kind: &TurnEventKind) -> bool {
     matches!(
-        event.kind,
+        kind,
         TurnEventKind::Blocked
             | TurnEventKind::Completed
             | TurnEventKind::Failed

--- a/crates/ironclaw_event_projections/src/pending_gate_projection.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection.rs
@@ -5,7 +5,7 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserI
 use ironclaw_turns::{
     EventCursor as TurnEventCursor, GateRef, MAX_TURN_EVENT_PROJECTION_LIMIT, TurnBlockedGateKind,
     TurnEventKind, TurnEventProjectionSource, TurnEventSink, TurnLifecycleEvent, TurnRunId,
-    TurnScope,
+    TurnScope, TurnStatus,
 };
 use serde::{Deserialize, Serialize};
 
@@ -225,11 +225,20 @@ impl PendingGateProjection {
     async fn project_event(&self, event: TurnLifecycleEvent) -> Result<(), ProjectionError> {
         match event.kind {
             TurnEventKind::Blocked => {
-                let Some(gate_kind) = TurnBlockedGateKind::from_status(event.status) else {
+                // Defensive status guard for malformed legacy rows where
+                // `kind == Blocked` but `status` is non-blocked. `gate_kind`
+                // itself is read straight from `event.blocked_gate.gate_kind`
+                // — no parallel derivation.
+                if !matches!(
+                    event.status,
+                    TurnStatus::BlockedApproval
+                        | TurnStatus::BlockedAuth
+                        | TurnStatus::BlockedResource
+                ) {
                     return Ok(());
-                };
+                }
                 self.sink
-                    .upsert_pending_gate(row_from_blocked_event(&event, gate_kind)?)
+                    .upsert_pending_gate(row_from_blocked_event(&event)?)
                     .await?;
             }
             TurnEventKind::Completed
@@ -318,7 +327,6 @@ impl TurnEventSink for PendingGateProjection {
 
 fn row_from_blocked_event(
     event: &TurnLifecycleEvent,
-    gate_kind: TurnBlockedGateKind,
 ) -> Result<PendingGateProjectionRow, ProjectionError> {
     let blocked_gate =
         event
@@ -336,7 +344,7 @@ fn row_from_blocked_event(
     Ok(PendingGateProjectionRow {
         key: key_from_lifecycle_event(event)?,
         source_cursor: event.cursor,
-        gate_kind: gate_kind.into(),
+        gate_kind: blocked_gate.gate_kind.into(),
         gate_ref: blocked_gate.gate_ref.clone(),
         blocked_at,
     })

--- a/crates/ironclaw_event_projections/src/pending_gate_projection.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection.rs
@@ -5,40 +5,42 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserI
 use ironclaw_turns::{
     EventCursor as TurnEventCursor, MAX_TURN_EVENT_PROJECTION_LIMIT, TurnBlockedGateKind,
     TurnEventKind, TurnEventProjectionSource, TurnEventSink, TurnLifecycleEvent, TurnRunId,
-    TurnScope, TurnStatus,
+    TurnScope,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::ProjectionError;
 
+/// Stable consumer id used to persist pending-gate replay progress.
+///
+/// Cursor stores key this value with a [`TurnScope`] so replay progress for
+/// this read model cannot collide with other turn-event consumers.
 pub const PENDING_GATE_PROJECTION_CONSUMER_ID: &str = "pending_gate_projection.v1";
 
+/// Pending gate category projected from a blocked turn lifecycle event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
-pub enum PendingGateProjectionGateKind {
+pub enum PendingGateKind {
     Approval,
     Auth,
     Resource,
 }
 
-impl TryFrom<TurnBlockedGateKind> for PendingGateProjectionGateKind {
-    type Error = ProjectionError;
-
-    fn try_from(kind: TurnBlockedGateKind) -> Result<Self, Self::Error> {
-        Ok(match kind {
+impl From<TurnBlockedGateKind> for PendingGateKind {
+    fn from(kind: TurnBlockedGateKind) -> Self {
+        match kind {
             TurnBlockedGateKind::Approval => Self::Approval,
             TurnBlockedGateKind::Auth => Self::Auth,
             TurnBlockedGateKind::Resource => Self::Resource,
-            _ => {
-                return Err(ProjectionError::InvalidRequest {
-                    reason: "unsupported turn blocked gate kind",
-                });
-            }
-        })
+        }
     }
 }
 
+/// Identity key for one projected pending gate row.
+///
+/// The key is scoped by tenant, optional agent/project, owner, thread, and run
+/// so terminal/resume events can remove only the matching blocked run.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PendingGateProjectionKey {
     pub tenant_id: TenantId,
@@ -51,6 +53,11 @@ pub struct PendingGateProjectionKey {
     pub run_id: TurnRunId,
 }
 
+/// Materialized pending gate row produced by the projection consumer.
+///
+/// Rows intentionally carry only stable resolver metadata. They must not grow
+/// to include approval reasons, raw prompts, tool input, backend details, or
+/// host paths.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingGateProjectionRow {
     pub key: PendingGateProjectionKey,
@@ -60,11 +67,16 @@ pub struct PendingGateProjectionRow {
     /// blocked event cannot resurrect a gate that live delivery already
     /// removed with a newer terminal/resume event.
     pub source_cursor: TurnEventCursor,
-    pub gate_kind: PendingGateProjectionGateKind,
+    pub gate_kind: PendingGateKind,
     pub gate_ref: String,
     pub blocked_at: Timestamp,
 }
 
+/// Storage boundary for projected pending gate rows.
+///
+/// Implementations must apply the cursor ordering guard described on each
+/// method and should enforce bounded per-scope retention through row limits,
+/// TTL eviction, or an equivalent storage policy.
 #[async_trait]
 pub trait PendingGateProjectionSink: Send + Sync {
     /// Upsert a pending-gate row only if `row.source_cursor` is not older than
@@ -83,6 +95,7 @@ pub trait PendingGateProjectionSink: Send + Sync {
     ) -> Result<(), ProjectionError>;
 }
 
+/// Durable cursor store for pending-gate replay progress.
 #[async_trait]
 pub trait PendingGateProjectionCursorStore: Send + Sync {
     /// Load the last durable replay cursor for this consumer and turn scope.
@@ -107,6 +120,7 @@ pub trait PendingGateProjectionCursorStore: Send + Sync {
     ) -> Result<(), ProjectionError>;
 }
 
+/// Summary returned after replaying one scope page into the pending-gate sink.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingGateProjectionReplay {
     pub processed: usize,
@@ -114,6 +128,11 @@ pub struct PendingGateProjectionReplay {
     pub truncated: bool,
 }
 
+/// Turn-event consumer that maintains the pending-gate read model.
+///
+/// Live [`TurnEventSink`] delivery updates rows without advancing the durable
+/// replay cursor; explicit replay owns cursor progress so a crash cannot skip
+/// turn lifecycle events that were not durably folded yet.
 #[derive(Clone)]
 pub struct PendingGateProjection {
     consumer_id: &'static str,
@@ -172,9 +191,10 @@ impl PendingGateProjection {
                 operation: "read_turn_events_after",
             })?;
 
-        if page.rebase_required.is_some() {
-            return Err(ProjectionError::InvalidRequest {
-                reason: "turn event replay requires rebase",
+        if let Some(earliest) = page.rebase_required {
+            return Err(ProjectionError::TurnEventRebaseRequired {
+                requested: after,
+                earliest,
             });
         }
 
@@ -204,9 +224,12 @@ impl PendingGateProjection {
         advance_cursor: bool,
     ) -> Result<(), ProjectionError> {
         match event.kind {
-            TurnEventKind::Blocked if is_projectable_blocked_status(event.status) => {
+            TurnEventKind::Blocked => {
+                let Some(gate_kind) = TurnBlockedGateKind::from_status(event.status) else {
+                    return Ok(());
+                };
                 self.sink
-                    .upsert_pending_gate(row_from_blocked_event(&event)?)
+                    .upsert_pending_gate(row_from_blocked_event(&event, gate_kind)?)
                     .await?;
             }
             TurnEventKind::Completed
@@ -235,21 +258,22 @@ impl TurnEventSink for PendingGateProjection {
     async fn publish(&self, event: TurnLifecycleEvent) -> Result<(), ironclaw_turns::TurnError> {
         self.project_event(event, false)
             .await
-            .map_err(|_| ironclaw_turns::TurnError::Unavailable {
-                reason: "pending gate projection failed".to_string(),
+            .map_err(|error| match error {
+                ProjectionError::InvalidRequest { reason } => {
+                    ironclaw_turns::TurnError::InvalidRequest {
+                        reason: format!("pending gate projection failed: {reason}"),
+                    }
+                }
+                other => ironclaw_turns::TurnError::Unavailable {
+                    reason: format!("pending gate projection failed: {other}"),
+                },
             })
     }
 }
 
-fn is_projectable_blocked_status(status: TurnStatus) -> bool {
-    matches!(
-        status,
-        TurnStatus::BlockedApproval | TurnStatus::BlockedAuth | TurnStatus::BlockedResource
-    )
-}
-
 fn row_from_blocked_event(
     event: &TurnLifecycleEvent,
+    gate_kind: TurnBlockedGateKind,
 ) -> Result<PendingGateProjectionRow, ProjectionError> {
     let blocked_gate = event
         .blocked_gate
@@ -264,7 +288,7 @@ fn row_from_blocked_event(
     Ok(PendingGateProjectionRow {
         key: key_from_lifecycle_event(event)?,
         source_cursor: event.cursor,
-        gate_kind: blocked_gate.gate_kind.try_into()?,
+        gate_kind: gate_kind.into(),
         gate_ref: blocked_gate.gate_ref.as_str().to_string(),
         blocked_at,
     })
@@ -291,783 +315,4 @@ fn key_from_lifecycle_event(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::{
-        collections::HashMap,
-        sync::{Arc, Mutex},
-    };
-
-    use async_trait::async_trait;
-    use chrono::{TimeZone, Utc};
-    use ironclaw_turns::{GateRef, TurnBlockedGateMetadata};
-
-    use super::*;
-
-    #[derive(Default)]
-    struct MemorySink {
-        rows: Mutex<HashMap<PendingGateProjectionKey, PendingGateProjectionRow>>,
-        last_applied: Mutex<HashMap<PendingGateProjectionKey, TurnEventCursor>>,
-    }
-
-    impl MemorySink {
-        fn rows(&self) -> Vec<PendingGateProjectionRow> {
-            self.rows
-                .lock()
-                .expect("memory sink lock")
-                .values()
-                .cloned()
-                .collect()
-        }
-
-        fn should_apply(&self, key: &PendingGateProjectionKey, cursor: TurnEventCursor) -> bool {
-            let mut last_applied = self.last_applied.lock().expect("last applied lock");
-            let entry = last_applied.entry(key.clone()).or_default();
-            if cursor < *entry {
-                return false;
-            }
-            *entry = cursor;
-            true
-        }
-    }
-
-    #[async_trait]
-    impl PendingGateProjectionSink for MemorySink {
-        async fn upsert_pending_gate(
-            &self,
-            row: PendingGateProjectionRow,
-        ) -> Result<(), ProjectionError> {
-            if !self.should_apply(&row.key, row.source_cursor) {
-                return Ok(());
-            }
-            self.rows
-                .lock()
-                .expect("memory sink lock")
-                .insert(row.key.clone(), row);
-            Ok(())
-        }
-
-        async fn remove_pending_gate(
-            &self,
-            key: PendingGateProjectionKey,
-            source_cursor: TurnEventCursor,
-        ) -> Result<(), ProjectionError> {
-            if !self.should_apply(&key, source_cursor) {
-                return Ok(());
-            }
-            self.rows.lock().expect("memory sink lock").remove(&key);
-            Ok(())
-        }
-    }
-
-    #[derive(Default)]
-    struct MemoryCursorStore {
-        cursors: Mutex<HashMap<(String, TurnScope), TurnEventCursor>>,
-        advances: Mutex<Vec<TurnEventCursor>>,
-    }
-
-    impl MemoryCursorStore {
-        fn set(&self, consumer_id: &str, scope: &TurnScope, cursor: TurnEventCursor) {
-            self.cursors
-                .lock()
-                .expect("memory cursor lock")
-                .insert((consumer_id.to_string(), scope.clone()), cursor);
-        }
-
-        fn advances(&self) -> Vec<TurnEventCursor> {
-            self.advances.lock().expect("advances lock").clone()
-        }
-    }
-
-    #[async_trait]
-    impl PendingGateProjectionCursorStore for MemoryCursorStore {
-        async fn load_pending_gate_cursor(
-            &self,
-            consumer_id: &str,
-            scope: &TurnScope,
-        ) -> Result<TurnEventCursor, ProjectionError> {
-            Ok(*self
-                .cursors
-                .lock()
-                .expect("memory cursor lock")
-                .get(&(consumer_id.to_string(), scope.clone()))
-                .unwrap_or(&TurnEventCursor::default()))
-        }
-
-        async fn advance_pending_gate_cursor(
-            &self,
-            consumer_id: &str,
-            scope: &TurnScope,
-            cursor: TurnEventCursor,
-        ) -> Result<(), ProjectionError> {
-            let mut cursors = self.cursors.lock().expect("memory cursor lock");
-            let entry = cursors
-                .entry((consumer_id.to_string(), scope.clone()))
-                .or_default();
-            *entry = (*entry).max(cursor);
-            self.advances.lock().expect("advances lock").push(cursor);
-            Ok(())
-        }
-    }
-
-    struct MemoryTurnEventSource {
-        events: Vec<TurnLifecycleEvent>,
-        requested_limits: Mutex<Vec<usize>>,
-    }
-
-    impl MemoryTurnEventSource {
-        fn new(events: Vec<TurnLifecycleEvent>) -> Self {
-            Self {
-                events,
-                requested_limits: Mutex::new(Vec::new()),
-            }
-        }
-
-        fn requested_limits(&self) -> Vec<usize> {
-            self.requested_limits
-                .lock()
-                .expect("requested limits lock")
-                .clone()
-        }
-    }
-
-    #[async_trait]
-    impl TurnEventProjectionSource for MemoryTurnEventSource {
-        async fn read_turn_events_after(
-            &self,
-            scope: &TurnScope,
-            after: Option<TurnEventCursor>,
-            limit: usize,
-        ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
-            self.requested_limits
-                .lock()
-                .expect("requested limits lock")
-                .push(limit);
-            let after = after.unwrap_or_default();
-            let mut entries = self
-                .events
-                .iter()
-                .filter(|event| &event.scope == scope && event.cursor > after)
-                .cloned()
-                .collect::<Vec<_>>();
-            entries.sort_by_key(|event| event.cursor);
-            let truncated = entries.len() > limit;
-            if truncated {
-                entries.truncate(limit);
-            }
-            let next_cursor = entries.last().map(|event| event.cursor).unwrap_or(after);
-            Ok(ironclaw_turns::TurnEventPage {
-                entries,
-                next_cursor,
-                truncated,
-                rebase_required: None,
-            })
-        }
-    }
-
-    struct FailingTurnEventSource;
-
-    #[async_trait]
-    impl TurnEventProjectionSource for FailingTurnEventSource {
-        async fn read_turn_events_after(
-            &self,
-            _scope: &TurnScope,
-            _after: Option<TurnEventCursor>,
-            _limit: usize,
-        ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
-            Err(ironclaw_turns::TurnError::Unavailable {
-                reason: "test source failure".to_string(),
-            })
-        }
-    }
-
-    struct RebaseTurnEventSource;
-
-    #[async_trait]
-    impl TurnEventProjectionSource for RebaseTurnEventSource {
-        async fn read_turn_events_after(
-            &self,
-            _scope: &TurnScope,
-            _after: Option<TurnEventCursor>,
-            _limit: usize,
-        ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
-            Ok(ironclaw_turns::TurnEventPage {
-                entries: Vec::new(),
-                next_cursor: TurnEventCursor(5),
-                truncated: false,
-                rebase_required: Some(TurnEventCursor(5)),
-            })
-        }
-    }
-
-    fn scope(thread: &str) -> TurnScope {
-        TurnScope::new(
-            TenantId::new("tenant-a").expect("tenant"),
-            Some(AgentId::new("agent-a").expect("agent")),
-            Some(ProjectId::new("project-a").expect("project")),
-            ThreadId::new(thread).expect("thread"),
-        )
-    }
-
-    fn blocked_event(cursor: u64, scope: TurnScope, run_id: TurnRunId) -> TurnLifecycleEvent {
-        blocked_event_with(
-            cursor,
-            scope,
-            run_id,
-            TurnStatus::BlockedApproval,
-            TurnBlockedGateKind::Approval,
-            "gate:approval-a",
-        )
-    }
-
-    fn blocked_event_with(
-        cursor: u64,
-        scope: TurnScope,
-        run_id: TurnRunId,
-        status: TurnStatus,
-        gate_kind: TurnBlockedGateKind,
-        gate_ref: &str,
-    ) -> TurnLifecycleEvent {
-        TurnLifecycleEvent {
-            cursor: TurnEventCursor(cursor),
-            scope,
-            occurred_at: Some(Utc.with_ymd_and_hms(2026, 5, 20, 1, 2, 3).unwrap()),
-            owner_user_id: Some(UserId::new("owner-a").expect("user")),
-            run_id,
-            status,
-            kind: TurnEventKind::Blocked,
-            blocked_gate: Some(TurnBlockedGateMetadata {
-                gate_ref: GateRef::new(gate_ref).expect("gate ref"),
-                gate_kind,
-            }),
-            sanitized_reason: Some("approval_required".to_string()),
-        }
-    }
-
-    fn lifecycle_event(
-        cursor: u64,
-        scope: TurnScope,
-        run_id: TurnRunId,
-        status: TurnStatus,
-        kind: TurnEventKind,
-    ) -> TurnLifecycleEvent {
-        TurnLifecycleEvent {
-            cursor: TurnEventCursor(cursor),
-            scope,
-            occurred_at: Some(Utc.with_ymd_and_hms(2026, 5, 20, 1, 3, 3).unwrap()),
-            owner_user_id: Some(UserId::new("owner-a").expect("user")),
-            run_id,
-            status,
-            kind,
-            blocked_gate: None,
-            sanitized_reason: None,
-        }
-    }
-
-    fn projection(
-        sink: Arc<MemorySink>,
-        cursor_store: Arc<MemoryCursorStore>,
-    ) -> PendingGateProjection {
-        PendingGateProjection::new(sink, cursor_store)
-    }
-
-    #[tokio::test]
-    async fn blocked_event_upserts_pending_gate_row() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store.clone());
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-
-        projection
-            .project_event(blocked_event(1, scope.clone(), run_id), true)
-            .await
-            .unwrap();
-
-        let rows = sink.rows();
-        assert_eq!(rows.len(), 1);
-        let row = &rows[0];
-        assert_eq!(row.key.tenant_id, scope.tenant_id);
-        assert_eq!(row.key.agent_id, scope.agent_id);
-        assert_eq!(row.key.project_id, scope.project_id);
-        assert_eq!(row.key.owner_user_id.as_str(), "owner-a");
-        assert_eq!(row.key.thread_id, scope.thread_id);
-        assert_eq!(row.key.run_id, run_id);
-        assert_eq!(row.source_cursor, TurnEventCursor(1));
-        assert_eq!(row.gate_kind, PendingGateProjectionGateKind::Approval);
-        assert_eq!(row.gate_ref, "gate:approval-a");
-        assert_eq!(
-            cursor_store
-                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
-                .await
-                .unwrap(),
-            TurnEventCursor(1)
-        );
-    }
-
-    #[tokio::test]
-    async fn publish_projects_blocked_event_without_advancing_replay_cursor() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store.clone());
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-
-        projection
-            .publish(blocked_event(7, scope.clone(), run_id))
-            .await
-            .unwrap();
-
-        assert_eq!(sink.rows().len(), 1);
-        assert_eq!(
-            cursor_store
-                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
-                .await
-                .unwrap(),
-            TurnEventCursor::default(),
-            "live tail projection must not skip durable replay backlog"
-        );
-    }
-
-    #[derive(Default)]
-    struct FailingSink;
-
-    #[async_trait]
-    impl PendingGateProjectionSink for FailingSink {
-        async fn upsert_pending_gate(
-            &self,
-            _row: PendingGateProjectionRow,
-        ) -> Result<(), ProjectionError> {
-            Err(ProjectionError::Source {
-                operation: "failing_upsert",
-            })
-        }
-
-        async fn remove_pending_gate(
-            &self,
-            _key: PendingGateProjectionKey,
-            _source_cursor: TurnEventCursor,
-        ) -> Result<(), ProjectionError> {
-            Err(ProjectionError::Source {
-                operation: "failing_remove",
-            })
-        }
-    }
-
-    #[tokio::test]
-    async fn publish_maps_projection_failure_to_turn_unavailable() {
-        let projection = PendingGateProjection::new(
-            Arc::new(FailingSink),
-            Arc::new(MemoryCursorStore::default()),
-        );
-        let err = projection
-            .publish(blocked_event(1, scope("thread-a"), TurnRunId::new()))
-            .await
-            .unwrap_err();
-
-        assert!(matches!(err, ironclaw_turns::TurnError::Unavailable { .. }));
-    }
-
-    #[tokio::test]
-    async fn malformed_blocked_metadata_errors_without_advancing_cursor() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink, cursor_store.clone());
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-
-        for mutate in [
-            |event: &mut TurnLifecycleEvent| event.blocked_gate = None,
-            |event: &mut TurnLifecycleEvent| event.occurred_at = None,
-            |event: &mut TurnLifecycleEvent| event.owner_user_id = None,
-        ] {
-            let mut event = blocked_event(1, scope.clone(), run_id);
-            mutate(&mut event);
-            projection.project_event(event, true).await.unwrap_err();
-            assert_eq!(
-                cursor_store
-                    .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
-                    .await
-                    .unwrap(),
-                TurnEventCursor::default()
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn auth_and_resource_blocked_events_upsert_expected_gate_kinds() {
-        for (status, source_kind, projected_kind, gate_ref) in [
-            (
-                TurnStatus::BlockedAuth,
-                TurnBlockedGateKind::Auth,
-                PendingGateProjectionGateKind::Auth,
-                "gate:auth-a",
-            ),
-            (
-                TurnStatus::BlockedResource,
-                TurnBlockedGateKind::Resource,
-                PendingGateProjectionGateKind::Resource,
-                "gate:resource-a",
-            ),
-        ] {
-            let sink = Arc::new(MemorySink::default());
-            let cursor_store = Arc::new(MemoryCursorStore::default());
-            let projection = projection(sink.clone(), cursor_store);
-            let scope = scope("thread-a");
-            let run_id = TurnRunId::new();
-
-            projection
-                .project_event(
-                    blocked_event_with(1, scope, run_id, status, source_kind, gate_ref),
-                    true,
-                )
-                .await
-                .unwrap();
-
-            let rows = sink.rows();
-            assert_eq!(rows.len(), 1);
-            assert_eq!(rows[0].gate_kind, projected_kind);
-            assert_eq!(rows[0].gate_ref, gate_ref);
-        }
-    }
-
-    #[tokio::test]
-    async fn resumed_and_terminal_events_remove_exact_row() {
-        for (status, kind) in [
-            (TurnStatus::Queued, TurnEventKind::Resumed),
-            (TurnStatus::Completed, TurnEventKind::Completed),
-            (TurnStatus::Failed, TurnEventKind::Failed),
-            (TurnStatus::Cancelled, TurnEventKind::Cancelled),
-        ] {
-            let sink = Arc::new(MemorySink::default());
-            let cursor_store = Arc::new(MemoryCursorStore::default());
-            let projection = projection(sink.clone(), cursor_store);
-            let scope = scope("thread-a");
-            let run_id = TurnRunId::new();
-
-            projection
-                .project_event(blocked_event(1, scope.clone(), run_id), true)
-                .await
-                .unwrap();
-            projection
-                .project_event(
-                    lifecycle_event(2, scope, run_id, status, kind.clone()),
-                    true,
-                )
-                .await
-                .unwrap();
-
-            assert!(sink.rows().is_empty(), "failed to remove for {kind:?}");
-        }
-    }
-
-    #[tokio::test]
-    async fn replaying_same_stream_is_idempotent() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store.clone());
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-        let source = MemoryTurnEventSource::new(vec![blocked_event(1, scope.clone(), run_id)]);
-
-        projection.replay_scope(&source, &scope, 100).await.unwrap();
-        cursor_store.set(
-            PENDING_GATE_PROJECTION_CONSUMER_ID,
-            &scope,
-            TurnEventCursor::default(),
-        );
-        projection.replay_scope(&source, &scope, 100).await.unwrap();
-
-        assert_eq!(sink.rows().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn stale_replay_blocked_event_does_not_resurrect_live_removed_gate() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store);
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-
-        projection
-            .publish(lifecycle_event(
-                2,
-                scope.clone(),
-                run_id,
-                TurnStatus::Completed,
-                TurnEventKind::Completed,
-            ))
-            .await
-            .unwrap();
-        projection
-            .project_event(blocked_event(1, scope, run_id), false)
-            .await
-            .unwrap();
-
-        assert!(
-            sink.rows().is_empty(),
-            "older replay upsert must not resurrect a gate removed by newer live delivery"
-        );
-    }
-
-    #[tokio::test]
-    async fn replay_recovers_when_crash_happens_after_row_write_before_cursor_advance() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store);
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-        let source = MemoryTurnEventSource::new(vec![
-            blocked_event(1, scope.clone(), run_id),
-            lifecycle_event(
-                2,
-                scope.clone(),
-                run_id,
-                TurnStatus::Completed,
-                TurnEventKind::Completed,
-            ),
-        ]);
-
-        sink.upsert_pending_gate(
-            row_from_blocked_event(&blocked_event(1, scope.clone(), run_id)).unwrap(),
-        )
-        .await
-        .unwrap();
-
-        let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
-
-        assert_eq!(replay.processed, 2);
-        assert_eq!(replay.next_cursor, TurnEventCursor(2));
-        assert!(sink.rows().is_empty());
-    }
-
-    #[tokio::test]
-    async fn replay_recovers_when_crash_happens_after_remove_before_cursor_advance() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store.clone());
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-        let source = MemoryTurnEventSource::new(vec![
-            blocked_event(1, scope.clone(), run_id),
-            lifecycle_event(
-                2,
-                scope.clone(),
-                run_id,
-                TurnStatus::Completed,
-                TurnEventKind::Completed,
-            ),
-        ]);
-
-        cursor_store.set(
-            PENDING_GATE_PROJECTION_CONSUMER_ID,
-            &scope,
-            TurnEventCursor(1),
-        );
-
-        let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
-
-        assert_eq!(replay.processed, 1);
-        assert_eq!(replay.next_cursor, TurnEventCursor(2));
-        assert!(sink.rows().is_empty());
-    }
-
-    #[tokio::test]
-    async fn replay_advances_cursor_once_per_page_after_successful_projection() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink, cursor_store.clone());
-        let scope = scope("thread-a");
-        let run_id = TurnRunId::new();
-        let source = MemoryTurnEventSource::new(vec![
-            blocked_event(1, scope.clone(), run_id),
-            lifecycle_event(
-                2,
-                scope.clone(),
-                run_id,
-                TurnStatus::Completed,
-                TurnEventKind::Completed,
-            ),
-        ]);
-
-        projection.replay_scope(&source, &scope, 100).await.unwrap();
-
-        assert_eq!(cursor_store.advances(), vec![TurnEventCursor(2)]);
-    }
-
-    #[tokio::test]
-    async fn replay_caps_requested_page_size() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink, cursor_store);
-        let scope = scope("thread-a");
-        let events = (1..=MAX_TURN_EVENT_PROJECTION_LIMIT as u64 + 1)
-            .map(|cursor| blocked_event(cursor, scope.clone(), TurnRunId::new()))
-            .collect::<Vec<_>>();
-        let source = MemoryTurnEventSource::new(events);
-
-        let replay = projection
-            .replay_scope(&source, &scope, MAX_TURN_EVENT_PROJECTION_LIMIT + 10)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            source.requested_limits(),
-            vec![MAX_TURN_EVENT_PROJECTION_LIMIT]
-        );
-        assert_eq!(replay.processed, MAX_TURN_EVENT_PROJECTION_LIMIT);
-        assert!(replay.truncated);
-    }
-
-    #[tokio::test]
-    async fn replay_scope_error_exits_do_not_mutate_rows_or_cursor() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store.clone());
-        let scope = scope("thread-a");
-        let source = MemoryTurnEventSource::new(Vec::new());
-
-        projection
-            .replay_scope(&source, &scope, 0)
-            .await
-            .unwrap_err();
-        projection
-            .replay_scope(&FailingTurnEventSource, &scope, 100)
-            .await
-            .unwrap_err();
-        projection
-            .replay_scope(&RebaseTurnEventSource, &scope, 100)
-            .await
-            .unwrap_err();
-
-        assert!(sink.rows().is_empty());
-        assert_eq!(
-            cursor_store
-                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
-                .await
-                .unwrap(),
-            TurnEventCursor::default()
-        );
-        assert!(cursor_store.advances().is_empty());
-    }
-
-    #[tokio::test]
-    async fn cursor_advance_is_monotonic_under_interleaved_replay() {
-        let cursor_store = MemoryCursorStore::default();
-        let scope = scope("thread-a");
-
-        cursor_store
-            .advance_pending_gate_cursor(
-                PENDING_GATE_PROJECTION_CONSUMER_ID,
-                &scope,
-                TurnEventCursor(100),
-            )
-            .await
-            .unwrap();
-        cursor_store
-            .advance_pending_gate_cursor(
-                PENDING_GATE_PROJECTION_CONSUMER_ID,
-                &scope,
-                TurnEventCursor(1),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            cursor_store
-                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
-                .await
-                .unwrap(),
-            TurnEventCursor(100)
-        );
-    }
-
-    #[tokio::test]
-    async fn terminal_remove_does_not_delete_neighboring_runs() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store);
-        let scope = scope("thread-a");
-        let removed_run = TurnRunId::new();
-        let kept_run = TurnRunId::new();
-
-        projection
-            .project_event(blocked_event(1, scope.clone(), removed_run), true)
-            .await
-            .unwrap();
-        projection
-            .project_event(blocked_event(2, scope.clone(), kept_run), true)
-            .await
-            .unwrap();
-        projection
-            .project_event(
-                lifecycle_event(
-                    3,
-                    scope,
-                    removed_run,
-                    TurnStatus::Completed,
-                    TurnEventKind::Completed,
-                ),
-                true,
-            )
-            .await
-            .unwrap();
-
-        let rows = sink.rows();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].key.run_id, kept_run);
-    }
-
-    #[tokio::test]
-    async fn terminal_remove_preserves_same_thread_rows_in_other_agent_project_scopes() {
-        let sink = Arc::new(MemorySink::default());
-        let cursor_store = Arc::new(MemoryCursorStore::default());
-        let projection = projection(sink.clone(), cursor_store);
-        let tenant = TenantId::new("tenant-a").expect("tenant");
-        let thread = ThreadId::new("thread-a").expect("thread");
-        let scope_a = TurnScope::new(
-            tenant.clone(),
-            Some(AgentId::new("agent-a").expect("agent")),
-            Some(ProjectId::new("project-a").expect("project")),
-            thread.clone(),
-        );
-        let scope_b = TurnScope::new(
-            tenant,
-            Some(AgentId::new("agent-b").expect("agent")),
-            Some(ProjectId::new("project-b").expect("project")),
-            thread,
-        );
-        let removed_run = TurnRunId::new();
-        let kept_run = TurnRunId::new();
-
-        projection
-            .project_event(blocked_event(1, scope_a.clone(), removed_run), false)
-            .await
-            .unwrap();
-        projection
-            .project_event(blocked_event(2, scope_b, kept_run), false)
-            .await
-            .unwrap();
-        projection
-            .project_event(
-                lifecycle_event(
-                    3,
-                    scope_a,
-                    removed_run,
-                    TurnStatus::Completed,
-                    TurnEventKind::Completed,
-                ),
-                false,
-            )
-            .await
-            .unwrap();
-
-        let rows = sink.rows();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].key.run_id, kept_run);
-        assert_eq!(rows[0].key.agent_id.as_ref().unwrap().as_str(), "agent-b");
-        assert_eq!(
-            rows[0].key.project_id.as_ref().unwrap().as_str(),
-            "project-b"
-        );
-    }
-}
+mod tests;

--- a/crates/ironclaw_event_projections/src/pending_gate_projection.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserId};
 use ironclaw_turns::{
-    EventCursor as TurnEventCursor, MAX_TURN_EVENT_PROJECTION_LIMIT, TurnBlockedGateKind,
+    EventCursor as TurnEventCursor, GateRef, MAX_TURN_EVENT_PROJECTION_LIMIT, TurnBlockedGateKind,
     TurnEventKind, TurnEventProjectionSource, TurnEventSink, TurnLifecycleEvent, TurnRunId,
     TurnScope,
 };
@@ -68,7 +68,7 @@ pub struct PendingGateProjectionRow {
     /// removed with a newer terminal/resume event.
     pub source_cursor: TurnEventCursor,
     pub gate_kind: PendingGateKind,
-    pub gate_ref: String,
+    pub gate_ref: GateRef,
     pub blocked_at: Timestamp,
 }
 
@@ -202,7 +202,7 @@ impl PendingGateProjection {
         let mut next_cursor = after;
         for event in page.entries {
             next_cursor = event.cursor;
-            self.project_event(event, false).await?;
+            self.project_replay_event(event).await?;
             processed += 1;
         }
         if processed > 0 {
@@ -251,6 +251,18 @@ impl PendingGateProjection {
         }
         Ok(())
     }
+
+    async fn project_replay_event(&self, event: TurnLifecycleEvent) -> Result<(), ProjectionError> {
+        match self.project_event(event.clone(), false).await {
+            Ok(()) => Ok(()),
+            Err(ProjectionError::InvalidRequest { reason })
+                if is_replayable_legacy_metadata_gap(&event, reason) =>
+            {
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 #[async_trait]
@@ -289,7 +301,7 @@ fn row_from_blocked_event(
         key: key_from_lifecycle_event(event)?,
         source_cursor: event.cursor,
         gate_kind: gate_kind.into(),
-        gate_ref: blocked_gate.gate_ref.as_str().to_string(),
+        gate_ref: blocked_gate.gate_ref.clone(),
         blocked_at,
     })
 }
@@ -312,6 +324,30 @@ fn key_from_lifecycle_event(
         thread_id: event.scope.thread_id.clone(),
         run_id: event.run_id,
     })
+}
+
+fn is_replayable_legacy_metadata_gap(event: &TurnLifecycleEvent, reason: &'static str) -> bool {
+    let missing_metadata = matches!(
+        reason,
+        "blocked turn event missing gate metadata"
+            | "blocked turn event missing timestamp"
+            | "turn event missing owner metadata"
+    );
+    if !missing_metadata {
+        return false;
+    }
+
+    // Replay can encounter events retained from before pending-gate metadata
+    // existed. Those historical events could not have produced a resolvable
+    // pending-gate row, so skip them and let the replay cursor advance.
+    matches!(
+        event.kind,
+        TurnEventKind::Blocked
+            | TurnEventKind::Completed
+            | TurnEventKind::Failed
+            | TurnEventKind::Cancelled
+            | TurnEventKind::Resumed
+    )
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_event_projections/src/pending_gate_projection.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection.rs
@@ -1,0 +1,1073 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp, UserId};
+use ironclaw_turns::{
+    EventCursor as TurnEventCursor, MAX_TURN_EVENT_PROJECTION_LIMIT, TurnBlockedGateKind,
+    TurnEventKind, TurnEventProjectionSource, TurnEventSink, TurnLifecycleEvent, TurnRunId,
+    TurnScope, TurnStatus,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::ProjectionError;
+
+pub const PENDING_GATE_PROJECTION_CONSUMER_ID: &str = "pending_gate_projection.v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PendingGateProjectionGateKind {
+    Approval,
+    Auth,
+    Resource,
+}
+
+impl TryFrom<TurnBlockedGateKind> for PendingGateProjectionGateKind {
+    type Error = ProjectionError;
+
+    fn try_from(kind: TurnBlockedGateKind) -> Result<Self, Self::Error> {
+        Ok(match kind {
+            TurnBlockedGateKind::Approval => Self::Approval,
+            TurnBlockedGateKind::Auth => Self::Auth,
+            TurnBlockedGateKind::Resource => Self::Resource,
+            _ => {
+                return Err(ProjectionError::InvalidRequest {
+                    reason: "unsupported turn blocked gate kind",
+                });
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PendingGateProjectionKey {
+    pub tenant_id: TenantId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
+    pub owner_user_id: UserId,
+    pub thread_id: ThreadId,
+    pub run_id: TurnRunId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingGateProjectionRow {
+    pub key: PendingGateProjectionKey,
+    /// Cursor of the lifecycle event that produced this row.
+    ///
+    /// Sinks use this as the per-key ordering guard so replay of an older
+    /// blocked event cannot resurrect a gate that live delivery already
+    /// removed with a newer terminal/resume event.
+    pub source_cursor: TurnEventCursor,
+    pub gate_kind: PendingGateProjectionGateKind,
+    pub gate_ref: String,
+    pub blocked_at: Timestamp,
+}
+
+#[async_trait]
+pub trait PendingGateProjectionSink: Send + Sync {
+    /// Upsert a pending-gate row only if `row.source_cursor` is not older than
+    /// the last event already applied for `row.key`.
+    async fn upsert_pending_gate(
+        &self,
+        row: PendingGateProjectionRow,
+    ) -> Result<(), ProjectionError>;
+
+    /// Remove a pending-gate row only if `source_cursor` is not older than the
+    /// last event already applied for `key`.
+    async fn remove_pending_gate(
+        &self,
+        key: PendingGateProjectionKey,
+        source_cursor: TurnEventCursor,
+    ) -> Result<(), ProjectionError>;
+}
+
+#[async_trait]
+pub trait PendingGateProjectionCursorStore: Send + Sync {
+    /// Load the last durable replay cursor for this consumer and turn scope.
+    async fn load_pending_gate_cursor(
+        &self,
+        consumer_id: &str,
+        scope: &TurnScope,
+    ) -> Result<TurnEventCursor, ProjectionError>;
+
+    /// Advance the durable replay cursor monotonically.
+    ///
+    /// Implementations must persist `max(current, cursor)` atomically for the
+    /// `(consumer_id, scope)` key. Live [`TurnEventSink`] delivery updates the
+    /// read model only and intentionally does not call this method; replay from
+    /// the durable turn event source owns cursor progress so it cannot skip a
+    /// backlog gap.
+    async fn advance_pending_gate_cursor(
+        &self,
+        consumer_id: &str,
+        scope: &TurnScope,
+        cursor: TurnEventCursor,
+    ) -> Result<(), ProjectionError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingGateProjectionReplay {
+    pub processed: usize,
+    pub next_cursor: TurnEventCursor,
+    pub truncated: bool,
+}
+
+#[derive(Clone)]
+pub struct PendingGateProjection {
+    consumer_id: &'static str,
+    sink: Arc<dyn PendingGateProjectionSink>,
+    cursor_store: Arc<dyn PendingGateProjectionCursorStore>,
+}
+
+impl PendingGateProjection {
+    pub fn new(
+        sink: Arc<dyn PendingGateProjectionSink>,
+        cursor_store: Arc<dyn PendingGateProjectionCursorStore>,
+    ) -> Self {
+        Self {
+            consumer_id: PENDING_GATE_PROJECTION_CONSUMER_ID,
+            sink,
+            cursor_store,
+        }
+    }
+
+    pub fn with_consumer_id(
+        consumer_id: &'static str,
+        sink: Arc<dyn PendingGateProjectionSink>,
+        cursor_store: Arc<dyn PendingGateProjectionCursorStore>,
+    ) -> Self {
+        Self {
+            consumer_id,
+            sink,
+            cursor_store,
+        }
+    }
+
+    pub async fn replay_scope<S>(
+        &self,
+        source: &S,
+        scope: &TurnScope,
+        limit: usize,
+    ) -> Result<PendingGateProjectionReplay, ProjectionError>
+    where
+        S: TurnEventProjectionSource + ?Sized,
+    {
+        if limit == 0 {
+            return Err(ProjectionError::InvalidRequest {
+                reason: "pending gate replay limit must be greater than zero",
+            });
+        }
+
+        let after = self
+            .cursor_store
+            .load_pending_gate_cursor(self.consumer_id, scope)
+            .await?;
+        let effective_limit = limit.min(MAX_TURN_EVENT_PROJECTION_LIMIT);
+        let page = source
+            .read_turn_events_after(scope, Some(after), effective_limit)
+            .await
+            .map_err(|_| ProjectionError::Source {
+                operation: "read_turn_events_after",
+            })?;
+
+        if page.rebase_required.is_some() {
+            return Err(ProjectionError::InvalidRequest {
+                reason: "turn event replay requires rebase",
+            });
+        }
+
+        let mut processed = 0;
+        let mut next_cursor = after;
+        for event in page.entries {
+            next_cursor = event.cursor;
+            self.project_event(event, false).await?;
+            processed += 1;
+        }
+        if processed > 0 {
+            self.cursor_store
+                .advance_pending_gate_cursor(self.consumer_id, scope, next_cursor)
+                .await?;
+        }
+
+        Ok(PendingGateProjectionReplay {
+            processed,
+            next_cursor,
+            truncated: page.truncated,
+        })
+    }
+
+    async fn project_event(
+        &self,
+        event: TurnLifecycleEvent,
+        advance_cursor: bool,
+    ) -> Result<(), ProjectionError> {
+        match event.kind {
+            TurnEventKind::Blocked if is_projectable_blocked_status(event.status) => {
+                self.sink
+                    .upsert_pending_gate(row_from_blocked_event(&event)?)
+                    .await?;
+            }
+            TurnEventKind::Completed
+            | TurnEventKind::Failed
+            | TurnEventKind::Cancelled
+            | TurnEventKind::Resumed => {
+                let source_cursor = event.cursor;
+                self.sink
+                    .remove_pending_gate(key_from_lifecycle_event(&event)?, source_cursor)
+                    .await?;
+            }
+            _ => {}
+        }
+
+        if advance_cursor {
+            self.cursor_store
+                .advance_pending_gate_cursor(self.consumer_id, &event.scope, event.cursor)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TurnEventSink for PendingGateProjection {
+    async fn publish(&self, event: TurnLifecycleEvent) -> Result<(), ironclaw_turns::TurnError> {
+        self.project_event(event, false)
+            .await
+            .map_err(|_| ironclaw_turns::TurnError::Unavailable {
+                reason: "pending gate projection failed".to_string(),
+            })
+    }
+}
+
+fn is_projectable_blocked_status(status: TurnStatus) -> bool {
+    matches!(
+        status,
+        TurnStatus::BlockedApproval | TurnStatus::BlockedAuth | TurnStatus::BlockedResource
+    )
+}
+
+fn row_from_blocked_event(
+    event: &TurnLifecycleEvent,
+) -> Result<PendingGateProjectionRow, ProjectionError> {
+    let blocked_gate = event
+        .blocked_gate
+        .as_ref()
+        .ok_or(ProjectionError::InvalidRequest {
+            reason: "blocked turn event missing gate metadata",
+        })?;
+    let blocked_at = event.occurred_at.ok_or(ProjectionError::InvalidRequest {
+        reason: "blocked turn event missing timestamp",
+    })?;
+
+    Ok(PendingGateProjectionRow {
+        key: key_from_lifecycle_event(event)?,
+        source_cursor: event.cursor,
+        gate_kind: blocked_gate.gate_kind.try_into()?,
+        gate_ref: blocked_gate.gate_ref.as_str().to_string(),
+        blocked_at,
+    })
+}
+
+fn key_from_lifecycle_event(
+    event: &TurnLifecycleEvent,
+) -> Result<PendingGateProjectionKey, ProjectionError> {
+    let owner_user_id = event
+        .owner_user_id
+        .clone()
+        .ok_or(ProjectionError::InvalidRequest {
+            reason: "turn event missing owner metadata",
+        })?;
+
+    Ok(PendingGateProjectionKey {
+        tenant_id: event.scope.tenant_id.clone(),
+        agent_id: event.scope.agent_id.clone(),
+        project_id: event.scope.project_id.clone(),
+        owner_user_id,
+        thread_id: event.scope.thread_id.clone(),
+        run_id: event.run_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use chrono::{TimeZone, Utc};
+    use ironclaw_turns::{GateRef, TurnBlockedGateMetadata};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MemorySink {
+        rows: Mutex<HashMap<PendingGateProjectionKey, PendingGateProjectionRow>>,
+        last_applied: Mutex<HashMap<PendingGateProjectionKey, TurnEventCursor>>,
+    }
+
+    impl MemorySink {
+        fn rows(&self) -> Vec<PendingGateProjectionRow> {
+            self.rows
+                .lock()
+                .expect("memory sink lock")
+                .values()
+                .cloned()
+                .collect()
+        }
+
+        fn should_apply(&self, key: &PendingGateProjectionKey, cursor: TurnEventCursor) -> bool {
+            let mut last_applied = self.last_applied.lock().expect("last applied lock");
+            let entry = last_applied.entry(key.clone()).or_default();
+            if cursor < *entry {
+                return false;
+            }
+            *entry = cursor;
+            true
+        }
+    }
+
+    #[async_trait]
+    impl PendingGateProjectionSink for MemorySink {
+        async fn upsert_pending_gate(
+            &self,
+            row: PendingGateProjectionRow,
+        ) -> Result<(), ProjectionError> {
+            if !self.should_apply(&row.key, row.source_cursor) {
+                return Ok(());
+            }
+            self.rows
+                .lock()
+                .expect("memory sink lock")
+                .insert(row.key.clone(), row);
+            Ok(())
+        }
+
+        async fn remove_pending_gate(
+            &self,
+            key: PendingGateProjectionKey,
+            source_cursor: TurnEventCursor,
+        ) -> Result<(), ProjectionError> {
+            if !self.should_apply(&key, source_cursor) {
+                return Ok(());
+            }
+            self.rows.lock().expect("memory sink lock").remove(&key);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct MemoryCursorStore {
+        cursors: Mutex<HashMap<(String, TurnScope), TurnEventCursor>>,
+        advances: Mutex<Vec<TurnEventCursor>>,
+    }
+
+    impl MemoryCursorStore {
+        fn set(&self, consumer_id: &str, scope: &TurnScope, cursor: TurnEventCursor) {
+            self.cursors
+                .lock()
+                .expect("memory cursor lock")
+                .insert((consumer_id.to_string(), scope.clone()), cursor);
+        }
+
+        fn advances(&self) -> Vec<TurnEventCursor> {
+            self.advances.lock().expect("advances lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl PendingGateProjectionCursorStore for MemoryCursorStore {
+        async fn load_pending_gate_cursor(
+            &self,
+            consumer_id: &str,
+            scope: &TurnScope,
+        ) -> Result<TurnEventCursor, ProjectionError> {
+            Ok(*self
+                .cursors
+                .lock()
+                .expect("memory cursor lock")
+                .get(&(consumer_id.to_string(), scope.clone()))
+                .unwrap_or(&TurnEventCursor::default()))
+        }
+
+        async fn advance_pending_gate_cursor(
+            &self,
+            consumer_id: &str,
+            scope: &TurnScope,
+            cursor: TurnEventCursor,
+        ) -> Result<(), ProjectionError> {
+            let mut cursors = self.cursors.lock().expect("memory cursor lock");
+            let entry = cursors
+                .entry((consumer_id.to_string(), scope.clone()))
+                .or_default();
+            *entry = (*entry).max(cursor);
+            self.advances.lock().expect("advances lock").push(cursor);
+            Ok(())
+        }
+    }
+
+    struct MemoryTurnEventSource {
+        events: Vec<TurnLifecycleEvent>,
+        requested_limits: Mutex<Vec<usize>>,
+    }
+
+    impl MemoryTurnEventSource {
+        fn new(events: Vec<TurnLifecycleEvent>) -> Self {
+            Self {
+                events,
+                requested_limits: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn requested_limits(&self) -> Vec<usize> {
+            self.requested_limits
+                .lock()
+                .expect("requested limits lock")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl TurnEventProjectionSource for MemoryTurnEventSource {
+        async fn read_turn_events_after(
+            &self,
+            scope: &TurnScope,
+            after: Option<TurnEventCursor>,
+            limit: usize,
+        ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
+            self.requested_limits
+                .lock()
+                .expect("requested limits lock")
+                .push(limit);
+            let after = after.unwrap_or_default();
+            let mut entries = self
+                .events
+                .iter()
+                .filter(|event| &event.scope == scope && event.cursor > after)
+                .cloned()
+                .collect::<Vec<_>>();
+            entries.sort_by_key(|event| event.cursor);
+            let truncated = entries.len() > limit;
+            if truncated {
+                entries.truncate(limit);
+            }
+            let next_cursor = entries.last().map(|event| event.cursor).unwrap_or(after);
+            Ok(ironclaw_turns::TurnEventPage {
+                entries,
+                next_cursor,
+                truncated,
+                rebase_required: None,
+            })
+        }
+    }
+
+    struct FailingTurnEventSource;
+
+    #[async_trait]
+    impl TurnEventProjectionSource for FailingTurnEventSource {
+        async fn read_turn_events_after(
+            &self,
+            _scope: &TurnScope,
+            _after: Option<TurnEventCursor>,
+            _limit: usize,
+        ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
+            Err(ironclaw_turns::TurnError::Unavailable {
+                reason: "test source failure".to_string(),
+            })
+        }
+    }
+
+    struct RebaseTurnEventSource;
+
+    #[async_trait]
+    impl TurnEventProjectionSource for RebaseTurnEventSource {
+        async fn read_turn_events_after(
+            &self,
+            _scope: &TurnScope,
+            _after: Option<TurnEventCursor>,
+            _limit: usize,
+        ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
+            Ok(ironclaw_turns::TurnEventPage {
+                entries: Vec::new(),
+                next_cursor: TurnEventCursor(5),
+                truncated: false,
+                rebase_required: Some(TurnEventCursor(5)),
+            })
+        }
+    }
+
+    fn scope(thread: &str) -> TurnScope {
+        TurnScope::new(
+            TenantId::new("tenant-a").expect("tenant"),
+            Some(AgentId::new("agent-a").expect("agent")),
+            Some(ProjectId::new("project-a").expect("project")),
+            ThreadId::new(thread).expect("thread"),
+        )
+    }
+
+    fn blocked_event(cursor: u64, scope: TurnScope, run_id: TurnRunId) -> TurnLifecycleEvent {
+        blocked_event_with(
+            cursor,
+            scope,
+            run_id,
+            TurnStatus::BlockedApproval,
+            TurnBlockedGateKind::Approval,
+            "gate:approval-a",
+        )
+    }
+
+    fn blocked_event_with(
+        cursor: u64,
+        scope: TurnScope,
+        run_id: TurnRunId,
+        status: TurnStatus,
+        gate_kind: TurnBlockedGateKind,
+        gate_ref: &str,
+    ) -> TurnLifecycleEvent {
+        TurnLifecycleEvent {
+            cursor: TurnEventCursor(cursor),
+            scope,
+            occurred_at: Some(Utc.with_ymd_and_hms(2026, 5, 20, 1, 2, 3).unwrap()),
+            owner_user_id: Some(UserId::new("owner-a").expect("user")),
+            run_id,
+            status,
+            kind: TurnEventKind::Blocked,
+            blocked_gate: Some(TurnBlockedGateMetadata {
+                gate_ref: GateRef::new(gate_ref).expect("gate ref"),
+                gate_kind,
+            }),
+            sanitized_reason: Some("approval_required".to_string()),
+        }
+    }
+
+    fn lifecycle_event(
+        cursor: u64,
+        scope: TurnScope,
+        run_id: TurnRunId,
+        status: TurnStatus,
+        kind: TurnEventKind,
+    ) -> TurnLifecycleEvent {
+        TurnLifecycleEvent {
+            cursor: TurnEventCursor(cursor),
+            scope,
+            occurred_at: Some(Utc.with_ymd_and_hms(2026, 5, 20, 1, 3, 3).unwrap()),
+            owner_user_id: Some(UserId::new("owner-a").expect("user")),
+            run_id,
+            status,
+            kind,
+            blocked_gate: None,
+            sanitized_reason: None,
+        }
+    }
+
+    fn projection(
+        sink: Arc<MemorySink>,
+        cursor_store: Arc<MemoryCursorStore>,
+    ) -> PendingGateProjection {
+        PendingGateProjection::new(sink, cursor_store)
+    }
+
+    #[tokio::test]
+    async fn blocked_event_upserts_pending_gate_row() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store.clone());
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+
+        projection
+            .project_event(blocked_event(1, scope.clone(), run_id), true)
+            .await
+            .unwrap();
+
+        let rows = sink.rows();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.key.tenant_id, scope.tenant_id);
+        assert_eq!(row.key.agent_id, scope.agent_id);
+        assert_eq!(row.key.project_id, scope.project_id);
+        assert_eq!(row.key.owner_user_id.as_str(), "owner-a");
+        assert_eq!(row.key.thread_id, scope.thread_id);
+        assert_eq!(row.key.run_id, run_id);
+        assert_eq!(row.source_cursor, TurnEventCursor(1));
+        assert_eq!(row.gate_kind, PendingGateProjectionGateKind::Approval);
+        assert_eq!(row.gate_ref, "gate:approval-a");
+        assert_eq!(
+            cursor_store
+                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+                .await
+                .unwrap(),
+            TurnEventCursor(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_projects_blocked_event_without_advancing_replay_cursor() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store.clone());
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+
+        projection
+            .publish(blocked_event(7, scope.clone(), run_id))
+            .await
+            .unwrap();
+
+        assert_eq!(sink.rows().len(), 1);
+        assert_eq!(
+            cursor_store
+                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+                .await
+                .unwrap(),
+            TurnEventCursor::default(),
+            "live tail projection must not skip durable replay backlog"
+        );
+    }
+
+    #[derive(Default)]
+    struct FailingSink;
+
+    #[async_trait]
+    impl PendingGateProjectionSink for FailingSink {
+        async fn upsert_pending_gate(
+            &self,
+            _row: PendingGateProjectionRow,
+        ) -> Result<(), ProjectionError> {
+            Err(ProjectionError::Source {
+                operation: "failing_upsert",
+            })
+        }
+
+        async fn remove_pending_gate(
+            &self,
+            _key: PendingGateProjectionKey,
+            _source_cursor: TurnEventCursor,
+        ) -> Result<(), ProjectionError> {
+            Err(ProjectionError::Source {
+                operation: "failing_remove",
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_maps_projection_failure_to_turn_unavailable() {
+        let projection = PendingGateProjection::new(
+            Arc::new(FailingSink),
+            Arc::new(MemoryCursorStore::default()),
+        );
+        let err = projection
+            .publish(blocked_event(1, scope("thread-a"), TurnRunId::new()))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ironclaw_turns::TurnError::Unavailable { .. }));
+    }
+
+    #[tokio::test]
+    async fn malformed_blocked_metadata_errors_without_advancing_cursor() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink, cursor_store.clone());
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+
+        for mutate in [
+            |event: &mut TurnLifecycleEvent| event.blocked_gate = None,
+            |event: &mut TurnLifecycleEvent| event.occurred_at = None,
+            |event: &mut TurnLifecycleEvent| event.owner_user_id = None,
+        ] {
+            let mut event = blocked_event(1, scope.clone(), run_id);
+            mutate(&mut event);
+            projection.project_event(event, true).await.unwrap_err();
+            assert_eq!(
+                cursor_store
+                    .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+                    .await
+                    .unwrap(),
+                TurnEventCursor::default()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_and_resource_blocked_events_upsert_expected_gate_kinds() {
+        for (status, source_kind, projected_kind, gate_ref) in [
+            (
+                TurnStatus::BlockedAuth,
+                TurnBlockedGateKind::Auth,
+                PendingGateProjectionGateKind::Auth,
+                "gate:auth-a",
+            ),
+            (
+                TurnStatus::BlockedResource,
+                TurnBlockedGateKind::Resource,
+                PendingGateProjectionGateKind::Resource,
+                "gate:resource-a",
+            ),
+        ] {
+            let sink = Arc::new(MemorySink::default());
+            let cursor_store = Arc::new(MemoryCursorStore::default());
+            let projection = projection(sink.clone(), cursor_store);
+            let scope = scope("thread-a");
+            let run_id = TurnRunId::new();
+
+            projection
+                .project_event(
+                    blocked_event_with(1, scope, run_id, status, source_kind, gate_ref),
+                    true,
+                )
+                .await
+                .unwrap();
+
+            let rows = sink.rows();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].gate_kind, projected_kind);
+            assert_eq!(rows[0].gate_ref, gate_ref);
+        }
+    }
+
+    #[tokio::test]
+    async fn resumed_and_terminal_events_remove_exact_row() {
+        for (status, kind) in [
+            (TurnStatus::Queued, TurnEventKind::Resumed),
+            (TurnStatus::Completed, TurnEventKind::Completed),
+            (TurnStatus::Failed, TurnEventKind::Failed),
+            (TurnStatus::Cancelled, TurnEventKind::Cancelled),
+        ] {
+            let sink = Arc::new(MemorySink::default());
+            let cursor_store = Arc::new(MemoryCursorStore::default());
+            let projection = projection(sink.clone(), cursor_store);
+            let scope = scope("thread-a");
+            let run_id = TurnRunId::new();
+
+            projection
+                .project_event(blocked_event(1, scope.clone(), run_id), true)
+                .await
+                .unwrap();
+            projection
+                .project_event(
+                    lifecycle_event(2, scope, run_id, status, kind.clone()),
+                    true,
+                )
+                .await
+                .unwrap();
+
+            assert!(sink.rows().is_empty(), "failed to remove for {kind:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn replaying_same_stream_is_idempotent() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store.clone());
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+        let source = MemoryTurnEventSource::new(vec![blocked_event(1, scope.clone(), run_id)]);
+
+        projection.replay_scope(&source, &scope, 100).await.unwrap();
+        cursor_store.set(
+            PENDING_GATE_PROJECTION_CONSUMER_ID,
+            &scope,
+            TurnEventCursor::default(),
+        );
+        projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+        assert_eq!(sink.rows().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_replay_blocked_event_does_not_resurrect_live_removed_gate() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store);
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+
+        projection
+            .publish(lifecycle_event(
+                2,
+                scope.clone(),
+                run_id,
+                TurnStatus::Completed,
+                TurnEventKind::Completed,
+            ))
+            .await
+            .unwrap();
+        projection
+            .project_event(blocked_event(1, scope, run_id), false)
+            .await
+            .unwrap();
+
+        assert!(
+            sink.rows().is_empty(),
+            "older replay upsert must not resurrect a gate removed by newer live delivery"
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_recovers_when_crash_happens_after_row_write_before_cursor_advance() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store);
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+        let source = MemoryTurnEventSource::new(vec![
+            blocked_event(1, scope.clone(), run_id),
+            lifecycle_event(
+                2,
+                scope.clone(),
+                run_id,
+                TurnStatus::Completed,
+                TurnEventKind::Completed,
+            ),
+        ]);
+
+        sink.upsert_pending_gate(
+            row_from_blocked_event(&blocked_event(1, scope.clone(), run_id)).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+        assert_eq!(replay.processed, 2);
+        assert_eq!(replay.next_cursor, TurnEventCursor(2));
+        assert!(sink.rows().is_empty());
+    }
+
+    #[tokio::test]
+    async fn replay_recovers_when_crash_happens_after_remove_before_cursor_advance() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store.clone());
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+        let source = MemoryTurnEventSource::new(vec![
+            blocked_event(1, scope.clone(), run_id),
+            lifecycle_event(
+                2,
+                scope.clone(),
+                run_id,
+                TurnStatus::Completed,
+                TurnEventKind::Completed,
+            ),
+        ]);
+
+        cursor_store.set(
+            PENDING_GATE_PROJECTION_CONSUMER_ID,
+            &scope,
+            TurnEventCursor(1),
+        );
+
+        let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+        assert_eq!(replay.processed, 1);
+        assert_eq!(replay.next_cursor, TurnEventCursor(2));
+        assert!(sink.rows().is_empty());
+    }
+
+    #[tokio::test]
+    async fn replay_advances_cursor_once_per_page_after_successful_projection() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink, cursor_store.clone());
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+        let source = MemoryTurnEventSource::new(vec![
+            blocked_event(1, scope.clone(), run_id),
+            lifecycle_event(
+                2,
+                scope.clone(),
+                run_id,
+                TurnStatus::Completed,
+                TurnEventKind::Completed,
+            ),
+        ]);
+
+        projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+        assert_eq!(cursor_store.advances(), vec![TurnEventCursor(2)]);
+    }
+
+    #[tokio::test]
+    async fn replay_caps_requested_page_size() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink, cursor_store);
+        let scope = scope("thread-a");
+        let events = (1..=MAX_TURN_EVENT_PROJECTION_LIMIT as u64 + 1)
+            .map(|cursor| blocked_event(cursor, scope.clone(), TurnRunId::new()))
+            .collect::<Vec<_>>();
+        let source = MemoryTurnEventSource::new(events);
+
+        let replay = projection
+            .replay_scope(&source, &scope, MAX_TURN_EVENT_PROJECTION_LIMIT + 10)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            source.requested_limits(),
+            vec![MAX_TURN_EVENT_PROJECTION_LIMIT]
+        );
+        assert_eq!(replay.processed, MAX_TURN_EVENT_PROJECTION_LIMIT);
+        assert!(replay.truncated);
+    }
+
+    #[tokio::test]
+    async fn replay_scope_error_exits_do_not_mutate_rows_or_cursor() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store.clone());
+        let scope = scope("thread-a");
+        let source = MemoryTurnEventSource::new(Vec::new());
+
+        projection
+            .replay_scope(&source, &scope, 0)
+            .await
+            .unwrap_err();
+        projection
+            .replay_scope(&FailingTurnEventSource, &scope, 100)
+            .await
+            .unwrap_err();
+        projection
+            .replay_scope(&RebaseTurnEventSource, &scope, 100)
+            .await
+            .unwrap_err();
+
+        assert!(sink.rows().is_empty());
+        assert_eq!(
+            cursor_store
+                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+                .await
+                .unwrap(),
+            TurnEventCursor::default()
+        );
+        assert!(cursor_store.advances().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cursor_advance_is_monotonic_under_interleaved_replay() {
+        let cursor_store = MemoryCursorStore::default();
+        let scope = scope("thread-a");
+
+        cursor_store
+            .advance_pending_gate_cursor(
+                PENDING_GATE_PROJECTION_CONSUMER_ID,
+                &scope,
+                TurnEventCursor(100),
+            )
+            .await
+            .unwrap();
+        cursor_store
+            .advance_pending_gate_cursor(
+                PENDING_GATE_PROJECTION_CONSUMER_ID,
+                &scope,
+                TurnEventCursor(1),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            cursor_store
+                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+                .await
+                .unwrap(),
+            TurnEventCursor(100)
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_remove_does_not_delete_neighboring_runs() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store);
+        let scope = scope("thread-a");
+        let removed_run = TurnRunId::new();
+        let kept_run = TurnRunId::new();
+
+        projection
+            .project_event(blocked_event(1, scope.clone(), removed_run), true)
+            .await
+            .unwrap();
+        projection
+            .project_event(blocked_event(2, scope.clone(), kept_run), true)
+            .await
+            .unwrap();
+        projection
+            .project_event(
+                lifecycle_event(
+                    3,
+                    scope,
+                    removed_run,
+                    TurnStatus::Completed,
+                    TurnEventKind::Completed,
+                ),
+                true,
+            )
+            .await
+            .unwrap();
+
+        let rows = sink.rows();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key.run_id, kept_run);
+    }
+
+    #[tokio::test]
+    async fn terminal_remove_preserves_same_thread_rows_in_other_agent_project_scopes() {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store);
+        let tenant = TenantId::new("tenant-a").expect("tenant");
+        let thread = ThreadId::new("thread-a").expect("thread");
+        let scope_a = TurnScope::new(
+            tenant.clone(),
+            Some(AgentId::new("agent-a").expect("agent")),
+            Some(ProjectId::new("project-a").expect("project")),
+            thread.clone(),
+        );
+        let scope_b = TurnScope::new(
+            tenant,
+            Some(AgentId::new("agent-b").expect("agent")),
+            Some(ProjectId::new("project-b").expect("project")),
+            thread,
+        );
+        let removed_run = TurnRunId::new();
+        let kept_run = TurnRunId::new();
+
+        projection
+            .project_event(blocked_event(1, scope_a.clone(), removed_run), false)
+            .await
+            .unwrap();
+        projection
+            .project_event(blocked_event(2, scope_b, kept_run), false)
+            .await
+            .unwrap();
+        projection
+            .project_event(
+                lifecycle_event(
+                    3,
+                    scope_a,
+                    removed_run,
+                    TurnStatus::Completed,
+                    TurnEventKind::Completed,
+                ),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let rows = sink.rows();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key.run_id, kept_run);
+        assert_eq!(rows[0].key.agent_id.as_ref().unwrap().as_str(), "agent-b");
+        assert_eq!(
+            rows[0].key.project_id.as_ref().unwrap().as_str(),
+            "project-b"
+        );
+    }
+}

--- a/crates/ironclaw_event_projections/src/pending_gate_projection/tests.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection/tests.rs
@@ -1,0 +1,584 @@
+mod support;
+
+use std::sync::Arc;
+
+use ironclaw_turns::{TurnBlockedGateKind, TurnEventKind, TurnRunId, TurnStatus};
+
+use super::*;
+use support::*;
+
+#[tokio::test]
+async fn blocked_event_upserts_pending_gate_row() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store.clone());
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+
+    projection
+        .project_event(blocked_event(1, scope.clone(), run_id), true)
+        .await
+        .unwrap();
+
+    let rows = sink.rows();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.key.tenant_id, scope.tenant_id);
+    assert_eq!(row.key.agent_id, scope.agent_id);
+    assert_eq!(row.key.project_id, scope.project_id);
+    assert_eq!(row.key.owner_user_id.as_str(), "owner-a");
+    assert_eq!(row.key.thread_id, scope.thread_id);
+    assert_eq!(row.key.run_id, run_id);
+    assert_eq!(row.source_cursor, TurnEventCursor(1));
+    assert_eq!(row.gate_kind, PendingGateKind::Approval);
+    assert_eq!(row.gate_ref, "gate:approval-a");
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor(1)
+    );
+}
+
+#[tokio::test]
+async fn publish_projects_blocked_event_without_advancing_replay_cursor() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store.clone());
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+
+    projection
+        .publish(blocked_event(7, scope.clone(), run_id))
+        .await
+        .unwrap();
+
+    assert_eq!(sink.rows().len(), 1);
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor::default(),
+        "live tail projection must not skip durable replay backlog"
+    );
+}
+
+#[derive(Default)]
+struct FailingSink;
+
+#[async_trait]
+impl PendingGateProjectionSink for FailingSink {
+    async fn upsert_pending_gate(
+        &self,
+        _row: PendingGateProjectionRow,
+    ) -> Result<(), ProjectionError> {
+        Err(ProjectionError::Source {
+            operation: "failing_upsert",
+        })
+    }
+
+    async fn remove_pending_gate(
+        &self,
+        _key: PendingGateProjectionKey,
+        _source_cursor: TurnEventCursor,
+    ) -> Result<(), ProjectionError> {
+        Err(ProjectionError::Source {
+            operation: "failing_remove",
+        })
+    }
+}
+
+#[tokio::test]
+async fn publish_maps_projection_failure_to_turn_unavailable() {
+    let projection = PendingGateProjection::new(
+        Arc::new(FailingSink),
+        Arc::new(MemoryCursorStore::default()),
+    );
+    let err = projection
+        .publish(blocked_event(1, scope("thread-a"), TurnRunId::new()))
+        .await
+        .unwrap_err();
+
+    match err {
+        ironclaw_turns::TurnError::Unavailable { reason } => {
+            assert!(reason.contains("failing_upsert"));
+        }
+        other => panic!("expected unavailable error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn publish_maps_invalid_projection_failure_to_turn_invalid_request() {
+    let projection = PendingGateProjection::new(
+        Arc::new(MemorySink::default()),
+        Arc::new(MemoryCursorStore::default()),
+    );
+    let mut event = blocked_event(1, scope("thread-a"), TurnRunId::new());
+    event.blocked_gate = None;
+
+    let err = projection.publish(event).await.unwrap_err();
+
+    match err {
+        ironclaw_turns::TurnError::InvalidRequest { reason } => {
+            assert!(reason.contains("blocked turn event missing gate metadata"));
+        }
+        other => panic!("expected invalid request error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn blocked_event_with_non_projectable_status_does_not_upsert_row() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store);
+    let scope = scope("thread-a");
+
+    projection
+        .project_event(
+            blocked_event_with(
+                1,
+                scope,
+                TurnRunId::new(),
+                TurnStatus::Running,
+                TurnBlockedGateKind::Approval,
+                "gate:approval-a",
+            ),
+            true,
+        )
+        .await
+        .unwrap();
+
+    assert!(sink.rows().is_empty());
+}
+
+#[tokio::test]
+async fn malformed_blocked_metadata_errors_without_advancing_cursor() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink, cursor_store.clone());
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+
+    for mutate in [
+        |event: &mut TurnLifecycleEvent| event.blocked_gate = None,
+        |event: &mut TurnLifecycleEvent| event.occurred_at = None,
+        |event: &mut TurnLifecycleEvent| event.owner_user_id = None,
+    ] {
+        let mut event = blocked_event(1, scope.clone(), run_id);
+        mutate(&mut event);
+        projection.project_event(event, true).await.unwrap_err();
+        assert_eq!(
+            cursor_store
+                .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+                .await
+                .unwrap(),
+            TurnEventCursor::default()
+        );
+    }
+}
+
+#[tokio::test]
+async fn auth_and_resource_blocked_events_upsert_expected_gate_kinds() {
+    for (status, source_kind, projected_kind, gate_ref) in [
+        (
+            TurnStatus::BlockedAuth,
+            TurnBlockedGateKind::Auth,
+            PendingGateKind::Auth,
+            "gate:auth-a",
+        ),
+        (
+            TurnStatus::BlockedResource,
+            TurnBlockedGateKind::Resource,
+            PendingGateKind::Resource,
+            "gate:resource-a",
+        ),
+    ] {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store);
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+
+        projection
+            .project_event(
+                blocked_event_with(1, scope, run_id, status, source_kind, gate_ref),
+                true,
+            )
+            .await
+            .unwrap();
+
+        let rows = sink.rows();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].gate_kind, projected_kind);
+        assert_eq!(rows[0].gate_ref, gate_ref);
+    }
+}
+
+#[tokio::test]
+async fn resumed_and_terminal_events_remove_exact_row() {
+    for (status, kind) in [
+        (TurnStatus::Queued, TurnEventKind::Resumed),
+        (TurnStatus::Completed, TurnEventKind::Completed),
+        (TurnStatus::Failed, TurnEventKind::Failed),
+        (TurnStatus::Cancelled, TurnEventKind::Cancelled),
+    ] {
+        let sink = Arc::new(MemorySink::default());
+        let cursor_store = Arc::new(MemoryCursorStore::default());
+        let projection = projection(sink.clone(), cursor_store);
+        let scope = scope("thread-a");
+        let run_id = TurnRunId::new();
+
+        projection
+            .project_event(blocked_event(1, scope.clone(), run_id), true)
+            .await
+            .unwrap();
+        projection
+            .project_event(
+                lifecycle_event(2, scope, run_id, status, kind.clone()),
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert!(sink.rows().is_empty(), "failed to remove for {kind:?}");
+    }
+}
+
+#[tokio::test]
+async fn replaying_same_stream_is_idempotent() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store.clone());
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+    let source = MemoryTurnEventSource::new(vec![blocked_event(1, scope.clone(), run_id)]);
+
+    projection.replay_scope(&source, &scope, 100).await.unwrap();
+    cursor_store.set(
+        PENDING_GATE_PROJECTION_CONSUMER_ID,
+        &scope,
+        TurnEventCursor::default(),
+    );
+    projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+    assert_eq!(sink.rows().len(), 1);
+}
+
+#[tokio::test]
+async fn stale_replay_blocked_event_does_not_resurrect_live_removed_gate() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store);
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+
+    projection
+        .publish(lifecycle_event(
+            2,
+            scope.clone(),
+            run_id,
+            TurnStatus::Completed,
+            TurnEventKind::Completed,
+        ))
+        .await
+        .unwrap();
+    projection
+        .project_event(blocked_event(1, scope, run_id), false)
+        .await
+        .unwrap();
+
+    assert!(
+        sink.rows().is_empty(),
+        "older replay upsert must not resurrect a gate removed by newer live delivery"
+    );
+}
+
+#[tokio::test]
+async fn replay_recovers_when_crash_happens_after_row_write_before_cursor_advance() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store);
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+    let source = MemoryTurnEventSource::new(vec![
+        blocked_event(1, scope.clone(), run_id),
+        lifecycle_event(
+            2,
+            scope.clone(),
+            run_id,
+            TurnStatus::Completed,
+            TurnEventKind::Completed,
+        ),
+    ]);
+
+    sink.upsert_pending_gate(
+        row_from_blocked_event(
+            &blocked_event(1, scope.clone(), run_id),
+            TurnBlockedGateKind::Approval,
+        )
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+    assert_eq!(replay.processed, 2);
+    assert_eq!(replay.next_cursor, TurnEventCursor(2));
+    assert!(sink.rows().is_empty());
+}
+
+#[tokio::test]
+async fn replay_recovers_when_crash_happens_after_remove_before_cursor_advance() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store.clone());
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+    let source = MemoryTurnEventSource::new(vec![
+        blocked_event(1, scope.clone(), run_id),
+        lifecycle_event(
+            2,
+            scope.clone(),
+            run_id,
+            TurnStatus::Completed,
+            TurnEventKind::Completed,
+        ),
+    ]);
+
+    cursor_store.set(
+        PENDING_GATE_PROJECTION_CONSUMER_ID,
+        &scope,
+        TurnEventCursor(1),
+    );
+
+    let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+    assert_eq!(replay.processed, 1);
+    assert_eq!(replay.next_cursor, TurnEventCursor(2));
+    assert!(sink.rows().is_empty());
+}
+
+#[tokio::test]
+async fn replay_advances_cursor_once_per_page_after_successful_projection() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink, cursor_store.clone());
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+    let source = MemoryTurnEventSource::new(vec![
+        blocked_event(1, scope.clone(), run_id),
+        lifecycle_event(
+            2,
+            scope.clone(),
+            run_id,
+            TurnStatus::Completed,
+            TurnEventKind::Completed,
+        ),
+    ]);
+
+    projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+    assert_eq!(cursor_store.advances(), vec![TurnEventCursor(2)]);
+}
+
+#[tokio::test]
+async fn replay_caps_requested_page_size() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink, cursor_store);
+    let scope = scope("thread-a");
+    let events = (1..=MAX_TURN_EVENT_PROJECTION_LIMIT as u64 + 1)
+        .map(|cursor| blocked_event(cursor, scope.clone(), TurnRunId::new()))
+        .collect::<Vec<_>>();
+    let source = MemoryTurnEventSource::new(events);
+
+    let replay = projection
+        .replay_scope(&source, &scope, MAX_TURN_EVENT_PROJECTION_LIMIT + 10)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        source.requested_limits(),
+        vec![MAX_TURN_EVENT_PROJECTION_LIMIT]
+    );
+    assert_eq!(replay.processed, MAX_TURN_EVENT_PROJECTION_LIMIT);
+    assert!(replay.truncated);
+}
+
+#[tokio::test]
+async fn replay_scope_error_exits_do_not_mutate_rows_or_cursor() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store.clone());
+    let scope = scope("thread-a");
+    let source = MemoryTurnEventSource::new(Vec::new());
+
+    projection
+        .replay_scope(&source, &scope, 0)
+        .await
+        .unwrap_err();
+    projection
+        .replay_scope(&FailingTurnEventSource, &scope, 100)
+        .await
+        .unwrap_err();
+    projection
+        .replay_scope(&RebaseTurnEventSource, &scope, 100)
+        .await
+        .unwrap_err();
+
+    assert!(sink.rows().is_empty());
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor::default()
+    );
+    assert!(cursor_store.advances().is_empty());
+}
+
+#[tokio::test]
+async fn replay_scope_reports_turn_event_rebase_required() {
+    let projection = PendingGateProjection::new(
+        Arc::new(MemorySink::default()),
+        Arc::new(MemoryCursorStore::default()),
+    );
+    let scope = scope("thread-a");
+
+    let err = projection
+        .replay_scope(&RebaseTurnEventSource, &scope, 100)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ProjectionError::TurnEventRebaseRequired {
+            requested: TurnEventCursor(0),
+            earliest: TurnEventCursor(5)
+        }
+    ));
+}
+
+#[tokio::test]
+async fn cursor_advance_is_monotonic_under_interleaved_replay() {
+    let cursor_store = MemoryCursorStore::default();
+    let scope = scope("thread-a");
+
+    cursor_store
+        .advance_pending_gate_cursor(
+            PENDING_GATE_PROJECTION_CONSUMER_ID,
+            &scope,
+            TurnEventCursor(100),
+        )
+        .await
+        .unwrap();
+    cursor_store
+        .advance_pending_gate_cursor(
+            PENDING_GATE_PROJECTION_CONSUMER_ID,
+            &scope,
+            TurnEventCursor(1),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor(100)
+    );
+}
+
+#[tokio::test]
+async fn terminal_remove_does_not_delete_neighboring_runs() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store);
+    let scope = scope("thread-a");
+    let removed_run = TurnRunId::new();
+    let kept_run = TurnRunId::new();
+
+    projection
+        .project_event(blocked_event(1, scope.clone(), removed_run), true)
+        .await
+        .unwrap();
+    projection
+        .project_event(blocked_event(2, scope.clone(), kept_run), true)
+        .await
+        .unwrap();
+    projection
+        .project_event(
+            lifecycle_event(
+                3,
+                scope,
+                removed_run,
+                TurnStatus::Completed,
+                TurnEventKind::Completed,
+            ),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let rows = sink.rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key.run_id, kept_run);
+}
+
+#[tokio::test]
+async fn terminal_remove_preserves_same_thread_rows_in_other_agent_project_scopes() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store);
+    let tenant = TenantId::new("tenant-a").expect("tenant");
+    let thread = ThreadId::new("thread-a").expect("thread");
+    let scope_a = TurnScope::new(
+        tenant.clone(),
+        Some(AgentId::new("agent-a").expect("agent")),
+        Some(ProjectId::new("project-a").expect("project")),
+        thread.clone(),
+    );
+    let scope_b = TurnScope::new(
+        tenant,
+        Some(AgentId::new("agent-b").expect("agent")),
+        Some(ProjectId::new("project-b").expect("project")),
+        thread,
+    );
+    let removed_run = TurnRunId::new();
+    let kept_run = TurnRunId::new();
+
+    projection
+        .project_event(blocked_event(1, scope_a.clone(), removed_run), false)
+        .await
+        .unwrap();
+    projection
+        .project_event(blocked_event(2, scope_b, kept_run), false)
+        .await
+        .unwrap();
+    projection
+        .project_event(
+            lifecycle_event(
+                3,
+                scope_a,
+                removed_run,
+                TurnStatus::Completed,
+                TurnEventKind::Completed,
+            ),
+            false,
+        )
+        .await
+        .unwrap();
+
+    let rows = sink.rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key.run_id, kept_run);
+    assert_eq!(rows[0].key.agent_id.as_ref().unwrap().as_str(), "agent-b");
+    assert_eq!(
+        rows[0].key.project_id.as_ref().unwrap().as_str(),
+        "project-b"
+    );
+}

--- a/crates/ironclaw_event_projections/src/pending_gate_projection/tests/mod.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection/tests/mod.rs
@@ -2,7 +2,7 @@ mod support;
 
 use std::sync::Arc;
 
-use ironclaw_turns::{TurnBlockedGateKind, TurnEventKind, TurnRunId, TurnStatus};
+use ironclaw_turns::{GateRef, TurnBlockedGateKind, TurnEventKind, TurnRunId, TurnStatus};
 
 use super::*;
 use support::*;
@@ -31,7 +31,7 @@ async fn blocked_event_upserts_pending_gate_row() {
     assert_eq!(row.key.run_id, run_id);
     assert_eq!(row.source_cursor, TurnEventCursor(1));
     assert_eq!(row.gate_kind, PendingGateKind::Approval);
-    assert_eq!(row.gate_ref, "gate:approval-a");
+    assert_eq!(row.gate_ref.as_str(), "gate:approval-a");
     assert_eq!(
         cursor_store
             .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
@@ -212,7 +212,7 @@ async fn auth_and_resource_blocked_events_upsert_expected_gate_kinds() {
         let rows = sink.rows();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].gate_kind, projected_kind);
-        assert_eq!(rows[0].gate_ref, gate_ref);
+        assert_eq!(rows[0].gate_ref.as_str(), gate_ref);
     }
 }
 
@@ -382,6 +382,119 @@ async fn replay_advances_cursor_once_per_page_after_successful_projection() {
     projection.replay_scope(&source, &scope, 100).await.unwrap();
 
     assert_eq!(cursor_store.advances(), vec![TurnEventCursor(2)]);
+}
+
+#[tokio::test]
+async fn replay_skips_legacy_events_missing_projection_metadata_and_advances_cursor() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store.clone());
+    let scope = scope("thread-a");
+    let legacy_run = TurnRunId::new();
+    let blocked_run = TurnRunId::new();
+    let mut legacy_terminal = lifecycle_event(
+        1,
+        scope.clone(),
+        legacy_run,
+        TurnStatus::Completed,
+        TurnEventKind::Completed,
+    );
+    legacy_terminal.owner_user_id = None;
+    let source = MemoryTurnEventSource::new(vec![
+        legacy_terminal,
+        blocked_event(2, scope.clone(), blocked_run),
+    ]);
+
+    let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+    assert_eq!(replay.processed, 2);
+    assert_eq!(replay.next_cursor, TurnEventCursor(2));
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor(2)
+    );
+    let rows = sink.rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key.run_id, blocked_run);
+}
+
+#[tokio::test]
+async fn custom_consumer_id_uses_isolated_replay_cursor() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let scope = scope("thread-a");
+    let run_one = TurnRunId::new();
+    let run_two = TurnRunId::new();
+    let source = MemoryTurnEventSource::new(vec![
+        blocked_event(1, scope.clone(), run_one),
+        blocked_event(2, scope.clone(), run_two),
+    ]);
+    cursor_store.set("pending_gate_projection.test.a", &scope, TurnEventCursor(1));
+    let projection_a = PendingGateProjection::with_consumer_id(
+        "pending_gate_projection.test.a",
+        sink.clone(),
+        cursor_store.clone(),
+    );
+    let projection_b = PendingGateProjection::with_consumer_id(
+        "pending_gate_projection.test.b",
+        sink,
+        cursor_store.clone(),
+    );
+
+    let replay_a = projection_a
+        .replay_scope(&source, &scope, 100)
+        .await
+        .unwrap();
+    let replay_b = projection_b
+        .replay_scope(&source, &scope, 100)
+        .await
+        .unwrap();
+
+    assert_eq!(replay_a.processed, 1);
+    assert_eq!(replay_b.processed, 2);
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor("pending_gate_projection.test.a", &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor(2)
+    );
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor("pending_gate_projection.test.b", &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor(2)
+    );
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor::default()
+    );
+}
+
+#[test]
+fn pending_gate_row_keeps_gate_ref_strongly_typed() {
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = GateRef::new("gate:typed-a").expect("gate ref");
+    let event = blocked_event_with(
+        1,
+        scope,
+        run_id,
+        TurnStatus::BlockedApproval,
+        TurnBlockedGateKind::Approval,
+        gate_ref.as_str(),
+    );
+
+    let row = row_from_blocked_event(&event, TurnBlockedGateKind::Approval).unwrap();
+
+    assert_eq!(row.gate_ref, gate_ref);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_event_projections/src/pending_gate_projection/tests/mod.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection/tests/mod.rs
@@ -321,11 +321,7 @@ async fn replay_recovers_when_crash_happens_after_row_write_before_cursor_advanc
     ]);
 
     sink.upsert_pending_gate(
-        row_from_blocked_event(
-            &blocked_event(1, scope.clone(), run_id),
-            TurnBlockedGateKind::Approval,
-        )
-        .unwrap(),
+        row_from_blocked_event(&blocked_event(1, scope.clone(), run_id)).unwrap(),
     )
     .await
     .unwrap();
@@ -499,7 +495,7 @@ fn pending_gate_row_keeps_gate_ref_strongly_typed() {
         gate_ref.as_str(),
     );
 
-    let row = row_from_blocked_event(&event, TurnBlockedGateKind::Approval).unwrap();
+    let row = row_from_blocked_event(&event).unwrap();
 
     assert_eq!(row.gate_ref, gate_ref);
 }

--- a/crates/ironclaw_event_projections/src/pending_gate_projection/tests/mod.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection/tests/mod.rs
@@ -16,7 +16,7 @@ async fn blocked_event_upserts_pending_gate_row() {
     let run_id = TurnRunId::new();
 
     projection
-        .project_event(blocked_event(1, scope.clone(), run_id), true)
+        .project_event_and_advance_cursor(blocked_event(1, scope.clone(), run_id))
         .await
         .unwrap();
 
@@ -136,17 +136,14 @@ async fn blocked_event_with_non_projectable_status_does_not_upsert_row() {
     let scope = scope("thread-a");
 
     projection
-        .project_event(
-            blocked_event_with(
-                1,
-                scope,
-                TurnRunId::new(),
-                TurnStatus::Running,
-                TurnBlockedGateKind::Approval,
-                "gate:approval-a",
-            ),
-            true,
-        )
+        .project_event_and_advance_cursor(blocked_event_with(
+            1,
+            scope,
+            TurnRunId::new(),
+            TurnStatus::Running,
+            TurnBlockedGateKind::Approval,
+            "gate:approval-a",
+        ))
         .await
         .unwrap();
 
@@ -168,7 +165,10 @@ async fn malformed_blocked_metadata_errors_without_advancing_cursor() {
     ] {
         let mut event = blocked_event(1, scope.clone(), run_id);
         mutate(&mut event);
-        projection.project_event(event, true).await.unwrap_err();
+        projection
+            .project_event_and_advance_cursor(event)
+            .await
+            .unwrap_err();
         assert_eq!(
             cursor_store
                 .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
@@ -202,10 +202,14 @@ async fn auth_and_resource_blocked_events_upsert_expected_gate_kinds() {
         let run_id = TurnRunId::new();
 
         projection
-            .project_event(
-                blocked_event_with(1, scope, run_id, status, source_kind, gate_ref),
-                true,
-            )
+            .project_event_and_advance_cursor(blocked_event_with(
+                1,
+                scope,
+                run_id,
+                status,
+                source_kind,
+                gate_ref,
+            ))
             .await
             .unwrap();
 
@@ -231,14 +235,17 @@ async fn resumed_and_terminal_events_remove_exact_row() {
         let run_id = TurnRunId::new();
 
         projection
-            .project_event(blocked_event(1, scope.clone(), run_id), true)
+            .project_event_and_advance_cursor(blocked_event(1, scope.clone(), run_id))
             .await
             .unwrap();
         projection
-            .project_event(
-                lifecycle_event(2, scope, run_id, status, kind.clone()),
-                true,
-            )
+            .project_event_and_advance_cursor(lifecycle_event(
+                2,
+                scope,
+                run_id,
+                status,
+                kind.clone(),
+            ))
             .await
             .unwrap();
 
@@ -285,7 +292,7 @@ async fn stale_replay_blocked_event_does_not_resurrect_live_removed_gate() {
         .await
         .unwrap();
     projection
-        .project_event(blocked_event(1, scope, run_id), false)
+        .project_event(blocked_event(1, scope, run_id))
         .await
         .unwrap();
 
@@ -616,24 +623,21 @@ async fn terminal_remove_does_not_delete_neighboring_runs() {
     let kept_run = TurnRunId::new();
 
     projection
-        .project_event(blocked_event(1, scope.clone(), removed_run), true)
+        .project_event_and_advance_cursor(blocked_event(1, scope.clone(), removed_run))
         .await
         .unwrap();
     projection
-        .project_event(blocked_event(2, scope.clone(), kept_run), true)
+        .project_event_and_advance_cursor(blocked_event(2, scope.clone(), kept_run))
         .await
         .unwrap();
     projection
-        .project_event(
-            lifecycle_event(
-                3,
-                scope,
-                removed_run,
-                TurnStatus::Completed,
-                TurnEventKind::Completed,
-            ),
-            true,
-        )
+        .project_event_and_advance_cursor(lifecycle_event(
+            3,
+            scope,
+            removed_run,
+            TurnStatus::Completed,
+            TurnEventKind::Completed,
+        ))
         .await
         .unwrap();
 
@@ -665,24 +669,21 @@ async fn terminal_remove_preserves_same_thread_rows_in_other_agent_project_scope
     let kept_run = TurnRunId::new();
 
     projection
-        .project_event(blocked_event(1, scope_a.clone(), removed_run), false)
+        .project_event(blocked_event(1, scope_a.clone(), removed_run))
         .await
         .unwrap();
     projection
-        .project_event(blocked_event(2, scope_b, kept_run), false)
+        .project_event(blocked_event(2, scope_b, kept_run))
         .await
         .unwrap();
     projection
-        .project_event(
-            lifecycle_event(
-                3,
-                scope_a,
-                removed_run,
-                TurnStatus::Completed,
-                TurnEventKind::Completed,
-            ),
-            false,
-        )
+        .project_event(lifecycle_event(
+            3,
+            scope_a,
+            removed_run,
+            TurnStatus::Completed,
+            TurnEventKind::Completed,
+        ))
         .await
         .unwrap();
 
@@ -693,5 +694,93 @@ async fn terminal_remove_preserves_same_thread_rows_in_other_agent_project_scope
     assert_eq!(
         rows[0].key.project_id.as_ref().unwrap().as_str(),
         "project-b"
+    );
+}
+
+// Cursor store that fails on `advance_pending_gate_cursor` after the first
+// successful sink write, used to exercise the post-write cursor-failure path.
+struct CursorAdvanceFailingStore;
+
+#[async_trait]
+impl PendingGateProjectionCursorStore for CursorAdvanceFailingStore {
+    async fn load_pending_gate_cursor(
+        &self,
+        _consumer_id: &str,
+        _scope: &TurnScope,
+    ) -> Result<TurnEventCursor, ProjectionError> {
+        Ok(TurnEventCursor::default())
+    }
+
+    async fn advance_pending_gate_cursor(
+        &self,
+        _consumer_id: &str,
+        _scope: &TurnScope,
+        _cursor: TurnEventCursor,
+    ) -> Result<(), ProjectionError> {
+        Err(ProjectionError::Source {
+            operation: "advance_failing",
+        })
+    }
+}
+
+#[tokio::test]
+async fn replay_scope_surfaces_cursor_advance_failure_after_sink_writes() {
+    let sink = Arc::new(MemorySink::default());
+    let projection = PendingGateProjection::new(sink.clone(), Arc::new(CursorAdvanceFailingStore));
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+    let source = MemoryTurnEventSource::new(vec![blocked_event(1, scope.clone(), run_id)]);
+
+    let err = projection
+        .replay_scope(&source, &scope, 100)
+        .await
+        .expect_err("cursor advance failure must surface");
+
+    assert!(matches!(
+        err,
+        ProjectionError::Source {
+            operation: "advance_failing"
+        }
+    ));
+
+    // Sink wrote the row; on retry the per-key cursor guard in a real sink
+    // suppresses the duplicate upsert. Verifying the row is present
+    // exercises the at-least-once contract this finding raises.
+    assert_eq!(sink.rows().len(), 1);
+}
+
+#[tokio::test]
+async fn replay_skips_non_projectable_event_kinds_and_advances_cursor() {
+    let sink = Arc::new(MemorySink::default());
+    let cursor_store = Arc::new(MemoryCursorStore::default());
+    let projection = projection(sink.clone(), cursor_store.clone());
+    let scope = scope("thread-a");
+    let run_id = TurnRunId::new();
+
+    // Submitted lifecycle event is a non-projectable kind — replay must
+    // advance the cursor past it without writing or removing any row.
+    let mut submitted = lifecycle_event(
+        1,
+        scope.clone(),
+        run_id,
+        TurnStatus::Queued,
+        TurnEventKind::Submitted,
+    );
+    // Drop owner metadata to also verify the silent-skip path does not need
+    // projection metadata for non-projectable kinds.
+    submitted.owner_user_id = None;
+    let source = MemoryTurnEventSource::new(vec![submitted]);
+
+    let replay = projection.replay_scope(&source, &scope, 100).await.unwrap();
+
+    assert_eq!(replay.processed, 1);
+    assert_eq!(replay.next_cursor, TurnEventCursor(1));
+    assert!(sink.rows().is_empty());
+    assert_eq!(
+        cursor_store
+            .load_pending_gate_cursor(PENDING_GATE_PROJECTION_CONSUMER_ID, &scope)
+            .await
+            .unwrap(),
+        TurnEventCursor(1)
     );
 }

--- a/crates/ironclaw_event_projections/src/pending_gate_projection/tests/support.rs
+++ b/crates/ironclaw_event_projections/src/pending_gate_projection/tests/support.rs
@@ -1,0 +1,281 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
+use ironclaw_turns::{GateRef, TurnBlockedGateMetadata, TurnStatus};
+
+use super::super::*;
+
+#[derive(Default)]
+pub(super) struct MemorySink {
+    rows: Mutex<HashMap<PendingGateProjectionKey, PendingGateProjectionRow>>,
+    last_applied: Mutex<HashMap<PendingGateProjectionKey, TurnEventCursor>>,
+}
+
+impl MemorySink {
+    pub(super) fn rows(&self) -> Vec<PendingGateProjectionRow> {
+        self.rows
+            .lock()
+            .expect("memory sink lock")
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    fn should_apply(&self, key: &PendingGateProjectionKey, cursor: TurnEventCursor) -> bool {
+        let mut last_applied = self.last_applied.lock().expect("last applied lock");
+        let entry = last_applied.entry(key.clone()).or_default();
+        if cursor < *entry {
+            return false;
+        }
+        *entry = cursor;
+        true
+    }
+}
+
+#[async_trait]
+impl PendingGateProjectionSink for MemorySink {
+    async fn upsert_pending_gate(
+        &self,
+        row: PendingGateProjectionRow,
+    ) -> Result<(), ProjectionError> {
+        if !self.should_apply(&row.key, row.source_cursor) {
+            return Ok(());
+        }
+        self.rows
+            .lock()
+            .expect("memory sink lock")
+            .insert(row.key.clone(), row);
+        Ok(())
+    }
+
+    async fn remove_pending_gate(
+        &self,
+        key: PendingGateProjectionKey,
+        source_cursor: TurnEventCursor,
+    ) -> Result<(), ProjectionError> {
+        if !self.should_apply(&key, source_cursor) {
+            return Ok(());
+        }
+        self.rows.lock().expect("memory sink lock").remove(&key);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub(super) struct MemoryCursorStore {
+    cursors: Mutex<HashMap<(String, TurnScope), TurnEventCursor>>,
+    advances: Mutex<Vec<TurnEventCursor>>,
+}
+
+impl MemoryCursorStore {
+    pub(super) fn set(&self, consumer_id: &str, scope: &TurnScope, cursor: TurnEventCursor) {
+        self.cursors
+            .lock()
+            .expect("memory cursor lock")
+            .insert((consumer_id.to_string(), scope.clone()), cursor);
+    }
+
+    pub(super) fn advances(&self) -> Vec<TurnEventCursor> {
+        self.advances.lock().expect("advances lock").clone()
+    }
+}
+
+#[async_trait]
+impl PendingGateProjectionCursorStore for MemoryCursorStore {
+    async fn load_pending_gate_cursor(
+        &self,
+        consumer_id: &str,
+        scope: &TurnScope,
+    ) -> Result<TurnEventCursor, ProjectionError> {
+        Ok(*self
+            .cursors
+            .lock()
+            .expect("memory cursor lock")
+            .get(&(consumer_id.to_string(), scope.clone()))
+            .unwrap_or(&TurnEventCursor::default()))
+    }
+
+    async fn advance_pending_gate_cursor(
+        &self,
+        consumer_id: &str,
+        scope: &TurnScope,
+        cursor: TurnEventCursor,
+    ) -> Result<(), ProjectionError> {
+        let mut cursors = self.cursors.lock().expect("memory cursor lock");
+        let entry = cursors
+            .entry((consumer_id.to_string(), scope.clone()))
+            .or_default();
+        *entry = (*entry).max(cursor);
+        self.advances.lock().expect("advances lock").push(cursor);
+        Ok(())
+    }
+}
+
+pub(super) struct MemoryTurnEventSource {
+    events: Vec<TurnLifecycleEvent>,
+    requested_limits: Mutex<Vec<usize>>,
+}
+
+impl MemoryTurnEventSource {
+    pub(super) fn new(events: Vec<TurnLifecycleEvent>) -> Self {
+        Self {
+            events,
+            requested_limits: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(super) fn requested_limits(&self) -> Vec<usize> {
+        self.requested_limits
+            .lock()
+            .expect("requested limits lock")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl TurnEventProjectionSource for MemoryTurnEventSource {
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        after: Option<TurnEventCursor>,
+        limit: usize,
+    ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
+        self.requested_limits
+            .lock()
+            .expect("requested limits lock")
+            .push(limit);
+        let after = after.unwrap_or_default();
+        let mut entries = self
+            .events
+            .iter()
+            .filter(|event| &event.scope == scope && event.cursor > after)
+            .cloned()
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|event| event.cursor);
+        let truncated = entries.len() > limit;
+        if truncated {
+            entries.truncate(limit);
+        }
+        let next_cursor = entries.last().map(|event| event.cursor).unwrap_or(after);
+        Ok(ironclaw_turns::TurnEventPage {
+            entries,
+            next_cursor,
+            truncated,
+            rebase_required: None,
+        })
+    }
+}
+
+pub(super) struct FailingTurnEventSource;
+
+#[async_trait]
+impl TurnEventProjectionSource for FailingTurnEventSource {
+    async fn read_turn_events_after(
+        &self,
+        _scope: &TurnScope,
+        _after: Option<TurnEventCursor>,
+        _limit: usize,
+    ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
+        Err(ironclaw_turns::TurnError::Unavailable {
+            reason: "test source failure".to_string(),
+        })
+    }
+}
+
+pub(super) struct RebaseTurnEventSource;
+
+#[async_trait]
+impl TurnEventProjectionSource for RebaseTurnEventSource {
+    async fn read_turn_events_after(
+        &self,
+        _scope: &TurnScope,
+        _after: Option<TurnEventCursor>,
+        _limit: usize,
+    ) -> Result<ironclaw_turns::TurnEventPage, ironclaw_turns::TurnError> {
+        Ok(ironclaw_turns::TurnEventPage {
+            entries: Vec::new(),
+            next_cursor: TurnEventCursor(5),
+            truncated: false,
+            rebase_required: Some(TurnEventCursor(5)),
+        })
+    }
+}
+
+pub(super) fn scope(thread: &str) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant-a").expect("tenant"),
+        Some(AgentId::new("agent-a").expect("agent")),
+        Some(ProjectId::new("project-a").expect("project")),
+        ThreadId::new(thread).expect("thread"),
+    )
+}
+
+pub(super) fn blocked_event(
+    cursor: u64,
+    scope: TurnScope,
+    run_id: TurnRunId,
+) -> TurnLifecycleEvent {
+    blocked_event_with(
+        cursor,
+        scope,
+        run_id,
+        TurnStatus::BlockedApproval,
+        TurnBlockedGateKind::Approval,
+        "gate:approval-a",
+    )
+}
+
+pub(super) fn blocked_event_with(
+    cursor: u64,
+    scope: TurnScope,
+    run_id: TurnRunId,
+    status: TurnStatus,
+    gate_kind: TurnBlockedGateKind,
+    gate_ref: &str,
+) -> TurnLifecycleEvent {
+    TurnLifecycleEvent {
+        cursor: TurnEventCursor(cursor),
+        scope,
+        occurred_at: Some(Utc.with_ymd_and_hms(2026, 5, 20, 1, 2, 3).unwrap()),
+        owner_user_id: Some(UserId::new("owner-a").expect("user")),
+        run_id,
+        status,
+        kind: TurnEventKind::Blocked,
+        blocked_gate: Some(TurnBlockedGateMetadata {
+            gate_ref: GateRef::new(gate_ref).expect("gate ref"),
+            gate_kind,
+        }),
+        sanitized_reason: Some("approval_required".to_string()),
+    }
+}
+
+pub(super) fn lifecycle_event(
+    cursor: u64,
+    scope: TurnScope,
+    run_id: TurnRunId,
+    status: TurnStatus,
+    kind: TurnEventKind,
+) -> TurnLifecycleEvent {
+    TurnLifecycleEvent {
+        cursor: TurnEventCursor(cursor),
+        scope,
+        occurred_at: Some(Utc.with_ymd_and_hms(2026, 5, 20, 1, 3, 3).unwrap()),
+        owner_user_id: Some(UserId::new("owner-a").expect("user")),
+        run_id,
+        status,
+        kind,
+        blocked_gate: None,
+        sanitized_reason: None,
+    }
+}
+
+pub(super) fn projection(
+    sink: Arc<MemorySink>,
+    cursor_store: Arc<MemoryCursorStore>,
+) -> PendingGateProjection {
+    PendingGateProjection::new(sink, cursor_store)
+}

--- a/crates/ironclaw_event_streams/src/manager.rs
+++ b/crates/ironclaw_event_streams/src/manager.rs
@@ -596,6 +596,11 @@ fn map_projection_error(error: ProjectionError) -> ProjectionStreamError {
         ProjectionError::InvalidRequest { reason } => {
             ProjectionStreamError::InvalidRequest { reason }
         }
+        ProjectionError::MissingProjectionMetadata { .. } => {
+            ProjectionStreamError::InvalidRequest {
+                reason: "projection metadata missing on lifecycle event",
+            }
+        }
         ProjectionError::RebaseRequired { .. } => ProjectionStreamError::InvalidRequest {
             reason: "projection rebase required outside subscribe flow",
         },

--- a/crates/ironclaw_event_streams/src/manager.rs
+++ b/crates/ironclaw_event_streams/src/manager.rs
@@ -599,6 +599,9 @@ fn map_projection_error(error: ProjectionError) -> ProjectionStreamError {
         ProjectionError::RebaseRequired { .. } => ProjectionStreamError::InvalidRequest {
             reason: "projection rebase required outside subscribe flow",
         },
+        ProjectionError::TurnEventRebaseRequired { .. } => ProjectionStreamError::InvalidRequest {
+            reason: "turn event projection rebase required outside subscribe flow",
+        },
         ProjectionError::Source { .. } => ProjectionStreamError::Source,
     }
 }

--- a/crates/ironclaw_event_streams/tests/event_stream_manager_contract/core.rs
+++ b/crates/ironclaw_event_streams/tests/event_stream_manager_contract/core.rs
@@ -289,6 +289,23 @@ async fn fetch_snapshot_maps_projection_snapshot_errors() {
                 reason: "projection rebase required outside subscribe flow",
             },
         ),
+        (
+            ProjectionError::TurnEventRebaseRequired {
+                requested: ironclaw_turns::EventCursor(0),
+                earliest: ironclaw_turns::EventCursor(5),
+            },
+            ProjectionStreamError::InvalidRequest {
+                reason: "turn event projection rebase required outside subscribe flow",
+            },
+        ),
+        (
+            ProjectionError::MissingProjectionMetadata {
+                field: ironclaw_event_projections::MissingMetadataField::OwnerUserId,
+            },
+            ProjectionStreamError::InvalidRequest {
+                reason: "projection metadata missing on lifecycle event",
+            },
+        ),
     ] {
         let manager = EventStreamManager::new(
             Arc::new(FailingSnapshotProjectionService {

--- a/crates/ironclaw_event_streams/tests/event_stream_manager_contract/subscription.rs
+++ b/crates/ironclaw_event_streams/tests/event_stream_manager_contract/subscription.rs
@@ -223,6 +223,23 @@ async fn subscribe_resume_maps_projection_update_errors() {
             },
             ProjectionStreamError::Source,
         ),
+        (
+            ProjectionError::TurnEventRebaseRequired {
+                requested: ironclaw_turns::EventCursor(0),
+                earliest: ironclaw_turns::EventCursor(5),
+            },
+            ProjectionStreamError::InvalidRequest {
+                reason: "turn event projection rebase required outside subscribe flow",
+            },
+        ),
+        (
+            ProjectionError::MissingProjectionMetadata {
+                field: ironclaw_event_projections::MissingMetadataField::OwnerUserId,
+            },
+            ProjectionStreamError::InvalidRequest {
+                reason: "projection metadata missing on lifecycle event",
+            },
+        ),
     ] {
         let manager = EventStreamManager::new(
             Arc::new(FailingUpdatesProjectionService {

--- a/crates/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
+++ b/crates/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
@@ -292,6 +292,13 @@ impl EventProjectionService for FailingUpdatesProjectionService {
                 requested: requested.clone(),
                 earliest: earliest.clone(),
             },
+            ProjectionError::TurnEventRebaseRequired {
+                requested,
+                earliest,
+            } => ProjectionError::TurnEventRebaseRequired {
+                requested: *requested,
+                earliest: *earliest,
+            },
             ProjectionError::Source { operation } => ProjectionError::Source { operation },
         };
         Err(error)
@@ -318,6 +325,13 @@ impl EventProjectionService for FailingSnapshotProjectionService {
             } => ProjectionError::RebaseRequired {
                 requested: requested.clone(),
                 earliest: earliest.clone(),
+            },
+            ProjectionError::TurnEventRebaseRequired {
+                requested,
+                earliest,
+            } => ProjectionError::TurnEventRebaseRequired {
+                requested: *requested,
+                earliest: *earliest,
             },
             ProjectionError::Source { operation } => ProjectionError::Source { operation },
         })

--- a/crates/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
+++ b/crates/ironclaw_event_streams/tests/event_stream_manager_contract/support/fakes.rs
@@ -285,6 +285,9 @@ impl EventProjectionService for FailingUpdatesProjectionService {
             ProjectionError::InvalidRequest { reason } => {
                 ProjectionError::InvalidRequest { reason }
             }
+            ProjectionError::MissingProjectionMetadata { field } => {
+                ProjectionError::MissingProjectionMetadata { field: *field }
+            }
             ProjectionError::RebaseRequired {
                 requested,
                 earliest,
@@ -318,6 +321,9 @@ impl EventProjectionService for FailingSnapshotProjectionService {
         Err(match &self.error {
             ProjectionError::InvalidRequest { reason } => {
                 ProjectionError::InvalidRequest { reason }
+            }
+            ProjectionError::MissingProjectionMetadata { field } => {
+                ProjectionError::MissingProjectionMetadata { field: *field }
             }
             ProjectionError::RebaseRequired {
                 requested,

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -16,9 +16,9 @@ use ironclaw_product_adapters::{
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor as TurnEventCursor,
     GateRef, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,
-    RunProfileVersion, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnBlockedGateKind,
-    TurnBlockedGateMetadata, TurnError, TurnEventKind, TurnEventPage, TurnLifecycleEvent,
-    TurnRunState, TurnStatus,
+    RunProfileVersion, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse,
+    TurnBlockedGateKind, TurnBlockedGateMetadata, TurnError, TurnEventKind, TurnEventPage,
+    TurnLifecycleEvent, TurnRunState, TurnStatus,
 };
 
 mod cursor_validation;

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -16,8 +16,9 @@ use ironclaw_product_adapters::{
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor as TurnEventCursor,
     GateRef, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,
-    RunProfileVersion, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnError,
-    TurnEventKind, TurnEventPage, TurnLifecycleEvent, TurnRunState, TurnStatus,
+    RunProfileVersion, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnBlockedGateKind,
+    TurnBlockedGateMetadata, TurnError, TurnEventKind, TurnEventPage, TurnLifecycleEvent,
+    TurnRunState, TurnStatus,
 };
 
 mod cursor_validation;

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -93,9 +93,15 @@ async fn webui_event_stream_resumes_mixed_batch_without_skipping_turn_event() {
             events: vec![TurnLifecycleEvent {
                 cursor: TurnEventCursor(1),
                 scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
                 run_id: turn_run,
                 status: TurnStatus::BlockedAuth,
                 kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: GateRef::new("gate:auth-required").unwrap(),
+                    gate_kind: TurnBlockedGateKind::Auth,
+                }),
                 sanitized_reason: Some("GitHub authentication required".to_string()),
             }],
         }),
@@ -264,9 +270,12 @@ async fn webui_event_stream_emits_keepalive_when_only_turn_cursor_advances() {
             events: vec![TurnLifecycleEvent {
                 cursor: TurnEventCursor(1),
                 scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
                 run_id,
                 status: TurnStatus::Running,
                 kind: TurnEventKind::RunnerHeartbeat,
+                blocked_gate: None,
                 sanitized_reason: None,
             }],
         }),
@@ -317,18 +326,27 @@ async fn webui_event_stream_reads_past_filtered_turn_event_pages() {
         .map(|cursor| TurnLifecycleEvent {
             cursor: TurnEventCursor(cursor),
             scope: scope.clone(),
+            occurred_at: Some(chrono::Utc::now()),
+            owner_user_id: Some(user_id.clone()),
             run_id,
             status: TurnStatus::Running,
             kind: TurnEventKind::RunnerHeartbeat,
+            blocked_gate: None,
             sanitized_reason: None,
         })
         .collect::<Vec<_>>();
     events.push(TurnLifecycleEvent {
         cursor: TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1),
         scope: scope.clone(),
+        occurred_at: Some(chrono::Utc::now()),
+        owner_user_id: Some(user_id.clone()),
         run_id,
         status: TurnStatus::BlockedAuth,
         kind: TurnEventKind::Blocked,
+        blocked_gate: Some(TurnBlockedGateMetadata {
+            gate_ref: GateRef::new("gate:auth-required").unwrap(),
+            gate_kind: TurnBlockedGateKind::Auth,
+        }),
         sanitized_reason: Some("GitHub authentication required".to_string()),
     });
     let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
@@ -392,9 +410,15 @@ async fn webui_event_stream_does_not_prompt_for_stale_blocked_event() {
             events: vec![TurnLifecycleEvent {
                 cursor: TurnEventCursor(1),
                 scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
                 run_id,
                 status: TurnStatus::BlockedAuth,
                 kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: GateRef::new("gate:auth-required").unwrap(),
+                    gate_kind: TurnBlockedGateKind::Auth,
+                }),
                 sanitized_reason: Some("stale auth gate".to_string()),
             }],
         }),

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -73,11 +73,12 @@ pub struct TurnLifecycleEvent {
 impl TurnLifecycleEvent {
     /// Return the transport-facing lifecycle event view.
     ///
-    /// Internal projection consumers may need gate metadata to materialize
-    /// read models, but public lifecycle snapshots must not expose resolution
-    /// refs that can later be used to act on a gate.
+    /// Internal projection consumers may need gate and owner metadata to
+    /// materialize read models, but public lifecycle snapshots must not expose
+    /// resolution refs or owner identity.
     pub fn into_public_projection_entry(mut self) -> Self {
         self.blocked_gate = None;
+        self.owner_user_id = None;
         self
     }
 }
@@ -391,12 +392,13 @@ mod tests {
     }
 
     #[test]
-    fn public_projection_entry_strips_blocked_gate_metadata() {
+    fn public_projection_entry_strips_internal_projection_metadata() {
         let event = blocked_event(1, scope("thread-a"));
 
         let public = event.into_public_projection_entry();
 
         assert_eq!(public.blocked_gate, None);
+        assert_eq!(public.owner_user_id, None);
         assert_eq!(
             public.sanitized_reason.as_deref(),
             Some("approval_required")
@@ -422,7 +424,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn projection_service_strips_blocked_gate_metadata_from_snapshot() {
+    async fn projection_service_strips_internal_projection_metadata_from_snapshot() {
         let scope = scope("thread-a");
         let source = MemoryProjectionSource {
             events: vec![blocked_event(1, scope.clone())],
@@ -440,5 +442,6 @@ mod tests {
 
         assert_eq!(snapshot.entries.len(), 1);
         assert_eq!(snapshot.entries[0].blocked_gate, None);
+        assert_eq!(snapshot.entries[0].owner_user_id, None);
     }
 }

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -30,7 +30,6 @@ pub enum TurnEventKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[non_exhaustive]
 pub enum TurnBlockedGateKind {
     Approval,
     Auth,
@@ -282,7 +281,7 @@ pub(crate) fn project_turn_events(
     scoped_events.sort_by_key(|event| event.cursor);
 
     let latest_scoped_cursor = scoped_events.last().map(|event| event.cursor);
-    let rebase_required = if retention_floor > EventCursor::default() && after <= retention_floor {
+    let rebase_required = if retention_floor > EventCursor::default() && after < retention_floor {
         Some(retention_floor)
     } else if let Some(latest) = latest_scoped_cursor {
         (after > latest).then_some(latest)
@@ -313,5 +312,133 @@ pub(crate) fn project_turn_events(
         next_cursor,
         truncated,
         rebase_required: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+
+    use crate::{
+        GateRef, TurnError, TurnRunId, TurnScope, TurnStatus,
+        events::{
+            EventCursor, TurnBlockedGateKind, TurnBlockedGateMetadata, TurnEventKind,
+            TurnEventPage, TurnEventProjectionService, TurnEventProjectionSource,
+            TurnLifecycleEvent, project_turn_events,
+        },
+    };
+
+    fn scope(thread: &str) -> TurnScope {
+        TurnScope::new(
+            TenantId::new("tenant-a").expect("tenant"),
+            Some(AgentId::new("agent-a").expect("agent")),
+            Some(ProjectId::new("project-a").expect("project")),
+            ThreadId::new(thread).expect("thread"),
+        )
+    }
+
+    fn blocked_event(cursor: u64, scope: TurnScope) -> TurnLifecycleEvent {
+        TurnLifecycleEvent {
+            cursor: EventCursor(cursor),
+            scope,
+            occurred_at: None,
+            owner_user_id: Some(UserId::new("owner-a").expect("owner")),
+            run_id: TurnRunId::new(),
+            status: TurnStatus::BlockedApproval,
+            kind: TurnEventKind::Blocked,
+            blocked_gate: Some(TurnBlockedGateMetadata {
+                gate_ref: GateRef::new("gate:approval-a").expect("gate ref"),
+                gate_kind: TurnBlockedGateKind::Approval,
+            }),
+            sanitized_reason: Some("approval_required".to_string()),
+        }
+    }
+
+    struct MemoryProjectionSource {
+        events: Vec<TurnLifecycleEvent>,
+    }
+
+    #[async_trait]
+    impl TurnEventProjectionSource for MemoryProjectionSource {
+        async fn read_turn_events_after(
+            &self,
+            scope: &TurnScope,
+            after: Option<EventCursor>,
+            limit: usize,
+        ) -> Result<TurnEventPage, TurnError> {
+            Ok(project_turn_events(
+                &self.events,
+                scope,
+                after,
+                limit,
+                EventCursor::default(),
+            ))
+        }
+    }
+
+    #[test]
+    fn blocked_gate_kind_from_status_ignores_non_blocked_statuses() {
+        for status in [
+            TurnStatus::Queued,
+            TurnStatus::Running,
+            TurnStatus::Completed,
+            TurnStatus::Failed,
+            TurnStatus::Cancelled,
+        ] {
+            assert_eq!(TurnBlockedGateKind::from_status(status), None);
+        }
+    }
+
+    #[test]
+    fn public_projection_entry_strips_blocked_gate_metadata() {
+        let event = blocked_event(1, scope("thread-a"));
+
+        let public = event.into_public_projection_entry();
+
+        assert_eq!(public.blocked_gate, None);
+        assert_eq!(
+            public.sanitized_reason.as_deref(),
+            Some("approval_required")
+        );
+    }
+
+    #[test]
+    fn project_turn_events_allows_cursor_equal_to_retention_floor() {
+        let scope = scope("thread-a");
+        let event = blocked_event(6, scope.clone());
+
+        let page = project_turn_events(
+            std::slice::from_ref(&event),
+            &scope,
+            Some(EventCursor(5)),
+            10,
+            EventCursor(5),
+        );
+
+        assert_eq!(page.rebase_required, None);
+        assert_eq!(page.entries, vec![event]);
+        assert_eq!(page.next_cursor, EventCursor(6));
+    }
+
+    #[tokio::test]
+    async fn projection_service_strips_blocked_gate_metadata_from_snapshot() {
+        let scope = scope("thread-a");
+        let source = MemoryProjectionSource {
+            events: vec![blocked_event(1, scope.clone())],
+        };
+        let service = TurnEventProjectionService::new(std::sync::Arc::new(source));
+
+        let snapshot = service
+            .snapshot(crate::events::TurnEventProjectionRequest {
+                scope,
+                after: None,
+                limit: 10,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(snapshot.entries.len(), 1);
+        assert_eq!(snapshot.entries[0].blocked_gate, None);
     }
 }

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -66,6 +66,11 @@ pub struct TurnLifecycleEvent {
     pub kind: TurnEventKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blocked_gate: Option<TurnBlockedGateMetadata>,
+    // `skip_serializing_if` matches the other optional fields above:
+    // pre-projection event rows emitted `"sanitized_reason": null`; new rows
+    // omit the field entirely. `serde(default)` rehydrates omitted fields as
+    // `None`, so the wire change is round-trip safe in both directions and
+    // adapters that persist `TurnLifecycleEvent` do not need a migration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sanitized_reason: Option<String>,
 }

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::{sync::Arc, sync::Mutex};
 use thiserror::Error;
 
-use crate::{TurnError, TurnRunId, TurnScope, TurnStatus};
+use ironclaw_host_api::{Timestamp, UserId};
+
+use crate::{GateRef, TurnError, TurnRunId, TurnScope, TurnStatus};
 
 const MAX_IN_MEMORY_EVENTS: usize = 10_000;
 pub const MAX_TURN_EVENT_PROJECTION_LIMIT: usize = 1_000;
@@ -26,14 +28,59 @@ pub enum TurnEventKind {
     Failed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TurnBlockedGateKind {
+    Approval,
+    Auth,
+    Resource,
+}
+
+impl TurnBlockedGateKind {
+    pub fn from_status(status: TurnStatus) -> Option<Self> {
+        match status {
+            TurnStatus::BlockedApproval => Some(Self::Approval),
+            TurnStatus::BlockedAuth => Some(Self::Auth),
+            TurnStatus::BlockedResource => Some(Self::Resource),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnBlockedGateMetadata {
+    pub gate_ref: GateRef,
+    pub gate_kind: TurnBlockedGateKind,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnLifecycleEvent {
     pub cursor: EventCursor,
     pub scope: TurnScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<Timestamp>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_user_id: Option<UserId>,
     pub run_id: TurnRunId,
     pub status: TurnStatus,
     pub kind: TurnEventKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_gate: Option<TurnBlockedGateMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sanitized_reason: Option<String>,
+}
+
+impl TurnLifecycleEvent {
+    /// Return the transport-facing lifecycle event view.
+    ///
+    /// Internal projection consumers may need gate metadata to materialize
+    /// read models, but public lifecycle snapshots must not expose resolution
+    /// refs that can later be used to act on a gate.
+    pub fn into_public_projection_entry(mut self) -> Self {
+        self.blocked_gate = None;
+        self
+    }
 }
 
 #[async_trait]
@@ -208,7 +255,11 @@ where
             });
         }
         Ok(TurnEventProjectionSnapshot {
-            entries: page.entries,
+            entries: page
+                .entries
+                .into_iter()
+                .map(TurnLifecycleEvent::into_public_projection_entry)
+                .collect(),
             next_cursor: TurnEventProjectionCursor::for_scope(request.scope, page.next_cursor),
             truncated: page.truncated,
         })

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -41,7 +41,8 @@ pub use coordinator::{
     TurnAdmissionPolicy, TurnCoordinator, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,
 };
 pub use events::{
-    EventCursor, InMemoryTurnEventSink, TurnEventKind, TurnEventPage, TurnEventProjectionCursor,
+    EventCursor, InMemoryTurnEventSink, MAX_TURN_EVENT_PROJECTION_LIMIT, TurnBlockedGateKind,
+    TurnBlockedGateMetadata, TurnEventKind, TurnEventPage, TurnEventProjectionCursor,
     TurnEventProjectionError, TurnEventProjectionRequest, TurnEventProjectionService,
     TurnEventProjectionSnapshot, TurnEventProjectionSource, TurnEventSink, TurnLifecycleEvent,
 };

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -959,12 +959,27 @@ impl Inner {
         kind: TurnEventKind,
         sanitized_reason: Option<String>,
     ) {
+        let blocked_gate = if kind == TurnEventKind::Blocked {
+            record.gate_ref.clone().and_then(|gate_ref| {
+                crate::events::TurnBlockedGateKind::from_status(record.status).map(|gate_kind| {
+                    crate::events::TurnBlockedGateMetadata {
+                        gate_ref,
+                        gate_kind,
+                    }
+                })
+            })
+        } else {
+            None
+        };
         self.events.push(TurnLifecycleEvent {
             cursor: record.event_cursor,
             scope: record.scope.clone(),
+            occurred_at: Some(Utc::now()),
+            owner_user_id: Some(record.actor.user_id.clone()),
             run_id: record.run_id,
             status: record.status,
             kind,
+            blocked_gate,
             sanitized_reason,
         });
         if self.events.len() > self.limits.max_events {

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -481,9 +481,15 @@ fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
     let event = TurnLifecycleEvent {
         cursor: EventCursor(2),
         scope: scope.clone(),
+        occurred_at: Some(fixed_time()),
+        owner_user_id: Some(UserId::new("user-checkpoint-public").unwrap()),
         run_id,
         status: TurnStatus::BlockedApproval,
         kind: TurnEventKind::Blocked,
+        blocked_gate: Some(ironclaw_turns::TurnBlockedGateMetadata {
+            gate_ref: GateRef::new("gate-checkpoint-public").unwrap(),
+            gate_kind: ironclaw_turns::TurnBlockedGateKind::Approval,
+        }),
         sanitized_reason: Some("checkpointed".to_string()),
     };
     let snapshot = TurnPersistenceSnapshot {

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -2107,8 +2107,22 @@ async fn runner_claim_and_block_update_persistent_run_lock_and_checkpoint_record
     assert_eq!(checkpoint.checkpoint_id, checkpoint_id);
     assert_eq!(checkpoint.run_id, run_id);
     assert_eq!(checkpoint.sequence, 1);
-    assert_eq!(checkpoint.gate_ref, gate_ref);
+    assert_eq!(checkpoint.gate_ref, gate_ref.clone());
     assert_eq!(checkpoint.state_ref, state_ref);
+
+    let blocked_event = store
+        .events()
+        .into_iter()
+        .find(|event| event.kind == TurnEventKind::Blocked && event.run_id == run_id)
+        .unwrap();
+    assert_eq!(blocked_event.owner_user_id, Some(actor().user_id));
+    assert!(blocked_event.occurred_at.is_some());
+    let blocked_gate = blocked_event.blocked_gate.unwrap();
+    assert_eq!(blocked_gate.gate_ref, gate_ref);
+    assert_eq!(
+        blocked_gate.gate_kind,
+        ironclaw_turns::TurnBlockedGateKind::Approval
+    );
 }
 
 #[tokio::test]
@@ -3932,9 +3946,12 @@ async fn in_memory_event_sink_retains_a_bounded_tail() {
         sink.publish(TurnLifecycleEvent {
             cursor: EventCursor(cursor),
             scope: scope("thread-a"),
+            occurred_at: None,
+            owner_user_id: None,
             run_id: TurnRunId::new(),
             status: TurnStatus::Queued,
             kind: TurnEventKind::Submitted,
+            blocked_gate: None,
             sanitized_reason: None,
         })
         .await

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -2125,6 +2125,82 @@ async fn runner_claim_and_block_update_persistent_run_lock_and_checkpoint_record
     );
 }
 
+async fn block_run_with_reason_yields_expected_blocked_gate(
+    thread_id: &str,
+    idem_key: &str,
+    reason_builder: impl Fn(GateRef) -> BlockedReason,
+    expected_kind: ironclaw_turns::TurnBlockedGateKind,
+    gate_ref_str: &str,
+) {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request(thread_id, idem_key))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let gate_ref = GateRef::new(gate_ref_str).unwrap();
+    let state_ref = LoopCheckpointStateRef::new("checkpoint:reason-block-state").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref,
+            reason: reason_builder(gate_ref.clone()),
+        })
+        .await
+        .unwrap();
+
+    let blocked_event = store
+        .events()
+        .into_iter()
+        .find(|event| event.kind == TurnEventKind::Blocked && event.run_id == run_id)
+        .expect("block_run emits a Blocked lifecycle event");
+    let blocked_gate = blocked_event
+        .blocked_gate
+        .expect("block_run sets blocked_gate metadata for the reason");
+    assert_eq!(blocked_gate.gate_ref, gate_ref);
+    assert_eq!(blocked_gate.gate_kind, expected_kind);
+}
+
+#[tokio::test]
+async fn block_run_auth_emits_blocked_event_with_auth_gate_kind() {
+    block_run_with_reason_yields_expected_blocked_gate(
+        "thread-block-auth",
+        "idem-submit-auth",
+        |gate_ref| BlockedReason::Auth { gate_ref },
+        ironclaw_turns::TurnBlockedGateKind::Auth,
+        "auth-gate",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn block_run_resource_emits_blocked_event_with_resource_gate_kind() {
+    block_run_with_reason_yields_expected_blocked_gate(
+        "thread-block-resource",
+        "idem-submit-resource",
+        |gate_ref| BlockedReason::Resource { gate_ref },
+        ironclaw_turns::TurnBlockedGateKind::Resource,
+        "resource-gate",
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn resume_updates_persisted_run_binding_refs_and_replay_envelope() {
     let (coordinator, store) = coordinator();

--- a/docs/reborn/contracts/events-projections.md
+++ b/docs/reborn/contracts/events-projections.md
@@ -115,6 +115,19 @@ Reducer rules:
 - may cache output, but cache is not source of truth
 - must tolerate unknown future event types by ignoring or preserving them according to version policy
 
+Projection crates may consume typed domain-event contracts from the owning
+domain crate when the read model is explicitly about that domain. For example,
+`ironclaw_event_projections` may consume `ironclaw_turns::TurnLifecycleEvent`
+to derive pending-gate rows from blocked/resumed/terminal turn facts. That does
+not make projections the source of truth for turn state, and it does not permit
+imports from product composition, root `src/`, or legacy engine pending-gate
+types.
+
+Read-model keys must preserve the full scope needed to enforce read isolation.
+Turn-derived pending-gate rows preserve tenant, agent, project, owner, thread,
+and run identity; a sink must not collapse rows to tenant/thread when the source
+`TurnScope` carries narrower agent/project boundaries.
+
 ---
 
 ## 6. Reconnect and resume


### PR DESCRIPTION
## Purpose

This is the prerequisite PR for the Reborn subagent-spawn stack. It implements the pending-gate projection foundation described in #3798 and the design-doc PR #3814.

The immediate problem is not subagent-specific: Reborn turn execution can move a run into a blocked state and emit a `TurnLifecycleEvent`, but the product-facing pending-gate read model is a separate surface. Without a projection boundary, approvals/auth/resource gates created by Reborn turns can become invisible to the UI or require fragile dual-writes. Subagents make this gap urgent because child runs must be able to request approval on their own child thread, but the fix is intentionally general for every Reborn blocked turn.

## Design Intent

The design goal is a single source of truth for gate lifecycle state:

- `ironclaw_turns` remains the authoritative owner of turn state and lifecycle events.
- Pending-gate UI state becomes a derived read model of `TurnLifecycleEvent`, not a second authoritative write path.
- The projection is replayable, cursor-based, idempotent, and keyed by tenant/user/thread/run so it cannot delete or expose another user's gate.
- Blocked-event metadata is explicit and redacted: enough to materialize the read model, without raw tool inputs, prompts, secret material, backend errors, or host paths.

This follows the #3798 requirement that approval surfacing should be a projection rather than a `block_run()` write-hook bridge. That avoids split-brain behavior where turn state and UI gate state disagree.

## What Changed

- Added `crates/ironclaw_event_projections/src/pending_gate_projection.rs`.
  - Defines neutral projection DTOs and a `PendingGateProjectionSink`.
  - Projects blocked turn lifecycle events into pending-gate rows.
  - Removes pending-gate rows on resumed or terminal lifecycle events.
  - Preserves idempotency through stable projection keys and cursor handling.
- Extended `TurnLifecycleEvent` with blocked-gate metadata needed for projection.
  - Includes owner metadata and redacted gate metadata.
  - Keeps public lifecycle projection entries sanitized.
- Added `TurnEventProjectionSource` support and projection cursor behavior around the existing turn event stream.
- Added event projection docs under `docs/reborn/contracts/events-projections.md` and crate-local guidance in `crates/ironclaw_event_projections/CLAUDE.md`.
- Added architecture guardrail coverage so the new projection crate remains a Reborn read-model boundary and does not import legacy/root pending-gate implementation types.

## Why This Is Phase 0

Phase 0 deliberately lands before the subagent mechanisms:

- Blocking subagents will use `AwaitDependentRun`, but child runs may independently block on approval/auth/resource gates.
- A child approval must surface on the child thread for the same owner as the parent.
- That only works if Reborn blocked turns can be projected into the product pending-gate surface without ad hoc bridge writes.

This PR does not add subagent spawning. It only closes the general projection gap that subagents depend on.

## Stack Position

- Base: `reborn-integration`
- This PR: Phase 0 prerequisite
- Next: #3868 Phase 1 contracts
- Then: #3869 Phase 2 mechanisms
- Then: #3870 Phase 3 integration

## Review Notes

Review this as an event/read-model boundary change, not as a subagent feature PR. The important questions are:

- Is `TurnLifecycleEvent` still the only source of truth for Reborn gate lifecycle projection?
- Are projection keys scoped tightly enough by tenant/user/thread/run?
- Does the projection fail closed when required metadata is absent?
- Is the new crate still independent from legacy/root pending-gate implementation details?

## Validation

Latest validation run after the full stack was assembled:

- `cargo test -p ironclaw_turns -p ironclaw_agent_loop -p ironclaw_loop_support --tests`
- `cargo test -p ironclaw_reborn -p ironclaw_reborn_composition -p ironclaw_product_workflow --tests`
- `cargo fmt --check`
- `cargo clippy -p ironclaw_agent_loop -p ironclaw_turns -p ironclaw_loop_support -p ironclaw_reborn -p ironclaw_reborn_composition -p ironclaw_product_workflow --tests -- -D warnings`

Refs #3798
Design context: #3814
