### PR TITLE
feat(product-workflow): add read-path guard and command routed ack

### DIFF
--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -144,6 +144,37 @@ pub struct InboundCommandPayload {
     pub trigger: ProductTriggerReason,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RoutedCommandName(String);
+
+impl RoutedCommandName {
+    pub fn new(value: impl Into<String>) -> Result<Self, ProductAdapterError> {
+        let value = value.into();
+        validate_command_name(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<RoutedCommandName> for String {
+    fn from(value: RoutedCommandName) -> Self {
+        value.0
+    }
+}
+
+impl<'de> Deserialize<'de> for RoutedCommandName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
 impl InboundCommandPayload {
     pub fn new(
         command: impl Into<String>,
@@ -631,6 +662,9 @@ pub enum ProductInboundAck {
         accepted_message_ref: AcceptedMessageRef,
         active_run_id: TurnRunId,
     },
+    CommandRouted {
+        command: RoutedCommandName,
+    },
     Rejected(ProductRejection),
     Duplicate {
         prior: Box<ProductInboundAck>,
@@ -643,6 +677,7 @@ impl ProductInboundAck {
         match self {
             Self::Accepted { .. }
             | Self::DeferredBusy { .. }
+            | Self::CommandRouted { .. }
             | Self::Duplicate { .. }
             | Self::NoOp => true,
             Self::Rejected(rejection) => {

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -144,7 +144,7 @@ pub struct InboundCommandPayload {
     pub trigger: ProductTriggerReason,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct RoutedCommandName(String);
 
 impl RoutedCommandName {
@@ -222,14 +222,6 @@ pub fn parse_product_slash_command(
         .unwrap_or(without_slash.len());
     let command_slice = &without_slash[..command_end];
     let arguments_slice = without_slash[command_end..].trim_start();
-    validate_command_name(command_slice)
-        .map_err(|error| ProductSlashCommandParseError::InvalidPayload(error.to_string()))?;
-    validate_payload_string(
-        "command arguments",
-        arguments_slice,
-        COMMAND_ARGUMENTS_MAX_BYTES,
-    )
-    .map_err(|error| ProductSlashCommandParseError::InvalidPayload(error.to_string()))?;
 
     let command = command_slice.to_ascii_lowercase();
     let arguments = arguments_slice.to_string();
@@ -762,6 +754,16 @@ mod tests {
             "trigger": "direct_chat"
         });
         assert!(serde_json::from_value::<UserMessagePayload>(forged).is_err());
+    }
+
+    #[test]
+    fn routed_command_name_rejects_invalid_inputs() {
+        for input in ["", "bad name", "bad\\name", "bad\nname"] {
+            assert!(
+                RoutedCommandName::new(input).is_err(),
+                "expected {input:?} to be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/ironclaw_product_adapters/src/lib.rs
+++ b/crates/ironclaw_product_adapters/src/lib.rs
@@ -47,7 +47,7 @@ pub use inbound::{
     ParsedProductInbound, ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload,
     ProductRejection, ProductRejectionDisposition, ProductRejectionKind,
     ProductSlashCommandParseError, ProductTriggerReason, ProjectionSubscriptionPayload,
-    TrustedInboundContext, UserMessagePayload, parse_product_slash_command,
+    RoutedCommandName, TrustedInboundContext, UserMessagePayload, parse_product_slash_command,
 };
 pub use outbound::{
     AuthPromptView, FinalReplyView, GatePromptView, ProductOutboundEnvelope,

--- a/crates/ironclaw_product_adapters/tests/product_slash_command_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/product_slash_command_contract.rs
@@ -49,7 +49,7 @@ fn slash_parser_rejects_invalid_command_names() {
 }
 
 #[test]
-fn slash_parser_rejects_oversized_command_and_arguments_before_payload_build() {
+fn slash_parser_rejects_oversized_command_and_arguments() {
     let oversized_command = format!("/{}", "h".repeat(257));
     let err = parse_product_slash_command(&oversized_command, ProductTriggerReason::BotCommand)
         .expect_err("oversized command must fail");

--- a/crates/ironclaw_product_adapters/tests/review_findings_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/review_findings_contract.rs
@@ -10,7 +10,8 @@ use ironclaw_product_adapters::{
     ProductRejectionKind, ProductSurfaceKind, ProductTriggerReason, ProductWorkflow,
     ProjectionCursor, ProjectionStream, ProjectionSubscriptionPayload,
     ProjectionSubscriptionRequest, ProtocolAuthEvidence, ProtocolHttpEgress,
-    ProtocolHttpEgressError, RedactedString, TrustedInboundContext, UserMessagePayload,
+    ProtocolHttpEgressError, RedactedString, RoutedCommandName, TrustedInboundContext,
+    UserMessagePayload,
 };
 use ironclaw_turns::{AcceptedMessageRef, ReplyTargetBindingRef, TurnRunId};
 
@@ -552,6 +553,12 @@ fn ack_and_rejection_types_are_unambiguous_and_typed() {
             ProductRejectionKind::PolicyDenied,
             "policy denied",
         ))
+        .is_durable_outcome()
+    );
+    assert!(
+        ProductInboundAck::CommandRouted {
+            command: RoutedCommandName::new("status").expect("valid command"),
+        }
         .is_durable_outcome()
     );
     assert!(ironclaw_product_adapters::fakes::ensure_durable_outcome(

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -90,6 +90,17 @@ impl ProductWorkflow for DefaultProductWorkflow {
         &self,
         envelope: ProductInboundEnvelope,
     ) -> Result<ProductInboundAck, ProductAdapterError> {
+        if matches!(
+            envelope.payload(),
+            ProductInboundPayload::SubscriptionRequest(_)
+        ) {
+            return Err(ProductAdapterError::MalformedInboundPayload {
+                reason: RedactedString::new(
+                    "subscription_request must be resolved through resolve_projection_subscription",
+                ),
+            });
+        }
+
         let source_binding_key =
             SourceBindingKey::new(envelope.source_binding_key()).map_err(|reason| {
                 ProductAdapterError::from(ProductWorkflowError::BindingResolutionFailed { reason })

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -16,7 +16,9 @@ use ironclaw_turns::{
 };
 use tracing::debug;
 
-use crate::action::{ActionDispatchKind, ActionFingerprintKey, SourceBindingKey};
+use crate::action::{
+    ActionDispatchKind, ActionFingerprintKey, ProductCommandName, SourceBindingKey,
+};
 use crate::binding::{
     ConversationBindingService, ProductConversationRouteKind, ResolveBindingRequest,
     ResolvedBinding,
@@ -337,7 +339,7 @@ async fn dispatch_payload(
                 }
             }
             let ack = command_service.execute(context, command).await?;
-            let dispatch_kind = dispatch_kind_from_command_ack(&ack, envelope.payload())?;
+            let dispatch_kind = dispatch_kind_from_command_ack(&ack)?;
             Ok(DispatchedAction { ack, dispatch_kind })
         }
         ProductInboundPayload::ApprovalResolution(_) => {
@@ -391,18 +393,21 @@ fn dispatch_kind_from_ack(
 
 fn dispatch_kind_from_command_ack(
     ack: &ProductInboundAck,
-    payload: &ProductInboundPayload,
 ) -> Result<ActionDispatchKind, ProductWorkflowError> {
     match ack {
-        ProductInboundAck::Accepted { .. } | ProductInboundAck::DeferredBusy { .. } => {
-            Err(ProductWorkflowError::UnsupportedActionKind {
-                kind: "turn_ack_from_product_command".into(),
-            })
-        }
+        ProductInboundAck::CommandRouted { command } => Ok(ActionDispatchKind::Command {
+            command: ProductCommandName::new(command.as_str())
+                .map_err(|reason| ProductWorkflowError::TurnSubmissionRejected { reason })?,
+        }),
         ProductInboundAck::Rejected(rejection) => Ok(ActionDispatchKind::Rejected {
             kind: rejection.kind.clone(),
         }),
-        _ => ActionDispatchKind::try_from_payload(payload),
+        ProductInboundAck::Accepted { .. }
+        | ProductInboundAck::DeferredBusy { .. }
+        | ProductInboundAck::Duplicate { .. }
+        | ProductInboundAck::NoOp => Err(ProductWorkflowError::UnsupportedActionKind {
+            kind: "non_command_ack_from_product_command".into(),
+        }),
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -96,7 +96,10 @@ impl ProductWorkflow for DefaultProductWorkflow {
             envelope.payload(),
             ProductInboundPayload::SubscriptionRequest(_)
         ) {
-            return Err(ProductAdapterError::MalformedInboundPayload {
+            return Err(ProductAdapterError::WorkflowRejected {
+                kind: ProductWorkflowRejectionKind::InvalidRequest,
+                status_code: 400,
+                retryable: false,
                 reason: RedactedString::new(
                     "subscription_request must be resolved through resolve_projection_subscription",
                 ),

--- a/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
@@ -8,7 +8,7 @@ use ironclaw_product_adapters::{
     AdapterInstallationId, AuthRequirement, ExternalActorRef, ExternalConversationRef,
     ExternalEventId, InboundCommandPayload, ProductAdapterId, ProductInboundAck,
     ProductInboundEnvelope, ProductInboundPayload, ProductTriggerReason, ProductWorkflow,
-    ProtocolAuthEvidence, TrustedInboundContext,
+    ProtocolAuthEvidence, RoutedCommandName, TrustedInboundContext,
 };
 use ironclaw_product_workflow::{
     ActionDispatchKind, DefaultProductWorkflow, FakeConversationBindingService,
@@ -17,6 +17,12 @@ use ironclaw_product_workflow::{
     ProductModelCommand, ProductWorkflowError,
 };
 use ironclaw_turns::{AcceptedMessageRef, TurnRunId};
+
+fn routed_command_ack(command: &str) -> ProductInboundAck {
+    ProductInboundAck::CommandRouted {
+        command: RoutedCommandName::new(command).expect("valid routed command"),
+    }
+}
 
 fn sample_command_envelope(
     event_suffix: &str,
@@ -138,7 +144,7 @@ async fn command_payload_dispatches_through_command_service_not_inbound_turn_ser
     let binding = Arc::new(FakeConversationBindingService::new());
     let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
     let command_service = Arc::new(RecordingProductCommandService::with_ack(
-        ProductInboundAck::NoOp,
+        routed_command_ack("model"),
     ));
     let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
         .with_product_command_admission_service(admission_service)
@@ -148,7 +154,10 @@ async fn command_payload_dispatches_through_command_service_not_inbound_turn_ser
 
     let ack = workflow.accept_inbound(envelope).await.expect("accept");
 
-    assert!(matches!(ack, ProductInboundAck::NoOp));
+    assert!(matches!(
+        ack,
+        ProductInboundAck::CommandRouted { command } if command.as_str() == "model"
+    ));
     assert_eq!(inbound.accepted_count(), 0);
     assert_eq!(inbound.attempt_count(), 0);
     assert_eq!(inbound.replay_attempt_count(), 0);
@@ -163,8 +172,8 @@ async fn command_payload_dispatches_through_command_service_not_inbound_turn_ser
     let settled = ledger.settled_actions();
     assert_eq!(settled.len(), 1);
     assert!(matches!(
-        settled[0].dispatch_kind,
-        Some(ActionDispatchKind::Command { .. })
+        &settled[0].dispatch_kind,
+        Some(ActionDispatchKind::Command { command }) if command.as_str() == "model"
     ));
 }
 
@@ -199,7 +208,7 @@ async fn command_admission_receives_authority_context_and_action_metadata() {
     let binding = Arc::new(FakeConversationBindingService::new());
     let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
     let command_service = Arc::new(RecordingProductCommandService::with_ack(
-        ProductInboundAck::NoOp,
+        routed_command_ack("status"),
     ));
     let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
         .with_product_command_admission_service(admission_service.clone())
@@ -214,7 +223,10 @@ async fn command_admission_receives_authority_context_and_action_metadata() {
 
     let ack = workflow.accept_inbound(envelope).await.expect("accept");
 
-    assert!(matches!(ack, ProductInboundAck::NoOp));
+    assert!(matches!(
+        ack,
+        ProductInboundAck::CommandRouted { command } if command.as_str() == "status"
+    ));
     let records = admission_service.records();
     assert_eq!(records.len(), 1);
     let (context, command) = &records[0];

--- a/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
@@ -325,33 +325,65 @@ async fn default_command_service_rejects_when_admission_is_supplied() {
 }
 
 #[tokio::test]
-async fn command_service_turn_ack_is_rejected_before_turn_dispatch_kind_is_recorded() {
-    let inbound = Arc::new(FakeInboundTurnService::new());
-    let ledger = Arc::new(FakeIdempotencyLedger::new());
-    let binding = Arc::new(FakeConversationBindingService::new());
-    let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
-    let command_service = Arc::new(RecordingProductCommandService::with_ack(
-        ProductInboundAck::Accepted {
-            accepted_message_ref: AcceptedMessageRef::new("msg:command").expect("valid ref"),
-            submitted_run_id: TurnRunId::new(),
-        },
-    ));
-    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
-        .with_product_command_admission_service(admission_service)
-        .with_product_command_service(command_service);
-    let envelope = sample_command_envelope("command-turn-ack", "status", "");
+async fn command_service_non_command_acks_are_rejected_before_dispatch_kind_is_recorded() {
+    let cases = [
+        (
+            "accepted",
+            ProductInboundAck::Accepted {
+                accepted_message_ref: AcceptedMessageRef::new("msg:command-accepted")
+                    .expect("valid ref"),
+                submitted_run_id: TurnRunId::new(),
+            },
+        ),
+        (
+            "deferred_busy",
+            ProductInboundAck::DeferredBusy {
+                accepted_message_ref: AcceptedMessageRef::new("msg:command-deferred")
+                    .expect("valid ref"),
+                active_run_id: TurnRunId::new(),
+            },
+        ),
+        (
+            "duplicate",
+            ProductInboundAck::Duplicate {
+                prior: Box::new(ProductInboundAck::NoOp),
+            },
+        ),
+        ("noop", ProductInboundAck::NoOp),
+    ];
 
-    workflow
-        .accept_inbound(envelope)
-        .await
-        .expect_err("turn-shaped command ack must fail");
+    for (case, ack) in cases {
+        let inbound = Arc::new(FakeInboundTurnService::new());
+        let ledger = Arc::new(FakeIdempotencyLedger::new());
+        let binding = Arc::new(FakeConversationBindingService::new());
+        let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
+        let command_service = Arc::new(RecordingProductCommandService::with_ack(ack));
+        let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+            .with_product_command_admission_service(admission_service)
+            .with_product_command_service(command_service.clone());
+        let envelope = sample_command_envelope(case, "status", "");
 
-    assert_eq!(inbound.accepted_count(), 0);
-    assert_eq!(ledger.released_count(), 0);
-    let settled = ledger.settled_actions();
-    assert_eq!(settled.len(), 1);
-    assert!(matches!(
-        settled[0].dispatch_kind,
-        Some(ActionDispatchKind::Rejected { .. })
-    ));
+        let err = workflow
+            .accept_inbound(envelope)
+            .await
+            .expect_err("non-command command ack must fail");
+
+        assert!(!err.is_retryable(), "{case}");
+        assert_eq!(
+            command_service.commands(),
+            vec![ProductCommand::Status],
+            "{case}"
+        );
+        assert_eq!(inbound.accepted_count(), 0, "{case}");
+        assert_eq!(ledger.released_count(), 0, "{case}");
+        let settled = ledger.settled_actions();
+        assert_eq!(settled.len(), 1, "{case}");
+        assert!(
+            matches!(
+                &settled[0].dispatch_kind,
+                Some(ActionDispatchKind::Rejected { .. })
+            ),
+            "{case}"
+        );
+    }
 }

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -944,6 +944,31 @@ async fn noop_returns_noop_ack() {
 }
 
 #[tokio::test]
+async fn subscription_request_via_accept_inbound_rejects_without_ledger_row() {
+    let (workflow, inbound, ledger) = build_workflow();
+    let envelope = sample_envelope_with_payload(
+        "projection-read-path",
+        ProductInboundPayload::SubscriptionRequest(
+            ProjectionSubscriptionPayload::new(None, None).expect("valid subscription"),
+        ),
+    );
+
+    let err = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("subscription requests use the projection resolver, not accept_inbound");
+
+    assert!(matches!(
+        err,
+        ProductAdapterError::MalformedInboundPayload { .. }
+    ));
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+}
+
+#[tokio::test]
 async fn projection_subscription_resolves_through_binding_service() {
     let (workflow, inbound, _ledger, binding_service) = build_workflow_with_binding();
     let binding = fake_binding();

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -960,7 +960,12 @@ async fn subscription_request_via_accept_inbound_rejects_without_ledger_row() {
 
     assert!(matches!(
         err,
-        ProductAdapterError::MalformedInboundPayload { .. }
+        ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::InvalidRequest,
+            status_code: 400,
+            retryable: false,
+            ..
+        }
     ));
     assert_eq!(inbound.accepted_count(), 0);
     assert_eq!(ledger.settled_count(), 0);


### PR DESCRIPTION
Refs #3280

## Summary

This PR lands two small, reviewable ProductWorkflow slices:

- Keep `SubscriptionRequest` payloads out of the mutating `accept_inbound` / `ProductInboundAction` ledger path.
- Add an explicit `CommandRouted` product acknowledgement so admitted product commands settle with a product-safe command outcome instead of reusing `NoOp`.

The remaining #3280 work stays in the owning follow-up lanes below; this PR does not guess those service boundaries.

## Implemented in this PR

### Subscription/read path guard

- Reject `SubscriptionRequest` payloads submitted through `ProductWorkflow::accept_inbound`.
- Direct callers to `resolve_projection_subscription` for the read/subscription path.
- Add caller-level regression coverage proving the read path does not touch `InboundTurnService` or the mutating idempotency ledger.

### Command routed ack taxonomy

- Add `ProductInboundAck::CommandRouted { command }`.
- Add a bounded `RoutedCommandName` wire type.
- Treat `CommandRouted` as a durable outcome.
- Map `CommandRouted` to `ActionDispatchKind::Command` in the workflow ledger.
- Reject turn-shaped/noop command-service acknowledgements before recording them as routed commands.

## Boundaries / follow-up lanes

This PR is intentionally not trying to complete all of #3280.

| Area not implemented here | Current behavior in this PR | Owning follow-up | Why it stays out of this PR |
| --- | --- | --- | --- |
| Approval/auth resolution routing (`ApprovalResolution`, `AuthResolution`, eventual `GateHandled` ack) | Still treated as unsupported product action kinds. | #3094 / #3889 | ProductWorkflow should dispatch these only through `ApprovalInteractionService` / `AuthInteractionService`. Those services own actor authority, stale/expired gate handling, fingerprints, and resume/cancel decisions. Wiring this directly to `TurnCoordinator` here would bypass the intended interaction boundary. |
| Full product command compatibility matrix | This PR only adds the safe successful outcome shape (`CommandRouted`) after the existing command service seam executes. | #3286 | #3286 owns the complete legacy command behavior matrix. This PR should not guess command semantics beyond recording that an admitted command was routed safely. |
| Mission routing / `MissionSubmitted` or `MissionSuppressed` outcomes | Not wired. Mission-like actions remain outside this slice. | #3278 | Mission routing requires the explicit `MissionService` integration shape and policy around mission intent vs ordinary chat. Implementing it here would risk recreating hidden v1 OnEvent behavior. |
| Durable projection fanout / EventStreamManager ownership | This PR only keeps subscription requests out of the mutating inbound ledger and uses the existing `resolve_projection_subscription` read path. | #3281 | ProductInboundAction ledger rows are for mutating actions. Durable stream/fanout/cursor ownership belongs to EventStreamManager, so this PR should not create high-volume inbound-action rows or invent fanout persistence. |
| Linked thread actions / typed system actions | Not routed by this PR. | #3280 follow-up | There is no concrete downstream service seam in the current branch for these action kinds. Keeping them unsupported is safer than adding an ad-hoc ProductWorkflow branch that later has to be unwound. |

## Validation

- `cargo fmt --all`
- `cargo clippy -p ironclaw_product_workflow --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_product_adapters --features test-support,host-auth-mint --all-targets -- -D warnings`
