### PR TITLE
feat(reborn): handle product auth oauth callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,6 +4164,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "url",

--- a/crates/ironclaw_auth/Cargo.toml
+++ b/crates/ironclaw_auth/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
+subtle = "2"
 thiserror = "2"
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -12,12 +12,12 @@ use crate::{
     CredentialAccountListRequest, CredentialAccountMutation, CredentialAccountProjection,
     CredentialAccountSelectionRequest, CredentialAccountService, CredentialAccountStatus,
     CredentialOwnership, CredentialSetupService, ManualTokenSetupRequest, NewAuthFlow,
-    NewCredentialAccount, OAuthCallbackInput, OAuthProviderCallbackRequest, OAuthProviderExchange,
-    ProviderCallbackOutcome, SecretCleanupAction, SecretCleanupReport, SecretCleanupRequest,
-    SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
-    cleanup::SecretCleanupAction::Deactivate, flow::credential_status_for_completed_flow,
-    interaction::PendingSecretInteraction, provider::validate_provider_callback_request,
-    scope_matches,
+    NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackInput,
+    OAuthProviderCallbackRequest, OAuthProviderExchange, ProviderCallbackOutcome,
+    SecretCleanupAction, SecretCleanupReport, SecretCleanupRequest, SecretCleanupService,
+    SecretSubmitRequest, SecretSubmitResult, cleanup::SecretCleanupAction::Deactivate,
+    flow::credential_status_for_completed_flow, interaction::PendingSecretInteraction,
+    provider::validate_provider_callback_request, scope_matches,
 };
 
 #[derive(Default)]
@@ -101,6 +101,50 @@ impl AuthFlowManager for InMemoryAuthProductServices {
             return Err(AuthProductError::CrossScopeDenied);
         }
         Ok(Some(record.clone()))
+    }
+
+    async fn claim_oauth_callback(
+        &self,
+        scope: &crate::AuthProductScope,
+        request: OAuthCallbackClaimRequest,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        let now = Utc::now();
+        let mut state = self.lock_state();
+        let record = state
+            .flows
+            .get_mut(&request.flow_id)
+            .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
+        if !scope_matches(scope, &record.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if record.opaque_state_hash.as_ref() != Some(&request.opaque_state_hash) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if record.provider != request.provider {
+            return Err(AuthProductError::TokenExchangeFailed);
+        }
+        if record.pkce_verifier_hash.as_ref() != Some(&request.pkce_verifier_hash) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if crate::is_terminal_status(record.status) {
+            return match record.status {
+                AuthFlowStatus::Completed => Ok(record.clone()),
+                AuthFlowStatus::Canceled => Err(AuthProductError::Canceled),
+                _ => Err(AuthProductError::FlowAlreadyTerminal),
+            };
+        }
+        if now > record.expires_at {
+            record.status = AuthFlowStatus::Expired;
+            record.error = Some(crate::AuthErrorCode::UnknownOrExpiredFlow);
+            record.updated_at = now;
+            return Err(AuthProductError::UnknownOrExpiredFlow);
+        }
+        if record.status != AuthFlowStatus::AwaitingUser {
+            return Err(AuthProductError::FlowAlreadyTerminal);
+        }
+        record.status = AuthFlowStatus::CallbackReceived;
+        record.updated_at = now;
+        Ok(record.clone())
     }
 
     async fn complete_oauth_callback(

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -12,7 +12,7 @@ use crate::{
     CredentialAccountListRequest, CredentialAccountMutation, CredentialAccountProjection,
     CredentialAccountSelectionRequest, CredentialAccountService, CredentialAccountStatus,
     CredentialOwnership, CredentialSetupService, ManualTokenSetupRequest, NewAuthFlow,
-    NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackInput,
+    NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
     OAuthProviderCallbackRequest, OAuthProviderExchange, ProviderCallbackOutcome,
     SecretCleanupAction, SecretCleanupReport, SecretCleanupRequest, SecretCleanupService,
     SecretSubmitRequest, SecretSubmitResult, cleanup::SecretCleanupAction::Deactivate,
@@ -117,13 +117,21 @@ impl AuthFlowManager for InMemoryAuthProductServices {
         if !scope_matches(scope, &record.scope) {
             return Err(AuthProductError::CrossScopeDenied);
         }
-        if record.opaque_state_hash.as_ref() != Some(&request.opaque_state_hash) {
+        if !record
+            .opaque_state_hash
+            .as_ref()
+            .is_some_and(|expected| expected.constant_time_eq(&request.opaque_state_hash))
+        {
             return Err(AuthProductError::CrossScopeDenied);
         }
         if record.provider != request.provider {
             return Err(AuthProductError::TokenExchangeFailed);
         }
-        if record.pkce_verifier_hash.as_ref() != Some(&request.pkce_verifier_hash) {
+        if !record
+            .pkce_verifier_hash
+            .as_ref()
+            .is_some_and(|expected| expected.constant_time_eq(&request.pkce_verifier_hash))
+        {
             return Err(AuthProductError::CrossScopeDenied);
         }
         if crate::is_terminal_status(record.status) {
@@ -171,8 +179,10 @@ impl AuthFlowManager for InMemoryAuthProductServices {
                 if exchange.provider != record.provider {
                     return Err(AuthProductError::TokenExchangeFailed);
                 }
-                if callback.expected_pkce_verifier_hash.as_ref()
-                    != Some(&exchange.pkce_verifier_hash)
+                if !callback
+                    .expected_pkce_verifier_hash
+                    .as_ref()
+                    .is_some_and(|expected| expected.constant_time_eq(&exchange.pkce_verifier_hash))
                 {
                     return Err(AuthProductError::CrossScopeDenied);
                 }
@@ -201,6 +211,24 @@ impl AuthFlowManager for InMemoryAuthProductServices {
             emitted_at: now,
         });
         Ok(completed)
+    }
+
+    async fn fail_oauth_callback(
+        &self,
+        scope: &crate::AuthProductScope,
+        input: OAuthCallbackFailureInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        let now = Utc::now();
+        let mut state = self.lock_state();
+        let record = state
+            .flows
+            .get_mut(&input.flow_id)
+            .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
+        let _callback = prepare_callback_flow(record, scope, &input.opaque_state_hash, now)?;
+        record.status = AuthFlowStatus::Failed;
+        record.error = Some(input.error);
+        record.updated_at = now;
+        Ok(record.clone())
     }
 
     async fn cancel_flow(
@@ -550,7 +578,11 @@ fn prepare_callback_flow(
         record.updated_at = now;
         return Err(AuthProductError::UnknownOrExpiredFlow);
     }
-    if record.opaque_state_hash.as_ref() != Some(opaque_state_hash) {
+    if !record
+        .opaque_state_hash
+        .as_ref()
+        .is_some_and(|expected| expected.constant_time_eq(opaque_state_hash))
+    {
         return Err(AuthProductError::CrossScopeDenied);
     }
     Ok(PreparedCallbackFlow {

--- a/crates/ironclaw_auth/src/flow.rs
+++ b/crates/ironclaw_auth/src/flow.rs
@@ -28,6 +28,8 @@ pub enum AuthFlowStatus {
     Pending,
     AwaitingUser,
     CallbackReceived,
+    /// Reserved for production stores that split durable claim, provider
+    /// exchange, and account mutation across asynchronous workers.
     Completing,
     Completed,
     Failed,
@@ -164,6 +166,14 @@ pub struct OAuthCallbackInput {
     pub outcome: ProviderCallbackOutcome,
 }
 
+/// Terminal failure input for an already-claimed OAuth callback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthCallbackFailureInput {
+    pub flow_id: AuthFlowId,
+    pub opaque_state_hash: OpaqueStateHash,
+    pub error: AuthErrorCode,
+}
+
 /// Pre-egress claim for an authorized OAuth callback. This validates and marks
 /// the scoped flow before one-shot provider exchange can consume a raw code.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -194,6 +204,12 @@ pub trait AuthFlowManager: Send + Sync {
         &self,
         scope: &AuthProductScope,
         input: OAuthCallbackInput,
+    ) -> Result<AuthFlowRecord, AuthProductError>;
+
+    async fn fail_oauth_callback(
+        &self,
+        scope: &AuthProductScope,
+        input: OAuthCallbackFailureInput,
     ) -> Result<AuthFlowRecord, AuthProductError>;
 
     async fn cancel_flow(

--- a/crates/ironclaw_auth/src/flow.rs
+++ b/crates/ironclaw_auth/src/flow.rs
@@ -164,6 +164,16 @@ pub struct OAuthCallbackInput {
     pub outcome: ProviderCallbackOutcome,
 }
 
+/// Pre-egress claim for an authorized OAuth callback. This validates and marks
+/// the scoped flow before one-shot provider exchange can consume a raw code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthCallbackClaimRequest {
+    pub flow_id: AuthFlowId,
+    pub opaque_state_hash: OpaqueStateHash,
+    pub provider: AuthProviderId,
+    pub pkce_verifier_hash: crate::PkceVerifierHash,
+}
+
 #[async_trait]
 pub trait AuthFlowManager: Send + Sync {
     async fn create_flow(&self, request: NewAuthFlow) -> Result<AuthFlowRecord, AuthProductError>;
@@ -173,6 +183,12 @@ pub trait AuthFlowManager: Send + Sync {
         scope: &AuthProductScope,
         flow_id: AuthFlowId,
     ) -> Result<Option<AuthFlowRecord>, AuthProductError>;
+
+    async fn claim_oauth_callback(
+        &self,
+        scope: &AuthProductScope,
+        request: OAuthCallbackClaimRequest,
+    ) -> Result<AuthFlowRecord, AuthProductError>;
 
     async fn complete_oauth_callback(
         &self,

--- a/crates/ironclaw_auth/src/ids.rs
+++ b/crates/ironclaw_auth/src/ids.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 use uuid::Uuid;
 
 use crate::{AuthProductError, validate_public_text};
@@ -92,6 +93,12 @@ macro_rules! validated_string {
 macro_rules! digest_string {
     ($name:ident, $label:literal) => {
         string_newtype!($name, |value| validate_digest_text(value, $label));
+
+        impl $name {
+            pub fn constant_time_eq(&self, other: &Self) -> bool {
+                self.0.as_bytes().ct_eq(other.0.as_bytes()).into()
+            }
+        }
     };
 }
 

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -32,7 +32,8 @@ pub use fakes::InMemoryAuthProductServices;
 pub use flow::{
     AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthFlowKind, AuthFlowManager,
     AuthFlowRecord, AuthFlowStatus, CredentialAccountUpdateBinding, NewAuthFlow,
-    OAuthCallbackClaimRequest, OAuthCallbackInput, ProviderCallbackOutcome,
+    OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
+    ProviderCallbackOutcome,
 };
 pub use ids::{
     AuthFlowId, AuthGateRef, AuthInteractionId, AuthProviderId, AuthSessionId,

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -32,7 +32,7 @@ pub use fakes::InMemoryAuthProductServices;
 pub use flow::{
     AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthFlowKind, AuthFlowManager,
     AuthFlowRecord, AuthFlowStatus, CredentialAccountUpdateBinding, NewAuthFlow,
-    OAuthCallbackInput, ProviderCallbackOutcome,
+    OAuthCallbackClaimRequest, OAuthCallbackInput, ProviderCallbackOutcome,
 };
 pub use ids::{
     AuthFlowId, AuthGateRef, AuthInteractionId, AuthProviderId, AuthSessionId,

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -11,9 +11,10 @@
   wire product auth through V1 OAuth routes, V1 pending maps, V1
   `ExtensionManager`, V1 secret stores, or route-local raw HTTP clients.
 - OAuth callback routes should only parse/validate HTTP input and call
-  `RebornProductAuthServices::handle_oauth_callback`; the handler must exchange
-  provider material through `AuthProviderClient`, complete the flow through
-  `AuthFlowManager`, and emit typed continuations.
+  `RebornProductAuthServices::handle_oauth_callback`; the handler must claim
+  the scoped flow/state/provider through `AuthFlowManager` before exchanging
+  provider material through `AuthProviderClient`, then complete the flow and
+  emit typed continuations.
 - Blocked run-state approval/auth gate rendering and resume belongs to #3094;
   keep this crate's #3811 auth seam reusable by that layer without implementing
   a second gate-resolution path.

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -10,6 +10,10 @@
 - Product auth composition must use `ironclaw_auth` trait-shaped ports. Do not
   wire product auth through V1 OAuth routes, V1 pending maps, V1
   `ExtensionManager`, V1 secret stores, or route-local raw HTTP clients.
+- OAuth callback routes should only parse/validate HTTP input and call
+  `RebornProductAuthServices::handle_oauth_callback`; the handler must exchange
+  provider material through `AuthProviderClient`, complete the flow through
+  `AuthFlowManager`, and emit typed continuations.
 - Blocked run-state approval/auth gate rendering and resume belongs to #3094;
   keep this crate's #3811 auth seam reusable by that layer without implementing
   a second gate-resolution path.

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -6,10 +6,11 @@ use ironclaw_auth::{
     AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowManager,
     AuthFlowStatus, AuthInteractionService, AuthProductError, AuthProductScope, AuthProviderClient,
     CredentialAccountId, CredentialAccountService, CredentialSetupService,
-    InMemoryAuthProductServices, OAuthCallbackClaimRequest, OAuthCallbackInput,
-    OAuthProviderCallbackRequest, OpaqueStateHash, ProviderCallbackOutcome, SecretCleanupService,
+    InMemoryAuthProductServices, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
+    OAuthCallbackInput, OAuthProviderCallbackRequest, OpaqueStateHash, ProviderCallbackOutcome,
+    SecretCleanupService,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[async_trait]
 pub trait RebornAuthContinuationDispatcher: Send + Sync {
@@ -59,7 +60,7 @@ pub enum RebornOAuthCallbackOutcome {
 }
 
 /// Stable sanitized callback response safe for Web/CLI/API surfaces.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RebornOAuthCallbackResponse {
     pub flow_id: AuthFlowId,
     pub status: AuthFlowStatus,
@@ -69,7 +70,7 @@ pub struct RebornOAuthCallbackResponse {
 }
 
 /// Stable sanitized callback failure safe for route rendering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RebornOAuthCallbackError {
     pub code: AuthErrorCode,
     pub retryable: bool,
@@ -240,11 +241,36 @@ impl RebornProductAuthServices {
                 if claimed.status == AuthFlowStatus::Completed {
                     claimed
                 } else {
-                    let exchange = self
+                    let exchange = match self
                         .provider_client
                         .exchange_callback(provider_request)
                         .await
-                        .map_err(RebornOAuthCallbackError::from)?;
+                    {
+                        Ok(exchange) => exchange,
+                        Err(error) => {
+                            let error_code = error.code();
+                            if let Err(fail_error) = self
+                                .flow_manager
+                                .fail_oauth_callback(
+                                    &request.scope,
+                                    OAuthCallbackFailureInput {
+                                        flow_id: request.flow_id,
+                                        opaque_state_hash: request.opaque_state_hash,
+                                        error: error_code,
+                                    },
+                                )
+                                .await
+                            {
+                                tracing::debug!(
+                                    flow_id = %request.flow_id,
+                                    exchange_error_code = ?error_code,
+                                    fail_error_code = ?fail_error.code(),
+                                    "reborn auth callback provider exchange failed and flow failure update failed"
+                                );
+                            }
+                            return Err(error.into());
+                        }
+                    };
                     self.flow_manager
                         .complete_oauth_callback(
                             &request.scope,
@@ -319,9 +345,9 @@ mod tests {
         CredentialAccount, CredentialAccountId, CredentialAccountListPage,
         CredentialAccountListRequest, CredentialAccountMutation, CredentialAccountProjection,
         CredentialAccountSelectionRequest, CredentialAccountStatus, NewAuthFlow,
-        NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackInput,
-        OAuthProviderCallbackRequest, OAuthProviderExchange, SecretCleanupReport,
-        SecretCleanupRequest, SecretSubmitRequest, SecretSubmitResult,
+        NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
+        OAuthCallbackInput, OAuthProviderCallbackRequest, OAuthProviderExchange,
+        SecretCleanupReport, SecretCleanupRequest, SecretSubmitRequest, SecretSubmitResult,
     };
 
     struct SharedAuthTestDouble;
@@ -426,6 +452,14 @@ mod tests {
             &self,
             _scope: &AuthProductScope,
             _input: OAuthCallbackInput,
+        ) -> Result<AuthFlowRecord, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
+        async fn fail_oauth_callback(
+            &self,
+            _scope: &AuthProductScope,
+            _input: OAuthCallbackFailureInput,
         ) -> Result<AuthFlowRecord, AuthProductError> {
             unreachable!("constructor tests do not call auth-flow methods")
         }

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -1,9 +1,89 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use chrono::Utc;
 use ironclaw_auth::{
-    AuthFlowManager, AuthInteractionService, AuthProviderClient, CredentialAccountService,
-    CredentialSetupService, InMemoryAuthProductServices, SecretCleanupService,
+    AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowManager,
+    AuthFlowStatus, AuthInteractionService, AuthProductError, AuthProductScope, AuthProviderClient,
+    CredentialAccountId, CredentialAccountService, CredentialSetupService,
+    InMemoryAuthProductServices, OAuthCallbackInput, OAuthProviderCallbackRequest, OpaqueStateHash,
+    ProviderCallbackOutcome, SecretCleanupService,
 };
+use serde::Serialize;
+
+#[async_trait]
+pub trait RebornAuthContinuationDispatcher: Send + Sync {
+    async fn dispatch_auth_continuation(
+        &self,
+        event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError>;
+}
+
+#[derive(Debug, Default)]
+struct NoopAuthContinuationDispatcher;
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for NoopAuthContinuationDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        _event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        Ok(())
+    }
+}
+
+/// Parsed OAuth callback request handed from a host-owned HTTP route into the
+/// Reborn product-auth boundary.
+///
+/// Raw query/body parsing and hashing are host-route responsibilities. This
+/// type intentionally receives only the validated scope, flow id, state hash,
+/// and one-shot provider exchange input. It is not serializable because the
+/// authorized outcome can carry raw OAuth code/verifier material inside
+/// [`OAuthProviderCallbackRequest`].
+#[derive(Debug)]
+pub struct RebornOAuthCallbackRequest {
+    pub scope: AuthProductScope,
+    pub flow_id: AuthFlowId,
+    pub opaque_state_hash: OpaqueStateHash,
+    pub outcome: RebornOAuthCallbackOutcome,
+}
+
+/// Host-route OAuth callback parse result.
+#[derive(Debug)]
+pub enum RebornOAuthCallbackOutcome {
+    Authorized {
+        provider_request: OAuthProviderCallbackRequest,
+    },
+    ProviderDenied,
+    Malformed,
+}
+
+/// Stable sanitized callback response safe for Web/CLI/API surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RebornOAuthCallbackResponse {
+    pub flow_id: AuthFlowId,
+    pub status: AuthFlowStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_account_id: Option<CredentialAccountId>,
+    pub continuation: AuthContinuationRef,
+}
+
+/// Stable sanitized callback failure safe for route rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct RebornOAuthCallbackError {
+    pub code: AuthErrorCode,
+    pub retryable: bool,
+}
+
+impl From<AuthProductError> for RebornOAuthCallbackError {
+    fn from(error: AuthProductError) -> Self {
+        let code = error.code();
+        Self {
+            code,
+            retryable: matches!(code, AuthErrorCode::BackendUnavailable),
+        }
+    }
+}
 
 /// Reborn product-auth service bundle exposed by the composition root.
 ///
@@ -20,6 +100,7 @@ pub struct RebornProductAuthServices {
     credential_account_service: Arc<dyn CredentialAccountService>,
     provider_client: Arc<dyn AuthProviderClient>,
     cleanup_service: Arc<dyn SecretCleanupService>,
+    continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
 }
 
 impl std::fmt::Debug for RebornProductAuthServices {
@@ -38,6 +119,10 @@ impl std::fmt::Debug for RebornProductAuthServices {
             )
             .field("provider_client", &"Arc<dyn AuthProviderClient>")
             .field("cleanup_service", &"Arc<dyn SecretCleanupService>")
+            .field(
+                "continuation_dispatcher",
+                &"Arc<dyn RebornAuthContinuationDispatcher>",
+            )
             .finish()
     }
 }
@@ -58,6 +143,7 @@ impl RebornProductAuthServices {
             credential_account_service,
             provider_client,
             cleanup_service,
+            continuation_dispatcher: Arc::new(NoopAuthContinuationDispatcher),
         }
     }
 
@@ -116,6 +202,71 @@ impl RebornProductAuthServices {
 
     pub fn cleanup_service(&self) -> Arc<dyn SecretCleanupService> {
         self.cleanup_service.clone()
+    }
+
+    pub fn with_provider_client(mut self, provider_client: Arc<dyn AuthProviderClient>) -> Self {
+        self.provider_client = provider_client;
+        self
+    }
+
+    pub fn with_continuation_dispatcher(
+        mut self,
+        dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
+    ) -> Self {
+        self.continuation_dispatcher = dispatcher;
+        self
+    }
+
+    pub async fn handle_oauth_callback(
+        &self,
+        request: RebornOAuthCallbackRequest,
+    ) -> Result<RebornOAuthCallbackResponse, RebornOAuthCallbackError> {
+        let outcome = match request.outcome {
+            RebornOAuthCallbackOutcome::Authorized { provider_request } => {
+                let exchange = self
+                    .provider_client
+                    .exchange_callback(provider_request)
+                    .await
+                    .map_err(RebornOAuthCallbackError::from)?;
+                ProviderCallbackOutcome::Authorized { exchange }
+            }
+            RebornOAuthCallbackOutcome::ProviderDenied => ProviderCallbackOutcome::Denied,
+            RebornOAuthCallbackOutcome::Malformed => {
+                return Err(AuthProductError::MalformedCallback.into());
+            }
+        };
+
+        let completed = self
+            .flow_manager
+            .complete_oauth_callback(
+                &request.scope,
+                OAuthCallbackInput {
+                    flow_id: request.flow_id,
+                    opaque_state_hash: request.opaque_state_hash,
+                    outcome,
+                },
+            )
+            .await
+            .map_err(RebornOAuthCallbackError::from)?;
+
+        let event = AuthContinuationEvent {
+            flow_id: completed.id,
+            scope: completed.scope.clone(),
+            continuation: completed.continuation.clone(),
+            credential_account_id: completed.credential_account_id,
+            emitted_at: Utc::now(),
+        };
+        self.continuation_dispatcher
+            .dispatch_auth_continuation(event)
+            .await
+            .map_err(RebornOAuthCallbackError::from)?;
+
+        Ok(RebornOAuthCallbackResponse {
+            flow_id: completed.id,
+            status: completed.status,
+            credential_account_id: completed.credential_account_id,
+            continuation: completed.continuation,
+        })
     }
 
     pub(crate) fn local_dev_in_memory() -> Self {

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -6,8 +6,8 @@ use ironclaw_auth::{
     AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowManager,
     AuthFlowStatus, AuthInteractionService, AuthProductError, AuthProductScope, AuthProviderClient,
     CredentialAccountId, CredentialAccountService, CredentialSetupService,
-    InMemoryAuthProductServices, OAuthCallbackInput, OAuthProviderCallbackRequest, OpaqueStateHash,
-    ProviderCallbackOutcome, SecretCleanupService,
+    InMemoryAuthProductServices, OAuthCallbackClaimRequest, OAuthCallbackInput,
+    OAuthProviderCallbackRequest, OpaqueStateHash, ProviderCallbackOutcome, SecretCleanupService,
 };
 use serde::Serialize;
 
@@ -221,33 +221,59 @@ impl RebornProductAuthServices {
         &self,
         request: RebornOAuthCallbackRequest,
     ) -> Result<RebornOAuthCallbackResponse, RebornOAuthCallbackError> {
-        let outcome = match request.outcome {
+        let completed = match request.outcome {
             RebornOAuthCallbackOutcome::Authorized { provider_request } => {
-                let exchange = self
-                    .provider_client
-                    .exchange_callback(provider_request)
+                let claimed = self
+                    .flow_manager
+                    .claim_oauth_callback(
+                        &request.scope,
+                        OAuthCallbackClaimRequest {
+                            flow_id: request.flow_id,
+                            opaque_state_hash: request.opaque_state_hash.clone(),
+                            provider: provider_request.provider.clone(),
+                            pkce_verifier_hash: provider_request.pkce_verifier_hash.clone(),
+                        },
+                    )
                     .await
                     .map_err(RebornOAuthCallbackError::from)?;
-                ProviderCallbackOutcome::Authorized { exchange }
+
+                if claimed.status == AuthFlowStatus::Completed {
+                    claimed
+                } else {
+                    let exchange = self
+                        .provider_client
+                        .exchange_callback(provider_request)
+                        .await
+                        .map_err(RebornOAuthCallbackError::from)?;
+                    self.flow_manager
+                        .complete_oauth_callback(
+                            &request.scope,
+                            OAuthCallbackInput {
+                                flow_id: request.flow_id,
+                                opaque_state_hash: request.opaque_state_hash,
+                                outcome: ProviderCallbackOutcome::Authorized { exchange },
+                            },
+                        )
+                        .await
+                        .map_err(RebornOAuthCallbackError::from)?
+                }
             }
-            RebornOAuthCallbackOutcome::ProviderDenied => ProviderCallbackOutcome::Denied,
+            RebornOAuthCallbackOutcome::ProviderDenied => self
+                .flow_manager
+                .complete_oauth_callback(
+                    &request.scope,
+                    OAuthCallbackInput {
+                        flow_id: request.flow_id,
+                        opaque_state_hash: request.opaque_state_hash,
+                        outcome: ProviderCallbackOutcome::Denied,
+                    },
+                )
+                .await
+                .map_err(RebornOAuthCallbackError::from)?,
             RebornOAuthCallbackOutcome::Malformed => {
                 return Err(AuthProductError::MalformedCallback.into());
             }
         };
-
-        let completed = self
-            .flow_manager
-            .complete_oauth_callback(
-                &request.scope,
-                OAuthCallbackInput {
-                    flow_id: request.flow_id,
-                    opaque_state_hash: request.opaque_state_hash,
-                    outcome,
-                },
-            )
-            .await
-            .map_err(RebornOAuthCallbackError::from)?;
 
         let event = AuthContinuationEvent {
             flow_id: completed.id,
@@ -261,11 +287,15 @@ impl RebornProductAuthServices {
             .dispatch_auth_continuation(event)
             .await
         {
-            tracing::warn!(
+            tracing::debug!(
                 flow_id = %completed.id,
                 error_code = ?error.code(),
                 "reborn auth callback completed but continuation dispatch failed"
             );
+            return Err(RebornOAuthCallbackError {
+                code: AuthErrorCode::BackendUnavailable,
+                retryable: true,
+            });
         }
 
         Ok(RebornOAuthCallbackResponse {
@@ -289,9 +319,9 @@ mod tests {
         CredentialAccount, CredentialAccountId, CredentialAccountListPage,
         CredentialAccountListRequest, CredentialAccountMutation, CredentialAccountProjection,
         CredentialAccountSelectionRequest, CredentialAccountStatus, NewAuthFlow,
-        NewCredentialAccount, OAuthCallbackInput, OAuthProviderCallbackRequest,
-        OAuthProviderExchange, SecretCleanupReport, SecretCleanupRequest, SecretSubmitRequest,
-        SecretSubmitResult,
+        NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackInput,
+        OAuthProviderCallbackRequest, OAuthProviderExchange, SecretCleanupReport,
+        SecretCleanupRequest, SecretSubmitRequest, SecretSubmitResult,
     };
 
     struct SharedAuthTestDouble;
@@ -381,6 +411,14 @@ mod tests {
             _scope: &AuthProductScope,
             _flow_id: AuthFlowId,
         ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
+        async fn claim_oauth_callback(
+            &self,
+            _scope: &AuthProductScope,
+            _request: OAuthCallbackClaimRequest,
+        ) -> Result<AuthFlowRecord, AuthProductError> {
             unreachable!("constructor tests do not call auth-flow methods")
         }
 

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -256,10 +256,17 @@ impl RebornProductAuthServices {
             credential_account_id: completed.credential_account_id,
             emitted_at: Utc::now(),
         };
-        self.continuation_dispatcher
+        if let Err(error) = self
+            .continuation_dispatcher
             .dispatch_auth_continuation(event)
             .await
-            .map_err(RebornOAuthCallbackError::from)?;
+        {
+            tracing::warn!(
+                flow_id = %completed.id,
+                error_code = ?error.code(),
+                "reborn auth callback completed but continuation dispatch failed"
+            );
+        }
 
         Ok(RebornOAuthCallbackResponse {
             flow_id: completed.id,

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -44,7 +44,10 @@ mod webui_ws_origin;
 
 use ironclaw_runtime_policy::{EffectiveRuntimePolicy as ResolvedRuntimePolicy, ResolveError};
 
-pub use auth::RebornProductAuthServices;
+pub use auth::{
+    RebornAuthContinuationDispatcher, RebornOAuthCallbackError, RebornOAuthCallbackOutcome,
+    RebornOAuthCallbackRequest, RebornOAuthCallbackResponse, RebornProductAuthServices,
+};
 pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};
 pub use input::RebornBuildInput;

--- a/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
+++ b/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
@@ -16,7 +16,7 @@ use ironclaw_auth::{
 use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
 use ironclaw_reborn_composition::{
     RebornAuthContinuationDispatcher, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
-    RebornProductAuthServices,
+    RebornOAuthCallbackResponse, RebornProductAuthServices,
 };
 use secrecy::SecretString;
 
@@ -231,6 +231,8 @@ async fn oauth_callback_handler_completes_flow_and_dispatches_typed_continuation
     );
 
     let serialized = serde_json::to_string(&response).unwrap();
+    let parsed: RebornOAuthCallbackResponse = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(parsed, response);
     assert!(!serialized.contains("raw-auth-code"));
     assert!(!serialized.contains("raw-pkce-verifier"));
     assert!(!serialized.contains("oauth-access-"));
@@ -281,6 +283,29 @@ async fn oauth_callback_handler_rejects_wrong_state_without_provider_exchange_or
         .handle_oauth_callback(request)
         .await
         .expect_err("wrong state is rejected before provider exchange");
+
+    assert_eq!(error.code, AuthErrorCode::CrossScopeDenied);
+    assert_eq!(provider_client.calls(), 0);
+    assert!(dispatcher.events().is_empty());
+}
+
+#[tokio::test]
+async fn oauth_callback_handler_rejects_wrong_pkce_without_provider_exchange_or_dispatch() {
+    let dispatcher = Arc::new(RecordingContinuationDispatcher::default());
+    let provider_client = Arc::new(CountingProviderClient::default());
+    let services = auth_services(dispatcher.clone()).with_provider_client(provider_client.clone());
+    let owner = scope("alice");
+    let flow_id = create_flow(&services, owner.clone()).await;
+    let mut request = authorized_request(owner, flow_id);
+    let RebornOAuthCallbackOutcome::Authorized { provider_request } = &mut request.outcome else {
+        panic!("authorized request expected");
+    };
+    provider_request.pkce_verifier_hash = pkce_hash("wrong-pkce");
+
+    let error = services
+        .handle_oauth_callback(request)
+        .await
+        .expect_err("wrong pkce is rejected before provider exchange");
 
     assert_eq!(error.code, AuthErrorCode::CrossScopeDenied);
     assert_eq!(provider_client.calls(), 0);
@@ -353,7 +378,7 @@ async fn oauth_callback_handler_routes_exchange_failures_through_provider_bounda
     let flow_id = create_flow(&services, owner.clone()).await;
 
     let error = services
-        .handle_oauth_callback(authorized_request(owner, flow_id))
+        .handle_oauth_callback(authorized_request(owner.clone(), flow_id))
         .await
         .expect_err("provider exchange failure surfaces sanitized error");
 
@@ -361,6 +386,24 @@ async fn oauth_callback_handler_routes_exchange_failures_through_provider_bounda
     assert!(!error.retryable);
     assert!(dispatcher.events().is_empty());
     let serialized = serde_json::to_string(&error).unwrap();
+    let parsed: ironclaw_reborn_composition::RebornOAuthCallbackError =
+        serde_json::from_str(&serialized).unwrap();
+    assert_eq!(parsed, error);
     assert!(!serialized.contains("raw-auth-code"));
     assert!(!serialized.contains("raw-pkce-verifier"));
+
+    let flow = services
+        .flow_manager()
+        .get_flow(&owner, flow_id)
+        .await
+        .expect("flow lookup")
+        .expect("flow record");
+    assert_eq!(flow.status, ironclaw_auth::AuthFlowStatus::Failed);
+    assert_eq!(flow.error, Some(AuthErrorCode::TokenExchangeFailed));
+
+    let retry = services
+        .handle_oauth_callback(authorized_request(owner, flow_id))
+        .await
+        .expect_err("failed flow rejects retry");
+    assert_eq!(retry.code, AuthErrorCode::FlowAlreadyTerminal);
 }

--- a/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
+++ b/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
@@ -1,0 +1,259 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{Duration, Utc};
+use ironclaw_auth::{
+    AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId,
+    AuthFlowKind, AuthProductError, AuthProductScope, AuthProviderClient, AuthProviderId,
+    AuthSessionId, AuthSurface, AuthorizationCodeHash, CredentialAccountLabel,
+    InMemoryAuthProductServices, LifecyclePackageRef, NewAuthFlow, OAuthAuthorizationCode,
+    OAuthProviderCallbackRequest, OAuthProviderExchange, OpaqueStateHash, PkceVerifierHash,
+    PkceVerifierSecret,
+};
+use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
+use ironclaw_reborn_composition::{
+    RebornAuthContinuationDispatcher, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
+    RebornProductAuthServices,
+};
+use secrecy::SecretString;
+
+#[derive(Default)]
+struct RecordingContinuationDispatcher {
+    events: Mutex<Vec<AuthContinuationEvent>>,
+}
+
+impl RecordingContinuationDispatcher {
+    fn events(&self) -> Vec<AuthContinuationEvent> {
+        self.events
+            .lock()
+            .expect("continuation event lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for RecordingContinuationDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        self.events
+            .lock()
+            .expect("continuation event lock poisoned")
+            .push(event);
+        Ok(())
+    }
+}
+
+struct FailingProviderClient {
+    error: AuthProductError,
+}
+
+#[async_trait]
+impl AuthProviderClient for FailingProviderClient {
+    async fn exchange_callback(
+        &self,
+        _request: OAuthProviderCallbackRequest,
+    ) -> Result<OAuthProviderExchange, AuthProductError> {
+        Err(self.error.clone())
+    }
+}
+
+fn auth_services(dispatcher: Arc<RecordingContinuationDispatcher>) -> RebornProductAuthServices {
+    RebornProductAuthServices::from_shared(Arc::new(InMemoryAuthProductServices::new()))
+        .with_continuation_dispatcher(dispatcher)
+}
+
+fn scope(user: &str) -> AuthProductScope {
+    AuthProductScope::new(
+        ResourceScope::local_default(UserId::new(user).unwrap(), InvocationId::new()).unwrap(),
+        AuthSurface::Callback,
+    )
+    .with_session_id(AuthSessionId::new(format!("callback-session-{user}")).unwrap())
+}
+
+fn provider() -> AuthProviderId {
+    AuthProviderId::new("github").unwrap()
+}
+
+fn label() -> CredentialAccountLabel {
+    CredentialAccountLabel::new("work github").unwrap()
+}
+
+fn state_hash(value: &str) -> OpaqueStateHash {
+    OpaqueStateHash::new(value).unwrap()
+}
+
+fn pkce_hash(value: &str) -> PkceVerifierHash {
+    PkceVerifierHash::new(value).unwrap()
+}
+
+fn code_hash(value: &str) -> AuthorizationCodeHash {
+    AuthorizationCodeHash::new(value).unwrap()
+}
+
+fn secret(value: &str) -> SecretString {
+    SecretString::from(value.to_string())
+}
+
+async fn create_flow(services: &RebornProductAuthServices, scope: AuthProductScope) -> AuthFlowId {
+    services
+        .flow_manager()
+        .create_flow(NewAuthFlow {
+            scope,
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: provider(),
+            challenge: AuthChallenge::OAuthUrl {
+                authorization_url: "https://provider.example/oauth".to_string(),
+                expires_at: Utc::now() + Duration::minutes(5),
+            },
+            continuation: AuthContinuationRef::LifecycleActivation {
+                package_ref: LifecyclePackageRef::new("github-extension").unwrap(),
+            },
+            opaque_state_hash: Some(state_hash("state-hash")),
+            pkce_verifier_hash: Some(pkce_hash("pkce-hash")),
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect("flow")
+        .id
+}
+
+fn authorized_request(scope: AuthProductScope, flow_id: AuthFlowId) -> RebornOAuthCallbackRequest {
+    RebornOAuthCallbackRequest {
+        scope,
+        flow_id,
+        opaque_state_hash: state_hash("state-hash"),
+        outcome: RebornOAuthCallbackOutcome::Authorized {
+            provider_request: OAuthProviderCallbackRequest {
+                provider: provider(),
+                account_label: label(),
+                authorization_code: OAuthAuthorizationCode::new(secret("raw-auth-code")).unwrap(),
+                authorization_code_hash: code_hash("code-hash"),
+                pkce_verifier: PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap(),
+                pkce_verifier_hash: pkce_hash("pkce-hash"),
+                scopes: vec!["repo".to_string()],
+            },
+        },
+    }
+}
+
+#[tokio::test]
+async fn oauth_callback_handler_completes_flow_and_dispatches_typed_continuation() {
+    let dispatcher = Arc::new(RecordingContinuationDispatcher::default());
+    let services = auth_services(dispatcher.clone());
+    let owner = scope("alice");
+    let flow_id = create_flow(&services, owner.clone()).await;
+    let request = authorized_request(owner.clone(), flow_id);
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("raw-auth-code"));
+    assert!(!debug.contains("raw-pkce-verifier"));
+
+    let response = services
+        .handle_oauth_callback(request)
+        .await
+        .expect("callback completes");
+
+    assert_eq!(response.flow_id, flow_id);
+    assert!(response.credential_account_id.is_some());
+    assert_eq!(
+        response.continuation,
+        AuthContinuationRef::LifecycleActivation {
+            package_ref: LifecyclePackageRef::new("github-extension").unwrap()
+        }
+    );
+
+    let events = dispatcher.events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].flow_id, flow_id);
+    assert_eq!(events[0].scope, owner);
+    assert_eq!(events[0].continuation, response.continuation);
+    assert_eq!(
+        events[0].credential_account_id,
+        response.credential_account_id
+    );
+
+    let serialized = serde_json::to_string(&response).unwrap();
+    assert!(!serialized.contains("raw-auth-code"));
+    assert!(!serialized.contains("raw-pkce-verifier"));
+    assert!(!serialized.contains("oauth-access-"));
+    assert!(!serialized.contains("oauth-refresh-"));
+}
+
+#[tokio::test]
+async fn oauth_callback_handler_returns_sanitized_failures_without_dispatch() {
+    let dispatcher = Arc::new(RecordingContinuationDispatcher::default());
+    let services = auth_services(dispatcher.clone());
+    let owner = scope("alice");
+
+    let stale = services
+        .handle_oauth_callback(RebornOAuthCallbackRequest {
+            scope: owner.clone(),
+            flow_id: AuthFlowId::new(),
+            opaque_state_hash: state_hash("state-hash"),
+            outcome: RebornOAuthCallbackOutcome::ProviderDenied,
+        })
+        .await
+        .expect_err("unknown flow fails");
+    assert_eq!(stale.code, AuthErrorCode::UnknownOrExpiredFlow);
+
+    let malformed = services
+        .handle_oauth_callback(RebornOAuthCallbackRequest {
+            scope: owner.clone(),
+            flow_id: AuthFlowId::new(),
+            opaque_state_hash: state_hash("state-hash"),
+            outcome: RebornOAuthCallbackOutcome::Malformed,
+        })
+        .await
+        .expect_err("malformed callback fails");
+    assert_eq!(malformed.code, AuthErrorCode::MalformedCallback);
+
+    let denied_flow = create_flow(&services, owner.clone()).await;
+    let provider_denied = services
+        .handle_oauth_callback(RebornOAuthCallbackRequest {
+            scope: owner.clone(),
+            flow_id: denied_flow,
+            opaque_state_hash: state_hash("state-hash"),
+            outcome: RebornOAuthCallbackOutcome::ProviderDenied,
+        })
+        .await
+        .expect_err("provider denial fails");
+    assert_eq!(provider_denied.code, AuthErrorCode::ProviderDenied);
+
+    let cross_scope_flow = create_flow(&services, owner.clone()).await;
+    let cross_scope = services
+        .handle_oauth_callback(RebornOAuthCallbackRequest {
+            scope: scope("bob"),
+            flow_id: cross_scope_flow,
+            opaque_state_hash: state_hash("state-hash"),
+            outcome: RebornOAuthCallbackOutcome::ProviderDenied,
+        })
+        .await
+        .expect_err("foreign callback denied");
+    assert_eq!(cross_scope.code, AuthErrorCode::CrossScopeDenied);
+
+    assert!(dispatcher.events().is_empty());
+}
+
+#[tokio::test]
+async fn oauth_callback_handler_routes_exchange_failures_through_provider_boundary() {
+    let dispatcher = Arc::new(RecordingContinuationDispatcher::default());
+    let services =
+        auth_services(dispatcher.clone()).with_provider_client(Arc::new(FailingProviderClient {
+            error: AuthProductError::TokenExchangeFailed,
+        }));
+    let owner = scope("alice");
+    let flow_id = create_flow(&services, owner.clone()).await;
+
+    let error = services
+        .handle_oauth_callback(authorized_request(owner, flow_id))
+        .await
+        .expect_err("provider exchange failure surfaces sanitized error");
+
+    assert_eq!(error.code, AuthErrorCode::TokenExchangeFailed);
+    assert!(!error.retryable);
+    assert!(dispatcher.events().is_empty());
+    let serialized = serde_json::to_string(&error).unwrap();
+    assert!(!serialized.contains("raw-auth-code"));
+    assert!(!serialized.contains("raw-pkce-verifier"));
+}

--- a/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
+++ b/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
@@ -7,8 +7,8 @@ use ironclaw_auth::{
     AuthFlowKind, AuthProductError, AuthProductScope, AuthProviderClient, AuthProviderId,
     AuthSessionId, AuthSurface, AuthorizationCodeHash, CredentialAccountLabel,
     InMemoryAuthProductServices, LifecyclePackageRef, NewAuthFlow, OAuthAuthorizationCode,
-    OAuthProviderCallbackRequest, OAuthProviderExchange, OpaqueStateHash, PkceVerifierHash,
-    PkceVerifierSecret,
+    OAuthAuthorizationUrl, OAuthProviderCallbackRequest, OAuthProviderExchange, OpaqueStateHash,
+    PkceVerifierHash, PkceVerifierSecret, ProviderScope,
 };
 use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
 use ironclaw_reborn_composition::{
@@ -59,6 +59,20 @@ impl AuthProviderClient for FailingProviderClient {
     }
 }
 
+struct FailingContinuationDispatcher {
+    error: AuthProductError,
+}
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for FailingContinuationDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        _event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        Err(self.error.clone())
+    }
+}
+
 fn auth_services(dispatcher: Arc<RecordingContinuationDispatcher>) -> RebornProductAuthServices {
     RebornProductAuthServices::from_shared(Arc::new(InMemoryAuthProductServices::new()))
         .with_continuation_dispatcher(dispatcher)
@@ -81,15 +95,32 @@ fn label() -> CredentialAccountLabel {
 }
 
 fn state_hash(value: &str) -> OpaqueStateHash {
-    OpaqueStateHash::new(value).unwrap()
+    OpaqueStateHash::new(fake_digest(value)).unwrap()
 }
 
 fn pkce_hash(value: &str) -> PkceVerifierHash {
-    PkceVerifierHash::new(value).unwrap()
+    PkceVerifierHash::new(fake_digest(value)).unwrap()
 }
 
 fn code_hash(value: &str) -> AuthorizationCodeHash {
-    AuthorizationCodeHash::new(value).unwrap()
+    AuthorizationCodeHash::new(fake_digest(value)).unwrap()
+}
+
+fn fake_digest(value: &str) -> String {
+    format!(
+        "{:064x}",
+        value.bytes().fold(0_u64, |hash, byte| {
+            hash.wrapping_mul(31).wrapping_add(u64::from(byte))
+        })
+    )
+}
+
+fn authorization_url(value: &str) -> OAuthAuthorizationUrl {
+    OAuthAuthorizationUrl::new(value).unwrap()
+}
+
+fn provider_scope(value: &str) -> ProviderScope {
+    ProviderScope::new(value).unwrap()
 }
 
 fn secret(value: &str) -> SecretString {
@@ -104,12 +135,13 @@ async fn create_flow(services: &RebornProductAuthServices, scope: AuthProductSco
             kind: AuthFlowKind::IntegrationCredential,
             provider: provider(),
             challenge: AuthChallenge::OAuthUrl {
-                authorization_url: "https://provider.example/oauth".to_string(),
+                authorization_url: authorization_url("https://provider.example/oauth"),
                 expires_at: Utc::now() + Duration::minutes(5),
             },
             continuation: AuthContinuationRef::LifecycleActivation {
                 package_ref: LifecyclePackageRef::new("github-extension").unwrap(),
             },
+            update_binding: None,
             opaque_state_hash: Some(state_hash("state-hash")),
             pkce_verifier_hash: Some(pkce_hash("pkce-hash")),
             expires_at: Utc::now() + Duration::minutes(5),
@@ -132,7 +164,7 @@ fn authorized_request(scope: AuthProductScope, flow_id: AuthFlowId) -> RebornOAu
                 authorization_code_hash: code_hash("code-hash"),
                 pkce_verifier: PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap(),
                 pkce_verifier_hash: pkce_hash("pkce-hash"),
-                scopes: vec!["repo".to_string()],
+                scopes: vec![provider_scope("repo")],
             },
         },
     }
@@ -178,6 +210,37 @@ async fn oauth_callback_handler_completes_flow_and_dispatches_typed_continuation
     assert!(!serialized.contains("raw-pkce-verifier"));
     assert!(!serialized.contains("oauth-access-"));
     assert!(!serialized.contains("oauth-refresh-"));
+}
+
+#[tokio::test]
+async fn oauth_callback_handler_preserves_success_when_continuation_dispatch_fails() {
+    let services =
+        RebornProductAuthServices::from_shared(Arc::new(InMemoryAuthProductServices::new()))
+            .with_continuation_dispatcher(Arc::new(FailingContinuationDispatcher {
+                error: AuthProductError::BackendUnavailable,
+            }));
+    let owner = scope("alice");
+    let flow_id = create_flow(&services, owner.clone()).await;
+
+    let response = services
+        .handle_oauth_callback(authorized_request(owner.clone(), flow_id))
+        .await
+        .expect("completed flow success is preserved");
+
+    assert_eq!(response.flow_id, flow_id);
+    assert_eq!(response.status, ironclaw_auth::AuthFlowStatus::Completed);
+    assert!(response.credential_account_id.is_some());
+
+    let retry = services
+        .handle_oauth_callback(RebornOAuthCallbackRequest {
+            scope: owner,
+            flow_id,
+            opaque_state_hash: state_hash("state-hash"),
+            outcome: RebornOAuthCallbackOutcome::ProviderDenied,
+        })
+        .await
+        .expect_err("terminal flow rejects retry");
+    assert_eq!(retry.code, AuthErrorCode::FlowAlreadyTerminal);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
+++ b/crates/ironclaw_reborn_composition/tests/auth_callbacks.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
@@ -56,6 +59,28 @@ impl AuthProviderClient for FailingProviderClient {
         _request: OAuthProviderCallbackRequest,
     ) -> Result<OAuthProviderExchange, AuthProductError> {
         Err(self.error.clone())
+    }
+}
+
+#[derive(Default)]
+struct CountingProviderClient {
+    calls: AtomicUsize,
+}
+
+impl CountingProviderClient {
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl AuthProviderClient for CountingProviderClient {
+    async fn exchange_callback(
+        &self,
+        _request: OAuthProviderCallbackRequest,
+    ) -> Result<OAuthProviderExchange, AuthProductError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(AuthProductError::TokenExchangeFailed)
     }
 }
 
@@ -213,34 +238,53 @@ async fn oauth_callback_handler_completes_flow_and_dispatches_typed_continuation
 }
 
 #[tokio::test]
-async fn oauth_callback_handler_preserves_success_when_continuation_dispatch_fails() {
-    let services =
-        RebornProductAuthServices::from_shared(Arc::new(InMemoryAuthProductServices::new()))
-            .with_continuation_dispatcher(Arc::new(FailingContinuationDispatcher {
-                error: AuthProductError::BackendUnavailable,
-            }));
+async fn oauth_callback_handler_returns_retryable_error_when_continuation_dispatch_fails() {
+    let shared_auth = Arc::new(InMemoryAuthProductServices::new());
+    let services = RebornProductAuthServices::from_shared(shared_auth.clone())
+        .with_continuation_dispatcher(Arc::new(FailingContinuationDispatcher {
+            error: AuthProductError::TokenExchangeFailed,
+        }));
     let owner = scope("alice");
     let flow_id = create_flow(&services, owner.clone()).await;
 
-    let response = services
+    let error = services
         .handle_oauth_callback(authorized_request(owner.clone(), flow_id))
         .await
-        .expect("completed flow success is preserved");
+        .expect_err("dispatch failure is reported to caller");
 
-    assert_eq!(response.flow_id, flow_id);
-    assert_eq!(response.status, ironclaw_auth::AuthFlowStatus::Completed);
-    assert!(response.credential_account_id.is_some());
+    assert_eq!(error.code, AuthErrorCode::BackendUnavailable);
+    assert!(error.retryable);
 
-    let retry = services
-        .handle_oauth_callback(RebornOAuthCallbackRequest {
-            scope: owner,
-            flow_id,
-            opaque_state_hash: state_hash("state-hash"),
-            outcome: RebornOAuthCallbackOutcome::ProviderDenied,
-        })
+    let dispatcher = Arc::new(RecordingContinuationDispatcher::default());
+    let retry = RebornProductAuthServices::from_shared(shared_auth)
+        .with_continuation_dispatcher(dispatcher.clone())
+        .handle_oauth_callback(authorized_request(owner.clone(), flow_id))
         .await
-        .expect_err("terminal flow rejects retry");
-    assert_eq!(retry.code, AuthErrorCode::FlowAlreadyTerminal);
+        .expect("completed callback can be retried for continuation dispatch");
+
+    assert_eq!(retry.flow_id, flow_id);
+    assert_eq!(retry.status, ironclaw_auth::AuthFlowStatus::Completed);
+    assert_eq!(dispatcher.events().len(), 1);
+}
+
+#[tokio::test]
+async fn oauth_callback_handler_rejects_wrong_state_without_provider_exchange_or_dispatch() {
+    let dispatcher = Arc::new(RecordingContinuationDispatcher::default());
+    let provider_client = Arc::new(CountingProviderClient::default());
+    let services = auth_services(dispatcher.clone()).with_provider_client(provider_client.clone());
+    let owner = scope("alice");
+    let flow_id = create_flow(&services, owner.clone()).await;
+    let mut request = authorized_request(owner, flow_id);
+    request.opaque_state_hash = state_hash("wrong-state");
+
+    let error = services
+        .handle_oauth_callback(request)
+        .await
+        .expect_err("wrong state is rejected before provider exchange");
+
+    assert_eq!(error.code, AuthErrorCode::CrossScopeDenied);
+    assert_eq!(provider_client.calls(), 0);
+    assert!(dispatcher.events().is_empty());
 }
 
 #[tokio::test]

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -1,7 +1,7 @@
 # Reborn Product Auth Contract
 
 - **Status:** contract and composition seam
-- **Issue:** #3289 / #3810 / #3811
+- **Issue:** #3289 / #3810 / #3811 / #3812
 - **Crate:** `crates/ironclaw_auth`
 - **Composition:** `ironclaw_reborn_composition::RebornProductAuthServices`
 
@@ -15,9 +15,10 @@ providers, extensions, MCP servers, WASM tools/channels, and future identity
 login flows.
 
 This slice is contract-first. It defines Reborn-native vocabulary and fake
-services, and #3811 adds a Reborn composition seam. It does not migrate
-production OAuth routes, extension setup routes, CLI/setup flows, durable
-secret storage, or runtime credential injection.
+services, #3811 adds a Reborn composition seam, and #3812 adds callback
+completion handling for host-mounted Reborn OAuth callback routes. It does not
+migrate production extension setup routes, CLI/setup flows, durable secret
+storage, or runtime credential injection.
 
 Behavior may remain compatible with legacy UX. Code paths must not mingle V1
 components with Reborn components: V1 route handlers, pending maps, extension
@@ -44,6 +45,14 @@ respective Reborn substrate contracts.
 auth ports above. WebUI/setup/extension surfaces should call this bundle once
 routes are migrated instead of reconstructing auth-flow stores, credential
 stores, provider clients, or cleanup services locally.
+
+Host-owned OAuth callback routes should parse and validate their HTTP input,
+derive hashes for opaque state/code/verifier values, then call
+`RebornProductAuthServices::handle_oauth_callback`. The handler performs
+provider exchange through `AuthProviderClient`, completes the auth flow through
+`AuthFlowManager`, and dispatches an `AuthContinuationEvent` to the injected
+continuation dispatcher. Callback route code must not activate extensions,
+resume turns, replay prompts, or dispatch runtime work directly.
 
 The blocked-run interaction loop is separate: #3094 owns listing/rendering
 approval/auth gates from blocked run-state and routing user decisions back into
@@ -213,7 +222,7 @@ strings.
 | Product behavior | V1 evidence path | Reborn owner | First-slice status |
 | --- | --- | --- | --- |
 | Extension/provider OAuth start | `src/extensions/manager.rs`, `src/auth/mod.rs` | `AuthFlowManager`, `CredentialSetupService`, `AuthProviderClient` | Contracted; production migration deferred |
-| Hosted OAuth callback | `src/channels/web/features/oauth/mod.rs` | `AuthFlowManager`, continuation sink | Contracted; Reborn-native callback route deferred |
+| Hosted OAuth callback | `src/channels/web/features/oauth/mod.rs` | `RebornProductAuthServices::handle_oauth_callback`, continuation dispatcher | Reborn handler seam ready; HTTP route mounting deferred |
 | Local OAuth callback | `src/extensions/manager.rs`, `src/auth/oauth.rs` | `AuthFlowManager`, `AuthProviderClient` | Inventory only |
 | Manual token entry from chat | `src/agent/agent_loop.rs`, `src/agent/thread_ops.rs` | `AuthInteractionService` secure submit | Contracted; route migration deferred |
 | Engine/gate auth credential submit | `src/bridge/router.rs` | `AuthInteractionService`, `CredentialSetupService`, typed continuation | Contracted; migration deferred |

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -48,11 +48,15 @@ stores, provider clients, or cleanup services locally.
 
 Host-owned OAuth callback routes should parse and validate their HTTP input,
 derive hashes for opaque state/code/verifier values, then call
-`RebornProductAuthServices::handle_oauth_callback`. The handler performs
-provider exchange through `AuthProviderClient`, completes the auth flow through
-`AuthFlowManager`, and dispatches an `AuthContinuationEvent` to the injected
-continuation dispatcher. Callback route code must not activate extensions,
-resume turns, replay prompts, or dispatch runtime work directly.
+`RebornProductAuthServices::handle_oauth_callback`. The handler claims the flow
+through `AuthFlowManager`, performs provider exchange through
+`AuthProviderClient`, completes the auth flow through `AuthFlowManager`, and
+dispatches an `AuthContinuationEvent` to the injected continuation dispatcher.
+If continuation dispatch fails, the handler returns a sanitized retryable error
+instead of reporting callback success; retrying an already-completed callback
+may re-dispatch the typed continuation without re-exchanging provider code.
+Callback route code must not activate extensions, resume turns, replay prompts,
+or dispatch runtime work directly.
 
 The blocked-run interaction loop is separate: #3094 owns listing/rendering
 approval/auth gates from blocked run-state and routing user decisions back into
@@ -100,8 +104,9 @@ Rules:
   redacted metadata only.
 - Raw OAuth state, authorization code, PKCE verifier, access token, refresh
   token, and provider response bodies must not be serialized or projected.
-- Public callbacks exchange raw code/verifier through non-serializable one-shot
-  provider inputs before completing the flow.
+- Public callbacks must validate and claim the scoped flow/state/provider/PKCE
+  hash before exchanging raw code/verifier through non-serializable one-shot
+  provider inputs and completing the flow.
 - Callback completion emits typed continuations; callback routes must not
   directly activate extensions, resume turns, replay messages, or dispatch work.
 - Terminal flows cannot be completed or canceled again.


### PR DESCRIPTION
## Summary

- Added a Reborn composition-owned `RebornProductAuthServices::handle_oauth_callback` boundary for hosted OAuth callback routes.
- Route authorized callbacks through the Reborn `AuthProviderClient` and `AuthFlowManager`, then emit typed `AuthContinuationEvent`s through an injected dispatcher.
- Return stable sanitized callback responses/errors and document route responsibilities so callback code does not activate extensions, resume turns, replay prompts, or dispatch runtime work directly.
- Added caller-level contract coverage for success, stale callback, malformed callback, provider denial, token exchange failure, cross-scope denial, and secret redaction.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Related #3812
Related #3289

Stacked on #3878, which is stacked on #3865. This PR implements the composition handler/continuation slice; actual HTTP route mounting remains deferred until the Reborn host route surface lands.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_composition --test auth_callbacks --locked`, `cargo test -p ironclaw_reborn_composition --locked`, `cargo test -p ironclaw_architecture reborn_product_auth_contract_stays_reborn_native --locked`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; composition/facade behavior covered by contract tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo check -p ironclaw_reborn_composition --features libsql --locked`
- `cargo check -p ironclaw_reborn_composition --features postgres --locked`
- `git diff --check`

## Security Impact

Yes. This touches the Reborn OAuth callback/auth boundary. It keeps provider exchange, flow completion, account updates, and continuation scheduling inside Reborn product-auth composition, returns sanitized error codes, and adds regression coverage that raw OAuth code/verifier/token material is not exposed in callback output. It does not add a listener, route mount, new network egress path, or durable secret encryption changes.

## Database Impact

None. No migrations or schema changes.

## Blast Radius

Limited to `ironclaw_reborn_composition` product-auth facade behavior, docs, and callback contract tests. The implementation depends on the auth contracts from #3865 and the composition seam from #3878.

## Rollback Plan

Revert this PR to remove the callback handler seam, continuation dispatcher hook, docs, and tests. The lower-level auth contracts and composition seam remain intact in the parent PRs.

## Review Follow-Through

Reviewer judgment requested on whether this should close #3812 now or stay as a stacked handler slice until actual Reborn HTTP route mounting lands. The PR intentionally does not use V1 OAuth routes or route-local pending auth state.

---

**Review track**: C