### PR TITLE
test: fix four pre-existing test failures

### DIFF
--- a/crates/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/ironclaw_capabilities/tests/support/mod.rs
@@ -228,6 +228,7 @@ pub fn extension_id() -> ExtensionId {
 }
 
 const ECHO_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
 id = "echo"
 name = "Echo"
 version = "0.1.0"
@@ -243,5 +244,7 @@ id = "echo.say"
 description = "Echoes input"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = {}
+visibility = "host_internal"
+input_schema_ref = "schemas/echo/say.input.v1.json"
+output_schema_ref = "schemas/echo/say.output.v1.json"
 "#;

--- a/crates/ironclaw_processes/tests/process_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_store_contract.rs
@@ -711,19 +711,24 @@ async fn resource_managed_store_denies_before_process_record_creation() {
         .set_limit(
             ResourceAccount::tenant(scope.tenant_id.clone()),
             ResourceLimits {
-                max_process_count: Some(0),
+                max_process_count: Some(1),
                 ..ResourceLimits::default()
             },
         )
         .unwrap();
     let store = ResourceManagedProcessStore::new(InMemoryProcessStore::new(), governor.clone());
 
+    let exceeding_estimate = ResourceEstimate {
+        process_count: Some(2),
+        concurrency_slots: Some(1),
+        ..ResourceEstimate::default()
+    };
     let err = store
         .start(process_start_with_estimate(
             process_id,
             invocation_id,
             scope.clone(),
-            process_estimate(),
+            exceeding_estimate,
         ))
         .await
         .unwrap_err();

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -5745,6 +5745,7 @@ impl ScriptBackend for E2eEchoScriptBackend {
 }
 
 const E2E_SCRIPT_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
 id = "script"
 name = "Script Echo"
 version = "0.1.0"
@@ -5762,7 +5763,9 @@ id = "script.echo"
 description = "Echo text through Reborn adapter e2e"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "host_internal"
+input_schema_ref = "schemas/script/echo.input.v1.json"
+output_schema_ref = "schemas/script/echo.output.v1.json"
 "#;
 
 /// Test-only evidence port that bypasses all durable evidence checks.

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -44,35 +44,49 @@ mod tests {
 
     #[test]
     fn test_run_generates_output() {
-        let completion = Completion { shell: Shell::Zsh };
-        let mut cmd = crate::cli::Cli::command();
-        let bin_name = cmd.get_name().to_string();
-        let mut buf = Vec::new();
-        generate(completion.shell, &mut cmd, bin_name, &mut buf);
-        assert!(!buf.is_empty(), "generate() should produce output");
+        // clap_complete's generate() recurses through the Cli command tree and overflows
+        // the default 2 MiB test thread stack in debug builds. Run on a larger stack.
+        let handle = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let completion = Completion { shell: Shell::Zsh };
+                let mut cmd = crate::cli::Cli::command();
+                let bin_name = cmd.get_name().to_string();
+                let mut buf = Vec::new();
+                generate(completion.shell, &mut cmd, bin_name, &mut buf);
+                assert!(!buf.is_empty(), "generate() should produce output");
+            })
+            .expect("spawn test thread");
+        handle.join().expect("test thread panicked");
     }
 
     #[test]
     fn test_zsh_compdef_guard_applied() {
-        let mut cmd = crate::cli::Cli::command();
-        let bin_name = cmd.get_name().to_string();
-        let mut buf = Vec::new();
-        generate(Shell::Zsh, &mut cmd, bin_name.clone(), &mut buf);
-        let raw = String::from_utf8(buf).unwrap();
+        let handle = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let mut cmd = crate::cli::Cli::command();
+                let bin_name = cmd.get_name().to_string();
+                let mut buf = Vec::new();
+                generate(Shell::Zsh, &mut cmd, bin_name.clone(), &mut buf);
+                let raw = String::from_utf8(buf).unwrap();
 
-        // Apply the same patching logic as run()
-        let bare = format!("compdef _{0} {0}", bin_name);
-        let guarded = format!("(( $+functions[compdef] )) && compdef _{0} {0}", bin_name);
-        let patched = raw.replace(&bare, &guarded);
+                // Apply the same patching logic as run()
+                let bare = format!("compdef _{0} {0}", bin_name);
+                let guarded = format!("(( $+functions[compdef] )) && compdef _{0} {0}", bin_name);
+                let patched = raw.replace(&bare, &guarded);
 
-        let bare_compdef = format!("    compdef _{0} {0}\n", bin_name);
-        assert!(
-            !patched.contains(&bare_compdef),
-            "bare compdef should not appear after patching"
-        );
-        assert!(
-            patched.contains("$+functions[compdef]"),
-            "patched output should contain compdef guard"
-        );
+                let bare_compdef = format!("    compdef _{0} {0}\n", bin_name);
+                assert!(
+                    !patched.contains(&bare_compdef),
+                    "bare compdef should not appear after patching"
+                );
+                assert!(
+                    patched.contains("$+functions[compdef]"),
+                    "patched output should contain compdef guard"
+                );
+            })
+            .expect("spawn test thread");
+        handle.join().expect("test thread panicked");
     }
 }

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -42,51 +42,56 @@ mod tests {
     use super::*;
     use clap::CommandFactory;
 
+    /// clap_complete's `generate()` recurses through the Cli command tree and
+    /// overflows the default 2 MiB test thread stack in debug builds. Run the
+    /// body on a 16 MiB stack to keep these tests reliable across profiles.
+    fn run_on_large_stack<F>(f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(f)
+            .expect("spawn test thread")
+            .join()
+            .expect("test thread panicked");
+    }
+
     #[test]
     fn test_run_generates_output() {
-        // clap_complete's generate() recurses through the Cli command tree and overflows
-        // the default 2 MiB test thread stack in debug builds. Run on a larger stack.
-        let handle = std::thread::Builder::new()
-            .stack_size(16 * 1024 * 1024)
-            .spawn(|| {
-                let completion = Completion { shell: Shell::Zsh };
-                let mut cmd = crate::cli::Cli::command();
-                let bin_name = cmd.get_name().to_string();
-                let mut buf = Vec::new();
-                generate(completion.shell, &mut cmd, bin_name, &mut buf);
-                assert!(!buf.is_empty(), "generate() should produce output");
-            })
-            .expect("spawn test thread");
-        handle.join().expect("test thread panicked");
+        run_on_large_stack(|| {
+            let completion = Completion { shell: Shell::Zsh };
+            let mut cmd = crate::cli::Cli::command();
+            let bin_name = cmd.get_name().to_string();
+            let mut buf = Vec::new();
+            generate(completion.shell, &mut cmd, bin_name, &mut buf);
+            assert!(!buf.is_empty(), "generate() should produce output");
+        });
     }
 
     #[test]
     fn test_zsh_compdef_guard_applied() {
-        let handle = std::thread::Builder::new()
-            .stack_size(16 * 1024 * 1024)
-            .spawn(|| {
-                let mut cmd = crate::cli::Cli::command();
-                let bin_name = cmd.get_name().to_string();
-                let mut buf = Vec::new();
-                generate(Shell::Zsh, &mut cmd, bin_name.clone(), &mut buf);
-                let raw = String::from_utf8(buf).unwrap();
+        run_on_large_stack(|| {
+            let mut cmd = crate::cli::Cli::command();
+            let bin_name = cmd.get_name().to_string();
+            let mut buf = Vec::new();
+            generate(Shell::Zsh, &mut cmd, bin_name.clone(), &mut buf);
+            let raw = String::from_utf8(buf).expect("generated zsh script should be valid utf8");
 
-                // Apply the same patching logic as run()
-                let bare = format!("compdef _{0} {0}", bin_name);
-                let guarded = format!("(( $+functions[compdef] )) && compdef _{0} {0}", bin_name);
-                let patched = raw.replace(&bare, &guarded);
+            // Apply the same patching logic as run()
+            let bare = format!("compdef _{0} {0}", bin_name);
+            let guarded = format!("(( $+functions[compdef] )) && compdef _{0} {0}", bin_name);
+            let patched = raw.replace(&bare, &guarded);
 
-                let bare_compdef = format!("    compdef _{0} {0}\n", bin_name);
-                assert!(
-                    !patched.contains(&bare_compdef),
-                    "bare compdef should not appear after patching"
-                );
-                assert!(
-                    patched.contains("$+functions[compdef]"),
-                    "patched output should contain compdef guard"
-                );
-            })
-            .expect("spawn test thread");
-        handle.join().expect("test thread panicked");
+            let bare_compdef = format!("    compdef _{0} {0}\n", bin_name);
+            assert!(
+                !patched.contains(&bare_compdef),
+                "bare compdef should not appear after patching"
+            );
+            assert!(
+                patched.contains("$+functions[compdef]"),
+                "patched output should contain compdef guard"
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary

Four buckets of pre-existing test failures on `reborn-integration`, all verified unrelated to recent feature work:

- **`ironclaw_capabilities::capability_host_contract::*` (5 tests)** — `ECHO_MANIFEST` fixture used the old `parameters_schema = {}` field; refresh to the v2 schema (`schema_version`, `visibility`, `input_schema_ref`, `output_schema_ref`).
- **`ironclaw_reborn::loop_driver_host::{text_only_host_e2e_…, turn_runner_worker_…}`** — same `parameters_schema` fixture drift in `E2E_SCRIPT_MANIFEST`.
- **`ironclaw_processes::process_store_contract::resource_managed_store_denies_before_process_record_creation`** — test set `max_process_count: Some(0)` and expected `LimitExceeded`, but the `0 = unlimited` convention in `check_integer` filters that out. Switch to `Some(1)` with an estimate requesting 2 processes.
- **`cli::completion::tests::{test_run_generates_output, test_zsh_compdef_guard_applied}`** — `clap_complete::generate` recurses through the Cli command tree and overflows the default 2 MiB test thread stack in debug builds. Wrap both tests in a 16 MiB-stack `std::thread::Builder::spawn`.

## Test plan

- [x] `cargo test -p ironclaw_capabilities --test capability_host_contract` — 5/5 pass
- [x] `cargo test -p ironclaw_reborn --test loop_driver_host text_only_host_e2e_invokes_script_capability_through_real_host_runtime` — pass
- [x] `cargo test -p ironclaw_reborn --test loop_driver_host turn_runner_worker_drives_script_capability_through_real_host_runtime` — pass
- [x] `cargo test -p ironclaw_processes --test process_store_contract resource_managed_store_denies_before_process_record_creation` — pass
- [x] `cargo test --lib cli::completion` — 2/2 pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p ironclaw_capabilities -p ironclaw_processes -p ironclaw_reborn --tests --all-features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)