### PR TITLE
feat(reborn): Phase 4 — composition wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,7 @@ name = "ironclaw_reborn_composition"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum 0.8.9",
  "chrono",
  "deadpool-postgres",
  "ironclaw_authorization",
@@ -4727,7 +4728,9 @@ dependencies = [
  "ironclaw_host_runtime",
  "ironclaw_llm",
  "ironclaw_loop_support",
+ "ironclaw_native_extensions",
  "ironclaw_network",
+ "ironclaw_oauth",
  "ironclaw_processes",
  "ironclaw_product_adapters",
  "ironclaw_product_workflow",
@@ -4742,6 +4745,7 @@ dependencies = [
  "ironclaw_threads",
  "ironclaw_trust",
  "ironclaw_turns",
+ "ironclaw_webui_v2",
  "libsql",
  "secrecy",
  "serde",

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -131,6 +131,14 @@ impl FirstPartyCapabilityRegistry {
         T: FirstPartyCapabilityHandler + 'static,
     {
         let handler: Arc<dyn FirstPartyCapabilityHandler> = handler;
+        self.insert_dyn_handler(capability_id, handler);
+    }
+
+    pub fn insert_dyn_handler(
+        &mut self,
+        capability_id: CapabilityId,
+        handler: Arc<dyn FirstPartyCapabilityHandler>,
+    ) {
         self.handlers.insert(capability_id, handler);
     }
 

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -22,6 +22,11 @@ root-llm-provider = [
     "ironclaw_llm/registry-provider-factory",
     "ironclaw_reborn/root-llm-provider",
 ]
+webui-v2-beta = [
+    "dep:axum",
+    "dep:ironclaw_webui_v2",
+    "ironclaw_webui_v2/webui-v2-beta",
+]
 libsql = [
     "dep:libsql",
     "ironclaw_filesystem/libsql",
@@ -41,6 +46,7 @@ postgres = [
 
 [dependencies]
 async-trait = "0.1"
+axum = { version = "0.8", optional = true }
 chrono = "0.4"
 deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_authorization = { path = "../ironclaw_authorization" }
@@ -50,7 +56,9 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime" }
 ironclaw_llm = { path = "../ironclaw_llm", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support" }
+ironclaw_native_extensions = { path = "../ironclaw_native_extensions" }
 ironclaw_network = { path = "../ironclaw_network" }
+ironclaw_oauth = { path = "../ironclaw_oauth" }
 ironclaw_processes = { path = "../ironclaw_processes" }
 ironclaw_product_adapters = { path = "../ironclaw_product_adapters" }
 ironclaw_product_workflow = { path = "../ironclaw_product_workflow" }
@@ -64,6 +72,7 @@ ironclaw_secrets = { path = "../ironclaw_secrets" }
 ironclaw_threads = { path = "../ironclaw_threads" }
 ironclaw_trust = { path = "../ironclaw_trust" }
 ironclaw_turns = { path = "../ironclaw_turns" }
+ironclaw_webui_v2 = { path = "../ironclaw_webui_v2", optional = true }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }

--- a/crates/ironclaw_reborn_composition/src/error.rs
+++ b/crates/ironclaw_reborn_composition/src/error.rs
@@ -38,6 +38,12 @@ pub enum RebornBuildError {
     Turn(#[from] ironclaw_turns::TurnError),
     #[error("reborn mount view construction failed")]
     Mount(#[from] ironclaw_host_api::HostApiError),
+    #[error("reborn native extension registration failed")]
+    NativeExtension(#[from] ironclaw_native_extensions::NativeExtensionError),
+    #[error("reborn native extension registry build failed")]
+    Extension(#[from] ironclaw_extensions::ExtensionError),
+    #[error("reborn OAuth runtime build failed")]
+    OAuth(#[from] ironclaw_oauth::OAuthError),
 }
 
 impl From<ironclaw_host_runtime::ProductionWiringReport> for RebornBuildError {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -5,14 +5,18 @@ use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::LocalFilesystem;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy;
-use ironclaw_host_api::{EffectKind, PackageId};
+use ironclaw_host_api::{EffectKind, NetworkPolicy, PackageId};
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, FirstPartyCapabilityRegistry, HostRuntimeServices,
     builtin_first_party_handlers, builtin_first_party_package,
 };
+use ironclaw_native_extensions::EnvConfig;
+use ironclaw_network::{PolicyNetworkHttpEgress, ReqwestNetworkTransport};
+use ironclaw_oauth::{OAuthRuntime, ProviderRegistry};
 use ironclaw_processes::ProcessServices;
 use ironclaw_resources::InMemoryResourceGovernor;
-use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
+use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateStore};
+use ironclaw_secrets::{InMemorySecretStore, SecretStore};
 use ironclaw_threads::InMemorySessionThreadService;
 use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -31,8 +35,46 @@ use crate::{
 pub struct RebornServices {
     pub host_runtime: Option<Arc<dyn ironclaw_host_runtime::HostRuntime>>,
     pub turn_coordinator: Option<Arc<dyn ironclaw_turns::TurnCoordinator>>,
+    pub native_extensions: Option<Arc<NativeExtensionServices>>,
     pub readiness: RebornReadiness,
     pub(crate) local_runtime: Option<Arc<RebornLocalRuntimeServices>>,
+}
+
+#[derive(Clone)]
+pub struct NativeExtensionServices {
+    oauth_runtime: OAuthRuntime,
+    oauth_provider_ids: Vec<String>,
+    network_policies: Vec<NetworkPolicy>,
+}
+
+impl std::fmt::Debug for NativeExtensionServices {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("NativeExtensionServices")
+            .field("oauth_provider_ids", &self.oauth_provider_ids)
+            .field("network_policy_count", &self.network_policies.len())
+            .finish()
+    }
+}
+
+impl NativeExtensionServices {
+    pub fn oauth_runtime(&self) -> OAuthRuntime {
+        self.oauth_runtime.clone()
+    }
+
+    pub fn oauth_provider_ids(&self) -> &[String] {
+        &self.oauth_provider_ids
+    }
+
+    pub fn network_policies(&self) -> &[NetworkPolicy] {
+        &self.network_policies
+    }
+}
+
+struct NativeExtensionComposition {
+    extension_registry: ExtensionRegistry,
+    first_party_capabilities: FirstPartyCapabilityRegistry,
+    services: NativeExtensionServices,
 }
 
 pub(crate) struct RebornLocalRuntimeServices {
@@ -48,6 +90,7 @@ impl std::fmt::Debug for RebornServices {
             .debug_struct("RebornServices")
             .field("host_runtime", &self.host_runtime.is_some())
             .field("turn_coordinator", &self.turn_coordinator.is_some())
+            .field("native_extensions", &self.native_extensions)
             .field("readiness", &self.readiness)
             .field("local_runtime", &self.local_runtime.is_some())
             .finish()
@@ -59,6 +102,7 @@ impl RebornServices {
         Self {
             host_runtime: None,
             turn_coordinator: None,
+            native_extensions: None,
             readiness: RebornReadiness::disabled(),
             local_runtime: None,
         }
@@ -136,6 +180,15 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
 
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let run_state_for_native: Arc<dyn RunStateStore> = run_state.clone();
+    let native = compose_native_extensions(
+        local_dev_extension_registry()?,
+        local_dev_first_party_handlers()?,
+        &EnvConfig::from_env(),
+        Arc::clone(&secret_store),
+        Some(run_state_for_native),
+    )?;
     let turn_state = Arc::new(InMemoryTurnStateStore::default());
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         turn_state: Arc::clone(&turn_state),
@@ -145,15 +198,16 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     });
 
     let mut services = HostRuntimeServices::new(
-        Arc::new(local_dev_extension_registry()?),
+        Arc::new(native.extension_registry),
         Arc::new(filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("reborn-app-v1")?,
     )
-    .with_first_party_capabilities(Arc::new(local_dev_first_party_handlers()?))
+    .with_first_party_capabilities(Arc::new(native.first_party_capabilities))
     .with_trust_policy(Arc::new(local_dev_first_party_trust_policy()?))
+    .with_secret_store(Arc::clone(&secret_store))
     .with_run_state(Arc::clone(&run_state))
     .with_approval_requests(Arc::clone(&approval_requests))
     .with_turn_state(Arc::clone(&turn_state));
@@ -171,8 +225,58 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
+        native_extensions: Some(Arc::new(native.services)),
         readiness: readiness_for(input.profile, true, true),
         local_runtime: Some(local_runtime),
+    })
+}
+
+fn compose_native_extensions<S>(
+    mut extension_registry: ExtensionRegistry,
+    mut first_party_capabilities: FirstPartyCapabilityRegistry,
+    env: &EnvConfig,
+    secrets: Arc<S>,
+    run_state: Option<Arc<dyn RunStateStore>>,
+) -> Result<NativeExtensionComposition, RebornBuildError>
+where
+    S: SecretStore + 'static,
+{
+    let registration = ironclaw_native_extensions::register_all(env, secrets.clone())?;
+
+    for package in registration.packages {
+        extension_registry.insert(package)?;
+    }
+    for (capability_id, handler) in registration.handlers {
+        first_party_capabilities.insert_dyn_handler(capability_id, handler);
+    }
+
+    let mut provider_registry = ProviderRegistry::new();
+    for provider in registration.oauth_providers {
+        provider_registry.register(provider)?;
+    }
+    let oauth_provider_ids = provider_registry
+        .ids()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let provider_registry = Arc::new(provider_registry);
+    let egress: Arc<dyn ironclaw_network::NetworkHttpEgress> = Arc::new(
+        PolicyNetworkHttpEgress::new(ReqwestNetworkTransport::default()),
+    );
+    let secrets: Arc<dyn SecretStore> = secrets;
+    let mut oauth_builder = OAuthRuntime::builder(provider_registry, egress, secrets);
+    if let Some(run_state) = run_state {
+        oauth_builder = oauth_builder.run_state(run_state);
+    }
+    let oauth_runtime = oauth_builder.from_env()?;
+
+    Ok(NativeExtensionComposition {
+        extension_registry,
+        first_party_capabilities,
+        services: NativeExtensionServices {
+            oauth_runtime,
+            oauth_provider_ids,
+            network_policies: registration.network_policies,
+        },
     })
 }
 
@@ -372,8 +476,9 @@ async fn build_libsql_production(
     let leases = Arc::new(FilesystemCapabilityLeaseStore::new(Arc::clone(
         &scoped_filesystem,
     )));
-
-    let scoped_filesystem = crate::wrap_scoped(Arc::clone(&filesystem));
+    let run_state = Arc::new(ironclaw_run_state::FilesystemRunStateStore::new(
+        Arc::clone(&scoped_filesystem),
+    ));
 
     let secret_crypto = Arc::new(ironclaw_secrets::SecretsCrypto::new(secret_master_key)?);
     let secret_store = Arc::new(FilesystemSecretStore::new(
@@ -386,14 +491,24 @@ async fn build_libsql_production(
         auth_token,
     };
 
+    let run_state_for_native: Arc<dyn RunStateStore> = run_state.clone();
+    let native = compose_native_extensions(
+        ExtensionRegistry::new(),
+        FirstPartyCapabilityRegistry::new(),
+        &EnvConfig::from_env(),
+        Arc::clone(&secret_store),
+        Some(run_state_for_native),
+    )?;
+
     let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
+        Arc::new(native.extension_registry),
         Arc::clone(&filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::filesystem(Arc::clone(&scoped_filesystem)),
         CapabilitySurfaceVersion::new("reborn-app-v1")?,
     )
+    .with_first_party_capabilities(Arc::new(native.first_party_capabilities))
     .with_trust_policy(production_wiring.trust_policy)
     .with_runtime_policy(production_wiring.runtime_policy)
     .with_capability_leases(leases)
@@ -414,6 +529,7 @@ async fn build_libsql_production(
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
+        native_extensions: Some(Arc::new(native.services)),
         readiness: readiness_for(profile, true, true),
         local_runtime: None,
     })
@@ -439,8 +555,9 @@ async fn build_postgres_production(
     let leases = Arc::new(FilesystemCapabilityLeaseStore::new(Arc::clone(
         &scoped_filesystem,
     )));
-
-    let scoped_filesystem = crate::wrap_scoped(Arc::clone(&filesystem));
+    let run_state = Arc::new(ironclaw_run_state::FilesystemRunStateStore::new(
+        Arc::clone(&scoped_filesystem),
+    ));
 
     let secret_crypto = Arc::new(ironclaw_secrets::SecretsCrypto::new(secret_master_key)?);
     let secret_store = Arc::new(FilesystemSecretStore::new(
@@ -450,14 +567,24 @@ async fn build_postgres_production(
 
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url };
 
+    let run_state_for_native: Arc<dyn RunStateStore> = run_state.clone();
+    let native = compose_native_extensions(
+        ExtensionRegistry::new(),
+        FirstPartyCapabilityRegistry::new(),
+        &EnvConfig::from_env(),
+        Arc::clone(&secret_store),
+        Some(run_state_for_native),
+    )?;
+
     let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
+        Arc::new(native.extension_registry),
         Arc::clone(&filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::filesystem(Arc::clone(&scoped_filesystem)),
         CapabilitySurfaceVersion::new("reborn-app-v1")?,
     )
+    .with_first_party_capabilities(Arc::new(native.first_party_capabilities))
     .with_trust_policy(production_wiring.trust_policy)
     .with_runtime_policy(production_wiring.runtime_policy)
     .with_capability_leases(leases)
@@ -478,6 +605,7 @@ async fn build_postgres_production(
     Ok(RebornServices {
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
+        native_extensions: Some(Arc::new(native.services)),
         readiness: readiness_for(profile, true, true),
         local_runtime: None,
     })

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -33,7 +33,7 @@ mod webui;
 use ironclaw_runtime_policy::{EffectiveRuntimePolicy as ResolvedRuntimePolicy, ResolveError};
 
 pub use error::RebornBuildError;
-pub use factory::{RebornServices, build_reborn_services};
+pub use factory::{NativeExtensionServices, RebornServices, build_reborn_services};
 pub use input::RebornBuildInput;
 #[cfg(feature = "root-llm-provider")]
 pub use llm_catalog::{
@@ -57,6 +57,8 @@ pub use runtime_input::{
 };
 #[cfg(feature = "root-llm-provider")]
 pub use runtime_input::{RebornLlmConfig, ResolvedRebornLlm};
+#[cfg(feature = "webui-v2-beta")]
+pub use webui::build_webui_v2_router_with_oauth;
 
 /// Reborn model purpose slot names exposed for diagnostic callers.
 ///

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -54,3 +54,17 @@ pub(crate) fn build_webui_services(
         readiness: services.readiness,
     })
 }
+
+/// Build the WebChat v2 router with the Reborn OAuth callback router mounted.
+///
+/// The WebUI crate owns authenticated product routes; the OAuth crate owns
+/// `/auth/callback/{provider_id}`. Composition is the only layer that sees both
+/// route sets and the native extension OAuth runtime.
+#[cfg(feature = "webui-v2-beta")]
+pub fn build_webui_v2_router_with_oauth(
+    state: ironclaw_webui_v2::WebUiV2State,
+    native_extensions: &crate::NativeExtensionServices,
+) -> axum::Router {
+    ironclaw_webui_v2::webui_v2_router(state)
+        .merge(ironclaw_oauth::router(native_extensions.oauth_runtime()))
+}

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -308,6 +308,7 @@ async fn disabled_returns_empty_services() {
 
     assert!(services.host_runtime.is_none());
     assert!(services.turn_coordinator.is_none());
+    assert!(services.native_extensions.is_none());
     assert_eq!(services.readiness.state, RebornReadinessState::Disabled);
 }
 
@@ -323,6 +324,7 @@ async fn local_dev_builds_facades_without_production_claim() {
 
     assert!(services.host_runtime.is_some());
     assert!(services.turn_coordinator.is_some());
+    assert!(services.native_extensions.is_some());
     assert_eq!(services.readiness.state, RebornReadinessState::DevOnly);
     assert!(services.readiness.facades.host_runtime);
     assert!(services.readiness.facades.turn_coordinator);
@@ -539,6 +541,37 @@ async fn production_rejects_memory_libsql_event_store() {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn production_composes_native_extension_services() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("reborn-native.db");
+    let db = libsql_db_at(&db_path).await;
+    let (notifier, handle) = live_wake_notifier();
+
+    let services = build_reborn_services(
+        RebornBuildInput::libsql(
+            RebornCompositionProfile::MigrationDryRun,
+            "test-owner",
+            db,
+            db_path.to_string_lossy(),
+            None,
+            test_master_key(),
+        )
+        .with_production_trust_policy(production_trust_policy())
+        .with_runtime_policy(production_runtime_policy())
+        .with_turn_run_wake_notifier(notifier),
+    )
+    .await
+    .unwrap();
+
+    handle.shutdown().await;
+
+    assert!(services.host_runtime.is_some());
+    assert!(services.turn_coordinator.is_some());
+    assert!(services.native_extensions.is_some());
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn migration_dry_run_validates_libsql_shape() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("reborn.db");
@@ -585,6 +618,7 @@ async fn migration_dry_run_validates_libsql_shape() {
     );
     assert!(services.host_runtime.is_some());
     assert!(services.turn_coordinator.is_some());
+    assert!(services.native_extensions.is_some());
 }
 
 #[cfg(feature = "postgres")]
@@ -634,4 +668,5 @@ async fn migration_dry_run_validates_postgres_planned_turn_profile() {
     );
     assert!(services.host_runtime.is_some());
     assert!(services.turn_coordinator.is_some());
+    assert!(services.native_extensions.is_some());
 }


### PR DESCRIPTION
## Phase 4 — Composition wiring

Part of the **Google Extensions** build sequence (design: `docs/reborn/2026-05-20-google-extensions-design.md`). This phase wires the `ironclaw_oauth` and `ironclaw_native_extensions` crates into service construction via `ironclaw_reborn_composition`.

### What this delivers

In `crates/ironclaw_reborn_composition::factory`:

- Calls **`ironclaw_native_extensions::register_all`** during service construction.
- Merges the returned **packages** into `ExtensionRegistry`.
- Merges the returned **first-party handlers** into `FirstPartyCapabilityRegistry`.
- Merges the returned **OAuth providers** into an OAuth `ProviderRegistry`.
- Builds the OAuth runtime with **`OAuthRuntime::from_env`**.
- Lets Reborn WebUI v2 composition mount the **OAuth callback router**.
- Retains native **network policies** for downstream capability network enforcement.

### Constraints honored

- Composition-owned wiring stays in `crates/ironclaw_reborn_composition`.
- No hardcoded Google capability paths in product entrypoints.
- No Calendar/Gmail capabilities invented here (those are Phases 5–6).
- Disabled-profile behavior preserved; production host/runtime defaults unchanged except additive native services.

### Tests

Production composition integration test (`tests/facade_factory.rs`) proves native-extension services are built; local-dev facade builds without a production claim.

### Files changed

8 files, +217 / −11. `ironclaw_reborn_composition` (`factory.rs`, `webui.rs`, `lib.rs`, `error.rs`, `Cargo.toml`, `facade_factory.rs` test) and `ironclaw_host_runtime/first_party.rs`.

### Verification

```
cargo check -p ironclaw_reborn_composition
cargo check -p ironclaw_reborn_composition --features webui-v2-beta
cargo check -p ironclaw_reborn_composition --features libsql
cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings
cargo test -p ironclaw_reborn_composition local_dev_builds_facades_without_production_claim
cargo test -p ironclaw_reborn_composition --features libsql production_composes_native_extension_services
cargo test -p ironclaw_architecture reborn_native_extension_provider_boundaries_hold
cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold
```

### Review status

✅ Codex review: **approved** (iter 1).

### Stacked PR

Base: `arch/phase-3-ironclaw-native-extensions-scaffold-google-provider-registration` (Phase 3). Merge Phases 1–3 first.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
