### PR TITLE
[Draft] Subagent spawn phase 4 verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,6 +4800,7 @@ dependencies = [
  "ironclaw_trust",
  "ironclaw_turns",
  "libsql",
+ "parking_lot",
  "rust_decimal",
  "secrecy",
  "serde",

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -164,6 +164,53 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
             .await;
 
         let outcomes = batch.outcomes;
+        // Multiple AwaitDependentRun outcomes within the same batch that
+        // share a single gate_ref must coalesce into ONE gate exit: each
+        // outcome's result_ref still gets appended (so the parent observes
+        // every child's result on resume), but the loop transitions to
+        // BlockedDependentRun via a single gate step rather than firing
+        // handle_gate once per outcome. Falling through to the per-outcome
+        // loop would call handle_gate N times for the same gate, causing
+        // duplicate gate records and (worse) racing resume attempts.
+        if !batch.stopped_on_suspension
+            && let Some((shared_gate_ref, first_call)) =
+                shared_await_dependent_gate(&visible_calls, &outcomes)
+        {
+            for (call, outcome) in visible_calls.iter().zip(outcomes.iter()) {
+                push_call_signature_once(&mut state, &mut signatures, call)?;
+                if let CapabilityOutcome::AwaitDependentRun {
+                    result_ref,
+                    safe_summary,
+                    ..
+                } = outcome
+                {
+                    let result = CapabilityResultMessage {
+                        result_ref: result_ref.clone(),
+                        safe_summary: safe_summary.clone(),
+                        terminate_hint: false,
+                    };
+                    append_capability_result_ref(ctx.host, call, &result).await?;
+                    push_completed_result(&mut state, result);
+                }
+            }
+            match GateStage
+                .process(
+                    ctx,
+                    GateInput {
+                        state,
+                        call: first_call,
+                        kind: GateKind::AwaitDependentRun,
+                        gate_ref: shared_gate_ref,
+                    },
+                )
+                .await?
+            {
+                BatchStep::Continue(next) => {
+                    return self.completed_turn(ctx, *next, result_refs_start).await;
+                }
+                BatchStep::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
+            }
+        }
         if !batch.stopped_on_suspension {
             // Non-suspended batches record completed outcomes before gates so
             // partial parallel progress is durable in any later suspension
@@ -581,4 +628,33 @@ async fn append_spawned_child_result(
     append_capability_result_ref(host, call, &result).await?;
     push_completed_result(state, result);
     Ok(())
+}
+
+fn shared_await_dependent_gate(
+    calls: &[CapabilityCallCandidate],
+    outcomes: &[CapabilityOutcome],
+) -> Option<(ironclaw_turns::LoopGateRef, CapabilityCallCandidate)> {
+    let mut shared_gate: Option<ironclaw_turns::LoopGateRef> = None;
+    let mut first_call: Option<CapabilityCallCandidate> = None;
+    let mut count = 0_usize;
+    for (call, outcome) in calls.iter().zip(outcomes.iter()) {
+        let CapabilityOutcome::AwaitDependentRun { gate_ref, .. } = outcome else {
+            continue;
+        };
+        if let Some(existing) = shared_gate.as_ref() {
+            if existing != gate_ref {
+                return None;
+            }
+        } else {
+            shared_gate = Some(gate_ref.clone());
+            first_call = Some(call.clone());
+        }
+        count += 1;
+    }
+    (count > 1).then(|| {
+        (
+            shared_gate.expect("counted gate"),
+            first_call.expect("counted call"),
+        )
+    })
 }

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -164,58 +164,23 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
             .await;
 
         let outcomes = batch.outcomes;
-        // Multiple AwaitDependentRun outcomes within the same batch that
-        // share a single gate_ref must coalesce into ONE gate exit: each
-        // outcome's result_ref still gets appended (so the parent observes
-        // every child's result on resume), but the loop transitions to
-        // BlockedDependentRun via a single gate step rather than firing
-        // handle_gate once per outcome. Falling through to the per-outcome
-        // loop would call handle_gate N times for the same gate, causing
-        // duplicate gate records and (worse) racing resume attempts.
-        if !batch.stopped_on_suspension
-            && let Some((shared_gate_ref, first_call)) =
-                shared_await_dependent_gate(&visible_calls, &outcomes)
-        {
-            for (call, outcome) in visible_calls.iter().zip(outcomes.iter()) {
-                push_call_signature_once(&mut state, &mut signatures, call)?;
-                if let CapabilityOutcome::AwaitDependentRun {
-                    result_ref,
-                    safe_summary,
-                    ..
-                } = outcome
-                {
-                    let result = CapabilityResultMessage {
-                        result_ref: result_ref.clone(),
-                        safe_summary: safe_summary.clone(),
-                        terminate_hint: false,
-                    };
-                    append_capability_result_ref(ctx.host, call, &result).await?;
-                    push_completed_result(&mut state, result);
-                }
-            }
-            match GateStage
-                .process(
-                    ctx,
-                    GateInput {
-                        state,
-                        call: first_call,
-                        kind: GateKind::AwaitDependentRun,
-                        gate_ref: shared_gate_ref,
-                    },
-                )
-                .await?
-            {
-                BatchStep::Continue(next) => {
-                    return self.completed_turn(ctx, *next, result_refs_start).await;
-                }
-                BatchStep::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
-            }
-        }
+        // Multiple AwaitDependentRun outcomes that share a single gate_ref
+        // must coalesce into ONE gate exit: each outcome's result_ref is
+        // appended as a completed result (so the parent observes every
+        // child's result on resume) and a single GateStage step transitions
+        // the loop to BlockedDependentRun. Firing one gate step per outcome
+        // would create duplicate gate records and race the resume attempts.
+        let coalesce_gate = if !batch.stopped_on_suspension {
+            shared_await_dependent_gate(&visible_calls, &outcomes).map(|(gate, _)| gate)
+        } else {
+            None
+        };
         if !batch.stopped_on_suspension {
-            // Non-suspended batches record completed outcomes before gates so
-            // partial parallel progress is durable in any later suspension
-            // checkpoint.
+            // Non-suspended batches record completed (and coalesced-await)
+            // outcomes before handling any remaining gates so partial parallel
+            // progress is durable in any later suspension checkpoint.
             let mut pending_outcomes = Vec::new();
+            let mut coalesced_call: Option<CapabilityCallCandidate> = None;
             for (call, outcome) in visible_calls.into_iter().zip(outcomes) {
                 match outcome {
                     CapabilityOutcome::Completed(result) => {
@@ -238,11 +203,34 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                         )
                         .await?;
                     }
+                    CapabilityOutcome::AwaitDependentRun {
+                        gate_ref,
+                        result_ref,
+                        safe_summary,
+                    } if coalesce_gate.as_ref().is_some_and(|gate| gate == &gate_ref) => {
+                        push_call_signature_once(&mut state, &mut signatures, &call)?;
+                        let result = CapabilityResultMessage {
+                            result_ref,
+                            safe_summary,
+                            terminate_hint: false,
+                        };
+                        append_capability_result_ref(ctx.host, &call, &result).await?;
+                        push_completed_result(&mut state, result);
+                        if coalesced_call.is_none() {
+                            coalesced_call = Some(call);
+                        }
+                    }
                     other => {
                         pending_outcomes.push((call, other));
                     }
                 }
             }
+            // Drain non-await/non-completed outcomes (denied, failed, other
+            // gates) BEFORE the coalesced gate fires. The shared-gate fast
+            // path early-returns via `completed_turn` on `BatchStep::Continue`,
+            // so anything left in `pending_outcomes` after the gate step would
+            // be silently dropped — losing signature bookkeeping and side
+            // effects for outcomes the parent must observe on resume.
             for (call, outcome) in pending_outcomes {
                 push_call_signature_once(&mut state, &mut signatures, &call)?;
                 match self
@@ -251,6 +239,25 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                 {
                     BatchStep::Continue(next) => {
                         state = *next;
+                    }
+                    BatchStep::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
+                }
+            }
+            if let (Some(shared_gate_ref), Some(first_call)) = (coalesce_gate, coalesced_call) {
+                match GateStage
+                    .process(
+                        ctx,
+                        GateInput {
+                            state,
+                            call: first_call,
+                            kind: GateKind::AwaitDependentRun,
+                            gate_ref: shared_gate_ref,
+                        },
+                    )
+                    .await?
+                {
+                    BatchStep::Continue(next) => {
+                        return self.completed_turn(ctx, *next, result_refs_start).await;
                     }
                     BatchStep::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
                 }
@@ -638,23 +645,133 @@ fn shared_await_dependent_gate(
     let mut first_call: Option<CapabilityCallCandidate> = None;
     let mut count = 0_usize;
     for (call, outcome) in calls.iter().zip(outcomes.iter()) {
-        let CapabilityOutcome::AwaitDependentRun { gate_ref, .. } = outcome else {
-            continue;
-        };
-        if let Some(existing) = shared_gate.as_ref() {
-            if existing != gate_ref {
+        match outcome {
+            CapabilityOutcome::AwaitDependentRun { gate_ref, .. } => {
+                if let Some(existing) = shared_gate.as_ref() {
+                    if existing != gate_ref {
+                        return None;
+                    }
+                } else {
+                    shared_gate = Some(gate_ref.clone());
+                    first_call = Some(call.clone());
+                }
+                count += 1;
+            }
+            other if other.is_suspension() => {
                 return None;
             }
-        } else {
-            shared_gate = Some(gate_ref.clone());
-            first_call = Some(call.clone());
+            _ => {}
         }
-        count += 1;
     }
-    (count > 1).then(|| {
-        (
-            shared_gate.expect("counted gate"),
-            first_call.expect("counted call"),
-        )
-    })
+    // Only coalesce when at least two AwaitDependentRun outcomes share the
+    // same gate — that is the case the fast path exists for. A single
+    // AwaitDependentRun (with or without sibling completed outcomes) has no
+    // coalescing benefit, and routing through this path would diverge the
+    // completed-first durability ordering the non-suspended branch
+    // guarantees. Fall back to the per-outcome path for single-await batches.
+    if count <= 1 {
+        return None;
+    }
+    shared_gate.zip(first_call)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_turns::{
+        LoopGateRef, LoopResultRef,
+        run_profile::{CapabilityInputRef, CapabilitySurfaceVersion},
+    };
+
+    fn call(input: &str) -> CapabilityCallCandidate {
+        let capability_id = ironclaw_host_api::CapabilityId::new("test.cap").unwrap();
+        CapabilityCallCandidate {
+            surface_version: CapabilitySurfaceVersion::new("test-v1").unwrap(),
+            capability_id: capability_id.clone(),
+            effective_capability_ids: vec![capability_id],
+            input_ref: CapabilityInputRef::new(format!("input:{input}")).unwrap(),
+            provider_replay: None,
+        }
+    }
+
+    fn await_dependent(gate: &str, result: &str) -> CapabilityOutcome {
+        CapabilityOutcome::AwaitDependentRun {
+            gate_ref: LoopGateRef::new(gate).unwrap(),
+            result_ref: LoopResultRef::new(format!("result:{result}")).unwrap(),
+            safe_summary: "summary".to_string(),
+        }
+    }
+
+    fn completed(result: &str) -> CapabilityOutcome {
+        CapabilityOutcome::Completed(CapabilityResultMessage {
+            result_ref: LoopResultRef::new(format!("result:{result}")).unwrap(),
+            safe_summary: "summary".to_string(),
+            terminate_hint: false,
+        })
+    }
+
+    #[test]
+    fn returns_some_for_two_outcomes_sharing_one_gate() {
+        let calls = vec![call("a"), call("b")];
+        let outcomes = vec![
+            await_dependent("gate:batch-1", "r1"),
+            await_dependent("gate:batch-1", "r2"),
+        ];
+        let result = shared_await_dependent_gate(&calls, &outcomes);
+        assert!(result.is_some());
+        let (gate, first) = result.unwrap();
+        assert_eq!(gate.as_str(), "gate:batch-1");
+        assert_eq!(first.input_ref.as_str(), "input:a");
+    }
+
+    #[test]
+    fn returns_none_for_divergent_gate_refs() {
+        let calls = vec![call("a"), call("b")];
+        let outcomes = vec![
+            await_dependent("gate:a", "r1"),
+            await_dependent("gate:b", "r2"),
+        ];
+        assert!(shared_await_dependent_gate(&calls, &outcomes).is_none());
+    }
+
+    #[test]
+    fn returns_none_for_single_await_with_completed_sibling() {
+        // Single AwaitDependentRun has no coalescing benefit; fall back to
+        // the per-outcome path for completed-first durability ordering.
+        let calls = vec![call("a"), call("b")];
+        let outcomes = vec![await_dependent("gate:1", "r1"), completed("r2")];
+        assert!(shared_await_dependent_gate(&calls, &outcomes).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_non_await_suspension_present() {
+        let calls = vec![call("a"), call("b")];
+        let outcomes = vec![
+            await_dependent("gate:1", "r1"),
+            CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:approval").unwrap(),
+                safe_summary: "approval".to_string(),
+            },
+        ];
+        assert!(shared_await_dependent_gate(&calls, &outcomes).is_none());
+    }
+
+    #[test]
+    fn returns_none_for_empty_outcomes() {
+        assert!(shared_await_dependent_gate(&[], &[]).is_none());
+    }
+
+    #[test]
+    fn returns_some_for_two_awaits_with_completed_between() {
+        let calls = vec![call("a"), call("b"), call("c")];
+        let outcomes = vec![
+            await_dependent("gate:batch-2", "r1"),
+            completed("r2"),
+            await_dependent("gate:batch-2", "r3"),
+        ];
+        let result = shared_await_dependent_gate(&calls, &outcomes);
+        assert!(result.is_some());
+        let (gate, _) = result.unwrap();
+        assert_eq!(gate.as_str(), "gate:batch-2");
+    }
 }

--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -170,8 +170,8 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
         // child's result on resume) and a single GateStage step transitions
         // the loop to BlockedDependentRun. Firing one gate step per outcome
         // would create duplicate gate records and race the resume attempts.
-        let coalesce_gate = if !batch.stopped_on_suspension {
-            shared_await_dependent_gate(&visible_calls, &outcomes).map(|(gate, _)| gate)
+        let coalesced_gate_step = if !batch.stopped_on_suspension {
+            shared_await_dependent_gate(&visible_calls, &outcomes)
         } else {
             None
         };
@@ -180,7 +180,6 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
             // outcomes before handling any remaining gates so partial parallel
             // progress is durable in any later suspension checkpoint.
             let mut pending_outcomes = Vec::new();
-            let mut coalesced_call: Option<CapabilityCallCandidate> = None;
             for (call, outcome) in visible_calls.into_iter().zip(outcomes) {
                 match outcome {
                     CapabilityOutcome::Completed(result) => {
@@ -207,7 +206,10 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                         gate_ref,
                         result_ref,
                         safe_summary,
-                    } if coalesce_gate.as_ref().is_some_and(|gate| gate == &gate_ref) => {
+                    } if coalesced_gate_step
+                        .as_ref()
+                        .is_some_and(|(gate, _)| gate == &gate_ref) =>
+                    {
                         push_call_signature_once(&mut state, &mut signatures, &call)?;
                         let result = CapabilityResultMessage {
                             result_ref,
@@ -216,9 +218,6 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                         };
                         append_capability_result_ref(ctx.host, &call, &result).await?;
                         push_completed_result(&mut state, result);
-                        if coalesced_call.is_none() {
-                            coalesced_call = Some(call);
-                        }
                     }
                     other => {
                         pending_outcomes.push((call, other));
@@ -243,7 +242,7 @@ impl ExecutorStage<CapabilityInput> for CapabilityStage {
                     BatchStep::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
                 }
             }
-            if let (Some(shared_gate_ref), Some(first_call)) = (coalesce_gate, coalesced_call) {
+            if let Some((shared_gate_ref, first_call)) = coalesced_gate_step {
                 match GateStage
                     .process(
                         ctx,

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -323,6 +323,7 @@ struct SpawnContext {
     child_scope: ThreadScope,
     child_run_id: TurnRunId,
     tree_root: TurnRunId,
+    gate_override: Option<GateRef>,
 }
 
 #[derive(Default)]
@@ -437,6 +438,15 @@ impl SubagentSpawnCapabilityPort {
         invocation: &CapabilityInvocation,
         args: SpawnSubagentArgs,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        self.handle_spawn_with_gate(invocation, args, None).await
+    }
+
+    async fn handle_spawn_with_gate(
+        &self,
+        invocation: &CapabilityInvocation,
+        args: SpawnSubagentArgs,
+        gate_override: Option<GateRef>,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         let Some(spawn_slot) = self.reserve_spawn_slot() else {
             return Ok(spawn_rejected("fanout_cap_exceeded"));
         };
@@ -505,6 +515,7 @@ impl SubagentSpawnCapabilityPort {
             child_scope,
             child_run_id,
             tree_root,
+            gate_override,
         };
 
         let result = self
@@ -589,6 +600,7 @@ impl SubagentSpawnCapabilityPort {
             child_scope,
             child_run_id,
             tree_root,
+            gate_override,
         } = ctx;
         let child_thread_id =
             ThreadId::new(format!("subagent-{}", child_run_id.as_uuid().simple()))
@@ -597,11 +609,14 @@ impl SubagentSpawnCapabilityPort {
         // The gate ref is also returned as a `LoopGateRef`; keep the opaque
         // suffix colon-free so it satisfies the model-visible loop ref
         // contract (`gate:<ascii-id>` with only alnum/underscore/dash/dot).
-        let gate_ref = GateRef::new(match mode {
-            SpawnSubagentMode::Blocking => format!("gate:subagent.{child_run_id}"),
-            SpawnSubagentMode::Background => format!("gate:subagent-bg.{child_run_id}"),
-        })
-        .map_err(invalid_static_ref)?;
+        let gate_ref = match gate_override {
+            Some(gate_ref) => gate_ref,
+            None => GateRef::new(match mode {
+                SpawnSubagentMode::Blocking => format!("gate:subagent.{child_run_id}"),
+                SpawnSubagentMode::Background => format!("gate:subagent-bg.{child_run_id}"),
+            })
+            .map_err(invalid_static_ref)?,
+        };
         let payload = spawn_result_payload(
             child_run_id,
             &child_thread_id,
@@ -863,6 +878,19 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         request: CapabilityBatchInvocation,
     ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
         let mut outcomes = Vec::with_capacity(request.invocations.len());
+        let spawn_count = request
+            .invocations
+            .iter()
+            .filter(|invocation| self.is_spawn(&invocation.capability_id))
+            .count();
+        let batch_blocking_gate = if spawn_count > 1 {
+            Some(
+                GateRef::new(format!("gate:subagent-batch.{}", TurnRunId::new()))
+                    .map_err(invalid_static_ref)?,
+            )
+        } else {
+            None
+        };
         let mut index = 0_usize;
         while index < request.invocations.len() {
             let invocation = &request.invocations[index];
@@ -875,11 +903,15 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                         .spawn_input_codec
                         .decode(&self.run_context, &invocation.input_ref)
                         .await?;
-                    self.handle_spawn(invocation, args).await?
+                    let gate_override = (args.spawn_mode() == SpawnSubagentMode::Blocking)
+                        .then(|| batch_blocking_gate.clone())
+                        .flatten();
+                    self.handle_spawn_with_gate(invocation, args, gate_override)
+                        .await?
                 };
                 let suspended = outcome.is_suspension();
                 outcomes.push(outcome);
-                if suspended && request.stop_on_first_suspension {
+                if suspended && request.stop_on_first_suspension && batch_blocking_gate.is_none() {
                     return Ok(CapabilityBatchOutcome {
                         outcomes,
                         stopped_on_suspension: true,

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -433,14 +433,6 @@ impl SubagentSpawnCapabilityPort {
         }
     }
 
-    async fn handle_spawn(
-        &self,
-        invocation: &CapabilityInvocation,
-        args: SpawnSubagentArgs,
-    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
-        self.handle_spawn_with_gate(invocation, args, None).await
-    }
-
     async fn handle_spawn_with_gate(
         &self,
         invocation: &CapabilityInvocation,
@@ -612,8 +604,8 @@ impl SubagentSpawnCapabilityPort {
         let gate_ref = match gate_override {
             Some(gate_ref) => gate_ref,
             None => GateRef::new(match mode {
-                SpawnSubagentMode::Blocking => format!("gate:subagent.{child_run_id}"),
-                SpawnSubagentMode::Background => format!("gate:subagent-bg.{child_run_id}"),
+                SpawnSubagentMode::Blocking => format!("gate:subagent-{child_run_id}"),
+                SpawnSubagentMode::Background => format!("gate:subagent-bg-{child_run_id}"),
             })
             .map_err(invalid_static_ref)?,
         };
@@ -868,7 +860,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 .spawn_input_codec
                 .decode(&self.run_context, &request.input_ref)
                 .await?;
-            return self.handle_spawn(&request, args).await;
+            return self.handle_spawn_with_gate(&request, args, None).await;
         }
         self.inner.invoke_capability(request).await
     }
@@ -878,14 +870,29 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         request: CapabilityBatchInvocation,
     ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
         let mut outcomes = Vec::with_capacity(request.invocations.len());
-        let spawn_count = request
-            .invocations
-            .iter()
-            .filter(|invocation| self.is_spawn(&invocation.capability_id))
-            .count();
-        let batch_blocking_gate = if spawn_count > 1 {
+        // Pre-decode every spawn invocation so we know how many are Blocking
+        // before allocating the shared batch gate. Only batches with at least
+        // two Blocking spawns benefit from gate coalescing; otherwise the gate
+        // would be created and never registered, wasting a TurnRunId.
+        let mut spawn_args: HashMap<usize, SpawnSubagentArgs> = HashMap::new();
+        let mut blocking_count = 0_usize;
+        for (idx, invocation) in request.invocations.iter().enumerate() {
+            if !self.is_spawn(&invocation.capability_id) {
+                continue;
+            }
+            let args = self
+                .deps
+                .spawn_input_codec
+                .decode(&self.run_context, &invocation.input_ref)
+                .await?;
+            if args.spawn_mode() == SpawnSubagentMode::Blocking {
+                blocking_count += 1;
+            }
+            spawn_args.insert(idx, args);
+        }
+        let batch_blocking_gate = if blocking_count > 1 {
             Some(
-                GateRef::new(format!("gate:subagent-batch.{}", TurnRunId::new()))
+                GateRef::new(format!("gate:subagent-batch-{}", TurnRunId::new()))
                     .map_err(invalid_static_ref)?,
             )
         } else {
@@ -898,20 +905,28 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 let outcome = if let Some(outcome) = self.authorize_spawn(invocation).await? {
                     outcome
                 } else {
-                    let args = self
-                        .deps
-                        .spawn_input_codec
-                        .decode(&self.run_context, &invocation.input_ref)
-                        .await?;
+                    let args = spawn_args.remove(&index).ok_or_else(|| {
+                        AgentLoopHostError::new(
+                            AgentLoopHostErrorKind::Invalid,
+                            "subagent spawn args missing from pre-decode pass",
+                        )
+                    })?;
                     let gate_override = (args.spawn_mode() == SpawnSubagentMode::Blocking)
                         .then(|| batch_blocking_gate.clone())
                         .flatten();
                     self.handle_spawn_with_gate(invocation, args, gate_override)
                         .await?
                 };
+                let batch_await_dependent = matches!(
+                    &outcome,
+                    CapabilityOutcome::AwaitDependentRun { gate_ref, .. }
+                        if batch_blocking_gate
+                            .as_ref()
+                            .is_some_and(|batch_gate| batch_gate == gate_ref)
+                );
                 let suspended = outcome.is_suspension();
                 outcomes.push(outcome);
-                if suspended && request.stop_on_first_suspension && batch_blocking_gate.is_none() {
+                if suspended && request.stop_on_first_suspension && !batch_await_dependent {
                     return Ok(CapabilityBatchOutcome {
                         outcomes,
                         stopped_on_suspension: true,

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -1168,6 +1168,112 @@ async fn invoke_batch_coalesces_blocking_spawns_under_single_gate() {
 }
 
 #[tokio::test]
+async fn invoke_batch_mixed_spawn_and_non_spawn_capabilities() {
+    let context = test_run_context_with_agent_actor("spawn-batch-mixed").await;
+    let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: turn_store,
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        goal_store: Arc::new(NoopGoalStore),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: SpawnSubagentArgs {
+                subagent_kind: SubagentKindId::new("general").unwrap(),
+                task: "shared task".to_string(),
+                handoff: None,
+                mode: SpawnSubagentMode::Blocking,
+            },
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+    let input_ref_a = CapabilityInputRef::new("input:spawn-a").unwrap();
+    let input_ref_inner = CapabilityInputRef::new("input:inner").unwrap();
+    let input_ref_b = CapabilityInputRef::new("input:spawn-b").unwrap();
+    {
+        let mut refs = port.auth_input_refs.lock().unwrap();
+        refs.insert(
+            input_ref_a.clone(),
+            CapabilityInputRef::new("input:auth-a").unwrap(),
+        );
+        refs.insert(
+            input_ref_b.clone(),
+            CapabilityInputRef::new("input:auth-b").unwrap(),
+        );
+    }
+
+    let spawn_id = CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap();
+    let inner_id = CapabilityId::new("inner.echo").unwrap();
+    let surface_version = CapabilitySurfaceVersion::new("surface:test").unwrap();
+    let batch_outcome = port
+        .invoke_capability_batch(CapabilityBatchInvocation {
+            invocations: vec![
+                CapabilityInvocation {
+                    surface_version: surface_version.clone(),
+                    capability_id: spawn_id.clone(),
+                    input_ref: input_ref_a,
+                },
+                CapabilityInvocation {
+                    surface_version: surface_version.clone(),
+                    capability_id: inner_id,
+                    input_ref: input_ref_inner,
+                },
+                CapabilityInvocation {
+                    surface_version,
+                    capability_id: spawn_id,
+                    input_ref: input_ref_b,
+                },
+            ],
+            stop_on_first_suspension: true,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(batch_outcome.outcomes.len(), 3);
+    assert!(
+        !batch_outcome.stopped_on_suspension,
+        "shared spawn gate must not stop the mixed batch early"
+    );
+    let CapabilityOutcome::AwaitDependentRun {
+        gate_ref: first_gate,
+        ..
+    } = &batch_outcome.outcomes[0]
+    else {
+        panic!("first outcome should be a blocking spawn");
+    };
+    let CapabilityOutcome::Completed(inner_result) = &batch_outcome.outcomes[1] else {
+        panic!("second outcome should come from the inner non-spawn port");
+    };
+    let CapabilityOutcome::AwaitDependentRun {
+        gate_ref: second_gate,
+        ..
+    } = &batch_outcome.outcomes[2]
+    else {
+        panic!("third outcome should be a blocking spawn");
+    };
+    assert_eq!(first_gate, second_gate);
+    assert_eq!(inner_result.result_ref.as_str(), "result:auth");
+    assert_eq!(child_runs.requests().len(), 2);
+    let awaited = gate_store.records();
+    assert_eq!(awaited.len(), 1);
+    assert_eq!(awaited[0].gate_ref.as_str(), first_gate.as_str());
+}
+
+#[tokio::test]
 async fn invoke_batch_skips_shared_gate_for_single_blocking_spawn() {
     let context = test_run_context_with_agent_actor("spawn-batch-single").await;
     let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -158,9 +158,16 @@ impl LoopCapabilityPort for AuthPassPort {
 
     async fn invoke_capability_batch(
         &self,
-        _request: CapabilityBatchInvocation,
+        request: CapabilityBatchInvocation,
     ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
-        unreachable!("batch auth is not used by these tests")
+        let mut outcomes = Vec::with_capacity(request.invocations.len());
+        for invocation in request.invocations {
+            outcomes.push(self.invoke_capability(invocation).await?);
+        }
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension: false,
+        })
     }
 }
 
@@ -1067,6 +1074,158 @@ fn spawn_rejected_preserves_spawn_specific_reason_kind() {
 
     assert_eq!(denied.reason_kind.as_str(), "depth_cap_exceeded");
     assert!(denied.safe_summary.contains("depth_cap_exceeded"));
+}
+
+#[tokio::test]
+async fn invoke_batch_coalesces_blocking_spawns_under_single_gate() {
+    let context = test_run_context_with_agent_actor("spawn-batch-coalesce").await;
+    let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: turn_store,
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        goal_store: Arc::new(NoopGoalStore),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: SpawnSubagentArgs {
+                subagent_kind: SubagentKindId::new("general").unwrap(),
+                task: "shared task".to_string(),
+                handoff: None,
+                mode: SpawnSubagentMode::Blocking,
+            },
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        context.clone(),
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+    let input_ref_a = CapabilityInputRef::new("input:spawn-a").unwrap();
+    let input_ref_b = CapabilityInputRef::new("input:spawn-b").unwrap();
+    {
+        let mut refs = port.auth_input_refs.lock().unwrap();
+        refs.insert(
+            input_ref_a.clone(),
+            CapabilityInputRef::new("input:auth-a").unwrap(),
+        );
+        refs.insert(
+            input_ref_b.clone(),
+            CapabilityInputRef::new("input:auth-b").unwrap(),
+        );
+    }
+
+    let make_invocation = |input_ref: CapabilityInputRef| CapabilityInvocation {
+        surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+        capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        input_ref,
+    };
+    let batch_outcome = port
+        .invoke_capability_batch(CapabilityBatchInvocation {
+            invocations: vec![make_invocation(input_ref_a), make_invocation(input_ref_b)],
+            stop_on_first_suspension: true,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(batch_outcome.outcomes.len(), 2);
+    assert!(
+        !batch_outcome.stopped_on_suspension,
+        "shared batch gate must suppress stop_on_first_suspension"
+    );
+
+    let mut gate_refs = Vec::new();
+    for outcome in &batch_outcome.outcomes {
+        let CapabilityOutcome::AwaitDependentRun { gate_ref, .. } = outcome else {
+            panic!("expected await dependent run, got: {:?}", outcome);
+        };
+        gate_refs.push(gate_ref.as_str().to_string());
+    }
+    assert_eq!(
+        gate_refs[0], gate_refs[1],
+        "both blocking spawns must share the batch gate"
+    );
+    assert!(
+        gate_refs[0].contains("subagent-batch"),
+        "shared gate must use batch naming: {}",
+        gate_refs[0]
+    );
+    let requests = child_runs.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "both children submitted through spawn tree port"
+    );
+}
+
+#[tokio::test]
+async fn invoke_batch_skips_shared_gate_for_single_blocking_spawn() {
+    let context = test_run_context_with_agent_actor("spawn-batch-single").await;
+    let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: turn_store,
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        goal_store: Arc::new(NoopGoalStore),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: SpawnSubagentArgs {
+                subagent_kind: SubagentKindId::new("general").unwrap(),
+                task: "task".to_string(),
+                handoff: None,
+                mode: SpawnSubagentMode::Blocking,
+            },
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        context.clone(),
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+    port.auth_input_refs
+        .lock()
+        .unwrap()
+        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+
+    let batch_outcome = port
+        .invoke_capability_batch(CapabilityBatchInvocation {
+            invocations: vec![CapabilityInvocation {
+                surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+                capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+                input_ref: input_ref(),
+            }],
+            stop_on_first_suspension: true,
+        })
+        .await
+        .unwrap();
+
+    let CapabilityOutcome::AwaitDependentRun { gate_ref, .. } = &batch_outcome.outcomes[0] else {
+        panic!("expected await dependent");
+    };
+    assert!(
+        !gate_ref.as_str().contains("subagent-batch"),
+        "single blocking spawn must not allocate batch gate: {}",
+        gate_ref.as_str()
+    );
 }
 
 #[test]

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -48,6 +48,7 @@ ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0", opti
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+parking_lot = "0.12"
 secrecy = { version = "0.10", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/ironclaw_reborn/src/production_readiness.rs
+++ b/crates/ironclaw_reborn/src/production_readiness.rs
@@ -104,6 +104,9 @@ pub enum RebornLoopProductionComponent {
     TurnStateStore,
     SubagentGoalStore,
     SubagentCompletionObserver,
+    SubagentResultTombstoneStore,
+    SubagentAutonomousContinuationBudget,
+    SubagentRestartReconciler,
     WakeNotifier,
     ProgressEvents,
 }
@@ -356,6 +359,9 @@ pub struct RebornLoopComponentGraphReadiness {
     pub turn_state_store: RebornComponentReadiness,
     pub subagent_goal_store: RebornComponentReadiness,
     pub subagent_completion_observer: RebornComponentReadiness,
+    pub subagent_result_tombstone_store: RebornComponentReadiness,
+    pub subagent_autonomous_continuation_budget: RebornComponentReadiness,
+    pub subagent_restart_reconciler: RebornComponentReadiness,
     pub wake_notifier: RebornComponentReadiness,
     pub progress_events: RebornComponentReadiness,
 }
@@ -375,6 +381,13 @@ impl RebornLoopComponentGraphReadiness {
             turn_state_store: RebornComponentReadiness::production_verified(required),
             subagent_goal_store: RebornComponentReadiness::production_verified(required),
             subagent_completion_observer: RebornComponentReadiness::production_verified(required),
+            subagent_result_tombstone_store: RebornComponentReadiness::production_verified(
+                required,
+            ),
+            subagent_autonomous_continuation_budget: RebornComponentReadiness::production_verified(
+                required,
+            ),
+            subagent_restart_reconciler: RebornComponentReadiness::production_verified(required),
             wake_notifier: RebornComponentReadiness::production_verified(required),
             progress_events: RebornComponentReadiness::production_verified(required),
         }
@@ -436,6 +449,18 @@ impl RebornLoopComponentGraphReadiness {
             (
                 RebornLoopProductionComponent::SubagentCompletionObserver,
                 self.subagent_completion_observer,
+            ),
+            (
+                RebornLoopProductionComponent::SubagentResultTombstoneStore,
+                self.subagent_result_tombstone_store,
+            ),
+            (
+                RebornLoopProductionComponent::SubagentAutonomousContinuationBudget,
+                self.subagent_autonomous_continuation_budget,
+            ),
+            (
+                RebornLoopProductionComponent::SubagentRestartReconciler,
+                self.subagent_restart_reconciler,
             ),
             (
                 RebornLoopProductionComponent::WakeNotifier,
@@ -732,6 +757,13 @@ fn component_subject(component: RebornLoopProductionComponent) -> &'static str {
         RebornLoopProductionComponent::TurnStateStore => "turn_state_store",
         RebornLoopProductionComponent::SubagentGoalStore => "subagent_goal_store",
         RebornLoopProductionComponent::SubagentCompletionObserver => "subagent_completion_observer",
+        RebornLoopProductionComponent::SubagentResultTombstoneStore => {
+            "subagent_result_tombstone_store"
+        }
+        RebornLoopProductionComponent::SubagentAutonomousContinuationBudget => {
+            "subagent_autonomous_continuation_budget"
+        }
+        RebornLoopProductionComponent::SubagentRestartReconciler => "subagent_restart_reconciler",
         RebornLoopProductionComponent::WakeNotifier => "wake_notifier",
         RebornLoopProductionComponent::ProgressEvents => "progress_events",
     }

--- a/crates/ironclaw_reborn/src/subagent/completion_observer.rs
+++ b/crates/ironclaw_reborn/src/subagent/completion_observer.rs
@@ -643,14 +643,7 @@ fn awaited_child_record_from_persisted(
     child_record: TurnRunRecord,
     metadata: SubagentThreadMetadata,
 ) -> Result<AwaitedChildSetRecord, TurnError> {
-    // Mirrors the spawn path's `LoopGateRef`-compatible gate token format.
-    // The separator after the `gate:` prefix must stay colon-free because
-    // `LoopGateRef` rejects additional colons in the opaque id.
-    let gate_ref = GateRef::new(match metadata.mode {
-        SpawnSubagentMode::Blocking => format!("gate:subagent-{}", child_record.run_id),
-        SpawnSubagentMode::Background => format!("gate:subagent-bg-{}", child_record.run_id),
-    })
-    .map_err(|reason| TurnError::InvalidRequest { reason })?;
+    let gate_ref = recovered_gate_ref(&parent_record, &child_record, metadata.mode)?;
     let parent_run_context = LoopRunContext::new(
         parent_record.scope.clone(),
         parent_record.turn_id,
@@ -675,6 +668,27 @@ fn awaited_child_record_from_persisted(
         result_ref: metadata.result_ref,
         mode: metadata.mode,
     })
+}
+
+fn recovered_gate_ref(
+    parent_record: &TurnRunRecord,
+    child_record: &TurnRunRecord,
+    mode: SpawnSubagentMode,
+) -> Result<GateRef, TurnError> {
+    if mode == SpawnSubagentMode::Blocking
+        && parent_record.status == TurnStatus::BlockedDependentRun
+        && let Some(gate_ref) = parent_record.gate_ref.clone()
+    {
+        return Ok(gate_ref);
+    }
+    // Mirrors the spawn path's `LoopGateRef`-compatible gate token format.
+    // The separator after the `gate:` prefix must stay colon-free because
+    // `LoopGateRef` rejects additional colons in the opaque id.
+    GateRef::new(match mode {
+        SpawnSubagentMode::Blocking => format!("gate:subagent-{}", child_record.run_id),
+        SpawnSubagentMode::Background => format!("gate:subagent-bg-{}", child_record.run_id),
+    })
+    .map_err(|reason| TurnError::InvalidRequest { reason })
 }
 
 fn parse_subagent_thread_metadata(raw: &str) -> Option<SubagentThreadMetadata> {
@@ -1641,6 +1655,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn persisted_blocking_reconstruction_preserves_existing_parent_gate_ref() {
+        let parent_gate = GateRef::new("gate:subagent.legacy-blocking").unwrap();
+        let parent_run_id = TurnRunId::new();
+        let child_run_id = TurnRunId::new();
+        let parent_scope = TurnScope::new(
+            TenantId::new("tenant").unwrap(),
+            Some(AgentId::new("agent").unwrap()),
+            None,
+            ThreadId::new("legacy-parent-thread").unwrap(),
+        );
+        let child_scope = TurnScope::new(
+            parent_scope.tenant_id.clone(),
+            parent_scope.agent_id.clone(),
+            None,
+            ThreadId::new("legacy-child-thread").unwrap(),
+        );
+        let mut parent_context =
+            ironclaw_agent_loop::test_support::test_run_context("legacy-parent");
+        parent_context.scope = parent_scope.clone();
+        parent_context.thread_id = parent_scope.thread_id.clone();
+        parent_context.run_id = parent_run_id;
+        let mut child_context = ironclaw_agent_loop::test_support::test_run_context("legacy-child");
+        child_context.scope = child_scope;
+        child_context.thread_id = ThreadId::new("legacy-child-thread").unwrap();
+        child_context.run_id = child_run_id;
+
+        let mut parent_record = turn_record_for_context(&parent_context, None, 0, None);
+        parent_record.status = TurnStatus::BlockedDependentRun;
+        parent_record.gate_ref = Some(parent_gate.clone());
+        let child_record = turn_record_for_context(&child_context, Some(parent_run_id), 1, None);
+
+        let reconstructed = awaited_child_record_from_persisted(
+            parent_record,
+            child_record,
+            SubagentThreadMetadata {
+                kind: SubagentThreadKind::Subagent,
+                parent_run_id,
+                parent_thread_id: parent_scope.thread_id,
+                tree_root_run_id: parent_run_id,
+                child_run_id,
+                subagent_kind: SubagentKindId::new("general").unwrap(),
+                mode: SpawnSubagentMode::Blocking,
+                result_ref: LoopResultRef::new("result:subagent.legacy").unwrap(),
+                handoff: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(reconstructed.gate_ref, parent_gate);
+    }
+
+    #[tokio::test]
     async fn recovery_required_child_resolves_parent_reference() {
         let tenant = TenantId::new("tenant").unwrap();
         let agent = AgentId::new("agent").unwrap();
@@ -1906,7 +1972,7 @@ mod tests {
             .await
             .unwrap();
 
-        let gate_ref = GateRef::new(format!("gate:subagent:{}", child_run_id)).unwrap();
+        let gate_ref = GateRef::new(format!("gate:subagent-{}", child_run_id)).unwrap();
         let gate_store = Arc::new(BoundedSubagentGateResolutionStore::new());
         let goal_store = Arc::new(InMemoryBoundedSubagentGoalStore::new());
         let mut parent_run_context =
@@ -1973,6 +2039,202 @@ mod tests {
             turn_state_store.releases(),
             vec![(parent_scope, parent_run_id, 1)]
         );
+    }
+
+    #[tokio::test]
+    async fn shared_batch_terminal_event_claims_all_states_once() {
+        let tenant = TenantId::new("tenant").unwrap();
+        let agent = AgentId::new("agent").unwrap();
+        let owner = UserId::new("owner").unwrap();
+        let parent_scope = TurnScope::new(
+            tenant.clone(),
+            Some(agent.clone()),
+            None,
+            ThreadId::new("shared-parent-thread").unwrap(),
+        );
+        let parent_thread_scope = ThreadScope {
+            tenant_id: tenant.clone(),
+            agent_id: agent.clone(),
+            project_id: None,
+            owner_user_id: Some(owner.clone()),
+            mission_id: None,
+        };
+        let child_a_scope = TurnScope::new(
+            tenant.clone(),
+            Some(agent.clone()),
+            None,
+            ThreadId::new("shared-child-a-thread").unwrap(),
+        );
+        let child_b_scope = TurnScope::new(
+            tenant,
+            Some(agent),
+            None,
+            ThreadId::new("shared-child-b-thread").unwrap(),
+        );
+        let child_thread_scope = ThreadScope {
+            tenant_id: parent_thread_scope.tenant_id.clone(),
+            agent_id: parent_thread_scope.agent_id.clone(),
+            project_id: None,
+            owner_user_id: Some(owner.clone()),
+            mission_id: None,
+        };
+        let parent_run_id = TurnRunId::new();
+        let child_a_run_id = TurnRunId::new();
+        let child_b_run_id = TurnRunId::new();
+        let result_ref = LoopResultRef::new("result:subagent.shared").unwrap();
+        let gate_ref = GateRef::new("gate:subagent-batch-shared-observer").unwrap();
+
+        let turn_state_store = Arc::new(RecordingTurnStateStore::default());
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        thread_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: parent_thread_scope.clone(),
+                thread_id: Some(parent_scope.thread_id.clone()),
+                created_by_actor_id: "test".to_string(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        thread_service
+            .append_tool_result_reference(AppendToolResultReferenceRequest {
+                scope: parent_thread_scope,
+                thread_id: parent_scope.thread_id.clone(),
+                turn_run_id: parent_run_id.to_string(),
+                result_ref: result_ref.as_str().to_string(),
+                safe_summary: ToolResultSafeSummary::new("subagents spawned blocking").unwrap(),
+                provider_call: None,
+            })
+            .await
+            .unwrap();
+        for (scope, run_id, final_text) in [
+            (
+                child_a_scope.clone(),
+                child_a_run_id,
+                "first shared child final",
+            ),
+            (
+                child_b_scope.clone(),
+                child_b_run_id,
+                "second shared child final",
+            ),
+        ] {
+            thread_service
+                .ensure_thread(EnsureThreadRequest {
+                    scope: child_thread_scope.clone(),
+                    thread_id: Some(scope.thread_id.clone()),
+                    created_by_actor_id: "test".to_string(),
+                    title: None,
+                    metadata_json: None,
+                })
+                .await
+                .unwrap();
+            let draft = thread_service
+                .append_assistant_draft(AppendAssistantDraftRequest {
+                    scope: child_thread_scope.clone(),
+                    thread_id: scope.thread_id.clone(),
+                    turn_run_id: run_id.to_string(),
+                    content: MessageContent::text("draft"),
+                })
+                .await
+                .unwrap();
+            thread_service
+                .finalize_assistant_message(
+                    &child_thread_scope,
+                    &scope.thread_id,
+                    draft.message_id,
+                    MessageContent::text(final_text),
+                )
+                .await
+                .unwrap();
+        }
+
+        let gate_store = Arc::new(BoundedSubagentGateResolutionStore::new());
+        let goal_store = Arc::new(InMemoryBoundedSubagentGoalStore::new());
+        let mut parent_run_context =
+            ironclaw_agent_loop::test_support::test_run_context("completion-observer-shared");
+        parent_run_context.scope = parent_scope.clone();
+        parent_run_context.thread_id = parent_scope.thread_id.clone();
+        parent_run_context.run_id = parent_run_id;
+        for (child_scope, child_run_id) in [
+            (child_a_scope.clone(), child_a_run_id),
+            (child_b_scope.clone(), child_b_run_id),
+        ] {
+            gate_store
+                .record_awaited_child(AwaitedChildSetRecord {
+                    gate_ref: gate_ref.clone(),
+                    parent_run_context: parent_run_context.clone(),
+                    tree_root_run_id: parent_run_id,
+                    child_scope: child_scope.clone(),
+                    child_run_id,
+                    child_thread_id: child_scope.thread_id.clone(),
+                    source_binding_ref: SourceBindingRef::new(format!(
+                        "subagent-source:{child_run_id}"
+                    ))
+                    .unwrap(),
+                    reply_target_binding_ref: ReplyTargetBindingRef::new(format!(
+                        "subagent-reply:{child_run_id}"
+                    ))
+                    .unwrap(),
+                    subagent_kind: SubagentKindId::new("general").unwrap(),
+                    spawn_capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
+                        .unwrap(),
+                    result_ref: result_ref.clone(),
+                    mode: SpawnSubagentMode::Blocking,
+                })
+                .await
+                .unwrap();
+        }
+
+        let result_writer = Arc::new(RecordingResultWriter::new(result_ref));
+        let coordinator = Arc::new(RecordingCoordinator::default());
+        let observer = SubagentCompletionObserver::new(
+            Arc::clone(&gate_store),
+            goal_store,
+            turn_state_store.clone(),
+            result_writer.clone(),
+            coordinator.clone(),
+            thread_service,
+        )
+        .unwrap();
+
+        observer
+            .handle_terminal(&TurnLifecycleEvent {
+                cursor: EventCursor(21),
+                scope: child_a_scope,
+                occurred_at: None,
+                owner_user_id: Some(owner.clone()),
+                run_id: child_a_run_id,
+                status: TurnStatus::Completed,
+                kind: TurnEventKind::Completed,
+                blocked_gate: None,
+                sanitized_reason: None,
+            })
+            .await
+            .unwrap();
+        assert!(result_writer.writes().is_empty());
+        assert!(coordinator.resumed.lock().unwrap().is_empty());
+
+        observer
+            .handle_terminal(&TurnLifecycleEvent {
+                cursor: EventCursor(22),
+                scope: child_b_scope,
+                occurred_at: None,
+                owner_user_id: Some(owner),
+                run_id: child_b_run_id,
+                status: TurnStatus::Completed,
+                kind: TurnEventKind::Completed,
+                blocked_gate: None,
+                sanitized_reason: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result_writer.writes().len(), 2);
+        assert_eq!(turn_state_store.releases().len(), 2);
+        let resumed = coordinator.resumed.lock().unwrap().clone();
+        assert_eq!(resumed.len(), 1);
+        assert_eq!(resumed[0].gate_resolution_ref, gate_ref);
     }
 
     #[tokio::test]
@@ -2051,7 +2313,7 @@ mod tests {
             .await
             .unwrap();
 
-        let gate_ref = GateRef::new(format!("gate:subagent:{}", child_run_id)).unwrap();
+        let gate_ref = GateRef::new(format!("gate:subagent-{}", child_run_id)).unwrap();
         let gate_store = Arc::new(BoundedSubagentGateResolutionStore::new());
         let goal_store = Arc::new(InMemoryBoundedSubagentGoalStore::new());
         let mut parent_run_context =

--- a/crates/ironclaw_reborn/src/subagent/completion_observer.rs
+++ b/crates/ironclaw_reborn/src/subagent/completion_observer.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, OnceLock};
+use std::{
+    collections::HashSet,
+    sync::{Arc, OnceLock},
+};
 
 use async_trait::async_trait;
 use ironclaw_host_api::CapabilityId;
@@ -104,18 +107,14 @@ where
             .record_child_terminal(event.run_id, terminal_event_from_lifecycle(event))
             .map_err(map_host_error)?;
         self.recover_missing_gate_record(event).await?;
-        let mut claimed = Vec::new();
-        while let Some(state) = self
+        let claimed = self
             .gate_store
-            .claim_next_terminal_state_for_child(event.run_id)
-            .map_err(map_host_error)?
-        {
-            claimed.push(state);
-        }
-        let claimed_gates = claimed
+            .claim_all_terminal_states_for_child(event.run_id)
+            .map_err(map_host_error)?;
+        let claimed_gates: HashSet<GateRef> = claimed
             .iter()
             .map(|state| state.record.gate_ref.clone())
-            .collect::<Vec<_>>();
+            .collect();
         if let Err(error) = self.handle_claimed_terminal_states(claimed).await {
             for gate_ref in claimed_gates {
                 let _ = self.gate_store.release_terminal_claim(&gate_ref);
@@ -129,7 +128,8 @@ where
         &self,
         states: Vec<crate::subagent::gate_resolution::AwaitedChildState>,
     ) -> Result<(), TurnError> {
-        let mut delivered_gates = Vec::new();
+        let mut delivered_gates: HashSet<GateRef> = HashSet::new();
+        let mut parent_resume_gates = HashSet::new();
         let mut parent_resumes = Vec::new();
         for state in states {
             let terminal_event = state.terminal_event.ok_or_else(|| TurnError::Unavailable {
@@ -139,11 +139,7 @@ where
                 SpawnSubagentMode::Blocking => {
                     self.write_terminal_result(&state.record, &terminal_event)
                         .await?;
-                    if !parent_resumes.iter().any(
-                        |(record, _): &(AwaitedChildSetRecord, AwaitedChildTerminalEvent)| {
-                            record.gate_ref == state.record.gate_ref
-                        },
-                    ) {
+                    if parent_resume_gates.insert(state.record.gate_ref.clone()) {
                         parent_resumes.push((state.record.clone(), terminal_event.clone()));
                     }
                 }
@@ -157,9 +153,7 @@ where
                 .delete_goal(&state.record.child_scope, state.record.child_run_id)
                 .await
                 .map_err(map_host_error)?;
-            if !delivered_gates.contains(&state.record.gate_ref) {
-                delivered_gates.push(state.record.gate_ref.clone());
-            }
+            delivered_gates.insert(state.record.gate_ref.clone());
         }
         for (record, terminal_event) in parent_resumes {
             self.resume_parent(&terminal_event, &record).await?;
@@ -653,8 +647,8 @@ fn awaited_child_record_from_persisted(
     // The separator after the `gate:` prefix must stay colon-free because
     // `LoopGateRef` rejects additional colons in the opaque id.
     let gate_ref = GateRef::new(match metadata.mode {
-        SpawnSubagentMode::Blocking => format!("gate:subagent.{}", child_record.run_id),
-        SpawnSubagentMode::Background => format!("gate:subagent-bg.{}", child_record.run_id),
+        SpawnSubagentMode::Blocking => format!("gate:subagent-{}", child_record.run_id),
+        SpawnSubagentMode::Background => format!("gate:subagent-bg-{}", child_record.run_id),
     })
     .map_err(|reason| TurnError::InvalidRequest { reason })?;
     let parent_run_context = LoopRunContext::new(
@@ -1269,7 +1263,7 @@ mod tests {
         parent_run_context.run_id = parent_run_id;
         gate_store
             .record_awaited_child(AwaitedChildSetRecord {
-                gate_ref: GateRef::new("gate:subagent-bg:test").unwrap(),
+                gate_ref: GateRef::new("gate:subagent-bg-test").unwrap(),
                 parent_run_context,
                 tree_root_run_id,
                 child_scope: child_scope.clone(),
@@ -1418,7 +1412,7 @@ mod tests {
         parent_run_context.run_id = parent_run_id;
         gate_store
             .record_awaited_child(AwaitedChildSetRecord {
-                gate_ref: GateRef::new("gate:subagent-bg:recovered").unwrap(),
+                gate_ref: GateRef::new("gate:subagent-bg-recovered").unwrap(),
                 parent_run_context,
                 tree_root_run_id: parent_run_id,
                 child_scope: child_scope.clone(),
@@ -1725,7 +1719,7 @@ mod tests {
         parent_run_context.run_id = parent_run_id;
         gate_store
             .record_awaited_child(AwaitedChildSetRecord {
-                gate_ref: GateRef::new("gate:subagent-bg:recovery-required").unwrap(),
+                gate_ref: GateRef::new("gate:subagent-bg-recovery-required").unwrap(),
                 parent_run_context,
                 tree_root_run_id: parent_run_id,
                 child_scope: child_scope.clone(),

--- a/crates/ironclaw_reborn/src/subagent/completion_observer.rs
+++ b/crates/ironclaw_reborn/src/subagent/completion_observer.rs
@@ -104,39 +104,48 @@ where
             .record_child_terminal(event.run_id, terminal_event_from_lifecycle(event))
             .map_err(map_host_error)?;
         self.recover_missing_gate_record(event).await?;
+        let mut claimed = Vec::new();
         while let Some(state) = self
             .gate_store
             .claim_next_terminal_state_for_child(event.run_id)
             .map_err(map_host_error)?
         {
-            if let Err(error) = self.handle_claimed_terminal_state(state).await {
-                let (gate_ref, error) = error;
+            claimed.push(state);
+        }
+        let claimed_gates = claimed
+            .iter()
+            .map(|state| state.record.gate_ref.clone())
+            .collect::<Vec<_>>();
+        if let Err(error) = self.handle_claimed_terminal_states(claimed).await {
+            for gate_ref in claimed_gates {
                 let _ = self.gate_store.release_terminal_claim(&gate_ref);
-                return Err(error);
             }
+            return Err(error);
         }
         Ok(())
     }
 
-    async fn handle_claimed_terminal_state(
+    async fn handle_claimed_terminal_states(
         &self,
-        state: crate::subagent::gate_resolution::AwaitedChildState,
-    ) -> Result<(), (GateRef, TurnError)> {
-        let terminal_event = state.terminal_event.ok_or_else(|| {
-            (
-                state.record.gate_ref.clone(),
-                TurnError::Unavailable {
-                    reason: "subagent gate replay selected state without terminal metadata"
-                        .to_string(),
-                },
-            )
-        })?;
-        let result = async {
+        states: Vec<crate::subagent::gate_resolution::AwaitedChildState>,
+    ) -> Result<(), TurnError> {
+        let mut delivered_gates = Vec::new();
+        let mut parent_resumes = Vec::new();
+        for state in states {
+            let terminal_event = state.terminal_event.ok_or_else(|| TurnError::Unavailable {
+                reason: "subagent gate replay selected state without terminal metadata".to_string(),
+            })?;
             match state.record.mode {
                 SpawnSubagentMode::Blocking => {
                     self.write_terminal_result(&state.record, &terminal_event)
                         .await?;
-                    self.resume_parent(&terminal_event, &state.record).await?;
+                    if !parent_resumes.iter().any(
+                        |(record, _): &(AwaitedChildSetRecord, AwaitedChildTerminalEvent)| {
+                            record.gate_ref == state.record.gate_ref
+                        },
+                    ) {
+                        parent_resumes.push((state.record.clone(), terminal_event.clone()));
+                    }
                 }
                 SpawnSubagentMode::Background => {
                     self.write_terminal_result(&state.record, &terminal_event)
@@ -148,17 +157,23 @@ where
                 .delete_goal(&state.record.child_scope, state.record.child_run_id)
                 .await
                 .map_err(map_host_error)?;
+            if !delivered_gates.contains(&state.record.gate_ref) {
+                delivered_gates.push(state.record.gate_ref.clone());
+            }
+        }
+        for (record, terminal_event) in parent_resumes {
+            self.resume_parent(&terminal_event, &record).await?;
+        }
+        for gate_ref in delivered_gates {
             self.gate_store
-                .mark_delivered(&state.record.gate_ref)
+                .mark_delivered(&gate_ref)
                 .map_err(map_host_error)?;
             self.gate_store
-                .delete_awaited_child(&state.record.gate_ref)
+                .delete_awaited_child(&gate_ref)
                 .await
                 .map_err(map_host_error)?;
-            Ok(())
         }
-        .await;
-        result.map_err(|error| (state.record.gate_ref, error))
+        Ok(())
     }
 
     async fn is_subagent_child(&self, event: &TurnLifecycleEvent) -> Result<bool, TurnError> {

--- a/crates/ironclaw_reborn/src/subagent/gate_resolution.rs
+++ b/crates/ironclaw_reborn/src/subagent/gate_resolution.rs
@@ -109,46 +109,10 @@ impl BoundedSubagentGateResolutionStore {
         child_run_id: TurnRunId,
     ) -> Result<Option<AwaitedChildState>, AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        while let Some(gate_ref) = inner
-            .deliverable_by_child
-            .get_mut(&child_run_id)
-            .and_then(VecDeque::pop_front)
-        {
-            let claim_result = inner
-                .by_gate
-                .get_mut(&gate_ref)
-                .and_then(|states| try_claim_one_state(states));
-            if let Some((claimed, more_unclaimed)) = claim_result {
-                if more_unclaimed {
-                    inner
-                        .deliverable_by_child
-                        .entry(child_run_id)
-                        .or_default()
-                        .push_front(gate_ref);
-                }
-                return Ok(Some(claimed));
-            }
-            // Gate exists but not every sibling under it is terminal yet.
-            // Re-queue the gate so a future `record_child_terminal` for this
-            // child doesn't see an empty queue — without this requeue the
-            // gate would orphan from this child's view and rely entirely on
-            // sibling-driven requeues, which is fragile under recovery or
-            // event replay.
-            if inner
-                .by_gate
-                .get(&gate_ref)
-                .is_some_and(|states| !states.iter().all(|s| s.terminal_status.is_some()))
-            {
-                inner
-                    .deliverable_by_child
-                    .entry(child_run_id)
-                    .or_default()
-                    .push_front(gate_ref);
-                return Ok(None);
-            }
+        match claim_deliverable_state_for_child(&mut inner, child_run_id) {
+            DeliverableClaim::Claimed(state) => Ok(Some(*state)),
+            DeliverableClaim::Empty | DeliverableClaim::PendingSibling => Ok(None),
         }
-        inner.deliverable_by_child.remove(&child_run_id);
-        Ok(None)
     }
 
     // Drains every deliverable state for `child_run_id` under a single lock
@@ -163,49 +127,10 @@ impl BoundedSubagentGateResolutionStore {
     ) -> Result<Vec<AwaitedChildState>, AgentLoopHostError> {
         let mut claimed = Vec::new();
         let mut inner = lock(&self.inner)?;
-        while let Some(gate_ref) = inner
-            .deliverable_by_child
-            .get_mut(&child_run_id)
-            .and_then(VecDeque::pop_front)
+        while let DeliverableClaim::Claimed(state) =
+            claim_deliverable_state_for_child(&mut inner, child_run_id)
         {
-            let claim_result = inner
-                .by_gate
-                .get_mut(&gate_ref)
-                .and_then(|states| try_claim_one_state(states));
-            match claim_result {
-                Some((state, more_unclaimed)) => {
-                    if more_unclaimed {
-                        inner
-                            .deliverable_by_child
-                            .entry(child_run_id)
-                            .or_default()
-                            .push_front(gate_ref);
-                    }
-                    claimed.push(state);
-                }
-                None => {
-                    // Either gate missing or not all siblings terminal. If
-                    // the gate still exists with pending siblings, requeue so
-                    // the next `record_child_terminal` for this child doesn't
-                    // see an empty queue. (Same defensive requeue as
-                    // `claim_next_terminal_state_for_child`.)
-                    if inner
-                        .by_gate
-                        .get(&gate_ref)
-                        .is_some_and(|states| !states.iter().all(|s| s.terminal_status.is_some()))
-                    {
-                        inner
-                            .deliverable_by_child
-                            .entry(child_run_id)
-                            .or_default()
-                            .push_front(gate_ref);
-                        break;
-                    }
-                }
-            }
-        }
-        if claimed.is_empty() {
-            inner.deliverable_by_child.remove(&child_run_id);
+            claimed.push(*state);
         }
         Ok(claimed)
     }
@@ -283,13 +208,14 @@ impl BoundedSubagentGateResolutionStore {
         gate_ref: &GateRef,
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        if let Some(states) = inner.by_gate.get_mut(gate_ref)
-            && let Some(state) = states
+        if let Some(states) = inner.by_gate.get_mut(gate_ref) {
+            for state in states
                 .iter_mut()
-                .find(|s| s.descendant_reservation_release_claimed)
-        {
-            state.descendant_reservation_release_claimed = false;
-            state.descendant_reservation_released = true;
+                .filter(|state| state.descendant_reservation_release_claimed)
+            {
+                state.descendant_reservation_release_claimed = false;
+                state.descendant_reservation_released = true;
+            }
         }
         Ok(())
     }
@@ -299,12 +225,13 @@ impl BoundedSubagentGateResolutionStore {
         gate_ref: &GateRef,
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        if let Some(states) = inner.by_gate.get_mut(gate_ref)
-            && let Some(state) = states
-                .iter_mut()
-                .find(|s| s.descendant_reservation_release_claimed)
-        {
-            state.descendant_reservation_release_claimed = false;
+        if let Some(states) = inner.by_gate.get_mut(gate_ref) {
+            for state in states.iter_mut().filter(|state| {
+                state.descendant_reservation_release_claimed
+                    && !state.descendant_reservation_released
+            }) {
+                state.descendant_reservation_release_claimed = false;
+            }
         }
         Ok(())
     }
@@ -347,7 +274,7 @@ impl BoundedSubagentGateResolutionStore {
     }
 
     pub fn is_empty(&self) -> Result<bool, AgentLoopHostError> {
-        Ok(lock(&self.inner)?.by_gate.is_empty())
+        Ok(lock(&self.inner)?.total_states == 0)
     }
 }
 
@@ -444,6 +371,56 @@ fn is_subagent_terminal_status(status: TurnStatus) -> bool {
 // so this never returns `Err`.
 fn lock<T>(mutex: &Mutex<T>) -> Result<parking_lot::MutexGuard<'_, T>, AgentLoopHostError> {
     Ok(mutex.lock())
+}
+
+enum DeliverableClaim {
+    Claimed(Box<AwaitedChildState>),
+    PendingSibling,
+    Empty,
+}
+
+fn claim_deliverable_state_for_child(
+    inner: &mut GateResolutionInner,
+    child_run_id: TurnRunId,
+) -> DeliverableClaim {
+    while let Some(gate_ref) = inner
+        .deliverable_by_child
+        .get_mut(&child_run_id)
+        .and_then(VecDeque::pop_front)
+    {
+        let claim_result = inner
+            .by_gate
+            .get_mut(&gate_ref)
+            .and_then(|states| try_claim_one_state(states));
+        if let Some((claimed, more_unclaimed)) = claim_result {
+            if more_unclaimed {
+                inner
+                    .deliverable_by_child
+                    .entry(child_run_id)
+                    .or_default()
+                    .push_front(gate_ref);
+            }
+            return DeliverableClaim::Claimed(Box::new(claimed));
+        }
+        // Gate exists but not every sibling under it is terminal yet.
+        // Re-queue the gate so a future `record_child_terminal` for this
+        // child doesn't see an empty queue; otherwise recovery or event
+        // replay can orphan the gate from this child's view.
+        if inner
+            .by_gate
+            .get(&gate_ref)
+            .is_some_and(|states| !states.iter().all(|s| s.terminal_status.is_some()))
+        {
+            inner
+                .deliverable_by_child
+                .entry(child_run_id)
+                .or_default()
+                .push_front(gate_ref);
+            return DeliverableClaim::PendingSibling;
+        }
+    }
+    inner.deliverable_by_child.remove(&child_run_id);
+    DeliverableClaim::Empty
 }
 
 /// Tries to claim one undelivered terminal state from the given gate's state
@@ -545,7 +522,7 @@ mod tests {
     async fn record_child_terminal_rejects_non_terminal_statuses() {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_run_id = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent:test").unwrap();
+        let gate = GateRef::new("gate:subagent-test").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_run_id))
             .await
@@ -695,7 +672,7 @@ mod tests {
     async fn descendant_release_claim_can_be_retried_before_marked_released() {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_run_id = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent:test").unwrap();
+        let gate = GateRef::new("gate:subagent-test").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_run_id))
             .await
@@ -770,7 +747,7 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_a = TurnRunId::new();
         let child_b = TurnRunId::new();
-        let gate = "gate:subagent-batch.pending";
+        let gate = "gate:subagent-batch-pending";
         store
             .record_awaited_child(record(gate, child_a))
             .await
@@ -796,7 +773,7 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_a = TurnRunId::new();
         let child_b = TurnRunId::new();
-        let gate = "gate:subagent-batch.partial";
+        let gate = "gate:subagent-batch-partial";
         store
             .record_awaited_child(record(gate, child_a))
             .await
@@ -827,7 +804,7 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_a = TurnRunId::new();
         let child_b = TurnRunId::new();
-        let gate = "gate:subagent-batch.order";
+        let gate = "gate:subagent-batch-order";
         store
             .record_awaited_child(record(gate, child_a))
             .await
@@ -849,7 +826,7 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_a = TurnRunId::new();
         let child_b = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent-batch.descendant").unwrap();
+        let gate = GateRef::new("gate:subagent-batch-descendant").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_a))
             .await
@@ -873,11 +850,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn descendant_reservation_mark_releases_all_claimed_states() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = GateRef::new("gate:subagent-batch-descendant-mark").unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_b))
+            .await
+            .unwrap();
+
+        assert!(store.claim_descendant_reservation_release(&gate).unwrap());
+        assert!(store.claim_descendant_reservation_release(&gate).unwrap());
+        store.mark_descendant_reservation_released(&gate).unwrap();
+
+        assert!(
+            !store.claim_descendant_reservation_release(&gate).unwrap(),
+            "mark must apply to every already claimed sibling state"
+        );
+    }
+
+    #[tokio::test]
+    async fn descendant_reservation_release_claim_retries_all_claimed_states() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = GateRef::new("gate:subagent-batch-descendant-retry").unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_b))
+            .await
+            .unwrap();
+
+        assert!(store.claim_descendant_reservation_release(&gate).unwrap());
+        assert!(store.claim_descendant_reservation_release(&gate).unwrap());
+        store.release_descendant_reservation_claim(&gate).unwrap();
+
+        assert!(store.claim_descendant_reservation_release(&gate).unwrap());
+        assert!(store.claim_descendant_reservation_release(&gate).unwrap());
+    }
+
+    #[tokio::test]
     async fn release_terminal_claim_requeues_all_claimed_states_under_shared_gate() {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_a = TurnRunId::new();
         let child_b = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent-batch.requeue").unwrap();
+        let gate = GateRef::new("gate:subagent-batch-requeue").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_a))
             .await
@@ -919,7 +944,7 @@ mod tests {
         let child_a = TurnRunId::new();
         let child_b = TurnRunId::new();
         let child_c = TurnRunId::new();
-        let gate = "gate:subagent-batch.drain";
+        let gate = "gate:subagent-batch-drain";
         store
             .record_awaited_child(record(gate, child_a))
             .await
@@ -955,7 +980,7 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_a = TurnRunId::new();
         let child_b = TurnRunId::new();
-        let gate = "gate:subagent-batch.requeue-on-pending";
+        let gate = "gate:subagent-batch-requeue-on-pending";
         store
             .record_awaited_child(record(gate, child_a))
             .await
@@ -999,7 +1024,7 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         let child = TurnRunId::new();
         store
-            .record_awaited_child(record("gate:subagent.idempotent", child))
+            .record_awaited_child(record("gate:subagent-idempotent", child))
             .await
             .unwrap();
 
@@ -1040,7 +1065,7 @@ mod tests {
     #[tokio::test]
     async fn record_awaited_child_capacity_counts_total_states_not_keys() {
         let store = BoundedSubagentGateResolutionStore::new();
-        let shared_gate = "gate:subagent-batch.capacity";
+        let shared_gate = "gate:subagent-batch-capacity";
         // Filling the bound through a single shared gate must hit the cap.
         for _ in 0..MAX_GATE_RECORDS {
             store
@@ -1053,5 +1078,22 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(error.kind, AgentLoopHostErrorKind::BudgetExceeded);
+    }
+
+    #[tokio::test]
+    async fn is_empty_tracks_total_state_count() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let gate = GateRef::new("gate:subagent-empty-total").unwrap();
+
+        assert!(store.is_empty().unwrap());
+        store
+            .record_awaited_child(record(gate.as_str(), TurnRunId::new()))
+            .await
+            .unwrap();
+        assert_eq!(store.len().unwrap(), 1);
+        assert!(!store.is_empty().unwrap());
+        store.delete_awaited_child(&gate).await.unwrap();
+        assert_eq!(store.len().unwrap(), 0);
+        assert!(store.is_empty().unwrap());
     }
 }

--- a/crates/ironclaw_reborn/src/subagent/gate_resolution.rs
+++ b/crates/ironclaw_reborn/src/subagent/gate_resolution.rs
@@ -37,7 +37,7 @@ pub struct BoundedSubagentGateResolutionStore {
 
 #[derive(Default)]
 struct GateResolutionInner {
-    by_gate: HashMap<GateRef, AwaitedChildState>,
+    by_gate: HashMap<GateRef, Vec<AwaitedChildState>>,
     gates_by_child: HashMap<TurnRunId, Vec<GateRef>>,
     deliverable_by_child: HashMap<TurnRunId, VecDeque<GateRef>>,
 }
@@ -66,10 +66,19 @@ impl BoundedSubagentGateResolutionStore {
             return Ok(());
         };
         for gate_ref in gate_refs {
-            if let Some(state) = inner.by_gate.get_mut(&gate_ref) {
-                state.terminal_status = Some(terminal_status);
-                state.terminal_event = Some(terminal_event.clone());
-                if !state.delivery_claimed && !state.delivered_to_parent {
+            if let Some(states) = inner.by_gate.get_mut(&gate_ref) {
+                let mut any_deliverable = false;
+                for state in states
+                    .iter_mut()
+                    .filter(|state| state.record.child_run_id == child_run_id)
+                {
+                    state.terminal_status = Some(terminal_status);
+                    state.terminal_event = Some(terminal_event.clone());
+                    if !state.delivery_claimed && !state.delivered_to_parent {
+                        any_deliverable = true;
+                    }
+                }
+                if any_deliverable {
                     deliverable.push(gate_ref);
                 }
             }
@@ -92,13 +101,17 @@ impl BoundedSubagentGateResolutionStore {
             .get_mut(&child_run_id)
             .and_then(VecDeque::pop_front)
         {
-            if let Some(state) = inner.by_gate.get_mut(&gate_ref)
-                && state.terminal_status.is_some()
-                && !state.delivery_claimed
-                && !state.delivered_to_parent
-            {
-                state.delivery_claimed = true;
-                return Ok(Some(state.clone()));
+            if let Some(states) = inner.by_gate.get_mut(&gate_ref) {
+                if !states.iter().all(|state| state.terminal_status.is_some()) {
+                    continue;
+                }
+                if let Some(state) = states
+                    .iter_mut()
+                    .find(|state| !state.delivery_claimed && !state.delivered_to_parent)
+                {
+                    state.delivery_claimed = true;
+                    return Ok(Some(state.clone()));
+                }
             }
         }
         inner.deliverable_by_child.remove(&child_run_id);
@@ -107,27 +120,32 @@ impl BoundedSubagentGateResolutionStore {
 
     pub fn mark_delivered(&self, gate_ref: &GateRef) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        if let Some(state) = inner.by_gate.get_mut(gate_ref) {
-            state.delivery_claimed = false;
-            state.delivered_to_parent = true;
+        if let Some(states) = inner.by_gate.get_mut(gate_ref) {
+            for state in states {
+                state.delivery_claimed = false;
+                state.delivered_to_parent = true;
+            }
         }
         Ok(())
     }
 
     pub fn release_terminal_claim(&self, gate_ref: &GateRef) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        let child_run_id = if let Some(state) = inner.by_gate.get_mut(gate_ref)
-            && !state.delivered_to_parent
-        {
-            state.delivery_claimed = false;
-            state
-                .terminal_status
-                .is_some()
-                .then_some(state.record.child_run_id)
+        let to_requeue: Vec<TurnRunId> = if let Some(states) = inner.by_gate.get_mut(gate_ref) {
+            let mut cids = Vec::new();
+            for state in states.iter_mut().filter(|state| !state.delivered_to_parent) {
+                if state.delivery_claimed {
+                    state.delivery_claimed = false;
+                    if state.terminal_status.is_some() {
+                        cids.push(state.record.child_run_id);
+                    }
+                }
+            }
+            cids
         } else {
-            None
+            Vec::new()
         };
-        if let Some(child_run_id) = child_run_id {
+        for child_run_id in to_requeue {
             inner
                 .deliverable_by_child
                 .entry(child_run_id)
@@ -144,7 +162,9 @@ impl BoundedSubagentGateResolutionStore {
         Ok(inner
             .by_gate
             .values()
-            .filter(|state| state.terminal_status.is_some() && !state.delivered_to_parent)
+            .filter(|states| states.iter().all(|state| state.terminal_status.is_some()))
+            .flat_map(|states| states.iter())
+            .filter(|state| !state.delivered_to_parent)
             .cloned()
             .collect())
     }
@@ -154,7 +174,13 @@ impl BoundedSubagentGateResolutionStore {
         gate_ref: &GateRef,
     ) -> Result<bool, AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        let Some(state) = inner.by_gate.get_mut(gate_ref) else {
+        let Some(states) = inner.by_gate.get_mut(gate_ref) else {
+            return Ok(false);
+        };
+        let Some(state) = states
+            .iter_mut()
+            .find(|state| !state.descendant_reservation_released)
+        else {
             return Ok(false);
         };
         if state.descendant_reservation_released || state.descendant_reservation_release_claimed {
@@ -169,9 +195,11 @@ impl BoundedSubagentGateResolutionStore {
         gate_ref: &GateRef,
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        if let Some(state) = inner.by_gate.get_mut(gate_ref) {
-            state.descendant_reservation_release_claimed = false;
-            state.descendant_reservation_released = true;
+        if let Some(states) = inner.by_gate.get_mut(gate_ref) {
+            for state in states {
+                state.descendant_reservation_release_claimed = false;
+                state.descendant_reservation_released = true;
+            }
         }
         Ok(())
     }
@@ -181,10 +209,10 @@ impl BoundedSubagentGateResolutionStore {
         gate_ref: &GateRef,
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        if let Some(state) = inner.by_gate.get_mut(gate_ref)
-            && !state.descendant_reservation_released
-        {
-            state.descendant_reservation_release_claimed = false;
+        if let Some(states) = inner.by_gate.get_mut(gate_ref) {
+            for state in states.iter_mut().filter(|s| !s.descendant_reservation_released) {
+                state.descendant_reservation_release_claimed = false;
+            }
         }
         Ok(())
     }
@@ -193,7 +221,10 @@ impl BoundedSubagentGateResolutionStore {
         &self,
         gate_ref: &GateRef,
     ) -> Result<Option<AwaitedChildState>, AgentLoopHostError> {
-        Ok(lock(&self.inner)?.by_gate.get(gate_ref).cloned())
+        Ok(lock(&self.inner)?
+            .by_gate
+            .get(gate_ref)
+            .and_then(|states| states.first().cloned()))
     }
 
     pub fn subagent_kind_for_child(
@@ -206,7 +237,8 @@ impl BoundedSubagentGateResolutionStore {
         };
         Ok(gates
             .iter()
-            .find_map(|gate| inner.by_gate.get(gate))
+            .filter_map(|gate| inner.by_gate.get(gate))
+            .find_map(|states| states.first())
             .map(|state| state.record.subagent_kind.clone()))
     }
 
@@ -227,12 +259,6 @@ impl SubagentGateResolutionStore for BoundedSubagentGateResolutionStore {
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
         let gate_ref = record.gate_ref.clone();
-        if inner.by_gate.contains_key(&gate_ref) {
-            return Err(AgentLoopHostError::new(
-                AgentLoopHostErrorKind::InvalidInvocation,
-                "subagent awaited-child gate already exists",
-            ));
-        }
         if inner.by_gate.len() >= MAX_GATE_RECORDS {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::BudgetExceeded,
@@ -244,9 +270,11 @@ impl SubagentGateResolutionStore for BoundedSubagentGateResolutionStore {
             .entry(record.child_run_id)
             .or_default()
             .push(gate_ref.clone());
-        inner.by_gate.insert(
-            gate_ref.clone(),
-            AwaitedChildState {
+        inner
+            .by_gate
+            .entry(gate_ref.clone())
+            .or_default()
+            .push(AwaitedChildState {
                 record,
                 terminal_status: None,
                 terminal_event: None,
@@ -254,20 +282,25 @@ impl SubagentGateResolutionStore for BoundedSubagentGateResolutionStore {
                 descendant_reservation_released: false,
                 delivery_claimed: false,
                 delivered_to_parent: false,
-            },
-        );
+            });
         Ok(())
     }
 
     async fn delete_awaited_child(&self, gate_ref: &GateRef) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
         if let Some(old) = inner.by_gate.remove(gate_ref) {
-            prune_child_index(&mut inner.gates_by_child, old.record.child_run_id, gate_ref);
-            prune_deliverable_child_index(
-                &mut inner.deliverable_by_child,
-                old.record.child_run_id,
-                gate_ref,
-            );
+            for state in old {
+                prune_child_index(
+                    &mut inner.gates_by_child,
+                    state.record.child_run_id,
+                    gate_ref,
+                );
+                prune_deliverable_child_index(
+                    &mut inner.deliverable_by_child,
+                    state.record.child_run_id,
+                    gate_ref,
+                );
+            }
         }
         Ok(())
     }

--- a/crates/ironclaw_reborn/src/subagent/gate_resolution.rs
+++ b/crates/ironclaw_reborn/src/subagent/gate_resolution.rs
@@ -7,6 +7,7 @@ use ironclaw_turns::{
     EventCursor, GateRef, TurnEventKind, TurnRunId, TurnStatus,
     run_profile::{AgentLoopHostError, AgentLoopHostErrorKind},
 };
+use parking_lot::Mutex;
 
 const MAX_GATE_RECORDS: usize = 4096;
 
@@ -32,7 +33,7 @@ pub struct AwaitedChildTerminalEvent {
 
 #[derive(Default)]
 pub struct BoundedSubagentGateResolutionStore {
-    inner: std::sync::Mutex<GateResolutionInner>,
+    inner: Mutex<GateResolutionInner>,
 }
 
 #[derive(Default)]
@@ -40,6 +41,10 @@ struct GateResolutionInner {
     by_gate: HashMap<GateRef, Vec<AwaitedChildState>>,
     gates_by_child: HashMap<TurnRunId, Vec<GateRef>>,
     deliverable_by_child: HashMap<TurnRunId, VecDeque<GateRef>>,
+    // Cached total state count across all gate keys. Maintained alongside
+    // every push to `by_gate` and prune via `delete_awaited_child`, so the
+    // capacity check stays O(1) instead of summing every Vec under the lock.
+    total_states: usize,
 }
 
 impl BoundedSubagentGateResolutionStore {
@@ -72,6 +77,14 @@ impl BoundedSubagentGateResolutionStore {
                     .iter_mut()
                     .filter(|state| state.record.child_run_id == child_run_id)
                 {
+                    // Skip if this child's terminal was already recorded —
+                    // event replay or recovery may redeliver the same
+                    // terminal; treat the first one as authoritative so the
+                    // event payload (cursor, status, sanitized_reason) is
+                    // never silently overwritten by a later duplicate.
+                    if state.terminal_status.is_some() {
+                        continue;
+                    }
                     state.terminal_status = Some(terminal_status);
                     state.terminal_event = Some(terminal_event.clone());
                     if !state.delivery_claimed && !state.delivered_to_parent {
@@ -101,21 +114,100 @@ impl BoundedSubagentGateResolutionStore {
             .get_mut(&child_run_id)
             .and_then(VecDeque::pop_front)
         {
-            if let Some(states) = inner.by_gate.get_mut(&gate_ref) {
-                if !states.iter().all(|state| state.terminal_status.is_some()) {
-                    continue;
+            let claim_result = inner
+                .by_gate
+                .get_mut(&gate_ref)
+                .and_then(|states| try_claim_one_state(states));
+            if let Some((claimed, more_unclaimed)) = claim_result {
+                if more_unclaimed {
+                    inner
+                        .deliverable_by_child
+                        .entry(child_run_id)
+                        .or_default()
+                        .push_front(gate_ref);
                 }
-                if let Some(state) = states
-                    .iter_mut()
-                    .find(|state| !state.delivery_claimed && !state.delivered_to_parent)
-                {
-                    state.delivery_claimed = true;
-                    return Ok(Some(state.clone()));
-                }
+                return Ok(Some(claimed));
+            }
+            // Gate exists but not every sibling under it is terminal yet.
+            // Re-queue the gate so a future `record_child_terminal` for this
+            // child doesn't see an empty queue — without this requeue the
+            // gate would orphan from this child's view and rely entirely on
+            // sibling-driven requeues, which is fragile under recovery or
+            // event replay.
+            if inner
+                .by_gate
+                .get(&gate_ref)
+                .is_some_and(|states| !states.iter().all(|s| s.terminal_status.is_some()))
+            {
+                inner
+                    .deliverable_by_child
+                    .entry(child_run_id)
+                    .or_default()
+                    .push_front(gate_ref);
+                return Ok(None);
             }
         }
         inner.deliverable_by_child.remove(&child_run_id);
         Ok(None)
+    }
+
+    // Drains every deliverable state for `child_run_id` under a single lock
+    // acquisition. Each shared batch gate is requeued internally while there
+    // are remaining unclaimed states, so callers see one Vec containing every
+    // state this child unblocks. Equivalent to looping
+    // `claim_next_terminal_state_for_child` until None, but takes the lock
+    // exactly once.
+    pub fn claim_all_terminal_states_for_child(
+        &self,
+        child_run_id: TurnRunId,
+    ) -> Result<Vec<AwaitedChildState>, AgentLoopHostError> {
+        let mut claimed = Vec::new();
+        let mut inner = lock(&self.inner)?;
+        while let Some(gate_ref) = inner
+            .deliverable_by_child
+            .get_mut(&child_run_id)
+            .and_then(VecDeque::pop_front)
+        {
+            let claim_result = inner
+                .by_gate
+                .get_mut(&gate_ref)
+                .and_then(|states| try_claim_one_state(states));
+            match claim_result {
+                Some((state, more_unclaimed)) => {
+                    if more_unclaimed {
+                        inner
+                            .deliverable_by_child
+                            .entry(child_run_id)
+                            .or_default()
+                            .push_front(gate_ref);
+                    }
+                    claimed.push(state);
+                }
+                None => {
+                    // Either gate missing or not all siblings terminal. If
+                    // the gate still exists with pending siblings, requeue so
+                    // the next `record_child_terminal` for this child doesn't
+                    // see an empty queue. (Same defensive requeue as
+                    // `claim_next_terminal_state_for_child`.)
+                    if inner
+                        .by_gate
+                        .get(&gate_ref)
+                        .is_some_and(|states| !states.iter().all(|s| s.terminal_status.is_some()))
+                    {
+                        inner
+                            .deliverable_by_child
+                            .entry(child_run_id)
+                            .or_default()
+                            .push_front(gate_ref);
+                        break;
+                    }
+                }
+            }
+        }
+        if claimed.is_empty() {
+            inner.deliverable_by_child.remove(&child_run_id);
+        }
+        Ok(claimed)
     }
 
     pub fn mark_delivered(&self, gate_ref: &GateRef) -> Result<(), AgentLoopHostError> {
@@ -177,15 +269,11 @@ impl BoundedSubagentGateResolutionStore {
         let Some(states) = inner.by_gate.get_mut(gate_ref) else {
             return Ok(false);
         };
-        let Some(state) = states
-            .iter_mut()
-            .find(|state| !state.descendant_reservation_released)
-        else {
+        let Some(state) = states.iter_mut().find(|state| {
+            !state.descendant_reservation_released && !state.descendant_reservation_release_claimed
+        }) else {
             return Ok(false);
         };
-        if state.descendant_reservation_released || state.descendant_reservation_release_claimed {
-            return Ok(false);
-        }
         state.descendant_reservation_release_claimed = true;
         Ok(true)
     }
@@ -195,11 +283,13 @@ impl BoundedSubagentGateResolutionStore {
         gate_ref: &GateRef,
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        if let Some(states) = inner.by_gate.get_mut(gate_ref) {
-            for state in states {
-                state.descendant_reservation_release_claimed = false;
-                state.descendant_reservation_released = true;
-            }
+        if let Some(states) = inner.by_gate.get_mut(gate_ref)
+            && let Some(state) = states
+                .iter_mut()
+                .find(|s| s.descendant_reservation_release_claimed)
+        {
+            state.descendant_reservation_release_claimed = false;
+            state.descendant_reservation_released = true;
         }
         Ok(())
     }
@@ -209,14 +299,20 @@ impl BoundedSubagentGateResolutionStore {
         gate_ref: &GateRef,
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
-        if let Some(states) = inner.by_gate.get_mut(gate_ref) {
-            for state in states.iter_mut().filter(|s| !s.descendant_reservation_released) {
-                state.descendant_reservation_release_claimed = false;
-            }
+        if let Some(states) = inner.by_gate.get_mut(gate_ref)
+            && let Some(state) = states
+                .iter_mut()
+                .find(|s| s.descendant_reservation_release_claimed)
+        {
+            state.descendant_reservation_release_claimed = false;
         }
         Ok(())
     }
 
+    // Probe for gate presence and gate-level metadata (subagent_kind, mode,
+    // parent context) that is uniform across every state under a shared
+    // batch gate. Callers that need per-child state must iterate the full
+    // Vec via the dedicated APIs.
     pub fn state_for_gate(
         &self,
         gate_ref: &GateRef,
@@ -243,7 +339,11 @@ impl BoundedSubagentGateResolutionStore {
     }
 
     pub fn len(&self) -> Result<usize, AgentLoopHostError> {
-        Ok(lock(&self.inner)?.by_gate.len())
+        Ok(lock(&self.inner)?
+            .by_gate
+            .values()
+            .map(|states| states.len())
+            .sum())
     }
 
     pub fn is_empty(&self) -> Result<bool, AgentLoopHostError> {
@@ -259,7 +359,7 @@ impl SubagentGateResolutionStore for BoundedSubagentGateResolutionStore {
     ) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
         let gate_ref = record.gate_ref.clone();
-        if inner.by_gate.len() >= MAX_GATE_RECORDS {
+        if inner.total_states >= MAX_GATE_RECORDS {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::BudgetExceeded,
                 "subagent awaited-child gate store is at capacity",
@@ -283,12 +383,14 @@ impl SubagentGateResolutionStore for BoundedSubagentGateResolutionStore {
                 delivery_claimed: false,
                 delivered_to_parent: false,
             });
+        inner.total_states += 1;
         Ok(())
     }
 
     async fn delete_awaited_child(&self, gate_ref: &GateRef) -> Result<(), AgentLoopHostError> {
         let mut inner = lock(&self.inner)?;
         if let Some(old) = inner.by_gate.remove(gate_ref) {
+            inner.total_states = inner.total_states.saturating_sub(old.len());
             for state in old {
                 prune_child_index(
                     &mut inner.gates_by_child,
@@ -336,15 +438,32 @@ fn is_subagent_terminal_status(status: TurnStatus) -> bool {
     status.is_terminal() || status == TurnStatus::RecoveryRequired
 }
 
-fn lock<T>(
-    mutex: &std::sync::Mutex<T>,
-) -> Result<std::sync::MutexGuard<'_, T>, AgentLoopHostError> {
-    mutex.lock().map_err(|_| {
-        AgentLoopHostError::new(
-            AgentLoopHostErrorKind::Unavailable,
-            "subagent gate store mutex poisoned",
-        )
-    })
+// Infallible parking_lot lock helper retained for call-site compatibility
+// (every public method threads a `?` through this) and to make a future
+// switch back to a fallible store easy. `parking_lot::Mutex` cannot poison,
+// so this never returns `Err`.
+fn lock<T>(mutex: &Mutex<T>) -> Result<parking_lot::MutexGuard<'_, T>, AgentLoopHostError> {
+    Ok(mutex.lock())
+}
+
+/// Tries to claim one undelivered terminal state from the given gate's state
+/// vector. Returns `Some((state, more_unclaimed))` if a state was claimed,
+/// where `more_unclaimed` indicates whether further unclaimed terminal states
+/// remain in the same gate vector (used by callers to decide whether to
+/// requeue the gate for another drain pass).
+fn try_claim_one_state(states: &mut [AwaitedChildState]) -> Option<(AwaitedChildState, bool)> {
+    if !states.iter().all(|state| state.terminal_status.is_some()) {
+        return None;
+    }
+    let state = states
+        .iter_mut()
+        .find(|state| !state.delivery_claimed && !state.delivered_to_parent)?;
+    state.delivery_claimed = true;
+    let claimed = state.clone();
+    let more_unclaimed = states
+        .iter()
+        .any(|s| !s.delivery_claimed && !s.delivered_to_parent);
+    Some((claimed, more_unclaimed))
 }
 
 #[cfg(test)]
@@ -399,7 +518,7 @@ mod tests {
     async fn records_terminal_child_once_until_marked_delivered() {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_run_id = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent:test").unwrap();
+        let gate = GateRef::new("gate:subagent-test").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_run_id))
             .await
@@ -445,11 +564,11 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_run_id = TurnRunId::new();
         store
-            .record_awaited_child(record("gate:subagent:first", child_run_id))
+            .record_awaited_child(record("gate:subagent-first", child_run_id))
             .await
             .unwrap();
         store
-            .record_awaited_child(record("gate:subagent:second", child_run_id))
+            .record_awaited_child(record("gate:subagent-second", child_run_id))
             .await
             .unwrap();
         store
@@ -476,7 +595,7 @@ mod tests {
     async fn terminal_claim_release_allows_retry() {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_run_id = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent:test").unwrap();
+        let gate = GateRef::new("gate:subagent-test").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_run_id))
             .await
@@ -498,10 +617,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminal_claim_release_resets_only_undelivered_states_for_shared_gate() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let delivered_child = TurnRunId::new();
+        let retry_child = TurnRunId::new();
+        let gate = GateRef::new("gate:subagent-batch-test").unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), delivered_child))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), retry_child))
+            .await
+            .unwrap();
+        store
+            .record_child_terminal(delivered_child, terminal_event(TurnStatus::Completed))
+            .unwrap();
+        store
+            .record_child_terminal(retry_child, terminal_event(TurnStatus::Completed))
+            .unwrap();
+
+        assert!(
+            store
+                .claim_next_terminal_state_for_child(delivered_child)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .claim_next_terminal_state_for_child(retry_child)
+                .unwrap()
+                .is_some()
+        );
+        {
+            let mut inner = store.inner.lock();
+            let states = inner.by_gate.get_mut(&gate).expect("gate states");
+            let delivered = states
+                .iter_mut()
+                .find(|state| state.record.child_run_id == delivered_child)
+                .expect("delivered child state");
+            delivered.delivered_to_parent = true;
+        }
+
+        store.release_terminal_claim(&gate).unwrap();
+
+        let retried = store
+            .claim_next_terminal_state_for_child(retry_child)
+            .unwrap()
+            .expect("undelivered state should be claimable after release");
+        assert_eq!(retried.record.child_run_id, retry_child);
+        assert!(
+            store
+                .claim_next_terminal_state_for_child(delivered_child)
+                .unwrap()
+                .is_none(),
+            "delivered state should not become claimable again"
+        );
+    }
+
+    #[tokio::test]
     async fn marks_descendant_release_once() {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_run_id = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent:test").unwrap();
+        let gate = GateRef::new("gate:subagent-test").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_run_id))
             .await
@@ -532,7 +710,7 @@ mod tests {
     async fn delete_removes_child_index() {
         let store = BoundedSubagentGateResolutionStore::new();
         let child_run_id = TurnRunId::new();
-        let gate = GateRef::new("gate:subagent:test").unwrap();
+        let gate = GateRef::new("gate:subagent-test").unwrap();
         store
             .record_awaited_child(record(gate.as_str(), child_run_id))
             .await
@@ -557,13 +735,13 @@ mod tests {
         let store = BoundedSubagentGateResolutionStore::new();
         for index in 0..MAX_GATE_RECORDS {
             store
-                .record_awaited_child(record(&format!("gate:subagent:{index}"), TurnRunId::new()))
+                .record_awaited_child(record(&format!("gate:subagent-{index}"), TurnRunId::new()))
                 .await
                 .unwrap();
         }
 
         let error = store
-            .record_awaited_child(record("gate:subagent:overflow", TurnRunId::new()))
+            .record_awaited_child(record("gate:subagent-overflow", TurnRunId::new()))
             .await
             .unwrap_err();
 
@@ -571,7 +749,7 @@ mod tests {
         assert_eq!(store.len().unwrap(), MAX_GATE_RECORDS);
         assert!(
             store
-                .state_for_gate(&GateRef::new("gate:subagent:0").unwrap())
+                .state_for_gate(&GateRef::new("gate:subagent-0").unwrap())
                 .unwrap()
                 .is_some()
         );
@@ -585,5 +763,295 @@ mod tests {
             sanitized_reason: None,
             owner_user_id: Some(ironclaw_host_api::UserId::new("owner").unwrap()),
         }
+    }
+
+    #[tokio::test]
+    async fn claim_returns_none_when_sibling_on_shared_gate_is_still_pending() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = "gate:subagent-batch.pending";
+        store
+            .record_awaited_child(record(gate, child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate, child_b))
+            .await
+            .unwrap();
+
+        store
+            .record_child_terminal(child_a, terminal_event(TurnStatus::Completed))
+            .unwrap();
+
+        let claim_a = store.claim_next_terminal_state_for_child(child_a).unwrap();
+        assert!(
+            claim_a.is_none(),
+            "shared batch gate must not yield while sibling pending"
+        );
+    }
+
+    #[tokio::test]
+    async fn undelivered_terminal_states_excludes_partially_complete_shared_gates() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = "gate:subagent-batch.partial";
+        store
+            .record_awaited_child(record(gate, child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate, child_b))
+            .await
+            .unwrap();
+        store
+            .record_child_terminal(child_a, terminal_event(TurnStatus::Completed))
+            .unwrap();
+
+        let undelivered = store.undelivered_terminal_states().unwrap();
+        assert!(
+            undelivered.is_empty(),
+            "partial shared gate must not surface as undelivered"
+        );
+
+        store
+            .record_child_terminal(child_b, terminal_event(TurnStatus::Completed))
+            .unwrap();
+        let undelivered = store.undelivered_terminal_states().unwrap();
+        assert_eq!(undelivered.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn state_for_gate_returns_first_registered_state_for_shared_gate() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = "gate:subagent-batch.order";
+        store
+            .record_awaited_child(record(gate, child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate, child_b))
+            .await
+            .unwrap();
+
+        let state = store
+            .state_for_gate(&GateRef::new(gate).unwrap())
+            .unwrap()
+            .expect("gate present");
+        assert_eq!(state.record.child_run_id, child_a);
+    }
+
+    #[tokio::test]
+    async fn descendant_reservation_release_claims_one_state_per_call() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = GateRef::new("gate:subagent-batch.descendant").unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_b))
+            .await
+            .unwrap();
+
+        assert!(store.claim_descendant_reservation_release(&gate).unwrap());
+        store.mark_descendant_reservation_released(&gate).unwrap();
+        assert!(
+            store.claim_descendant_reservation_release(&gate).unwrap(),
+            "second sibling must still be claimable"
+        );
+        store.mark_descendant_reservation_released(&gate).unwrap();
+        assert!(
+            !store.claim_descendant_reservation_release(&gate).unwrap(),
+            "no further claims once both siblings released"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_terminal_claim_requeues_all_claimed_states_under_shared_gate() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = GateRef::new("gate:subagent-batch.requeue").unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate.as_str(), child_b))
+            .await
+            .unwrap();
+        store
+            .record_child_terminal(child_a, terminal_event(TurnStatus::Completed))
+            .unwrap();
+        store
+            .record_child_terminal(child_b, terminal_event(TurnStatus::Completed))
+            .unwrap();
+
+        let claimed = store.claim_all_terminal_states_for_child(child_b).unwrap();
+        assert_eq!(claimed.len(), 2);
+
+        // Simulate handle_claimed_terminal_states failure: release every
+        // claimed state. Calling release_terminal_claim multiple times for
+        // the same shared gate must be idempotent — it resets every claimed
+        // state once and re-enqueues the gate for a subsequent attempt.
+        for state in &claimed {
+            store
+                .release_terminal_claim(&state.record.gate_ref)
+                .unwrap();
+        }
+        let reclaimed = store.claim_all_terminal_states_for_child(child_b).unwrap();
+        assert_eq!(
+            reclaimed.len(),
+            2,
+            "all states must be reclaimable after release"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_all_terminal_states_drains_shared_gate_in_single_call() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let child_c = TurnRunId::new();
+        let gate = "gate:subagent-batch.drain";
+        store
+            .record_awaited_child(record(gate, child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate, child_b))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate, child_c))
+            .await
+            .unwrap();
+        store
+            .record_child_terminal(child_a, terminal_event(TurnStatus::Completed))
+            .unwrap();
+        store
+            .record_child_terminal(child_b, terminal_event(TurnStatus::Completed))
+            .unwrap();
+        store
+            .record_child_terminal(child_c, terminal_event(TurnStatus::Completed))
+            .unwrap();
+
+        let claimed = store.claim_all_terminal_states_for_child(child_c).unwrap();
+        assert_eq!(
+            claimed.len(),
+            3,
+            "single drain call must yield every state under shared batch gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_requeues_gate_when_sibling_pending() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child_a = TurnRunId::new();
+        let child_b = TurnRunId::new();
+        let gate = "gate:subagent-batch.requeue-on-pending";
+        store
+            .record_awaited_child(record(gate, child_a))
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(record(gate, child_b))
+            .await
+            .unwrap();
+        store
+            .record_child_terminal(child_a, terminal_event(TurnStatus::Completed))
+            .unwrap();
+
+        // child A's claim sees B still pending; must return None AND requeue
+        // the gate so a future sibling-driven recorder still finds it.
+        let first = store.claim_next_terminal_state_for_child(child_a).unwrap();
+        assert!(first.is_none());
+
+        // Sanity check: gate ref still queued for child A.
+        {
+            let inner = store.inner.lock();
+            assert!(
+                inner
+                    .deliverable_by_child
+                    .get(&child_a)
+                    .map(|q| q.iter().any(|g| g.as_str() == gate))
+                    .unwrap_or(false),
+                "gate must be requeued for child A when sibling is pending"
+            );
+        }
+
+        // Once B terminates, both states drain via either child's claim.
+        store
+            .record_child_terminal(child_b, terminal_event(TurnStatus::Completed))
+            .unwrap();
+        let drained = store.claim_all_terminal_states_for_child(child_b).unwrap();
+        assert_eq!(drained.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn record_child_terminal_is_idempotent_on_replay() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let child = TurnRunId::new();
+        store
+            .record_awaited_child(record("gate:subagent.idempotent", child))
+            .await
+            .unwrap();
+
+        let first_event = AwaitedChildTerminalEvent {
+            status: TurnStatus::Completed,
+            kind: TurnEventKind::Completed,
+            cursor: EventCursor(1),
+            sanitized_reason: Some("first".to_string()),
+            owner_user_id: Some(ironclaw_host_api::UserId::new("owner").unwrap()),
+        };
+        let replay_event = AwaitedChildTerminalEvent {
+            status: TurnStatus::Failed,
+            kind: TurnEventKind::Failed,
+            cursor: EventCursor(2),
+            sanitized_reason: Some("replay overwrites first".to_string()),
+            owner_user_id: Some(ironclaw_host_api::UserId::new("owner").unwrap()),
+        };
+        store
+            .record_child_terminal(child, first_event.clone())
+            .unwrap();
+        store
+            .record_child_terminal(child, replay_event.clone())
+            .unwrap();
+
+        let claimed = store
+            .claim_next_terminal_state_for_child(child)
+            .unwrap()
+            .expect("delivery available");
+        let recorded = claimed.terminal_event.expect("terminal event present");
+        assert_eq!(
+            recorded.sanitized_reason.as_deref(),
+            Some("first"),
+            "first terminal is authoritative; replay must not overwrite"
+        );
+        assert_eq!(recorded.cursor, EventCursor(1));
+    }
+
+    #[tokio::test]
+    async fn record_awaited_child_capacity_counts_total_states_not_keys() {
+        let store = BoundedSubagentGateResolutionStore::new();
+        let shared_gate = "gate:subagent-batch.capacity";
+        // Filling the bound through a single shared gate must hit the cap.
+        for _ in 0..MAX_GATE_RECORDS {
+            store
+                .record_awaited_child(record(shared_gate, TurnRunId::new()))
+                .await
+                .unwrap();
+        }
+        let error = store
+            .record_awaited_child(record(shared_gate, TurnRunId::new()))
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind, AgentLoopHostErrorKind::BudgetExceeded);
     }
 }

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -339,35 +339,40 @@ impl TurnRunnerWorker {
         let runner_id = claimed.runner_id;
         let lease_token = claimed.lease_token;
 
-        let heartbeat_cancel = CancellationToken::new();
-        let heartbeat = heartbeat_loop(
-            Arc::clone(&self.transition_port),
-            run_id,
-            runner_id,
-            lease_token,
-            self.config.heartbeat_interval,
-            heartbeat_cancel.clone(),
-        );
-        tokio::pin!(heartbeat);
+        let exit_result = {
+            let heartbeat_cancel = CancellationToken::new();
+            let heartbeat = heartbeat_loop(
+                Arc::clone(&self.transition_port),
+                run_id,
+                runner_id,
+                lease_token,
+                self.config.heartbeat_interval,
+                heartbeat_cancel.clone(),
+            );
+            tokio::pin!(heartbeat);
 
-        // Resolve driver from registry and invoke it. Driver panics indicate
-        // unknown partial state, so convert them to RecoveryRequired.
-        let driver = AssertUnwindSafe(self.invoke_driver(&claimed)).catch_unwind();
-        tokio::pin!(driver);
+            // Resolve driver from registry and invoke it. Driver panics indicate
+            // unknown partial state, so convert them to RecoveryRequired.
+            let driver = AssertUnwindSafe(self.invoke_driver(&claimed)).catch_unwind();
+            tokio::pin!(driver);
 
-        let exit_result = tokio::select! {
-            result = &mut driver => match result {
-                Ok(result) => result,
-                Err(_) => Err(DriverInvocationError::DriverPanic),
-            },
-            heartbeat_result = &mut heartbeat => match heartbeat_result {
-                Ok(()) => Err(DriverInvocationError::HeartbeatStopped),
-                Err(err) => Err(DriverInvocationError::HeartbeatFailed(err)),
-            },
-            () = cancel.cancelled() => Err(DriverInvocationError::WorkerCancelled),
+            let exit_result = tokio::select! {
+                result = &mut driver => match result {
+                    Ok(result) => result,
+                    Err(_) => Err(DriverInvocationError::DriverPanic),
+                },
+                heartbeat_result = &mut heartbeat => match heartbeat_result {
+                    Ok(()) => Err(DriverInvocationError::HeartbeatStopped),
+                    Err(err) => Err(DriverInvocationError::HeartbeatFailed(err)),
+                },
+                () = cancel.cancelled() => Err(DriverInvocationError::WorkerCancelled),
+            };
+
+            heartbeat_cancel.cancel();
+            exit_result
         };
-
-        heartbeat_cancel.cancel();
+        // Keep heartbeat scoped above so a losing heartbeat future is dropped
+        // before exit application re-enters the same turn-state store.
 
         // Apply the exit or record recovery
         match exit_result {

--- a/crates/ironclaw_reborn/tests/production_readiness.rs
+++ b/crates/ironclaw_reborn/tests/production_readiness.rs
@@ -149,6 +149,75 @@ fn production_readiness_rejects_missing_subagent_completion_observer() {
 }
 
 #[test]
+fn production_readiness_rejects_non_durable_subagent_tombstone_store() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.subagent_result_tombstone_store =
+        RebornComponentReadiness::non_durable(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::SubagentResultTombstoneStore,
+        RebornLoopProductionIssueKind::NonDurableImplementation
+    ));
+}
+
+#[test]
+fn production_readiness_rejects_missing_subagent_autonomous_continuation_budget() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.subagent_autonomous_continuation_budget =
+        RebornComponentReadiness::missing(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::SubagentAutonomousContinuationBudget,
+        RebornLoopProductionIssueKind::Missing
+    ));
+}
+
+#[test]
+fn production_readiness_rejects_missing_subagent_restart_reconciler() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.subagent_restart_reconciler =
+        RebornComponentReadiness::missing(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::SubagentRestartReconciler,
+        RebornLoopProductionIssueKind::Missing
+    ));
+}
+
+#[test]
 fn production_readiness_rejects_noop_wake_notifier() {
     let mut registry = DriverRegistry::new();
     let key = register_driver(&mut registry, "text_loop", DriverKind::Production);

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -18,6 +18,8 @@
 //! import `TurnCoordinator`, `SessionThreadService`, `HostManagedModel
 //! Gateway`, etc.
 
+use std::sync::Arc;
+
 mod auth;
 mod error;
 mod factory;
@@ -123,6 +125,7 @@ pub fn reborn_model_slot_names() -> Vec<&'static str> {
 pub struct RebornRuntimeReadinessSnapshot {
     pub text_only_driver: RebornRuntimeComponentStatus,
     pub planned_driver: RebornRuntimeComponentStatus,
+    pub subagent_planned_driver: RebornRuntimeComponentStatus,
     pub planned_default_profile: RebornRuntimeComponentStatus,
 }
 
@@ -161,9 +164,19 @@ pub fn reborn_runtime_readiness_snapshot() -> RebornRuntimeReadinessSnapshot {
             ironclaw_reborn::text_loop_driver::TextOnlyModelReplyDriverConfig::default(),
         ),
     );
-    let planned_driver = match ironclaw_reborn::app_loop_family::build_loop_family_registry() {
+    let family_registry = ironclaw_reborn::app_loop_family::build_loop_family_registry();
+    let planned_driver = match &family_registry {
         Ok(family_registry) => RebornRuntimeComponentStatus::from_result(
             ironclaw_reborn::planned_driver_factory::register_default_planned_driver(
+                &mut registry,
+                Arc::clone(family_registry),
+            ),
+        ),
+        Err(error) => RebornRuntimeComponentStatus::Failed(error.to_string()),
+    };
+    let subagent_planned_driver = match family_registry {
+        Ok(family_registry) => RebornRuntimeComponentStatus::from_result(
+            ironclaw_reborn::planned_driver_factory::register_subagent_planned_driver(
                 &mut registry,
                 family_registry,
             ),
@@ -176,12 +189,10 @@ pub fn reborn_runtime_readiness_snapshot() -> RebornRuntimeReadinessSnapshot {
     RebornRuntimeReadinessSnapshot {
         text_only_driver,
         planned_driver,
+        subagent_planned_driver,
         planned_default_profile,
     }
 }
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use std::sync::Arc;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use async_trait::async_trait;

--- a/crates/ironclaw_reborn_composition/tests/subagent_runtime_wiring.rs
+++ b/crates/ironclaw_reborn_composition/tests/subagent_runtime_wiring.rs
@@ -1,0 +1,25 @@
+use ironclaw_reborn_composition::{
+    RebornRuntimeComponentStatus, reborn_runtime_readiness_snapshot,
+};
+
+#[test]
+fn readiness_snapshot_reports_subagent_driver_wiring() {
+    let snapshot = reborn_runtime_readiness_snapshot();
+
+    assert_eq!(
+        snapshot.text_only_driver,
+        RebornRuntimeComponentStatus::Initialized
+    );
+    assert_eq!(
+        snapshot.planned_driver,
+        RebornRuntimeComponentStatus::Initialized
+    );
+    assert_eq!(
+        snapshot.subagent_planned_driver,
+        RebornRuntimeComponentStatus::Initialized
+    );
+    assert_eq!(
+        snapshot.planned_default_profile,
+        RebornRuntimeComponentStatus::Initialized
+    );
+}

--- a/crates/ironclaw_turns/src/ids.rs
+++ b/crates/ironclaw_turns/src/ids.rs
@@ -249,6 +249,24 @@ impl PartialEq<GateRef> for LoopGateRef {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{GateRef, LoopGateRef};
+
+    #[test]
+    fn gate_ref_eq_loop_gate_ref_matches_exact_gate_string() {
+        let gate_ref = GateRef::new("gate:subagent-test").unwrap();
+        let loop_gate_ref = LoopGateRef::new("gate:subagent-test").unwrap();
+        let other_loop_gate_ref = LoopGateRef::new("gate:subagent-other").unwrap();
+        let other_gate_ref = GateRef::new("gate:subagent-other").unwrap();
+
+        assert_eq!(gate_ref, loop_gate_ref);
+        assert_eq!(loop_gate_ref, gate_ref);
+        assert_ne!(gate_ref, other_loop_gate_ref);
+        assert_ne!(loop_gate_ref, other_gate_ref);
+    }
+}
+
 impl RunProfileId {
     pub fn default_profile() -> Self {
         Self::from_trusted_static("default")

--- a/crates/ironclaw_turns/src/ids.rs
+++ b/crates/ironclaw_turns/src/ids.rs
@@ -233,6 +233,22 @@ loop_ref!(LoopGateRef, "loop_gate_ref", "gate:");
 loop_ref!(LoopUsageSummaryRef, "loop_usage_summary_ref", "usage:");
 loop_ref!(LoopDiagnosticRef, "loop_diagnostic_ref", "diag:");
 
+// GateRef and LoopGateRef carry the same validated `gate:<id>` string by
+// design (the model-visible `LoopGateRef` is constructed from the host-side
+// `GateRef`). Cross-type equality enforces that invariant at the type
+// system instead of via ad-hoc `.as_str()` string compares in callers.
+impl PartialEq<LoopGateRef> for GateRef {
+    fn eq(&self, other: &LoopGateRef) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<GateRef> for LoopGateRef {
+    fn eq(&self, other: &GateRef) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
 impl RunProfileId {
     pub fn default_profile() -> Self {
         Self::from_trusted_static("default")

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -385,6 +385,118 @@ async fn background_spawn_surfaces_child_approval_without_blocking_parent() {
 }
 
 #[tokio::test]
+async fn background_child_approval_surfaces_while_parent_is_still_running() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![spawn_call(
+                "spawn_concurrent_background_child_approval",
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": "approval while parent runs",
+                    "mode": "background",
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::DelayedResponseForRequest {
+            request_contains: "parent keeps running while child waits".to_string(),
+            response: HostManagedModelResponse::assistant_reply("parent eventually finished"),
+            delay: Duration::from_secs(2),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::ProviderToolCallsForRequest {
+            request_contains: "approval while parent runs".to_string(),
+            calls: vec![subagent_allowed_tool_call("concurrent_child_approval_tool")],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::ResponseForRequest {
+            request_contains: "approval while parent runs".to_string(),
+            response: HostManagedModelResponse::assistant_reply(
+                "concurrent background child approved output",
+            ),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = tokio::time::timeout(
+        WaitConfig::default().timeout,
+        RebornBinaryE2EHarness::with_harness_blocked_evidence_unscoped_worker(
+            "room-subagent-concurrent-background-child-approval",
+            model_gateway,
+            RecordingTestCapabilityPort::spawn_auth_then_approval_then_allowed_tool_with_spawn_subagent(),
+        ),
+    )
+    .await
+    .expect("spawn harness timed out")
+    .expect("spawn harness");
+    harness.start_workers(2);
+
+    let submitted = harness
+        .submit_text(
+            "event-subagent-concurrent-background-child-approval",
+            "parent keeps running while child waits",
+        )
+        .await
+        .expect("submit root turn");
+    let child = await_single_child(&harness, &submitted).await;
+    assert_child_thread_invariants(&submitted, &child);
+    harness
+        .wait_for_status_in_scope(
+            child.scope.clone(),
+            child.run_id,
+            TurnStatus::BlockedApproval,
+        )
+        .await
+        .expect("background child approval surfaces");
+    assert_eq!(
+        harness
+            .run_state(submitted.run_id)
+            .await
+            .expect("parent run state")
+            .status,
+        TurnStatus::Running,
+        "background child approval must surface while the parent turn is still running"
+    );
+
+    harness
+        .resume_blocked_turn_in_scope(child.scope.clone(), submitted.actor.clone(), child.run_id)
+        .await
+        .expect("resume background child approval");
+    harness
+        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+        .await
+        .expect("background child completes after approval");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("parent completes after its long-running model call");
+    harness
+        .assert_final_reply("parent eventually finished")
+        .await
+        .expect("parent final reply");
+
+    let child_history = harness
+        .history_for_thread_in_scope(
+            child_thread_scope(&submitted, &child),
+            child.scope.thread_id.clone(),
+        )
+        .await
+        .expect("child history");
+    assert!(
+        child_history.iter().any(|message| {
+            message.content.as_deref() == Some("concurrent background child approved output")
+        }),
+        "approved background child writes its final reply while parent is independently running"
+    );
+    assert_eq!(
+        harness.capability_invocations().len(),
+        2,
+        "spawn auth plus the child approval gate should reach the inner capability port"
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
 async fn parallel_blocking_spawn_resumes_once_after_last_child() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -6,6 +6,7 @@ mod support;
 use std::time::Duration;
 
 use ironclaw_host_api::CapabilityId;
+use ironclaw_host_runtime::READ_FILE_CAPABILITY_ID;
 use ironclaw_loop_support::{
     DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID, HostManagedModelMessageRole, HostManagedModelResponse,
 };
@@ -160,6 +161,224 @@ async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
             ),
         "parent resume request includes the child completion tool result: {:#?}",
         harness.model_requests()[2].messages
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![spawn_call(
+                "spawn_blocking_child_approval",
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": "call an approval-gated tool",
+                    "mode": "blocking",
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![subagent_allowed_tool_call("child_approval_tool")],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("child approved output"),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("parent saw approved child"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = tokio::time::timeout(
+        WaitConfig::default().timeout,
+        RebornBinaryE2EHarness::with_harness_blocked_evidence_unscoped_worker(
+            "room-subagent-child-approval",
+            model_gateway,
+            RecordingTestCapabilityPort::spawn_auth_then_approval_then_allowed_tool_with_spawn_subagent(),
+        ),
+    )
+    .await
+    .expect("spawn harness timed out")
+    .expect("spawn harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-subagent-child-approval",
+            "spawn a child that needs approval",
+        )
+        .await
+        .expect("submit root turn");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::BlockedDependentRun)
+        .await
+        .expect("parent blocks on approval-gated child");
+
+    let child = await_single_child(&harness, &submitted).await;
+    assert_child_thread_invariants(&submitted, &child);
+    harness
+        .wait_for_status_in_scope(
+            child.scope.clone(),
+            child.run_id,
+            TurnStatus::BlockedApproval,
+        )
+        .await
+        .expect("child blocks on approval");
+    assert_eq!(
+        harness
+            .run_state(submitted.run_id)
+            .await
+            .expect("parent run state")
+            .status,
+        TurnStatus::BlockedDependentRun,
+        "parent must remain parked while the child approval is pending"
+    );
+
+    harness
+        .resume_blocked_turn_in_scope(child.scope.clone(), submitted.actor.clone(), child.run_id)
+        .await
+        .expect("resume child approval");
+    harness
+        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+        .await
+        .expect("child completes after approval");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("parent resumes after approved child completion");
+    harness
+        .assert_final_reply("parent saw approved child")
+        .await
+        .expect("parent final reply");
+    assert!(
+        harness
+            .model_requests()
+            .last()
+            .expect("parent resume request")
+            .messages
+            .iter()
+            .any(
+                |message| message.role == HostManagedModelMessageRole::ToolResult
+                    && message.content.contains("child approved output")
+            ),
+        "parent resume request includes the approved child's final output"
+    );
+    assert_eq!(
+        harness.capability_invocations().len(),
+        2,
+        "spawn auth plus the child approval gate should reach the inner capability port"
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn background_spawn_surfaces_child_approval_without_blocking_parent() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![spawn_call(
+                "spawn_background_child_approval",
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": "call an approval-gated tool in background",
+                    "mode": "background",
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply(
+                "parent continued while child approval pending",
+            ),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![subagent_allowed_tool_call("background_child_approval_tool")],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("background child approved output"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = tokio::time::timeout(
+        WaitConfig::default().timeout,
+        RebornBinaryE2EHarness::with_harness_blocked_evidence_unscoped_worker(
+            "room-subagent-background-child-approval",
+            model_gateway,
+            RecordingTestCapabilityPort::spawn_auth_then_approval_then_allowed_tool_with_spawn_subagent(),
+        ),
+    )
+    .await
+    .expect("spawn harness timed out")
+    .expect("spawn harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-subagent-background-child-approval",
+            "spawn a background child that needs approval",
+        )
+        .await
+        .expect("submit root turn");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("background parent completes before child approval resolves");
+    harness
+        .assert_final_reply("parent continued while child approval pending")
+        .await
+        .expect("parent final reply");
+
+    let child = await_single_child(&harness, &submitted).await;
+    assert_child_thread_invariants(&submitted, &child);
+    harness
+        .wait_for_status_in_scope(
+            child.scope.clone(),
+            child.run_id,
+            TurnStatus::BlockedApproval,
+        )
+        .await
+        .expect("background child blocks on approval");
+    assert_eq!(
+        harness
+            .run_state(submitted.run_id)
+            .await
+            .expect("parent run state")
+            .status,
+        TurnStatus::Completed,
+        "background child approval must not reopen or block the completed parent"
+    );
+
+    harness
+        .resume_blocked_turn_in_scope(child.scope.clone(), submitted.actor.clone(), child.run_id)
+        .await
+        .expect("resume background child approval");
+    harness
+        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+        .await
+        .expect("background child completes after approval");
+    let child_history = harness
+        .history_for_thread_in_scope(
+            child_thread_scope(&submitted, &child),
+            child.scope.thread_id.clone(),
+        )
+        .await
+        .expect("child history");
+    assert!(
+        child_history.iter().any(|message| {
+            message.content.as_deref() == Some("background child approved output")
+        }),
+        "approved background child writes its final reply"
+    );
+    assert_eq!(
+        harness.capability_invocations().len(),
+        2,
+        "spawn auth plus the child approval gate should reach the inner capability port"
     );
     harness.assert_model_exhausted();
     harness.shutdown().await;
@@ -370,6 +589,14 @@ fn spawn_call(
 
 fn spawn_capability_id() -> CapabilityId {
     CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).expect("valid capability id")
+}
+
+fn subagent_allowed_tool_call(call_id: impl Into<String>) -> RebornScriptedProviderToolCall {
+    RebornScriptedProviderToolCall::new(
+        CapabilityId::new(READ_FILE_CAPABILITY_ID).expect("valid capability id"),
+        call_id,
+        serde_json::json!({"message": "hi"}),
+    )
 }
 
 async fn await_single_child(

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -1,0 +1,432 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use std::time::Duration;
+
+use ironclaw_host_api::CapabilityId;
+use ironclaw_loop_support::{
+    DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID, HostManagedModelMessageRole, HostManagedModelResponse,
+};
+use ironclaw_turns::TurnStatus;
+use reborn_support::{
+    config::WaitConfig,
+    harness::{RebornBinaryE2EHarness, RecordingTestCapabilityPort, SubmittedTurn},
+    model_replay::{
+        RebornModelReplayStep, RebornScriptedProviderToolCall, RebornTraceReplayModelGateway,
+    },
+};
+
+#[tokio::test]
+async fn background_spawn_delivers_child_result_and_parent_followup_runs() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![spawn_call(
+                "spawn_background",
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": "summarize the fixture",
+                    "handoff": "parent context",
+                    "mode": "background",
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("parent continued"),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("child finished"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = spawn_harness("room-subagent-background", model_gateway).await;
+    harness.start();
+
+    let submitted = harness
+        .submit_text("event-subagent-background", "delegate in background")
+        .await
+        .expect("submit root turn");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("parent completes without blocking on background child");
+    harness
+        .assert_final_reply("parent continued")
+        .await
+        .expect("parent final reply");
+
+    let child = await_single_child(&harness, &submitted).await;
+    harness
+        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+        .await
+        .expect("background child completes");
+    assert_child_thread_invariants(&submitted, &child);
+
+    let child_history = harness
+        .history_for_thread_in_scope(
+            child_thread_scope(&submitted, &child),
+            child.scope.thread_id.clone(),
+        )
+        .await
+        .expect("child history");
+    assert!(
+        child_history.iter().any(|message| message
+            .content
+            .as_deref()
+            .is_some_and(|content| content.contains("summarize the fixture"))),
+        "child receives the parent task as an inbound message"
+    );
+    assert!(
+        child_history
+            .iter()
+            .any(|message| message.content.as_deref() == Some("child finished")),
+        "child writes its own final reply"
+    );
+
+    assert!(
+        harness.model_requests()[1]
+            .messages
+            .iter()
+            .any(
+                |message| message.role == HostManagedModelMessageRole::ToolResult
+                    && message.content.contains("subagent spawned in background")
+            ),
+        "parent follow-up request includes the background spawn tool result"
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![spawn_call(
+                "spawn_blocking",
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": "answer for the parent",
+                    "mode": "blocking",
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::DelayedResponse {
+            response: HostManagedModelResponse::assistant_reply("blocking child output"),
+            delay: Duration::from_millis(50),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("parent resumed"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = spawn_harness("room-subagent-blocking", model_gateway).await;
+    harness.start();
+
+    let submitted = harness
+        .submit_text("event-subagent-blocking", "delegate and wait")
+        .await
+        .expect("submit root turn");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::BlockedDependentRun)
+        .await
+        .expect("parent parks on dependent child");
+
+    let child = await_single_child(&harness, &submitted).await;
+    harness
+        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+        .await
+        .expect("blocking child completes");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("parent resumes after child completion");
+    harness
+        .assert_final_reply("parent resumed")
+        .await
+        .expect("parent final reply");
+    assert_child_thread_invariants(&submitted, &child);
+    assert!(
+        harness.model_requests()[2]
+            .messages
+            .iter()
+            .any(
+                |message| message.role == HostManagedModelMessageRole::ToolResult
+                    && message.content.contains("Subagent completed")
+            ),
+        "parent resume request includes the child completion tool result: {:#?}",
+        harness.model_requests()[2].messages
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn parallel_blocking_spawn_resumes_once_after_last_child() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![
+                spawn_call(
+                    "spawn_blocking_a",
+                    serde_json::json!({
+                        "flavor_id": "general",
+                        "task": "same goal",
+                        "mode": "blocking",
+                    }),
+                ),
+                spawn_call(
+                    "spawn_blocking_b",
+                    serde_json::json!({
+                        "flavor_id": "general",
+                        "task": "same goal",
+                        "mode": "blocking",
+                    }),
+                ),
+                spawn_call(
+                    "spawn_blocking_c",
+                    serde_json::json!({
+                        "flavor_id": "general",
+                        "task": "same goal",
+                        "mode": "blocking",
+                    }),
+                ),
+            ],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::DelayedResponse {
+            response: HostManagedModelResponse::assistant_reply("child one"),
+            delay: Duration::from_millis(50),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::DelayedResponse {
+            response: HostManagedModelResponse::assistant_reply("child two"),
+            delay: Duration::from_millis(50),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::DelayedResponse {
+            response: HostManagedModelResponse::assistant_reply("child three"),
+            delay: Duration::from_millis(50),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("all children complete"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = spawn_harness("room-subagent-parallel-blocking", model_gateway).await;
+    harness.start();
+
+    let submitted = harness
+        .submit_text("event-subagent-parallel-blocking", "spawn three children")
+        .await
+        .expect("submit root turn");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::BlockedDependentRun)
+        .await
+        .expect("parent blocks on child set");
+
+    let children = await_children(&harness, &submitted, 3).await;
+    let child_run_ids = children
+        .iter()
+        .map(|child| child.run_id)
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(child_run_ids.len(), 3, "each spawn creates a distinct run");
+    for child in &children {
+        assert_child_thread_invariants(&submitted, child);
+    }
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("parent resumes after all children");
+    harness
+        .assert_final_reply("all children complete")
+        .await
+        .expect("parent final reply");
+    assert!(
+        harness.model_requests()[4]
+            .messages
+            .iter()
+            .filter(
+                |message| message.role == HostManagedModelMessageRole::ToolResult
+                    && message.content.contains("Subagent completed")
+            )
+            .count()
+            >= 3,
+        "parent resume request contains all child completion results"
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn fork_bomb_fanout_cap_rejects_before_submit_turn() {
+    let calls = (0..5)
+        .map(|index| {
+            spawn_call(
+                format!("spawn_background_{index}"),
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": format!("child {index}"),
+                    "mode": "background",
+                }),
+            )
+        })
+        .collect::<Vec<_>>();
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls,
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("fanout handled"),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("child 0"),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("child 1"),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("child 2"),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("child 3"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = spawn_harness("room-subagent-fanout-cap", model_gateway).await;
+    harness.start();
+
+    let submitted = harness
+        .submit_text("event-subagent-fanout-cap", "try too many children")
+        .await
+        .expect("submit root turn");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("parent completes after denial");
+    harness
+        .assert_final_reply("fanout handled")
+        .await
+        .expect("parent final reply");
+
+    let children = await_children(&harness, &submitted, 4).await;
+    assert_eq!(
+        children.len(),
+        4,
+        "fifth spawn is rejected before child submission"
+    );
+    for child in &children {
+        harness
+            .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+            .await
+            .expect("accepted background child completes");
+    }
+    assert!(
+        harness.model_requests()[1]
+            .messages
+            .iter()
+            .any(
+                |message| message.role == HostManagedModelMessageRole::ToolResult
+                    && message.content.contains("fanout_cap_exceeded")
+            ),
+        "denied spawn is returned to the parent as a tool result"
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+async fn spawn_harness(
+    conversation_id: &str,
+    model_gateway: RebornTraceReplayModelGateway,
+) -> RebornBinaryE2EHarness {
+    tokio::time::timeout(
+        WaitConfig::default().timeout,
+        RebornBinaryE2EHarness::with_harness_blocked_evidence_unscoped_worker(
+            conversation_id,
+            model_gateway,
+            RecordingTestCapabilityPort::echo_with_spawn_subagent(),
+        ),
+    )
+    .await
+    .expect("spawn harness timed out")
+    .expect("spawn harness")
+}
+
+fn spawn_call(
+    call_id: impl Into<String>,
+    arguments: serde_json::Value,
+) -> RebornScriptedProviderToolCall {
+    RebornScriptedProviderToolCall::new(spawn_capability_id(), call_id, arguments)
+}
+
+fn spawn_capability_id() -> CapabilityId {
+    CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).expect("valid capability id")
+}
+
+async fn await_single_child(
+    harness: &RebornBinaryE2EHarness,
+    submitted: &SubmittedTurn,
+) -> ironclaw_turns::TurnRunRecord {
+    let mut children = await_children(harness, submitted, 1).await;
+    children.pop().expect("one child")
+}
+
+async fn await_children(
+    harness: &RebornBinaryE2EHarness,
+    submitted: &SubmittedTurn,
+    expected: usize,
+) -> Vec<ironclaw_turns::TurnRunRecord> {
+    let wait = WaitConfig::default();
+    let deadline = tokio::time::Instant::now() + wait.timeout;
+    loop {
+        let children = harness
+            .children_of(&submitted.scope, submitted.run_id)
+            .await
+            .expect("children");
+        if children.len() >= expected {
+            return children;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for {expected} children; observed {}",
+                children.len()
+            );
+        }
+        tokio::time::sleep(wait.poll_interval).await;
+    }
+}
+
+fn assert_child_thread_invariants(parent: &SubmittedTurn, child: &ironclaw_turns::TurnRunRecord) {
+    assert_eq!(child.parent_run_id, Some(parent.run_id));
+    assert_eq!(child.subagent_depth, 1);
+    assert_eq!(child.spawn_tree_root_run_id, Some(parent.run_id));
+    assert_eq!(child.scope.tenant_id, parent.scope.tenant_id);
+    assert_eq!(child.scope.agent_id, parent.scope.agent_id);
+    assert_eq!(child.scope.project_id, parent.scope.project_id);
+    assert_ne!(
+        child.scope.thread_id, parent.scope.thread_id,
+        "child must run on a distinct thread"
+    );
+}
+
+fn child_thread_scope(
+    parent: &SubmittedTurn,
+    child: &ironclaw_turns::TurnRunRecord,
+) -> ironclaw_threads::ThreadScope {
+    ironclaw_threads::ThreadScope {
+        tenant_id: child.scope.tenant_id.clone(),
+        agent_id: child.scope.agent_id.clone().expect("agent-scoped turn"),
+        project_id: child.scope.project_id.clone(),
+        owner_user_id: parent.thread_scope.owner_user_id.clone(),
+        mission_id: None,
+    }
+}

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -124,6 +124,7 @@ pub type HarnessWaitConfig = WaitConfig;
 const TEST_CAPABILITY_ID: &str = "test.echo";
 const TEST_CAPABILITY_SURFACE_VERSION: &str = "trace_replay_v1";
 const SPAWN_SUBAGENT_TOOL_NAME: &str = "spawn_subagent";
+const SUBAGENT_ALLOWED_TEST_TOOL_NAME: &str = "test_read_file";
 
 type HarnessResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 type HarnessCapabilityParts = (
@@ -1013,6 +1014,27 @@ impl RebornBinaryE2EHarness {
             .gate_ref
             .ok_or("blocked run missing gate ref")?;
         self.resume_with_gate(run_id, blocked).await
+    }
+
+    pub async fn resume_blocked_turn_in_scope(
+        &self,
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+    ) -> HarnessResult<()> {
+        let blocked = self
+            .run_state_in_scope(scope.clone(), run_id)
+            .await?
+            .gate_ref
+            .ok_or("blocked run missing gate ref")?;
+        self.resume_with_gate_as(
+            scope,
+            actor,
+            run_id,
+            blocked,
+            format!("resume-{run_id}"),
+        )
+        .await
     }
 
     pub async fn resume_with_gate(
@@ -2010,6 +2032,7 @@ fn host_runtime_harness_error(error: impl std::fmt::Display) -> AgentLoopHostErr
 pub struct RecordingTestCapabilityPort {
     mode: CapabilityMode,
     expose_spawn_subagent: bool,
+    use_subagent_allowed_tool: bool,
     invocations: Arc<Mutex<Vec<CapabilityInvocation>>>,
     next_result: Arc<AtomicUsize>,
     approval_calls: Arc<AtomicUsize>,
@@ -2019,28 +2042,63 @@ pub struct RecordingTestCapabilityPort {
 enum CapabilityMode {
     Echo,
     ApprovalThenEcho,
+    SpawnAuthThenApprovalThenEcho,
 }
 
 impl RecordingTestCapabilityPort {
     pub fn echo() -> Self {
-        Self::new(CapabilityMode::Echo, false)
+        Self::new(CapabilityMode::Echo, false, false)
     }
 
     pub fn echo_with_spawn_subagent() -> Self {
-        Self::new(CapabilityMode::Echo, true)
+        Self::new(CapabilityMode::Echo, true, false)
     }
 
     pub fn approval_then_echo() -> Self {
-        Self::new(CapabilityMode::ApprovalThenEcho, false)
+        Self::new(CapabilityMode::ApprovalThenEcho, false, false)
     }
 
-    fn new(mode: CapabilityMode, expose_spawn_subagent: bool) -> Self {
+    pub fn approval_then_echo_with_spawn_subagent() -> Self {
+        Self::new(CapabilityMode::ApprovalThenEcho, true, false)
+    }
+
+    pub fn spawn_auth_then_approval_then_echo_with_spawn_subagent() -> Self {
+        Self::new(CapabilityMode::SpawnAuthThenApprovalThenEcho, true, false)
+    }
+
+    pub fn spawn_auth_then_approval_then_allowed_tool_with_spawn_subagent() -> Self {
+        Self::new(CapabilityMode::SpawnAuthThenApprovalThenEcho, true, true)
+    }
+
+    fn new(
+        mode: CapabilityMode,
+        expose_spawn_subagent: bool,
+        use_subagent_allowed_tool: bool,
+    ) -> Self {
         Self {
             mode,
             expose_spawn_subagent,
+            use_subagent_allowed_tool,
             invocations: Arc::new(Mutex::new(Vec::new())),
             next_result: Arc::new(AtomicUsize::new(1)),
             approval_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn primary_capability_id(&self) -> CapabilityId {
+        let id = if self.use_subagent_allowed_tool {
+            READ_FILE_CAPABILITY_ID
+        } else {
+            TEST_CAPABILITY_ID
+        };
+        CapabilityId::new(id).expect("valid capability id")
+    }
+
+    fn primary_tool_name(&self) -> &'static str {
+        if self.use_subagent_allowed_tool {
+            SUBAGENT_ALLOWED_TEST_TOOL_NAME
+        } else {
+            "test_echo"
         }
     }
 
@@ -2053,8 +2111,7 @@ impl RecordingTestCapabilityPort {
     }
 
     fn capability_allowlist(&self) -> Vec<CapabilityId> {
-        let mut allowlist =
-            vec![CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id")];
+        let mut allowlist = vec![self.primary_capability_id()];
         if self.expose_spawn_subagent {
             allowlist.push(
                 CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
@@ -2079,8 +2136,8 @@ impl RecordingTestCapabilityPort {
 impl LoopCapabilityPort for RecordingTestCapabilityPort {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
         let mut definitions = vec![ProviderToolDefinition {
-            capability_id: CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id"),
-            name: "test_echo".to_string(),
+            capability_id: self.primary_capability_id(),
+            name: self.primary_tool_name().to_string(),
             description: "Echo a test payload".to_string(),
             parameters: json!({
                 "type": "object",
@@ -2118,7 +2175,7 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
         let capability_id = if self.expose_spawn_subagent && call.name == SPAWN_SUBAGENT_TOOL_NAME {
             CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).expect("valid capability id")
         } else {
-            CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id")
+            self.primary_capability_id()
         };
         Ok(CapabilityCallCandidate {
             surface_version: CapabilitySurfaceVersion::new(TEST_CAPABILITY_SURFACE_VERSION)
@@ -2146,10 +2203,10 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
         _request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
         let mut descriptors = vec![CapabilityDescriptorView {
-            capability_id: CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id"),
+            capability_id: self.primary_capability_id(),
             provider: Some(ExtensionId::new("test").expect("valid provider")),
             runtime: RuntimeKind::FirstParty,
-            safe_name: "test_echo".to_string(),
+            safe_name: self.primary_tool_name().to_string(),
             safe_description: "Echo a test payload".to_string(),
             concurrency_hint: ConcurrencyHint::SafeForParallel,
             parameters_schema: json!({"type": "object"}),
@@ -2185,6 +2242,18 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
                 gate_ref: LoopGateRef::new("gate:test-approval").expect("valid gate ref"),
                 safe_summary: "test approval required".to_string(),
             });
+        }
+        if matches!(self.mode, CapabilityMode::SpawnAuthThenApprovalThenEcho) {
+            match self.approval_calls.fetch_add(1, Ordering::SeqCst) {
+                0 => return Ok(self.completed_result()),
+                1 => {
+                    return Ok(CapabilityOutcome::ApprovalRequired {
+                        gate_ref: LoopGateRef::new("gate:test-approval").expect("valid gate ref"),
+                        safe_summary: "test approval required".to_string(),
+                    });
+                }
+                _ => {}
+            }
         }
         Ok(self.completed_result())
     }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -151,7 +151,7 @@ pub struct RebornBinaryE2EHarness {
     milestone_sink: Arc<ironclaw_turns::run_profile::InMemoryLoopHostMilestoneSink>,
     worker: Arc<TurnRunnerWorker>,
     cancel: CancellationToken,
-    worker_task: Option<JoinHandle<()>>,
+    worker_tasks: Vec<JoinHandle<()>>,
     _turn_root: Arc<tempfile::TempDir>,
     _wake_sender: TurnRunnerWakeSender,
 }
@@ -912,26 +912,32 @@ impl RebornBinaryE2EHarness {
             milestone_sink,
             worker: composition.worker,
             cancel: CancellationToken::new(),
-            worker_task: None,
+            worker_tasks: Vec::new(),
             _turn_root: turn_root,
             _wake_sender: composition.wake_sender,
         }
     }
 
     pub fn start(&mut self) {
-        if self.worker_task.is_some() {
+        self.start_workers(1);
+    }
+
+    pub fn start_workers(&mut self, count: usize) {
+        if !self.worker_tasks.is_empty() {
             return;
         }
-        let worker = Arc::clone(&self.worker);
-        let cancel = self.cancel.clone();
-        self.worker_task = Some(tokio::spawn(async move {
-            worker.run(cancel).await;
-        }));
+        for _ in 0..count.max(1) {
+            let worker = Arc::clone(&self.worker);
+            let cancel = self.cancel.clone();
+            self.worker_tasks.push(tokio::spawn(async move {
+                worker.run(cancel).await;
+            }));
+        }
     }
 
     pub async fn shutdown(&mut self) {
         self.cancel.cancel();
-        if let Some(task) = self.worker_task.take() {
+        for task in self.worker_tasks.drain(..) {
             let _ = task.await;
         }
     }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -46,9 +46,9 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
-    HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
-    HostManagedModelRequest, HostRuntimeLoopCapabilityPortFactory, JsonSpawnSubagentInputCodec,
-    LoopCapabilityResultWriter,
+    DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID, HostIdentityContextBuildError,
+    HostIdentityContextCandidate, HostIdentityContextSource, HostManagedModelRequest,
+    HostRuntimeLoopCapabilityPortFactory, JsonSpawnSubagentInputCodec, LoopCapabilityResultWriter,
 };
 use ironclaw_network::{PolicyNetworkHttpEgress, ReqwestNetworkTransport};
 use ironclaw_product_adapters::{
@@ -93,7 +93,8 @@ use ironclaw_turns::{
     GetRunStateRequest, IdempotencyKey, InMemoryCheckpointStateStore, LoopBlockedKind,
     LoopCheckpointKind, LoopCheckpointStore, LoopGateRef, LoopResultRef, ReplyTargetBindingRef,
     ResumeTurnRequest, SanitizedCancelReason, SourceBindingRef, TurnActor, TurnCoordinator,
-    TurnError, TurnRunId, TurnRunState, TurnScope, TurnStateStore, TurnStatus,
+    TurnError, TurnRunId, TurnRunRecord, TurnRunState, TurnScope, TurnSpawnTreeStateStore,
+    TurnStateStore, TurnStatus,
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, CapabilityBatchInvocation,
         CapabilityBatchOutcome, CapabilityCallCandidate, CapabilityDescriptorView,
@@ -122,6 +123,7 @@ pub type HarnessWaitConfig = WaitConfig;
 
 const TEST_CAPABILITY_ID: &str = "test.echo";
 const TEST_CAPABILITY_SURFACE_VERSION: &str = "trace_replay_v1";
+const SPAWN_SUBAGENT_TOOL_NAME: &str = "spawn_subagent";
 
 type HarnessResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 type HarnessCapabilityParts = (
@@ -262,6 +264,21 @@ impl RebornBinaryE2EHarness {
             model_gateway,
             capability_port,
             false,
+            false,
+        )
+        .await
+    }
+
+    pub async fn with_harness_blocked_evidence_unscoped_worker(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_options_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            true,
             false,
         )
         .await
@@ -1182,6 +1199,14 @@ impl RebornBinaryE2EHarness {
             .messages)
     }
 
+    pub async fn children_of(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> HarnessResult<Vec<TurnRunRecord>> {
+        Ok(self.turn_store.children_of(scope, run_id).await?)
+    }
+
     pub fn model_requests(&self) -> Vec<HostManagedModelRequest> {
         self.model_gateway.requests()
     }
@@ -1251,8 +1276,10 @@ impl LoopExitEvidencePort for HarnessLoopExitEvidencePort {
         if !self.accept_harness_blocked_evidence {
             return Ok(false);
         }
-        if request.blocked.kind != LoopBlockedKind::Approval
-            || GateRef::new(request.blocked.gate_ref.as_str()).is_err()
+        if !matches!(
+            request.blocked.kind,
+            LoopBlockedKind::Approval | LoopBlockedKind::AwaitDependentRun
+        ) || GateRef::new(request.blocked.gate_ref.as_str()).is_err()
         {
             return Ok(false);
         }
@@ -1317,9 +1344,7 @@ impl HarnessCapabilityMode {
                         port: Arc::clone(&port),
                     }),
                     Arc::new(StaticCapabilitySurfaceProfileResolver {
-                        allow_set: CapabilityAllowSet::allowlist([CapabilityId::new(
-                            TEST_CAPABILITY_ID,
-                        )?]),
+                        allow_set: CapabilityAllowSet::allowlist(port.capability_allowlist()),
                     }),
                     capability_io.clone(),
                     capability_io,
@@ -1984,6 +2009,7 @@ fn host_runtime_harness_error(error: impl std::fmt::Display) -> AgentLoopHostErr
 #[derive(Clone)]
 pub struct RecordingTestCapabilityPort {
     mode: CapabilityMode,
+    expose_spawn_subagent: bool,
     invocations: Arc<Mutex<Vec<CapabilityInvocation>>>,
     next_result: Arc<AtomicUsize>,
     approval_calls: Arc<AtomicUsize>,
@@ -1997,16 +2023,21 @@ enum CapabilityMode {
 
 impl RecordingTestCapabilityPort {
     pub fn echo() -> Self {
-        Self::new(CapabilityMode::Echo)
+        Self::new(CapabilityMode::Echo, false)
+    }
+
+    pub fn echo_with_spawn_subagent() -> Self {
+        Self::new(CapabilityMode::Echo, true)
     }
 
     pub fn approval_then_echo() -> Self {
-        Self::new(CapabilityMode::ApprovalThenEcho)
+        Self::new(CapabilityMode::ApprovalThenEcho, false)
     }
 
-    fn new(mode: CapabilityMode) -> Self {
+    fn new(mode: CapabilityMode, expose_spawn_subagent: bool) -> Self {
         Self {
             mode,
+            expose_spawn_subagent,
             invocations: Arc::new(Mutex::new(Vec::new())),
             next_result: Arc::new(AtomicUsize::new(1)),
             approval_calls: Arc::new(AtomicUsize::new(0)),
@@ -2019,6 +2050,18 @@ impl RecordingTestCapabilityPort {
 
     pub fn invocation_count(&self) -> usize {
         self.invocations.lock().unwrap().len()
+    }
+
+    fn capability_allowlist(&self) -> Vec<CapabilityId> {
+        let mut allowlist =
+            vec![CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id")];
+        if self.expose_spawn_subagent {
+            allowlist.push(
+                CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
+                    .expect("valid capability id"),
+            );
+        }
+        allowlist
     }
 
     fn completed_result(&self) -> CapabilityOutcome {
@@ -2035,7 +2078,7 @@ impl RecordingTestCapabilityPort {
 #[async_trait]
 impl LoopCapabilityPort for RecordingTestCapabilityPort {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
-        Ok(vec![ProviderToolDefinition {
+        let mut definitions = vec![ProviderToolDefinition {
             capability_id: CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id"),
             name: "test_echo".to_string(),
             description: "Echo a test payload".to_string(),
@@ -2045,20 +2088,43 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
                     "message": {"type": "string"}
                 }
             }),
-        }])
+        }];
+        if self.expose_spawn_subagent {
+            definitions.push(ProviderToolDefinition {
+                capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
+                    .expect("valid capability id"),
+                name: SPAWN_SUBAGENT_TOOL_NAME.to_string(),
+                description: "Spawn a subagent child run".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "flavor_id": {"type": "string"},
+                        "task": {"type": "string"},
+                        "handoff": {"type": "string"},
+                        "mode": {"type": "string", "enum": ["blocking", "background"]},
+                        "run_in_background": {"type": "boolean"}
+                    },
+                    "required": ["flavor_id", "task"]
+                }),
+            });
+        }
+        Ok(definitions)
     }
 
     async fn register_provider_tool_call(
         &self,
         call: ProviderToolCall,
     ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
+        let capability_id = if self.expose_spawn_subagent && call.name == SPAWN_SUBAGENT_TOOL_NAME {
+            CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).expect("valid capability id")
+        } else {
+            CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id")
+        };
         Ok(CapabilityCallCandidate {
             surface_version: CapabilitySurfaceVersion::new(TEST_CAPABILITY_SURFACE_VERSION)
                 .expect("valid surface version"),
-            capability_id: CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id"),
-            effective_capability_ids: vec![
-                CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id"),
-            ],
+            capability_id: capability_id.clone(),
+            effective_capability_ids: vec![capability_id],
             input_ref: CapabilityInputRef::new(format!("input:{}", call.id))
                 .expect("valid input ref"),
             provider_replay: Some(ProviderToolCallReplay {
@@ -2079,18 +2145,31 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
         &self,
         _request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        let mut descriptors = vec![CapabilityDescriptorView {
+            capability_id: CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id"),
+            provider: Some(ExtensionId::new("test").expect("valid provider")),
+            runtime: RuntimeKind::FirstParty,
+            safe_name: "test_echo".to_string(),
+            safe_description: "Echo a test payload".to_string(),
+            concurrency_hint: ConcurrencyHint::SafeForParallel,
+            parameters_schema: json!({"type": "object"}),
+        }];
+        if self.expose_spawn_subagent {
+            descriptors.push(CapabilityDescriptorView {
+                capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID)
+                    .expect("valid capability id"),
+                provider: Some(ExtensionId::new("test").expect("valid provider")),
+                runtime: RuntimeKind::FirstParty,
+                safe_name: SPAWN_SUBAGENT_TOOL_NAME.to_string(),
+                safe_description: "Spawn a subagent child run".to_string(),
+                concurrency_hint: ConcurrencyHint::Exclusive,
+                parameters_schema: json!({"type": "object"}),
+            });
+        }
         Ok(VisibleCapabilitySurface {
             version: CapabilitySurfaceVersion::new(TEST_CAPABILITY_SURFACE_VERSION)
                 .expect("valid surface version"),
-            descriptors: vec![CapabilityDescriptorView {
-                capability_id: CapabilityId::new(TEST_CAPABILITY_ID).expect("valid capability id"),
-                provider: Some(ExtensionId::new("test").expect("valid provider")),
-                runtime: RuntimeKind::FirstParty,
-                safe_name: "test_echo".to_string(),
-                safe_description: "Echo a test payload".to_string(),
-                concurrency_hint: ConcurrencyHint::SafeForParallel,
-                parameters_schema: json!({"type": "object"}),
-            }],
+            descriptors,
         })
     }
 

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -1033,14 +1033,8 @@ impl RebornBinaryE2EHarness {
             .await?
             .gate_ref
             .ok_or("blocked run missing gate ref")?;
-        self.resume_with_gate_as(
-            scope,
-            actor,
-            run_id,
-            blocked,
-            format!("resume-{run_id}"),
-        )
-        .await
+        self.resume_with_gate_as(scope, actor, run_id, blocked, format!("resume-{run_id}"))
+            .await
     }
 
     pub async fn resume_with_gate(

--- a/tests/support/reborn/model_replay.rs
+++ b/tests/support/reborn/model_replay.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::VecDeque,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -49,6 +50,11 @@ pub enum RebornModelReplayStep {
     AssertProviderToolsThenResponse {
         capability_ids: Vec<CapabilityId>,
         response: HostManagedModelResponse,
+        expected_tool_results: Vec<ExpectedToolResult>,
+    },
+    DelayedResponse {
+        response: HostManagedModelResponse,
+        delay: Duration,
         expected_tool_results: Vec<ExpectedToolResult>,
     },
     ProviderToolCalls {
@@ -100,6 +106,10 @@ enum ReplayOutput {
         capability_ids: Vec<CapabilityId>,
         response: HostManagedModelResponse,
     },
+    DelayedResponse {
+        response: HostManagedModelResponse,
+        delay: Duration,
+    },
     ProviderToolCalls(Vec<RebornScriptedProviderToolCall>),
 }
 
@@ -148,6 +158,14 @@ impl RebornTraceReplayModelGateway {
                             capability_ids,
                             response,
                         },
+                        expected_tool_results,
+                    },
+                    RebornModelReplayStep::DelayedResponse {
+                        response,
+                        delay,
+                        expected_tool_results,
+                    } => ReplayStep {
+                        output: ReplayOutput::DelayedResponse { response, delay },
                         expected_tool_results,
                     },
                     RebornModelReplayStep::ProviderToolCalls {
@@ -207,6 +225,10 @@ impl HostManagedModelGateway for RebornTraceReplayModelGateway {
                     "trace replay provider tool assertions require capability-aware model streaming",
                 ))
             }
+            ReplayOutput::DelayedResponse { response, delay } => {
+                tokio::time::sleep(delay).await;
+                Ok(response)
+            }
             ReplayOutput::ProviderToolCalls(_) => Err(HostManagedModelError::safe(
                 HostManagedModelErrorKind::InvalidRequest,
                 "trace replay provider tool calls require capability-aware model streaming",
@@ -227,6 +249,10 @@ impl HostManagedModelGateway for RebornTraceReplayModelGateway {
                 response,
             } => {
                 assert_provider_tools(capabilities, &capability_ids).await?;
+                Ok(response)
+            }
+            ReplayOutput::DelayedResponse { response, delay } => {
+                tokio::time::sleep(delay).await;
                 Ok(response)
             }
             ReplayOutput::ProviderToolCalls(calls) => {

--- a/tests/support/reborn/model_replay.rs
+++ b/tests/support/reborn/model_replay.rs
@@ -52,12 +52,28 @@ pub enum RebornModelReplayStep {
         response: HostManagedModelResponse,
         expected_tool_results: Vec<ExpectedToolResult>,
     },
+    ResponseForRequest {
+        request_contains: String,
+        response: HostManagedModelResponse,
+        expected_tool_results: Vec<ExpectedToolResult>,
+    },
     DelayedResponse {
         response: HostManagedModelResponse,
         delay: Duration,
         expected_tool_results: Vec<ExpectedToolResult>,
     },
+    DelayedResponseForRequest {
+        request_contains: String,
+        response: HostManagedModelResponse,
+        delay: Duration,
+        expected_tool_results: Vec<ExpectedToolResult>,
+    },
     ProviderToolCalls {
+        calls: Vec<RebornScriptedProviderToolCall>,
+        expected_tool_results: Vec<ExpectedToolResult>,
+    },
+    ProviderToolCallsForRequest {
+        request_contains: String,
         calls: Vec<RebornScriptedProviderToolCall>,
         expected_tool_results: Vec<ExpectedToolResult>,
     },
@@ -95,6 +111,7 @@ struct ReplayState {
 #[derive(Debug, Clone)]
 struct ReplayStep {
     output: ReplayOutput,
+    request_contains: Option<String>,
     expected_tool_results: Vec<ExpectedToolResult>,
 }
 
@@ -130,6 +147,7 @@ impl RebornTraceReplayModelGateway {
                 .into_iter()
                 .map(|response| ReplayStep {
                     output: ReplayOutput::Response(response),
+                    request_contains: None,
                     expected_tool_results: Vec::new(),
                 })
                 .collect(),
@@ -147,6 +165,16 @@ impl RebornTraceReplayModelGateway {
                         expected_tool_results,
                     } => ReplayStep {
                         output: ReplayOutput::Response(response),
+                        request_contains: None,
+                        expected_tool_results,
+                    },
+                    RebornModelReplayStep::ResponseForRequest {
+                        request_contains,
+                        response,
+                        expected_tool_results,
+                    } => ReplayStep {
+                        output: ReplayOutput::Response(response),
+                        request_contains: Some(request_contains),
                         expected_tool_results,
                     },
                     RebornModelReplayStep::AssertProviderToolsThenResponse {
@@ -158,6 +186,7 @@ impl RebornTraceReplayModelGateway {
                             capability_ids,
                             response,
                         },
+                        request_contains: None,
                         expected_tool_results,
                     },
                     RebornModelReplayStep::DelayedResponse {
@@ -166,6 +195,17 @@ impl RebornTraceReplayModelGateway {
                         expected_tool_results,
                     } => ReplayStep {
                         output: ReplayOutput::DelayedResponse { response, delay },
+                        request_contains: None,
+                        expected_tool_results,
+                    },
+                    RebornModelReplayStep::DelayedResponseForRequest {
+                        request_contains,
+                        response,
+                        delay,
+                        expected_tool_results,
+                    } => ReplayStep {
+                        output: ReplayOutput::DelayedResponse { response, delay },
+                        request_contains: Some(request_contains),
                         expected_tool_results,
                     },
                     RebornModelReplayStep::ProviderToolCalls {
@@ -173,6 +213,16 @@ impl RebornTraceReplayModelGateway {
                         expected_tool_results,
                     } => ReplayStep {
                         output: ReplayOutput::ProviderToolCalls(calls),
+                        request_contains: None,
+                        expected_tool_results,
+                    },
+                    RebornModelReplayStep::ProviderToolCallsForRequest {
+                        request_contains,
+                        calls,
+                        expected_tool_results,
+                    } => ReplayStep {
+                        output: ReplayOutput::ProviderToolCalls(calls),
+                        request_contains: Some(request_contains),
                         expected_tool_results,
                     },
                 })
@@ -273,16 +323,30 @@ impl RebornTraceReplayModelGateway {
                 "trace replay lock poisoned",
             )
         })?;
-        let Some(step) = state.steps.front().cloned() else {
+        let Some(position) = state
+            .steps
+            .iter()
+            .position(|step| step.matches_request(&request))
+        else {
             return Err(HostManagedModelError::safe(
                 HostManagedModelErrorKind::Unavailable,
-                "trace replay exhausted",
+                format!(
+                    "trace replay has no matching step for request messages: {}",
+                    request_message_summary(&request)
+                ),
             ));
         };
+        let step = state
+            .steps
+            .get(position)
+            .expect("matched replay step position")
+            .clone();
         validate_expected_tool_results(&request, &step.expected_tool_results)?;
         state.requests.push(request);
-        state.steps.pop_front();
-        Ok(step)
+        Ok(state
+            .steps
+            .remove(position)
+            .expect("matched replay step remains"))
     }
 }
 
@@ -318,6 +382,30 @@ async fn provider_tool_definitions(
     capabilities
         .tool_definitions()
         .map_err(capability_host_error)
+}
+
+impl ReplayStep {
+    fn matches_request(&self, request: &HostManagedModelRequest) -> bool {
+        let Some(needle) = &self.request_contains else {
+            return true;
+        };
+        request
+            .messages
+            .iter()
+            .any(|message| message.content.contains(needle))
+    }
+}
+
+fn request_message_summary(request: &HostManagedModelRequest) -> String {
+    request
+        .messages
+        .iter()
+        .map(|message| {
+            let snippet = message.content.chars().take(80).collect::<String>();
+            format!("{:?}:{snippet}", message.role)
+        })
+        .collect::<Vec<_>>()
+        .join(" | ")
 }
 
 async fn provider_tool_calls_response(
@@ -374,6 +462,7 @@ fn capability_host_error(error: AgentLoopHostError) -> HostManagedModelError {
 fn replay_step(step: TraceStep) -> Result<ReplayStep, RebornTraceReplayError> {
     Ok(ReplayStep {
         output: ReplayOutput::Response(response_from_trace(step.response)?),
+        request_contains: None,
         expected_tool_results: step.expected_tool_results,
     })
 }


### PR DESCRIPTION
## Purpose

This PR is Phase 4 of the Reborn subagent-spawn stack from #3798 and the design-doc PR #3814. It now covers both parts of the Phase 4 verification slice:

- production-readiness and composition-facade gates for the Phase 0-3 runtime pieces
- caller-visible Reborn E2E coverage for `builtin.spawn_subagent` through the real turn runner, child runs, and parent resume path

## What Changed

### Production Readiness

- Extended `RebornLoopProductionComponent` with the remaining subagent readiness dependencies:
  - `SubagentResultTombstoneStore`
  - `SubagentAutonomousContinuationBudget`
  - `SubagentRestartReconciler`
- Added fail-closed readiness tests for missing/non-production-safe subagent components.
- Extended composition readiness with `subagent_planned_driver` and verified it through the public composition facade.

### Spawn E2E Harness

- Added `tests/reborn_subagent_spawn_e2e.rs`, which drives `builtin.spawn_subagent` through the composed Reborn runtime instead of helper-only tests.
- Exposed `spawn_subagent` in the test capability surface and added harness helpers for child-run lookup and child-thread history assertions.
- Added delayed replay responses so blocking tests can prove the parent parks before child completion.
- Added request-matched replay responses and multi-worker harness startup so concurrent parent/child model calls can be asserted deterministically.
- Added scoped approval-resume helpers so tests can resolve gates on child runs, not only on the parent thread.

### Runtime Fixes Exposed by E2E

- Fixed invalid dependent-run gate refs by using `gate:subagent.<run_id>` / `gate:subagent-bg.<run_id>` instead of an extra colon in the opaque id.
- Added shared-gate handling for parallel blocking spawns so all child result refs are appended before the parent parks on one dependent-run gate.
- Updated subagent gate resolution to track multiple awaited children per gate and resume the parent once after the whole child set completes.
- Fixed a turn-runner deadlock where a losing heartbeat future could retain the turn-state lock while `apply_exit` tried to re-enter the same store.

## E2E Coverage Added

Active, non-ignored E2E coverage now verifies:

- background spawn submits a child, lets the parent continue, and the child completes on its own thread
- blocking spawn parks the parent, completes the child, resumes the parent, and injects the child result
- blocking spawn with an approval-gated child keeps the parent parked on the dependent child while the child is `BlockedApproval`, then resumes parent after the child approval is resolved
- background spawn with an approval-gated child lets the parent complete, leaves the child approval gate visible/resolvable through the child run, and completes the child after approval
- background spawn with an approval-gated child surfaces the child approval while the parent turn is still `Running` under two worker loops, then lets the parent and child complete independently
- parallel blocking spawn creates distinct child runs, waits for all children, and resumes the parent once with all child results
- fanout cap rejects the fifth child before submit while accepted background children still complete
- child-thread invariants: parent run id, subagent depth, spawn tree root, scope envelope, and distinct child thread id

## Explicitly Not Claimed Yet

This PR still does not mark the whole `/subagents spawn` user-facing parity row complete. The current evidence is the Reborn internal runtime path for `builtin.spawn_subagent`; legacy command parity, docs/parity updates, and broader product-surface cutover remain separate work.

## Stack Position

- Base: #3870 Phase 3 integration (`arch/phase-3-integration`)
- This PR: Phase 4 readiness, composition-facade verification, and spawn E2E expansion
- Follow-up: remaining #3798 parity/product documentation and any broader user-facing command cutover

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test --test reborn_subagent_spawn_e2e -- --nocapture`
- `cargo test -p ironclaw_reborn subagent::gate_resolution --lib`
- `cargo test -p ironclaw_reborn turn_runner --lib`
- `cargo test -p ironclaw_reborn -p ironclaw_agent_loop -p ironclaw_loop_support -p ironclaw_turns subagent`
- `cargo clippy -p ironclaw_reborn -p ironclaw_agent_loop -p ironclaw_loop_support -p ironclaw_turns --tests`

Known unrelated warning during E2E compile: `ironclaw_llm` has existing unused-import warnings for `path::Path` and `SecretString`.

Refs #3798
Design context: #3814
