### PR TITLE
feat(reborn): wire product auth composition seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4760,6 +4760,7 @@ dependencies = [
  "deadpool-postgres",
  "http 1.4.0",
  "http-body-util",
+ "ironclaw_auth",
  "ironclaw_authorization",
  "ironclaw_event_projections",
  "ironclaw_event_streams",

--- a/crates/ironclaw_architecture/tests/reborn_composition_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_composition_boundaries.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 const COMPOSITION_CRATE: &str = "ironclaw_reborn_composition";
 
 const SUBSTRATE_CRATES: &[&str] = &[
+    "ironclaw_auth",
     "ironclaw_host_api",
     "ironclaw_storage",
     "ironclaw_filesystem",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -1152,10 +1152,16 @@ fn reborn_product_auth_contract_stays_reborn_native() {
 
     let mut violations = Vec::new();
     collect_forbidden_uses(&auth_src, &root, &forbidden, &mut violations);
+    collect_forbidden_reborn_auth_file_uses(
+        &root.join("crates/ironclaw_reborn_composition/src/auth.rs"),
+        &root,
+        &forbidden,
+        &mut violations,
+    );
 
     assert!(
         violations.is_empty(),
-        "Reborn product auth can be behavior-compatible with v1, but implementation code paths must not mingle with v1 routes, v1 extension/secrets managers, raw provider transport, or raw secret records:\n{}",
+        "Reborn product auth can be behavior-compatible with v1, but implementation and composition code paths must not mingle with v1 routes, v1 extension/secrets managers, raw provider transport, or raw secret records:\n{}",
         violations.join("\n")
     );
 }
@@ -2249,6 +2255,26 @@ fn collect_forbidden_uses(
                     ));
                 }
             }
+        }
+    }
+}
+
+fn collect_forbidden_reborn_auth_file_uses(
+    path: &std::path::Path,
+    root: &std::path::Path,
+    forbidden: &[ForbiddenUse],
+    violations: &mut Vec<String>,
+) {
+    let contents = std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    for rule in forbidden {
+        if contents.contains(rule.pattern) {
+            violations.push(format!(
+                "{} contains forbidden product-auth implementation pattern `{}`: {}",
+                path.strip_prefix(root).unwrap_or(path).display(),
+                rule.pattern,
+                rule.reason
+            ));
         }
     }
 }

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -2265,8 +2265,11 @@ fn collect_forbidden_reborn_auth_file_uses(
     forbidden: &[ForbiddenUse],
     violations: &mut Vec<String>,
 ) {
-    let contents = std::fs::read_to_string(path)
-        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let message = format!(
+        "failed to read Reborn product-auth boundary file {}",
+        path.display()
+    );
+    let contents = std::fs::read_to_string(path).expect(&message);
     for rule in forbidden {
         if contents.contains(rule.pattern) {
             violations.push(format!(
@@ -2277,4 +2280,42 @@ fn collect_forbidden_reborn_auth_file_uses(
             ));
         }
     }
+}
+
+#[test]
+fn collect_forbidden_reborn_auth_file_uses_detects_violation() {
+    let root = std::env::temp_dir().join(format!(
+        "ironclaw-reborn-auth-boundary-test-{}",
+        std::process::id()
+    ));
+    let src = root.join("crates/ironclaw_reborn_composition/src");
+    std::fs::create_dir_all(&src).expect("test source directory must be created");
+    let auth_rs = src.join("auth.rs");
+    std::fs::write(&auth_rs, "fn forbidden() { let _ = \"reqwest\"; }\n")
+        .expect("test auth.rs must be written");
+
+    let mut violations = Vec::new();
+    collect_forbidden_reborn_auth_file_uses(
+        &auth_rs,
+        &root,
+        &[ForbiddenUse {
+            pattern: "reqwest",
+            reason: "provider transport must stay outside product auth composition",
+        }],
+        &mut violations,
+    );
+
+    std::fs::remove_dir_all(&root).expect("test source directory must be removed");
+
+    assert_eq!(violations.len(), 1);
+    assert!(
+        violations[0].contains("crates/ironclaw_reborn_composition/src/auth.rs"),
+        "violation should report the relative auth.rs path: {:?}",
+        violations
+    );
+    assert!(
+        violations[0].contains("provider transport must stay outside product auth composition"),
+        "violation should report the forbidden-use reason: {:?}",
+        violations
+    );
 }

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -1,12 +1,18 @@
 # ironclaw_reborn_composition guardrails
 
 - Own only top-level Reborn composition for production/app startup.
-- Expose facade-shaped handles only: `HostRuntime`, `TurnCoordinator`, WebUI `RebornServicesApi`, readiness.
+- Expose facade-shaped handles only: `HostRuntime`, `TurnCoordinator`, product-auth `RebornProductAuthServices`, WebUI `RebornServicesApi`, readiness.
 - Keep lower substrate handles private to factories and owning crates.
 - Do not depend on the root `ironclaw` crate or `src/` modules.
 - Do not add legacy bridge modes here until an accepted migration contract exists.
 - Do not route live v1/product traffic here; callers must opt in through explicit Reborn adapters.
 - Production and migration-dry-run profiles must fail closed on local-only or missing required handles.
+- Product auth composition must use `ironclaw_auth` trait-shaped ports. Do not
+  wire product auth through V1 OAuth routes, V1 pending maps, V1
+  `ExtensionManager`, V1 secret stores, or route-local raw HTTP clients.
+- Blocked run-state approval/auth gate rendering and resume belongs to #3094;
+  keep this crate's #3811 auth seam reusable by that layer without implementing
+  a second gate-resolution path.
 
 ## WebUI v2 native surface (`webui-v2-beta` feature)
 

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -57,6 +57,7 @@ postgres = [
 async-trait = "0.1"
 chrono = "0.4"
 deadpool-postgres = { version = "0.14", optional = true }
+ironclaw_auth = { path = "../ironclaw_auth" }
 ironclaw_authorization = { path = "../ironclaw_authorization" }
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 ironclaw_event_streams = { path = "../ironclaw_event_streams" }

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -61,6 +61,12 @@ impl RebornProductAuthServices {
         }
     }
 
+    /// Builds a bundle from one object that implements every product-auth port.
+    ///
+    /// This is primarily for unified fakes such as
+    /// [`InMemoryAuthProductServices`]. Production composition should prefer
+    /// [`Self::new`] so storage, provider egress, interaction, and cleanup can
+    /// be supplied by separate implementations.
     pub fn from_shared<T>(services: Arc<T>) -> Self
     where
         T: AuthFlowManager
@@ -114,5 +120,215 @@ impl RebornProductAuthServices {
 
     pub(crate) fn local_dev_in_memory() -> Self {
         Self::from_shared(Arc::new(InMemoryAuthProductServices::new()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_auth::{
+        AuthChallenge, AuthFlowId, AuthFlowRecord, AuthProductError, AuthProductScope,
+        CredentialAccount, CredentialAccountId, CredentialAccountListPage,
+        CredentialAccountListRequest, CredentialAccountMutation, CredentialAccountProjection,
+        CredentialAccountSelectionRequest, CredentialAccountStatus, NewAuthFlow,
+        NewCredentialAccount, OAuthCallbackInput, OAuthProviderCallbackRequest,
+        OAuthProviderExchange, SecretCleanupReport, SecretCleanupRequest, SecretSubmitRequest,
+        SecretSubmitResult,
+    };
+
+    struct SharedAuthTestDouble;
+
+    fn arc_data_ptr<T: ?Sized>(arc: &Arc<T>) -> *const () {
+        Arc::as_ptr(arc) as *const ()
+    }
+
+    #[test]
+    fn reborn_product_auth_services_new_accepts_separate_impls() {
+        let flow_manager: Arc<dyn AuthFlowManager> = Arc::new(SharedAuthTestDouble);
+        let interaction_service: Arc<dyn AuthInteractionService> = Arc::new(SharedAuthTestDouble);
+        let credential_setup_service: Arc<dyn CredentialSetupService> =
+            Arc::new(SharedAuthTestDouble);
+        let credential_account_service: Arc<dyn CredentialAccountService> =
+            Arc::new(SharedAuthTestDouble);
+        let provider_client: Arc<dyn AuthProviderClient> = Arc::new(SharedAuthTestDouble);
+        let cleanup_service: Arc<dyn SecretCleanupService> = Arc::new(SharedAuthTestDouble);
+
+        let services = RebornProductAuthServices::new(
+            flow_manager.clone(),
+            interaction_service.clone(),
+            credential_setup_service.clone(),
+            credential_account_service.clone(),
+            provider_client.clone(),
+            cleanup_service.clone(),
+        );
+
+        assert_eq!(
+            arc_data_ptr(&services.flow_manager()),
+            arc_data_ptr(&flow_manager)
+        );
+        assert_eq!(
+            arc_data_ptr(&services.interaction_service()),
+            arc_data_ptr(&interaction_service)
+        );
+        assert_eq!(
+            arc_data_ptr(&services.credential_setup_service()),
+            arc_data_ptr(&credential_setup_service)
+        );
+        assert_eq!(
+            arc_data_ptr(&services.credential_account_service()),
+            arc_data_ptr(&credential_account_service)
+        );
+        assert_eq!(
+            arc_data_ptr(&services.provider_client()),
+            arc_data_ptr(&provider_client)
+        );
+        assert_eq!(
+            arc_data_ptr(&services.cleanup_service()),
+            arc_data_ptr(&cleanup_service)
+        );
+    }
+
+    #[test]
+    fn reborn_product_auth_services_from_shared_clones_arc_per_trait() {
+        let shared = Arc::new(SharedAuthTestDouble);
+        let shared_ptr = arc_data_ptr(&shared);
+
+        let services = RebornProductAuthServices::from_shared(shared);
+
+        assert_eq!(arc_data_ptr(&services.flow_manager()), shared_ptr);
+        assert_eq!(arc_data_ptr(&services.interaction_service()), shared_ptr);
+        assert_eq!(
+            arc_data_ptr(&services.credential_setup_service()),
+            shared_ptr
+        );
+        assert_eq!(
+            arc_data_ptr(&services.credential_account_service()),
+            shared_ptr
+        );
+        assert_eq!(arc_data_ptr(&services.provider_client()), shared_ptr);
+        assert_eq!(arc_data_ptr(&services.cleanup_service()), shared_ptr);
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlowManager for SharedAuthTestDouble {
+        async fn create_flow(
+            &self,
+            _request: NewAuthFlow,
+        ) -> Result<AuthFlowRecord, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
+        async fn get_flow(
+            &self,
+            _scope: &AuthProductScope,
+            _flow_id: AuthFlowId,
+        ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
+        async fn complete_oauth_callback(
+            &self,
+            _scope: &AuthProductScope,
+            _input: OAuthCallbackInput,
+        ) -> Result<AuthFlowRecord, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
+        async fn cancel_flow(
+            &self,
+            _scope: &AuthProductScope,
+            _flow_id: AuthFlowId,
+        ) -> Result<AuthFlowRecord, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AuthInteractionService for SharedAuthTestDouble {
+        async fn request_secret_input(
+            &self,
+            _request: ironclaw_auth::ManualTokenSetupRequest,
+        ) -> Result<AuthChallenge, AuthProductError> {
+            unreachable!("constructor tests do not call auth-interaction methods")
+        }
+
+        async fn submit_manual_token(
+            &self,
+            _scope: &AuthProductScope,
+            _request: SecretSubmitRequest,
+        ) -> Result<SecretSubmitResult, AuthProductError> {
+            unreachable!("constructor tests do not call auth-interaction methods")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CredentialSetupService for SharedAuthTestDouble {
+        async fn create_or_update_account(
+            &self,
+            _request: CredentialAccountMutation,
+        ) -> Result<CredentialAccount, AuthProductError> {
+            unreachable!("constructor tests do not call credential-setup methods")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CredentialAccountService for SharedAuthTestDouble {
+        async fn create_account(
+            &self,
+            _request: NewCredentialAccount,
+        ) -> Result<CredentialAccount, AuthProductError> {
+            unreachable!("constructor tests do not call credential-account methods")
+        }
+
+        async fn get_account(
+            &self,
+            _scope: &AuthProductScope,
+            _account_id: CredentialAccountId,
+        ) -> Result<Option<CredentialAccount>, AuthProductError> {
+            unreachable!("constructor tests do not call credential-account methods")
+        }
+
+        async fn list_accounts(
+            &self,
+            _request: CredentialAccountListRequest,
+        ) -> Result<CredentialAccountListPage, AuthProductError> {
+            unreachable!("constructor tests do not call credential-account methods")
+        }
+
+        async fn update_status(
+            &self,
+            _scope: &AuthProductScope,
+            _account_id: CredentialAccountId,
+            _status: CredentialAccountStatus,
+        ) -> Result<CredentialAccount, AuthProductError> {
+            unreachable!("constructor tests do not call credential-account methods")
+        }
+
+        async fn select_unique_configured_account(
+            &self,
+            _request: CredentialAccountSelectionRequest,
+        ) -> Result<CredentialAccountProjection, AuthProductError> {
+            unreachable!("constructor tests do not call credential-account methods")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AuthProviderClient for SharedAuthTestDouble {
+        async fn exchange_callback(
+            &self,
+            _request: OAuthProviderCallbackRequest,
+        ) -> Result<OAuthProviderExchange, AuthProductError> {
+            unreachable!("constructor tests do not call provider-client methods")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SecretCleanupService for SharedAuthTestDouble {
+        async fn cleanup_for_lifecycle(
+            &self,
+            _request: SecretCleanupRequest,
+        ) -> Result<SecretCleanupReport, AuthProductError> {
+            unreachable!("constructor tests do not call cleanup methods")
+        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use ironclaw_auth::{
+    AuthFlowManager, AuthInteractionService, AuthProviderClient, CredentialAccountService,
+    CredentialSetupService, InMemoryAuthProductServices, SecretCleanupService,
+};
+
+/// Reborn product-auth service bundle exposed by the composition root.
+///
+/// This is the single composition seam for product-facing auth flows,
+/// credential accounts, secure manual-token interactions, provider exchange,
+/// and lifecycle cleanup. It deliberately exposes trait-shaped ports only:
+/// WebUI/setup/extension callers should enter here instead of reaching into
+/// lower auth stores, provider clients, or route-local state.
+#[derive(Clone)]
+pub struct RebornProductAuthServices {
+    flow_manager: Arc<dyn AuthFlowManager>,
+    interaction_service: Arc<dyn AuthInteractionService>,
+    credential_setup_service: Arc<dyn CredentialSetupService>,
+    credential_account_service: Arc<dyn CredentialAccountService>,
+    provider_client: Arc<dyn AuthProviderClient>,
+    cleanup_service: Arc<dyn SecretCleanupService>,
+}
+
+impl std::fmt::Debug for RebornProductAuthServices {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RebornProductAuthServices")
+            .field("flow_manager", &"Arc<dyn AuthFlowManager>")
+            .field("interaction_service", &"Arc<dyn AuthInteractionService>")
+            .field(
+                "credential_setup_service",
+                &"Arc<dyn CredentialSetupService>",
+            )
+            .field(
+                "credential_account_service",
+                &"Arc<dyn CredentialAccountService>",
+            )
+            .field("provider_client", &"Arc<dyn AuthProviderClient>")
+            .field("cleanup_service", &"Arc<dyn SecretCleanupService>")
+            .finish()
+    }
+}
+
+impl RebornProductAuthServices {
+    pub fn new(
+        flow_manager: Arc<dyn AuthFlowManager>,
+        interaction_service: Arc<dyn AuthInteractionService>,
+        credential_setup_service: Arc<dyn CredentialSetupService>,
+        credential_account_service: Arc<dyn CredentialAccountService>,
+        provider_client: Arc<dyn AuthProviderClient>,
+        cleanup_service: Arc<dyn SecretCleanupService>,
+    ) -> Self {
+        Self {
+            flow_manager,
+            interaction_service,
+            credential_setup_service,
+            credential_account_service,
+            provider_client,
+            cleanup_service,
+        }
+    }
+
+    pub fn from_shared<T>(services: Arc<T>) -> Self
+    where
+        T: AuthFlowManager
+            + AuthInteractionService
+            + CredentialSetupService
+            + CredentialAccountService
+            + AuthProviderClient
+            + SecretCleanupService
+            + 'static,
+    {
+        let flow_manager: Arc<dyn AuthFlowManager> = services.clone();
+        let interaction_service: Arc<dyn AuthInteractionService> = services.clone();
+        let credential_setup_service: Arc<dyn CredentialSetupService> = services.clone();
+        let credential_account_service: Arc<dyn CredentialAccountService> = services.clone();
+        let provider_client: Arc<dyn AuthProviderClient> = services.clone();
+        let cleanup_service: Arc<dyn SecretCleanupService> = services;
+
+        Self::new(
+            flow_manager,
+            interaction_service,
+            credential_setup_service,
+            credential_account_service,
+            provider_client,
+            cleanup_service,
+        )
+    }
+
+    pub fn flow_manager(&self) -> Arc<dyn AuthFlowManager> {
+        self.flow_manager.clone()
+    }
+
+    pub fn interaction_service(&self) -> Arc<dyn AuthInteractionService> {
+        self.interaction_service.clone()
+    }
+
+    pub fn credential_setup_service(&self) -> Arc<dyn CredentialSetupService> {
+        self.credential_setup_service.clone()
+    }
+
+    pub fn credential_account_service(&self) -> Arc<dyn CredentialAccountService> {
+        self.credential_account_service.clone()
+    }
+
+    pub fn provider_client(&self) -> Arc<dyn AuthProviderClient> {
+        self.provider_client.clone()
+    }
+
+    pub fn cleanup_service(&self) -> Arc<dyn SecretCleanupService> {
+        self.cleanup_service.clone()
+    }
+
+    pub(crate) fn local_dev_in_memory() -> Self {
+        Self::from_shared(Arc::new(InMemoryAuthProductServices::new()))
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -197,15 +197,19 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         Arc::new(services.host_runtime_for_local_testing());
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(DefaultTurnCoordinator::new(turn_state));
+    let product_auth = Some(
+        product_auth_services
+            .unwrap_or_else(|| Arc::new(RebornProductAuthServices::local_dev_in_memory())),
+    );
+    let product_auth_ready = product_auth.is_some();
 
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
-        product_auth: Some(
-            product_auth_services
-                .unwrap_or_else(|| Arc::new(RebornProductAuthServices::local_dev_in_memory())),
-        ),
-        readiness: readiness_for(profile, true, true, true),
+        // Local-dev always composes a safe in-memory product-auth boundary when
+        // the caller does not inject one; readiness tracks the assembled facade.
+        product_auth,
+        readiness: readiness_for(profile, true, true, product_auth_ready),
         local_runtime: Some(local_runtime),
     })
 }
@@ -368,17 +372,13 @@ async fn build_production_shaped(
             // TODO(process-port): if production enables FirstParty runtime,
             // HostRuntimeServices must be given a production process port;
             // otherwise the LocalHostProcessPort default is rejected.
-            build_libsql_production(
+            let context = RebornProductionBuildContext {
                 profile,
                 wiring_config,
                 production_wiring,
-                db,
-                path_or_url,
-                auth_token,
-                secret_master_key,
                 product_auth_services,
-            )
-            .await
+            };
+            build_libsql_production(context, db, path_or_url, auth_token, secret_master_key).await
         }
         #[cfg(feature = "postgres")]
         RebornStorageInput::Postgres {
@@ -394,16 +394,13 @@ async fn build_production_shaped(
             // TODO(process-port): if production enables FirstParty runtime,
             // HostRuntimeServices must be given a production process port;
             // otherwise the LocalHostProcessPort default is rejected.
-            build_postgres_production(
+            let context = RebornProductionBuildContext {
                 profile,
                 wiring_config,
                 production_wiring,
-                pool,
-                url,
-                secret_master_key,
                 product_auth_services,
-            )
-            .await
+            };
+            build_postgres_production(context, pool, url, secret_master_key).await
         }
     }
 }
@@ -413,6 +410,14 @@ struct RebornProductionWiring {
     trust_policy: Arc<HostTrustPolicy>,
     runtime_policy: EffectiveRuntimePolicy,
     turn_run_wake_notifier: Arc<ironclaw_host_runtime::SchedulerTurnRunWakeNotifier>,
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+struct RebornProductionBuildContext {
+    profile: RebornCompositionProfile,
+    wiring_config: ironclaw_host_runtime::ProductionWiringConfig,
+    production_wiring: RebornProductionWiring,
+    product_auth_services: Option<Arc<RebornProductAuthServices>>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -448,18 +453,22 @@ fn planned_run_profile_resolver() -> Result<Arc<InMemoryRunProfileResolver>, Reb
 
 #[cfg(feature = "libsql")]
 async fn build_libsql_production(
-    profile: RebornCompositionProfile,
-    wiring_config: ironclaw_host_runtime::ProductionWiringConfig,
-    production_wiring: RebornProductionWiring,
+    context: RebornProductionBuildContext,
     db: Arc<libsql::Database>,
     path_or_url: String,
     auth_token: Option<ironclaw_secrets::SecretMaterial>,
     secret_master_key: ironclaw_secrets::SecretMaterial,
-    product_auth_services: Option<Arc<RebornProductAuthServices>>,
 ) -> Result<RebornServices, RebornBuildError> {
     use ironclaw_authorization::FilesystemCapabilityLeaseStore;
     use ironclaw_filesystem::LibSqlRootFilesystem;
     use ironclaw_secrets::FilesystemSecretStore;
+
+    let RebornProductionBuildContext {
+        profile,
+        wiring_config,
+        production_wiring,
+        product_auth_services,
+    } = context;
 
     let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&db)));
     filesystem.run_migrations().await?;
@@ -510,11 +519,12 @@ async fn build_libsql_production(
         Arc::new(services.turn_coordinator_for_production()?);
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
         Arc::new(services.host_runtime_for_production(&wiring_config)?);
+    let product_auth_ready = product_auth_services.is_some();
 
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
-        readiness: readiness_for(profile, true, true, product_auth_services.is_some()),
+        readiness: readiness_for(profile, true, true, product_auth_ready),
         product_auth: product_auth_services,
         local_runtime: None,
     })
@@ -522,17 +532,21 @@ async fn build_libsql_production(
 
 #[cfg(feature = "postgres")]
 async fn build_postgres_production(
-    profile: RebornCompositionProfile,
-    wiring_config: ironclaw_host_runtime::ProductionWiringConfig,
-    production_wiring: RebornProductionWiring,
+    context: RebornProductionBuildContext,
     pool: deadpool_postgres::Pool,
     url: ironclaw_secrets::SecretMaterial,
     secret_master_key: ironclaw_secrets::SecretMaterial,
-    product_auth_services: Option<Arc<RebornProductAuthServices>>,
 ) -> Result<RebornServices, RebornBuildError> {
     use ironclaw_authorization::FilesystemCapabilityLeaseStore;
     use ironclaw_filesystem::PostgresRootFilesystem;
     use ironclaw_secrets::FilesystemSecretStore;
+
+    let RebornProductionBuildContext {
+        profile,
+        wiring_config,
+        production_wiring,
+        product_auth_services,
+    } = context;
 
     let filesystem = Arc::new(PostgresRootFilesystem::new(pool.clone()));
     filesystem.run_migrations().await?;
@@ -580,11 +594,12 @@ async fn build_postgres_production(
         Arc::new(services.turn_coordinator_for_production()?);
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
         Arc::new(services.host_runtime_for_production(&wiring_config)?);
+    let product_auth_ready = product_auth_services.is_some();
 
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
-        readiness: readiness_for(profile, true, true, product_auth_services.is_some()),
+        readiness: readiness_for(profile, true, true, product_auth_ready),
         product_auth: product_auth_services,
         local_runtime: None,
     })
@@ -643,5 +658,19 @@ mod tests {
         assert!(services.product_auth.is_none());
         assert!(services.local_runtime.is_none());
         assert_eq!(services.readiness.state, RebornReadinessState::Disabled);
+    }
+
+    #[test]
+    fn production_readiness_reflects_product_auth_presence() {
+        let without_auth = readiness_for(RebornCompositionProfile::Production, true, true, false);
+        assert_eq!(
+            without_auth.state,
+            RebornReadinessState::ProductionValidated
+        );
+        assert!(!without_auth.facades.product_auth);
+
+        let with_auth = readiness_for(RebornCompositionProfile::Production, true, true, true);
+        assert_eq!(with_auth.state, RebornReadinessState::ProductionValidated);
+        assert!(with_auth.facades.product_auth);
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -30,12 +30,13 @@ use ironclaw_turns::{
 use crate::input::RebornStorageInput;
 use crate::{
     RebornBuildError, RebornBuildInput, RebornCompositionProfile, RebornFacadeReadiness,
-    RebornReadiness, RebornReadinessState,
+    RebornProductAuthServices, RebornReadiness, RebornReadinessState,
 };
 
 pub struct RebornServices {
     pub host_runtime: Option<Arc<dyn ironclaw_host_runtime::HostRuntime>>,
     pub turn_coordinator: Option<Arc<dyn ironclaw_turns::TurnCoordinator>>,
+    pub product_auth: Option<Arc<RebornProductAuthServices>>,
     pub readiness: RebornReadiness,
     pub(crate) local_runtime: Option<Arc<RebornLocalRuntimeServices>>,
 }
@@ -54,6 +55,7 @@ impl std::fmt::Debug for RebornServices {
             .debug_struct("RebornServices")
             .field("host_runtime", &self.host_runtime.is_some())
             .field("turn_coordinator", &self.turn_coordinator.is_some())
+            .field("product_auth", &self.product_auth.is_some())
             .field("readiness", &self.readiness)
             .field("local_runtime", &self.local_runtime.is_some())
             .finish()
@@ -65,6 +67,7 @@ impl RebornServices {
         Self {
             host_runtime: None,
             turn_coordinator: None,
+            product_auth: None,
             readiness: RebornReadiness::disabled(),
             local_runtime: None,
         }
@@ -105,10 +108,17 @@ fn production_config(
 }
 
 async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, RebornBuildError> {
+    let RebornBuildInput {
+        profile,
+        storage,
+        runtime_policy,
+        product_auth_services,
+        ..
+    } = input;
     let RebornStorageInput::LocalDev {
         root,
         workspace_root,
-    } = input.storage
+    } = storage
     else {
         return Err(RebornBuildError::InvalidConfig {
             reason: "local-dev profile requires local-dev storage input".to_string(),
@@ -177,7 +187,7 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     .with_run_state(Arc::clone(&run_state))
     .with_approval_requests(Arc::clone(&approval_requests))
     .with_turn_state(Arc::clone(&turn_state));
-    if let Some(runtime_policy) = input.runtime_policy {
+    if let Some(runtime_policy) = runtime_policy {
         services = services.with_runtime_policy(runtime_policy);
     }
     // TODO(process-port): local-dev intentionally uses the default
@@ -191,7 +201,11 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
-        readiness: readiness_for(input.profile, true, true),
+        product_auth: Some(
+            product_auth_services
+                .unwrap_or_else(|| Arc::new(RebornProductAuthServices::local_dev_in_memory())),
+        ),
+        readiness: readiness_for(profile, true, true, true),
         local_runtime: Some(local_runtime),
     })
 }
@@ -311,6 +325,7 @@ async fn build_production_shaped(
         required_runtime_backends,
         require_runtime_http_egress,
         require_wasm_credentials,
+        product_auth_services,
     } = input;
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     let wiring_config = production_config(
@@ -326,6 +341,7 @@ async fn build_production_shaped(
         required_runtime_backends,
         require_runtime_http_egress,
         require_wasm_credentials,
+        product_auth_services,
     );
 
     match storage {
@@ -360,6 +376,7 @@ async fn build_production_shaped(
                 path_or_url,
                 auth_token,
                 secret_master_key,
+                product_auth_services,
             )
             .await
         }
@@ -384,6 +401,7 @@ async fn build_production_shaped(
                 pool,
                 url,
                 secret_master_key,
+                product_auth_services,
             )
             .await
         }
@@ -437,6 +455,7 @@ async fn build_libsql_production(
     path_or_url: String,
     auth_token: Option<ironclaw_secrets::SecretMaterial>,
     secret_master_key: ironclaw_secrets::SecretMaterial,
+    product_auth_services: Option<Arc<RebornProductAuthServices>>,
 ) -> Result<RebornServices, RebornBuildError> {
     use ironclaw_authorization::FilesystemCapabilityLeaseStore;
     use ironclaw_filesystem::LibSqlRootFilesystem;
@@ -495,7 +514,8 @@ async fn build_libsql_production(
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
-        readiness: readiness_for(profile, true, true),
+        readiness: readiness_for(profile, true, true, product_auth_services.is_some()),
+        product_auth: product_auth_services,
         local_runtime: None,
     })
 }
@@ -508,6 +528,7 @@ async fn build_postgres_production(
     pool: deadpool_postgres::Pool,
     url: ironclaw_secrets::SecretMaterial,
     secret_master_key: ironclaw_secrets::SecretMaterial,
+    product_auth_services: Option<Arc<RebornProductAuthServices>>,
 ) -> Result<RebornServices, RebornBuildError> {
     use ironclaw_authorization::FilesystemCapabilityLeaseStore;
     use ironclaw_filesystem::PostgresRootFilesystem;
@@ -563,7 +584,8 @@ async fn build_postgres_production(
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
-        readiness: readiness_for(profile, true, true),
+        readiness: readiness_for(profile, true, true, product_auth_services.is_some()),
+        product_auth: product_auth_services,
         local_runtime: None,
     })
 }
@@ -572,6 +594,7 @@ fn readiness_for(
     profile: RebornCompositionProfile,
     host_runtime: bool,
     turn_coordinator: bool,
+    product_auth: bool,
 ) -> RebornReadiness {
     let state = match profile {
         RebornCompositionProfile::Disabled => RebornReadinessState::Disabled,
@@ -585,6 +608,7 @@ fn readiness_for(
         facades: RebornFacadeReadiness {
             host_runtime,
             turn_coordinator,
+            product_auth,
         },
     }
 }
@@ -605,6 +629,7 @@ mod tests {
 
         assert!(services.host_runtime.is_some());
         assert!(services.turn_coordinator.is_some());
+        assert!(services.product_auth.is_some());
         assert!(services.local_runtime.is_some());
         assert_eq!(services.readiness.state, RebornReadinessState::DevOnly);
     }
@@ -615,6 +640,7 @@ mod tests {
 
         assert!(services.host_runtime.is_none());
         assert!(services.turn_coordinator.is_none());
+        assert!(services.product_auth.is_none());
         assert!(services.local_runtime.is_none());
         assert_eq!(services.readiness.state, RebornReadinessState::Disabled);
     }

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -5,7 +5,7 @@ use ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy;
 use ironclaw_host_runtime::SchedulerTurnRunWakeNotifier;
 use ironclaw_trust::HostTrustPolicy;
 
-use crate::RebornCompositionProfile;
+use crate::{RebornCompositionProfile, RebornProductAuthServices};
 
 pub struct RebornBuildInput {
     pub(crate) profile: RebornCompositionProfile,
@@ -17,6 +17,7 @@ pub struct RebornBuildInput {
     pub(crate) required_runtime_backends: Vec<ironclaw_host_api::RuntimeKind>,
     pub(crate) require_runtime_http_egress: bool,
     pub(crate) require_wasm_credentials: bool,
+    pub(crate) product_auth_services: Option<Arc<RebornProductAuthServices>>,
 }
 
 pub(crate) enum RebornStorageInput {
@@ -162,6 +163,16 @@ impl RebornBuildInput {
         self
     }
 
+    /// Inject a Reborn-native product-auth composition bundle.
+    ///
+    /// Production callers should provide durable implementations here once the
+    /// auth-flow and credential-account storage substrate is available. The
+    /// composition root never falls back to V1 route state or V1 secret stores.
+    pub fn with_product_auth_services(mut self, services: Arc<RebornProductAuthServices>) -> Self {
+        self.product_auth_services = Some(services);
+        self
+    }
+
     fn new(
         profile: RebornCompositionProfile,
         owner_id: impl Into<String>,
@@ -177,6 +188,7 @@ impl RebornBuildInput {
             required_runtime_backends: Vec::new(),
             require_runtime_http_egress: false,
             require_wasm_credentials: false,
+            product_auth_services: None,
         }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -192,3 +192,30 @@ impl RebornBuildInput {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ironclaw_auth::InMemoryAuthProductServices;
+
+    use super::*;
+
+    #[test]
+    fn with_product_auth_services_records_injected_bundle() {
+        let product_auth = Arc::new(RebornProductAuthServices::from_shared(Arc::new(
+            InMemoryAuthProductServices::new(),
+        )));
+
+        let input = RebornBuildInput::disabled("test-owner")
+            .with_product_auth_services(Arc::clone(&product_auth));
+
+        assert!(Arc::ptr_eq(
+            input
+                .product_auth_services
+                .as_ref()
+                .expect("builder should retain injected product auth services"),
+            &product_auth
+        ));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! Two entry points:
 //!
-//! - [`build_reborn_services`] — substrate-only facades (host runtime,
-//!   turn coordinator). Useful when an outer harness wires the loop
+//! - [`build_reborn_services`] — substrate/product facades (host runtime,
+//!   turn coordinator, product auth). Useful when an outer harness wires the loop
 //!   drivers / turn-runner itself (e.g. v1 `AppBuilder`).
 //! - [`build_reborn_runtime`] — full runtime assembly: substrate + loop
 //!   driver registry + LLM model gateway (under `root-llm-provider`) +
@@ -18,6 +18,7 @@
 //! import `TurnCoordinator`, `SessionThreadService`, `HostManagedModel
 //! Gateway`, etc.
 
+mod auth;
 mod error;
 mod factory;
 mod input;
@@ -43,6 +44,7 @@ mod webui_ws_origin;
 
 use ironclaw_runtime_policy::{EffectiveRuntimePolicy as ResolvedRuntimePolicy, ResolveError};
 
+pub use auth::RebornProductAuthServices;
 pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};
 pub use input::RebornBuildInput;

--- a/crates/ironclaw_reborn_composition/src/readiness.rs
+++ b/crates/ironclaw_reborn_composition/src/readiness.rs
@@ -16,6 +16,7 @@ pub enum RebornReadinessState {
 pub struct RebornFacadeReadiness {
     pub host_runtime: bool,
     pub turn_coordinator: bool,
+    pub product_auth: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -33,6 +34,7 @@ impl RebornReadiness {
             facades: RebornFacadeReadiness {
                 host_runtime: false,
                 turn_coordinator: false,
+                product_auth: false,
             },
         }
     }

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -391,10 +391,13 @@ async fn local_dev_product_auth_entrypoint_redacts_manual_token_submit() {
 
     let accounts = product_auth
         .credential_account_service()
-        .list_accounts(&scope, &provider)
+        .list_accounts(ironclaw_auth::CredentialAccountListRequest::new(
+            scope.clone(),
+            provider,
+        ))
         .await
         .unwrap();
-    assert_eq!(accounts.len(), 1);
+    assert_eq!(accounts.accounts.len(), 1);
     let serialized = serde_json::to_string(&accounts).unwrap();
     assert!(!serialized.contains("super-secret-token"));
     assert!(!serialized.contains("manual-access-"));

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -46,6 +46,7 @@ use ironclaw_turns::{
     TurnScope,
     runner::{ClaimedTurnRun, TurnRunTransitionPort},
 };
+use secrecy::SecretString;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 fn test_master_key() -> SecretMaterial {
@@ -327,6 +328,88 @@ async fn local_dev_builds_facades_without_production_claim() {
     assert_eq!(services.readiness.state, RebornReadinessState::DevOnly);
     assert!(services.readiness.facades.host_runtime);
     assert!(services.readiness.facades.turn_coordinator);
+    assert!(services.readiness.facades.product_auth);
+    assert!(services.product_auth.is_some());
+}
+
+#[tokio::test]
+async fn local_dev_product_auth_entrypoint_redacts_manual_token_submit() {
+    let dir = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(RebornBuildInput::local_dev(
+        "test-owner",
+        dir.path().to_path_buf(),
+    ))
+    .await
+    .unwrap();
+    let product_auth = services
+        .product_auth
+        .as_ref()
+        .expect("local-dev composes product auth");
+    let scope = auth_scope("alice");
+    let provider = ironclaw_auth::AuthProviderId::new("github").unwrap();
+    let label = ironclaw_auth::CredentialAccountLabel::new("work github").unwrap();
+
+    let challenge = product_auth
+        .interaction_service()
+        .request_secret_input(ironclaw_auth::ManualTokenSetupRequest {
+            scope: scope.clone(),
+            provider: provider.clone(),
+            label: label.clone(),
+            continuation: ironclaw_auth::AuthContinuationRef::SetupOnly,
+            expires_at: chrono::Utc::now() + chrono::Duration::minutes(5),
+        })
+        .await
+        .unwrap();
+    let ironclaw_auth::AuthChallenge::ManualTokenRequired {
+        interaction_id,
+        provider: challenge_provider,
+        label: challenge_label,
+        ..
+    } = challenge
+    else {
+        panic!("expected manual-token challenge");
+    };
+    assert_eq!(challenge_provider, provider);
+    assert_eq!(challenge_label, label);
+
+    let submit = ironclaw_auth::SecretSubmitRequest {
+        interaction_id,
+        secret: SecretString::from("super-secret-token".to_string()),
+    };
+    let debug = format!("{submit:?}");
+    assert!(!debug.contains("super-secret-token"));
+
+    let result = product_auth
+        .interaction_service()
+        .submit_manual_token(&scope, submit)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.status,
+        ironclaw_auth::CredentialAccountStatus::Configured
+    );
+
+    let accounts = product_auth
+        .credential_account_service()
+        .list_accounts(&scope, &provider)
+        .await
+        .unwrap();
+    assert_eq!(accounts.len(), 1);
+    let serialized = serde_json::to_string(&accounts).unwrap();
+    assert!(!serialized.contains("super-secret-token"));
+    assert!(!serialized.contains("manual-access-"));
+}
+
+fn auth_scope(user: &str) -> ironclaw_auth::AuthProductScope {
+    ironclaw_auth::AuthProductScope::new(
+        ironclaw_host_api::ResourceScope::local_default(
+            ironclaw_host_api::UserId::new(user).unwrap(),
+            ironclaw_host_api::InvocationId::new(),
+        )
+        .unwrap(),
+        ironclaw_auth::AuthSurface::Web,
+    )
+    .with_session_id(ironclaw_auth::AuthSessionId::new(format!("session-{user}")).unwrap())
 }
 
 #[cfg(feature = "libsql")]

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -1,8 +1,9 @@
 # Reborn Product Auth Contract
 
-**Status:** first-slice contract draft
-**Issue:** #3289 / #3810
-**Crate:** `crates/ironclaw_auth`
+- **Status:** contract and composition seam
+- **Issue:** #3289 / #3810 / #3811
+- **Crate:** `crates/ironclaw_auth`
+- **Composition:** `ironclaw_reborn_composition::RebornProductAuthServices`
 
 ---
 
@@ -14,8 +15,9 @@ providers, extensions, MCP servers, WASM tools/channels, and future identity
 login flows.
 
 This slice is contract-first. It defines Reborn-native vocabulary and fake
-services, but does not migrate production OAuth routes, extension setup routes,
-CLI/setup flows, durable secret storage, or runtime credential injection.
+services, and #3811 adds a Reborn composition seam. It does not migrate
+production OAuth routes, extension setup routes, CLI/setup flows, durable
+secret storage, or runtime credential injection.
 
 Behavior may remain compatible with legacy UX. Code paths must not mingle V1
 components with Reborn components: V1 route handlers, pending maps, extension
@@ -37,6 +39,17 @@ manager authority, and V1 secret stores are inventory evidence only.
 Low-level encrypted storage, leases, host-mediated HTTP credential injection,
 approval interaction UI, and no-exposure enforcement remain owned by their
 respective Reborn substrate contracts.
+
+`RebornProductAuthServices` is the single composition bundle for the product
+auth ports above. WebUI/setup/extension surfaces should call this bundle once
+routes are migrated instead of reconstructing auth-flow stores, credential
+stores, provider clients, or cleanup services locally.
+
+The blocked-run interaction loop is separate: #3094 owns listing/rendering
+approval/auth gates from blocked run-state and routing user decisions back into
+the trusted resume path. That issue should consume the auth-flow boundary here
+for auth gates; it must not create a second credential-account or OAuth-flow
+model.
 
 ---
 
@@ -173,6 +186,11 @@ metadata.
 
 Future production implementations must route provider HTTP through Reborn
 network/egress policy and return sanitized errors.
+
+The composition root may expose an in-memory product-auth bundle only for
+local-dev/testing. Production profiles must receive durable Reborn-native auth
+services explicitly; they must not fall back to V1 pending maps, V1 route
+state, or V1 secret stores as product authority.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `RebornProductAuthServices` as the single Reborn composition seam for product auth flows, secure manual-token interactions, credential setup/accounts, provider exchange, and cleanup.
- Wires the seam into `build_reborn_services` readiness: local-dev gets the in-memory Reborn auth implementation, while production only reports product-auth ready when a Reborn-native bundle is explicitly injected.
- Adds caller-level composition coverage for manual-token submit redaction and updates architecture guardrails/docs to keep #3811 separate from #3094 blocked-run gate resolution.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Closes #3811
Related #3289
Stacked on #3865 (`feat/reborn-auth-product-contracts`). After #3865 lands, this PR should be retargeted to `reborn-integration`.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_composition --locked`, `cargo test -p ironclaw_auth --locked`, `cargo test -p ironclaw_architecture reborn_product_auth_contract_stays_reborn_native --locked`, `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold --locked`, `cargo test -p ironclaw_architecture no_substrate_crate_depends_on_composition_root --locked`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: Not applicable; composition and contract behavior are covered by tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings`
- `cargo check -p ironclaw_reborn_composition --features libsql --locked`
- `cargo check -p ironclaw_reborn_composition --features postgres --locked`
- `git diff --check`

## Security Impact

Yes. This adds the Reborn-native product-auth composition seam. It keeps callers on trait-shaped product-auth ports and documents that production must inject durable Reborn auth services explicitly instead of falling back to V1 routes, V1 pending maps, V1 `ExtensionManager`, V1 secret stores, or route-local raw HTTP clients. No production OAuth route, listener, raw provider transport, durable secret storage, token material handling, runtime credential injection, or database schema is added in this slice.

## Database Impact

None. This wires composition/readiness and tests only; durable product-auth storage remains future substrate work.

## Blast Radius

Limited to `ironclaw_reborn_composition`, the product-auth contract docs, and architecture guardrails. Existing V1 auth behavior is untouched. Local-dev now reports product-auth readiness through the in-memory Reborn auth implementation; production reports it only when explicitly injected.

## Rollback Plan

Revert this PR to remove the composition bundle, readiness flag, docs, and guardrail updates. No data migration or runtime cleanup is required.

## Review Follow-Through

Reviewer judgment requested on the exact composition surface and readiness semantics. #3094 remains separate: blocked run-state approval/auth gate listing, user decisions, and trusted resume should consume this auth boundary rather than adding a second auth model.

---

**Review track**: C