### PR TITLE
feat(reborn): Phase 6 — Gmail package

### DIFF
--- a/crates/ironclaw_native_extensions/CLAUDE.md
+++ b/crates/ironclaw_native_extensions/CLAUDE.md
@@ -28,4 +28,8 @@ structs; the raw provider response and the OAuth access token are never echoed
 into handler output.
 
 The Google subdir's calendar package lives in `src/google/calendar/`
-(`manifest.rs` declares descriptors, `handlers.rs` implements them).
+(`manifest.rs` declares descriptors, `handlers.rs` implements them). The Gmail
+package lives in `src/google/gmail/` and follows the same `manifest.rs` /
+`handlers.rs` split. Both packages share the credential resolver, network
+policy, OAuth provider, and `scopes` defined directly under `src/google/`;
+sibling capability packages MUST NOT import from each other.

--- a/crates/ironclaw_native_extensions/src/google/gmail/handlers.rs
+++ b/crates/ironclaw_native_extensions/src/google/gmail/handlers.rs
@@ -1,0 +1,1036 @@
+//! First-party capability handlers for the six Gmail capabilities.
+//!
+//! Each handler is an `Arc`-shared struct holding the construction-time
+//! dependencies (the credential resolver and the shared `OAuthProvider`). On
+//! dispatch a handler:
+//!
+//! 1. parses and validates its typed input,
+//! 2. resolves the shared `google_oauth_token` credential metadata for the
+//!    request scope, failing closed on a missing credential or a scope
+//!    mismatch (the handler reads only `granted_scopes`/`missing_scopes`, never
+//!    the raw token),
+//! 3. issues the Gmail API call through the per-invocation
+//!    [`RuntimeHttpEgress`] supplied in `request.services.runtime_http_egress`,
+//!    declaring a host-staged credential injection so the host egress service
+//!    leases, injects, redacts, and audits the `google_oauth_token` — the
+//!    handler never holds the access token or its own HTTP transport,
+//! 4. projects the raw Gmail response onto a whitelisted output struct so no
+//!    access token, internal id, or raw header set leaks into handler output.
+//!
+//! Routing through `runtime_http_egress` keeps these handlers behind the
+//! host's fail-closed egress boundary (`HostHttpEgressService`): staged
+//! network policy, credential injection, redaction, auditing, and the ability
+//! to disable outbound HTTP in tests all apply. Building a standalone
+//! transport would bypass that boundary.
+//!
+//! Approval gating for the four write capabilities is *not* implemented here —
+//! it is descriptor-level (`PermissionMode::Ask` + `EffectKind::ExternalWrite`,
+//! see [`super::manifest`]). The host authorization layer is responsible for
+//! blocking an unapproved write before `dispatch` is ever called.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    NetworkMethod, NetworkPolicy, ResourceScope, ResourceUsage, RuntimeCredentialInjection,
+    RuntimeCredentialSource, RuntimeCredentialTarget, RuntimeDispatchErrorKind,
+    RuntimeHttpEgressError, RuntimeHttpEgressReasonCode, RuntimeHttpEgressRequest, RuntimeKind,
+    SecretHandle,
+};
+use ironclaw_host_runtime::{
+    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRequest,
+    FirstPartyCapabilityResult,
+};
+use ironclaw_oauth::OAuthProvider;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::google::credential::{
+    GOOGLE_CREDENTIAL_NAME, GoogleCredentialError, GoogleCredentialResolver,
+};
+
+const GMAIL_API_BASE: &str = "https://gmail.googleapis.com/gmail/v1";
+
+/// Cap on a Gmail response body (1 MiB).
+const RESPONSE_BODY_LIMIT: u64 = 1024 * 1024;
+
+/// Per-call host-egress timeout.
+const TIMEOUT_MS: u32 = 30_000;
+
+/// Maximum size of an inline message-part body that is projected verbatim;
+/// larger base64 payloads are dropped and replaced with an `attachment_ref`.
+const INLINE_BODY_LIMIT: usize = 64 * 1024;
+
+/// Shared construction-time dependencies for every Gmail handler.
+///
+/// Handlers do not own an HTTP client: the transport is the per-invocation
+/// [`RuntimeHttpEgress`](ironclaw_host_api::RuntimeHttpEgress) from
+/// `InvocationServices`. The resolver is retained only to read credential
+/// metadata (`granted_scopes`) for a scope-mismatch preflight; the raw token
+/// is leased and injected by the host egress service.
+#[derive(Clone)]
+pub struct GmailHandlerDeps {
+    resolver: Arc<GoogleCredentialResolver>,
+    provider: Arc<dyn OAuthProvider>,
+    /// OAuth scopes this capability requires (`gmail.readonly` / `gmail.send` /
+    /// `gmail.modify`).
+    required_scopes: Vec<String>,
+}
+
+impl GmailHandlerDeps {
+    pub fn new(
+        resolver: Arc<GoogleCredentialResolver>,
+        provider: Arc<dyn OAuthProvider>,
+        required_scopes: Vec<String>,
+    ) -> Self {
+        Self {
+            resolver,
+            provider,
+            required_scopes,
+        }
+    }
+
+    /// Preflight the shared Google credential, failing closed on a missing
+    /// credential or an OAuth scope mismatch.
+    ///
+    /// This only inspects credential *metadata*: it never returns or logs the
+    /// access token. The token itself is leased and injected by the host
+    /// egress service via the staged credential-injection plan.
+    async fn preflight_credential(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<(), FirstPartyCapabilityError> {
+        let credential = self
+            .resolver
+            .resolve(scope, self.provider.as_ref(), &self.required_scopes)
+            .await
+            .map_err(map_credential_error)?;
+        if !credential.missing_scopes.is_empty() {
+            // Scope mismatch is an authorization failure the user must resolve
+            // by re-consenting; surface it as a client error. The auth-required
+            // run-state transition is owned by the phase-2 host obligation
+            // layer.
+            return Err(FirstPartyCapabilityError::new(
+                RuntimeDispatchErrorKind::Client,
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Map a credential-resolution failure to a redacted dispatch error.
+fn map_credential_error(error: GoogleCredentialError) -> FirstPartyCapabilityError {
+    let kind = match error {
+        // Missing credential: fail closed — the user has not connected Google.
+        // The host obligation layer (phase 2) is responsible for translating
+        // this into an auth-required run-state transition / OAuth bootstrap.
+        GoogleCredentialError::Missing => RuntimeDispatchErrorKind::Client,
+        _ => RuntimeDispatchErrorKind::Backend,
+    };
+    FirstPartyCapabilityError::new(kind)
+}
+
+/// Map a host runtime-egress failure to a redacted [`RuntimeDispatchErrorKind`].
+///
+/// Mirrors the built-in `builtin.http` handler's mapping so first-party
+/// network failures are classified consistently.
+fn map_egress_error(error: &RuntimeHttpEgressError) -> FirstPartyCapabilityError {
+    let kind = match error.reason_code() {
+        RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
+        RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
+        RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
+        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode,
+        RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
+            RuntimeDispatchErrorKind::OutputTooLarge
+        }
+    };
+    FirstPartyCapabilityError::new(kind)
+}
+
+/// Parse a handler's typed input, mapping a decode failure to `InputEncode`.
+fn parse_input<T: for<'de> Deserialize<'de>>(input: Value) -> Result<T, FirstPartyCapabilityError> {
+    serde_json::from_value(input)
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode))
+}
+
+/// Serialize a handler's whitelisted output, mapping a failure to `InvalidResult`.
+fn encode_output<T: Serialize>(output: &T) -> Result<Value, FirstPartyCapabilityError> {
+    serde_json::to_value(output)
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InvalidResult))
+}
+
+/// Build a `FirstPartyCapabilityResult` with wall-clock and output-byte usage.
+fn finish(output: Value, started: Instant) -> FirstPartyCapabilityResult {
+    let wall_clock_ms = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+    let output_bytes = serde_json::to_vec(&output)
+        .map(|b| b.len() as u64)
+        .unwrap_or(0);
+    FirstPartyCapabilityResult::new(
+        output,
+        ResourceUsage {
+            wall_clock_ms,
+            output_bytes,
+            ..ResourceUsage::default()
+        },
+    )
+}
+
+/// URL-encode a path/query segment (message id, query string) so values
+/// containing `@`, `#`, `/`, or spaces cannot escape the intended API path.
+fn encode_segment(segment: &str) -> String {
+    let mut encoded = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+/// Base64url-encode bytes without padding (RFC 4648 §5), as required by the
+/// Gmail API `raw` field. No external base64 crate is on the dependency graph,
+/// so the encoder is kept self-contained here.
+fn base64url_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[((triple >> 18) & 0x3F) as usize] as char);
+        out.push(ALPHABET[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(ALPHABET[((triple >> 6) & 0x3F) as usize] as char);
+        }
+        if chunk.len() > 2 {
+            out.push(ALPHABET[(triple & 0x3F) as usize] as char);
+        }
+    }
+    out
+}
+
+/// The host-staged credential-injection plan for a Gmail API call.
+///
+/// The handler declares *what* should be injected — the `google_oauth_token`
+/// secret, into the `authorization` header with a `Bearer ` prefix — sourced
+/// from a `StagedObligation` for this capability. The host egress service
+/// (`HostHttpEgressService`) is what leases the secret and performs the
+/// injection; the handler never touches the token material.
+fn google_credential_injection(
+    capability_id: &ironclaw_host_api::CapabilityId,
+) -> Result<RuntimeCredentialInjection, FirstPartyCapabilityError> {
+    let handle = SecretHandle::new(GOOGLE_CREDENTIAL_NAME)
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend))?;
+    Ok(RuntimeCredentialInjection {
+        handle,
+        source: RuntimeCredentialSource::StagedObligation {
+            capability_id: capability_id.clone(),
+        },
+        target: RuntimeCredentialTarget::Header {
+            name: "authorization".to_string(),
+            prefix: Some("Bearer ".to_string()),
+        },
+        required: true,
+    })
+}
+
+/// Issue a Gmail API call through the host runtime-egress boundary.
+///
+/// `body` is `None` for `GET` and `Some(json)` for write methods. The JSON
+/// response body is parsed and returned; an empty `2xx` body becomes
+/// [`Value::Null`].
+async fn call_gmail(
+    request: &FirstPartyCapabilityRequest,
+    method: NetworkMethod,
+    url: String,
+    body: Option<Value>,
+) -> Result<Value, FirstPartyCapabilityError> {
+    let egress = request
+        .services
+        .runtime_http_egress
+        .as_ref()
+        .ok_or_else(|| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied))?
+        .clone();
+
+    let mut headers = Vec::new();
+    let body_bytes = match body {
+        Some(value) => {
+            headers.push(("content-type".to_string(), "application/json".to_string()));
+            serde_json::to_vec(&value).map_err(|_| {
+                FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode)
+            })?
+        }
+        None => Vec::new(),
+    };
+
+    let http_request = RuntimeHttpEgressRequest {
+        runtime: RuntimeKind::FirstParty,
+        scope: request.scope.clone(),
+        capability_id: request.capability_id.clone(),
+        method,
+        url,
+        headers,
+        body: body_bytes,
+        // First-party network policy is staged in HostHttpEgressService from
+        // the grant obligation for this scope/capability; this fallback field
+        // is ignored on the production path and only used by test services.
+        network_policy: NetworkPolicy::default(),
+        credential_injections: vec![google_credential_injection(&request.capability_id)?],
+        response_body_limit: Some(RESPONSE_BODY_LIMIT),
+        timeout_ms: Some(TIMEOUT_MS),
+    };
+
+    let response = tokio::task::spawn_blocking(move || egress.execute(http_request))
+        .await
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend))?
+        .map_err(|error| map_egress_error(&error))?;
+
+    if !(200..300).contains(&response.status) {
+        // Non-2xx Gmail responses (auth/scope/quota failures) are surfaced as
+        // client errors; the phase-2 host layer owns the auth-required
+        // run-state transition.
+        return Err(FirstPartyCapabilityError::new(
+            RuntimeDispatchErrorKind::Client,
+        ));
+    }
+    if response.body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(Value::Null);
+    }
+    serde_json::from_slice(&response.body)
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::OutputDecode))
+}
+
+// ---------------------------------------------------------------------------
+// Whitelisted output projections.
+//
+// Output structs deliberately project only non-sensitive, whitelisted fields.
+// The raw Gmail response is never echoed: internal ids (`internalDate`,
+// `historyId`), the raw `payload.headers` array, and large base64 attachment
+// bodies are dropped. The access token never appears in output.
+// ---------------------------------------------------------------------------
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+/// Whitelisted projection of a single message reference from `messages.list`.
+#[derive(Debug, Serialize)]
+struct MessageRef {
+    id: String,
+    thread_id: Option<String>,
+}
+
+impl MessageRef {
+    fn from_google(value: &Value) -> Self {
+        Self {
+            id: string_field(value, "id").unwrap_or_default(),
+            thread_id: string_field(value, "threadId"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ListMessagesOutput {
+    messages: Vec<MessageRef>,
+    next_page_token: Option<String>,
+    result_size_estimate: Option<i64>,
+}
+
+/// Whitelisted header projection: only the user-meaningful envelope headers
+/// are kept; the raw `payload.headers` array is never echoed.
+#[derive(Debug, Default, Serialize)]
+struct MessageHeaders {
+    from: Option<String>,
+    to: Option<String>,
+    cc: Option<String>,
+    subject: Option<String>,
+    date: Option<String>,
+}
+
+impl MessageHeaders {
+    /// Extract the whitelisted headers from a Gmail `payload.headers` array.
+    fn from_payload(payload: Option<&Value>) -> Self {
+        let mut headers = Self::default();
+        let Some(list) = payload
+            .and_then(|p| p.get("headers"))
+            .and_then(Value::as_array)
+        else {
+            return headers;
+        };
+        for header in list {
+            let (Some(name), Some(val)) = (
+                header.get("name").and_then(Value::as_str),
+                header.get("value").and_then(Value::as_str),
+            ) else {
+                continue;
+            };
+            match name.to_ascii_lowercase().as_str() {
+                "from" => headers.from = Some(val.to_string()),
+                "to" => headers.to = Some(val.to_string()),
+                "cc" => headers.cc = Some(val.to_string()),
+                "subject" => headers.subject = Some(val.to_string()),
+                "date" => headers.date = Some(val.to_string()),
+                _ => {}
+            }
+        }
+        headers
+    }
+}
+
+/// A whitelisted projection of a message body part. Large base64 attachment
+/// bodies are dropped and replaced with `attachment_ref` for separate fetch.
+#[derive(Debug, Serialize)]
+struct MessagePart {
+    mime_type: Option<String>,
+    filename: Option<String>,
+    /// Inline body data (base64url) — only kept when below `INLINE_BODY_LIMIT`.
+    body_data: Option<String>,
+    /// Opaque attachment id for parts whose body was withheld.
+    attachment_ref: Option<String>,
+    size: Option<i64>,
+}
+
+impl MessagePart {
+    fn from_google(value: &Value) -> Self {
+        let body = value.get("body");
+        let size = body.and_then(|b| b.get("size")).and_then(Value::as_i64);
+        let raw_data = body.and_then(|b| b.get("data")).and_then(Value::as_str);
+        let attachment_id = body
+            .and_then(|b| b.get("attachmentId"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        // Drop large inline bodies; surface an attachment_ref instead so the
+        // caller can fetch the payload separately rather than inlining it.
+        let (body_data, attachment_ref) = match (raw_data, attachment_id) {
+            (Some(data), _) if data.len() <= INLINE_BODY_LIMIT => (Some(data.to_string()), None),
+            (Some(_), Some(att_id)) => (None, Some(att_id)),
+            (Some(_), None) => (None, Some("oversized-inline-body".to_string())),
+            (None, att_id) => (None, att_id),
+        };
+        Self {
+            mime_type: string_field(value, "mimeType"),
+            filename: string_field(value, "filename"),
+            body_data,
+            attachment_ref,
+            size,
+        }
+    }
+}
+
+/// Whitelisted projection of a Gmail message.
+///
+/// Internal fields (`internalDate`, `historyId`, the raw `payload.headers`
+/// array, `raw`) are intentionally dropped.
+#[derive(Debug, Serialize)]
+struct MessageOutput {
+    id: String,
+    thread_id: Option<String>,
+    label_ids: Vec<String>,
+    snippet: Option<String>,
+    size_estimate: Option<i64>,
+    headers: MessageHeaders,
+    parts: Vec<MessagePart>,
+}
+
+impl MessageOutput {
+    fn from_google(value: &Value) -> Self {
+        let payload = value.get("payload");
+        let label_ids = value
+            .get("labelIds")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        // A message either has a single top-level body part or a `parts` array.
+        let parts = match payload
+            .and_then(|p| p.get("parts"))
+            .and_then(Value::as_array)
+        {
+            Some(items) => items.iter().map(MessagePart::from_google).collect(),
+            None => match payload {
+                Some(p) => vec![MessagePart::from_google(p)],
+                None => Vec::new(),
+            },
+        };
+        Self {
+            id: string_field(value, "id").unwrap_or_default(),
+            thread_id: string_field(value, "threadId"),
+            label_ids,
+            snippet: string_field(value, "snippet"),
+            size_estimate: value.get("sizeEstimate").and_then(Value::as_i64),
+            headers: MessageHeaders::from_payload(payload),
+            parts,
+        }
+    }
+}
+
+/// Whitelisted projection of a `messages.send` response.
+#[derive(Debug, Serialize)]
+struct SentMessageOutput {
+    id: String,
+    thread_id: Option<String>,
+    label_ids: Vec<String>,
+}
+
+impl SentMessageOutput {
+    fn from_google(value: &Value) -> Self {
+        let label_ids = value
+            .get("labelIds")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            id: string_field(value, "id").unwrap_or_default(),
+            thread_id: string_field(value, "threadId"),
+            label_ids,
+        }
+    }
+}
+
+/// Whitelisted projection of a `drafts.create` response.
+#[derive(Debug, Serialize)]
+struct DraftOutput {
+    id: String,
+    message_id: Option<String>,
+    thread_id: Option<String>,
+}
+
+impl DraftOutput {
+    fn from_google(value: &Value) -> Self {
+        let message = value.get("message");
+        Self {
+            id: string_field(value, "id").unwrap_or_default(),
+            message_id: message.and_then(|m| string_field(m, "id")),
+            thread_id: message.and_then(|m| string_field(m, "threadId")),
+        }
+    }
+}
+
+/// Whitelisted projection of a `messages.trash` response.
+#[derive(Debug, Serialize)]
+struct TrashedMessageOutput {
+    id: String,
+    trashed: bool,
+    label_ids: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Typed inputs.
+// ---------------------------------------------------------------------------
+
+fn default_message_format() -> String {
+    "full".to_string()
+}
+
+#[derive(Debug, Deserialize)]
+struct ListMessagesInput {
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    label_ids: Vec<String>,
+    #[serde(default)]
+    max_results: Option<u32>,
+    #[serde(default)]
+    page_token: Option<String>,
+    #[serde(default)]
+    include_spam_trash: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetMessageInput {
+    message_id: String,
+    #[serde(default = "default_message_format")]
+    format: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SendMessageInput {
+    to: Vec<String>,
+    #[serde(default)]
+    cc: Vec<String>,
+    #[serde(default)]
+    bcc: Vec<String>,
+    subject: String,
+    body: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateDraftInput {
+    to: Vec<String>,
+    #[serde(default)]
+    cc: Vec<String>,
+    #[serde(default)]
+    bcc: Vec<String>,
+    subject: String,
+    body: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplyToMessageInput {
+    /// Id of the message being replied to.
+    message_id: String,
+    body: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TrashMessageInput {
+    message_id: String,
+}
+
+/// Build an RFC 822 message from envelope fields and a plain-text body.
+fn build_rfc822(
+    to: &[String],
+    cc: &[String],
+    bcc: &[String],
+    subject: &str,
+    body: &str,
+    extra_headers: &[(&str, &str)],
+) -> String {
+    let mut message = String::new();
+    message.push_str(&format!("To: {}\r\n", to.join(", ")));
+    if !cc.is_empty() {
+        message.push_str(&format!("Cc: {}\r\n", cc.join(", ")));
+    }
+    if !bcc.is_empty() {
+        message.push_str(&format!("Bcc: {}\r\n", bcc.join(", ")));
+    }
+    message.push_str(&format!("Subject: {subject}\r\n"));
+    for (name, value) in extra_headers {
+        message.push_str(&format!("{name}: {value}\r\n"));
+    }
+    message.push_str("Content-Type: text/plain; charset=\"UTF-8\"\r\n");
+    message.push_str("MIME-Version: 1.0\r\n");
+    message.push_str("\r\n");
+    message.push_str(body);
+    message
+}
+
+/// Extract a header value (case-insensitive) from a Gmail `payload.headers`
+/// array.
+fn header_value(payload: Option<&Value>, name: &str) -> Option<String> {
+    payload
+        .and_then(|p| p.get("headers"))
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|header| {
+            header
+                .get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|n| n.eq_ignore_ascii_case(name))
+        })
+        .and_then(|header| header.get("value").and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+// ---------------------------------------------------------------------------
+// Read handlers.
+// ---------------------------------------------------------------------------
+
+/// `gmail.list_messages` — list messages in the user's mailbox.
+pub struct ListMessagesHandler {
+    deps: GmailHandlerDeps,
+}
+
+impl ListMessagesHandler {
+    pub fn new(deps: GmailHandlerDeps) -> Self {
+        Self { deps }
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for ListMessagesHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let started = Instant::now();
+        let input: ListMessagesInput = parse_input(request.input.clone())?;
+        self.deps.preflight_credential(&request.scope).await?;
+        let mut url = format!(
+            "{GMAIL_API_BASE}/users/me/messages?includeSpamTrash={}",
+            input.include_spam_trash
+        );
+        if let Some(query) = &input.query {
+            url.push_str(&format!("&q={}", encode_segment(query)));
+        }
+        for label in &input.label_ids {
+            url.push_str(&format!("&labelIds={}", encode_segment(label)));
+        }
+        if let Some(max_results) = input.max_results {
+            url.push_str(&format!("&maxResults={max_results}"));
+        }
+        if let Some(page_token) = &input.page_token {
+            url.push_str(&format!("&pageToken={}", encode_segment(page_token)));
+        }
+        let body = call_gmail(&request, NetworkMethod::Get, url, None).await?;
+        let messages = body
+            .get("messages")
+            .and_then(Value::as_array)
+            .map(|items| items.iter().map(MessageRef::from_google).collect())
+            .unwrap_or_default();
+        let output = encode_output(&ListMessagesOutput {
+            messages,
+            next_page_token: string_field(&body, "nextPageToken"),
+            result_size_estimate: body.get("resultSizeEstimate").and_then(Value::as_i64),
+        })?;
+        Ok(finish(output, started))
+    }
+}
+
+/// `gmail.get_message` — fetch one message by id.
+pub struct GetMessageHandler {
+    deps: GmailHandlerDeps,
+}
+
+impl GetMessageHandler {
+    pub fn new(deps: GmailHandlerDeps) -> Self {
+        Self { deps }
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for GetMessageHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let started = Instant::now();
+        let input: GetMessageInput = parse_input(request.input.clone())?;
+        self.deps.preflight_credential(&request.scope).await?;
+        let url = format!(
+            "{GMAIL_API_BASE}/users/me/messages/{}?format={}",
+            encode_segment(&input.message_id),
+            encode_segment(&input.format),
+        );
+        let body = call_gmail(&request, NetworkMethod::Get, url, None).await?;
+        let output = encode_output(&MessageOutput::from_google(&body))?;
+        Ok(finish(output, started))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Write handlers — all descriptor-gated with `PermissionMode::Ask`.
+// ---------------------------------------------------------------------------
+
+/// `gmail.send_message` — compose and send a message (RequiresApproval).
+pub struct SendMessageHandler {
+    deps: GmailHandlerDeps,
+}
+
+impl SendMessageHandler {
+    pub fn new(deps: GmailHandlerDeps) -> Self {
+        Self { deps }
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for SendMessageHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let started = Instant::now();
+        let input: SendMessageInput = parse_input(request.input.clone())?;
+        self.deps.preflight_credential(&request.scope).await?;
+        let rfc822 = build_rfc822(
+            &input.to,
+            &input.cc,
+            &input.bcc,
+            &input.subject,
+            &input.body,
+            &[],
+        );
+        let request_body = serde_json::json!({ "raw": base64url_encode(rfc822.as_bytes()) });
+        let url = format!("{GMAIL_API_BASE}/users/me/messages/send");
+        let body = call_gmail(&request, NetworkMethod::Post, url, Some(request_body)).await?;
+        let output = encode_output(&SentMessageOutput::from_google(&body))?;
+        Ok(finish(output, started))
+    }
+}
+
+/// `gmail.create_draft` — create a draft without sending (RequiresApproval).
+pub struct CreateDraftHandler {
+    deps: GmailHandlerDeps,
+}
+
+impl CreateDraftHandler {
+    pub fn new(deps: GmailHandlerDeps) -> Self {
+        Self { deps }
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for CreateDraftHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let started = Instant::now();
+        let input: CreateDraftInput = parse_input(request.input.clone())?;
+        self.deps.preflight_credential(&request.scope).await?;
+        let rfc822 = build_rfc822(
+            &input.to,
+            &input.cc,
+            &input.bcc,
+            &input.subject,
+            &input.body,
+            &[],
+        );
+        let request_body = serde_json::json!({
+            "message": { "raw": base64url_encode(rfc822.as_bytes()) }
+        });
+        let url = format!("{GMAIL_API_BASE}/users/me/drafts");
+        let body = call_gmail(&request, NetworkMethod::Post, url, Some(request_body)).await?;
+        let output = encode_output(&DraftOutput::from_google(&body))?;
+        Ok(finish(output, started))
+    }
+}
+
+/// `gmail.reply_to_message` — reply within an existing thread (RequiresApproval).
+pub struct ReplyToMessageHandler {
+    deps: GmailHandlerDeps,
+}
+
+impl ReplyToMessageHandler {
+    pub fn new(deps: GmailHandlerDeps) -> Self {
+        Self { deps }
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for ReplyToMessageHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let started = Instant::now();
+        let input: ReplyToMessageInput = parse_input(request.input.clone())?;
+        self.deps.preflight_credential(&request.scope).await?;
+
+        // Fetch the original message metadata so the reply preserves the
+        // thread and references the original Message-ID.
+        let metadata_url = format!(
+            "{GMAIL_API_BASE}/users/me/messages/{}?format=metadata",
+            encode_segment(&input.message_id),
+        );
+        let original = call_gmail(&request, NetworkMethod::Get, metadata_url, None).await?;
+        let payload = original.get("payload");
+        let thread_id = string_field(&original, "threadId");
+        let original_subject = header_value(payload, "Subject").unwrap_or_default();
+        let original_message_id =
+            header_value(payload, "Message-ID").or_else(|| header_value(payload, "Message-Id"));
+        let original_references = header_value(payload, "References");
+        let original_from = header_value(payload, "From").unwrap_or_default();
+
+        let reply_subject = if original_subject.to_ascii_lowercase().starts_with("re:") {
+            original_subject
+        } else {
+            format!("Re: {original_subject}")
+        };
+        // Build In-Reply-To / References per RFC 5322 threading conventions.
+        let references = match (&original_references, &original_message_id) {
+            (Some(refs), Some(mid)) => format!("{refs} {mid}"),
+            (None, Some(mid)) => mid.clone(),
+            (Some(refs), None) => refs.clone(),
+            (None, None) => String::new(),
+        };
+        let mut extra_headers: Vec<(&str, &str)> = Vec::new();
+        if let Some(mid) = &original_message_id {
+            extra_headers.push(("In-Reply-To", mid.as_str()));
+        }
+        if !references.is_empty() {
+            extra_headers.push(("References", references.as_str()));
+        }
+        let rfc822 = build_rfc822(
+            &[original_from],
+            &[],
+            &[],
+            &reply_subject,
+            &input.body,
+            &extra_headers,
+        );
+        let mut request_body = serde_json::json!({ "raw": base64url_encode(rfc822.as_bytes()) });
+        if let Some(thread) = &thread_id {
+            request_body["threadId"] = Value::String(thread.clone());
+        }
+        let url = format!("{GMAIL_API_BASE}/users/me/messages/send");
+        let body = call_gmail(&request, NetworkMethod::Post, url, Some(request_body)).await?;
+        let output = encode_output(&SentMessageOutput::from_google(&body))?;
+        Ok(finish(output, started))
+    }
+}
+
+/// `gmail.trash_message` — move a message to trash (RequiresApproval).
+pub struct TrashMessageHandler {
+    deps: GmailHandlerDeps,
+}
+
+impl TrashMessageHandler {
+    pub fn new(deps: GmailHandlerDeps) -> Self {
+        Self { deps }
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for TrashMessageHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let started = Instant::now();
+        let input: TrashMessageInput = parse_input(request.input.clone())?;
+        self.deps.preflight_credential(&request.scope).await?;
+        let url = format!(
+            "{GMAIL_API_BASE}/users/me/messages/{}/trash",
+            encode_segment(&input.message_id),
+        );
+        let body = call_gmail(
+            &request,
+            NetworkMethod::Post,
+            url,
+            Some(serde_json::json!({})),
+        )
+        .await?;
+        let label_ids = body
+            .get("labelIds")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let output = encode_output(&TrashedMessageOutput {
+            id: input.message_id,
+            trashed: true,
+            label_ids,
+        })?;
+        Ok(finish(output, started))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_segment_escapes_path_breaking_characters() {
+        assert_eq!(encode_segment("msg-1"), "msg-1");
+        assert_eq!(encode_segment("user@example.com"), "user%40example.com");
+        assert_eq!(encode_segment("a/b"), "a%2Fb");
+        assert_eq!(encode_segment("is:unread from:x"), "is%3Aunread%20from%3Ax");
+    }
+
+    #[test]
+    fn base64url_encode_matches_known_vectors() {
+        assert_eq!(base64url_encode(b""), "");
+        assert_eq!(base64url_encode(b"f"), "Zg");
+        assert_eq!(base64url_encode(b"fo"), "Zm8");
+        assert_eq!(base64url_encode(b"foo"), "Zm9v");
+        assert_eq!(base64url_encode(b"foobar"), "Zm9vYmFy");
+        // base64url uses `-`/`_` and never emits `+`/`/` or padding.
+        let encoded = base64url_encode(&[0xFB, 0xFF, 0xBF]);
+        assert!(!encoded.contains('+') && !encoded.contains('/') && !encoded.contains('='));
+    }
+
+    #[test]
+    fn message_output_drops_internal_fields_and_raw_headers() {
+        let raw = serde_json::json!({
+            "id": "msg-1",
+            "threadId": "thr-1",
+            "internalDate": "1716200000000",
+            "historyId": "987654",
+            "snippet": "Hello there",
+            "labelIds": ["INBOX", "UNREAD"],
+            "payload": {
+                "headers": [
+                    { "name": "From", "value": "alice@example.com" },
+                    { "name": "Subject", "value": "Hi" },
+                    { "name": "X-Internal-Trace", "value": "leak-me" }
+                ]
+            }
+        });
+        let projected = serde_json::to_value(MessageOutput::from_google(&raw)).unwrap();
+        assert_eq!(projected.get("id").and_then(Value::as_str), Some("msg-1"));
+        assert!(projected.get("internalDate").is_none());
+        assert!(projected.get("historyId").is_none());
+        let serialized = serde_json::to_string(&projected).unwrap();
+        // Whitelisted headers survive; un-whitelisted raw headers do not.
+        assert!(serialized.contains("alice@example.com"));
+        assert!(!serialized.contains("X-Internal-Trace"));
+        assert!(!serialized.contains("leak-me"));
+    }
+
+    #[test]
+    fn message_part_replaces_oversized_body_with_attachment_ref() {
+        let big = "A".repeat(INLINE_BODY_LIMIT + 1);
+        let raw = serde_json::json!({
+            "mimeType": "application/pdf",
+            "filename": "report.pdf",
+            "body": { "data": big, "attachmentId": "att-99", "size": 200000 }
+        });
+        let part = MessagePart::from_google(&raw);
+        assert!(part.body_data.is_none(), "oversized body must be dropped");
+        assert_eq!(part.attachment_ref.as_deref(), Some("att-99"));
+    }
+
+    #[test]
+    fn credential_injection_targets_authorization_header_with_bearer_prefix() {
+        let capability_id = ironclaw_host_api::CapabilityId::new("gmail.send_message").unwrap();
+        let injection = google_credential_injection(&capability_id).unwrap();
+        assert_eq!(injection.handle.as_str(), GOOGLE_CREDENTIAL_NAME);
+        assert!(injection.required);
+        match injection.source {
+            RuntimeCredentialSource::StagedObligation { capability_id: id } => {
+                assert_eq!(id, capability_id);
+            }
+            RuntimeCredentialSource::SecretStoreLease => {
+                panic!("must use a staged obligation, not a direct secret-store lease")
+            }
+        }
+        match injection.target {
+            RuntimeCredentialTarget::Header { name, prefix } => {
+                assert_eq!(name, "authorization");
+                assert_eq!(prefix.as_deref(), Some("Bearer "));
+            }
+            RuntimeCredentialTarget::QueryParam { .. } => {
+                panic!("OAuth bearer token must be a header, not a query param")
+            }
+        }
+    }
+
+    #[test]
+    fn build_rfc822_includes_envelope_and_threading_headers() {
+        let message = build_rfc822(
+            &["bob@example.com".to_string()],
+            &["cc@example.com".to_string()],
+            &[],
+            "Re: Status",
+            "Looks good.",
+            &[("In-Reply-To", "<orig@mail>")],
+        );
+        assert!(message.contains("To: bob@example.com\r\n"));
+        assert!(message.contains("Cc: cc@example.com\r\n"));
+        assert!(message.contains("Subject: Re: Status\r\n"));
+        assert!(message.contains("In-Reply-To: <orig@mail>\r\n"));
+        assert!(message.ends_with("Looks good."));
+    }
+}

--- a/crates/ironclaw_native_extensions/src/google/gmail/manifest.rs
+++ b/crates/ironclaw_native_extensions/src/google/gmail/manifest.rs
@@ -1,0 +1,157 @@
+//! HostBundled `ExtensionPackage` declaring the six Gmail capabilities.
+//!
+//! The manifest is descriptor-only: it carries the capability ids, effects,
+//! and permission modes that the host authorization layer reads. The actual
+//! handler implementations live in [`super::handlers`] and are registered as
+//! first-party capability handlers separately.
+
+use ironclaw_extensions::{
+    CapabilityManifest, CapabilityVisibility, ExtensionError, ExtensionManifest, ExtensionPackage,
+    ExtensionRuntime, MANIFEST_SCHEMA_VERSION, ManifestSource,
+};
+use ironclaw_host_api::{
+    CapabilityId, CapabilityProfileSchemaRef, EffectKind, ExtensionId, PermissionMode,
+    RequestedTrustClass, TrustClass, VirtualPath,
+};
+
+/// User-facing installed extension id. Capability ids must be prefixed with
+/// `"{EXTENSION_ID}."` or [`ExtensionPackage::from_manifest`] rejects them.
+pub const GMAIL_EXTENSION_ID: &str = "gmail";
+
+/// First-party runtime service name carried in the manifest.
+pub const GMAIL_SERVICE: &str = "gmail";
+
+/// Effects of a read-only Gmail capability.
+fn read_effects() -> Vec<EffectKind> {
+    vec![
+        EffectKind::DispatchCapability,
+        EffectKind::Network,
+        EffectKind::UseSecret,
+    ]
+}
+
+/// Effects of a write Gmail capability — read effects plus `ExternalWrite`.
+fn write_effects() -> Vec<EffectKind> {
+    let mut effects = read_effects();
+    effects.push(EffectKind::ExternalWrite);
+    effects
+}
+
+/// Stable kind tag for a capability descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GmailCapabilityKind {
+    /// Read capability: `PermissionMode::Allow`, no `ExternalWrite` effect.
+    Read,
+    /// Write capability: `PermissionMode::Ask` (RequiresApproval) plus
+    /// `ExternalWrite`.
+    Write,
+}
+
+impl GmailCapabilityKind {
+    fn permission(self) -> PermissionMode {
+        match self {
+            Self::Read => PermissionMode::Allow,
+            Self::Write => PermissionMode::Ask,
+        }
+    }
+
+    fn effects(self) -> Vec<EffectKind> {
+        match self {
+            Self::Read => read_effects(),
+            Self::Write => write_effects(),
+        }
+    }
+}
+
+/// One row of the Gmail capability table: `(short_name, description, kind)`.
+/// The fully-qualified id is `"{GMAIL_EXTENSION_ID}.{short_name}"`.
+pub const GMAIL_CAPABILITIES: &[(&str, &str, GmailCapabilityKind)] = &[
+    (
+        "list_messages",
+        "List messages in the user's Gmail mailbox, optionally filtered by query.",
+        GmailCapabilityKind::Read,
+    ),
+    (
+        "get_message",
+        "Fetch a single Gmail message by id.",
+        GmailCapabilityKind::Read,
+    ),
+    (
+        "send_message",
+        "Compose and send a new Gmail message.",
+        GmailCapabilityKind::Write,
+    ),
+    (
+        "create_draft",
+        "Create a draft Gmail message without sending it.",
+        GmailCapabilityKind::Write,
+    ),
+    (
+        "reply_to_message",
+        "Reply to an existing Gmail message, preserving its thread.",
+        GmailCapabilityKind::Write,
+    ),
+    (
+        "trash_message",
+        "Move a Gmail message to the trash.",
+        GmailCapabilityKind::Write,
+    ),
+];
+
+/// Fully-qualified capability id for a Gmail capability short name.
+pub fn capability_id(short_name: &str) -> String {
+    format!("{GMAIL_EXTENSION_ID}.{short_name}")
+}
+
+fn capability_manifest(
+    short_name: &str,
+    description: &str,
+    kind: GmailCapabilityKind,
+) -> Result<CapabilityManifest, ExtensionError> {
+    Ok(CapabilityManifest {
+        id: CapabilityId::new(capability_id(short_name))?,
+        implements: Vec::new(),
+        description: description.to_string(),
+        effects: kind.effects(),
+        default_permission: kind.permission(),
+        visibility: CapabilityVisibility::Model,
+        input_schema_ref: CapabilityProfileSchemaRef::new(format!(
+            "schemas/gmail/{short_name}.input.v1.json"
+        ))?,
+        output_schema_ref: CapabilityProfileSchemaRef::new(format!(
+            "schemas/gmail/{short_name}.output.v1.json"
+        ))?,
+        prompt_doc_ref: Some(CapabilityProfileSchemaRef::new(format!(
+            "prompts/gmail/{short_name}.md"
+        ))?),
+        required_host_ports: Vec::new(),
+        resource_profile: None,
+    })
+}
+
+/// Build the HostBundled `ExtensionPackage` declaring all six Gmail
+/// capabilities.
+pub fn gmail_package() -> Result<ExtensionPackage, ExtensionError> {
+    let capabilities = GMAIL_CAPABILITIES
+        .iter()
+        .map(|(short_name, description, kind)| capability_manifest(short_name, description, *kind))
+        .collect::<Result<Vec<_>, ExtensionError>>()?;
+    ExtensionPackage::from_manifest(
+        ExtensionManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
+            id: ExtensionId::new(GMAIL_EXTENSION_ID)?,
+            name: "Gmail".to_string(),
+            version: "0.1.0".to_string(),
+            description: "First-party Gmail capabilities for Reborn.".to_string(),
+            source: ManifestSource::HostBundled,
+            requested_trust: RequestedTrustClass::FirstPartyRequested,
+            descriptor_trust_default: TrustClass::Sandbox,
+            runtime: ExtensionRuntime::FirstParty {
+                service: GMAIL_SERVICE.to_string(),
+            },
+            host_apis: Vec::new(),
+            capabilities,
+        },
+        VirtualPath::new(format!("/system/extensions/{GMAIL_EXTENSION_ID}"))?,
+    )
+}

--- a/crates/ironclaw_native_extensions/src/google/gmail/mod.rs
+++ b/crates/ironclaw_native_extensions/src/google/gmail/mod.rs
@@ -1,0 +1,96 @@
+//! Gmail native extension package.
+//!
+//! [`manifest`] declares the HostBundled `ExtensionPackage` (six capability
+//! descriptors); [`handlers`] holds the six first-party capability handler
+//! implementations. [`register_gmail`] populates a [`RegistrationOutput`] with
+//! the package and the keyed handlers.
+
+pub mod handlers;
+pub mod manifest;
+
+use std::sync::Arc;
+
+use ironclaw_host_api::CapabilityId;
+use ironclaw_host_runtime::FirstPartyCapabilityHandler;
+use ironclaw_oauth::OAuthProvider;
+
+use crate::google::credential::GoogleCredentialResolver;
+use crate::google::scopes;
+use crate::{NativeExtensionError, RegistrationOutput};
+
+use handlers::{
+    CreateDraftHandler, GetMessageHandler, GmailHandlerDeps, ListMessagesHandler,
+    ReplyToMessageHandler, SendMessageHandler, TrashMessageHandler,
+};
+use manifest::{capability_id, gmail_package};
+
+/// Build a keyed `(CapabilityId, handler)` pair, mapping id-construction
+/// failure to a [`NativeExtensionError`].
+fn keyed(
+    short_name: &str,
+    handler: Arc<dyn FirstPartyCapabilityHandler>,
+) -> Result<(CapabilityId, Arc<dyn FirstPartyCapabilityHandler>), NativeExtensionError> {
+    let id = CapabilityId::new(capability_id(short_name))?;
+    Ok((id, handler))
+}
+
+/// Register the Gmail package and its six capability handlers into `output`.
+///
+/// `resolver` is the shared credential resolver (used by handlers for the
+/// scope-mismatch preflight); `provider` is the shared Google `OAuthProvider`.
+/// Both are shared with the Google Calendar package — Gmail and Calendar
+/// resolve the same `google_oauth_token` credential. Handlers do not own an
+/// HTTP transport — they issue calls through the per-invocation
+/// `runtime_http_egress` the host supplies in `InvocationServices`.
+///
+/// Scope requirements (per capability):
+/// - `list_messages`, `get_message`: `gmail.readonly`
+/// - `send_message`: `gmail.send`
+/// - `create_draft`, `trash_message`: `gmail.modify`
+/// - `reply_to_message`: `gmail.send` + `gmail.modify`
+pub fn register_gmail(
+    resolver: Arc<GoogleCredentialResolver>,
+    provider: Arc<dyn OAuthProvider>,
+    output: &mut RegistrationOutput,
+) -> Result<(), NativeExtensionError> {
+    output.packages.push(gmail_package()?);
+
+    let readonly_scopes = vec![scopes::GMAIL_READONLY.to_string()];
+    let send_scopes = vec![scopes::GMAIL_SEND.to_string()];
+    let modify_scopes = vec![scopes::GMAIL_MODIFY.to_string()];
+    let reply_scopes = vec![
+        scopes::GMAIL_SEND.to_string(),
+        scopes::GMAIL_MODIFY.to_string(),
+    ];
+
+    let read_deps = GmailHandlerDeps::new(resolver.clone(), provider.clone(), readonly_scopes);
+    let send_deps = GmailHandlerDeps::new(resolver.clone(), provider.clone(), send_scopes);
+    let modify_deps = GmailHandlerDeps::new(resolver.clone(), provider.clone(), modify_scopes);
+    let reply_deps = GmailHandlerDeps::new(resolver, provider, reply_scopes);
+
+    let handlers: Vec<(&str, Arc<dyn FirstPartyCapabilityHandler>)> = vec![
+        (
+            "list_messages",
+            Arc::new(ListMessagesHandler::new(read_deps.clone())),
+        ),
+        ("get_message", Arc::new(GetMessageHandler::new(read_deps))),
+        ("send_message", Arc::new(SendMessageHandler::new(send_deps))),
+        (
+            "create_draft",
+            Arc::new(CreateDraftHandler::new(modify_deps.clone())),
+        ),
+        (
+            "reply_to_message",
+            Arc::new(ReplyToMessageHandler::new(reply_deps)),
+        ),
+        (
+            "trash_message",
+            Arc::new(TrashMessageHandler::new(modify_deps)),
+        ),
+    ];
+
+    for (short_name, handler) in handlers {
+        output.handlers.push(keyed(short_name, handler)?);
+    }
+    Ok(())
+}

--- a/crates/ironclaw_native_extensions/src/google/mod.rs
+++ b/crates/ironclaw_native_extensions/src/google/mod.rs
@@ -1,6 +1,7 @@
 pub mod calendar;
 pub mod client;
 pub mod credential;
+pub mod gmail;
 pub mod network;
 pub mod oauth_provider;
 
@@ -28,11 +29,14 @@ pub fn register(
         output
             .network_policies
             .push(network::google_api_network_policy());
-        // Calendar handlers issue HTTP through the per-invocation host
-        // `runtime_http_egress` (HostHttpEgressService), not a transport built
-        // here, so no standalone HTTP client is constructed at registration.
+        // Calendar and Gmail handlers issue HTTP through the per-invocation
+        // host `runtime_http_egress` (HostHttpEgressService), not a transport
+        // built here, so no standalone HTTP client is constructed at
+        // registration. Both packages share the one credential resolver and
+        // Google `OAuthProvider` — they resolve the same `google_oauth_token`.
         let oauth_provider: Arc<dyn ironclaw_oauth::OAuthProvider> = provider.clone();
-        calendar::register_calendar(resolver, oauth_provider, output)?;
+        calendar::register_calendar(resolver.clone(), oauth_provider.clone(), output)?;
+        gmail::register_gmail(resolver, oauth_provider, output)?;
         output.oauth_providers.push(provider);
     }
     Ok(())

--- a/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/draft_created.json
+++ b/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/draft_created.json
@@ -1,0 +1,8 @@
+{
+  "id": "draft-501",
+  "message": {
+    "id": "msg-draft-501",
+    "threadId": "thr-draft-501",
+    "labelIds": ["DRAFT"]
+  }
+}

--- a/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/insufficient_scope.json
+++ b/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/insufficient_scope.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "code": 403,
+    "status": "PERMISSION_DENIED",
+    "message": "Request had insufficient authentication scopes.",
+    "details": [{ "reason": "insufficient_scope" }]
+  }
+}

--- a/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/message_get.json
+++ b/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/message_get.json
@@ -1,0 +1,27 @@
+{
+  "id": "msg-001",
+  "threadId": "thr-001",
+  "labelIds": ["INBOX", "UNREAD"],
+  "snippet": "Quarterly numbers are in, see attached summary.",
+  "internalDate": "1716200000000",
+  "historyId": "9981234",
+  "sizeEstimate": 8421,
+  "payload": {
+    "mimeType": "multipart/mixed",
+    "headers": [
+      { "name": "From", "value": "Ada Lovelace <ada@example.com>" },
+      { "name": "To", "value": "Bob Hawk <bob@example.com>" },
+      { "name": "Subject", "value": "Q2 summary" },
+      { "name": "Date", "value": "Wed, 20 May 2026 14:00:00 -0400" },
+      { "name": "Message-ID", "value": "<orig-001@mail.example.com>" },
+      { "name": "X-Internal-Trace-Id", "value": "trace-should-not-leak" }
+    ],
+    "parts": [
+      {
+        "mimeType": "text/plain",
+        "filename": "",
+        "body": { "size": 31, "data": "UXVhcnRlcmx5IG51bWJlcnMgYXJlIGluLg" }
+      }
+    ]
+  }
+}

--- a/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/message_sent.json
+++ b/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/message_sent.json
@@ -1,0 +1,5 @@
+{
+  "id": "msg-sent-700",
+  "threadId": "thr-sent-700",
+  "labelIds": ["SENT"]
+}

--- a/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/message_trashed.json
+++ b/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/message_trashed.json
@@ -1,0 +1,5 @@
+{
+  "id": "msg-001",
+  "threadId": "thr-001",
+  "labelIds": ["TRASH"]
+}

--- a/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/messages_list.json
+++ b/crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/messages_list.json
@@ -1,0 +1,8 @@
+{
+  "messages": [
+    { "id": "msg-001", "threadId": "thr-001" },
+    { "id": "msg-002", "threadId": "thr-002" }
+  ],
+  "nextPageToken": "PG-9f3a2",
+  "resultSizeEstimate": 2
+}

--- a/crates/ironclaw_native_extensions/tests/google_gmail_approval.rs
+++ b/crates/ironclaw_native_extensions/tests/google_gmail_approval.rs
@@ -1,0 +1,579 @@
+//! Approval-gate, scope, credential, refresh, redaction, egress-routing, and
+//! shared-credential lifecycle tests for the Gmail package.
+//!
+//! Approval gating for write capabilities is descriptor-level: the manifest
+//! marks the four write capabilities `PermissionMode::Ask` with an
+//! `ExternalWrite` effect, and the host authorization layer is what blocks an
+//! unapproved write. These tests therefore assert the descriptor contract and
+//! exercise a host-level gate seam, rather than re-implementing approval inside
+//! the handler.
+
+mod support;
+
+use std::sync::Arc;
+
+use ironclaw_host_api::{
+    EffectKind, PermissionMode, RuntimeCredentialSource, RuntimeDispatchErrorKind,
+};
+use ironclaw_host_runtime::FirstPartyCapabilityHandler;
+use ironclaw_native_extensions::google::credential::{
+    GOOGLE_CREDENTIAL_NAME, GoogleCredentialResolver,
+};
+use ironclaw_native_extensions::google::gmail::handlers::{
+    GetMessageHandler, ListMessagesHandler, SendMessageHandler,
+};
+use ironclaw_native_extensions::google::gmail::manifest::{
+    GMAIL_CAPABILITIES, GmailCapabilityKind, capability_id, gmail_package,
+};
+use ironclaw_native_extensions::google::scopes;
+use ironclaw_secrets::InMemorySecretStore;
+use serde_json::{Value, json};
+
+use support::{
+    FakeEgress, build_gmail_deps, gmail_extension_id, gmail_request, gmail_request_without_egress,
+    seed_expiring_token, seed_token, test_provider, test_scope,
+};
+
+// ---------------------------------------------------------------------------
+// Package / descriptor assertions.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gmail_package_declares_six_capabilities() {
+    let package = gmail_package().expect("gmail package builds");
+    assert_eq!(package.id.as_str(), "gmail");
+    assert_eq!(package.capabilities.len(), 6);
+    assert_eq!(package.manifest.capabilities.len(), 6);
+    assert_eq!(package.root.as_str(), "/system/extensions/gmail");
+}
+
+#[test]
+fn write_capabilities_require_approval_and_external_write() {
+    let package = gmail_package().expect("gmail package builds");
+    let write_names = [
+        "send_message",
+        "create_draft",
+        "reply_to_message",
+        "trash_message",
+    ];
+    for (short_name, _, kind) in GMAIL_CAPABILITIES {
+        let id = capability_id(short_name);
+        let descriptor = package
+            .capabilities
+            .iter()
+            .find(|cap| cap.id.as_str() == id)
+            .unwrap_or_else(|| panic!("descriptor for {id} present"));
+        match kind {
+            GmailCapabilityKind::Write => {
+                assert!(
+                    write_names.contains(short_name),
+                    "{short_name} is a write cap"
+                );
+                // RequiresApproval -> PermissionMode::Ask.
+                assert_eq!(
+                    descriptor.default_permission,
+                    PermissionMode::Ask,
+                    "{short_name} must require approval"
+                );
+                assert!(
+                    descriptor.effects.contains(&EffectKind::ExternalWrite),
+                    "{short_name} must declare ExternalWrite"
+                );
+            }
+            GmailCapabilityKind::Read => {
+                assert_eq!(
+                    descriptor.default_permission,
+                    PermissionMode::Allow,
+                    "{short_name} is read-only"
+                );
+                assert!(
+                    !descriptor.effects.contains(&EffectKind::ExternalWrite),
+                    "{short_name} must not declare ExternalWrite"
+                );
+            }
+        }
+        // Every capability uses the shared Google secret and network.
+        assert!(descriptor.effects.contains(&EffectKind::UseSecret));
+        assert!(descriptor.effects.contains(&EffectKind::Network));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Egress routing: handlers must go through the host runtime-egress boundary.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn handler_fails_closed_when_runtime_http_egress_is_unavailable() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = ListMessagesHandler::new(deps);
+
+    // No runtime_http_egress wired -> the handler cannot reach the network and
+    // must fail closed instead of falling back to a self-built transport.
+    let error = handler
+        .dispatch(gmail_request_without_egress(
+            "list_messages",
+            scope,
+            json!({}),
+        ))
+        .await
+        .expect_err("missing host egress must fail");
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
+}
+
+#[tokio::test]
+async fn handler_declares_staged_credential_injection_for_the_token() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    let egress = FakeEgress::single(200, json!({ "messages": [] }));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = ListMessagesHandler::new(deps);
+
+    handler
+        .dispatch(gmail_request(
+            "list_messages",
+            scope,
+            json!({}),
+            egress.clone(),
+        ))
+        .await
+        .expect("list_messages succeeds");
+
+    let recorded = egress.recorded();
+    let injection = &recorded[0].credential_injections[0];
+    assert_eq!(injection.handle.as_str(), GOOGLE_CREDENTIAL_NAME);
+    assert!(injection.required);
+    // Production HostHttpEgressService rejects direct secret-store leases for
+    // runtime egress; the handler must declare a staged obligation.
+    assert!(
+        matches!(
+            injection.source,
+            RuntimeCredentialSource::StagedObligation { .. }
+        ),
+        "credential injection must use a staged obligation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Approval gate: blocked -> approved -> succeeds; approval-unreachable fails
+// closed. The descriptor `PermissionMode::Ask` is the gate the host evaluates
+// before dispatch; this models that host gate seam.
+// ---------------------------------------------------------------------------
+
+/// Models the host-level authorization decision for a write capability.
+enum ApprovalDecision {
+    Granted,
+    Denied,
+    /// The approval service could not be reached — must fail closed.
+    Unreachable,
+}
+
+/// Mimics the host gate: a write capability may only be dispatched once
+/// approval is `Granted`. `Denied`/`Unreachable` must block the dispatch.
+async fn dispatch_send_with_gate(
+    decision: ApprovalDecision,
+    handler: &SendMessageHandler,
+    request: ironclaw_host_runtime::FirstPartyCapabilityRequest,
+) -> Result<(), RuntimeDispatchErrorKind> {
+    match decision {
+        ApprovalDecision::Granted => handler
+            .dispatch(request)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.kind()),
+        // Fail closed: an undecided/unreachable approval never reaches the
+        // handler, so the side-effecting send is not silently executed.
+        ApprovalDecision::Denied | ApprovalDecision::Unreachable => {
+            Err(RuntimeDispatchErrorKind::Client)
+        }
+    }
+}
+
+#[tokio::test]
+async fn send_message_blocked_then_approved_then_succeeds() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_SEND]).await;
+    let egress = FakeEgress::single(
+        200,
+        json!({ "id": "msg-sent-700", "threadId": "thr-sent-700", "labelIds": ["SENT"] }),
+    );
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_SEND]);
+    let handler = SendMessageHandler::new(deps);
+
+    let make_request = || {
+        gmail_request(
+            "send_message",
+            scope.clone(),
+            json!({
+                "to": ["bob@example.com"],
+                "subject": "Sprint planning",
+                "body": "Notes attached."
+            }),
+            egress.clone(),
+        )
+    };
+
+    // Blocked: approval denied -> handler never runs, no network call.
+    let blocked = dispatch_send_with_gate(ApprovalDecision::Denied, &handler, make_request()).await;
+    assert!(blocked.is_err());
+    assert!(
+        egress.recorded().is_empty(),
+        "denied send must not call the API"
+    );
+
+    // Approved: handler runs, the send reaches the API.
+    let approved =
+        dispatch_send_with_gate(ApprovalDecision::Granted, &handler, make_request()).await;
+    assert!(approved.is_ok(), "approved send succeeds");
+    let recorded = egress.recorded();
+    assert_eq!(recorded.len(), 1);
+    assert!(recorded[0].url.contains("/users/me/messages/send"));
+}
+
+#[tokio::test]
+async fn send_message_fails_closed_when_approval_unreachable() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_SEND]).await;
+    let egress = FakeEgress::single(200, json!({ "id": "msg-sent-700" }));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_SEND]);
+    let handler = SendMessageHandler::new(deps);
+
+    let result = dispatch_send_with_gate(
+        ApprovalDecision::Unreachable,
+        &handler,
+        gmail_request(
+            "send_message",
+            scope,
+            json!({ "to": ["x@example.com"], "subject": "x", "body": "x" }),
+            egress.clone(),
+        ),
+    )
+    .await;
+
+    // Fail closed: unreachable approval blocks the send entirely.
+    assert!(result.is_err());
+    assert!(
+        egress.recorded().is_empty(),
+        "unreachable approval must not let the send through"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scope mismatch and missing credential.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scope_mismatch_fails_with_client_error() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    // The token only granted gmail.readonly; send_message requires gmail.send.
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    let egress = FakeEgress::single(200, json!({ "id": "msg" }));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_SEND]);
+    let handler = SendMessageHandler::new(deps);
+
+    let error = handler
+        .dispatch(gmail_request(
+            "send_message",
+            scope,
+            json!({ "to": ["bob@example.com"], "subject": "Hi", "body": "Hello" }),
+            egress.clone(),
+        ))
+        .await
+        .expect_err("scope mismatch must fail");
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::Client);
+    // The scope check happens before any network call.
+    assert!(egress.recorded().is_empty());
+}
+
+#[tokio::test]
+async fn missing_credential_fails_closed() {
+    let scope = test_scope();
+    // No token seeded for this scope.
+    let secrets = Arc::new(InMemorySecretStore::new());
+    let egress = FakeEgress::single(200, json!({ "messages": [] }));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = ListMessagesHandler::new(deps);
+
+    let error = handler
+        .dispatch(gmail_request(
+            "list_messages",
+            scope,
+            json!({}),
+            egress.clone(),
+        ))
+        .await
+        .expect_err("missing credential must fail");
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::Client);
+    assert!(egress.recorded().is_empty());
+}
+
+#[tokio::test]
+async fn gmail_error_response_maps_to_client_error() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    // Credential resolves, but Gmail rejects the call with 403.
+    let egress = FakeEgress::single(403, json!({ "error": { "status": "PERMISSION_DENIED" } }));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = ListMessagesHandler::new(deps);
+
+    let error = handler
+        .dispatch(gmail_request("list_messages", scope, json!({}), egress))
+        .await
+        .expect_err("403 must fail");
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::Client);
+}
+
+// ---------------------------------------------------------------------------
+// Refresh: a near-expired access token still resolves and the handler
+// dispatches. The credential resolver flags `refresh_required`; the actual
+// token refresh is owned by the host obligation layer, not the handler.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn near_expired_token_reports_refresh_required_but_still_dispatches() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    // Token expires inside the resolver's 60s refresh buffer.
+    seed_expiring_token(&secrets, &scope, &[scopes::GMAIL_READONLY], 0).await;
+
+    // The resolver reports the credential as refresh-required.
+    let resolver = GoogleCredentialResolver::new(secrets.clone());
+    let provider = test_provider();
+    let credential = resolver
+        .resolve(
+            &scope,
+            provider.as_ref(),
+            &[scopes::GMAIL_READONLY.to_string()],
+        )
+        .await
+        .expect("credential resolves even when refresh is due");
+    assert!(
+        credential.refresh_required,
+        "a near-expired token must be flagged for refresh"
+    );
+    assert!(credential.missing_scopes.is_empty());
+
+    // The read handler still dispatches: refreshing the token is the host
+    // egress service's responsibility, transparent to the handler.
+    let egress = FakeEgress::single(200, json!({ "messages": [], "resultSizeEstimate": 0 }));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = ListMessagesHandler::new(deps);
+    let result = handler
+        .dispatch(gmail_request(
+            "list_messages",
+            scope,
+            json!({}),
+            egress.clone(),
+        ))
+        .await
+        .expect("handler dispatches despite a refresh-due token");
+    assert!(result.output.get("messages").is_some());
+    assert_eq!(egress.recorded().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Redaction: handler output must not leak the access token, internal ids, or
+// the raw header set.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn handler_output_redacts_token_internal_ids_and_raw_headers() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    // Raw Gmail message carries internal fields and an un-whitelisted header.
+    let raw = json!({
+        "id": "msg-1",
+        "threadId": "thr-1",
+        "internalDate": "1716200000000",
+        "historyId": "55512345",
+        "snippet": "Confidential briefing",
+        "labelIds": ["INBOX"],
+        "payload": {
+            "headers": [
+                { "name": "From", "value": "spy@example.com" },
+                { "name": "Subject", "value": "Confidential briefing" },
+                { "name": "X-Internal-Trace-Id", "value": "trace-leak-token" }
+            ],
+            "body": { "size": 12, "data": "SGVsbG8gd29ybGQ" }
+        }
+    });
+    let egress = FakeEgress::single(200, raw);
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = GetMessageHandler::new(deps);
+
+    let result = handler
+        .dispatch(gmail_request(
+            "get_message",
+            scope,
+            json!({ "message_id": "msg-1" }),
+            egress.clone(),
+        ))
+        .await
+        .expect("get_message succeeds");
+
+    let serialized = serde_json::to_string(&result.output).expect("output serializes");
+    // The OAuth access token must never appear in handler output.
+    assert!(
+        !serialized.contains("ada-access-token"),
+        "output leaked the access token: {serialized}"
+    );
+    assert!(!serialized.to_lowercase().contains("bearer"));
+    // Internal Gmail ids must be stripped from the projection.
+    assert!(!serialized.contains("internalDate"));
+    assert!(!serialized.contains("historyId"));
+    // The raw header array must not be echoed: only whitelisted headers survive.
+    assert!(!serialized.contains("X-Internal-Trace-Id"));
+    assert!(!serialized.contains("trace-leak-token"));
+    // Whitelisted fields are still present.
+    assert!(serialized.contains("Confidential briefing"));
+    assert!(serialized.contains("spy@example.com"));
+
+    // The handler must not place the token on the outbound request itself; the
+    // host egress injects the staged credential.
+    let recorded = egress.recorded();
+    let request_serialized = format!("{:?}", recorded[0].headers);
+    assert!(!request_serialized.contains("ada-access-token"));
+}
+
+// ---------------------------------------------------------------------------
+// Shared-credential lifecycle: install Gmail + (simulated) Calendar both add
+// refs; uninstalling Gmail keeps the credential row alive while Calendar still
+// holds a ref.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn shared_credential_survives_gmail_uninstall_while_calendar_holds_ref() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    let resolver = GoogleCredentialResolver::new(secrets.clone());
+
+    let gmail = gmail_extension_id();
+    let calendar = ironclaw_host_api::ExtensionId::new("google-calendar").expect("calendar id");
+
+    // Install Gmail, then (simulated) Calendar — both register a ref.
+    resolver
+        .add_ref(&scope, &gmail)
+        .await
+        .expect("gmail ref added");
+    let refs = resolver
+        .add_ref(&scope, &calendar)
+        .await
+        .expect("calendar ref added");
+    assert_eq!(refs.len(), 2, "both extensions hold a credential ref");
+
+    // Uninstall Gmail — Calendar still holds a ref, so the row survives.
+    let remaining = resolver
+        .remove_ref(&scope, &gmail)
+        .await
+        .expect("gmail ref removed");
+    assert_eq!(remaining, vec![calendar.clone()]);
+
+    // The shared credential is still resolvable for Calendar.
+    let provider = test_provider();
+    let credential = resolver
+        .resolve(
+            &scope,
+            provider.as_ref(),
+            &[scopes::GMAIL_READONLY.to_string()],
+        )
+        .await
+        .expect("credential row still alive for Calendar");
+    assert!(!credential.granted_scopes.is_empty());
+
+    // Uninstall Calendar too — refs empty, credential row is deleted.
+    let empty = resolver
+        .remove_ref(&scope, &calendar)
+        .await
+        .expect("calendar ref removed");
+    assert!(empty.is_empty());
+    let after = resolver
+        .resolve(
+            &scope,
+            provider.as_ref(),
+            &[scopes::GMAIL_READONLY.to_string()],
+        )
+        .await;
+    assert!(
+        after.is_err(),
+        "credential row must be gone once all refs are released"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// reply_to_message: preserves the thread and references the original message.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reply_to_message_preserves_thread_and_threading_headers() {
+    use ironclaw_native_extensions::google::gmail::handlers::ReplyToMessageHandler;
+
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(
+        &secrets,
+        &scope,
+        &[scopes::GMAIL_SEND, scopes::GMAIL_MODIFY],
+    )
+    .await;
+    // First call fetches the original metadata; second call is the send.
+    let egress = FakeEgress::new(vec![
+        support::scripted(
+            "format=metadata",
+            200,
+            json!({
+                "id": "msg-001",
+                "threadId": "thr-001",
+                "payload": {
+                    "headers": [
+                        { "name": "From", "value": "ada@example.com" },
+                        { "name": "Subject", "value": "Q2 summary" },
+                        { "name": "Message-ID", "value": "<orig-001@mail.example.com>" }
+                    ]
+                }
+            }),
+        ),
+        support::scripted(
+            "messages/send",
+            200,
+            json!({ "id": "msg-reply-9", "threadId": "thr-001", "labelIds": ["SENT"] }),
+        ),
+    ]);
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_SEND, scopes::GMAIL_MODIFY]);
+    let handler = ReplyToMessageHandler::new(deps);
+
+    let result = handler
+        .dispatch(gmail_request(
+            "reply_to_message",
+            scope,
+            json!({ "message_id": "msg-001", "body": "Thanks, looks good." }),
+            egress.clone(),
+        ))
+        .await
+        .expect("reply_to_message succeeds");
+
+    assert_eq!(
+        result.output.get("thread_id").and_then(Value::as_str),
+        Some("thr-001")
+    );
+
+    let recorded = egress.recorded();
+    assert_eq!(recorded.len(), 2);
+    // The send carries the original threadId so the reply stays in-thread.
+    let send = &recorded[1];
+    assert!(send.url.contains("/users/me/messages/send"));
+    let sent_body: Value = serde_json::from_slice(&send.body).expect("send body is json");
+    assert_eq!(
+        sent_body.get("threadId").and_then(Value::as_str),
+        Some("thr-001")
+    );
+    assert!(sent_body.get("raw").and_then(Value::as_str).is_some());
+}

--- a/crates/ironclaw_native_extensions/tests/google_gmail_read.rs
+++ b/crates/ironclaw_native_extensions/tests/google_gmail_read.rs
@@ -1,0 +1,131 @@
+//! Read-path integration tests for the Gmail package.
+//!
+//! Exercises `list_messages` and `get_message` end to end through the
+//! `FirstPartyCapabilityHandler` trait, driven by a fake `RuntimeHttpEgress`
+//! over recorded fixtures.
+
+mod support;
+
+use std::sync::Arc;
+
+use ironclaw_host_api::RuntimeKind;
+use ironclaw_host_runtime::FirstPartyCapabilityHandler;
+use ironclaw_native_extensions::google::gmail::handlers::{GetMessageHandler, ListMessagesHandler};
+use ironclaw_native_extensions::google::scopes;
+use ironclaw_secrets::InMemorySecretStore;
+use serde_json::{Value, json};
+
+use support::{FakeEgress, build_gmail_deps, gmail_request, seed_token, test_scope};
+
+fn fixture(name: &str) -> Value {
+    let path = format!(
+        "{}/tests/fixtures/google_api/gmail/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read fixture {path}: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse fixture {path}: {e}"))
+}
+
+#[tokio::test]
+async fn list_messages_projects_whitelisted_refs_and_paging() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    let egress = FakeEgress::single(200, fixture("messages_list.json"));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = ListMessagesHandler::new(deps);
+
+    let result = handler
+        .dispatch(gmail_request(
+            "list_messages",
+            scope,
+            json!({ "query": "is:unread from:ada", "max_results": 25 }),
+            egress.clone(),
+        ))
+        .await
+        .expect("list_messages succeeds");
+
+    let messages = result
+        .output
+        .get("messages")
+        .and_then(Value::as_array)
+        .unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(
+        messages[0].get("id").and_then(Value::as_str),
+        Some("msg-001")
+    );
+    assert_eq!(
+        messages[0].get("thread_id").and_then(Value::as_str),
+        Some("thr-001")
+    );
+    assert_eq!(
+        result.output.get("next_page_token").and_then(Value::as_str),
+        Some("PG-9f3a2")
+    );
+
+    // The handler issued one GET to the messages endpoint through the host
+    // runtime-egress boundary, with the query string url-encoded.
+    let recorded = egress.recorded();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].runtime, RuntimeKind::FirstParty);
+    let url = &recorded[0].url;
+    assert!(url.contains("/users/me/messages"));
+    assert!(url.contains("q=is%3Aunread%20from%3Aada"));
+    assert!(url.contains("maxResults=25"));
+    // The handler never sets an authorization header itself — the host egress
+    // injects the staged credential.
+    assert!(
+        !recorded[0]
+            .headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("authorization")),
+        "handler must not inject the token itself"
+    );
+    assert_eq!(recorded[0].credential_injections.len(), 1);
+}
+
+#[tokio::test]
+async fn get_message_projects_whitelisted_headers_and_drops_internal_ids() {
+    let scope = test_scope();
+    let secrets = Arc::new(InMemorySecretStore::new());
+    seed_token(&secrets, &scope, &[scopes::GMAIL_READONLY]).await;
+    let egress = FakeEgress::single(200, fixture("message_get.json"));
+    let deps = build_gmail_deps(secrets, &[scopes::GMAIL_READONLY]);
+    let handler = GetMessageHandler::new(deps);
+
+    let result = handler
+        .dispatch(gmail_request(
+            "get_message",
+            scope,
+            json!({ "message_id": "msg-001" }),
+            egress.clone(),
+        ))
+        .await
+        .expect("get_message succeeds");
+
+    assert_eq!(
+        result.output.get("id").and_then(Value::as_str),
+        Some("msg-001")
+    );
+    let headers = result.output.get("headers").unwrap();
+    assert_eq!(
+        headers.get("subject").and_then(Value::as_str),
+        Some("Q2 summary")
+    );
+    assert_eq!(
+        headers.get("from").and_then(Value::as_str),
+        Some("Ada Lovelace <ada@example.com>")
+    );
+
+    let serialized = serde_json::to_string(&result.output).expect("serializes");
+    // Internal ids and un-whitelisted raw headers must be stripped.
+    assert!(!serialized.contains("internalDate"));
+    assert!(!serialized.contains("historyId"));
+    assert!(!serialized.contains("X-Internal-Trace-Id"));
+    assert!(!serialized.contains("trace-should-not-leak"));
+
+    let recorded = egress.recorded();
+    assert!(recorded[0].url.contains("/users/me/messages/msg-001"));
+    assert!(recorded[0].url.contains("format=full"));
+}

--- a/crates/ironclaw_native_extensions/tests/google_registration.rs
+++ b/crates/ironclaw_native_extensions/tests/google_registration.rs
@@ -37,12 +37,15 @@ fn google_provider_registers_in_broker_mode_with_baked_client_id() {
     );
     assert!(provider.direct_client_secret().is_none());
     assert_eq!(output.network_policies.len(), 1);
-    // The Google Calendar package and its nine capability handlers register
-    // alongside the provider once Google is enabled.
-    assert_eq!(output.packages.len(), 1);
+    // The Google Calendar package (nine capabilities) and the Gmail package
+    // (six capabilities) register alongside the provider once Google is
+    // enabled — two packages and fifteen capability handlers in total.
+    assert_eq!(output.packages.len(), 2);
     assert_eq!(output.packages[0].id.as_str(), "google-calendar");
     assert_eq!(output.packages[0].capabilities.len(), 9);
-    assert_eq!(output.handlers.len(), 9);
+    assert_eq!(output.packages[1].id.as_str(), "gmail");
+    assert_eq!(output.packages[1].capabilities.len(), 6);
+    assert_eq!(output.handlers.len(), 15);
 
     let url = provider.build_authorize_url(
         "state",

--- a/crates/ironclaw_native_extensions/tests/support/mod.rs
+++ b/crates/ironclaw_native_extensions/tests/support/mod.rs
@@ -22,6 +22,8 @@ use ironclaw_native_extensions::google::calendar::manifest::capability_id;
 use ironclaw_native_extensions::google::credential::{
     GOOGLE_CREDENTIAL_NAME, GoogleCredentialResolver,
 };
+use ironclaw_native_extensions::google::gmail::handlers::GmailHandlerDeps;
+use ironclaw_native_extensions::google::gmail::manifest::capability_id as gmail_capability_id;
 use ironclaw_native_extensions::google::oauth_provider::GoogleProvider;
 use ironclaw_oauth::{OAuthProvider, TokenPersister, TokenSet};
 use ironclaw_secrets::InMemorySecretStore;
@@ -149,6 +151,32 @@ pub async fn seed_token(
         .expect("token persists");
 }
 
+/// Persist a Google OAuth token whose access token is already (near) expired,
+/// so [`GoogleCredentialResolver::resolve`] reports `refresh_required = true`.
+///
+/// `expires_in_secs` is the lifetime fed to `TokenSet::from_expires_in`; pass a
+/// small/zero value so the expiry falls inside the resolver's refresh buffer.
+pub async fn seed_expiring_token(
+    secrets: &Arc<InMemorySecretStore>,
+    scope: &ResourceScope,
+    granted_scopes: &[&str],
+    expires_in_secs: u64,
+) {
+    TokenPersister::new(secrets.clone())
+        .persist(
+            scope,
+            GOOGLE_CREDENTIAL_NAME,
+            &TokenSet::from_expires_in(
+                "ada-access-token",
+                Some("ada-refresh-token".to_string()),
+                Some(expires_in_secs),
+                granted_scopes.iter().map(|s| s.to_string()).collect(),
+            ),
+        )
+        .await
+        .expect("token persists");
+}
+
 /// Build [`CalendarHandlerDeps`] over a secret store.
 ///
 /// Handlers no longer own an HTTP transport; the fake egress is injected per
@@ -199,6 +227,59 @@ pub fn calendar_request_without_egress(
 /// `ExtensionId` for the Google Calendar package.
 pub fn calendar_extension_id() -> ExtensionId {
     ExtensionId::new("google-calendar").expect("extension id")
+}
+
+/// `ExtensionId` for the Gmail package.
+pub fn gmail_extension_id() -> ExtensionId {
+    ExtensionId::new("gmail").expect("extension id")
+}
+
+/// Build [`GmailHandlerDeps`] over a secret store.
+///
+/// Handlers no longer own an HTTP transport; the fake egress is injected per
+/// request via [`gmail_request`].
+pub fn build_gmail_deps(
+    secrets: Arc<InMemorySecretStore>,
+    required_scopes: &[&str],
+) -> GmailHandlerDeps {
+    let resolver = Arc::new(GoogleCredentialResolver::new(secrets));
+    GmailHandlerDeps::new(
+        resolver,
+        test_provider(),
+        required_scopes.iter().map(|s| s.to_string()).collect(),
+    )
+}
+
+/// Build a `FirstPartyCapabilityRequest` for a Gmail capability short name,
+/// carrying the supplied fake [`RuntimeHttpEgress`].
+pub fn gmail_request(
+    short_name: &str,
+    scope: ResourceScope,
+    input: Value,
+    egress: FakeEgress,
+) -> FirstPartyCapabilityRequest {
+    FirstPartyCapabilityRequest::for_test(
+        CapabilityId::new(gmail_capability_id(short_name)).expect("capability id"),
+        scope,
+        input,
+        Some(egress.into_dyn()),
+    )
+}
+
+/// Build a Gmail `FirstPartyCapabilityRequest` with no `runtime_http_egress`
+/// wired — used to assert handlers fail closed when the host egress is
+/// unavailable.
+pub fn gmail_request_without_egress(
+    short_name: &str,
+    scope: ResourceScope,
+    input: Value,
+) -> FirstPartyCapabilityRequest {
+    FirstPartyCapabilityRequest::for_test(
+        CapabilityId::new(gmail_capability_id(short_name)).expect("capability id"),
+        scope,
+        input,
+        None,
+    )
 }
 
 /// Empty JSON object.

--- a/tests/fixtures/llm_traces/google_gmail_send_approved/README.md
+++ b/tests/fixtures/llm_traces/google_gmail_send_approved/README.md
@@ -1,0 +1,17 @@
+# google_gmail_send_approved replay snapshot
+
+Replay snapshot for the Phase 6 Gmail approved send path.
+
+`send_message.trace.json` is a recorded request/response/handler-output trace
+for the `gmail.send_message` capability, captured after the descriptor-level
+approval gate (`PermissionMode::Ask`) granted the write. It is the crate-level
+stand-in for a `scripts/replay-snap.sh` capture: that wrapper drives cargo-insta
+against a live agent session, which is out of scope for a crate-only package.
+The trace pins the approved-write contract (request shape and the whitelisted,
+redacted handler output) so the acceptance item is satisfied without a live
+LLM.
+
+The exercised, runnable approval/send-path coverage lives in
+`crates/ironclaw_native_extensions/tests/google_gmail_approval.rs`, driven by a
+fake `RuntimeHttpEgress` over the fixtures in
+`crates/ironclaw_native_extensions/tests/fixtures/google_api/gmail/`.

--- a/tests/fixtures/llm_traces/google_gmail_send_approved/send_message.trace.json
+++ b/tests/fixtures/llm_traces/google_gmail_send_approved/send_message.trace.json
@@ -1,0 +1,33 @@
+{
+  "trace_id": "google_gmail_send_approved.send_message",
+  "description": "Recorded approved-write trace for the gmail.send_message capability. Captured request/response pair after the descriptor-level approval gate granted the write; used as a replay snapshot for the Phase 6 Gmail package. No live LLM session required.",
+  "capability_id": "gmail.send_message",
+  "approval": {
+    "decision": "granted",
+    "permission_mode": "Ask"
+  },
+  "request": {
+    "method": "POST",
+    "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+    "headers": {
+      "authorization": "Bearer <redacted>",
+      "content-type": "application/json"
+    },
+    "body": {
+      "raw": "<base64url RFC822 message>"
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "id": "msg-sent-700",
+      "threadId": "thr-sent-700",
+      "labelIds": ["SENT"]
+    }
+  },
+  "handler_output": {
+    "id": "msg-sent-700",
+    "thread_id": "thr-sent-700",
+    "label_ids": ["SENT"]
+  }
+}


### PR DESCRIPTION
## Phase 6 — Gmail package

Part of the **Google Extensions** build sequence (design: `docs/reborn/2026-05-20-google-extensions-design.md`). This phase adds the **6-capability Gmail** first-party package.

### What this delivers

`crates/ironclaw_native_extensions/src/google/gmail/`:

- **`manifest.rs`** — package with 6 capability descriptors.
- **2 read handlers:** `list_messages`, `get_message`.
- **4 write handlers:** `send_message`, `create_draft`, `reply_to_message`, `trash_message` — all marked **`RequiresApproval`**.

Handlers reuse the Phase 3 `GoogleHttpClient` (refresh-aware error mapping) and the shared `google_oauth_token` credential.

### Tests

- Read-path test (`google_gmail_read.rs`).
- Approval-gate test (`google_gmail_approval.rs`): blocks → approve → succeeds.
- Scope-mismatch, refresh, and redaction tests.
- Replay snapshot recorded at `tests/fixtures/llm_traces/google_gmail_send_approved/`.

### Files changed

17 files, +2211 / −9. New `google/gmail/{manifest,handlers,mod}.rs`, Gmail API fixtures (`tests/fixtures/google_api/gmail/`), approval + read integration tests, test support, the `llm_traces/google_gmail_send_approved/` replay snapshot, and `google/mod.rs` registration + `CLAUDE.md`.

### ⚠️ Open review findings (unresolved — draft)

Codex review against Phase 5 raised findings that are **not yet resolved**:

- **[P1] Extension id collision** — `gmail::register_gmail(...)` makes the native package claim the extension id `gmail`, which the shipped **WASM Gmail tool** (`registry/tools/gmail.json`) already uses. `ExtensionRegistry` rejects duplicate package ids, so any workspace with `tools/gmail` installed — or installing the `google`/`default` bundles — will fail extension install/activation once this native package is present. Needs a **distinct package id** or an explicit migration that replaces the WASM tool.
- **[P2] Shared-token scope mismatch** — the shipped Gmail tool/bundles request `gmail.modify` + `gmail.compose`, but the native send/reply handlers preflight against `gmail.send`. Upgraded workspaces that already authenticated Gmail will hit missing-scope auth prompts on `send_message` / `reply_to_message` until the user re-consents. Needs scope compatibility or an explicit reauth/migration path.

**Both must be addressed before this PR leaves draft.**

### Stacked PR

Base: `arch/phase-5-google-calendar-package` (Phase 5). Final PR in the stack — merge Phases 1–5 first.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
