### PR TITLE
Add Docker sandbox command transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ jsonschema = { version = "0.45", default-features = false }
 # Shared types
 ironclaw_common = { path = "crates/ironclaw_common", version = "0.4.1" }
 ironclaw_host_api = { path = "crates/ironclaw_host_api", version = "0.1.0" }
+ironclaw_host_runtime = { path = "crates/ironclaw_host_runtime", version = "0.1.0" }
 ironclaw_loop_support = { path = "crates/ironclaw_loop_support", version = "0.1.0" }
 ironclaw_memory = { path = "crates/ironclaw_memory", version = "0.1.0" }
 ironclaw_runtime_policy = { path = "crates/ironclaw_runtime_policy", version = "0.1.0" }
@@ -247,7 +248,6 @@ ironclaw_llm = { path = "crates/ironclaw_llm", version = "0.1.0", features = ["t
 ironclaw_authorization = { path = "crates/ironclaw_authorization", version = "0.1.0" }
 ironclaw_extensions = { path = "crates/ironclaw_extensions", version = "0.1.0" }
 ironclaw_filesystem = { path = "crates/ironclaw_filesystem", version = "0.1.0" }
-ironclaw_host_runtime = { path = "crates/ironclaw_host_runtime", version = "0.1.0" }
 ironclaw_network = { path = "crates/ironclaw_network", version = "0.1.0" }
 ironclaw_processes = { path = "crates/ironclaw_processes", version = "0.1.0" }
 ironclaw_resources = { path = "crates/ironclaw_resources", version = "0.1.0" }

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -91,6 +91,7 @@ pub use planner::{ExecutionPlan, PlannerError, plan_capability};
 pub use process_port::{
     CommandExecutionOutput, CommandExecutionRequest, LocalHostProcessPort, RuntimeProcessError,
     RuntimeProcessPort, SandboxCommandTransport, TenantSandboxProcessPort,
+    TenantSandboxProcessScope,
 };
 pub use production::DefaultHostRuntime;
 pub use services::{

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -528,6 +528,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tenant_sandbox_process_port_scoped_accepts_matching_scope() {
+        let transport = std::sync::Arc::new(RecordingSandboxTransport::default());
+        let port = TenantSandboxProcessPort::new_scoped(
+            transport.clone(),
+            TenantSandboxProcessScope::new(
+                TenantId::new("tenant-a").unwrap(),
+                ProjectId::new("project-a").unwrap(),
+            ),
+        );
+
+        let output = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope {
+                    tenant_id: TenantId::new("tenant-a").unwrap(),
+                    user_id: ironclaw_host_api::UserId::new("user-a").unwrap(),
+                    agent_id: None,
+                    project_id: Some(ProjectId::new("project-a").unwrap()),
+                    mission_id: None,
+                    thread_id: None,
+                    invocation_id: ironclaw_host_api::InvocationId::new(),
+                },
+                mounts: None,
+                command: "echo sandbox".to_string(),
+                workdir: None,
+                timeout_secs: None,
+                extra_env: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output.output, "echo sandbox");
+        let requests = transport.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].scope.project_id,
+            Some(ProjectId::new("project-a").unwrap())
+        );
+    }
+
+    #[tokio::test]
     async fn tenant_sandbox_process_port_propagates_transport_error() {
         let port = TenantSandboxProcessPort::new(std::sync::Arc::new(FailingSandboxTransport));
 

--- a/crates/ironclaw_host_runtime/src/process_port.rs
+++ b/crates/ironclaw_host_runtime/src/process_port.rs
@@ -9,7 +9,7 @@
 use std::{collections::HashMap, path::PathBuf, process::Stdio, time::Duration};
 
 use async_trait::async_trait;
-use ironclaw_host_api::{MountView, ResourceScope};
+use ironclaw_host_api::{MountView, ProjectId, ResourceScope, TenantId};
 #[cfg(unix)]
 use libc::{SIGKILL, kill};
 use thiserror::Error;
@@ -113,10 +113,31 @@ pub trait SandboxCommandTransport: Send + Sync {
     ) -> Result<CommandExecutionOutput, RuntimeProcessError>;
 }
 
+/// Tenant/project binding for a tenant-isolated process port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TenantSandboxProcessScope {
+    tenant_id: TenantId,
+    project_id: ProjectId,
+}
+
+impl TenantSandboxProcessScope {
+    pub fn new(tenant_id: TenantId, project_id: ProjectId) -> Self {
+        Self {
+            tenant_id,
+            project_id,
+        }
+    }
+
+    fn matches(&self, scope: &ResourceScope) -> bool {
+        scope.tenant_id == self.tenant_id && scope.project_id.as_ref() == Some(&self.project_id)
+    }
+}
+
 /// Tenant-isolated process port backed by a sandbox command transport.
 #[derive(Clone)]
 pub struct TenantSandboxProcessPort {
     transport: std::sync::Arc<dyn SandboxCommandTransport>,
+    expected_scope: Option<TenantSandboxProcessScope>,
 }
 
 impl std::fmt::Debug for TenantSandboxProcessPort {
@@ -124,13 +145,31 @@ impl std::fmt::Debug for TenantSandboxProcessPort {
         formatter
             .debug_struct("TenantSandboxProcessPort")
             .field("transport", &"<sandbox command transport>")
+            .field("expected_scope", &self.expected_scope)
             .finish()
     }
 }
 
 impl TenantSandboxProcessPort {
     pub fn new(transport: std::sync::Arc<dyn SandboxCommandTransport>) -> Self {
-        Self { transport }
+        Self {
+            transport,
+            expected_scope: None,
+        }
+    }
+
+    pub fn new_scoped(
+        transport: std::sync::Arc<dyn SandboxCommandTransport>,
+        expected_scope: TenantSandboxProcessScope,
+    ) -> Self {
+        Self {
+            transport,
+            expected_scope: Some(expected_scope),
+        }
+    }
+
+    pub fn is_scope_bound(&self) -> bool {
+        self.expected_scope.is_some()
     }
 }
 
@@ -140,6 +179,13 @@ impl RuntimeProcessPort for TenantSandboxProcessPort {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        if let Some(expected_scope) = &self.expected_scope
+            && !expected_scope.matches(&request.scope)
+        {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "tenant sandbox process scope does not match bound project".to_string(),
+            ));
+        }
         let timeout = request
             .timeout_secs
             .map(Duration::from_secs)
@@ -444,6 +490,41 @@ mod tests {
             requests[0].timeout_secs,
             Some(DEFAULT_COMMAND_TIMEOUT.as_secs())
         );
+    }
+
+    #[tokio::test]
+    async fn tenant_sandbox_process_port_rejects_scope_mismatch() {
+        let transport = std::sync::Arc::new(RecordingSandboxTransport::default());
+        let port = TenantSandboxProcessPort::new_scoped(
+            transport.clone(),
+            TenantSandboxProcessScope::new(
+                TenantId::new("tenant-a").unwrap(),
+                ProjectId::new("project-a").unwrap(),
+            ),
+        );
+
+        let error = port
+            .run_command(CommandExecutionRequest {
+                scope: ResourceScope {
+                    tenant_id: TenantId::new("tenant-a").unwrap(),
+                    user_id: ironclaw_host_api::UserId::new("user-a").unwrap(),
+                    agent_id: None,
+                    project_id: Some(ProjectId::new("project-b").unwrap()),
+                    mission_id: None,
+                    thread_id: None,
+                    invocation_id: ironclaw_host_api::InvocationId::new(),
+                },
+                mounts: None,
+                command: "echo sandbox".to_string(),
+                workdir: None,
+                timeout_secs: None,
+                extra_env: HashMap::new(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error}").contains("scope does not match"));
+        assert!(transport.requests.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -1046,6 +1046,18 @@ where
         self
     }
 
+    pub fn with_tenant_sandbox_process_port_dyn(
+        mut self,
+        process_port: Arc<dyn RuntimeProcessPort>,
+    ) -> Self {
+        self.component_types.tenant_sandbox_process_port = Some(ProductionComponentType::named(
+            "dyn RuntimeProcessPort",
+            ProductionImplementationReadiness::UnverifiedProductionImplementation,
+        ));
+        self.tenant_sandbox_process_port = Some(process_port);
+        self
+    }
+
     /// Attaches the host HTTP egress shape required for production runtime
     /// adapters. The service must use staged network-policy handoffs and secret
     /// injection handoffs, not request-local/test policy fallback.

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -1046,6 +1046,23 @@ where
         self
     }
 
+    pub fn with_production_tenant_sandbox_process_port(
+        mut self,
+        process_port: Arc<TenantSandboxProcessPort>,
+    ) -> Self {
+        let readiness = if process_port.is_scope_bound() {
+            ProductionImplementationReadiness::ProductionCandidate
+        } else {
+            ProductionImplementationReadiness::UnverifiedProductionImplementation
+        };
+        self.component_types.tenant_sandbox_process_port = Some(ProductionComponentType::named(
+            "TenantSandboxProcessPort",
+            readiness,
+        ));
+        self.tenant_sandbox_process_port = Some(process_port);
+        self
+    }
+
     pub fn with_tenant_sandbox_process_port_dyn(
         mut self,
         process_port: Arc<dyn RuntimeProcessPort>,

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -1038,18 +1038,6 @@ where
         mut self,
         process_port: Arc<TenantSandboxProcessPort>,
     ) -> Self {
-        self.component_types.tenant_sandbox_process_port = Some(ProductionComponentType::named(
-            "TenantSandboxProcessPort",
-            ProductionImplementationReadiness::UnverifiedProductionImplementation,
-        ));
-        self.tenant_sandbox_process_port = Some(process_port);
-        self
-    }
-
-    pub fn with_production_tenant_sandbox_process_port(
-        mut self,
-        process_port: Arc<TenantSandboxProcessPort>,
-    ) -> Self {
         let readiness = if process_port.is_scope_bound() {
             ProductionImplementationReadiness::ProductionCandidate
         } else {
@@ -1063,7 +1051,7 @@ where
         self
     }
 
-    pub fn with_tenant_sandbox_process_port_dyn(
+    pub fn with_unverified_tenant_sandbox_process_port_dyn(
         mut self,
         process_port: Arc<dyn RuntimeProcessPort>,
     ) -> Self {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -47,8 +47,8 @@ use ironclaw_host_runtime::{
     ProductionWiringComponent, ProductionWiringConfig, ProductionWiringIssueKind,
     RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeCapabilityResumeRequest,
     RuntimeFailureKind, RuntimeProcessError, RuntimeProcessPort, RuntimeStatusRequest,
-    RuntimeWorkId, SandboxCommandTransport, TenantSandboxProcessPort, builtin_first_party_handlers,
-    builtin_first_party_package,
+    RuntimeWorkId, SandboxCommandTransport, TenantSandboxProcessPort, TenantSandboxProcessScope,
+    builtin_first_party_handlers, builtin_first_party_package,
 };
 use ironclaw_mcp::{McpError, McpExecutionRequest, McpExecutionResult, McpExecutor};
 use ironclaw_network::{
@@ -1211,6 +1211,41 @@ fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_builtin_s
             ProductionWiringIssueKind::UnverifiedProductionImplementation
         ),
         "configured tenant sandbox process port should clear missing but remain unverified: {report:?}"
+    );
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_builtin_first_party_package()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(builtin_first_party_handlers().unwrap()))
+    .with_runtime_policy(hosted_dev_runtime_policy())
+    .with_production_tenant_sandbox_process_port(Arc::new(
+        TenantSandboxProcessPort::new_scoped(
+            Arc::new(ProductionCandidateSandboxTransport),
+            TenantSandboxProcessScope::new(
+                TenantId::new("tenant-a").unwrap(),
+                ProjectId::new("project-a").unwrap(),
+            ),
+        ),
+    ));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([RuntimeKind::FirstParty]))
+        .expect_err("other local defaults should still keep this graph non-production");
+
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::RuntimeProcessPort,
+            ProductionWiringIssueKind::Missing
+        ) && !report.contains(
+            ProductionWiringComponent::RuntimeProcessPort,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "scoped production tenant sandbox process port should satisfy process-port guardrail: {report:?}"
     );
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1223,15 +1223,13 @@ fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_builtin_s
     )
     .with_first_party_capabilities(Arc::new(builtin_first_party_handlers().unwrap()))
     .with_runtime_policy(hosted_dev_runtime_policy())
-    .with_production_tenant_sandbox_process_port(Arc::new(
-        TenantSandboxProcessPort::new_scoped(
-            Arc::new(ProductionCandidateSandboxTransport),
-            TenantSandboxProcessScope::new(
-                TenantId::new("tenant-a").unwrap(),
-                ProjectId::new("project-a").unwrap(),
-            ),
+    .with_tenant_sandbox_process_port(Arc::new(TenantSandboxProcessPort::new_scoped(
+        Arc::new(ProductionCandidateSandboxTransport),
+        TenantSandboxProcessScope::new(
+            TenantId::new("tenant-a").unwrap(),
+            ProjectId::new("project-a").unwrap(),
         ),
-    ));
+    )));
 
     let report = services
         .validate_production_wiring(&ProductionWiringConfig::new([RuntimeKind::FirstParty]))

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -27,7 +27,7 @@ use ironclaw_turns::{
     InMemoryTurnStateStore,
 };
 
-use crate::input::RebornStorageInput;
+use crate::input::{RebornStorageInput, TenantSandboxProcessPortInput};
 use crate::{
     RebornBuildError, RebornBuildInput, RebornCompositionProfile, RebornFacadeReadiness,
     RebornReadiness, RebornReadinessState,
@@ -181,7 +181,14 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         services = services.with_runtime_policy(runtime_policy);
     }
     if let Some(process_port) = input.tenant_sandbox_process_port {
-        services = services.with_tenant_sandbox_process_port_dyn(process_port);
+        services = match process_port {
+            TenantSandboxProcessPortInput::ProductionCandidate(process_port) => {
+                services.with_production_tenant_sandbox_process_port(process_port)
+            }
+            TenantSandboxProcessPortInput::Unverified(process_port) => {
+                services.with_tenant_sandbox_process_port_dyn(process_port)
+            }
+        };
     }
 
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
@@ -394,7 +401,7 @@ struct RebornProductionWiring {
     trust_policy: Arc<HostTrustPolicy>,
     runtime_policy: EffectiveRuntimePolicy,
     turn_run_wake_notifier: Arc<ironclaw_host_runtime::SchedulerTurnRunWakeNotifier>,
-    tenant_sandbox_process_port: Option<Arc<dyn ironclaw_host_runtime::RuntimeProcessPort>>,
+    tenant_sandbox_process_port: Option<TenantSandboxProcessPortInput>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -402,7 +409,7 @@ fn production_wiring(
     trust_policy: Option<Arc<HostTrustPolicy>>,
     runtime_policy: Option<EffectiveRuntimePolicy>,
     turn_run_wake_notifier: Option<Arc<ironclaw_host_runtime::SchedulerTurnRunWakeNotifier>>,
-    tenant_sandbox_process_port: Option<Arc<dyn ironclaw_host_runtime::RuntimeProcessPort>>,
+    tenant_sandbox_process_port: Option<TenantSandboxProcessPortInput>,
 ) -> Result<RebornProductionWiring, RebornBuildError> {
     let trust_policy = trust_policy.ok_or(RebornBuildError::MissingProductionTrustPolicy)?;
     if !trust_policy.has_sources() {
@@ -489,7 +496,14 @@ async fn build_libsql_production(
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
     if let Some(process_port) = production_wiring.tenant_sandbox_process_port {
-        services = services.with_tenant_sandbox_process_port_dyn(process_port);
+        services = match process_port {
+            TenantSandboxProcessPortInput::ProductionCandidate(process_port) => {
+                services.with_production_tenant_sandbox_process_port(process_port)
+            }
+            TenantSandboxProcessPortInput::Unverified(process_port) => {
+                services.with_tenant_sandbox_process_port_dyn(process_port)
+            }
+        };
     }
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
@@ -560,7 +574,14 @@ async fn build_postgres_production(
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
     if let Some(process_port) = production_wiring.tenant_sandbox_process_port {
-        services = services.with_tenant_sandbox_process_port_dyn(process_port);
+        services = match process_port {
+            TenantSandboxProcessPortInput::ProductionCandidate(process_port) => {
+                services.with_production_tenant_sandbox_process_port(process_port)
+            }
+            TenantSandboxProcessPortInput::Unverified(process_port) => {
+                services.with_tenant_sandbox_process_port_dyn(process_port)
+            }
+        };
     }
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
@@ -646,10 +667,11 @@ mod tests {
     async fn local_dev_composes_injected_tenant_sandbox_process_port() {
         let dir = tempfile::tempdir().expect("tempdir");
         let process_port = Arc::new(RecordingProcessPort::default());
+        let process_port_dyn: Arc<dyn RuntimeProcessPort> = process_port.clone();
         let services = build_reborn_services(
             RebornBuildInput::local_dev("sandbox-port-owner", dir.path().join("local-dev"))
                 .with_runtime_policy(tenant_sandbox_process_policy())
-                .with_tenant_sandbox_process_port(process_port.clone()),
+                .with_unverified_tenant_sandbox_process_port_dyn(process_port_dyn),
         )
         .await
         .expect("local-dev services build");

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -104,6 +104,27 @@ fn production_config(
     config
 }
 
+fn apply_tenant_sandbox_process_port<F, G, S, R>(
+    services: HostRuntimeServices<F, G, S, R>,
+    process_port: Option<TenantSandboxProcessPortInput>,
+) -> HostRuntimeServices<F, G, S, R>
+where
+    F: ironclaw_filesystem::RootFilesystem + 'static,
+    G: ironclaw_resources::ResourceGovernor + 'static,
+    S: ironclaw_processes::ProcessStore + 'static,
+    R: ironclaw_processes::ProcessResultStore + 'static,
+{
+    match process_port {
+        Some(TenantSandboxProcessPortInput::ProductionCandidate(process_port)) => {
+            services.with_production_tenant_sandbox_process_port(process_port)
+        }
+        Some(TenantSandboxProcessPortInput::Unverified(process_port)) => {
+            services.with_tenant_sandbox_process_port_dyn(process_port)
+        }
+        None => services,
+    }
+}
+
 async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, RebornBuildError> {
     let RebornStorageInput::LocalDev {
         root,
@@ -180,16 +201,9 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     if let Some(runtime_policy) = input.runtime_policy {
         services = services.with_runtime_policy(runtime_policy);
     }
-    if let Some(process_port) = input.tenant_sandbox_process_port {
-        services = match process_port {
-            TenantSandboxProcessPortInput::ProductionCandidate(process_port) => {
-                services.with_production_tenant_sandbox_process_port(process_port)
-            }
-            TenantSandboxProcessPortInput::Unverified(process_port) => {
-                services.with_tenant_sandbox_process_port_dyn(process_port)
-            }
-        };
-    }
+    // Local-dev deliberately accepts injected process ports so composition tests
+    // can exercise tenant-sandbox routing without requiring Docker.
+    services = apply_tenant_sandbox_process_port(services, input.tenant_sandbox_process_port);
 
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
         Arc::new(services.host_runtime_for_local_testing());
@@ -495,16 +509,8 @@ async fn build_libsql_production(
     .with_filesystem_turn_state_store(scoped_filesystem)
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
-    if let Some(process_port) = production_wiring.tenant_sandbox_process_port {
-        services = match process_port {
-            TenantSandboxProcessPortInput::ProductionCandidate(process_port) => {
-                services.with_production_tenant_sandbox_process_port(process_port)
-            }
-            TenantSandboxProcessPortInput::Unverified(process_port) => {
-                services.with_tenant_sandbox_process_port_dyn(process_port)
-            }
-        };
-    }
+    services =
+        apply_tenant_sandbox_process_port(services, production_wiring.tenant_sandbox_process_port);
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);
@@ -573,16 +579,8 @@ async fn build_postgres_production(
     .with_filesystem_turn_state_store(scoped_filesystem)
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
-    if let Some(process_port) = production_wiring.tenant_sandbox_process_port {
-        services = match process_port {
-            TenantSandboxProcessPortInput::ProductionCandidate(process_port) => {
-                services.with_production_tenant_sandbox_process_port(process_port)
-            }
-            TenantSandboxProcessPortInput::Unverified(process_port) => {
-                services.with_tenant_sandbox_process_port_dyn(process_port)
-            }
-        };
-    }
+    services =
+        apply_tenant_sandbox_process_port(services, production_wiring.tenant_sandbox_process_port);
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -180,8 +180,9 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     if let Some(runtime_policy) = input.runtime_policy {
         services = services.with_runtime_policy(runtime_policy);
     }
-    // TODO(process-port): local-dev intentionally uses the default
-    // LocalHostProcessPort until a non-local process backend is composed.
+    if let Some(process_port) = input.tenant_sandbox_process_port {
+        services = services.with_tenant_sandbox_process_port_dyn(process_port);
+    }
 
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
         Arc::new(services.host_runtime_for_local_testing());
@@ -308,6 +309,7 @@ async fn build_production_shaped(
         production_trust_policy,
         runtime_policy,
         turn_run_wake_notifier,
+        tenant_sandbox_process_port,
         required_runtime_backends,
         require_runtime_http_egress,
         require_wasm_credentials,
@@ -323,6 +325,7 @@ async fn build_production_shaped(
         production_trust_policy,
         runtime_policy,
         turn_run_wake_notifier,
+        tenant_sandbox_process_port,
         required_runtime_backends,
         require_runtime_http_egress,
         require_wasm_credentials,
@@ -348,10 +351,8 @@ async fn build_production_shaped(
                 production_trust_policy,
                 runtime_policy,
                 turn_run_wake_notifier,
+                tenant_sandbox_process_port,
             )?;
-            // TODO(process-port): if production enables FirstParty runtime,
-            // HostRuntimeServices must be given a production process port;
-            // otherwise the LocalHostProcessPort default is rejected.
             build_libsql_production(
                 profile,
                 wiring_config,
@@ -373,10 +374,8 @@ async fn build_production_shaped(
                 production_trust_policy,
                 runtime_policy,
                 turn_run_wake_notifier,
+                tenant_sandbox_process_port,
             )?;
-            // TODO(process-port): if production enables FirstParty runtime,
-            // HostRuntimeServices must be given a production process port;
-            // otherwise the LocalHostProcessPort default is rejected.
             build_postgres_production(
                 profile,
                 wiring_config,
@@ -395,6 +394,7 @@ struct RebornProductionWiring {
     trust_policy: Arc<HostTrustPolicy>,
     runtime_policy: EffectiveRuntimePolicy,
     turn_run_wake_notifier: Arc<ironclaw_host_runtime::SchedulerTurnRunWakeNotifier>,
+    tenant_sandbox_process_port: Option<Arc<dyn ironclaw_host_runtime::RuntimeProcessPort>>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -402,6 +402,7 @@ fn production_wiring(
     trust_policy: Option<Arc<HostTrustPolicy>>,
     runtime_policy: Option<EffectiveRuntimePolicy>,
     turn_run_wake_notifier: Option<Arc<ironclaw_host_runtime::SchedulerTurnRunWakeNotifier>>,
+    tenant_sandbox_process_port: Option<Arc<dyn ironclaw_host_runtime::RuntimeProcessPort>>,
 ) -> Result<RebornProductionWiring, RebornBuildError> {
     let trust_policy = trust_policy.ok_or(RebornBuildError::MissingProductionTrustPolicy)?;
     if !trust_policy.has_sources() {
@@ -414,6 +415,7 @@ fn production_wiring(
         trust_policy,
         runtime_policy,
         turn_run_wake_notifier,
+        tenant_sandbox_process_port,
     })
 }
 
@@ -463,7 +465,7 @@ async fn build_libsql_production(
         auth_token,
     };
 
-    let services = HostRuntimeServices::new(
+    let mut services = HostRuntimeServices::new(
         Arc::new(builtin_extension_registry()?),
         Arc::clone(&filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
@@ -486,6 +488,9 @@ async fn build_libsql_production(
     .with_filesystem_turn_state_store(scoped_filesystem)
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
+    if let Some(process_port) = production_wiring.tenant_sandbox_process_port {
+        services = services.with_tenant_sandbox_process_port_dyn(process_port);
+    }
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);
@@ -531,7 +536,7 @@ async fn build_postgres_production(
 
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url };
 
-    let services = HostRuntimeServices::new(
+    let mut services = HostRuntimeServices::new(
         Arc::new(builtin_extension_registry()?),
         Arc::clone(&filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
@@ -554,6 +559,9 @@ async fn build_postgres_production(
     .with_filesystem_turn_state_store(scoped_filesystem)
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
+    if let Some(process_port) = production_wiring.tenant_sandbox_process_port {
+        services = services.with_tenant_sandbox_process_port_dyn(process_port);
+    }
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);
@@ -592,6 +600,21 @@ fn readiness_for(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use ironclaw_host_api::{
+        ApprovalPolicy, AuditMode, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet,
+        DeploymentMode, ExecutionContext, ExtensionId, FilesystemBackendKind, GrantConstraints,
+        NetworkMode, NetworkPolicy, NetworkTargetPattern, Principal, ProcessBackendKind,
+        ResourceEstimate, RuntimeKind, RuntimeProfile, SecretMode, TrustClass, UserId,
+    };
+    use ironclaw_host_runtime::{
+        CommandExecutionOutput, CommandExecutionRequest, RuntimeCapabilityOutcome,
+        RuntimeCapabilityRequest, RuntimeProcessError, RuntimeProcessPort, SHELL_CAPABILITY_ID,
+    };
+    use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+    use serde_json::json;
+    use std::sync::Mutex;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn local_dev_services_include_repl_runtime_substrate() {
@@ -617,5 +640,140 @@ mod tests {
         assert!(services.turn_coordinator.is_none());
         assert!(services.local_runtime.is_none());
         assert_eq!(services.readiness.state, RebornReadinessState::Disabled);
+    }
+
+    #[tokio::test]
+    async fn local_dev_composes_injected_tenant_sandbox_process_port() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let process_port = Arc::new(RecordingProcessPort::default());
+        let services = build_reborn_services(
+            RebornBuildInput::local_dev("sandbox-port-owner", dir.path().join("local-dev"))
+                .with_runtime_policy(tenant_sandbox_process_policy())
+                .with_tenant_sandbox_process_port(process_port.clone()),
+        )
+        .await
+        .expect("local-dev services build");
+        let host_runtime = services.host_runtime.expect("host runtime");
+
+        let outcome = host_runtime
+            .invoke_capability(RuntimeCapabilityRequest::new(
+                shell_execution_context(),
+                CapabilityId::new(SHELL_CAPABILITY_ID).unwrap(),
+                ResourceEstimate::default(),
+                json!({"command": "echo composed sandbox", "timeout": 9}),
+                trust_decision(),
+            ))
+            .await
+            .expect("capability invoke");
+
+        let RuntimeCapabilityOutcome::Completed(completed) = outcome else {
+            panic!("expected completed shell invocation, got {outcome:?}");
+        };
+        assert_eq!(completed.output["sandboxed"], json!(true));
+        assert_eq!(
+            completed.output["output"],
+            json!("sandbox port: echo composed sandbox")
+        );
+        let requests = process_port.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].command, "echo composed sandbox");
+        assert_eq!(requests[0].timeout_secs, Some(9));
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingProcessPort {
+        requests: Mutex<Vec<CommandExecutionRequest>>,
+    }
+
+    #[async_trait]
+    impl RuntimeProcessPort for RecordingProcessPort {
+        async fn run_command(
+            &self,
+            request: CommandExecutionRequest,
+        ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+            let command = request.command.clone();
+            self.requests.lock().unwrap().push(request);
+            Ok(CommandExecutionOutput {
+                output: format!("sandbox port: {command}"),
+                exit_code: 0,
+                sandboxed: true,
+                duration: Duration::from_millis(5),
+            })
+        }
+    }
+
+    fn tenant_sandbox_process_policy() -> ironclaw_host_api::EffectiveRuntimePolicy {
+        ironclaw_host_api::EffectiveRuntimePolicy {
+            deployment: DeploymentMode::LocalSingleUser,
+            requested_profile: RuntimeProfile::LocalDev,
+            resolved_profile: RuntimeProfile::LocalDev,
+            filesystem_backend: FilesystemBackendKind::HostWorkspace,
+            process_backend: ProcessBackendKind::TenantSandbox,
+            network_mode: NetworkMode::DirectLogged,
+            secret_mode: SecretMode::ScrubbedEnv,
+            approval_policy: ApprovalPolicy::AskDestructive,
+            audit_mode: AuditMode::LocalMinimal,
+        }
+    }
+
+    fn shell_execution_context() -> ExecutionContext {
+        let network = NetworkPolicy {
+            allowed_targets: vec![NetworkTargetPattern {
+                scheme: None,
+                host_pattern: "*".to_string(),
+                port: None,
+            }],
+            deny_private_ip_ranges: false,
+            max_egress_bytes: None,
+        };
+        let grant = CapabilityGrant {
+            id: CapabilityGrantId::new(),
+            capability: CapabilityId::new(SHELL_CAPABILITY_ID).unwrap(),
+            grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
+            issued_by: Principal::HostRuntime,
+            constraints: GrantConstraints {
+                allowed_effects: builtin_effects(),
+                mounts: MountView::default(),
+                network,
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: None,
+            },
+        };
+        ExecutionContext::local_default(
+            UserId::new("user").unwrap(),
+            ExtensionId::new("caller").unwrap(),
+            RuntimeKind::FirstParty,
+            TrustClass::FirstParty,
+            CapabilitySet {
+                grants: vec![grant],
+            },
+            MountView::default(),
+        )
+        .unwrap()
+    }
+
+    fn builtin_effects() -> Vec<EffectKind> {
+        vec![
+            EffectKind::DispatchCapability,
+            EffectKind::ReadFilesystem,
+            EffectKind::WriteFilesystem,
+            EffectKind::Network,
+            EffectKind::SpawnProcess,
+            EffectKind::ExecuteCode,
+        ]
+    }
+
+    fn trust_decision() -> TrustDecision {
+        TrustDecision {
+            effective_trust: EffectiveTrustClass::user_trusted(),
+            authority_ceiling: AuthorityCeiling {
+                allowed_effects: builtin_effects(),
+                max_resource_ceiling: None,
+            },
+            provenance: TrustProvenance::Default,
+            evaluated_at: chrono::Utc::now(),
+        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -116,10 +116,10 @@ where
 {
     match process_port {
         Some(TenantSandboxProcessPortInput::ProductionCandidate(process_port)) => {
-            services.with_production_tenant_sandbox_process_port(process_port)
+            services.with_tenant_sandbox_process_port(process_port)
         }
         Some(TenantSandboxProcessPortInput::Unverified(process_port)) => {
-            services.with_tenant_sandbox_process_port_dyn(process_port)
+            services.with_unverified_tenant_sandbox_process_port_dyn(process_port)
         }
         None => services,
     }

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -164,9 +164,11 @@ impl RebornBuildInput {
         mut self,
         process_port: Arc<TenantSandboxProcessPort>,
     ) -> Self {
-        self.tenant_sandbox_process_port = Some(
-            TenantSandboxProcessPortInput::ProductionCandidate(process_port),
-        );
+        self.tenant_sandbox_process_port = Some(if process_port.is_scope_bound() {
+            TenantSandboxProcessPortInput::ProductionCandidate(process_port)
+        } else {
+            TenantSandboxProcessPortInput::Unverified(process_port)
+        });
         self
     }
 

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy;
-use ironclaw_host_runtime::{RuntimeProcessPort, SchedulerTurnRunWakeNotifier};
+use ironclaw_host_runtime::{
+    RuntimeProcessPort, SchedulerTurnRunWakeNotifier, TenantSandboxProcessPort,
+};
 use ironclaw_trust::HostTrustPolicy;
 
 use crate::RebornCompositionProfile;
@@ -14,10 +16,15 @@ pub struct RebornBuildInput {
     pub(crate) production_trust_policy: Option<Arc<HostTrustPolicy>>,
     pub(crate) runtime_policy: Option<EffectiveRuntimePolicy>,
     pub(crate) turn_run_wake_notifier: Option<Arc<SchedulerTurnRunWakeNotifier>>,
-    pub(crate) tenant_sandbox_process_port: Option<Arc<dyn RuntimeProcessPort>>,
+    pub(crate) tenant_sandbox_process_port: Option<TenantSandboxProcessPortInput>,
     pub(crate) required_runtime_backends: Vec<ironclaw_host_api::RuntimeKind>,
     pub(crate) require_runtime_http_egress: bool,
     pub(crate) require_wasm_credentials: bool,
+}
+
+pub(crate) enum TenantSandboxProcessPortInput {
+    ProductionCandidate(Arc<TenantSandboxProcessPort>),
+    Unverified(Arc<dyn RuntimeProcessPort>),
 }
 
 pub(crate) enum RebornStorageInput {
@@ -155,9 +162,20 @@ impl RebornBuildInput {
 
     pub fn with_tenant_sandbox_process_port(
         mut self,
+        process_port: Arc<TenantSandboxProcessPort>,
+    ) -> Self {
+        self.tenant_sandbox_process_port = Some(
+            TenantSandboxProcessPortInput::ProductionCandidate(process_port),
+        );
+        self
+    }
+
+    pub fn with_unverified_tenant_sandbox_process_port_dyn(
+        mut self,
         process_port: Arc<dyn RuntimeProcessPort>,
     ) -> Self {
-        self.tenant_sandbox_process_port = Some(process_port);
+        self.tenant_sandbox_process_port =
+            Some(TenantSandboxProcessPortInput::Unverified(process_port));
         self
     }
 

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy;
-use ironclaw_host_runtime::SchedulerTurnRunWakeNotifier;
+use ironclaw_host_runtime::{RuntimeProcessPort, SchedulerTurnRunWakeNotifier};
 use ironclaw_trust::HostTrustPolicy;
 
 use crate::RebornCompositionProfile;
@@ -14,6 +14,7 @@ pub struct RebornBuildInput {
     pub(crate) production_trust_policy: Option<Arc<HostTrustPolicy>>,
     pub(crate) runtime_policy: Option<EffectiveRuntimePolicy>,
     pub(crate) turn_run_wake_notifier: Option<Arc<SchedulerTurnRunWakeNotifier>>,
+    pub(crate) tenant_sandbox_process_port: Option<Arc<dyn RuntimeProcessPort>>,
     pub(crate) required_runtime_backends: Vec<ironclaw_host_api::RuntimeKind>,
     pub(crate) require_runtime_http_egress: bool,
     pub(crate) require_wasm_credentials: bool,
@@ -152,6 +153,14 @@ impl RebornBuildInput {
         self
     }
 
+    pub fn with_tenant_sandbox_process_port(
+        mut self,
+        process_port: Arc<dyn RuntimeProcessPort>,
+    ) -> Self {
+        self.tenant_sandbox_process_port = Some(process_port);
+        self
+    }
+
     pub fn require_runtime_http_egress(mut self) -> Self {
         self.require_runtime_http_egress = true;
         self
@@ -174,6 +183,7 @@ impl RebornBuildInput {
             production_trust_policy: None,
             runtime_policy: None,
             turn_run_wake_notifier: None,
+            tenant_sandbox_process_port: None,
             required_runtime_backends: Vec::new(),
             require_runtime_http_egress: false,
             require_wasm_credentials: false,

--- a/src/bridge/sandbox/command_transport.rs
+++ b/src/bridge/sandbox/command_transport.rs
@@ -20,6 +20,8 @@ use super::protocol::{Request, Response, RpcError};
 use super::transport::SandboxTransport;
 
 const CONTAINER_PROJECT_ROOT: &str = "/project";
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+const MAX_MERGED_OUTPUT_BYTES: usize = 64 * 1024;
 
 /// Reborn process-command transport backed by the V1 sandbox daemon.
 #[derive(Debug, Clone)]
@@ -64,15 +66,24 @@ impl SandboxCommandTransport for DockerSandboxCommandTransport {
 
         let workdir = container_workdir(request.workdir.as_deref())?;
         let timeout_secs = request.timeout_secs;
+        let timeout = Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
         let start = Instant::now();
-        let output = self
-            .run_tool(serde_json::json!({
+        let output = match tokio::time::timeout(
+            timeout,
+            self.run_tool(serde_json::json!({
                 "command": request.command,
                 "workdir": workdir,
                 "timeout": timeout_secs,
-            }))
-            .await
-            .map_err(|error| map_shell_timeout(error, timeout_secs))?;
+            })),
+        )
+        .await
+        {
+            Ok(result) => result.map_err(|error| map_shell_timeout(error, timeout_secs))?,
+            Err(_) => {
+                self.transport.reset().await;
+                return Err(RuntimeProcessError::Timeout(timeout));
+            }
+        };
         let (merged_output, exit_code) = parse_shell_output(output)?;
         Ok(CommandExecutionOutput {
             output: merged_output,
@@ -111,7 +122,9 @@ fn map_shell_timeout(error: RuntimeProcessError, timeout_secs: Option<u64>) -> R
         RuntimeProcessError::ExecutionFailed(message)
             if message.to_ascii_lowercase().contains("timed out") =>
         {
-            RuntimeProcessError::Timeout(Duration::from_secs(timeout_secs.unwrap_or(120)))
+            RuntimeProcessError::Timeout(Duration::from_secs(
+                timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS),
+            ))
         }
         _ => error,
     }
@@ -138,9 +151,22 @@ fn parse_shell_output(output: Value) -> Result<(String, i64), RuntimeProcessErro
     } else if stderr.is_empty() {
         stdout.to_string()
     } else {
-        format!("{stdout}\n{stderr}")
+        let separator = if stdout.ends_with('\n') { "" } else { "\n" };
+        format!("{stdout}{separator}{stderr}")
     };
-    Ok((merged, exit_code))
+    Ok((truncate_merged_output(&merged), exit_code))
+}
+
+fn truncate_merged_output(output: &str) -> String {
+    if output.len() <= MAX_MERGED_OUTPUT_BYTES {
+        return output.to_string();
+    }
+    let mut end = MAX_MERGED_OUTPUT_BYTES;
+    while !output.is_char_boundary(end) {
+        end -= 1;
+    }
+    let truncated = &output[..end]; // safety: end is adjusted to a UTF-8 char boundary before slicing.
+    format!("{truncated}... [truncated]")
 }
 
 fn container_workdir(workdir: Option<&str>) -> Result<String, RuntimeProcessError> {
@@ -184,7 +210,9 @@ fn validate_relative_workdir(path: &str) -> Result<(), RuntimeProcessError> {
 mod tests {
     use super::*;
     use ironclaw_engine::MountError;
+    use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
     struct ScriptedTransport {
@@ -209,6 +237,26 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default)]
+    struct SlowTransport {
+        reset_count: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SandboxTransport for SlowTransport {
+        async fn dispatch(&self, _request: Request) -> Result<Response, MountError> {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(ok_response(serde_json::json!({
+                "stdout": "too late",
+                "exit_code": 0,
+            })))
+        }
+
+        async fn reset(&self) {
+            self.reset_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
     fn ok_response(output: Value) -> Response {
         Response {
             id: Some("x".to_string()),
@@ -226,6 +274,15 @@ mod tests {
             timeout_secs: Some(7),
             extra_env: Default::default(),
         }
+    }
+
+    fn non_empty_mounts() -> MountView {
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/workspace").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap()
     }
 
     #[tokio::test]
@@ -293,6 +350,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_scoped_mounts_until_daemon_contract_supports_it() {
+        let transport = ScriptedTransport::new(vec![]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+        let mut command = request("pwd");
+        command.mounts = Some(non_empty_mounts());
+
+        let error = adapter.run_command(command).await.unwrap_err();
+        assert!(format!("{error}").contains("scoped mounts"));
+    }
+
+    #[tokio::test]
+    async fn enforces_timeout_at_transport_boundary_and_resets_session() {
+        let transport = Arc::new(SlowTransport::default());
+        let adapter = DockerSandboxCommandTransport::new(transport.clone());
+        let mut command = request("sleep 60");
+        command.timeout_secs = Some(2);
+
+        let error = adapter.run_command(command).await.unwrap_err();
+
+        assert_eq!(error, RuntimeProcessError::Timeout(Duration::from_secs(2)));
+        assert_eq!(transport.reset_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn maps_daemon_timeout_to_process_timeout() {
         let transport = ScriptedTransport::new(vec![Ok(Response {
             id: Some("x".to_string()),
@@ -303,5 +384,60 @@ mod tests {
 
         let error = adapter.run_command(request("sleep 100")).await.unwrap_err();
         assert_eq!(error, RuntimeProcessError::Timeout(Duration::from_secs(7)));
+    }
+
+    #[tokio::test]
+    async fn transport_dispatch_error_maps_to_runtime_process_error() {
+        let transport = ScriptedTransport::new(vec![Err(MountError::Backend {
+            reason: "docker exec failed".to_string(),
+        })]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+
+        let error = adapter.run_command(request("pwd")).await.unwrap_err();
+
+        assert!(format!("{error}").contains("sandbox transport failed"));
+        assert!(format!("{error}").contains("docker exec failed"));
+    }
+
+    #[tokio::test]
+    async fn daemon_malformed_responses_are_rejected() {
+        let cases = [
+            Response {
+                id: Some("x".to_string()),
+                result: None,
+                error: None,
+            },
+            Response {
+                id: Some("x".to_string()),
+                result: Some(serde_json::json!({})),
+                error: None,
+            },
+            ok_response(serde_json::json!({
+                "stdout": "missing exit code",
+            })),
+        ];
+
+        for response in cases {
+            let transport = ScriptedTransport::new(vec![Ok(response)]);
+            let adapter = DockerSandboxCommandTransport::new(transport);
+
+            let error = adapter.run_command(request("pwd")).await.unwrap_err();
+
+            assert!(matches!(error, RuntimeProcessError::ExecutionFailed(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn merges_stdout_and_stderr_without_double_spacing() {
+        let transport = ScriptedTransport::new(vec![Ok(ok_response(serde_json::json!({
+            "stdout": "out\n",
+            "stderr": "err",
+            "exit_code": 0,
+        })))]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+
+        let output = adapter.run_command(request("cargo test")).await.unwrap();
+
+        assert_eq!(output.output, "out\nerr");
     }
 }

--- a/src/bridge/sandbox/command_transport.rs
+++ b/src/bridge/sandbox/command_transport.rs
@@ -49,6 +49,11 @@ impl SandboxCommandTransport for DockerSandboxCommandTransport {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        if request.command.contains('\0') {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox shell command must not contain null bytes".to_string(),
+            ));
+        }
         if !request.extra_env.is_empty() {
             return Err(RuntimeProcessError::ExecutionFailed(
                 "sandbox shell environment overrides are not supported yet".to_string(),
@@ -134,9 +139,14 @@ fn parse_shell_output(output: Value) -> Result<(String, i64), RuntimeProcessErro
     let stdout = output
         .get("stdout")
         .and_then(Value::as_str)
-        .or_else(|| output.get("output").and_then(Value::as_str))
-        .unwrap_or("");
+        .or_else(|| output.get("output").and_then(Value::as_str));
     let stderr = output.get("stderr").and_then(Value::as_str).unwrap_or("");
+    if stdout.is_none() && stderr.is_empty() {
+        return Err(RuntimeProcessError::ExecutionFailed(
+            "sandbox daemon shell output missing stdout/output".to_string(),
+        ));
+    }
+    let stdout = stdout.unwrap_or("");
     let exit_code = output
         .get("exit_code")
         .and_then(Value::as_i64)
@@ -173,6 +183,11 @@ fn container_workdir(workdir: Option<&str>) -> Result<String, RuntimeProcessErro
     let Some(workdir) = workdir.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(CONTAINER_PROJECT_ROOT.to_string());
     };
+    if workdir.contains('\0') {
+        return Err(RuntimeProcessError::ExecutionFailed(
+            "sandbox shell workdir must not contain null bytes".to_string(),
+        ));
+    }
     if workdir == CONTAINER_PROJECT_ROOT {
         return Ok(CONTAINER_PROJECT_ROOT.to_string());
     }
@@ -309,6 +324,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_null_byte_command() {
+        let transport = ScriptedTransport::new(vec![]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+
+        let error = adapter
+            .run_command(request("printf ok\0ignored"))
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error}").contains("null bytes"));
+    }
+
+    #[tokio::test]
     async fn accepts_merged_daemon_output_field() {
         let transport = ScriptedTransport::new(vec![Ok(ok_response(serde_json::json!({
             "output": "compiler says no",
@@ -336,6 +364,14 @@ mod tests {
         assert!(container_workdir(Some("/tmp")).is_err());
         assert!(container_workdir(Some("../escape")).is_err());
         assert!(container_workdir(Some("/project/../escape")).is_err());
+        assert!(container_workdir(Some("/project/\0/../etc")).is_err());
+    }
+
+    #[test]
+    fn container_workdir_handles_empty_and_whitespace_only_input() {
+        assert_eq!(container_workdir(Some("")).unwrap(), "/project");
+        assert_eq!(container_workdir(Some("   ")).unwrap(), "/project");
+        assert_eq!(container_workdir(Some("/project/")).unwrap(), "/project/");
     }
 
     #[tokio::test]
@@ -415,6 +451,14 @@ mod tests {
             ok_response(serde_json::json!({
                 "stdout": "missing exit code",
             })),
+            ok_response(serde_json::json!({
+                "exit_code": 0,
+            })),
+            ok_response(serde_json::json!({
+                "stdout": null,
+                "output": null,
+                "exit_code": 0,
+            })),
         ];
 
         for response in cases {
@@ -439,5 +483,17 @@ mod tests {
         let output = adapter.run_command(request("cargo test")).await.unwrap();
 
         assert_eq!(output.output, "out\nerr");
+    }
+
+    #[tokio::test]
+    async fn missing_stdout_and_output_fields_are_rejected() {
+        let transport = ScriptedTransport::new(vec![Ok(ok_response(serde_json::json!({
+            "exit_code": 0,
+        })))]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+
+        let error = adapter.run_command(request("pwd")).await.unwrap_err();
+
+        assert!(format!("{error}").contains("missing stdout/output"));
     }
 }

--- a/src/bridge/sandbox/command_transport.rs
+++ b/src/bridge/sandbox/command_transport.rs
@@ -253,6 +253,8 @@ mod tests {
             self.captured.lock().unwrap().push(request);
             self.responses.lock().unwrap().remove(0)
         }
+
+        async fn reset(&self) {}
     }
 
     #[derive(Debug, Default)]

--- a/src/bridge/sandbox/command_transport.rs
+++ b/src/bridge/sandbox/command_transport.rs
@@ -49,6 +49,9 @@ impl SandboxCommandTransport for DockerSandboxCommandTransport {
         &self,
         request: CommandExecutionRequest,
     ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        // Command authorization and shell policy checks happen before this
+        // placement adapter. This boundary still rejects bytes whose daemon or
+        // kernel interpretation can differ from the validated Rust string.
         if request.command.contains('\0') {
             return Err(RuntimeProcessError::ExecutionFailed(
                 "sandbox shell command must not contain null bytes".to_string(),

--- a/src/bridge/sandbox/command_transport.rs
+++ b/src/bridge/sandbox/command_transport.rs
@@ -1,0 +1,307 @@
+//! Command transport adapter for Reborn tenant-sandbox process execution.
+//!
+//! This is the V1 sandbox-daemon bridge behind Reborn's placement-neutral
+//! `SandboxCommandTransport` trait. First-party tools still talk only to
+//! `InvocationServices.process`; this adapter maps that abstract process effect
+//! to the existing Docker/NDJSON `execute_tool("shell", ...)` protocol.
+
+use std::path::{Component, Path};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use ironclaw_host_runtime::{
+    CommandExecutionOutput, CommandExecutionRequest, RuntimeProcessError, SandboxCommandTransport,
+};
+use serde_json::Value;
+use uuid::Uuid;
+
+use super::protocol::{Request, Response, RpcError};
+use super::transport::SandboxTransport;
+
+const CONTAINER_PROJECT_ROOT: &str = "/project";
+
+/// Reborn process-command transport backed by the V1 sandbox daemon.
+#[derive(Debug, Clone)]
+pub(crate) struct DockerSandboxCommandTransport {
+    transport: Arc<dyn SandboxTransport>,
+}
+
+impl DockerSandboxCommandTransport {
+    pub(crate) fn new(transport: Arc<dyn SandboxTransport>) -> Self {
+        Self { transport }
+    }
+
+    async fn run_tool(&self, input: Value) -> Result<Value, RuntimeProcessError> {
+        let request = Request::execute_tool(Uuid::new_v4().to_string(), "shell", input);
+        let response = self.transport.dispatch(request).await.map_err(|error| {
+            RuntimeProcessError::ExecutionFailed(format!("sandbox transport failed: {error}"))
+        })?;
+        unwrap_shell_response(response)
+    }
+}
+
+#[async_trait]
+impl SandboxCommandTransport for DockerSandboxCommandTransport {
+    async fn run_command(
+        &self,
+        request: CommandExecutionRequest,
+    ) -> Result<CommandExecutionOutput, RuntimeProcessError> {
+        if !request.extra_env.is_empty() {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox shell environment overrides are not supported yet".to_string(),
+            ));
+        }
+        if request
+            .mounts
+            .as_ref()
+            .is_some_and(|mounts| !mounts.mounts.is_empty())
+        {
+            return Err(RuntimeProcessError::ExecutionFailed(
+                "sandbox shell scoped mounts are not supported yet".to_string(),
+            ));
+        }
+
+        let workdir = container_workdir(request.workdir.as_deref())?;
+        let timeout_secs = request.timeout_secs;
+        let start = Instant::now();
+        let output = self
+            .run_tool(serde_json::json!({
+                "command": request.command,
+                "workdir": workdir,
+                "timeout": timeout_secs,
+            }))
+            .await
+            .map_err(|error| map_shell_timeout(error, timeout_secs))?;
+        let (merged_output, exit_code) = parse_shell_output(output)?;
+        Ok(CommandExecutionOutput {
+            output: merged_output,
+            exit_code,
+            sandboxed: true,
+            duration: start.elapsed(),
+        })
+    }
+}
+
+fn unwrap_shell_response(response: Response) -> Result<Value, RuntimeProcessError> {
+    if let Some(error) = response.error {
+        return Err(map_rpc_error(error));
+    }
+    let result = response.result.ok_or_else(|| {
+        RuntimeProcessError::ExecutionFailed(
+            "sandbox daemon returned neither result nor error for shell".to_string(),
+        )
+    })?;
+    result.get("output").cloned().ok_or_else(|| {
+        RuntimeProcessError::ExecutionFailed(
+            "sandbox daemon shell result missing output".to_string(),
+        )
+    })
+}
+
+fn map_rpc_error(error: RpcError) -> RuntimeProcessError {
+    RuntimeProcessError::ExecutionFailed(format!(
+        "sandbox shell failed: {} ({})",
+        error.message, error.code
+    ))
+}
+
+fn map_shell_timeout(error: RuntimeProcessError, timeout_secs: Option<u64>) -> RuntimeProcessError {
+    match &error {
+        RuntimeProcessError::ExecutionFailed(message)
+            if message.to_ascii_lowercase().contains("timed out") =>
+        {
+            RuntimeProcessError::Timeout(Duration::from_secs(timeout_secs.unwrap_or(120)))
+        }
+        _ => error,
+    }
+}
+
+fn parse_shell_output(output: Value) -> Result<(String, i64), RuntimeProcessError> {
+    let stdout = output
+        .get("stdout")
+        .and_then(Value::as_str)
+        .or_else(|| output.get("output").and_then(Value::as_str))
+        .unwrap_or("");
+    let stderr = output.get("stderr").and_then(Value::as_str).unwrap_or("");
+    let exit_code = output
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| {
+            RuntimeProcessError::ExecutionFailed(
+                "sandbox daemon shell output missing exit_code".to_string(),
+            )
+        })?;
+
+    let merged = if stdout.is_empty() {
+        stderr.to_string()
+    } else if stderr.is_empty() {
+        stdout.to_string()
+    } else {
+        format!("{stdout}\n{stderr}")
+    };
+    Ok((merged, exit_code))
+}
+
+fn container_workdir(workdir: Option<&str>) -> Result<String, RuntimeProcessError> {
+    let Some(workdir) = workdir.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(CONTAINER_PROJECT_ROOT.to_string());
+    };
+    if workdir == CONTAINER_PROJECT_ROOT {
+        return Ok(CONTAINER_PROJECT_ROOT.to_string());
+    }
+    let relative = if let Some(relative) = workdir.strip_prefix("/project/") {
+        relative
+    } else if workdir.starts_with('/') {
+        return Err(RuntimeProcessError::ExecutionFailed(format!(
+            "sandbox shell workdir must be under {CONTAINER_PROJECT_ROOT}: {workdir}"
+        )));
+    } else {
+        workdir
+    };
+    validate_relative_workdir(relative)?;
+    Ok(format!(
+        "{CONTAINER_PROJECT_ROOT}/{}",
+        relative.trim_start_matches('/')
+    ))
+}
+
+fn validate_relative_workdir(path: &str) -> Result<(), RuntimeProcessError> {
+    for component in Path::new(path).components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(RuntimeProcessError::ExecutionFailed(format!(
+                    "sandbox shell workdir contains unsupported path component: {path}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_engine::MountError;
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    struct ScriptedTransport {
+        captured: Mutex<Vec<Request>>,
+        responses: Mutex<Vec<Result<Response, MountError>>>,
+    }
+
+    impl ScriptedTransport {
+        fn new(responses: Vec<Result<Response, MountError>>) -> Arc<Self> {
+            Arc::new(Self {
+                captured: Mutex::new(Vec::new()),
+                responses: Mutex::new(responses),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl SandboxTransport for ScriptedTransport {
+        async fn dispatch(&self, request: Request) -> Result<Response, MountError> {
+            self.captured.lock().unwrap().push(request);
+            self.responses.lock().unwrap().remove(0)
+        }
+    }
+
+    fn ok_response(output: Value) -> Response {
+        Response {
+            id: Some("x".to_string()),
+            result: Some(serde_json::json!({"output": output})),
+            error: None,
+        }
+    }
+
+    fn request(command: &str) -> CommandExecutionRequest {
+        CommandExecutionRequest {
+            scope: ironclaw_host_api::ResourceScope::system(),
+            mounts: None,
+            command: command.to_string(),
+            workdir: None,
+            timeout_secs: Some(7),
+            extra_env: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatches_shell_execute_tool_request() {
+        let transport = ScriptedTransport::new(vec![Ok(ok_response(serde_json::json!({
+            "stdout": "hi\n",
+            "stderr": "",
+            "exit_code": 0,
+        })))]);
+        let adapter = DockerSandboxCommandTransport::new(transport.clone());
+
+        let output = adapter.run_command(request("printf hi")).await.unwrap();
+        assert_eq!(output.output, "hi\n");
+        assert_eq!(output.exit_code, 0);
+        assert!(output.sandboxed);
+
+        let captured = transport.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].method, "execute_tool");
+        assert_eq!(captured[0].params["name"], "shell");
+        assert_eq!(captured[0].params["input"]["command"], "printf hi");
+        assert_eq!(captured[0].params["input"]["workdir"], "/project");
+        assert_eq!(captured[0].params["input"]["timeout"], 7);
+    }
+
+    #[tokio::test]
+    async fn accepts_merged_daemon_output_field() {
+        let transport = ScriptedTransport::new(vec![Ok(ok_response(serde_json::json!({
+            "output": "compiler says no",
+            "success": false,
+            "exit_code": 2,
+        })))]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+
+        let output = adapter.run_command(request("cargo test")).await.unwrap();
+        assert_eq!(output.output, "compiler says no");
+        assert_eq!(output.exit_code, 2);
+    }
+
+    #[test]
+    fn workdir_must_stay_inside_project_root() {
+        assert_eq!(container_workdir(None).unwrap(), "/project");
+        assert_eq!(
+            container_workdir(Some("sub/dir")).unwrap(),
+            "/project/sub/dir"
+        );
+        assert_eq!(
+            container_workdir(Some("/project/sub")).unwrap(),
+            "/project/sub"
+        );
+        assert!(container_workdir(Some("/tmp")).is_err());
+        assert!(container_workdir(Some("../escape")).is_err());
+        assert!(container_workdir(Some("/project/../escape")).is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_env_until_daemon_contract_supports_it() {
+        let transport = ScriptedTransport::new(vec![]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+        let mut command = request("env");
+        command.extra_env.insert("A".to_string(), "B".to_string());
+
+        let error = adapter.run_command(command).await.unwrap_err();
+        assert!(format!("{error}").contains("environment overrides"));
+    }
+
+    #[tokio::test]
+    async fn maps_daemon_timeout_to_process_timeout() {
+        let transport = ScriptedTransport::new(vec![Ok(Response {
+            id: Some("x".to_string()),
+            result: None,
+            error: Some(RpcError::new("tool_error", "timed out after 7s")),
+        })]);
+        let adapter = DockerSandboxCommandTransport::new(transport);
+
+        let error = adapter.run_command(request("sleep 100")).await.unwrap_err();
+        assert_eq!(error, RuntimeProcessError::Timeout(Duration::from_secs(7)));
+    }
+}

--- a/src/bridge/sandbox/containerized_backend.rs
+++ b/src/bridge/sandbox/containerized_backend.rs
@@ -312,6 +312,8 @@ mod tests {
                 Ok(responses.remove(0))
             }
         }
+
+        async fn reset(&self) {}
     }
 
     fn ok_resp(output: Value) -> Response {

--- a/src/bridge/sandbox/docker_transport.rs
+++ b/src/bridge/sandbox/docker_transport.rs
@@ -181,6 +181,11 @@ impl SandboxTransport for DockerTransport {
 
         outcome
     }
+
+    async fn reset(&self) {
+        let mut guard = self.session.lock().await;
+        *guard = None;
+    }
 }
 
 async fn dispatch_one(

--- a/src/bridge/sandbox/manager.rs
+++ b/src/bridge/sandbox/manager.rs
@@ -1,15 +1,15 @@
-//! [`ProjectSandboxManager`] — owns one [`DockerTransport`] per project.
+//! [`ProjectSandboxManager`] — owns per-project sandbox handles.
 //!
 //! Lazily creates the per-project sandbox container on first use, hands out
-//! a shared [`SandboxTransport`] handle that the project's
-//! [`ContainerizedFilesystemBackend`] dispatches into, and exposes lifecycle
-//! hooks (`shutdown_project`, `shutdown_all`) for engine teardown.
+//! shared transport handles that the project's sandbox integrations dispatch
+//! into, and exposes lifecycle hooks (`shutdown_project`, `shutdown_all`) for
+//! engine teardown.
 //!
 //! The manager is the single owner of `bollard::Docker` so all sandbox
 //! activity routes through one connection. The Phase 6 router constructs
 //! exactly one `ProjectSandboxManager` and shares it across all projects.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -27,12 +27,28 @@ use super::docker_transport::DockerTransport;
 use super::lifecycle;
 use super::transport::SandboxTransport;
 
+struct ProjectSandboxHandles {
+    container_id: String,
+    filesystem_transport: Option<Arc<DockerTransport>>,
+    command_transport: Option<Arc<DockerSandboxCommandTransport>>,
+    process_ports: HashMap<TenantId, Arc<TenantSandboxProcessPort>>,
+}
+
+impl ProjectSandboxHandles {
+    fn new(container_id: String) -> Self {
+        Self {
+            container_id,
+            filesystem_transport: None,
+            command_transport: None,
+            process_ports: HashMap::new(),
+        }
+    }
+}
+
 /// One process-wide manager that vends sandbox transports per project.
 pub struct ProjectSandboxManager {
     docker: Docker,
-    transports: Mutex<HashMap<ProjectId, Arc<DockerTransport>>>,
-    command_transports: Mutex<HashMap<ProjectId, Arc<DockerSandboxCommandTransport>>>,
-    process_ports: Mutex<HashMap<(TenantId, ProjectId), Arc<TenantSandboxProcessPort>>>,
+    projects: Mutex<HashMap<ProjectId, ProjectSandboxHandles>>,
 }
 
 impl std::fmt::Debug for ProjectSandboxManager {
@@ -45,10 +61,51 @@ impl ProjectSandboxManager {
     pub fn new(docker: Docker) -> Self {
         Self {
             docker,
-            transports: Mutex::new(HashMap::new()),
-            command_transports: Mutex::new(HashMap::new()),
-            process_ports: Mutex::new(HashMap::new()),
+            projects: Mutex::new(HashMap::new()),
         }
+    }
+
+    async fn ensure_project_started(
+        &self,
+        projects: &mut HashMap<ProjectId, ProjectSandboxHandles>,
+        project_id: ProjectId,
+        host_workspace_path: &PathBuf,
+    ) -> Result<(), MountError> {
+        if projects.contains_key(&project_id) {
+            return Ok(());
+        }
+
+        let container_id =
+            lifecycle::ensure_running(&self.docker, project_id, host_workspace_path).await?;
+        projects.insert(project_id, ProjectSandboxHandles::new(container_id));
+        Ok(())
+    }
+
+    /// Get-or-create a Reborn sandbox process-command transport from a
+    /// started project's cached handles.
+    ///
+    /// This uses a separate Docker exec session from the containerized
+    /// filesystem backend, so long-running commands cannot monopolize
+    /// filesystem RPCs for the same project.
+    fn command_transport_for(
+        &self,
+        project_id: ProjectId,
+        handles: &mut ProjectSandboxHandles,
+    ) -> Arc<DockerSandboxCommandTransport> {
+        if let Some(existing) = &handles.command_transport {
+            return existing.clone();
+        }
+
+        debug!(
+            project_id = %project_id,
+            container_id = %handles.container_id,
+            "ProjectSandboxManager: created sandbox command transport"
+        );
+        let transport = Arc::new(DockerSandboxCommandTransport::new(Arc::new(
+            DockerTransport::new(self.docker.clone(), handles.container_id.clone()),
+        )));
+        handles.command_transport = Some(transport.clone());
+        transport
     }
 
     /// Get-or-create the transport for `project_id`. The first call ensures
@@ -65,56 +122,39 @@ impl ProjectSandboxManager {
         project_id: ProjectId,
         host_workspace_path: PathBuf,
     ) -> Result<Arc<dyn SandboxTransport>, MountError> {
-        let mut guard = self.transports.lock().await;
+        let mut projects = self.projects.lock().await;
 
         // Fast path: return cached transport.
-        if let Some(existing) = guard.get(&project_id) {
+        if let Some(existing) = projects
+            .get(&project_id)
+            .and_then(|handles| handles.filesystem_transport.as_ref())
+        {
             return Ok(existing.clone() as Arc<dyn SandboxTransport>);
         }
 
         // Slow path: create the container and transport while holding the
         // lock, so concurrent calls for the same project_id wait rather
         // than spawning a duplicate container.
-        let container_id =
-            lifecycle::ensure_running(&self.docker, project_id, &host_workspace_path).await?;
+        self.ensure_project_started(&mut projects, project_id, &host_workspace_path)
+            .await?;
+        let handles = projects
+            .get_mut(&project_id)
+            .ok_or_else(|| MountError::Backend {
+                reason: format!(
+                    "sandbox project cache missing after startup for project {project_id}"
+                ),
+            })?;
         debug!(
             project_id = %project_id,
-            container_id = %container_id,
+            container_id = %handles.container_id,
             "ProjectSandboxManager: created sandbox transport"
         );
-        let transport = Arc::new(DockerTransport::new(self.docker.clone(), container_id));
-        guard.insert(project_id, transport.clone());
+        let transport = Arc::new(DockerTransport::new(
+            self.docker.clone(),
+            handles.container_id.clone(),
+        ));
+        handles.filesystem_transport = Some(transport.clone());
         Ok(transport as Arc<dyn SandboxTransport>)
-    }
-
-    /// Get-or-create a Reborn sandbox process-command transport for `project_id`.
-    ///
-    /// This uses a separate Docker exec session from the containerized
-    /// filesystem backend, so long-running commands cannot monopolize
-    /// filesystem RPCs for the same project.
-    #[allow(dead_code)]
-    pub async fn command_transport_for(
-        &self,
-        project_id: ProjectId,
-        host_workspace_path: PathBuf,
-    ) -> Result<Arc<dyn SandboxCommandTransport>, MountError> {
-        let mut guard = self.command_transports.lock().await;
-        if let Some(existing) = guard.get(&project_id) {
-            return Ok(existing.clone() as Arc<dyn SandboxCommandTransport>);
-        }
-
-        let container_id =
-            lifecycle::ensure_running(&self.docker, project_id, &host_workspace_path).await?;
-        debug!(
-            project_id = %project_id,
-            container_id = %container_id,
-            "ProjectSandboxManager: created sandbox command transport"
-        );
-        let transport = Arc::new(DockerSandboxCommandTransport::new(Arc::new(
-            DockerTransport::new(self.docker.clone(), container_id),
-        )));
-        guard.insert(project_id, transport.clone());
-        Ok(transport as Arc<dyn SandboxCommandTransport>)
     }
 
     /// Get-or-create the Reborn tenant-sandbox process port for `project_id`.
@@ -130,16 +170,28 @@ impl ProjectSandboxManager {
         project_id: ProjectId,
         host_workspace_path: PathBuf,
     ) -> Result<Arc<TenantSandboxProcessPort>, MountError> {
+        let mut projects = self.projects.lock().await;
+        if let Some(existing) = projects
+            .get(&project_id)
+            .and_then(|handles| handles.process_ports.get(&tenant_id))
         {
-            let port_guard = self.process_ports.lock().await;
-            if let Some(existing) = port_guard.get(&(tenant_id.clone(), project_id)) {
-                return Ok(existing.clone());
-            }
+            return Ok(existing.clone());
         }
 
-        let transport = self
-            .command_transport_for(project_id, host_workspace_path)
+        self.ensure_project_started(&mut projects, project_id, &host_workspace_path)
             .await?;
+        let handles = projects
+            .get_mut(&project_id)
+            .ok_or_else(|| MountError::Backend {
+                reason: format!(
+                    "sandbox project cache missing after startup for project {project_id}"
+                ),
+            })?;
+        if let Some(existing) = handles.process_ports.get(&tenant_id) {
+            return Ok(existing.clone());
+        }
+
+        let transport = self.command_transport_for(project_id, handles);
         let scoped_project_id =
             HostProjectId::new(project_id.to_string()).map_err(|error| MountError::Backend {
                 reason: format!(
@@ -147,14 +199,10 @@ impl ProjectSandboxManager {
                 ),
             })?;
         let port = Arc::new(TenantSandboxProcessPort::new_scoped(
-            transport,
+            transport as Arc<dyn SandboxCommandTransport>,
             TenantSandboxProcessScope::new(tenant_id.clone(), scoped_project_id),
         ));
-        let mut port_guard = self.process_ports.lock().await;
-        if let Some(existing) = port_guard.get(&(tenant_id.clone(), project_id)) {
-            return Ok(existing.clone());
-        }
-        port_guard.insert((tenant_id, project_id), port.clone());
+        handles.process_ports.insert(tenant_id, port.clone());
         Ok(port)
     }
 
@@ -163,18 +211,10 @@ impl ProjectSandboxManager {
     /// quickly. Use [`Self::reset_project`] for full removal.
     #[allow(dead_code)]
     pub async fn shutdown_project(&self, project_id: ProjectId) {
-        let mut guard = self.transports.lock().await;
-        let had_filesystem_transport = guard.remove(&project_id).is_some();
-        drop(guard);
-        let mut command_guard = self.command_transports.lock().await;
-        let had_command_transport = command_guard.remove(&project_id).is_some();
-        drop(command_guard);
-        let mut port_guard = self.process_ports.lock().await;
-        let process_port_count = port_guard.len();
-        port_guard.retain(|(_, pid), _| *pid != project_id);
-        let had_process_port = process_port_count != port_guard.len();
-        drop(port_guard);
-        if had_filesystem_transport || had_command_transport || had_process_port {
+        let mut projects = self.projects.lock().await;
+        let had_project = projects.remove(&project_id).is_some();
+        drop(projects);
+        if had_project {
             lifecycle::stop(&self.docker, project_id).await;
         }
     }
@@ -184,15 +224,9 @@ impl ProjectSandboxManager {
     /// untouched — it's the user's data, not the sandbox's.
     #[allow(dead_code)]
     pub async fn reset_project(&self, project_id: ProjectId) {
-        let mut guard = self.transports.lock().await;
-        guard.remove(&project_id);
-        drop(guard);
-        let mut command_guard = self.command_transports.lock().await;
-        command_guard.remove(&project_id);
-        drop(command_guard);
-        let mut port_guard = self.process_ports.lock().await;
-        port_guard.retain(|(_, pid), _| *pid != project_id);
-        drop(port_guard);
+        let mut projects = self.projects.lock().await;
+        projects.remove(&project_id);
+        drop(projects);
         lifecycle::stop(&self.docker, project_id).await;
         lifecycle::remove(&self.docker, project_id).await;
     }
@@ -200,18 +234,10 @@ impl ProjectSandboxManager {
     /// Stop every cached transport. Called at engine teardown.
     #[allow(dead_code)]
     pub async fn shutdown_all(&self) {
-        let mut guard = self.transports.lock().await;
-        let mut pids: HashSet<ProjectId> = guard.keys().copied().collect();
-        guard.clear();
-        drop(guard);
-        let mut command_guard = self.command_transports.lock().await;
-        pids.extend(command_guard.keys().copied());
-        command_guard.clear();
-        drop(command_guard);
-        let mut port_guard = self.process_ports.lock().await;
-        pids.extend(port_guard.keys().map(|(_, pid)| *pid));
-        port_guard.clear();
-        drop(port_guard);
+        let mut projects = self.projects.lock().await;
+        let pids: Vec<ProjectId> = projects.keys().copied().collect();
+        projects.clear();
+        drop(projects);
         for pid in pids {
             lifecycle::stop(&self.docker, pid).await;
         }
@@ -246,14 +272,14 @@ mod tests {
                 error: None,
             })
         }
+
+        async fn reset(&self) {}
     }
 
     fn manager_for_test() -> ProjectSandboxManager {
         ProjectSandboxManager {
             docker: Docker::connect_with_local_defaults().expect("docker client config"),
-            transports: Mutex::new(HashMap::new()),
-            command_transports: Mutex::new(HashMap::new()),
-            process_ports: Mutex::new(HashMap::new()),
+            projects: Mutex::new(HashMap::new()),
         }
     }
 
@@ -290,20 +316,14 @@ mod tests {
     async fn command_transport_for_returns_cached_wrapper() {
         let manager = manager_for_test();
         let project_id = ProjectId::new();
-        manager
-            .command_transports
-            .lock()
-            .await
-            .insert(project_id, command_transport("command"));
+        let mut projects = manager.projects.lock().await;
+        let handles = projects
+            .entry(project_id)
+            .or_insert_with(|| ProjectSandboxHandles::new("test-container".to_string()));
+        handles.command_transport = Some(command_transport("command"));
 
-        let first = manager
-            .command_transport_for(project_id, PathBuf::from("/unused"))
-            .await
-            .unwrap();
-        let second = manager
-            .command_transport_for(project_id, PathBuf::from("/unused"))
-            .await
-            .unwrap();
+        let first = manager.command_transport_for(project_id, handles);
+        let second = manager.command_transport_for(project_id, handles);
 
         assert!(Arc::ptr_eq(&first, &second));
     }
@@ -313,11 +333,12 @@ mod tests {
         let manager = manager_for_test();
         let tenant_id = TenantId::new("tenant-a").unwrap();
         let project_id = ProjectId::new();
-        manager
-            .command_transports
-            .lock()
-            .await
-            .insert(project_id, command_transport("scoped"));
+        let mut projects = manager.projects.lock().await;
+        let handles = projects
+            .entry(project_id)
+            .or_insert_with(|| ProjectSandboxHandles::new("test-container".to_string()));
+        handles.command_transport = Some(command_transport("scoped"));
+        drop(projects);
 
         let first = manager
             .process_port_for(tenant_id.clone(), project_id, PathBuf::from("/unused"))

--- a/src/bridge/sandbox/manager.rs
+++ b/src/bridge/sandbox/manager.rs
@@ -15,9 +15,13 @@ use std::sync::Arc;
 
 use bollard::Docker;
 use ironclaw_engine::{MountError, ProjectId};
+use ironclaw_host_runtime::{
+    RuntimeProcessPort, SandboxCommandTransport, TenantSandboxProcessPort,
+};
 use tokio::sync::Mutex;
 use tracing::debug;
 
+use super::command_transport::DockerSandboxCommandTransport;
 use super::docker_transport::DockerTransport;
 use super::lifecycle;
 use super::transport::SandboxTransport;
@@ -76,6 +80,40 @@ impl ProjectSandboxManager {
         let transport = Arc::new(DockerTransport::new(self.docker.clone(), container_id));
         guard.insert(project_id, transport.clone());
         Ok(transport as Arc<dyn SandboxTransport>)
+    }
+
+    /// Get-or-create a Reborn sandbox process-command transport for `project_id`.
+    ///
+    /// This shares the same underlying Docker daemon channel as the
+    /// containerized filesystem backend, but exposes the host-runtime
+    /// `SandboxCommandTransport` seam instead of the engine mount backend.
+    #[allow(dead_code)]
+    pub async fn command_transport_for(
+        &self,
+        project_id: ProjectId,
+        host_workspace_path: PathBuf,
+    ) -> Result<Arc<dyn SandboxCommandTransport>, MountError> {
+        let transport = self.transport_for(project_id, host_workspace_path).await?;
+        Ok(Arc::new(DockerSandboxCommandTransport::new(transport))
+            as Arc<dyn SandboxCommandTransport>)
+    }
+
+    /// Get-or-create the Reborn tenant-sandbox process port for `project_id`.
+    ///
+    /// Composition roots can pass the returned port to
+    /// `HostRuntimeServices::with_tenant_sandbox_process_port` so planned
+    /// `ProcessBackendKind::TenantSandbox` execution lands in the Docker
+    /// sandbox daemon instead of local host processes.
+    #[allow(dead_code)]
+    pub async fn process_port_for(
+        &self,
+        project_id: ProjectId,
+        host_workspace_path: PathBuf,
+    ) -> Result<Arc<dyn RuntimeProcessPort>, MountError> {
+        let transport = self
+            .command_transport_for(project_id, host_workspace_path)
+            .await?;
+        Ok(Arc::new(TenantSandboxProcessPort::new(transport)) as Arc<dyn RuntimeProcessPort>)
     }
 
     /// Stop and forget the cached transport for `project_id`. The container

--- a/src/bridge/sandbox/manager.rs
+++ b/src/bridge/sandbox/manager.rs
@@ -15,9 +15,7 @@ use std::sync::Arc;
 
 use bollard::Docker;
 use ironclaw_engine::{MountError, ProjectId};
-use ironclaw_host_runtime::{
-    RuntimeProcessPort, SandboxCommandTransport, TenantSandboxProcessPort,
-};
+use ironclaw_host_runtime::{SandboxCommandTransport, TenantSandboxProcessPort};
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -30,6 +28,7 @@ use super::transport::SandboxTransport;
 pub struct ProjectSandboxManager {
     docker: Docker,
     transports: Mutex<HashMap<ProjectId, Arc<DockerTransport>>>,
+    command_transports: Mutex<HashMap<ProjectId, Arc<DockerTransport>>>,
 }
 
 impl std::fmt::Debug for ProjectSandboxManager {
@@ -43,6 +42,7 @@ impl ProjectSandboxManager {
         Self {
             docker,
             transports: Mutex::new(HashMap::new()),
+            command_transports: Mutex::new(HashMap::new()),
         }
     }
 
@@ -84,16 +84,31 @@ impl ProjectSandboxManager {
 
     /// Get-or-create a Reborn sandbox process-command transport for `project_id`.
     ///
-    /// This shares the same underlying Docker daemon channel as the
-    /// containerized filesystem backend, but exposes the host-runtime
-    /// `SandboxCommandTransport` seam instead of the engine mount backend.
+    /// This uses a separate Docker exec session from the containerized
+    /// filesystem backend, so long-running commands cannot monopolize
+    /// filesystem RPCs for the same project.
     #[allow(dead_code)]
     pub async fn command_transport_for(
         &self,
         project_id: ProjectId,
         host_workspace_path: PathBuf,
     ) -> Result<Arc<dyn SandboxCommandTransport>, MountError> {
-        let transport = self.transport_for(project_id, host_workspace_path).await?;
+        let mut guard = self.command_transports.lock().await;
+        if let Some(existing) = guard.get(&project_id) {
+            return Ok(Arc::new(DockerSandboxCommandTransport::new(
+                existing.clone() as Arc<dyn SandboxTransport>
+            )) as Arc<dyn SandboxCommandTransport>);
+        }
+
+        let container_id =
+            lifecycle::ensure_running(&self.docker, project_id, &host_workspace_path).await?;
+        debug!(
+            project_id = %project_id,
+            container_id = %container_id,
+            "ProjectSandboxManager: created sandbox command transport"
+        );
+        let transport = Arc::new(DockerTransport::new(self.docker.clone(), container_id));
+        guard.insert(project_id, transport.clone());
         Ok(Arc::new(DockerSandboxCommandTransport::new(transport))
             as Arc<dyn SandboxCommandTransport>)
     }
@@ -109,11 +124,11 @@ impl ProjectSandboxManager {
         &self,
         project_id: ProjectId,
         host_workspace_path: PathBuf,
-    ) -> Result<Arc<dyn RuntimeProcessPort>, MountError> {
+    ) -> Result<Arc<TenantSandboxProcessPort>, MountError> {
         let transport = self
             .command_transport_for(project_id, host_workspace_path)
             .await?;
-        Ok(Arc::new(TenantSandboxProcessPort::new(transport)) as Arc<dyn RuntimeProcessPort>)
+        Ok(Arc::new(TenantSandboxProcessPort::new(transport)))
     }
 
     /// Stop and forget the cached transport for `project_id`. The container
@@ -122,7 +137,11 @@ impl ProjectSandboxManager {
     #[allow(dead_code)]
     pub async fn shutdown_project(&self, project_id: ProjectId) {
         let mut guard = self.transports.lock().await;
-        if guard.remove(&project_id).is_some() {
+        let had_filesystem_transport = guard.remove(&project_id).is_some();
+        drop(guard);
+        let mut command_guard = self.command_transports.lock().await;
+        let had_command_transport = command_guard.remove(&project_id).is_some();
+        if had_filesystem_transport || had_command_transport {
             lifecycle::stop(&self.docker, project_id).await;
         }
     }
@@ -134,6 +153,9 @@ impl ProjectSandboxManager {
     pub async fn reset_project(&self, project_id: ProjectId) {
         let mut guard = self.transports.lock().await;
         guard.remove(&project_id);
+        drop(guard);
+        let mut command_guard = self.command_transports.lock().await;
+        command_guard.remove(&project_id);
         lifecycle::stop(&self.docker, project_id).await;
         lifecycle::remove(&self.docker, project_id).await;
     }
@@ -144,6 +166,16 @@ impl ProjectSandboxManager {
         let mut guard = self.transports.lock().await;
         let pids: Vec<ProjectId> = guard.keys().copied().collect();
         guard.clear();
+        drop(guard);
+        let mut command_guard = self.command_transports.lock().await;
+        let command_pids: Vec<ProjectId> = command_guard.keys().copied().collect();
+        command_guard.clear();
+        let mut pids = pids;
+        for pid in command_pids {
+            if !pids.contains(&pid) {
+                pids.push(pid);
+            }
+        }
         for pid in pids {
             lifecycle::stop(&self.docker, pid).await;
         }

--- a/src/bridge/sandbox/manager.rs
+++ b/src/bridge/sandbox/manager.rs
@@ -9,13 +9,16 @@
 //! activity routes through one connection. The Phase 6 router constructs
 //! exactly one `ProjectSandboxManager` and shares it across all projects.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use bollard::Docker;
 use ironclaw_engine::{MountError, ProjectId};
-use ironclaw_host_runtime::{SandboxCommandTransport, TenantSandboxProcessPort};
+use ironclaw_host_api::{ProjectId as HostProjectId, TenantId};
+use ironclaw_host_runtime::{
+    SandboxCommandTransport, TenantSandboxProcessPort, TenantSandboxProcessScope,
+};
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -28,7 +31,8 @@ use super::transport::SandboxTransport;
 pub struct ProjectSandboxManager {
     docker: Docker,
     transports: Mutex<HashMap<ProjectId, Arc<DockerTransport>>>,
-    command_transports: Mutex<HashMap<ProjectId, Arc<DockerTransport>>>,
+    command_transports: Mutex<HashMap<ProjectId, Arc<DockerSandboxCommandTransport>>>,
+    process_ports: Mutex<HashMap<(TenantId, ProjectId), Arc<TenantSandboxProcessPort>>>,
 }
 
 impl std::fmt::Debug for ProjectSandboxManager {
@@ -43,6 +47,7 @@ impl ProjectSandboxManager {
             docker,
             transports: Mutex::new(HashMap::new()),
             command_transports: Mutex::new(HashMap::new()),
+            process_ports: Mutex::new(HashMap::new()),
         }
     }
 
@@ -95,9 +100,7 @@ impl ProjectSandboxManager {
     ) -> Result<Arc<dyn SandboxCommandTransport>, MountError> {
         let mut guard = self.command_transports.lock().await;
         if let Some(existing) = guard.get(&project_id) {
-            return Ok(Arc::new(DockerSandboxCommandTransport::new(
-                existing.clone() as Arc<dyn SandboxTransport>
-            )) as Arc<dyn SandboxCommandTransport>);
+            return Ok(existing.clone() as Arc<dyn SandboxCommandTransport>);
         }
 
         let container_id =
@@ -107,10 +110,11 @@ impl ProjectSandboxManager {
             container_id = %container_id,
             "ProjectSandboxManager: created sandbox command transport"
         );
-        let transport = Arc::new(DockerTransport::new(self.docker.clone(), container_id));
+        let transport = Arc::new(DockerSandboxCommandTransport::new(Arc::new(
+            DockerTransport::new(self.docker.clone(), container_id),
+        )));
         guard.insert(project_id, transport.clone());
-        Ok(Arc::new(DockerSandboxCommandTransport::new(transport))
-            as Arc<dyn SandboxCommandTransport>)
+        Ok(transport as Arc<dyn SandboxCommandTransport>)
     }
 
     /// Get-or-create the Reborn tenant-sandbox process port for `project_id`.
@@ -122,13 +126,36 @@ impl ProjectSandboxManager {
     #[allow(dead_code)]
     pub async fn process_port_for(
         &self,
+        tenant_id: TenantId,
         project_id: ProjectId,
         host_workspace_path: PathBuf,
     ) -> Result<Arc<TenantSandboxProcessPort>, MountError> {
+        {
+            let port_guard = self.process_ports.lock().await;
+            if let Some(existing) = port_guard.get(&(tenant_id.clone(), project_id)) {
+                return Ok(existing.clone());
+            }
+        }
+
         let transport = self
             .command_transport_for(project_id, host_workspace_path)
             .await?;
-        Ok(Arc::new(TenantSandboxProcessPort::new(transport)))
+        let scoped_project_id =
+            HostProjectId::new(project_id.to_string()).map_err(|error| MountError::Backend {
+                reason: format!(
+                    "project id {project_id} cannot bind sandbox process scope: {error}"
+                ),
+            })?;
+        let port = Arc::new(TenantSandboxProcessPort::new_scoped(
+            transport,
+            TenantSandboxProcessScope::new(tenant_id.clone(), scoped_project_id),
+        ));
+        let mut port_guard = self.process_ports.lock().await;
+        if let Some(existing) = port_guard.get(&(tenant_id.clone(), project_id)) {
+            return Ok(existing.clone());
+        }
+        port_guard.insert((tenant_id, project_id), port.clone());
+        Ok(port)
     }
 
     /// Stop and forget the cached transport for `project_id`. The container
@@ -141,7 +168,13 @@ impl ProjectSandboxManager {
         drop(guard);
         let mut command_guard = self.command_transports.lock().await;
         let had_command_transport = command_guard.remove(&project_id).is_some();
-        if had_filesystem_transport || had_command_transport {
+        drop(command_guard);
+        let mut port_guard = self.process_ports.lock().await;
+        let process_port_count = port_guard.len();
+        port_guard.retain(|(_, pid), _| *pid != project_id);
+        let had_process_port = process_port_count != port_guard.len();
+        drop(port_guard);
+        if had_filesystem_transport || had_command_transport || had_process_port {
             lifecycle::stop(&self.docker, project_id).await;
         }
     }
@@ -156,6 +189,10 @@ impl ProjectSandboxManager {
         drop(guard);
         let mut command_guard = self.command_transports.lock().await;
         command_guard.remove(&project_id);
+        drop(command_guard);
+        let mut port_guard = self.process_ports.lock().await;
+        port_guard.retain(|(_, pid), _| *pid != project_id);
+        drop(port_guard);
         lifecycle::stop(&self.docker, project_id).await;
         lifecycle::remove(&self.docker, project_id).await;
     }
@@ -164,20 +201,141 @@ impl ProjectSandboxManager {
     #[allow(dead_code)]
     pub async fn shutdown_all(&self) {
         let mut guard = self.transports.lock().await;
-        let pids: Vec<ProjectId> = guard.keys().copied().collect();
+        let mut pids: HashSet<ProjectId> = guard.keys().copied().collect();
         guard.clear();
         drop(guard);
         let mut command_guard = self.command_transports.lock().await;
-        let command_pids: Vec<ProjectId> = command_guard.keys().copied().collect();
+        pids.extend(command_guard.keys().copied());
         command_guard.clear();
-        let mut pids = pids;
-        for pid in command_pids {
-            if !pids.contains(&pid) {
-                pids.push(pid);
-            }
-        }
+        drop(command_guard);
+        let mut port_guard = self.process_ports.lock().await;
+        pids.extend(port_guard.keys().map(|(_, pid)| *pid));
+        port_guard.clear();
+        drop(port_guard);
         for pid in pids {
             lifecycle::stop(&self.docker, pid).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
+    use ironclaw_host_runtime::RuntimeProcessPort;
+
+    use crate::bridge::sandbox::protocol::{Request, Response};
+
+    #[derive(Debug)]
+    struct StaticShellTransport {
+        stdout: &'static str,
+    }
+
+    #[async_trait]
+    impl SandboxTransport for StaticShellTransport {
+        async fn dispatch(&self, _request: Request) -> Result<Response, MountError> {
+            Ok(Response {
+                id: Some("manager-test".to_string()),
+                result: Some(serde_json::json!({
+                    "output": {
+                        "stdout": self.stdout,
+                        "exit_code": 0,
+                    }
+                })),
+                error: None,
+            })
+        }
+    }
+
+    fn manager_for_test() -> ProjectSandboxManager {
+        ProjectSandboxManager {
+            docker: Docker::connect_with_local_defaults().expect("docker client config"),
+            transports: Mutex::new(HashMap::new()),
+            command_transports: Mutex::new(HashMap::new()),
+            process_ports: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn command_transport(stdout: &'static str) -> Arc<DockerSandboxCommandTransport> {
+        Arc::new(DockerSandboxCommandTransport::new(Arc::new(
+            StaticShellTransport { stdout },
+        )))
+    }
+
+    fn host_scope(tenant_id: TenantId, project_id: ProjectId) -> ResourceScope {
+        ResourceScope {
+            tenant_id,
+            user_id: UserId::new("user-a").unwrap(),
+            agent_id: None,
+            project_id: Some(HostProjectId::new(project_id.to_string()).unwrap()),
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    fn command_request(scope: ResourceScope) -> ironclaw_host_runtime::CommandExecutionRequest {
+        ironclaw_host_runtime::CommandExecutionRequest {
+            scope,
+            mounts: None,
+            command: "printf manager".to_string(),
+            workdir: None,
+            timeout_secs: Some(5),
+            extra_env: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn command_transport_for_returns_cached_wrapper() {
+        let manager = manager_for_test();
+        let project_id = ProjectId::new();
+        manager
+            .command_transports
+            .lock()
+            .await
+            .insert(project_id, command_transport("command"));
+
+        let first = manager
+            .command_transport_for(project_id, PathBuf::from("/unused"))
+            .await
+            .unwrap();
+        let second = manager
+            .command_transport_for(project_id, PathBuf::from("/unused"))
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn process_port_for_returns_scoped_cached_port() {
+        let manager = manager_for_test();
+        let tenant_id = TenantId::new("tenant-a").unwrap();
+        let project_id = ProjectId::new();
+        manager
+            .command_transports
+            .lock()
+            .await
+            .insert(project_id, command_transport("scoped"));
+
+        let first = manager
+            .process_port_for(tenant_id.clone(), project_id, PathBuf::from("/unused"))
+            .await
+            .unwrap();
+        let second = manager
+            .process_port_for(tenant_id.clone(), project_id, PathBuf::from("/unused"))
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(first.is_scope_bound());
+
+        let output = first
+            .run_command(command_request(host_scope(tenant_id, project_id)))
+            .await
+            .unwrap();
+        assert_eq!(output.output, "scoped");
+        assert!(output.sandboxed);
     }
 }

--- a/src/bridge/sandbox/mod.rs
+++ b/src/bridge/sandbox/mod.rs
@@ -27,6 +27,7 @@
 //! [`EffectBridgeAdapter`]: super::EffectBridgeAdapter
 //! [`WorkspaceMounts`]: ironclaw_engine::WorkspaceMounts
 
+mod command_transport;
 mod containerized_backend;
 mod containerized_factory;
 mod docker_transport;

--- a/src/bridge/sandbox/transport.rs
+++ b/src/bridge/sandbox/transport.rs
@@ -31,5 +31,5 @@ pub trait SandboxTransport: Send + Sync + std::fmt::Debug {
     async fn dispatch(&self, request: Request) -> Result<Response, MountError>;
 
     /// Drop any cached command/session state so the next call reconnects.
-    async fn reset(&self) {}
+    async fn reset(&self);
 }

--- a/src/bridge/sandbox/transport.rs
+++ b/src/bridge/sandbox/transport.rs
@@ -29,4 +29,7 @@ pub trait SandboxTransport: Send + Sync + std::fmt::Debug {
     /// broken) and surface to the engine as [`MountError::Backend`].
     /// Tool-level failures are returned via `Response::error` instead.
     async fn dispatch(&self, request: Request) -> Result<Response, MountError>;
+
+    /// Drop any cached command/session state so the next call reconnects.
+    async fn reset(&self) {}
 }


### PR DESCRIPTION
## Summary
- add `DockerSandboxCommandTransport` for Reborn tenant-sandbox process execution
- map `CommandExecutionRequest` to V1 sandbox daemon `execute_tool("shell", ...)`
- parse daemon `stdout`/`stderr` or merged `output` plus `exit_code` into `CommandExecutionOutput`
- expose `ProjectSandboxManager::process_port_for(...)` for composition roots
- add `RebornBuildInput::with_tenant_sandbox_process_port(...)` and wire injected tenant sandbox process ports through Reborn composition

## Notes
- scoped mounts and env overrides fail closed for now because sandbox filesystem/env handoff is out of scope
- no sandbox filesystem port work in this PR

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw command_transport --lib`
- `cargo test -p ironclaw_reborn_composition local_dev_composes_injected_tenant_sandbox_process_port`
- `cargo test -p ironclaw_host_runtime builtin_shell`
- `cargo clippy -p ironclaw --lib --all-features -- -D warnings`
- `cargo clippy -p ironclaw_host_runtime --all-targets --all-features -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings`

## Baseline
- Full `cargo test -p ironclaw_host_runtime` still has unrelated HTTP contract failures in `first_party_runtime_contract` (`Network` vs expected `Backend`/`InvalidInput`).
