### PR TITLE
[codex] Route Reborn production builders through factory

### DIFF
--- a/crates/ironclaw_reborn_composition/src/error.rs
+++ b/crates/ironclaw_reborn_composition/src/error.rs
@@ -49,3 +49,44 @@ impl From<ironclaw_host_runtime::ProductionWiringReport> for RebornBuildError {
         Self::ProductionWiring { report }
     }
 }
+
+impl From<crate::RebornCompositionError> for RebornBuildError {
+    fn from(error: crate::RebornCompositionError) -> Self {
+        match error {
+            crate::RebornCompositionError::MissingSecretMasterKey => Self::MissingSecretMasterKey,
+            crate::RebornCompositionError::Mount(error) => Self::Mount(error),
+            crate::RebornCompositionError::Filesystem(error) => Self::Filesystem(error),
+            crate::RebornCompositionError::Resource(error) => Self::Resource(error),
+            crate::RebornCompositionError::RunState(error) => Self::RunState(error),
+            crate::RebornCompositionError::CapabilityLease(error) => Self::CapabilityLease(error),
+            crate::RebornCompositionError::Secret(error) => Self::Secret(error),
+            crate::RebornCompositionError::EventStore(error) => Self::EventStore(error),
+            crate::RebornCompositionError::Turn(error) => Self::Turn(error),
+            crate::RebornCompositionError::RunProfile(error) => Self::PlannedRunProfileResolver {
+                reason: error.to_string(),
+            },
+            error @ crate::RebornCompositionError::MissingTenantSandboxProcessPort => {
+                Self::InvalidConfig {
+                    reason: error.to_string(),
+                }
+            }
+            error @ crate::RebornCompositionError::UnexpectedTenantSandboxProcessPort { .. } => {
+                Self::InvalidConfig {
+                    reason: error.to_string(),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RebornBuildError;
+
+    #[test]
+    fn composition_missing_secret_master_key_stays_typed_for_facade_errors() {
+        let error = RebornBuildError::from(crate::RebornCompositionError::MissingSecretMasterKey);
+
+        assert!(matches!(error, RebornBuildError::MissingSecretMasterKey));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/error.rs
+++ b/crates/ironclaw_reborn_composition/src/error.rs
@@ -44,6 +44,12 @@ pub enum RebornBuildError {
     Mount(#[from] ironclaw_host_api::HostApiError),
 }
 
+impl From<ironclaw_host_runtime::ProductionWiringReport> for crate::RebornCompositionError {
+    fn from(report: ironclaw_host_runtime::ProductionWiringReport) -> Self {
+        Self::ProductionWiring { report }
+    }
+}
+
 impl From<ironclaw_host_runtime::ProductionWiringReport> for RebornBuildError {
     fn from(report: ironclaw_host_runtime::ProductionWiringReport) -> Self {
         Self::ProductionWiring { report }
@@ -65,12 +71,11 @@ impl From<crate::RebornCompositionError> for RebornBuildError {
             crate::RebornCompositionError::RunProfile(error) => Self::PlannedRunProfileResolver {
                 reason: error.to_string(),
             },
-            error @ crate::RebornCompositionError::MissingTenantSandboxProcessPort => {
-                Self::InvalidConfig {
-                    reason: error.to_string(),
-                }
+            crate::RebornCompositionError::ProductionWiring { report } => {
+                Self::ProductionWiring { report }
             }
-            error @ crate::RebornCompositionError::UnexpectedTenantSandboxProcessPort { .. } => {
+            error @ crate::RebornCompositionError::MissingTenantSandboxProcessPort
+            | error @ crate::RebornCompositionError::UnexpectedTenantSandboxProcessPort { .. } => {
                 Self::InvalidConfig {
                     reason: error.to_string(),
                 }
@@ -88,5 +93,41 @@ mod tests {
         let error = RebornBuildError::from(crate::RebornCompositionError::MissingSecretMasterKey);
 
         assert!(matches!(error, RebornBuildError::MissingSecretMasterKey));
+    }
+
+    #[test]
+    fn composition_missing_tenant_sandbox_process_port_becomes_invalid_config() {
+        let error =
+            RebornBuildError::from(crate::RebornCompositionError::MissingTenantSandboxProcessPort);
+
+        assert!(
+            matches!(error, RebornBuildError::InvalidConfig { reason } if reason == "production tenant-sandbox process backend requires a tenant sandbox process binding")
+        );
+    }
+
+    #[test]
+    fn composition_unexpected_tenant_sandbox_process_port_becomes_invalid_config() {
+        let error = RebornBuildError::from(
+            crate::RebornCompositionError::UnexpectedTenantSandboxProcessPort {
+                process_backend: ironclaw_host_api::ProcessBackendKind::LocalHost,
+            },
+        );
+
+        assert!(
+            matches!(error, RebornBuildError::InvalidConfig { reason } if reason == "production runtime policy uses LocalHost but a tenant sandbox process binding was supplied")
+        );
+    }
+
+    #[test]
+    fn composition_run_profile_becomes_planned_run_profile_resolver() {
+        let error = RebornBuildError::from(crate::RebornCompositionError::RunProfile(
+            ironclaw_turns::run_profile::RunProfileRegistryError::InvalidProfile {
+                reason: "broken run profile".to_string(),
+            },
+        ));
+
+        assert!(
+            matches!(error, RebornBuildError::PlannedRunProfileResolver { reason } if reason == "invalid run profile: broken run profile")
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -875,6 +875,7 @@ fn local_dev_bytes_capabilities() -> BackendCapabilities {
         .with(Capability::Delete)
 }
 
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn local_dev_scoped_filesystem(
     filesystem: Arc<LocalDevRootFilesystem>,
 ) -> Arc<ScopedFilesystem<LocalDevRootFilesystem>> {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -875,7 +875,6 @@ fn local_dev_bytes_capabilities() -> BackendCapabilities {
         .with(Capability::Delete)
 }
 
-#[cfg(feature = "libsql")]
 fn local_dev_scoped_filesystem(
     filesystem: Arc<LocalDevRootFilesystem>,
 ) -> Arc<ScopedFilesystem<LocalDevRootFilesystem>> {
@@ -1252,15 +1251,9 @@ async fn build_production_shaped(
 async fn resolve_secret_master_key(
     explicit: Option<ironclaw_secrets::SecretMaterial>,
 ) -> Result<ironclaw_secrets::SecretMaterial, RebornBuildError> {
-    if let Some(master_key) = explicit {
-        Ok(master_key)
-    } else if let Some(master_key) =
-        ironclaw_secrets::keychain::resolve_master_key_material().await?
-    {
-        Ok(master_key)
-    } else {
-        Err(RebornBuildError::MissingSecretMasterKey)
-    }
+    resolve_explicit_or_keychain_master_key(explicit)
+        .await?
+        .ok_or(RebornBuildError::MissingSecretMasterKey)
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1431,10 +1424,6 @@ where
     .await?;
     let services = apply_production_runtime_process_binding(services, process_binding);
 
-    // safety: `with_secret_store` is called unconditionally above on the same
-    // builder chain, so `try_with_host_http_egress` can only return a
-    // `Missing(SecretStore)` wiring report if the host-runtime builder API
-    // regresses; treat that as infallible here.
     let services = services
         .try_with_host_http_egress_with_body_store(
             ironclaw_network::PolicyNetworkHttpEgress::new(
@@ -1442,7 +1431,7 @@ where
             ),
             Arc::clone(&scoped_filesystem),
         )
-        .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
+        .map_err(crate::RebornCompositionError::from)?;
 
     Ok(services)
 }
@@ -1463,7 +1452,9 @@ async fn build_filesystem_secret_store<F>(
 where
     F: RootFilesystem + 'static,
 {
-    let master_key = resolve_composition_secret_master_key(master_key).await?;
+    let master_key = resolve_explicit_or_keychain_master_key(master_key)
+        .await?
+        .ok_or(crate::RebornCompositionError::MissingSecretMasterKey)?;
     let crypto = Arc::new(ironclaw_secrets::SecretsCrypto::new(master_key)?);
     Ok(Arc::new(FilesystemSecretStore::new(
         scoped_filesystem,
@@ -1472,17 +1463,17 @@ where
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-async fn resolve_composition_secret_master_key(
+async fn resolve_explicit_or_keychain_master_key(
     explicit: Option<ironclaw_secrets::SecretMaterial>,
-) -> Result<ironclaw_secrets::SecretMaterial, crate::RebornCompositionError> {
+) -> Result<Option<ironclaw_secrets::SecretMaterial>, ironclaw_secrets::SecretError> {
     if let Some(master_key) = explicit {
-        Ok(master_key)
+        Ok(Some(master_key))
     } else if let Some(master_key) =
         ironclaw_secrets::keychain::resolve_master_key_material().await?
     {
-        Ok(master_key)
+        Ok(Some(master_key))
     } else {
-        Err(crate::RebornCompositionError::MissingSecretMasterKey)
+        Ok(None)
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -43,7 +43,7 @@ use ironclaw_loop_support::FilesystemCheckpointStateStore;
 use ironclaw_processes::ProcessServices;
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
 use ironclaw_resources::InMemoryResourceGovernor;
-#[cfg(feature = "libsql")]
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_resources::{FilesystemResourceGovernorStore, PersistentResourceGovernor};
 #[cfg(feature = "libsql")]
 use ironclaw_run_state::{FilesystemApprovalRequestStore, FilesystemRunStateStore};
@@ -1324,6 +1324,166 @@ fn planned_run_profile_resolver() -> Result<Arc<InMemoryRunProfileResolver>, Reb
             },
         )?,
     ))
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+type FilesystemProductionHostRuntimeServices<F> = HostRuntimeServices<
+    F,
+    PersistentResourceGovernor<FilesystemResourceGovernorStore<F>>,
+    ironclaw_processes::FilesystemProcessStore<F>,
+    ironclaw_processes::FilesystemProcessResultStore<F>,
+>;
+
+#[cfg(feature = "libsql")]
+pub(crate) async fn build_libsql_production_host_runtime_services<TPolicy, TWake>(
+    config: crate::LibSqlProductionSubstrateConfig<TPolicy, TWake>,
+) -> Result<crate::LibSqlProductionHostRuntimeServices, crate::RebornCompositionError>
+where
+    TPolicy: ironclaw_trust::TrustPolicy + 'static,
+    TWake: ironclaw_turns::TurnRunWakeNotifier + 'static,
+{
+    let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&config.database)));
+    filesystem.run_migrations().await?;
+    build_filesystem_production_host_runtime_services(
+        filesystem,
+        config.event_store,
+        config.secret_master_key,
+        config.trust_policy,
+        config.runtime_policy,
+        config.turn_run_wake_notifier,
+        config.surface_version,
+    )
+    .await
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) async fn build_postgres_production_host_runtime_services<TPolicy, TWake>(
+    config: crate::PostgresProductionSubstrateConfig<TPolicy, TWake>,
+) -> Result<crate::PostgresProductionHostRuntimeServices, crate::RebornCompositionError>
+where
+    TPolicy: ironclaw_trust::TrustPolicy + 'static,
+    TWake: ironclaw_turns::TurnRunWakeNotifier + 'static,
+{
+    let filesystem = Arc::new(ironclaw_filesystem::PostgresRootFilesystem::new(
+        config.pool,
+    ));
+    filesystem.run_migrations().await?;
+    build_filesystem_production_host_runtime_services(
+        filesystem,
+        config.event_store,
+        config.secret_master_key,
+        config.trust_policy,
+        config.runtime_policy,
+        config.turn_run_wake_notifier,
+        config.surface_version,
+    )
+    .await
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+async fn build_filesystem_production_host_runtime_services<F, TPolicy, TWake>(
+    filesystem: Arc<F>,
+    event_store: ironclaw_reborn_event_store::RebornEventStoreConfig,
+    secret_master_key: Option<ironclaw_secrets::SecretMaterial>,
+    trust_policy: Arc<TPolicy>,
+    runtime_policy: crate::RebornProductionRuntimePolicy,
+    turn_run_wake_notifier: Arc<TWake>,
+    surface_version: CapabilitySurfaceVersion,
+) -> Result<FilesystemProductionHostRuntimeServices<F>, crate::RebornCompositionError>
+where
+    F: RootFilesystem + 'static,
+    TPolicy: ironclaw_trust::TrustPolicy + 'static,
+    TWake: ironclaw_turns::TurnRunWakeNotifier + 'static,
+{
+    let scoped_filesystem = crate::wrap_scoped(Arc::clone(&filesystem));
+    let process_services = ProcessServices::filesystem(Arc::clone(&scoped_filesystem));
+    let secret_store =
+        build_filesystem_secret_store(Arc::clone(&scoped_filesystem), secret_master_key).await?;
+    let resource_store = FilesystemResourceGovernorStore::new(Arc::clone(&scoped_filesystem));
+    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
+    let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new(Arc::clone(
+        &scoped_filesystem,
+    )));
+    let (runtime_policy, process_binding) = runtime_policy.into_parts();
+
+    let services = HostRuntimeServices::new(
+        Arc::new(ExtensionRegistry::new()),
+        filesystem,
+        governor,
+        Arc::new(GrantAuthorizer::new()),
+        process_services,
+        surface_version,
+    )
+    .with_trust_policy(trust_policy)
+    .with_runtime_policy(runtime_policy)
+    .with_capability_leases(capability_leases)
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_turn_run_wake_notifier(turn_run_wake_notifier)
+    .with_filesystem_run_state(Arc::clone(&scoped_filesystem))
+    .with_filesystem_turn_state_store(Arc::clone(&scoped_filesystem))
+    .with_run_profile_resolver(Arc::new(
+        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()?,
+    ))
+    .with_reborn_event_store_config(
+        ironclaw_reborn_event_store::RebornProfile::Production,
+        event_store,
+    )
+    .await?;
+    let services = apply_production_runtime_process_binding(services, process_binding);
+
+    // safety: `with_secret_store` is called unconditionally above on the same
+    // builder chain, so `try_with_host_http_egress` can only return a
+    // `Missing(SecretStore)` wiring report if the host-runtime builder API
+    // regresses; treat that as infallible here.
+    let services = services
+        .try_with_host_http_egress_with_body_store(
+            ironclaw_network::PolicyNetworkHttpEgress::new(
+                ironclaw_network::ReqwestNetworkTransport::default(),
+            ),
+            Arc::clone(&scoped_filesystem),
+        )
+        .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
+
+    Ok(services)
+}
+
+/// Build the per-process [`ironclaw_secrets::SecretStore`] over the shared
+/// [`ScopedFilesystem`].
+///
+/// Backend selection is now a property of the underlying
+/// [`RootFilesystem`] (libSQL/Postgres/in-memory), not of the secret store
+/// itself. Master-key correctness remains a lazy per-tenant decrypt check; the
+/// old startup sentinel/`verify_can_decrypt_existing_secrets` path was removed
+/// in PR #3679, not by this composition refactor.
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+async fn build_filesystem_secret_store<F>(
+    scoped_filesystem: Arc<ScopedFilesystem<F>>,
+    master_key: Option<ironclaw_secrets::SecretMaterial>,
+) -> Result<Arc<FilesystemSecretStore<F>>, crate::RebornCompositionError>
+where
+    F: RootFilesystem + 'static,
+{
+    let master_key = resolve_composition_secret_master_key(master_key).await?;
+    let crypto = Arc::new(ironclaw_secrets::SecretsCrypto::new(master_key)?);
+    Ok(Arc::new(FilesystemSecretStore::new(
+        scoped_filesystem,
+        crypto,
+    )))
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+async fn resolve_composition_secret_master_key(
+    explicit: Option<ironclaw_secrets::SecretMaterial>,
+) -> Result<ironclaw_secrets::SecretMaterial, crate::RebornCompositionError> {
+    if let Some(master_key) = explicit {
+        Ok(master_key)
+    } else if let Some(master_key) =
+        ironclaw_secrets::keychain::resolve_master_key_material().await?
+    {
+        Ok(master_key)
+    } else {
+        Err(crate::RebornCompositionError::MissingSecretMasterKey)
+    }
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -134,7 +134,8 @@ pub use webui::{RebornWebuiBundle, build_webui_services};
 pub use webui_rate_limit::RateLimitConfigError;
 #[cfg(feature = "webui-v2-beta")]
 pub use webui_serve::{
-    WebuiAuthenticator, WebuiServeConfig, WebuiServeConfigError, WebuiServeError, webui_v2_app,
+    PublicRouteMount, WebuiAuthenticator, WebuiServeConfig, WebuiServeConfigError, WebuiServeError,
+    webui_v2_app,
 };
 
 /// Re-exported identity vocabulary host binaries need to construct

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -134,8 +134,7 @@ pub use webui::{RebornWebuiBundle, build_webui_services};
 pub use webui_rate_limit::RateLimitConfigError;
 #[cfg(feature = "webui-v2-beta")]
 pub use webui_serve::{
-    PublicRouteMount, WebuiAuthenticator, WebuiServeConfig, WebuiServeConfigError, WebuiServeError,
-    webui_v2_app,
+    WebuiAuthenticator, WebuiServeConfig, WebuiServeConfigError, WebuiServeError, webui_v2_app,
 };
 
 /// Re-exported identity vocabulary host binaries need to construct
@@ -232,13 +231,7 @@ pub fn reborn_runtime_readiness_snapshot() -> RebornRuntimeReadinessSnapshot {
     }
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use async_trait::async_trait;
 use ironclaw_authorization::CapabilityLeaseError;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_authorization::{FilesystemCapabilityLeaseStore, GrantAuthorizer};
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_extensions::ExtensionRegistry;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "postgres")]
@@ -249,27 +242,22 @@ use ironclaw_host_api::ProcessBackendKind;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{
     MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, SYSTEM_RESERVED_ID,
-    SecretHandle, VirtualPath,
+    VirtualPath,
 };
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_network::{PolicyNetworkHttpEgress, ReqwestNetworkTransport};
+use ironclaw_processes::{FilesystemProcessResultStore, FilesystemProcessStore};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_processes::{FilesystemProcessResultStore, FilesystemProcessStore, ProcessServices};
+use ironclaw_reborn_event_store::RebornEventStoreConfig;
 use ironclaw_reborn_event_store::RebornEventStoreError;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_reborn_event_store::{RebornEventStoreConfig, RebornProfile};
 use ironclaw_resources::ResourceError;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_resources::{FilesystemResourceGovernorStore, PersistentResourceGovernor};
 use ironclaw_run_state::RunStateError;
 use ironclaw_secrets::SecretError;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_secrets::{
-    FilesystemSecretStore, SecretLease, SecretLeaseId, SecretMaterial, SecretMetadata, SecretStore,
-    SecretStoreError, SecretsCrypto,
-};
+use ironclaw_secrets::SecretMaterial;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_trust::TrustPolicy;
 use ironclaw_turns::TurnError;
@@ -448,10 +436,16 @@ pub enum RebornCompositionError {
     Turn(#[from] TurnError),
     #[error("reborn run-profile resolver substrate failed: {0}")]
     RunProfile(#[from] ironclaw_turns::run_profile::RunProfileRegistryError),
-    #[error("tenant-sandbox process backend requires explicit tenant sandbox process port")]
+    #[error("production tenant-sandbox process backend requires a tenant sandbox process binding")]
     MissingTenantSandboxProcessPort,
-    #[error("tenant sandbox process port was supplied for runtime backend {process_backend:?}")]
+    #[error(
+        "production runtime policy uses {process_backend:?} but a tenant sandbox process binding was supplied"
+    )]
     UnexpectedTenantSandboxProcessPort { process_backend: ProcessBackendKind },
+    #[error("reborn production wiring failed: {report:?}")]
+    ProductionWiring {
+        report: ironclaw_host_runtime::ProductionWiringReport,
+    },
 }
 
 /// Build production-wired host-runtime services over libSQL-backed substrates.
@@ -471,60 +465,7 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
-    let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&config.database)));
-    filesystem.run_migrations().await?;
-
-    let scoped_filesystem = wrap_scoped(Arc::clone(&filesystem));
-    let process_services = ProcessServices::filesystem(Arc::clone(&scoped_filesystem));
-
-    let secret_store =
-        build_filesystem_secret_store(Arc::clone(&scoped_filesystem), config.secret_master_key)
-            .await?;
-
-    let resource_store = FilesystemResourceGovernorStore::new(Arc::clone(&scoped_filesystem));
-    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
-
-    let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new(Arc::clone(
-        &scoped_filesystem,
-    )));
-
-    let (runtime_policy, process_binding) = config.runtime_policy.into_parts();
-
-    let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
-        filesystem,
-        governor,
-        Arc::new(GrantAuthorizer::new()),
-        process_services,
-        config.surface_version,
-    )
-    .with_trust_policy(config.trust_policy)
-    .with_runtime_policy(runtime_policy)
-    .with_capability_leases(capability_leases)
-    .with_secret_store(Arc::clone(&secret_store))
-    .with_turn_run_wake_notifier(config.turn_run_wake_notifier)
-    .with_filesystem_run_state(Arc::clone(&scoped_filesystem))
-    .with_filesystem_turn_state_store(Arc::clone(&scoped_filesystem))
-    .with_run_profile_resolver(Arc::new(
-        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()?,
-    ))
-    .with_reborn_event_store_config(RebornProfile::Production, config.event_store)
-    .await?;
-    let services =
-        crate::factory::apply_production_runtime_process_binding(services, process_binding);
-
-    // safety: `with_secret_store` is called unconditionally above on the same
-    // builder chain, so `try_with_host_http_egress` can only return a
-    // `Missing(SecretStore)` wiring report if the host-runtime builder API
-    // regresses; treat that as infallible here.
-    let services = services
-        .try_with_host_http_egress_with_body_store(
-            PolicyNetworkHttpEgress::new(ReqwestNetworkTransport::default()),
-            Arc::clone(&scoped_filesystem),
-        )
-        .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
-
-    Ok(services)
+    factory::build_libsql_production_host_runtime_services(config).await
 }
 
 /// Build production-wired host-runtime services over PostgreSQL-backed substrates.
@@ -541,199 +482,7 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
-    let filesystem = Arc::new(PostgresRootFilesystem::new(config.pool.clone()));
-    filesystem.run_migrations().await?;
-
-    let scoped_filesystem = wrap_scoped(Arc::clone(&filesystem));
-    let process_services = ProcessServices::filesystem(Arc::clone(&scoped_filesystem));
-
-    let secret_store =
-        build_filesystem_secret_store(Arc::clone(&scoped_filesystem), config.secret_master_key)
-            .await?;
-
-    let resource_store = FilesystemResourceGovernorStore::new(Arc::clone(&scoped_filesystem));
-    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
-
-    let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new(Arc::clone(
-        &scoped_filesystem,
-    )));
-
-    let (runtime_policy, process_binding) = config.runtime_policy.into_parts();
-
-    let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
-        filesystem,
-        governor,
-        Arc::new(GrantAuthorizer::new()),
-        process_services,
-        config.surface_version,
-    )
-    .with_trust_policy(config.trust_policy)
-    .with_runtime_policy(runtime_policy)
-    .with_capability_leases(capability_leases)
-    .with_secret_store(Arc::clone(&secret_store))
-    .with_turn_run_wake_notifier(config.turn_run_wake_notifier)
-    .with_filesystem_run_state(Arc::clone(&scoped_filesystem))
-    .with_filesystem_turn_state_store(Arc::clone(&scoped_filesystem))
-    .with_run_profile_resolver(Arc::new(
-        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()?,
-    ))
-    .with_reborn_event_store_config(RebornProfile::Production, config.event_store)
-    .await?;
-    let services =
-        crate::factory::apply_production_runtime_process_binding(services, process_binding);
-
-    // safety: `with_secret_store` is called unconditionally above on the same
-    // builder chain, so `try_with_host_http_egress` can only return a
-    // `Missing(SecretStore)` wiring report if the host-runtime builder API
-    // regresses; treat that as infallible here.
-    let services = services
-        .try_with_host_http_egress_with_body_store(
-            PolicyNetworkHttpEgress::new(ReqwestNetworkTransport::default()),
-            Arc::clone(&scoped_filesystem),
-        )
-        .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
-
-    Ok(services)
-}
-
-/// Build the per-process [`SecretStore`] over the shared
-/// [`ScopedFilesystem`].
-///
-/// Backend selection is now a property of the underlying
-/// [`RootFilesystem`] (libSQL/Postgres/in-memory), not of the secret store
-/// itself — see "Legacy per-backend store cleanup" in
-/// `docs/plans/2026-05-16-scoped-filesystem-tenant-isolation.md`. The
-/// startup readiness check
-/// ([`FilesystemSecretStore::verify_can_decrypt_existing_secrets`])
-/// preserves the same fail-loud-on-master-key-mismatch contract the deleted
-/// libSQL/Postgres backends carried.
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-async fn build_filesystem_secret_store<F>(
-    scoped_filesystem: Arc<ScopedFilesystem<F>>,
-    master_key: Option<SecretMaterial>,
-) -> Result<Arc<SharedSecretStore>, RebornCompositionError>
-where
-    F: RootFilesystem + 'static,
-{
-    let crypto = secrets_crypto(master_key).await?;
-    build_filesystem_secret_store_with_crypto(scoped_filesystem, crypto)
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-fn build_filesystem_secret_store_with_crypto<F>(
-    scoped_filesystem: Arc<ScopedFilesystem<F>>,
-    crypto: Arc<SecretsCrypto>,
-) -> Result<Arc<SharedSecretStore>, RebornCompositionError>
-where
-    F: RootFilesystem + 'static,
-{
-    let store = FilesystemSecretStore::new(scoped_filesystem, crypto);
-    // The FS-stored master-key sentinel was removed alongside the tenant-aware
-    // ScopedFilesystem rework — see filesystem_store.rs. Master-key
-    // correctness is verified on first per-tenant decrypt op.
-    let store: Arc<dyn SecretStore> = Arc::new(store);
-    Ok(Arc::new(SharedSecretStore::new(store)))
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-async fn secrets_crypto(
-    master_key: Option<SecretMaterial>,
-) -> Result<Arc<SecretsCrypto>, RebornCompositionError> {
-    let master_key = resolve_composition_secret_master_key(master_key).await?;
-    Ok(Arc::new(SecretsCrypto::new(master_key)?))
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-async fn resolve_composition_secret_master_key(
-    explicit: Option<SecretMaterial>,
-) -> Result<SecretMaterial, RebornCompositionError> {
-    if let Some(master_key) = explicit {
-        Ok(master_key)
-    } else if let Some(master_key) =
-        ironclaw_secrets::keychain::resolve_master_key_material().await?
-    {
-        Ok(master_key)
-    } else {
-        Err(RebornCompositionError::MissingSecretMasterKey)
-    }
-}
-
-// TODO(#3571): remove this adapter when the host-runtime services builder
-// accepts `Arc<dyn SecretStore>` directly. Until then, this newtype lets the
-// composition root pass a single concrete `SecretStore` impl to both the
-// substrate wiring and any future per-store adapters.
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-#[derive(Clone)]
-struct SharedSecretStore {
-    inner: Arc<dyn SecretStore>,
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-impl SharedSecretStore {
-    fn new(inner: Arc<dyn SecretStore>) -> Self {
-        Self { inner }
-    }
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-#[async_trait]
-impl SecretStore for SharedSecretStore {
-    async fn put(
-        &self,
-        scope: ResourceScope,
-        handle: SecretHandle,
-        material: SecretMaterial,
-    ) -> Result<SecretMetadata, SecretStoreError> {
-        self.inner.put(scope, handle, material).await
-    }
-
-    async fn metadata(
-        &self,
-        scope: &ResourceScope,
-        handle: &SecretHandle,
-    ) -> Result<Option<SecretMetadata>, SecretStoreError> {
-        self.inner.metadata(scope, handle).await
-    }
-
-    async fn delete(
-        &self,
-        scope: &ResourceScope,
-        handle: &SecretHandle,
-    ) -> Result<bool, SecretStoreError> {
-        self.inner.delete(scope, handle).await
-    }
-
-    async fn lease_once(
-        &self,
-        scope: &ResourceScope,
-        handle: &SecretHandle,
-    ) -> Result<SecretLease, SecretStoreError> {
-        self.inner.lease_once(scope, handle).await
-    }
-
-    async fn consume(
-        &self,
-        scope: &ResourceScope,
-        lease_id: SecretLeaseId,
-    ) -> Result<SecretMaterial, SecretStoreError> {
-        self.inner.consume(scope, lease_id).await
-    }
-
-    async fn revoke(
-        &self,
-        scope: &ResourceScope,
-        lease_id: SecretLeaseId,
-    ) -> Result<SecretLease, SecretStoreError> {
-        self.inner.revoke(scope, lease_id).await
-    }
-
-    async fn leases_for_scope(
-        &self,
-        scope: &ResourceScope,
-    ) -> Result<Vec<SecretLease>, SecretStoreError> {
-        self.inner.leases_for_scope(scope).await
-    }
+    factory::build_postgres_production_host_runtime_services(config).await
 }
 
 #[cfg(all(test, any(feature = "libsql", feature = "postgres")))]
@@ -940,6 +689,7 @@ mod two_tenant_isolation_tests {
     use super::*;
     use ironclaw_filesystem::InMemoryBackend;
     use ironclaw_host_api::{AgentId, InvocationId, ProjectId, SecretHandle, TenantId, UserId};
+    use ironclaw_secrets::{FilesystemSecretStore, SecretMaterial, SecretStore, SecretsCrypto};
     use secrecy::ExposeSecret;
 
     fn scope(tenant: &str, user: &str) -> ResourceScope {

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use std::sync::Arc;
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[cfg(feature = "libsql")]
 use chrono::Utc;
 #[cfg(feature = "postgres")]
 use deadpool_postgres::tokio_postgres;
@@ -12,13 +12,13 @@ use ironclaw_auth::{OAuthClientId, OAuthRedirectUri};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{
     AuditMode, DeploymentMode, EffectKind, FilesystemBackendKind, NetworkMode, PackageId,
-    ProcessBackendKind, RuntimeKind, RuntimeProfile, SecretMode, UserId,
+    ProcessBackendKind, RuntimeKind, RuntimeProfile, SecretMode,
     runtime_policy::{ApprovalPolicy, EffectiveRuntimePolicy},
 };
 #[cfg(feature = "libsql")]
 use ironclaw_host_api::{
     CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, ExecutionContext, ExtensionId,
-    GrantConstraints, MountView, NetworkPolicy, Principal, TrustClass,
+    GrantConstraints, MountView, NetworkPolicy, Principal, TrustClass, UserId,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_host_runtime::{CapabilitySurfacePolicy, SurfaceKind, VisibleCapabilityRequest};
@@ -27,11 +27,9 @@ use ironclaw_host_runtime::{
     SchedulerTurnRunWakeNotifier, TurnRunExecutor, TurnRunExecutorError, TurnRunScheduler,
     TurnRunSchedulerConfig, TurnRunSchedulerHandle,
 };
-#[cfg(all(feature = "postgres", not(feature = "libsql")))]
-use ironclaw_reborn_composition::RebornCompositionProfile;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_reborn_composition::RebornRuntimeProcessBinding;
 #[cfg(feature = "libsql")]
+use ironclaw_reborn_composition::RebornRuntimeProcessBinding;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_reborn_composition::{RebornBuildError, RebornCompositionProfile};
 use ironclaw_reborn_composition::{
     RebornBuildInput, RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest,
@@ -368,7 +366,7 @@ async fn local_dev_builds_facades_without_production_claim() {
     assert!(services.product_auth.is_some());
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[cfg(feature = "libsql")]
 fn test_sandbox_process_binding() -> RebornRuntimeProcessBinding {
     let process_port = Arc::new(ironclaw_host_runtime::TenantSandboxProcessPort::new(
         Arc::new(ProductionReadySandboxTransport),
@@ -376,11 +374,11 @@ fn test_sandbox_process_binding() -> RebornRuntimeProcessBinding {
     RebornRuntimeProcessBinding::tenant_sandbox(process_port)
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[cfg(feature = "libsql")]
 #[derive(Debug)]
 struct ProductionReadySandboxTransport;
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[cfg(feature = "libsql")]
 #[async_trait::async_trait]
 impl ironclaw_host_runtime::SandboxCommandTransport for ProductionReadySandboxTransport {
     async fn run_command(
@@ -787,10 +785,37 @@ async fn production_libsql_resolved_secret_master_key_rejects_invalid_env_key() 
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
-#[ignore = "TODO(#3856): restore when tenant sandbox process-port wiring exists"]
 async fn production_libsql_services_wire_first_party_runtime_http_egress() {
-    // Restore the ProductionValidated readiness and host_runtime.health()
-    // happy-path assertions that are temporarily fail-closed below.
+    let dir = tempfile::tempdir().unwrap();
+    let db = libsql_db_at(dir.path().join("reborn.db")).await;
+    let (notifier, handle) = live_wake_notifier();
+
+    let result = build_reborn_services(
+        RebornBuildInput::libsql(
+            RebornCompositionProfile::Production,
+            "test-owner",
+            db,
+            dir.path().join("events.db").to_string_lossy(),
+            None,
+            test_master_key(),
+        )
+        .with_production_trust_policy(production_trust_policy())
+        .with_runtime_policy(production_runtime_policy())
+        .with_turn_run_wake_notifier(notifier)
+        .with_runtime_process_binding(test_sandbox_process_binding()),
+    )
+    .await;
+
+    handle.shutdown().await;
+
+    let services =
+        result.expect("production libsql services should build with a sandbox process binding");
+    assert_eq!(
+        services.readiness.state,
+        RebornReadinessState::ProductionValidated
+    );
+    assert!(services.host_runtime.is_some());
+    assert!(services.turn_coordinator.is_some());
 }
 
 #[cfg(feature = "postgres")]
@@ -876,10 +901,37 @@ async fn production_postgres_services_require_process_port_for_first_party_runti
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
-#[ignore = "TODO(#3856): restore when tenant sandbox process-port wiring exists"]
 async fn migration_dry_run_validates_libsql_shape() {
-    // Restore the MigrationDryRunValidated readiness and planned-profile
-    // submit_turn assertions that are temporarily fail-closed below.
+    let dir = tempfile::tempdir().unwrap();
+    let db = libsql_db_at(dir.path().join("reborn.db")).await;
+    let (notifier, handle) = live_wake_notifier();
+
+    let result = build_reborn_services(
+        RebornBuildInput::libsql(
+            RebornCompositionProfile::MigrationDryRun,
+            "test-owner",
+            db,
+            dir.path().join("events.db").to_string_lossy(),
+            None,
+            test_master_key(),
+        )
+        .with_production_trust_policy(production_trust_policy())
+        .with_runtime_policy(production_runtime_policy())
+        .with_turn_run_wake_notifier(notifier)
+        .with_runtime_process_binding(test_sandbox_process_binding()),
+    )
+    .await;
+
+    handle.shutdown().await;
+
+    let services = result
+        .expect("migration dry-run libsql services should build with a sandbox process binding");
+    assert_eq!(
+        services.readiness.state,
+        RebornReadinessState::MigrationDryRunValidated
+    );
+    assert!(services.host_runtime.is_some());
+    assert!(services.turn_coordinator.is_some());
 }
 
 #[cfg(feature = "postgres")]
@@ -903,7 +955,7 @@ async fn migration_dry_run_requires_libsql_process_port_for_first_party_runtime(
             RebornCompositionProfile::MigrationDryRun,
             "test-owner",
             db,
-            db_path.to_string_lossy(),
+            dir.path().join("events.db").to_string_lossy(),
             None,
             test_master_key(),
         )

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -11,9 +11,8 @@ use deadpool_postgres::tokio_postgres;
 use ironclaw_auth::{OAuthClientId, OAuthRedirectUri};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{
-    AgentId, AuditMode, DeploymentMode, EffectKind, FilesystemBackendKind, NetworkMode, PackageId,
-    ProcessBackendKind, ProjectId, RuntimeKind, RuntimeProfile, SecretMode, TenantId, ThreadId,
-    UserId,
+    AuditMode, DeploymentMode, EffectKind, FilesystemBackendKind, NetworkMode, PackageId,
+    ProcessBackendKind, RuntimeKind, RuntimeProfile, SecretMode, UserId,
     runtime_policy::{ApprovalPolicy, EffectiveRuntimePolicy},
 };
 #[cfg(feature = "libsql")]
@@ -28,8 +27,6 @@ use ironclaw_host_runtime::{
     SchedulerTurnRunWakeNotifier, TurnRunExecutor, TurnRunExecutorError, TurnRunScheduler,
     TurnRunSchedulerConfig, TurnRunSchedulerHandle,
 };
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_reborn::planned_driver_factory::PLANNED_DEFAULT_PROFILE_ID;
 #[cfg(all(feature = "postgres", not(feature = "libsql")))]
 use ironclaw_reborn_composition::RebornCompositionProfile;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -48,9 +45,7 @@ use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPoli
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_turns::{
-    AcceptedMessageRef, IdempotencyKey, InMemoryTurnStateStore, ReplyTargetBindingRef,
-    RunProfileRequest, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor,
-    TurnScope,
+    InMemoryTurnStateStore,
     runner::{ClaimedTurnRun, TurnRunTransitionPort},
 };
 use secrecy::SecretString;
@@ -269,29 +264,6 @@ async fn libsql_db_at(path: impl AsRef<std::path::Path>) -> Arc<libsql::Database
             .await
             .unwrap(),
     )
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-fn submit_turn_request(thread: &str, idempotency_key: &str) -> SubmitTurnRequest {
-    SubmitTurnRequest {
-        scope: TurnScope::new(
-            TenantId::new("tenant1").unwrap(),
-            Some(AgentId::new("agent1").unwrap()),
-            Some(ProjectId::new("project1").unwrap()),
-            ThreadId::new(thread).unwrap(),
-        ),
-        actor: TurnActor::new(UserId::new("user1").unwrap()),
-        accepted_message_ref: AcceptedMessageRef::new(format!("message-{thread}")).unwrap(),
-        source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
-        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
-        requested_run_profile: Some(RunProfileRequest::new("default").unwrap()),
-        idempotency_key: IdempotencyKey::new(idempotency_key).unwrap(),
-        received_at: Utc::now(),
-        requested_run_id: None,
-        parent_run_id: None,
-        subagent_depth: 0,
-        spawn_tree_root_run_id: None,
-    }
 }
 
 #[cfg(feature = "postgres")]
@@ -815,13 +787,29 @@ async fn production_libsql_resolved_secret_master_key_rejects_invalid_env_key() 
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+#[ignore = "TODO(#3856): restore when tenant sandbox process-port wiring exists"]
 async fn production_libsql_services_wire_first_party_runtime_http_egress() {
+    // Restore the ProductionValidated readiness and host_runtime.health()
+    // happy-path assertions that are temporarily fail-closed below.
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+#[ignore = "TODO(#3856): restore when tenant sandbox process-port wiring exists"]
+async fn production_postgres_services_wire_first_party_runtime_http_egress() {
+    // Restore the ProductionValidated readiness and host_runtime.health()
+    // happy-path assertions that are temporarily fail-closed below.
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn production_libsql_services_require_process_port_for_first_party_runtime() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("reborn.db");
     let db = libsql_db_at(&db_path).await;
     let (notifier, handle) = live_wake_notifier();
 
-    let services = build_reborn_services(
+    let result = build_reborn_services(
         RebornBuildInput::libsql(
             RebornCompositionProfile::Production,
             "test-owner",
@@ -833,42 +821,31 @@ async fn production_libsql_services_wire_first_party_runtime_http_egress() {
         .with_production_trust_policy(production_trust_policy())
         .with_runtime_policy(production_runtime_policy())
         .with_turn_run_wake_notifier(notifier)
-        .with_runtime_process_binding(test_sandbox_process_binding())
         .with_required_runtime_backends([RuntimeKind::FirstParty])
         .require_runtime_http_egress(),
     )
-    .await
-    .unwrap();
-
-    let health = services
-        .host_runtime
-        .as_ref()
-        .expect("production must expose host runtime")
-        .health()
-        .await
-        .unwrap();
+    .await;
 
     handle.shutdown().await;
 
-    assert_eq!(
-        services.readiness.state,
-        RebornReadinessState::ProductionValidated
-    );
+    let Err(RebornBuildError::InvalidConfig { reason }) = result else {
+        panic!("expected production first-party runtime to require a process port, got {result:?}");
+    };
     assert!(
-        health.ready,
-        "first-party runtime and production HTTP egress should satisfy production wiring: {health:?}"
+        reason.contains("tenant sandbox process binding"),
+        "first-party shell capability should keep production wiring fail-closed until a tenant sandbox process port is configured: {reason}"
     );
 }
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
-async fn production_postgres_services_wire_first_party_runtime_http_egress() {
+async fn production_postgres_services_require_process_port_for_first_party_runtime() {
     let Some((_container, pool, database_url)) = postgres_pool_or_skip().await else {
         return;
     };
     let (notifier, handle) = live_wake_notifier();
 
-    let services = build_reborn_services(
+    let result = build_reborn_services(
         RebornBuildInput::postgres(
             RebornCompositionProfile::Production,
             "test-owner",
@@ -879,93 +856,83 @@ async fn production_postgres_services_wire_first_party_runtime_http_egress() {
         .with_production_trust_policy(production_trust_policy())
         .with_runtime_policy(production_runtime_policy())
         .with_turn_run_wake_notifier(notifier)
-        .with_runtime_process_binding(test_sandbox_process_binding())
         .with_required_runtime_backends([RuntimeKind::FirstParty])
         .require_runtime_http_egress(),
     )
-    .await
-    .unwrap();
-
-    let health = services
-        .host_runtime
-        .as_ref()
-        .expect("production must expose host runtime")
-        .health()
-        .await
-        .unwrap();
+    .await;
 
     handle.shutdown().await;
 
-    assert_eq!(
-        services.readiness.state,
-        RebornReadinessState::ProductionValidated
-    );
+    let Err(RebornBuildError::InvalidConfig { reason }) = result else {
+        panic!(
+            "expected postgres production first-party runtime to require a process port, got {result:?}"
+        );
+    };
     assert!(
-        health.ready,
-        "first-party runtime and production HTTP egress should satisfy Postgres production wiring: {health:?}"
+        reason.contains("tenant sandbox process binding"),
+        "postgres first-party shell capability should keep production wiring fail-closed until a tenant sandbox process port is configured: {reason}"
     );
 }
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+#[ignore = "TODO(#3856): restore when tenant sandbox process-port wiring exists"]
 async fn migration_dry_run_validates_libsql_shape() {
+    // Restore the MigrationDryRunValidated readiness and planned-profile
+    // submit_turn assertions that are temporarily fail-closed below.
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+#[ignore = "TODO(#3856): restore when tenant sandbox process-port wiring exists"]
+async fn migration_dry_run_validates_postgres_planned_turn_profile() {
+    // Restore the MigrationDryRunValidated readiness and planned-profile
+    // submit_turn assertions that are temporarily fail-closed below.
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn migration_dry_run_requires_libsql_process_port_for_first_party_runtime() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("reborn.db");
     let db = libsql_db_at(&db_path).await;
     let (notifier, handle) = live_wake_notifier();
 
-    let services = build_reborn_services(
+    let result = build_reborn_services(
         RebornBuildInput::libsql(
             RebornCompositionProfile::MigrationDryRun,
             "test-owner",
             db,
-            dir.path().join("events.db").to_string_lossy(),
+            db_path.to_string_lossy(),
             None,
             test_master_key(),
         )
         .with_production_trust_policy(production_trust_policy())
         .with_runtime_policy(production_runtime_policy())
-        .with_turn_run_wake_notifier(notifier)
-        .with_runtime_process_binding(test_sandbox_process_binding()),
+        .with_turn_run_wake_notifier(notifier),
     )
-    .await
-    .unwrap();
-
-    let response = services
-        .turn_coordinator
-        .as_ref()
-        .expect("migration dry-run must expose turn coordinator")
-        .submit_turn(submit_turn_request(
-            "thread-planned-profile",
-            "idem-planned-profile",
-        ))
-        .await
-        .unwrap();
-    let SubmitTurnResponse::Accepted {
-        resolved_run_profile_id,
-        ..
-    } = response;
-    assert_eq!(resolved_run_profile_id.as_str(), PLANNED_DEFAULT_PROFILE_ID);
+    .await;
 
     handle.shutdown().await;
 
-    assert_eq!(
-        services.readiness.state,
-        RebornReadinessState::MigrationDryRunValidated
+    let Err(RebornBuildError::InvalidConfig { reason }) = result else {
+        panic!("expected migration dry-run to require a process port, got {result:?}");
+    };
+    assert!(
+        reason.contains("tenant sandbox process binding"),
+        "migration dry-run should keep production-shaped first-party wiring fail-closed until a tenant sandbox process port is configured: {reason}"
     );
-    assert!(services.host_runtime.is_some());
-    assert!(services.turn_coordinator.is_some());
 }
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
-async fn migration_dry_run_validates_postgres_planned_turn_profile() {
+async fn migration_dry_run_requires_postgres_process_port_for_first_party_runtime() {
     let Some((_container, pool, database_url)) = postgres_pool_or_skip().await else {
         return;
     };
     let (notifier, handle) = live_wake_notifier();
 
-    let services = build_reborn_services(
+    let result = build_reborn_services(
         RebornBuildInput::postgres(
             RebornCompositionProfile::MigrationDryRun,
             "test-owner",
@@ -975,34 +942,17 @@ async fn migration_dry_run_validates_postgres_planned_turn_profile() {
         )
         .with_production_trust_policy(production_trust_policy())
         .with_runtime_policy(production_runtime_policy())
-        .with_turn_run_wake_notifier(notifier)
-        .with_runtime_process_binding(test_sandbox_process_binding()),
+        .with_turn_run_wake_notifier(notifier),
     )
-    .await
-    .unwrap();
-
-    let response = services
-        .turn_coordinator
-        .as_ref()
-        .expect("migration dry-run must expose turn coordinator")
-        .submit_turn(submit_turn_request(
-            "thread-postgres-planned-profile",
-            "idem-postgres-planned-profile",
-        ))
-        .await
-        .unwrap();
-    let SubmitTurnResponse::Accepted {
-        resolved_run_profile_id,
-        ..
-    } = response;
-    assert_eq!(resolved_run_profile_id.as_str(), PLANNED_DEFAULT_PROFILE_ID);
+    .await;
 
     handle.shutdown().await;
 
-    assert_eq!(
-        services.readiness.state,
-        RebornReadinessState::MigrationDryRunValidated
+    let Err(RebornBuildError::InvalidConfig { reason }) = result else {
+        panic!("expected postgres migration dry-run to require a process port, got {result:?}");
+    };
+    assert!(
+        reason.contains("tenant sandbox process binding"),
+        "postgres migration dry-run should keep production-shaped first-party wiring fail-closed until a tenant sandbox process port is configured: {reason}"
     );
-    assert!(services.host_runtime.is_some());
-    assert!(services.turn_coordinator.is_some());
 }


### PR DESCRIPTION
## Summary
- Moves filesystem-kernel-aware Reborn production host-runtime assembly into factory-owned helpers.
- Keeps the public libSQL/Postgres substrate APIs in `lib.rs` as thin wrappers that delegate to `factory.rs`.
- Routes facade production and migration-dry-run builders through the same shared factory path while preserving facade-only built-in first-party registration.
- Propagates production HTTP egress wiring failures through `RebornCompositionError` instead of keeping the old wrapper-local `expect` path.
- Adds regression coverage for production-shaped substrate wiring, local-only runtime policy guardrails, and facade fail-closed process-port validation.

Closes #3748.

## Why
PR #3749 was stale because `reborn-integration` now uses the unified `ironclaw_filesystem`/`ScopedFilesystem` kernel path for secrets, leases, resources, run state, turn state, and process stores. The underlying drift still existed, though: production graph assembly lived both in public substrate builders in `lib.rs` and in facade builders in `factory.rs`.

This PR fixes that in the current architecture by making `factory.rs` the single owner of production service graph construction while leaving the public substrate API shape intact.

## Validation
Passed:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p ironclaw_reborn_composition --no-default-features`
- `cargo check -p ironclaw_reborn_composition --features libsql --tests`
- `cargo check -p ironclaw_reborn_composition --features postgres --tests`
- `cargo check -p ironclaw_reborn_composition --features libsql,postgres`
- `cargo check -p ironclaw_reborn_composition --features postgres --tests`
- `cargo clippy -p ironclaw_reborn_composition --features libsql,postgres --tests -- -D warnings`
- `cargo test -p ironclaw_reborn_composition --features libsql --test libsql_substrate`
- `cargo test -p ironclaw_reborn_composition --features libsql --test facade_factory`
- `cargo test -p ironclaw_reborn_composition --features postgres --test postgres_substrate`
- `cargo test -p ironclaw_reborn_composition --features postgres --test facade_factory`
- `cargo test -p ironclaw_reborn_composition --features libsql,postgres --test facade_factory`

Note: production facade and migration-dry-run first-party runtime paths now explicitly assert the existing fail-closed process-port guardrail until tenant sandbox process-port wiring lands.