### PR TITLE
Add near ecosystem summary skill

### DIFF
--- a/skills/near-ecosystem-summary-skill/SKILL.md
+++ b/skills/near-ecosystem-summary-skill/SKILL.md
@@ -1,0 +1,60 @@
+# NEAR Ecosystem Summary Skill
+
+## Name
+near-ecosystem-summary-skill
+
+## Version
+1.0.0
+
+## Purpose
+This IronClaw skill takes NEAR ecosystem update text as input and converts it into a short, clear summary with key points, highlights, and one human-style community comment.
+
+The skill is designed for daily NEAR ecosystem reporting and can highlight updates related to:
+- NEAR Protocol
+- NEAR AI
+- IronClaw
+- NEAR Intents
+- Ecosystem developer activity
+
+## Input
+Plain text containing NEAR ecosystem updates, announcements, development activity, or community discussions.
+
+## Output
+A structured Markdown summary containing:
+1. Key updates
+2. Important highlights
+3. One human-style community comment
+
+## Behavior
+When the skill receives ecosystem update text, it should:
+- Identify the main NEAR ecosystem updates
+- Highlight mentions of IronClaw, NEAR AI, NEAR Protocol, and NEAR Intents
+- Convert the information into simple and clear bullet points
+- Generate one natural community-style comment
+- Keep the output concise and useful for daily reporting
+
+## Example Input
+NEAR AI released updates around IronClaw, encrypted agent execution, NEAR Intents, and ecosystem developer activity. The community is discussing how secure AI agents can help automate Web3 workflows.
+
+## Example Output
+## NEAR Ecosystem Daily Summary
+
+### Key Updates
+- NEAR AI released updates around IronClaw, encrypted agent execution, and NEAR Intents.
+- Ecosystem developer activity is increasing.
+- The community is discussing secure AI agents for Web3 workflow automation.
+
+### Highlights
+- IronClaw supports secure AI agent workflows.
+- NEAR AI is advancing agent infrastructure.
+- NEAR Intents can support cross-chain AI agent operations.
+
+### Community Comment
+NEAR's AI ecosystem is getting more practical with IronClaw, encrypted agent execution, and NEAR Intents. Secure agents could become a strong foundation for real Web3 automation.
+
+## Use Cases
+- Daily NEAR ecosystem reports
+- Community updates
+- Discord or Telegram summaries
+- Developer activity monitoring
+- AI/Web3 ecosystem newsletters

--- a/skills/near-ecosystem-summary-skill/TESTING.md
+++ b/skills/near-ecosystem-summary-skill/TESTING.md
@@ -1,0 +1,46 @@
+# Testing Guide: NEAR Ecosystem Summary Skill
+
+## Skill Name
+near-ecosystem-summary-skill
+
+## Test Purpose
+This document explains how to test the NEAR Ecosystem Summary Skill inside IronClaw.
+
+The goal is to confirm that the skill can:
+- Accept NEAR ecosystem update text as input
+- Generate a short structured summary
+- Highlight IronClaw, NEAR AI, NEAR Protocol, and NEAR Intents mentions
+- Create one human-style community comment
+
+## Sample Test Input
+NEAR AI released updates around IronClaw, encrypted agent execution, NEAR Intents, and ecosystem developer activity. The community is discussing how secure AI agents can help automate Web3 workflows.
+
+## Expected Output
+The skill should return a Markdown summary similar to:
+
+## NEAR Ecosystem Daily Summary
+
+### Key Updates
+- NEAR AI released updates around IronClaw, encrypted agent execution, and NEAR Intents.
+- Ecosystem developer activity is increasing.
+- The community is discussing secure AI agents for Web3 workflow automation.
+
+### Highlights
+- IronClaw supports secure AI agent workflows.
+- NEAR AI is advancing secure AI agent infrastructure.
+- NEAR Intents can support cross-chain AI agent operations.
+
+### Community Comment
+NEAR's AI ecosystem is becoming more useful for real Web3 automation. IronClaw, encrypted execution, and NEAR Intents together make the agent stack feel more practical and secure.
+
+## Actual Test Result
+The skill was tested inside IronClaw using the sample input.
+
+The output successfully included:
+- Key updates
+- Highlights
+- A community-style comment
+- Mentions of IronClaw, NEAR AI, and NEAR Intents
+
+## Status
+Test passed.


### PR DESCRIPTION
## Summary
This PR adds a custom IronClaw skill named `near-ecosystem-summary-skill`.

## Purpose
The skill takes NEAR ecosystem update text as input and converts it into a short, clear summary with key points, highlights for IronClaw/NEAR AI/NEAR Protocol/NEAR Intents mentions, and one human-style community comment.

## Files Added
- `skills/near-ecosystem-summary-skill/SKILL.md`
- `skills/near-ecosystem-summary-skill/TESTING.md`

## Test Example
Input:
NEAR AI released updates around IronClaw, encrypted agent execution, NEAR Intents, and ecosystem developer activity. The community is discussing how secure AI agents can help automate Web3 workflows.

Expected output:
A structured NEAR ecosystem daily summary with key updates, highlights, and a community-style comment.

## Testing
The skill was created and tested inside IronClaw. The test output successfully generated key updates, highlights, and a human-style community comment.