### PR TITLE
perf(hooks): restore batched capability dispatch when hooks active

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,15 +1087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,27 +1827,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc822414b18d1f5b1b33ce1441534e311e62fef86ebb5b9d382af857d0272c9"
+checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c646808b06f4532478d8d6057d74f15c3322f10d995d9486e7dcea405bf521a"
+checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5996f01a686b2349cdb379083ec5ad3e8cb8767fb2d495d3a4f2ee4163a18d"
+checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1864,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523fea83273f6a985520f57788809a4de2165794d9ab00fb1254fceb4f5aa00c"
+checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1875,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73d1e372730b5f64ed1a2bd9f01fe4686c8ec14a28034e3084e530c8d951878"
+checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1903,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0319c18165e93dc1ebf78946a8da0b1c341c95b4a39729a69574671639bdb5f"
+checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1916,24 +1907,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9195cd8aeecb55e401aa96b2eaa55921636e8246c127ed7908f7ef7e0d40f270"
+checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8976c2154b74136322befc74222ab5c7249edd7e2604f8cbef2b94975541ffb9"
+checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6038b3147c7982f4951150d5f96c7c06c1e7214b99d4b4a98607aadf8ded89d1"
+checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1943,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbd294abe236e23cc3d907b0936226b6a8342db7636daa9c7c72be1e323420e"
+checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1955,15 +1946,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a90b6ed3aba84189352a87badeb93b2126d3724225a42dc67fdce53d1b139c"
+checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ec0cc1a54e22925eacf4fc3dc815f907734d3b377899d19d52bec04863e853"
+checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1972,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
+checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
 
 [[package]]
 name = "crc"
@@ -3313,6 +3304,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3831,20 +3825,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "im-rc"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -6022,12 +6002,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.38.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -6730,9 +6710,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec12fe19a9588315a49fe5704502a9c02d6a198303314b0c7c86123b06d29e5"
+checksum = "dff0ead8b4616f81b3d3efd41ce41bcf9ea364a5d8df8be8a8a1f98b50104349"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -6742,9 +6722,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f7d5ef31ebf1b46cd7e722ffef934e670d7e462f49aa01cde07b9b76dca580"
+checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7012,15 +6992,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rangemap"
@@ -8077,19 +8048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serde_yml"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8242,16 +8200,6 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"
@@ -9570,12 +9518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9790,22 +9732,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
+checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
 dependencies = [
  "anyhow",
  "heck",
- "im-rc",
  "indexmap 2.14.0",
  "log",
  "petgraph",
- "serde",
- "serde_derive",
- "serde_yaml",
  "smallvec",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wat",
 ]
 
@@ -9827,6 +9765,16 @@ checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -9903,6 +9851,19 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
@@ -9914,20 +9875,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
+checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -9958,8 +9919,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -9978,9 +9939,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4172382dcc785c31d0e862c6780a18f5dd437914d22c4691351f965ef751c821"
+checksum = "7e84dbe3208c1336a41546beb75927b3b37e2e4fce06653d214b407136fbe295"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -10000,8 +9961,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -10009,9 +9970,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed398988226d7aa0505ac6bb576e09532ad722d702ec4e66365d78ed695c95f"
+checksum = "910b8dcadc0888344b2dea5a087c836b58156d4f455c52b6dac0bdc776a9d029"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -10029,9 +9990,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5ec9fff073ff13b81732d56a9515d761c245750bcda09093827f84130ebc25"
+checksum = "c223bd503db76df8d74d1fcca39e734d25f7a0c1dcaf1509b67f3855d1b0f803"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -10039,20 +10000,20 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.245.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935d9ab293ba27d1ec9aa7bc1b3a43993dbe961af2a8f23f90a11e1331b4c13f"
+checksum = "ab123ad511483a1b918399789d0cc7dea7c5c6476743df73949007b5b225fc74"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3820b174f477d2a7083209d1ad5353fcdb11eaea434b2137b8681029460dd3"
+checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -10062,9 +10023,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1679d205caf9766c6aa309d45bb3e7c634d7725e3164404df33824b9f7c4fb7"
+checksum = "c5a3bc28a172037c7864128bb208017a02bba659a59c27acacc048c09e25c1fc"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -10080,7 +10041,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -10089,9 +10050,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e505254058be5b0df458d670ee42d9eafe2349d04c1296e9dc01071dc20a85"
+checksum = "3c90a899a47d3da6e384e7b4cad61fdcb27535a395742b32440bdf9980ea83fa"
 dependencies = [
  "cc",
  "cfg-if",
@@ -10104,9 +10065,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2e05b345f1773e59c20e6ad7298fd6857cdea245023d88bb659c96d8f0ea72"
+checksum = "84f364747aa74c686b18925918e5cfd615a73c9613c7a31fc1cd86f42df12fbe"
 dependencies = [
  "cc",
  "object",
@@ -10116,9 +10077,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86701b234a4643e3f111869aa792b3a05a06e02d486ee9cb6c04dae16b52dab"
+checksum = "c3ba98c1492f530833e0d3cc17dbb0c3c57c9f1bb3b078ae44bb55a233e43eba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -10128,9 +10089,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63558d801beb83dde9b336eb4ae049019aee26627926edb32cd119d7e4c83cd"
+checksum = "94b8f8a89e8f3660646f820c7d8310a67094156bb866e9d56f1b00892e011206"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -10141,9 +10102,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737c4d956fc3a848541a064afb683dd2771132a6b125be5baaf95c4379aa47df"
+checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10152,16 +10113,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f599b79545e3bba0b7913406055ebede5bb0dabee9ba2015ef25a9f4c9f47807"
+checksum = "4b06e4ed07adc579645e5c55c67b3138c49da2e468fad52d3db7b7a098ecc733"
 dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -10169,22 +10130,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
+checksum = "0f08787948e3c983799d616ef7dd57463253e9ca8bab6607eef8134f12353f70"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.245.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c7daf53ba2f64aa089f47d9a54bec654a45b7b1b55660efecfb09a2e6cfbcf"
+checksum = "1b2f19834bc6edbc31ac95fdcfd5ddcd7643759265a1d545dec36ac6cc788ca8"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -10212,9 +10173,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c9c6cd3daf62a4fb75ac4742c976fee1939686ffe461a366ce6446c58a58a0"
+checksum = "c3e0c6efdbaf90906016be9ed9ff17b7b58f393876287beebe5bd7fa1de54dbb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10337,9 +10298,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8cfd3db2f05619c6f36f257d84327c11546e28d61e3a1c1220aaad553bc4b0"
+checksum = "17b644ab90da80bbca28973192978ac452cbd876955bb209e6ff2cd1955e43a7"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -10351,9 +10312,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7a197903e5b4ff5e13aef9c891960d71e92073600ecf4c86c7e795ac1c803"
+checksum = "521f9d558365357274d960340eb9eb4f4d768fafdc79f381fd2e13a85b925ebc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -10365,9 +10326,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6410b86fcec207070d9372b215d3470bad67215e6bbac46981a16999c4abbc28"
+checksum = "8a386e86021363c9f0abd1e189e8f8a729d9b5aab2bb7172a3e40f2ab647a936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10408,9 +10369,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "43.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dbb0cf07b0dfe7b7a1ca8efb8f94ba98bd0fb144c411ea1665c78f0449e958"
+checksum = "f16496e92d2b232f9d195ae74f71a674aabae7b7fa722d39068836723d3b653c"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -10419,7 +10380,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -10884,6 +10845,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,8 +159,11 @@ open = "5"
 pgvector = { version = "0.4", features = ["postgres"], optional = true }
 
 # WASM sandbox for untrusted tool execution
-wasmtime = { version = "43.0.2", features = ["component-model"] }
-wasmtime-wasi = "43.0.2"  # WASI support for component model
+# Pinned to 44.0.2: minimum patch that contains the fix for
+# RUSTSEC-2026-0149 (path_open(TRUNCATE) bypassing FilePerms::WRITE
+# host restriction). 43.x is end-of-life for this advisory.
+wasmtime = { version = "44.0.2", features = ["component-model"] }
+wasmtime-wasi = "44.0.2"  # WASI support for component model
 wasmparser = "0.245.1"  # WASM binary parsing for validation
 
 # Cryptography for secrets management

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -187,38 +187,145 @@ impl LoopCapabilityPort for HookedLoopCapabilityPort {
         &self,
         request: CapabilityBatchInvocation,
     ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
-        // Each invocation runs its own hook pre-flight. Hooks can deny one
-        // call in a batch without affecting others — the inner port still
-        // executes the non-denied calls.
+        // Two-phase batch dispatch that preserves the inner port's batch
+        // semantics when hooks are active:
+        //
+        //   Phase 1 — preflight: walk invocations in order, run each through
+        //   `BeforeCapability` hook dispatch, and translate restrictive
+        //   decisions (deny / pause / fail-closed) into outcome slots
+        //   immediately. Entries the hooks allow are queued for the inner
+        //   port. If a hook-translated outcome is itself a suspension and
+        //   `stop_on_first_suspension` is set, preflight stops there and the
+        //   remaining invocations are dropped — mirroring the previous
+        //   sequential semantics.
+        //
+        //   Phase 2 — inner batch: forward all queued (hook-allowed)
+        //   invocations to the inner port as a SINGLE `invoke_capability_batch`
+        //   call, then splice its outcomes back into their original index
+        //   positions. The inner port may stop early on its own suspensions;
+        //   any queued entry without a corresponding inner outcome is treated
+        //   the same as a hook-suspension stop (dropped, no observer).
+        //
+        //   AfterCapability observers fire per resolved entry in the merged
+        //   outcome vec, in original index order, matching the per-entry
+        //   semantics established in PR #3573 (serrrfirat P2 #3).
         let CapabilityBatchInvocation {
             invocations,
             stop_on_first_suspension,
         } = request;
-        let mut outcomes = Vec::with_capacity(invocations.len());
-        let mut stopped_on_suspension = false;
+
+        // Phase 1: preflight hooks for each invocation in order.
+        enum Slot {
+            /// Hook produced a final outcome — no inner call needed.
+            Resolved {
+                outcome: CapabilityOutcome,
+                provider: Option<ironclaw_host_api::ExtensionId>,
+            },
+            /// Hooks allowed; the inner port will produce the outcome.
+            Pending {
+                provider: Option<ironclaw_host_api::ExtensionId>,
+            },
+        }
+
+        let mut slots: Vec<Slot> = Vec::with_capacity(invocations.len());
+        let mut pending: Vec<CapabilityInvocation> = Vec::new();
+        let mut stopped_in_preflight = false;
         for invocation in invocations {
-            if stopped_on_suspension {
-                break;
-            }
             let provider = self
                 .provider_resolver
                 .provider_for(&invocation.capability_id.to_string())
                 .await;
             let dispatch = self.run_dispatch(&invocation, provider.clone()).await;
-            // Capture the inner result (Ok or Err) before dispatching
-            // AfterCapability observers — propagating an error with `?`
-            // here would skip observers for failed batch entries, which
-            // is inconsistent with the single-invocation path and hides
-            // failures from audit/telemetry (serrrfirat P2 #3, PR #3573).
-            let invocation_result: Result<CapabilityOutcome, AgentLoopHostError> =
-                match self.decision_to_outcome(&dispatch).await {
-                    Some(translated) => Ok(translated),
-                    None => self.inner.invoke_capability(invocation).await,
-                };
-            // Fire AfterCapability observers per batch entry, mirroring the
-            // single-invocation path. The provider is resolved per-invocation
-            // so the dispatcher can enforce `OwnCapabilities` scope on
-            // Installed observers (serrrfirat finding #3).
+            match self.decision_to_outcome(&dispatch).await {
+                Some(translated) => {
+                    let is_suspension = translated.is_suspension();
+                    slots.push(Slot::Resolved {
+                        outcome: translated,
+                        provider,
+                    });
+                    if is_suspension && stop_on_first_suspension {
+                        stopped_in_preflight = true;
+                        break;
+                    }
+                }
+                None => {
+                    slots.push(Slot::Pending {
+                        provider: provider.clone(),
+                    });
+                    pending.push(invocation);
+                }
+            }
+        }
+
+        // Phase 2: forward the surviving (hook-allowed) entries to the inner
+        // port as a SINGLE batched call. Empty batches skip the inner call so
+        // we don't perturb implementations that special-case empty input.
+        let inner_result: Result<CapabilityBatchOutcome, AgentLoopHostError> = if pending.is_empty()
+        {
+            Ok(CapabilityBatchOutcome {
+                outcomes: Vec::new(),
+                stopped_on_suspension: false,
+            })
+        } else {
+            self.inner
+                .invoke_capability_batch(CapabilityBatchInvocation {
+                    invocations: pending,
+                    stop_on_first_suspension,
+                })
+                .await
+        };
+
+        // If the inner port errored, we still owe per-entry AfterCapability
+        // observers for every slot we already produced an outcome for (Phase 1
+        // resolved slots). Pending slots have no outcome to observe against;
+        // matching the single-invocation path, we fire one observer per
+        // pending slot so failed batch entries remain visible to telemetry
+        // (serrrfirat P2 #3 on PR #3573).
+        let inner_outcome = match inner_result {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                for slot in slots {
+                    let provider = match slot {
+                        Slot::Resolved { provider, .. } => provider,
+                        Slot::Pending { provider } => provider,
+                    };
+                    let _ = self
+                        .dispatcher
+                        .dispatch_observer_at_with_provider(
+                            crate::registry::HookPointSpec::AfterCapability,
+                            self.tenant_id.clone(),
+                            provider,
+                        )
+                        .await;
+                }
+                return Err(err);
+            }
+        };
+        let CapabilityBatchOutcome {
+            outcomes: mut inner_outcomes,
+            stopped_on_suspension: inner_stopped,
+        } = inner_outcome;
+        // We pop from the front by reversing so we can take in original order.
+        inner_outcomes.reverse();
+
+        // Merge: walk slots in order, splicing inner outcomes into pending
+        // slots. Dispatch AfterCapability observer per merged entry.
+        let mut outcomes = Vec::with_capacity(slots.len());
+        let mut stopped_on_suspension = stopped_in_preflight;
+        for slot in slots {
+            let (outcome, provider) = match slot {
+                Slot::Resolved { outcome, provider } => (outcome, provider),
+                Slot::Pending { provider } => match inner_outcomes.pop() {
+                    Some(inner) => (inner, provider),
+                    None => {
+                        // Inner port stopped early (suspension) and consumed
+                        // fewer outcomes than we queued. Remaining pending
+                        // slots have no outcome — drop them, matching the
+                        // pre-refactor sequential break-out semantics.
+                        break;
+                    }
+                },
+            };
             let _ = self
                 .dispatcher
                 .dispatch_observer_at_with_provider(
@@ -227,11 +334,16 @@ impl LoopCapabilityPort for HookedLoopCapabilityPort {
                     provider,
                 )
                 .await;
-            let outcome = invocation_result?;
             if outcome.is_suspension() && stop_on_first_suspension {
                 stopped_on_suspension = true;
             }
             outcomes.push(outcome);
+            if stopped_on_suspension {
+                break;
+            }
+        }
+        if inner_stopped {
+            stopped_on_suspension = true;
         }
         Ok(CapabilityBatchOutcome {
             outcomes,
@@ -346,17 +458,26 @@ mod tests {
 
     struct AlwaysCompletedPort {
         calls: Mutex<Vec<CapabilityId>>,
+        /// Number of times `invoke_capability_batch` was called on the inner
+        /// port. Distinct from `calls.len()`, which counts the per-entry
+        /// `invoke_capability` invocations the batch impl makes underneath.
+        batch_calls: Mutex<Vec<Vec<CapabilityId>>>,
     }
 
     impl AlwaysCompletedPort {
         fn new() -> Self {
             Self {
                 calls: Mutex::new(Vec::new()),
+                batch_calls: Mutex::new(Vec::new()),
             }
         }
 
         fn calls(&self) -> Vec<CapabilityId> {
             self.calls.lock().expect("not poisoned").clone()
+        }
+
+        fn batch_calls(&self) -> Vec<Vec<CapabilityId>> {
+            self.batch_calls.lock().expect("not poisoned").clone()
         }
     }
 
@@ -399,6 +520,13 @@ mod tests {
             &self,
             request: CapabilityBatchInvocation,
         ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+            self.batch_calls.lock().expect("not poisoned").push(
+                request
+                    .invocations
+                    .iter()
+                    .map(|i| i.capability_id.clone())
+                    .collect(),
+            );
             let mut outcomes = Vec::with_capacity(request.invocations.len());
             for invocation in request.invocations {
                 outcomes.push(self.invoke_capability(invocation).await?);
@@ -706,7 +834,14 @@ mod tests {
                 &self,
                 _request: CapabilityBatchInvocation,
             ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
-                unreachable!()
+                // After the batched-dispatch refactor, the wrapper forwards
+                // hook-allowed invocations as a single batched call. Surface
+                // the same Unavailable error here so the observer-on-error
+                // contract from PR #3573 still has coverage.
+                Err(AgentLoopHostError::new(
+                    ironclaw_turns::run_profile::AgentLoopHostErrorKind::Unavailable,
+                    "inner port failed",
+                ))
             }
         }
 
@@ -785,6 +920,198 @@ mod tests {
         for entry in &outcome.outcomes {
             assert!(matches!(entry, CapabilityOutcome::Completed(_)));
         }
+    }
+
+    // ── Batched-dispatch regression coverage ───────────────────────────────
+    //
+    // The middleware previously degraded `invoke_capability_batch` into N
+    // sequential `invoke_capability` calls whenever any hook was registered,
+    // wiping out the O(1)-batch property that the inner port relies on for
+    // bulk-dispatch performance. The tests below pin the restored behavior
+    // (PR #3573 deferred refactor).
+
+    /// When NO hook denies, the wrapper must call the inner port's
+    /// `invoke_capability_batch` exactly once, with every invocation in a
+    /// single payload — not N times via `invoke_capability`.
+    #[tokio::test]
+    async fn batch_invocation_remains_batched_when_no_hooks_deny() {
+        struct AllowingHook;
+        #[async_trait]
+        impl RestrictedBeforeCapabilityHook for AllowingHook {
+            async fn evaluate(
+                &self,
+                _ctx: &BeforeCapabilityHookContext,
+                sink: &mut dyn RestrictedGateSink,
+            ) {
+                sink.pass();
+            }
+        }
+
+        let inner = Arc::new(AlwaysCompletedPort::new());
+        let (dispatcher, _) = dispatcher_with_restricted_hook("allowing", Box::new(AllowingHook));
+        let wrapped = HookedLoopCapabilityPort::new(inner.clone(), dispatcher, tenant());
+
+        let batch = CapabilityBatchInvocation {
+            invocations: vec![
+                invocation("cap.alpha"),
+                invocation("cap.beta"),
+                invocation("cap.gamma"),
+            ],
+            stop_on_first_suspension: false,
+        };
+        let outcome = wrapped.invoke_capability_batch(batch).await.expect("ok");
+        assert_eq!(outcome.outcomes.len(), 3);
+        // The critical perf invariant: ONE batched call, not three sequential.
+        let batch_calls = inner.batch_calls();
+        assert_eq!(
+            batch_calls.len(),
+            1,
+            "inner port must see exactly one batched call when hooks allow all entries; \
+             saw {} batched calls (sequential degradation)",
+            batch_calls.len()
+        );
+        assert_eq!(
+            batch_calls[0].len(),
+            3,
+            "all three entries batched together"
+        );
+    }
+
+    /// Partial denial: a hook denies some entries; the surviving entries
+    /// must still be forwarded as a SINGLE batched call to the inner port,
+    /// and the merged outcomes must be in original index order.
+    #[tokio::test]
+    async fn batch_invocation_filters_denied_entries_and_preserves_index_mapping() {
+        /// Denies only the capability whose name matches `target`.
+        struct SelectiveDenyHook {
+            target: &'static str,
+        }
+        #[async_trait]
+        impl RestrictedBeforeCapabilityHook for SelectiveDenyHook {
+            async fn evaluate(
+                &self,
+                ctx: &BeforeCapabilityHookContext,
+                sink: &mut dyn RestrictedGateSink,
+            ) {
+                if ctx.capability_name == self.target {
+                    sink.deny("selective deny");
+                } else {
+                    sink.pass();
+                }
+            }
+        }
+
+        let inner = Arc::new(AlwaysCompletedPort::new());
+        let (dispatcher, _) = dispatcher_with_restricted_hook(
+            "selective",
+            Box::new(SelectiveDenyHook { target: "cap.beta" }),
+        );
+        let wrapped = HookedLoopCapabilityPort::new(inner.clone(), dispatcher, tenant());
+
+        let batch = CapabilityBatchInvocation {
+            invocations: vec![
+                invocation("cap.alpha"),
+                invocation("cap.beta"),
+                invocation("cap.gamma"),
+            ],
+            stop_on_first_suspension: false,
+        };
+        let outcome = wrapped.invoke_capability_batch(batch).await.expect("ok");
+        assert_eq!(outcome.outcomes.len(), 3);
+        // Index 0 and 2 forwarded to inner; index 1 short-circuited to Denied.
+        assert!(matches!(
+            outcome.outcomes[0],
+            CapabilityOutcome::Completed(_)
+        ));
+        assert!(matches!(outcome.outcomes[1], CapabilityOutcome::Denied(_)));
+        assert!(matches!(
+            outcome.outcomes[2],
+            CapabilityOutcome::Completed(_)
+        ));
+
+        let batch_calls = inner.batch_calls();
+        assert_eq!(
+            batch_calls.len(),
+            1,
+            "remaining entries must be forwarded in a single batched call"
+        );
+        assert_eq!(
+            batch_calls[0].len(),
+            2,
+            "only the two non-denied entries reach the inner port"
+        );
+        // Order must match the original (allowed) order: alpha then gamma.
+        assert_eq!(batch_calls[0][0].as_str(), "cap.alpha");
+        assert_eq!(batch_calls[0][1].as_str(), "cap.gamma");
+    }
+
+    /// Even though the inner port is called only ONCE, `AfterCapability`
+    /// observers must fire per-entry against the merged outcome vec — the
+    /// per-entry telemetry contract from PR #3573 (serrrfirat finding #3)
+    /// is independent of the inner-port call topology.
+    #[tokio::test]
+    async fn batch_invocation_dispatches_after_capability_observer_per_entry() {
+        use crate::points::ObserverHookContext;
+        use crate::sink::{ObserverHook, ObserverSink};
+
+        struct CountingObserver {
+            seen: Arc<Mutex<u32>>,
+        }
+        #[async_trait]
+        impl ObserverHook for CountingObserver {
+            async fn observe(&self, _ctx: &ObserverHookContext, _sink: &mut dyn ObserverSink) {
+                *self.seen.lock().expect("not poisoned") += 1;
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(0u32));
+        let observer_id = HookId::for_builtin("test::after_cap_per_entry", HookVersion::ONE);
+        let mut registry = HookRegistry::new();
+        registry
+            .insert(HookBinding {
+                hook_id: observer_id,
+                hook_version: HookVersion::ONE,
+                trust_class: HookTrustClass::Builtin,
+                phase: HookPhase::Telemetry,
+                priority: HookPriority::DEFAULT,
+                point: HookPointSpec::AfterCapability,
+                owning_extension: None,
+                scope: HookBindingScope::Global,
+                poisoned: false,
+            })
+            .expect("ok");
+        let mut dispatcher = HookDispatcher::new(registry);
+        dispatcher.install_observer_impl(
+            observer_id,
+            crate::dispatch::ObserverHookImpl::Any(Box::new(CountingObserver {
+                seen: seen.clone(),
+            })),
+        );
+
+        let inner = Arc::new(AlwaysCompletedPort::new());
+        let wrapped = HookedLoopCapabilityPort::new(inner.clone(), Arc::new(dispatcher), tenant());
+
+        let batch = CapabilityBatchInvocation {
+            invocations: vec![
+                invocation("cap.alpha"),
+                invocation("cap.beta"),
+                invocation("cap.gamma"),
+            ],
+            stop_on_first_suspension: false,
+        };
+        let outcome = wrapped.invoke_capability_batch(batch).await.expect("ok");
+        assert_eq!(outcome.outcomes.len(), 3);
+        assert_eq!(
+            inner.batch_calls().len(),
+            1,
+            "inner port called exactly once (batched)"
+        );
+        assert_eq!(
+            *seen.lock().expect("not poisoned"),
+            3,
+            "AfterCapability observer must fire per merged entry (3 entries) \
+             even though the inner port was batched into a single call"
+        );
     }
 
     // ── C3 regression: provider resolver populates hook context ────────────

--- a/crates/ironclaw_wasm/Cargo.toml
+++ b/crates/ironclaw_wasm/Cargo.toml
@@ -9,8 +9,8 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 serde_json = "1"
 thiserror = "2"
 tracing = "0.1"
-wasmtime = { version = "43.0.2", features = ["component-model"] }
-wasmtime-wasi = "43.0.2"
+wasmtime = { version = "44.0.2", features = ["component-model"] }
+wasmtime-wasi = "44.0.2"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_wasm_product_adapters/Cargo.toml
+++ b/crates/ironclaw_wasm_product_adapters/Cargo.toml
@@ -24,7 +24,7 @@ subtle = "2"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = "0.1"
-wasmtime = { version = "43.0.2", features = ["component-model"] }
+wasmtime = { version = "44.0.2", features = ["component-model"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/crates/ironclaw_wasm_sandbox_core/Cargo.toml
+++ b/crates/ironclaw_wasm_sandbox_core/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [dependencies]
 thiserror = "2"
 tracing = "0.1"
-wasmtime = { version = "43.0.2", features = ["component-model"] }
-wasmtime-wasi = "43.0.2"
+wasmtime = { version = "44.0.2", features = ["component-model"] }
+wasmtime-wasi = "44.0.2"


### PR DESCRIPTION
## Summary

Follow-up to #3573 addressing one deferred HIGH refactor: the hooked
capability-port middleware was downgrading `invoke_capability_batch` into
N sequential `invoke_capability` calls whenever any hook was installed.
Behavior was correct; the *performance* was not — installing a single
hook collapsed bulk-dispatch into per-entry round-trips on the inner
port for the rest of the run.

This PR restores true batched dispatch through the hook layer without
changing the inner `LoopCapabilityPort` API.

## Before / after

**Before (`invoke_capability_batch` on `HookedLoopCapabilityPort`):**

```text
for invocation in invocations {
    let provider = resolve_provider(invocation).await;
    let dispatch = run_dispatch(invocation, provider).await;
    let outcome = match decision_to_outcome(dispatch) {
        Some(translated) => translated,
        None => inner.invoke_capability(invocation).await?,  // ← per-entry
    };
    fire_after_capability_observer(provider).await;
    push(outcome);
}
```

N invocations → up to N `invoke_capability` calls on the inner port,
even when every hook allows the batch through.

**After (two-phase):**

```text
// Phase 1 — preflight in order, translate restrictive decisions
// inline, queue allowed entries.
for invocation in invocations {
    let dispatch = run_dispatch(invocation, provider).await;
    match decision_to_outcome(dispatch) {
        Some(translated) => slot::Resolved(translated, provider),
        None             => { slot::Pending(provider); pending.push(invocation) }
    }
    // honor stop_on_first_suspension on hook-issued suspensions
}

// Phase 2 — single batched call to the inner port
let inner = inner.invoke_capability_batch(CapabilityBatchInvocation {
    invocations: pending,
    stop_on_first_suspension,
}).await?;

// Merge: walk slots in order, splice inner outcomes into pending slots,
// dispatch AfterCapability observer per merged entry, honor suspension stop.
```

N invocations → at most ONE `invoke_capability_batch` call on the inner
port. AfterCapability observers continue to fire per-entry against the
merged outcome vec, preserving the per-entry telemetry contract from
#3573 (serrrfirat finding #3). When the inner batch errors, observers
fire for every preflight-resolved slot before the error propagates,
keeping failed batch entries visible to telemetry.

## Semantics preserved

- Hook denial / pause translation order: unchanged (per-entry, in
  original order).
- `stop_on_first_suspension` against hook-issued suspensions: unchanged.
- `stop_on_first_suspension` against inner-issued suspensions: inner
  port's own early-stop is honored; remaining pending slots drop out of
  the result the same way the previous sequential break-out did.
- AfterCapability observer per-entry firing: preserved against the
  merged-result vec, in original index order.
- Observer-on-inner-error contract from #3573: preserved (observers fire
  for resolved + pending slots before error propagation).

## API scope

The inner `LoopCapabilityPort` API is unchanged. No downstream crates
were touched — this is a middleware-local refactor inside
`ironclaw_hooks`. If a follow-up wants to thread `allowed_indexes` into
the inner-port contract directly, that's a larger surface change that
should be discussed separately.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features` (clean)
- [x] `cargo test -p ironclaw_hooks` (188 passed)
- [x] `cargo test -p ironclaw_reborn` (passes across all binaries)
- [x] New regression tests in `crates/ironclaw_hooks/src/middleware/capability_port.rs`:
  - `batch_invocation_remains_batched_when_no_hooks_deny` — asserts
    inner port sees ONE batched call when hooks allow everything.
  - `batch_invocation_filters_denied_entries_and_preserves_index_mapping`
    — asserts partial denial still produces ONE batched inner call with
    the allowed entries, and merged outcomes are in original index order.
  - `batch_invocation_dispatches_after_capability_observer_per_entry`
    — asserts observer fires N times even though inner port is called
    once.
- [x] Updated existing `batch_dispatches_after_capability_observers_on_inner_error`
  to surface the same `Unavailable` error from the inner *batch* path so
  the observer-on-error invariant continues to be covered.

Refs #3573.