### PR TITLE
Add GitHub v2 read-only package

### DIFF
--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use ironclaw_dispatcher::{
@@ -6,13 +9,13 @@ use ironclaw_dispatcher::{
     RuntimeAdapterResult, RuntimeDispatchErrorKind, RuntimeDispatcher,
 };
 use ironclaw_extensions::{
-    ExtensionError, ExtensionLifecycleService, ExtensionRegistry, ManifestV2Error,
+    ExtensionError, ExtensionLifecycleService, ExtensionRegistry, ExtensionRuntime, ManifestV2Error,
 };
 use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, HostPath, MountView, ReservationStatus, ResourceEstimate,
-    ResourceReservationId, ResourceScope, ResourceUsage, RuntimeKind, TenantId, UserId,
-    VirtualPath,
+    CapabilityId, EffectKind, ExtensionId, HostPath, MountView, PermissionMode, ReservationStatus,
+    ResourceEstimate, ResourceReservationId, ResourceScope, ResourceUsage, RuntimeKind, TenantId,
+    UserId, VirtualPath,
 };
 use ironclaw_host_runtime::{
     discover_extensions_with_default_host_api_contracts, publish_hot_capability_catalog,
@@ -125,6 +128,89 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
     assert_eq!(requests[0].mounts, None);
     assert_eq!(requests[0].resource_reservation_id, Some(reservation_id));
     assert_eq!(requests[0].input, json!({"message":"hello"}));
+}
+
+#[tokio::test]
+async fn github_v2_package_discovers_and_publishes_read_only_hot_catalog() {
+    let (_storage, fs) = mounted_github_package_fs();
+    let registry = discover_extensions_with_default_host_api_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+    )
+    .await
+    .unwrap();
+    let extension_id = ExtensionId::new("github").unwrap();
+    let package = registry.get_extension(&extension_id).unwrap();
+
+    assert!(matches!(
+        &package.manifest.runtime,
+        ExtensionRuntime::Wasm { module } if module.as_str() == "wasm/github_tool.wasm"
+    ));
+    assert_eq!(
+        package
+            .capabilities
+            .iter()
+            .map(|capability| capability.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["github.search_issues", "github.get_issue"]
+    );
+    for capability in &package.manifest.capabilities {
+        assert_eq!(
+            capability.effects,
+            vec![EffectKind::Network, EffectKind::UseSecret]
+        );
+        assert_eq!(capability.default_permission, PermissionMode::Ask);
+        assert_eq!(
+            capability
+                .required_host_ports
+                .iter()
+                .map(|port| port.as_str())
+                .collect::<Vec<_>>(),
+            vec!["host.runtime.http_egress"]
+        );
+    }
+
+    let hot_catalog = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap();
+    assert_eq!(hot_catalog.capabilities.len(), 2);
+
+    let search = hot_catalog
+        .get(&CapabilityId::new("github.search_issues").unwrap())
+        .unwrap();
+    assert_eq!(search.descriptor.provider, extension_id);
+    assert_eq!(search.descriptor.runtime, RuntimeKind::Wasm);
+    assert_eq!(
+        search.descriptor.parameters_schema["properties"]["query"]["type"],
+        json!("string")
+    );
+    assert_eq!(
+        search.output_schema["properties"]["items"]["type"],
+        json!("array")
+    );
+    assert!(search
+        .prompt_doc
+        .as_deref()
+        .is_some_and(|doc| doc.contains("github.search_issues")
+            && doc.contains("github_token")));
+
+    let get_issue = hot_catalog
+        .get(&CapabilityId::new("github.get_issue").unwrap())
+        .unwrap();
+    assert_eq!(
+        get_issue.descriptor.parameters_schema["required"],
+        json!(["owner", "repo", "issue_number"])
+    );
+    assert_eq!(
+        get_issue.output_schema["required"],
+        json!(["number", "title", "state", "html_url"])
+    );
+    assert!(
+        get_issue
+            .prompt_doc
+            .as_deref()
+            .is_some_and(|doc| doc.contains("github.get_issue") && doc.contains("read-only"))
+    );
 }
 
 #[tokio::test]
@@ -283,6 +369,41 @@ fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, LocalFi
     )
     .unwrap();
     (storage, fs)
+}
+
+fn mounted_github_package_fs() -> (tempfile::TempDir, LocalFilesystem) {
+    let storage = tempdir().unwrap();
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("tools-src/github-reborn");
+    let package_root = storage.path().join("github");
+
+    for relative in [
+        "manifest.toml",
+        "schemas/github/search_issues.input.v1.json",
+        "schemas/github/search_issues.output.v1.json",
+        "schemas/github/get_issue.input.v1.json",
+        "schemas/github/get_issue.output.v1.json",
+        "prompts/github/search_issues.md",
+        "prompts/github/get_issue.md",
+    ] {
+        copy_package_file(&source_root, &package_root, relative);
+    }
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+    (storage, fs)
+}
+
+fn copy_package_file(source_root: &Path, package_root: &Path, relative: &str) {
+    let source = source_root.join(relative);
+    let destination = package_root.join(relative);
+    std::fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    std::fs::copy(source, destination).unwrap();
 }
 
 fn sample_scope() -> ResourceScope {

--- a/tools-src/github-reborn/manifest.toml
+++ b/tools-src/github-reborn/manifest.toml
@@ -1,0 +1,38 @@
+schema_version = "reborn.extension_manifest.v2"
+id = "github"
+name = "GitHub"
+version = "0.2.5"
+description = "Read-only GitHub issue lookup capabilities."
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/github_tool.wasm"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "github.search_issues"
+description = "Search GitHub issues and pull requests with the GitHub search query syntax."
+effects = ["network", "use_secret"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/github/search_issues.input.v1.json"
+output_schema_ref = "schemas/github/search_issues.output.v1.json"
+prompt_doc_ref = "prompts/github/search_issues.md"
+required_host_ports = ["host.runtime.http_egress"]
+
+[[capability_provider.tools.capabilities]]
+id = "github.get_issue"
+description = "Fetch one GitHub issue or pull request by repository and issue number."
+effects = ["network", "use_secret"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/github/get_issue.input.v1.json"
+output_schema_ref = "schemas/github/get_issue.output.v1.json"
+prompt_doc_ref = "prompts/github/get_issue.md"
+required_host_ports = ["host.runtime.http_egress"]

--- a/tools-src/github-reborn/prompts/github/get_issue.md
+++ b/tools-src/github-reborn/prompts/github/get_issue.md
@@ -1,0 +1,5 @@
+Use `github.get_issue` for read-only retrieval of one GitHub issue or pull request when the repository owner, repository name, and issue number are known.
+
+Pass `owner`, `repo`, and `issue_number` exactly. If the user provides a GitHub issue or pull request URL, extract those three fields before calling this capability.
+
+This capability reads from the GitHub API through the host HTTP egress port. It requires a configured `github_token` secret, but Extension Manifest v2 does not yet define a canonical credential declaration field, so the token requirement is documented here rather than declared in the manifest.

--- a/tools-src/github-reborn/prompts/github/search_issues.md
+++ b/tools-src/github-reborn/prompts/github/search_issues.md
@@ -1,0 +1,5 @@
+Use `github.search_issues` for read-only discovery of GitHub issues and pull requests.
+
+Provide a focused GitHub search query in `query`. Include qualifiers such as `repo:owner/name`, `org:name`, `is:issue`, `is:pr`, `state:open`, labels, authors, assignees, or `involves:@me` when the user asks for a narrow result set.
+
+This capability reads from the GitHub API through the host HTTP egress port. It requires a configured `github_token` secret, but Extension Manifest v2 does not yet define a canonical credential declaration field, so the token requirement is documented here rather than declared in the manifest.

--- a/tools-src/github-reborn/schemas/github/get_issue.input.v1.json
+++ b/tools-src/github-reborn/schemas/github/get_issue.input.v1.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitHub get issue input",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "owner": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Repository owner or organization."
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Repository name."
+    },
+    "issue_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Issue or pull request number."
+    }
+  },
+  "required": ["owner", "repo", "issue_number"]
+}

--- a/tools-src/github-reborn/schemas/github/get_issue.output.v1.json
+++ b/tools-src/github-reborn/schemas/github/get_issue.output.v1.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitHub get issue output",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "number": { "type": "integer", "minimum": 1 },
+    "title": { "type": "string" },
+    "state": { "type": "string" },
+    "html_url": { "type": "string" },
+    "body": { "type": ["string", "null"] },
+    "user": { "type": "object" },
+    "labels": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "assignees": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "milestone": { "type": ["object", "null"] },
+    "pull_request": { "type": "object" },
+    "created_at": { "type": "string" },
+    "updated_at": { "type": "string" },
+    "closed_at": { "type": ["string", "null"] }
+  },
+  "required": ["number", "title", "state", "html_url"]
+}

--- a/tools-src/github-reborn/schemas/github/search_issues.input.v1.json
+++ b/tools-src/github-reborn/schemas/github/search_issues.input.v1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitHub issue search input",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "query": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "GitHub issue search query. Use qualifiers such as repo:, org:, is:issue, is:pr, label:, state:, author:, assignee:, or involves:."
+    },
+    "page": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 1,
+      "description": "1-based results page."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 30,
+      "description": "Maximum number of results to return."
+    },
+    "sort": {
+      "type": "string",
+      "enum": ["comments", "created", "updated"],
+      "description": "Optional GitHub issue search sort field."
+    },
+    "order": {
+      "type": "string",
+      "enum": ["asc", "desc"],
+      "default": "desc",
+      "description": "Sort order when sort is supplied."
+    }
+  },
+  "required": ["query"]
+}

--- a/tools-src/github-reborn/schemas/github/search_issues.output.v1.json
+++ b/tools-src/github-reborn/schemas/github/search_issues.output.v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitHub issue search output",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "total_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total matching results reported by GitHub."
+    },
+    "incomplete_results": {
+      "type": "boolean",
+      "description": "Whether GitHub returned an incomplete result set."
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "number": { "type": "integer", "minimum": 1 },
+          "title": { "type": "string" },
+          "state": { "type": "string" },
+          "html_url": { "type": "string" },
+          "repository_url": { "type": "string" },
+          "user": { "type": "object" },
+          "pull_request": { "type": "object" },
+          "created_at": { "type": "string" },
+          "updated_at": { "type": "string" }
+        }
+      }
+    }
+  },
+  "required": ["items"]
+}


### PR DESCRIPTION
## Summary
- add an Extension Manifest v2 package for the bundled GitHub WASM tool
- publish only the read-only `github.search_issues` and `github.get_issue` capability surface
- add schemas, prompt docs, and host-runtime lifecycle coverage for hot catalog publication

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_host_runtime --test extension_v2_lifecycle_e2e`
- `cargo test -p ironclaw_extensions --test manifest_v2_contract`

Part of #3806. This PR intentionally stops at manifest/catalog publication; runtime invocation, credential egress, approval-gated mutation, and E2E coverage are split into follow-up PRs.