### PR TITLE
Initialize tracing for Reborn serve

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -46,6 +46,8 @@ pub(crate) struct ServeCommand {
 
 impl ServeCommand {
     pub(crate) fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        crate::runtime::init_tracing();
+
         // Build the runtime config from the operator's TOML.
         let runtime_input = crate::runtime::build_runtime_input(
             context.boot_config(),


### PR DESCRIPTION
## Summary

- initialize the Reborn CLI tracing subscriber when running `ironclaw-reborn serve`
- makes `IRONCLAW_REBORN_LOG=...` effective for WebChat v2 serve debugging

## Verification

```text
cargo fmt --all
cargo test -p ironclaw_reborn_cli serve_fails_closed_when_env_bearer_token_var_is_unset --features webui-v2-beta
cargo check -p ironclaw_reborn_cli --features webui-v2-beta
git diff --check
```

## Manual check after merge

```bash
IRONCLAW_REBORN_LOG='debug,ironclaw_reborn=trace,ironclaw_reborn_composition=trace,ironclaw_webui_v2=debug,ironclaw_reborn_webui_ingress=debug' \
IRONCLAW_REBORN_WEBUI_TOKEN='dev-token' \
IRONCLAW_REBORN_WEBUI_USER_ID='reborn-cli' \
OPENAI_API_KEY='...' \
cargo run -p ironclaw_reborn_cli --features webui-v2-beta -- serve \
  --host 127.0.0.1 \
  --port 3000
```