### PR TITLE
Align WebUI serve default agent with runtime

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -6,9 +6,10 @@ use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use clap::Args;
 use ironclaw_reborn_composition::{
-    RebornReadiness, RebornWebuiBundle, WebuiServeConfig, build_reborn_runtime,
-    build_webui_services, webui_v2_app,
+    RebornReadiness, RebornRuntimeIdentity, RebornWebuiBundle, WebuiServeConfig,
+    build_reborn_runtime, build_webui_services, webui_v2_app,
 };
+use ironclaw_reborn_config::IdentitySection;
 use ironclaw_reborn_webui_ingress::{
     EnvBearerAuthenticator, RebornWebuiServeOptions, serve_webui_v2,
 };
@@ -110,11 +111,10 @@ impl ServeCommand {
         // still 400. Mirror the same fallback rule the `run` command
         // uses: identity.default_agent or composition's default.
         let identity_section = config_file.as_ref().and_then(|file| file.identity.as_ref());
-        let default_agent_raw = identity_section
-            .and_then(|identity| identity.default_agent.as_deref())
-            .unwrap_or("reborn-cli");
+        let default_agent_raw =
+            resolve_webui_default_agent(identity_section, &runtime_input.identity);
         let default_agent_id =
-            ironclaw_reborn_composition::host_api::AgentId::new(default_agent_raw).map_err(
+            ironclaw_reborn_composition::host_api::AgentId::new(&default_agent_raw).map_err(
                 |err| anyhow!("[identity].default_agent `{default_agent_raw}` is invalid: {err}"),
             )?;
         let default_project_id = identity_section
@@ -300,6 +300,15 @@ impl ServeCommand {
     }
 }
 
+fn resolve_webui_default_agent(
+    identity_section: Option<&IdentitySection>,
+    runtime_identity: &RebornRuntimeIdentity,
+) -> String {
+    identity_section
+        .and_then(|identity| identity.default_agent.clone())
+        .unwrap_or_else(|| runtime_identity.agent_id.clone())
+}
+
 fn print_serve_banner(
     listen_addr: SocketAddr,
     env_token_var: &str,
@@ -323,4 +332,33 @@ fn print_serve_banner(
     }
     eprintln!("  readiness : {readiness:?}");
     eprintln!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webui_default_agent_falls_back_to_runtime_identity() {
+        let runtime_identity = RebornRuntimeIdentity::reborn_cli();
+
+        assert_eq!(
+            resolve_webui_default_agent(None, &runtime_identity),
+            "reborn-cli-agent"
+        );
+    }
+
+    #[test]
+    fn webui_default_agent_uses_config_override() {
+        let runtime_identity = RebornRuntimeIdentity::reborn_cli();
+        let identity = IdentitySection {
+            default_agent: Some("configured-agent".to_string()),
+            ..IdentitySection::default()
+        };
+
+        assert_eq!(
+            resolve_webui_default_agent(Some(&identity), &runtime_identity),
+            "configured-agent"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- align `ironclaw-reborn serve` WebUI caller defaults with the composed runtime identity
- preserve `[identity].default_agent` overrides while falling back to `RebornRuntimeIdentity::reborn_cli()` instead of hardcoded `reborn-cli`
- add focused coverage for default-agent fallback and config override behavior

## Why

WebUI-created threads were being stamped with agent `reborn-cli`, while the text-only loop driver host is scoped to the runtime identity's default `reborn-cli-agent`. That mismatch caused queued WebUI turns to fail with:

```text
host creation failed: loop driver host scope mismatch: text-only loop host requires a matching agent-scoped thread
```

## Verification

```text
cargo fmt --all
cargo test -p ironclaw_reborn_cli webui_default_agent --features webui-v2-beta
cargo test -p ironclaw_reborn_cli serve_fails_closed_when_env_bearer_token_var_is_unset --features webui-v2-beta
cargo check -p ironclaw_reborn_cli --features webui-v2-beta
git diff --check
```