### PR TITLE
refactor(loop_support): tighten capability_port (required sink, RAII dispatch guard, lock helper)

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -132,7 +132,7 @@ pub struct HostRuntimeLoopCapabilityPortFactory {
     visible_request: ironclaw_host_runtime::VisibleCapabilityRequest,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
-    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     execution_mounts: MountView,
 }
 
@@ -142,7 +142,7 @@ impl HostRuntimeLoopCapabilityPortFactory {
         visible_request: ironclaw_host_runtime::VisibleCapabilityRequest,
         input_resolver: Arc<dyn LoopCapabilityInputResolver>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
-        milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     ) -> Self {
         Self {
             runtime,
@@ -152,26 +152,6 @@ impl HostRuntimeLoopCapabilityPortFactory {
             milestone_sink,
             execution_mounts: MountView::default(),
         }
-    }
-
-    pub fn without_milestone_sink(
-        runtime: Arc<dyn HostRuntime>,
-        visible_request: ironclaw_host_runtime::VisibleCapabilityRequest,
-        input_resolver: Arc<dyn LoopCapabilityInputResolver>,
-        result_writer: Arc<dyn LoopCapabilityResultWriter>,
-    ) -> Self {
-        Self::new(
-            runtime,
-            visible_request,
-            input_resolver,
-            result_writer,
-            None,
-        )
-    }
-
-    pub fn with_milestone_sink(mut self, sink: Arc<dyn LoopHostMilestoneSink>) -> Self {
-        self.milestone_sink = Some(sink);
-        self
     }
 
     pub fn with_execution_mounts(mut self, mounts: MountView) -> Self {
@@ -184,17 +164,15 @@ impl HostRuntimeLoopCapabilityPortFactory {
     }
 
     fn port_for_run_context(&self, run_context: LoopRunContext) -> HostRuntimeLoopCapabilityPort {
-        let mut port = HostRuntimeLoopCapabilityPort::new(
+        HostRuntimeLoopCapabilityPort::new(
             Arc::clone(&self.runtime),
             run_context,
             self.visible_request.clone(),
             Arc::clone(&self.input_resolver),
             Arc::clone(&self.result_writer),
-        );
-        if let Some(sink) = &self.milestone_sink {
-            port = port.with_milestone_sink(Arc::clone(sink));
-        }
-        port.with_execution_mounts(self.execution_mounts.clone())
+            Arc::clone(&self.milestone_sink),
+        )
+        .with_execution_mounts(self.execution_mounts.clone())
     }
 }
 
@@ -360,17 +338,63 @@ enum DispatchReservation {
     LoopCompleted(Result<CapabilityOutcome, AgentLoopHostError>),
 }
 
+/// RAII guard for an `InFlight` dispatch reservation: if the holder drops
+/// without calling [`Self::commit`], the reservation is cleared and any
+/// waiters are notified. Clearing failures are logged but do not panic, since
+/// dropping happens on unwind paths where there's nothing useful to propagate.
+struct DispatchReservationGuard<'a> {
+    port: &'a HostRuntimeLoopCapabilityPort,
+    key: IdempotencyKey,
+    committed: bool,
+}
+
+impl DispatchReservationGuard<'_> {
+    fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for DispatchReservationGuard<'_> {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        if let Err(error) = self.port.clear_dispatch(&self.key) {
+            tracing::warn!(
+                cleanup_error = %error,
+                "failed to clean up dispatch reservation after early return"
+            );
+        }
+    }
+}
+
 pub struct HostRuntimeLoopCapabilityPort {
     runtime: Arc<dyn HostRuntime>,
     run_context: LoopRunContext,
     visible_request: ironclaw_host_runtime::VisibleCapabilityRequest,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
-    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     execution_mounts: MountView,
     snapshots: Mutex<HashMap<String, SurfaceSnapshot>>,
     current_surface_version: Mutex<Option<String>>,
     dispatch_records: Mutex<DispatchRecordStore>,
+}
+
+/// Lock a poisoned-aware `Mutex` and wrap a poison error as the canonical
+/// "<label> is unavailable" host error. Every store in this module is reached
+/// via this helper so the error message stays consistent and the call sites
+/// shrink to one line.
+fn lock_mut<'a, T>(
+    mutex: &'a Mutex<T>,
+    label: &'static str,
+) -> Result<std::sync::MutexGuard<'a, T>, AgentLoopHostError> {
+    mutex.lock().map_err(|_| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Unavailable,
+            format!("{label} is unavailable"),
+        )
+    })
 }
 
 impl HostRuntimeLoopCapabilityPort {
@@ -380,6 +404,7 @@ impl HostRuntimeLoopCapabilityPort {
         visible_request: ironclaw_host_runtime::VisibleCapabilityRequest,
         input_resolver: Arc<dyn LoopCapabilityInputResolver>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     ) -> Self {
         let input_resolver: Arc<dyn LoopCapabilityInputResolver> =
             Arc::new(ProviderToolCallInputResolver::new(input_resolver));
@@ -389,17 +414,12 @@ impl HostRuntimeLoopCapabilityPort {
             visible_request,
             input_resolver,
             result_writer,
-            milestone_sink: None,
+            milestone_sink,
             execution_mounts: MountView::default(),
             snapshots: Mutex::new(HashMap::new()),
             current_surface_version: Mutex::new(None),
             dispatch_records: Mutex::new(DispatchRecordStore::default()),
         }
-    }
-
-    pub fn with_milestone_sink(mut self, sink: Arc<dyn LoopHostMilestoneSink>) -> Self {
-        self.milestone_sink = Some(sink);
-        self
     }
 
     pub fn with_execution_mounts(mut self, mounts: MountView) -> Self {
@@ -411,12 +431,7 @@ impl HostRuntimeLoopCapabilityPort {
         &self,
         version: &ironclaw_turns::run_profile::CapabilitySurfaceVersion,
     ) -> Result<SurfaceSnapshot, AgentLoopHostError> {
-        let snapshots = self.snapshots.lock().map_err(|_| {
-            AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Unavailable,
-                "capability surface snapshot store is unavailable",
-            )
-        })?;
+        let snapshots = lock_mut(&self.snapshots, "capability surface snapshot store")?;
         snapshots.get(version.as_str()).cloned().ok_or_else(|| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::StaleSurface,
@@ -426,22 +441,12 @@ impl HostRuntimeLoopCapabilityPort {
     }
 
     fn current_snapshot(&self) -> Result<Option<(String, SurfaceSnapshot)>, AgentLoopHostError> {
-        let snapshots = self.snapshots.lock().map_err(|_| {
-            AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Unavailable,
-                "capability surface snapshot store is unavailable",
-            )
-        })?;
-        let version = self
-            .current_surface_version
-            .lock()
-            .map_err(|_| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unavailable,
-                    "capability surface snapshot pointer is unavailable",
-                )
-            })?
-            .clone();
+        let snapshots = lock_mut(&self.snapshots, "capability surface snapshot store")?;
+        let version = lock_mut(
+            &self.current_surface_version,
+            "capability surface snapshot pointer",
+        )?
+        .clone();
         let Some(version) = version else {
             return Ok(None);
         };
@@ -458,15 +463,7 @@ impl HostRuntimeLoopCapabilityPort {
         &self,
         key: &IdempotencyKey,
     ) -> Result<DispatchReservation, AgentLoopHostError> {
-        self.dispatch_records
-            .lock()
-            .map_err(|_| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unavailable,
-                    "capability dispatch record store is unavailable",
-                )
-            })?
-            .reserve(key)
+        lock_mut(&self.dispatch_records, "capability dispatch record store")?.reserve(key)
     }
 
     fn dispatch_in_flight_matches(
@@ -474,15 +471,10 @@ impl HostRuntimeLoopCapabilityPort {
         key: &IdempotencyKey,
         notify: &Arc<Notify>,
     ) -> Result<bool, AgentLoopHostError> {
-        self.dispatch_records
-            .lock()
-            .map(|records| records.in_flight_matches(key, notify))
-            .map_err(|_| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unavailable,
-                    "capability dispatch record store is unavailable",
-                )
-            })
+        Ok(
+            lock_mut(&self.dispatch_records, "capability dispatch record store")?
+                .in_flight_matches(key, notify),
+        )
     }
 
     fn record_runtime_completed(
@@ -491,22 +483,13 @@ impl HostRuntimeLoopCapabilityPort {
         requested_capability_id: CapabilityId,
         outcome: RuntimeCapabilityOutcome,
     ) -> Result<(), AgentLoopHostError> {
-        let notify = self
-            .dispatch_records
-            .lock()
-            .map_err(|_| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unavailable,
-                    "capability dispatch record store is unavailable",
-                )
-            })?
-            .record(
-                key,
-                DispatchRecord::RuntimeCompleted {
-                    requested_capability_id,
-                    outcome,
-                },
-            );
+        let notify = lock_mut(&self.dispatch_records, "capability dispatch record store")?.record(
+            key,
+            DispatchRecord::RuntimeCompleted {
+                requested_capability_id,
+                outcome,
+            },
+        );
         if let Some(notify) = notify {
             notify.notify_waiters();
         }
@@ -518,15 +501,7 @@ impl HostRuntimeLoopCapabilityPort {
         key: &IdempotencyKey,
         result: Result<CapabilityOutcome, AgentLoopHostError>,
     ) -> Result<(), AgentLoopHostError> {
-        let notify = self
-            .dispatch_records
-            .lock()
-            .map_err(|_| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unavailable,
-                    "capability dispatch record store is unavailable",
-                )
-            })?
+        let notify = lock_mut(&self.dispatch_records, "capability dispatch record store")?
             .record(key, DispatchRecord::LoopCompleted(result));
         if let Some(notify) = notify {
             notify.notify_waiters();
@@ -535,20 +510,28 @@ impl HostRuntimeLoopCapabilityPort {
     }
 
     fn clear_dispatch(&self, key: &IdempotencyKey) -> Result<(), AgentLoopHostError> {
-        let notify = self
-            .dispatch_records
-            .lock()
-            .map_err(|_| {
-                AgentLoopHostError::new(
-                    AgentLoopHostErrorKind::Unavailable,
-                    "capability dispatch record store is unavailable",
-                )
-            })?
-            .remove(key);
+        let notify =
+            lock_mut(&self.dispatch_records, "capability dispatch record store")?.remove(key);
         if let Some(notify) = notify {
             notify.notify_waiters();
         }
         Ok(())
+    }
+
+    /// Drop guard for an `InFlight` dispatch reservation. Releases the
+    /// reservation (and wakes any waiters) unless [`commit`] is called first.
+    /// Use after a successful `reserve_dispatch` returns `Reserved` so any
+    /// early-return error path between reservation and outcome recording
+    /// unwinds the reservation automatically.
+    fn dispatch_reservation_guard<'a>(
+        &'a self,
+        key: &IdempotencyKey,
+    ) -> DispatchReservationGuard<'a> {
+        DispatchReservationGuard {
+            port: self,
+            key: key.clone(),
+            committed: false,
+        }
     }
 
     fn validate_visible_request_scope(&self) -> Result<(), AgentLoopHostError> {
@@ -620,12 +603,11 @@ impl HostRuntimeLoopCapabilityPort {
         &self,
         capability_id: CapabilityId,
     ) -> Result<(), AgentLoopHostError> {
-        if let Some(milestone_sink) = &self.milestone_sink {
-            let milestones =
-                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
-            milestones.capability_invoked(capability_id).await?;
-        }
-        Ok(())
+        let milestones = LoopHostMilestoneEmitter::new(
+            self.run_context.clone(),
+            Arc::clone(&self.milestone_sink),
+        );
+        milestones.capability_invoked(capability_id).await
     }
 
     fn prepare_provider_tool_call(
@@ -790,20 +772,13 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
             })
             .collect();
 
-        let mut snapshots = self.snapshots.lock().map_err(|_| {
-            AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Unavailable,
-                "capability surface snapshot store is unavailable",
-            )
-        })?;
+        let mut snapshots = lock_mut(&self.snapshots, "capability surface snapshot store")?;
         snapshots.clear();
         snapshots.insert(version.as_str().to_string(), snapshot);
-        *self.current_surface_version.lock().map_err(|_| {
-            AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Unavailable,
-                "capability surface snapshot pointer is unavailable",
-            )
-        })? = Some(version.as_str().to_string());
+        *lock_mut(
+            &self.current_surface_version,
+            "capability surface snapshot pointer",
+        )? = Some(version.as_str().to_string());
 
         Ok(VisibleCapabilitySurface {
             version,
@@ -852,39 +827,21 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                 DispatchReservation::LoopCompleted(result) => return result,
             }
         }
-        let input = match self
+
+        // Any early `?` between reservation and `finish_runtime_outcome` unwinds
+        // the in-flight reservation via the guard's `Drop`. The success path
+        // calls `guard.commit()` so the dispatch record is replaced by
+        // `finish_runtime_outcome` rather than cleared.
+        let guard = self.dispatch_reservation_guard(&idempotency_key);
+
+        let input = self
             .input_resolver
             .resolve_capability_input(&self.run_context, &request.input_ref)
-            .await
-        {
-            Ok(input) => input,
-            Err(error) => {
-                if let Err(clear_error) = self.clear_dispatch(&idempotency_key) {
-                    tracing::warn!(
-                        cleanup_error = %clear_error,
-                        original_error = ?error,
-                        "failed to clean up state after input resolution failure"
-                    );
-                }
-                return Err(error);
-            }
-        };
+            .await?;
         let requested_capability_id = request.capability_id.clone();
-
-        if let Err(error) = self
-            .emit_capability_invoked(request.capability_id.clone())
-            .await
-        {
-            if let Err(clear_error) = self.clear_dispatch(&idempotency_key) {
-                tracing::warn!(
-                    cleanup_error = %clear_error,
-                    original_error = ?error,
-                    "failed to clean up state after milestone emission failure"
-                );
-            }
-            return Err(error);
-        }
-        let outcome = match self
+        self.emit_capability_invoked(request.capability_id.clone())
+            .await?;
+        let outcome = self
             .runtime
             .invoke_capability(
                 RuntimeCapabilityRequest::new(
@@ -905,19 +862,9 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
                 .with_idempotency_key(idempotency_key.clone()),
             )
             .await
-        {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                if let Err(clear_error) = self.clear_dispatch(&idempotency_key) {
-                    tracing::warn!(
-                        cleanup_error = %clear_error,
-                        original_error = ?error,
-                        "failed to clean up state after host runtime failure"
-                    );
-                }
-                return Err(host_runtime_error(error));
-            }
-        };
+            .map_err(host_runtime_error)?;
+
+        guard.commit();
         self.finish_runtime_outcome(&idempotency_key, &requested_capability_id, outcome)
             .await
     }
@@ -2260,7 +2207,7 @@ mod tests {
             visible_request(context),
             dummy_input_resolver(),
             dummy_result_writer(),
-            None,
+            dummy_milestone_sink(),
         )
         .with_execution_mounts(execution_mounts.clone());
 
@@ -2280,6 +2227,7 @@ mod tests {
             visible_request(context),
             dummy_input_resolver(),
             dummy_result_writer(),
+            dummy_milestone_sink(),
         )
         .with_execution_mounts(execution_mounts.clone());
 
@@ -2593,6 +2541,10 @@ mod tests {
 
     fn dummy_result_writer() -> Arc<dyn LoopCapabilityResultWriter> {
         Arc::new(NoopCapabilityIo)
+    }
+
+    fn dummy_milestone_sink() -> Arc<dyn LoopHostMilestoneSink> {
+        Arc::new(ironclaw_turns::run_profile::InMemoryLoopHostMilestoneSink::default())
     }
 
     struct NoopHostRuntime;

--- a/crates/ironclaw_loop_support/tests/host_capability_port_composition.rs
+++ b/crates/ironclaw_loop_support/tests/host_capability_port_composition.rs
@@ -24,8 +24,8 @@ use ironclaw_turns::{
     InMemoryRunProfileResolver, LoopResultRef, RunProfileResolutionRequest, RunProfileResolver,
     TurnId, TurnRunId, TurnScope,
     run_profile::{
-        AgentLoopHostError, AgentLoopHostErrorKind, LoopCapabilityPort, LoopRunContext,
-        ProviderToolCall, VisibleCapabilityRequest,
+        AgentLoopHostError, AgentLoopHostErrorKind, InMemoryLoopHostMilestoneSink,
+        LoopCapabilityPort, LoopRunContext, ProviderToolCall, VisibleCapabilityRequest,
     },
 };
 
@@ -74,7 +74,7 @@ async fn host_capability_port_composition_factory_builds_loop_capability_port() 
         visible_request,
         Arc::new(UnusedInputResolver),
         Arc::new(UnusedResultWriter),
-        None,
+        Arc::new(InMemoryLoopHostMilestoneSink::default()),
     );
     let port: Arc<dyn LoopCapabilityPort> = factory.for_run_context(run_context);
 
@@ -115,7 +115,7 @@ async fn visible_capability_request_rejects_caller_supplied_mounts() {
         visible_request,
         Arc::new(UnusedInputResolver),
         Arc::new(UnusedResultWriter),
-        None,
+        Arc::new(InMemoryLoopHostMilestoneSink::default()),
     );
     let port: Arc<dyn LoopCapabilityPort> = factory.for_run_context(run_context);
 
@@ -155,7 +155,7 @@ async fn factory_stages_provider_tool_call_arguments_without_custom_resolver_ove
         visible_request,
         Arc::new(UnusedInputResolver),
         Arc::new(UnusedResultWriter),
-        None,
+        Arc::new(InMemoryLoopHostMilestoneSink::default()),
     );
     let port: Arc<dyn LoopCapabilityPort> = factory.for_run_context(run_context);
 

--- a/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
+++ b/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
@@ -628,7 +628,7 @@ impl LoopCapabilityPortFactory for ProductLiveHostRuntimeCapabilityFactory {
                 model_policy_guard: Arc::new(NoOpPolicyGuard),
                 model_budget_accountant: Arc::new(NoOpBudgetAccountant),
                 safety_context: test_safety_context(),
-                milestone_sink: None,
+                milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
             },
         )
         .map_err(adapter_error)?;

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -3609,6 +3609,7 @@ async fn text_only_host_prompt_bundle_includes_surface_metadata_and_still_stream
         host_runtime_visible_request(&fixture, ["demo"]),
         Arc::new(InMemoryCapabilityIo::default()),
         Arc::new(InMemoryCapabilityIo::default()),
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -3677,8 +3678,8 @@ async fn text_only_host_routes_capability_invocation_through_host_runtime() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io.clone(),
-    )
-    .with_milestone_sink(fixture.milestone_sink.clone());
+        fixture.milestone_sink.clone(),
+    );
     let host = fixture
         .factory()
         .build_text_only_host_with_capabilities(
@@ -3736,6 +3737,7 @@ async fn text_only_host_profiled_capabilities_filter_surface_and_invocation() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let resolver = Arc::new(StaticCapabilitySurfaceProfileResolver::new(
         CapabilityAllowSet::allowlist([allowed_id.clone()]),
@@ -3802,6 +3804,7 @@ async fn default_strategy_filter_all_loses_to_host_profile_filter() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
 
     // The profile resolver only allows tool_a — this is the host-level filter.
@@ -3887,6 +3890,7 @@ async fn text_only_host_uses_fresh_execution_context_per_capability_invocation()
         visible_request.clone(),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -3974,6 +3978,7 @@ async fn text_only_host_rejects_outside_surface_capability_before_host_runtime()
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4039,6 +4044,7 @@ async fn text_only_host_sanitizes_runtime_failure_message_before_driver_output()
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4139,6 +4145,7 @@ async fn text_only_host_maps_runtime_suspension_and_process_outcomes() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4220,6 +4227,7 @@ async fn text_only_host_maps_explicit_unknown_runtime_outcome_to_failure() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4286,6 +4294,7 @@ async fn text_only_host_preserves_host_runtime_error_kind_and_summary() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4363,6 +4372,7 @@ async fn text_only_host_batch_stops_on_first_suspension_before_later_invocations
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4430,6 +4440,7 @@ async fn text_only_host_does_not_reinvoke_runtime_after_failed_outcome_retry() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io.clone(),
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4481,6 +4492,7 @@ async fn text_only_host_prompt_accepts_refetched_surface_version() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4548,6 +4560,7 @@ async fn text_only_host_waits_for_concurrent_duplicate_invocation_result() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4621,6 +4634,7 @@ async fn text_only_host_bounds_completed_dispatch_records() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4679,6 +4693,7 @@ async fn text_only_host_rejects_mismatched_capability_authority_context() {
         visible_request,
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
 
     let error = fixture
@@ -4731,6 +4746,7 @@ async fn text_only_host_does_not_reinvoke_runtime_after_result_write_failure_ret
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io.clone(),
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4794,6 +4810,7 @@ async fn text_only_host_rejects_runtime_outcome_for_different_capability() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io.clone(),
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4851,6 +4868,7 @@ async fn text_only_host_rejects_previous_surface_after_refetch() {
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -4957,8 +4975,8 @@ async fn text_only_host_e2e_invokes_script_capability_through_real_host_runtime(
         host_runtime_visible_request_with_dispatch_grant(&fixture, e2e_script_capability_id()),
         io.clone(),
         io.clone(),
-    )
-    .with_milestone_sink(fixture.milestone_sink.clone());
+        fixture.milestone_sink.clone(),
+    );
     let host = fixture
         .factory()
         .build_text_only_host_with_capabilities(
@@ -5016,6 +5034,7 @@ async fn text_only_host_denies_capability_without_provider_trust_before_host_run
         host_runtime_visible_request(&fixture, []),
         io.clone(),
         io,
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -5073,6 +5092,7 @@ async fn text_only_host_allows_retry_after_missing_capability_input_is_staged() 
         host_runtime_visible_request(&fixture, ["demo"]),
         io.clone(),
         io.clone(),
+        fixture.milestone_sink.clone(),
     );
     let host = fixture
         .factory()
@@ -5382,8 +5402,8 @@ impl LoopCapabilityPortFactory for TestHostRuntimeCapabilityFactory {
             self.visible_request.clone(),
             self.io.clone(),
             self.io.clone(),
-        )
-        .with_milestone_sink(self.milestone_sink.clone());
+            self.milestone_sink.clone(),
+        );
         Ok(Arc::new(port))
     }
 }
@@ -5862,8 +5882,8 @@ impl HostFactory for CapabilityHostFactory {
             self.visible_request.clone(),
             self.io.clone(),
             self.io.clone(),
-        )
-        .with_milestone_sink(self.milestone_sink.clone());
+            self.milestone_sink.clone(),
+        );
         RebornLoopDriverHostFactory::new(
             self.thread_service.clone(),
             self.thread_scope.clone(),

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -547,8 +547,8 @@ pub struct ProductLivePlannedRuntimeAdapterConfig {
     pub model_budget_accountant: Arc<dyn LoopModelBudgetAccountant>,
     /// Instruction-safety context passed into the planned runtime.
     pub safety_context: InstructionSafetyContext,
-    /// Optional sink for capability invocation milestones.
-    pub milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+    /// Sink for capability invocation milestones.
+    pub milestone_sink: Arc<dyn LoopHostMilestoneSink>,
 }
 
 /// Adapter bundle consumed by `build_product_live_planned_runtime`.
@@ -619,7 +619,7 @@ struct ProductLiveLoopCapabilityPortFactory {
     authority_resolver: Arc<dyn ProductLiveCapabilityAuthorityResolver>,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
-    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
 }
 
 impl ProductLiveLoopCapabilityPortFactory {
@@ -628,7 +628,7 @@ impl ProductLiveLoopCapabilityPortFactory {
         authority_resolver: Arc<dyn ProductLiveCapabilityAuthorityResolver>,
         input_resolver: Arc<dyn LoopCapabilityInputResolver>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
-        milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     ) -> Self {
         Self {
             runtime,
@@ -659,7 +659,7 @@ impl LoopCapabilityPortFactory for ProductLiveLoopCapabilityPortFactory {
             visible_request,
             Arc::clone(&self.input_resolver),
             Arc::clone(&self.result_writer),
-            self.milestone_sink.clone(),
+            Arc::clone(&self.milestone_sink),
         )
         .with_execution_mounts(execution_mounts);
         Ok(factory.for_run_context(run_context.clone()))

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -574,7 +574,7 @@ pub async fn build_reborn_runtime(
         &services,
         actor_user_id.clone(),
         model_gateway,
-        Some(milestone_sink.clone()),
+        milestone_sink.clone(),
     )
     .ok_or(RebornRuntimeError::HostRuntimeUnavailable)?;
     let capability_factory = local_dev_capabilities.capability_factory;

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -43,7 +43,7 @@ pub(super) fn capability_wiring(
     services: &RebornServices,
     user_id: UserId,
     model_gateway: Arc<dyn HostManagedModelGateway>,
-    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
 ) -> Option<LocalDevCapabilityWiring> {
     let runtime = services.host_runtime.clone()?;
     let capability_io = Arc::new(LocalDevCapabilityIo::default());
@@ -73,7 +73,7 @@ struct LocalDevLoopCapabilityPortFactory {
     user_id: UserId,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
-    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
 }
 
 impl LocalDevLoopCapabilityPortFactory {
@@ -82,7 +82,7 @@ impl LocalDevLoopCapabilityPortFactory {
         user_id: UserId,
         input_resolver: Arc<dyn LoopCapabilityInputResolver>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
-        milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     ) -> Self {
         Self {
             runtime,
@@ -111,7 +111,7 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             visible_request,
             Arc::clone(&self.input_resolver),
             Arc::clone(&self.result_writer),
-            self.milestone_sink.clone(),
+            Arc::clone(&self.milestone_sink),
         )
         .with_execution_mounts(execution_mounts);
         Ok(factory.for_run_context(run_context.clone()))

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -1192,7 +1192,7 @@ fn adapter_config() -> ProductLivePlannedRuntimeAdapterConfig {
             "adapter test safety policy",
         )
         .unwrap(),
-        milestone_sink: None,
+        milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
     }
 }
 

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -1416,7 +1416,7 @@ impl LoopCapabilityPortFactory for HostRuntimeHarnessCapabilityPortFactory {
             visible_request,
             self.harness.io.clone(),
             result_writer,
-            Some(milestone_sink),
+            milestone_sink,
         )
         .with_execution_mounts(execution_mounts)
         .for_run_context(run_context.clone());


### PR DESCRIPTION
## Summary

Three structural cleanups in `crates/ironclaw_loop_support/src/capability_port.rs`, no behavior change. Implements finding #2 from the recent thermo-nuclear code-quality review.

- **`milestone_sink` is now required**, not `Option<Arc<dyn LoopHostMilestoneSink>>`. Production wired a sink on every path (`build_reborn_runtime`, `loop_driver_host.rs`); the optionality was a type-system lie. The `with_milestone_sink` and `without_milestone_sink` builders are gone. Matches the `Option<Arc<…>>` anti-pattern called out in `.claude/rules/architecture.md`.
- **`DispatchReservationGuard` (RAII)** replaces three hand-rolled `if let Err(error) = ... { clear_dispatch(...); warn!(...); return ... }` blocks in `invoke_capability`. The guard clears the in-flight reservation on Drop unless `commit()` is called on the success path. Same cleanup semantics, same warn-level log on cleanup failure — but every new early-return path now inherits the unwind for free.
- **`lock_mut(&mutex, "<label>")` helper** collapses the repeated `.lock().map_err(|_| AgentLoopHostError::new(AgentLoopHostErrorKind::Unavailable, "<store> is unavailable"))` shape (60+ occurrences in the file, 9 of them in identical mutex blocks). Nine call sites now read as one line.

## Diff

```
9 files changed, 170 insertions(+), 198 deletions(-)
crates/ironclaw_loop_support/src/capability_port.rs                       | 124 +-, 172 -
crates/ironclaw_loop_support/tests/host_capability_port_composition.rs    |   5 +, 5 -
crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs      |   1 +, 1 -
crates/ironclaw_reborn/tests/loop_driver_host.rs                          |  26 +, 10 -
crates/ironclaw_reborn_composition/src/product_live_adapters.rs           |   5 +, 5 -
crates/ironclaw_reborn_composition/src/runtime.rs                         |   1 +, 1 -
crates/ironclaw_reborn_composition/src/runtime/local_dev.rs               |   4 +, 4 -
crates/ironclaw_reborn_composition/tests/product_live_adapters.rs         |   1 +, 1 -
tests/support/reborn/harness.rs                                           |   1 +, 1 -
```

`capability_port.rs` itself: 2707 → 2659 LOC. Still over the 1k-line threshold — that's a separate decomposition concern.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — clean, zero warnings
- [x] `cargo test -p ironclaw_loop_support` — 184 passed
- [x] `cargo test -p ironclaw_reborn` — 207 passed; 2 pre-existing failures in `text_only_host_e2e_invokes_script_capability_through_real_host_runtime` / `turn_runner_worker_drives_script_capability_through_real_host_runtime` confirmed present on the base branch (`ManifestV2(Parse { reason: "unknown field \`parameters_schema\`" })`) — unrelated to this PR
- [x] `cargo test -p ironclaw_reborn_composition` — 36 passed; 1 pre-existing failure in `local_dev_runtime_wires_input_skill_context_source_to_model_calls` (also reproduced on base branch) unrelated to this PR
- [x] `cargo test -p ironclaw_product_workflow` — 150 passed
- [x] `cargo test -p ironclaw_reborn_cli` — passes

## Out of scope

- Same `Option<Arc<dyn LoopHostMilestoneSink>>` shape exists on three other adapter types in `crates/ironclaw_loop_support/src/lib.rs` (`ThreadBackedLoopTranscriptPort`, `ThreadBackedLoopModelPort`, etc.) at lines 111, 387, 738. Worth following up but kept out of this PR to limit blast radius.
- The 1k+ file-size violations across `crates/` (executor.rs, filesystem_store.rs, etc.) are separate findings from the same review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)