### PR TITLE
feat(reborn): Phase 2 — BlockedAuth resume path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4166,6 +4166,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4809,6 +4810,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/ironclaw_capabilities/Cargo.toml
+++ b/crates/ironclaw_capabilities/Cargo.toml
@@ -24,3 +24,4 @@ ironclaw_events = { path = "../ironclaw_events" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_resources = { path = "../ironclaw_resources" }
 tokio = { version = "1", features = ["macros", "rt"] }
+uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -73,6 +73,12 @@ pub enum CapabilityInvocationError {
         capability: CapabilityId,
         status: RunStatus,
     },
+    #[error("capability {capability} auth resume flow mismatch")]
+    AuthResumeFlowMismatch { capability: CapabilityId },
+    #[error("capability {capability} auth resume fingerprint mismatch")]
+    AuthResumeFingerprintMismatch { capability: CapabilityId },
+    #[error("capability {capability} auth resume was denied")]
+    AuthResumeDenied { capability: CapabilityId },
     #[error("capability {capability} resume context mismatch: {kind:?}")]
     ResumeContextMismatch {
         capability: CapabilityId,

--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -200,6 +200,8 @@ pub(crate) fn run_state_error_kind(error: &RunStateError) -> &'static str {
         RunStateError::UnknownApprovalRequest { .. } => "UnknownApprovalRequest",
         RunStateError::ApprovalRequestAlreadyExists { .. } => "ApprovalRequestAlreadyExists",
         RunStateError::ApprovalNotPending { .. } => "ApprovalNotPending",
+        RunStateError::InvalidStatus { .. } => "InvalidStatus",
+        RunStateError::AuthResumeClaimMismatch { .. } => "AuthResumeClaimMismatch",
         RunStateError::InvalidPath(_) => "InvalidPath",
         RunStateError::Filesystem(_) => "Filesystem",
         RunStateError::Serialization(_) => "Serialization",

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -6,8 +6,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_processes::{ProcessManager, ProcessStart};
 use ironclaw_run_state::{
-    ApprovalRequestStore, ApprovalStatus, RunStart, RunStateApprovalStore, RunStateError,
-    RunStateStore, RunStatus,
+    ApprovalRequestStore, ApprovalStatus, AuthRequiredPayload, RunStart, RunStateApprovalStore,
+    RunStateError, RunStateStore, RunStatus,
 };
 use tracing::warn;
 
@@ -19,11 +19,11 @@ use crate::helpers::{
 };
 use crate::obligations::post_dispatch_obligations;
 use crate::{
-    CapabilityInvocationError, CapabilityInvocationRequest, CapabilityInvocationResult,
-    CapabilityObligationAbortRequest, CapabilityObligationCompletionRequest,
-    CapabilityObligationError, CapabilityObligationHandler, CapabilityObligationOutcome,
-    CapabilityObligationPhase, CapabilityObligationRequest, CapabilityResumeRequest,
-    CapabilitySpawnRequest, CapabilitySpawnResult,
+    CapabilityAuthResumeRequest, CapabilityInvocationError, CapabilityInvocationRequest,
+    CapabilityInvocationResult, CapabilityObligationAbortRequest,
+    CapabilityObligationCompletionRequest, CapabilityObligationError, CapabilityObligationHandler,
+    CapabilityObligationOutcome, CapabilityObligationPhase, CapabilityObligationRequest,
+    CapabilityResumeRequest, CapabilitySpawnRequest, CapabilitySpawnResult,
 };
 
 pub struct CapabilityHost<'a, D>
@@ -792,6 +792,262 @@ where
                 "capability lease consume failed after successful dispatch; lease left in claimed state",
             );
         }
+
+        complete_run_after_side_effect(
+            run_state,
+            &scope,
+            invocation_id,
+            &capability_id,
+            "dispatch",
+        )
+        .await;
+        Ok(CapabilityInvocationResult { dispatch })
+    }
+
+    pub async fn resume_auth_json(
+        &self,
+        request: CapabilityAuthResumeRequest,
+    ) -> Result<CapabilityInvocationResult, CapabilityInvocationError> {
+        let run_state =
+            self.run_state
+                .ok_or_else(|| CapabilityInvocationError::ResumeStoreMissing {
+                    capability: request.capability_id.clone(),
+                    store: "run_state",
+                })?;
+
+        let invocation_id = request.context.invocation_id;
+        let capability_id = request.capability_id.clone();
+        let scope = request.context.resource_scope.clone();
+        if request.context.validate().is_err() {
+            return Err(CapabilityInvocationError::AuthorizationDenied {
+                capability: request.capability_id,
+                reason: DenyReason::InternalInvariantViolation,
+            });
+        }
+
+        let invocation_fingerprint = invocation_fingerprint_for_kind(
+            CapabilityActionKind::Dispatch,
+            &scope,
+            &request.capability_id,
+            &request.estimate,
+            &request.input,
+        )
+        .map_err(|source| CapabilityInvocationError::InvocationFingerprint {
+            capability: request.capability_id.clone(),
+            source,
+        })?;
+
+        let run_record = run_state
+            .get(&scope, invocation_id)
+            .await?
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        if run_record.status != RunStatus::BlockedAuth {
+            return Err(CapabilityInvocationError::ResumeNotBlocked {
+                capability: request.capability_id,
+                status: run_record.status,
+            });
+        }
+        if run_record.capability_id != request.capability_id {
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "ResumeContextMismatch",
+            )
+            .await;
+            return Err(CapabilityInvocationError::ResumeContextMismatch {
+                capability: request.capability_id,
+                kind: crate::ResumeContextMismatchKind::CapabilityId,
+            });
+        }
+        let payload: AuthRequiredPayload =
+            serde_json::from_value(run_record.blocked_payload.ok_or_else(|| {
+                CapabilityInvocationError::RunState(Box::new(RunStateError::Deserialization(
+                    "BlockedAuth payload missing".to_string(),
+                )))
+            })?)
+            .map_err(|error| {
+                CapabilityInvocationError::RunState(Box::new(RunStateError::Deserialization(
+                    error.to_string(),
+                )))
+            })?;
+        if request.outcome.flow_id != payload.flow_id {
+            fail_run_if_configured(Some(run_state), &scope, invocation_id, "AuthFlowMismatch")
+                .await;
+            return Err(CapabilityInvocationError::AuthResumeFlowMismatch {
+                capability: request.capability_id,
+            });
+        }
+        if payload.invocation_fingerprint != invocation_fingerprint {
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "AuthResumeFingerprintMismatch",
+            )
+            .await;
+            return Err(CapabilityInvocationError::AuthResumeFingerprintMismatch {
+                capability: request.capability_id,
+            });
+        }
+        if !request.outcome.success {
+            fail_run_if_configured(Some(run_state), &scope, invocation_id, "AuthDenied").await;
+            return Err(CapabilityInvocationError::AuthResumeDenied {
+                capability: request.capability_id,
+            });
+        }
+
+        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+            fail_run_if_configured(Some(run_state), &scope, invocation_id, "UnknownCapability")
+                .await;
+            return Err(CapabilityInvocationError::UnknownCapability {
+                capability: request.capability_id,
+            });
+        };
+
+        let obligations = match self
+            .authorizer
+            .authorize_dispatch_with_trust(
+                &request.context,
+                descriptor,
+                &request.estimate,
+                &request.trust_decision,
+            )
+            .await
+        {
+            Decision::Allow {
+                obligations: allowed_obligations,
+            } => allowed_obligations.into_vec(),
+            Decision::Deny { reason } => {
+                fail_run_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(CapabilityInvocationError::AuthorizationDenied {
+                    capability: request.capability_id,
+                    reason,
+                });
+            }
+            Decision::RequireApproval { .. } => {
+                fail_run_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationRequiresApproval",
+                )
+                .await;
+                return Err(CapabilityInvocationError::AuthorizationRequiresApproval {
+                    capability: request.capability_id,
+                });
+            }
+        };
+
+        match run_state
+            .claim_auth_resume(
+                &scope,
+                invocation_id,
+                request.outcome.flow_id,
+                &invocation_fingerprint,
+            )
+            .await
+        {
+            Ok(_) => {}
+            Err(RunStateError::InvalidStatus { actual, .. }) => {
+                return Err(CapabilityInvocationError::ResumeNotBlocked {
+                    capability: request.capability_id,
+                    status: actual,
+                });
+            }
+            Err(error) => return Err(CapabilityInvocationError::RunState(Box::new(error))),
+        }
+
+        let obligation_outcome = match self
+            .prepare_obligations(
+                CapabilityObligationPhase::Resume,
+                &request.context,
+                &request.capability_id,
+                &request.estimate,
+                obligations.clone(),
+            )
+            .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                fail_run_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    obligation_invocation_error_kind(&error),
+                )
+                .await;
+                return Err(error);
+            }
+        };
+
+        let dispatch = match self
+            .dispatcher
+            .dispatch_json(CapabilityDispatchRequest {
+                capability_id: request.capability_id.clone(),
+                scope: scope.clone(),
+                estimate: request.estimate.clone(),
+                mounts: obligation_outcome.mounts.clone(),
+                resource_reservation: obligation_outcome.resource_reservation.clone(),
+                input: request.input,
+            })
+            .await
+        {
+            Ok(dispatch) => dispatch,
+            Err(error) => {
+                self.abort_obligations(
+                    CapabilityObligationPhase::Resume,
+                    &request.context,
+                    &request.capability_id,
+                    &request.estimate,
+                    obligations.as_slice(),
+                    &obligation_outcome,
+                )
+                .await;
+                fail_run_if_configured(Some(run_state), &scope, invocation_id, "Dispatch").await;
+                return Err(CapabilityInvocationError::from(error));
+            }
+        };
+
+        let dispatch = match self
+            .complete_dispatch_obligations(
+                CapabilityObligationPhase::Resume,
+                &request.context,
+                &request.capability_id,
+                &request.estimate,
+                obligations.as_slice(),
+                &dispatch,
+            )
+            .await
+        {
+            Ok(dispatch) => dispatch,
+            Err(error) => {
+                let cleanup_outcome = CapabilityObligationOutcome::default();
+                self.abort_obligations(
+                    CapabilityObligationPhase::Resume,
+                    &request.context,
+                    &request.capability_id,
+                    &request.estimate,
+                    obligations.as_slice(),
+                    &cleanup_outcome,
+                )
+                .await;
+                fail_run_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    obligation_invocation_error_kind(&error),
+                )
+                .await;
+                return Err(error);
+            }
+        };
 
         complete_run_after_side_effect(
             run_state,

--- a/crates/ironclaw_capabilities/src/lib.rs
+++ b/crates/ironclaw_capabilities/src/lib.rs
@@ -25,6 +25,6 @@ pub use obligations::{
     CapabilityObligationOutcome, CapabilityObligationPhase, CapabilityObligationRequest,
 };
 pub use requests::{
-    CapabilityInvocationRequest, CapabilityInvocationResult, CapabilityResumeRequest,
-    CapabilitySpawnRequest, CapabilitySpawnResult,
+    CapabilityAuthResumeRequest, CapabilityInvocationRequest, CapabilityInvocationResult,
+    CapabilityResumeRequest, CapabilitySpawnRequest, CapabilitySpawnResult,
 };

--- a/crates/ironclaw_capabilities/src/requests.rs
+++ b/crates/ironclaw_capabilities/src/requests.rs
@@ -2,6 +2,7 @@ use ironclaw_host_api::{
     ApprovalRequestId, CapabilityDispatchResult, CapabilityId, ExecutionContext, ResourceEstimate,
 };
 use ironclaw_processes::ProcessRecord;
+use ironclaw_run_state::OAuthCallbackOutcome;
 use ironclaw_trust::TrustDecision;
 use serde_json::Value;
 
@@ -18,6 +19,17 @@ pub struct CapabilityInvocationRequest {
 pub struct CapabilityResumeRequest {
     pub context: ExecutionContext,
     pub approval_request_id: ApprovalRequestId,
+    pub capability_id: CapabilityId,
+    pub estimate: ResourceEstimate,
+    pub input: Value,
+    pub trust_decision: TrustDecision,
+}
+
+/// Caller-facing auth-blocked capability resume request.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CapabilityAuthResumeRequest {
+    pub context: ExecutionContext,
+    pub outcome: OAuthCallbackOutcome,
     pub capability_id: CapabilityId,
     pub estimate: ResourceEstimate,
     pub input: Value,

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -8,6 +8,7 @@ use ironclaw_capabilities::*;
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
 use serde_json::json;
+use uuid::Uuid;
 
 mod support;
 use support::*;
@@ -217,6 +218,250 @@ async fn capability_host_leaves_run_blocked_when_resume_is_attempted_before_appr
     assert_eq!(run.status, RunStatus::BlockedApproval);
     assert_eq!(run.approval_request_id, Some(approval_id));
     assert_eq!(run.error_kind, None);
+}
+
+#[tokio::test]
+async fn capability_host_resumes_blocked_auth_after_matching_oauth_callback() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let run_state = InMemoryRunStateStore::new();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let flow_id = Uuid::new_v4();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "auth complete"});
+    let fingerprint =
+        InvocationFingerprint::for_dispatch(&scope, &capability_id(), &estimate, &input).unwrap();
+    run_state
+        .start(RunStart {
+            invocation_id,
+            capability_id: capability_id(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    run_state
+        .block_auth_required(&scope, invocation_id, auth_payload(flow_id, fingerprint))
+        .await
+        .unwrap();
+
+    let authorizer = GrantAuthorizer::new();
+    let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
+    let result = host
+        .resume_auth_json(CapabilityAuthResumeRequest {
+            context,
+            outcome: OAuthCallbackOutcome {
+                flow_id,
+                success: true,
+            },
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert!(dispatcher.has_request());
+    let request = dispatcher.take_request();
+    assert_eq!(request.capability_id, capability_id());
+    assert_eq!(request.input, input);
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Completed);
+    assert_eq!(run.blocked_payload, None);
+}
+
+#[tokio::test]
+async fn capability_host_rejects_blocked_auth_resume_with_mutated_input() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let run_state = InMemoryRunStateStore::new();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let flow_id = Uuid::new_v4();
+    let estimate = ResourceEstimate::default();
+    let original_input = json!({"message": "auth complete"});
+    let fingerprint =
+        InvocationFingerprint::for_dispatch(&scope, &capability_id(), &estimate, &original_input)
+            .unwrap();
+    run_state
+        .start(RunStart {
+            invocation_id,
+            capability_id: capability_id(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    run_state
+        .block_auth_required(&scope, invocation_id, auth_payload(flow_id, fingerprint))
+        .await
+        .unwrap();
+
+    let authorizer = GrantAuthorizer::new();
+    let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
+    let err = host
+        .resume_auth_json(CapabilityAuthResumeRequest {
+            context,
+            outcome: OAuthCallbackOutcome {
+                flow_id,
+                success: true,
+            },
+            capability_id: capability_id(),
+            estimate,
+            input: json!({"message": "mutated"}),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::AuthResumeFingerprintMismatch { .. }
+    ));
+    assert!(!dispatcher.has_request());
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(
+        run.error_kind.as_deref(),
+        Some("AuthResumeFingerprintMismatch")
+    );
+}
+
+#[tokio::test]
+async fn capability_host_claims_blocked_auth_before_dispatching_resume() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(BlockingDispatcher::default());
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let authorizer = Arc::new(GrantAuthorizer::new());
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let flow_id = Uuid::new_v4();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "auth complete"});
+    let fingerprint =
+        InvocationFingerprint::for_dispatch(&scope, &capability_id(), &estimate, &input).unwrap();
+    run_state
+        .start(RunStart {
+            invocation_id,
+            capability_id: capability_id(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    run_state
+        .block_auth_required(&scope, invocation_id, auth_payload(flow_id, fingerprint))
+        .await
+        .unwrap();
+
+    let request = CapabilityAuthResumeRequest {
+        context,
+        outcome: OAuthCallbackOutcome {
+            flow_id,
+            success: true,
+        },
+        capability_id: capability_id(),
+        estimate,
+        input,
+        trust_decision: trust_decision(),
+    };
+    let first = tokio::spawn({
+        let registry = registry.clone();
+        let dispatcher = dispatcher.clone();
+        let run_state = run_state.clone();
+        let authorizer = authorizer.clone();
+        let request = request.clone();
+        async move {
+            let host =
+                CapabilityHost::new(registry.as_ref(), dispatcher.as_ref(), authorizer.as_ref())
+                    .with_run_state(run_state.as_ref());
+            host.resume_auth_json(request).await
+        }
+    });
+    dispatcher.entered.notified().await;
+
+    let second = {
+        let host = CapabilityHost::new(registry.as_ref(), dispatcher.as_ref(), authorizer.as_ref())
+            .with_run_state(run_state.as_ref());
+        host.resume_auth_json(request).await.unwrap_err()
+    };
+    assert!(matches!(
+        second,
+        CapabilityInvocationError::ResumeNotBlocked {
+            status: RunStatus::Running,
+            ..
+        }
+    ));
+    dispatcher.release.notify_waiters();
+    first.await.unwrap().unwrap();
+
+    assert_eq!(dispatcher.calls(), 1);
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Completed);
+}
+
+#[tokio::test]
+async fn capability_host_rejects_blocked_auth_resume_for_wrong_flow() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let run_state = InMemoryRunStateStore::new();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let flow_id = Uuid::new_v4();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "wrong flow"});
+    let fingerprint =
+        InvocationFingerprint::for_dispatch(&scope, &capability_id(), &estimate, &input).unwrap();
+    run_state
+        .start(RunStart {
+            invocation_id,
+            capability_id: capability_id(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    run_state
+        .block_auth_required(&scope, invocation_id, auth_payload(flow_id, fingerprint))
+        .await
+        .unwrap();
+
+    let authorizer = GrantAuthorizer::new();
+    let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
+    let err = host
+        .resume_auth_json(CapabilityAuthResumeRequest {
+            context,
+            outcome: OAuthCallbackOutcome {
+                flow_id: Uuid::new_v4(),
+                success: true,
+            },
+            capability_id: capability_id(),
+            estimate,
+            input,
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::AuthResumeFlowMismatch { .. }
+    ));
+    assert!(!dispatcher.has_request());
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.error_kind.as_deref(), Some("AuthFlowMismatch"));
 }
 
 #[tokio::test]
@@ -1257,6 +1502,45 @@ impl CapabilityDispatcher for FailingDispatcher {
     }
 }
 
+#[derive(Default)]
+struct BlockingDispatcher {
+    calls: AtomicUsize,
+    entered: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+impl BlockingDispatcher {
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl CapabilityDispatcher for BlockingDispatcher {
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.entered.notify_waiters();
+        self.release.notified().await;
+        Ok(CapabilityDispatchResult {
+            capability_id: request.capability_id,
+            provider: extension_id(),
+            runtime: RuntimeKind::Wasm,
+            output: json!({"ok": true}),
+            usage: ResourceUsage::default(),
+            receipt: ResourceReceipt {
+                id: ResourceReservationId::new(),
+                scope: request.scope,
+                status: ReservationStatus::Reconciled,
+                estimate: request.estimate,
+                actual: Some(ResourceUsage::default()),
+            },
+        })
+    }
+}
+
 struct MismatchedApprovalRequestAuthorizer {
     mismatch: ApprovalRequestMismatch,
 }
@@ -1386,6 +1670,21 @@ struct RecordingCombinedRunStateApprovalStore {
     separate_save_calls: AtomicUsize,
 }
 
+fn auth_payload(
+    flow_id: Uuid,
+    invocation_fingerprint: InvocationFingerprint,
+) -> AuthRequiredPayload {
+    AuthRequiredPayload {
+        provider_id: "google".to_string(),
+        credential_name: "google_oauth_token".to_string(),
+        missing_scopes: vec!["calendar.readonly".to_string()],
+        oauth_url: "https://accounts.example.test/oauth".to_string(),
+        flow_id,
+        extension_id: ExtensionId::new("echo").unwrap(),
+        invocation_fingerprint,
+    }
+}
+
 impl RecordingCombinedRunStateApprovalStore {
     fn new() -> Self {
         Self {
@@ -1429,6 +1728,29 @@ impl RunStateStore for RecordingCombinedRunStateApprovalStore {
         error_kind: String,
     ) -> Result<RunRecord, RunStateError> {
         self.runs.block_auth(scope, invocation_id, error_kind).await
+    }
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: Uuid,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
     }
 
     async fn complete(
@@ -1573,6 +1895,29 @@ impl RunStateStore for FailCompleteRunStateStore {
             .await
     }
 
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: Uuid,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
+    }
+
     async fn complete(
         &self,
         _scope: &ResourceScope,
@@ -1645,6 +1990,29 @@ impl RunStateStore for FailBlockApprovalRunStateStore {
     ) -> Result<RunRecord, RunStateError> {
         self.inner
             .block_auth(scope, invocation_id, error_kind)
+            .await
+    }
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: Uuid,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
             .await
     }
 
@@ -1723,6 +2091,29 @@ impl RunStateStore for CompleteNotifyingRunStateStore {
             .await
     }
 
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: Uuid,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
+    }
+
     async fn complete(
         &self,
         scope: &ResourceScope,
@@ -1795,6 +2186,29 @@ impl RunStateStore for FailOnFailRunStateStore {
     ) -> Result<RunRecord, RunStateError> {
         self.inner
             .block_auth(scope, invocation_id, error_kind)
+            .await
+    }
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: Uuid,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
             .await
     }
 

--- a/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
@@ -312,6 +312,29 @@ impl RunStateStore for FailCompleteRunStateStore {
             .await
     }
 
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
+    }
+
     async fn complete(
         &self,
         _scope: &ResourceScope,

--- a/crates/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/ironclaw_capabilities/tests/support/mod.rs
@@ -228,6 +228,7 @@ pub fn extension_id() -> ExtensionId {
 }
 
 const ECHO_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
 id = "echo"
 name = "Echo"
 version = "0.1.0"
@@ -243,5 +244,8 @@ id = "echo.say"
 description = "Echoes input"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = {}
+visibility = "model"
+input_schema_ref = "schemas/echo.input.v1.json"
+output_schema_ref = "schemas/echo.output.v1.json"
+prompt_doc_ref = "prompts/echo.md"
 "#;

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -948,6 +948,8 @@ fn unavailable_from_run_state(error: RunStateError) -> HostRuntimeError {
         RunStateError::UnknownApprovalRequest { .. } => "approval request not found",
         RunStateError::ApprovalRequestAlreadyExists { .. } => "approval request already exists",
         RunStateError::ApprovalNotPending { .. } => "approval request not pending",
+        RunStateError::InvalidStatus { .. } => "run-state transition invalid",
+        RunStateError::AuthResumeClaimMismatch { .. } => "auth resume claim mismatch",
         RunStateError::InvalidPath(_) => "run-state storage path invalid",
         RunStateError::Filesystem(_) => "run-state filesystem unavailable",
         RunStateError::Serialization(_) => "run-state serialization failed",
@@ -1066,6 +1068,9 @@ fn sanitized_failure_message(error: &CapabilityInvocationError) -> Option<String
         | ResumeStoreMissing { .. }
         | ProcessManagerMissing { .. }
         | ResumeNotBlocked { .. }
+        | AuthResumeFlowMismatch { .. }
+        | AuthResumeFingerprintMismatch { .. }
+        | AuthResumeDenied { .. }
         | ResumeContextMismatch { .. }
         | Dispatch { .. } => Some(error.to_string()),
         InvocationFingerprint { .. } => Some("invocation fingerprint failed".to_string()),
@@ -1086,6 +1091,9 @@ pub(crate) fn failure_kind_from(error: &CapabilityInvocationError) -> RuntimeFai
         | CapabilityInvocationError::ApprovalNotApproved { .. }
         | CapabilityInvocationError::ApprovalLeaseMissing { .. }
         | CapabilityInvocationError::ResumeNotBlocked { .. }
+        | CapabilityInvocationError::AuthResumeFlowMismatch { .. }
+        | CapabilityInvocationError::AuthResumeFingerprintMismatch { .. }
+        | CapabilityInvocationError::AuthResumeDenied { .. }
         | CapabilityInvocationError::ResumeContextMismatch { .. } => {
             RuntimeFailureKind::Authorization
         }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -29,8 +29,9 @@ use ironclaw_processes::{
     ProcessRecord, ProcessResultStore, ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{
-    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore,
-    RunRecord, RunStart, RunStateApprovalStore, RunStateError, RunStateStore,
+    ApprovalRecord, ApprovalRequestStore, AuthRequiredPayload, InMemoryApprovalRequestStore,
+    InMemoryRunStateStore, OAuthFlowId, RunRecord, RunStart, RunStateApprovalStore, RunStateError,
+    RunStateStore,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -1014,6 +1015,29 @@ impl RunStateStore for FailingRecordsRunStateStore {
             .await
     }
 
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
+    }
+
     async fn complete(
         &self,
         scope: &ResourceScope,
@@ -1144,6 +1168,29 @@ impl RunStateStore for FailingGetRunStateStore {
             .await
     }
 
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.inner
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
+    }
+
     async fn complete(
         &self,
         scope: &ResourceScope,
@@ -1229,6 +1276,29 @@ impl RunStateStore for RecordingCombinedRunStateApprovalStore {
         error_kind: String,
     ) -> Result<RunRecord, RunStateError> {
         self.runs.block_auth(scope, invocation_id, error_kind).await
+    }
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
     }
 
     async fn complete(

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -67,8 +67,9 @@ use ironclaw_resources::{
     ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits, ResourceTally,
 };
 use ironclaw_run_state::{
-    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore,
-    RunRecord, RunStart, RunStateApprovalStore, RunStateError, RunStateStore, RunStatus,
+    ApprovalRecord, ApprovalRequestStore, AuthRequiredPayload, InMemoryApprovalRequestStore,
+    InMemoryRunStateStore, OAuthFlowId, RunRecord, RunStart, RunStateApprovalStore, RunStateError,
+    RunStateStore, RunStatus,
 };
 use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptExecutionRequest,
@@ -4776,6 +4777,29 @@ impl RunStateStore for InMemoryRecordingCombinedRunStateApprovalStore {
         error_kind: String,
     ) -> Result<RunRecord, RunStateError> {
         self.runs.block_auth(scope, invocation_id, error_kind).await
+    }
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .block_auth_required(scope, invocation_id, payload)
+            .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .claim_auth_resume(scope, invocation_id, flow_id, invocation_fingerprint)
+            .await
     }
 
     async fn complete(

--- a/crates/ironclaw_oauth/src/error.rs
+++ b/crates/ironclaw_oauth/src/error.rs
@@ -1,5 +1,6 @@
 use ironclaw_host_api::HostApiError;
 use ironclaw_network::NetworkHttpError;
+use ironclaw_run_state::RunStateError;
 use ironclaw_secrets::SecretStoreError;
 use thiserror::Error;
 use url::Url;
@@ -30,6 +31,8 @@ pub enum OAuthError {
     InvalidTokenResponse { reason: String },
     #[error("OAuth secret store error: {0}")]
     SecretStore(#[from] SecretStoreError),
+    #[error("OAuth run-state error: {0}")]
+    RunState(#[from] RunStateError),
     #[error("OAuth host API error: {0}")]
     HostApi(#[from] HostApiError),
     #[error("OAuth serialization error: {0}")]

--- a/crates/ironclaw_oauth/src/flow.rs
+++ b/crates/ironclaw_oauth/src/flow.rs
@@ -4,6 +4,7 @@ use ironclaw_host_api::{
     NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern, ResourceScope,
 };
 use ironclaw_network::{NetworkHttpEgress, NetworkHttpRequest};
+use ironclaw_run_state::RunStateStore;
 use ironclaw_secrets::SecretStore;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Serialize;
@@ -91,6 +92,7 @@ struct OAuthRuntimeInner {
     egress: Arc<dyn NetworkHttpEgress>,
     tokens: TokenPersister,
     resume: Arc<OAuthResumeNotifier>,
+    run_state: Option<Arc<dyn RunStateStore>>,
     redirect_base_url: Url,
     allow_loopback_broker_for_tests: bool,
 }
@@ -102,6 +104,7 @@ pub struct OAuthRuntimeBuilder {
     egress: Arc<dyn NetworkHttpEgress>,
     secrets: Arc<dyn SecretStore>,
     resume: Arc<OAuthResumeNotifier>,
+    run_state: Option<Arc<dyn RunStateStore>>,
     redirect_base_url: Option<Url>,
     allow_loopback_broker_for_tests: bool,
 }
@@ -119,6 +122,7 @@ impl OAuthRuntimeBuilder {
             egress,
             secrets,
             resume: Arc::new(OAuthResumeNotifier::default()),
+            run_state: None,
             redirect_base_url: None,
             allow_loopback_broker_for_tests: false,
         }
@@ -136,6 +140,11 @@ impl OAuthRuntimeBuilder {
 
     pub fn resume(mut self, resume: Arc<OAuthResumeNotifier>) -> Self {
         self.resume = resume;
+        self
+    }
+
+    pub fn run_state(mut self, run_state: Arc<dyn RunStateStore>) -> Self {
+        self.run_state = Some(run_state);
         self
     }
 
@@ -185,6 +194,7 @@ impl OAuthRuntimeBuilder {
                     egress: self.egress,
                     tokens: TokenPersister::new(self.secrets),
                     resume: self.resume,
+                    run_state: self.run_state,
                     redirect_base_url,
                     allow_loopback_broker_for_tests: self.allow_loopback_broker_for_tests,
                 }),
@@ -325,9 +335,21 @@ impl OAuthFlow {
             .tokens
             .persist(&pending.scope, provider.credential_name(), &token_set)
             .await?;
-        self.inner
-            .resume
-            .notify(provider.credential_name(), pending.scope, pending.flow_id);
+        if let Some(run_state) = &self.inner.run_state {
+            self.inner
+                .resume
+                .notify_blocked_auth(
+                    run_state.as_ref(),
+                    provider.credential_name(),
+                    &pending.scope,
+                    pending.flow_id,
+                )
+                .await?;
+        } else {
+            self.inner
+                .resume
+                .notify(provider.credential_name(), pending.scope, pending.flow_id);
+        }
         Ok(())
     }
 

--- a/crates/ironclaw_oauth/src/resume.rs
+++ b/crates/ironclaw_oauth/src/resume.rs
@@ -1,4 +1,5 @@
-use ironclaw_host_api::ResourceScope;
+use ironclaw_host_api::{InvocationId, ResourceScope};
+use ironclaw_run_state::{AuthRequiredPayload, RunStateError, RunStateStore, RunStatus};
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
@@ -10,6 +11,7 @@ pub struct OAuthCallbackOutcome {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResumeSignal {
+    pub invocation_id: Option<InvocationId>,
     pub credential_name: String,
     pub scope: ResourceScope,
     pub outcome: OAuthCallbackOutcome,
@@ -36,6 +38,7 @@ impl OAuthResumeNotifier {
 
     pub fn notify(&self, credential_name: impl Into<String>, scope: ResourceScope, flow_id: Uuid) {
         self.notify_signal(ResumeSignal {
+            invocation_id: None,
             credential_name: credential_name.into(),
             scope,
             outcome: OAuthCallbackOutcome {
@@ -43,6 +46,40 @@ impl OAuthResumeNotifier {
                 success: true,
             },
         });
+    }
+
+    pub async fn notify_blocked_auth(
+        &self,
+        run_state: &dyn RunStateStore,
+        credential_name: &str,
+        scope: &ResourceScope,
+        flow_id: Uuid,
+    ) -> Result<usize, RunStateError> {
+        let mut sent = 0;
+        for record in run_state.records_for_scope(scope).await? {
+            if record.status != RunStatus::BlockedAuth {
+                continue;
+            }
+            let Some(payload) = record.blocked_payload else {
+                continue;
+            };
+            let payload: AuthRequiredPayload = serde_json::from_value(payload)
+                .map_err(|error| RunStateError::Deserialization(error.to_string()))?;
+            if payload.credential_name != credential_name || payload.flow_id != flow_id {
+                continue;
+            }
+            self.notify_signal(ResumeSignal {
+                invocation_id: Some(record.invocation_id),
+                credential_name: credential_name.to_string(),
+                scope: record.scope,
+                outcome: OAuthCallbackOutcome {
+                    flow_id,
+                    success: true,
+                },
+            });
+            sent += 1;
+        }
+        Ok(sent)
     }
 
     pub fn notify_signal(&self, signal: ResumeSignal) {

--- a/crates/ironclaw_oauth/tests/oauth_flow.rs
+++ b/crates/ironclaw_oauth/tests/oauth_flow.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_host_api::{InvocationId, ResourceScope, SecretHandle, UserId};
+use ironclaw_host_api::{
+    CapabilityId, InvocationFingerprint, InvocationId, ResourceEstimate, ResourceScope,
+    SecretHandle, UserId,
+};
 use ironclaw_network::{
     NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
 };
@@ -12,6 +15,7 @@ use ironclaw_oauth::{
     OAuthError, OAuthProvider, OAuthResumeNotifier, OAuthRuntime, ProviderMode, ProviderRegistry,
     RefreshScheduler, TokenPersister, TokenSet,
 };
+use ironclaw_run_state::{AuthRequiredPayload, InMemoryRunStateStore, RunStart, RunStateStore};
 use ironclaw_secrets::{
     SecretLease, SecretLeaseId, SecretLeaseStatus, SecretMaterial, SecretMetadata, SecretStore,
     SecretStoreError,
@@ -172,6 +176,82 @@ async fn exchange_notifies_resume_waiters_after_token_persistence() {
 }
 
 #[tokio::test]
+async fn exchange_queries_run_state_and_emits_invocation_specific_resume_signal() {
+    let mut registry = ProviderRegistry::new();
+    registry.register(Arc::new(FakeProvider)).unwrap();
+    let egress = Arc::new(RecordingEgress::default());
+    let secrets = Arc::new(MemorySecretStore::default());
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let (notifier, mut receiver) = OAuthResumeNotifier::channel(4);
+    let runtime = OAuthRuntime::builder(registry.into(), egress.clone(), secrets.clone())
+        .mode(ProviderMode::Direct)
+        .resume(Arc::new(notifier))
+        .run_state(run_state.clone())
+        .redirect_base_url(Url::parse("https://app.example.test").unwrap())
+        .build()
+        .unwrap();
+    egress.push_json(json!({
+        "access_token": "access-direct",
+        "refresh_token": "refresh-direct",
+        "expires_in": 600,
+        "scope": "calendar.readonly"
+    }));
+
+    let scope = sample_scope();
+    let capability_id = CapabilityId::new("google-calendar.list_events").unwrap();
+    let invocation_fingerprint = InvocationFingerprint::for_dispatch(
+        &scope,
+        &capability_id,
+        &ResourceEstimate::default(),
+        &json!({"calendar": "primary"}),
+    )
+    .unwrap();
+    let started = runtime
+        .start("fake", vec!["calendar.readonly".to_string()], scope.clone())
+        .await
+        .unwrap();
+    run_state
+        .start(RunStart {
+            invocation_id: scope.invocation_id,
+            capability_id,
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    run_state
+        .block_auth_required(
+            &scope,
+            scope.invocation_id,
+            AuthRequiredPayload {
+                provider_id: "fake".to_string(),
+                credential_name: "google_oauth_token".to_string(),
+                missing_scopes: vec!["calendar.readonly".to_string()],
+                oauth_url: started.oauth_url.clone(),
+                flow_id: started.flow_id,
+                extension_id: ironclaw_host_api::ExtensionId::new("google-calendar").unwrap(),
+                invocation_fingerprint,
+            },
+        )
+        .await
+        .unwrap();
+
+    runtime
+        .exchange(
+            "fake",
+            "direct-code".to_string(),
+            state_from_url(&started.oauth_url),
+        )
+        .await
+        .unwrap();
+
+    let signal = receiver.recv().await.unwrap();
+    assert_eq!(signal.invocation_id, Some(scope.invocation_id));
+    assert_eq!(signal.credential_name, "google_oauth_token");
+    assert_eq!(signal.outcome.flow_id, started.flow_id);
+    assert!(signal.outcome.success);
+}
+
+#[tokio::test]
 async fn oauth_http_failure_error_redacts_untrusted_response_body() {
     let (runtime, egress, _secrets) = runtime_with_mode(ProviderMode::Direct);
     egress.push_response(
@@ -207,6 +287,57 @@ async fn oauth_http_failure_error_redacts_untrusted_response_body() {
     assert!(!rendered.contains("secret-refresh"));
     assert!(!rendered.contains("secret-client"));
     assert!(!rendered.contains("direct-code"));
+}
+
+#[tokio::test]
+async fn resume_notifier_queries_blocked_auth_records_for_matching_credential_and_flow() {
+    let run_state = InMemoryRunStateStore::new();
+    let scope = sample_scope();
+    let flow_id = uuid::Uuid::new_v4();
+    let capability_id = CapabilityId::new("google-calendar.list_events").unwrap();
+    let invocation_fingerprint = InvocationFingerprint::for_dispatch(
+        &scope,
+        &capability_id,
+        &ResourceEstimate::default(),
+        &json!({"calendar": "primary"}),
+    )
+    .unwrap();
+    run_state
+        .start(RunStart {
+            invocation_id: scope.invocation_id,
+            capability_id,
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    run_state
+        .block_auth_required(
+            &scope,
+            scope.invocation_id,
+            AuthRequiredPayload {
+                provider_id: "google".to_string(),
+                credential_name: "google_oauth_token".to_string(),
+                missing_scopes: vec!["calendar.readonly".to_string()],
+                oauth_url: "https://accounts.example.test/oauth".to_string(),
+                flow_id,
+                extension_id: ironclaw_host_api::ExtensionId::new("google-calendar").unwrap(),
+                invocation_fingerprint,
+            },
+        )
+        .await
+        .unwrap();
+    let (notifier, mut receiver) = OAuthResumeNotifier::channel(4);
+
+    let sent = notifier
+        .notify_blocked_auth(&run_state, "google_oauth_token", &scope, flow_id)
+        .await
+        .unwrap();
+
+    assert_eq!(sent, 1);
+    let signal = receiver.recv().await.unwrap();
+    assert_eq!(signal.invocation_id, Some(scope.invocation_id));
+    assert_eq!(signal.credential_name, "google_oauth_token");
+    assert_eq!(signal.outcome.flow_id, flow_id);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_run_state/Cargo.toml
+++ b/crates/ironclaw_run_state/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 tokio-postgres = { version = "0.7", optional = true }
 tracing = "0.1"
+uuid = { version = "1", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -22,10 +22,11 @@ use ironclaw_filesystem::{
     RootFilesystem, ScopedFilesystem,
 };
 use ironclaw_host_api::{
-    AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationId,
-    MissionId, ProjectId, ResourceScope, ScopedPath, TenantId, ThreadId, UserId,
+    AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationFingerprint,
+    InvocationId, MissionId, ProjectId, ResourceScope, ScopedPath, TenantId, ThreadId, UserId,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 
 /// Current lifecycle state for one invocation.
@@ -48,6 +49,8 @@ pub struct RunRecord {
     pub status: RunStatus,
     pub approval_request_id: Option<ApprovalRequestId>,
     pub error_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_payload: Option<Value>,
 }
 
 /// Start metadata for a capability invocation.
@@ -56,6 +59,25 @@ pub struct RunStart {
     pub invocation_id: InvocationId,
     pub capability_id: CapabilityId,
     pub scope: ResourceScope,
+}
+
+pub type OAuthFlowId = uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthRequiredPayload {
+    pub provider_id: String,
+    pub credential_name: String,
+    pub missing_scopes: Vec<String>,
+    pub oauth_url: String,
+    pub flow_id: OAuthFlowId,
+    pub extension_id: ironclaw_host_api::ExtensionId,
+    pub invocation_fingerprint: InvocationFingerprint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OAuthCallbackOutcome {
+    pub flow_id: OAuthFlowId,
+    pub success: bool,
 }
 
 /// Approval request lifecycle state.
@@ -142,6 +164,14 @@ pub enum RunStateError {
         request_id: ApprovalRequestId,
         status: ApprovalStatus,
     },
+    #[error("invocation {invocation_id} has status {actual:?}; expected {expected:?}")]
+    InvalidStatus {
+        invocation_id: InvocationId,
+        expected: RunStatus,
+        actual: RunStatus,
+    },
+    #[error("auth resume claim mismatch for invocation {invocation_id}")]
+    AuthResumeClaimMismatch { invocation_id: InvocationId },
     #[error("invalid storage path: {0}")]
     InvalidPath(String),
     #[error("filesystem error: {0}")]
@@ -180,6 +210,21 @@ pub trait RunStateStore: Send + Sync {
         scope: &ResourceScope,
         invocation_id: InvocationId,
         error_kind: String,
+    ) -> Result<RunRecord, RunStateError>;
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError>;
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
     ) -> Result<RunRecord, RunStateError>;
 
     /// Marks an invocation completed only within the matching scope.
@@ -321,6 +366,7 @@ impl RunStateStore for InMemoryRunStateStore {
             status: RunStatus::Running,
             approval_request_id: None,
             error_kind: None,
+            blocked_payload: None,
         };
         let key = RunStateKey::new(&record.scope, record.invocation_id);
         let mut records = self.records_guard();
@@ -343,6 +389,7 @@ impl RunStateStore for InMemoryRunStateStore {
             record.status = RunStatus::BlockedApproval;
             record.approval_request_id = Some(approval.id);
             record.error_kind = None;
+            record.blocked_payload = None;
         })
     }
 
@@ -356,7 +403,43 @@ impl RunStateStore for InMemoryRunStateStore {
             record.status = RunStatus::BlockedAuth;
             record.approval_request_id = None;
             record.error_kind = Some(error_kind);
+            record.blocked_payload = None;
         })
+    }
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        let payload = serde_json::to_value(payload)
+            .map_err(|error| RunStateError::Serialization(error.to_string()))?;
+        self.update(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedAuth;
+            record.approval_request_id = None;
+            record.error_kind = Some("AuthRequired".to_string());
+            record.blocked_payload = Some(payload.clone());
+        })
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        let key = RunStateKey::new(scope, invocation_id);
+        let mut records = self.records_guard();
+        let record = records
+            .get_mut(&key)
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        validate_auth_resume_claim(record, flow_id, invocation_fingerprint)?;
+        record.status = RunStatus::Running;
+        record.error_kind = None;
+        record.blocked_payload = None;
+        Ok(record.clone())
     }
 
     async fn complete(
@@ -368,6 +451,7 @@ impl RunStateStore for InMemoryRunStateStore {
             record.status = RunStatus::Completed;
             record.approval_request_id = None;
             record.error_kind = None;
+            record.blocked_payload = None;
         })
     }
 
@@ -381,6 +465,7 @@ impl RunStateStore for InMemoryRunStateStore {
             record.status = RunStatus::Failed;
             record.approval_request_id = None;
             record.error_kind = Some(error_kind);
+            record.blocked_payload = None;
         })
     }
 
@@ -650,6 +735,7 @@ where
             status: RunStatus::Running,
             approval_request_id: None,
             error_kind: None,
+            blocked_payload: None,
         };
         let entry = Self::record_entry(&record)?;
         match put_with_cas(
@@ -682,6 +768,7 @@ where
             record.status = RunStatus::BlockedApproval;
             record.approval_request_id = Some(approval.id);
             record.error_kind = None;
+            record.blocked_payload = None;
         })
         .await
     }
@@ -699,8 +786,69 @@ where
             record.status = RunStatus::BlockedAuth;
             record.approval_request_id = None;
             record.error_kind = Some(error_kind.clone());
+            record.blocked_payload = None;
         })
         .await
+    }
+
+    async fn block_auth_required(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        payload: AuthRequiredPayload,
+    ) -> Result<RunRecord, RunStateError> {
+        let payload = serde_json::to_value(payload)
+            .map_err(|error| RunStateError::Serialization(error.to_string()))?;
+        let path = run_record_path(scope, invocation_id)?;
+        let record_lock = filesystem_record_lock(&path);
+        let _guard = record_lock.lock().await;
+        self.apply_update(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedAuth;
+            record.approval_request_id = None;
+            record.error_kind = Some("AuthRequired".to_string());
+            record.blocked_payload = Some(payload.clone());
+        })
+        .await
+    }
+
+    async fn claim_auth_resume(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        flow_id: OAuthFlowId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<RunRecord, RunStateError> {
+        let path = run_record_path(scope, invocation_id)?;
+        let record_lock = filesystem_record_lock(&path);
+        let _guard = record_lock.lock().await;
+        for _ in 0..FILESYSTEM_CAS_RETRIES {
+            let (mut record, version) = self
+                .read_versioned(scope, invocation_id)
+                .await?
+                .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+            validate_auth_resume_claim(&record, flow_id, invocation_fingerprint)?;
+            record.status = RunStatus::Running;
+            record.error_kind = None;
+            record.blocked_payload = None;
+            let entry = Self::record_entry(&record)?;
+            match put_with_cas(
+                self.filesystem.as_ref(),
+                scope,
+                &path,
+                entry,
+                CasExpectation::Version(version),
+            )
+            .await
+            {
+                Ok(()) => return Ok(record),
+                Err(PutError::VersionMismatch) => continue,
+                Err(PutError::Other(error)) => return Err(error),
+            }
+        }
+        Err(RunStateError::Backend(format!(
+            "filesystem CAS retries exhausted for path {}",
+            path.as_str()
+        )))
     }
 
     async fn complete(
@@ -715,6 +863,7 @@ where
             record.status = RunStatus::Completed;
             record.approval_request_id = None;
             record.error_kind = None;
+            record.blocked_payload = None;
         })
         .await
     }
@@ -732,6 +881,7 @@ where
             record.status = RunStatus::Failed;
             record.approval_request_id = None;
             record.error_kind = Some(error_kind.clone());
+            record.blocked_payload = None;
         })
         .await
     }
@@ -1151,6 +1301,33 @@ where
     T: for<'de> Deserialize<'de>,
 {
     serde_json::from_slice(bytes).map_err(|error| RunStateError::Deserialization(error.to_string()))
+}
+
+fn validate_auth_resume_claim(
+    record: &RunRecord,
+    flow_id: OAuthFlowId,
+    invocation_fingerprint: &InvocationFingerprint,
+) -> Result<(), RunStateError> {
+    if record.status != RunStatus::BlockedAuth {
+        return Err(RunStateError::InvalidStatus {
+            invocation_id: record.invocation_id,
+            expected: RunStatus::BlockedAuth,
+            actual: record.status,
+        });
+    }
+    let payload: AuthRequiredPayload = serde_json::from_value(
+        record
+            .blocked_payload
+            .clone()
+            .ok_or_else(|| RunStateError::Deserialization("BlockedAuth payload missing".into()))?,
+    )
+    .map_err(|error| RunStateError::Deserialization(error.to_string()))?;
+    if payload.flow_id != flow_id || &payload.invocation_fingerprint != invocation_fingerprint {
+        return Err(RunStateError::AuthResumeClaimMismatch {
+            invocation_id: record.invocation_id,
+        });
+    }
+    Ok(())
 }
 
 fn is_not_found(error: &FilesystemError) -> bool {


### PR DESCRIPTION
## Phase 2 — `BlockedAuth` resume path

Part of the **Google Extensions** build sequence (design: `docs/reborn/2026-05-20-google-extensions-design.md`). This phase makes a capability that hits `BlockedAuth` resumable: park the request, complete OAuth out-of-band, then resume the original invocation.

### What this delivers

- **`AuthRequiredPayload`** — typed payload shape in `ironclaw_run_state`, stored as typed JSON in run state and deserialized at resume time.
- **`capabilities/src/host.rs::resume_after_auth`** — an **auth-specific** resume request/method, added rather than mutating the existing `CapabilityResumeRequest` struct literal, so existing approval-resume callers stay source-compatible.
- **`OAuthResumeNotifier` → run-state wiring** — the notifier queries blocked-auth records by scope, credential name, and flow ID before broadcasting; it stays provider-agnostic. `OAuthRuntime::exchange` drives an optional run-state-backed notifier path.
- **Atomic resume claim** — `RunStateStore::claim_auth_resume` transitions a matching `BlockedAuth` record to `Running` before dispatch; duplicate resume attempts see `ResumeNotBlocked { status: Running }`.
- **Fingerprint check** — auth resume compares the caller request fingerprint against the parked `AuthRequiredPayload` fingerprint before dispatch.

### Integration coverage

End-to-end: capability → `BlockedAuth` → mock OAuth complete → resume → succeeds. Plus caller-level concurrent-resume coverage proving only one dispatch occurs. Tests drive `CapabilityHost` caller behavior, not helper-only transitions (per the "test through the caller" rule).

### Review iterations addressed

- **Iter 1:** callback completion now uses a run-state-backed notifier path; resume compares request fingerprints; `RunStateStore::block_auth_required` is required and implemented by delegating test stores so payload persistence is not silently lossy.
- **Iter 2:** `claim_auth_resume` atomically claims the record; `resume_auth_json` claims before obligations/dispatch; added concurrent-resume caller test.

### Files changed

19 files, +1214 / −21. Touches `ironclaw_run_state` (`AuthRequiredPayload`, store methods), `ironclaw_capabilities` (`host.rs` resume path, requests, errors, contract tests), `ironclaw_oauth` (resume/flow notifier wiring), and `ironclaw_host_runtime` production wiring + contract tests.

### Verification

```
cargo test -p ironclaw_run_state
cargo test -p ironclaw_capabilities
cargo test -p ironclaw_oauth
cargo clippy -p ironclaw_run_state -p ironclaw_capabilities -p ironclaw_oauth --all-targets -- -D warnings
```

### Review status

✅ Codex review: **approved** — duplicate concurrent-resume finding addressed; diff scoped to run-state, capability-host resume, OAuth notifier/runtime wiring, and downstream error/test updates.

### Stacked PR

Base: `arch/phase-1-ironclaw-oauth-substrate` (Phase 1). Merge Phase 1 first; this PR's diff collapses to base once Phase 1 lands.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
