### PR TITLE
feat(host_runtime): SecurityAuditSink primitive for boundary decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,6 +4325,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/ironclaw_events/Cargo.toml
+++ b/crates/ironclaw_events/Cargo.toml
@@ -11,6 +11,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/crates/ironclaw_events/src/lib.rs
+++ b/crates/ironclaw_events/src/lib.rs
@@ -37,6 +37,7 @@ mod error;
 mod in_memory;
 mod jsonl;
 mod runtime_event;
+mod security_audit;
 mod sink;
 
 pub use cursor::{EventCursor, EventLogEntry, EventReplay, EventStreamKey, ReadScope};
@@ -47,6 +48,10 @@ pub use in_memory::{
 pub use jsonl::{parse_jsonl, replay_jsonl};
 pub use runtime_event::{
     RuntimeEvent, RuntimeEventId, RuntimeEventKind, UNCLASSIFIED_ERROR_KIND, sanitize_error_kind,
+};
+pub use security_audit::{
+    InMemorySecurityAuditSink, NoopSecurityAuditSink, SecurityAuditEvent, SecurityAuditSink,
+    SecurityBoundary, SecurityDecision, TracingSecurityAuditSink,
 };
 pub use sink::{
     AuditSink, DurableAuditLog, DurableAuditSink, DurableEventLog, DurableEventSink, EventSink,

--- a/crates/ironclaw_events/src/security_audit.rs
+++ b/crates/ironclaw_events/src/security_audit.rs
@@ -242,14 +242,14 @@ impl InMemorySecurityAuditSink {
     pub fn snapshot(&self) -> Vec<SecurityAuditEvent> {
         self.events
             .lock()
-            .expect("InMemorySecurityAuditSink mutex poisoned")
+            .expect("InMemorySecurityAuditSink mutex poisoned") // safety: test-only sink; poisoning means a test thread already panicked
             .clone()
     }
 
     pub fn len(&self) -> usize {
         self.events
             .lock()
-            .expect("InMemorySecurityAuditSink mutex poisoned")
+            .expect("InMemorySecurityAuditSink mutex poisoned") // safety: test-only sink; poisoning means a test thread already panicked
             .len()
     }
 
@@ -262,7 +262,7 @@ impl SecurityAuditSink for InMemorySecurityAuditSink {
     fn record(&self, event: SecurityAuditEvent) {
         self.events
             .lock()
-            .expect("InMemorySecurityAuditSink mutex poisoned")
+            .expect("InMemorySecurityAuditSink mutex poisoned") // safety: test-only sink; poisoning means a test thread already panicked
             .push(event);
     }
 }

--- a/crates/ironclaw_events/src/security_audit.rs
+++ b/crates/ironclaw_events/src/security_audit.rs
@@ -1,0 +1,374 @@
+//! Security-boundary audit primitive.
+//!
+//! [`SecurityAuditSink`] is a payload-free recording trait for *security
+//! decisions* — the moments when a defense-in-depth boundary in IronClaw
+//! Reborn allows, blocks, or otherwise re-shapes a request. It is intentionally
+//! distinct from [`AuditSink`](crate::AuditSink) (which carries control-plane
+//! `AuditEnvelope` records with full correlation context) and from
+//! [`EventSink`](crate::EventSink) (which carries runtime event transitions).
+//!
+//! # Why a dedicated sink?
+//!
+//! Across recent PR review on hooks (#3573), no-exposure guard (#3767),
+//! product-auth continuations (#3888), and the credential boundary (#3903),
+//! the same pattern keeps recurring: security boundaries emit their decisions
+//! via `tracing::warn!` or `tracing::error!`. The repo `CLAUDE.md` explicitly
+//! forbids `warn!`/`info!` for non-user-facing diagnostics — those levels
+//! corrupt the REPL/TUI rendering. CLAUDE.md *also* says:
+//!
+//! > LLM data is never deleted. All LLM output … is the most valuable data in
+//! > the system. Never strip, truncate, or delete it from the database. Mark
+//! > with timestamps, make filterable, but always retain.
+//!
+//! Security-boundary decisions are exactly this class of data: they must be
+//! retained, filterable by boundary/decision/scope, and never be the only
+//! signal carried on a `warn!` line.
+//!
+//! # Payload-free invariant
+//!
+//! [`SecurityAuditEvent`] deliberately has **no free-form `String` payload
+//! field** — there is no `details`, `message`, `value`, or `reason: String`
+//! into which a careless caller could stuff the secret/header/path that the
+//! boundary just rejected. The event records only:
+//!
+//! - which boundary fired ([`SecurityBoundary`])
+//! - what the decision was ([`SecurityDecision`])
+//! - a `'static` reason **code** (grep target — see below)
+//! - optional capability id and resource scope (already redaction-safe types)
+//! - a timestamp
+//!
+//! This invariant is **load-bearing**. Do not add a `String` field. If you
+//! need a new dimension, extend [`SecurityBoundary`] or [`SecurityDecision`],
+//! or add a `&'static str` code constant.
+//!
+//! # The `code` convention
+//!
+//! `SecurityAuditEvent::code` is a short, stable, `&'static str`. It exists
+//! so that SRE/ops can grep durable logs for a specific decision class
+//! (`leak_redact_failed`, `no_exposure_block_header`, `hook_deny_predicate`,
+//! `auth_continuation_replay`, `mcp_direct_lease_deny`, ...). Treat it like a
+//! metric name: lowercase, snake_case, never user-derived, never PII, never a
+//! secret. New codes should be added as `pub const` items in the module that
+//! owns the boundary so they are visible to consumers.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use ironclaw_host_api::{CapabilityId, ResourceScope};
+
+/// Identifies *which* security boundary produced an audit event.
+///
+/// New variants should be added when a new defense-in-depth surface is
+/// introduced. Prefer extending this enum over reusing an existing variant
+/// for an unrelated boundary — downstream filters and dashboards key off it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SecurityBoundary {
+    /// Output-redaction / leak-detection guard around obligation completion.
+    LeakDetector,
+    /// Egress guard that blocks redacted host paths / sensitive headers from
+    /// leaving the runtime. (PR #3767 follow-up adoption target.)
+    NoExposureGuard,
+    /// Credential channel boundary that gates secret-material handoff to
+    /// runtime adapters. (PR #3903 follow-up adoption target.)
+    CredentialChannel,
+    /// Auth continuation dispatcher that re-enters a paused product-auth
+    /// workflow. (PR #3888 follow-up adoption target.)
+    AuthContinuation,
+    /// Hook predicate / envelope rejection. (PR #3573 follow-up adoption
+    /// target.)
+    HookDeny,
+    /// MCP direct-lease boundary that gates raw protocol access.
+    McpDirectLease,
+}
+
+impl SecurityBoundary {
+    /// Stable short token for logging / metrics. Does not depend on
+    /// `Debug` formatting.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LeakDetector => "leak_detector",
+            Self::NoExposureGuard => "no_exposure_guard",
+            Self::CredentialChannel => "credential_channel",
+            Self::AuthContinuation => "auth_continuation",
+            Self::HookDeny => "hook_deny",
+            Self::McpDirectLease => "mcp_direct_lease",
+        }
+    }
+}
+
+/// What the boundary decided.
+///
+/// New variants should describe *categories* of decision (blocked, allowed,
+/// scope-mismatched, replay-rejected), not specific reasons — the specific
+/// reason goes in [`SecurityAuditEvent::code`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SecurityDecision {
+    /// Boundary denied the operation.
+    Blocked,
+    /// Boundary allowed the operation (recorded for retention/forensics).
+    Allowed,
+    /// Boundary observed a scope mismatch (e.g. wrong tenant/project).
+    ScopeMismatch,
+    /// Boundary rejected a replay or stale nonce.
+    ReplayRejected,
+}
+
+impl SecurityDecision {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::Allowed => "allowed",
+            Self::ScopeMismatch => "scope_mismatch",
+            Self::ReplayRejected => "replay_rejected",
+        }
+    }
+}
+
+/// A single security-boundary decision.
+///
+/// **Payload-free by construction.** See module-level docs for the invariant.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct SecurityAuditEvent {
+    pub boundary: SecurityBoundary,
+    pub decision: SecurityDecision,
+    pub capability_id: Option<CapabilityId>,
+    pub scope: Option<ResourceScope>,
+    pub timestamp: SystemTime,
+    /// Stable, lowercase, snake_case reason code. Grep target for SRE.
+    ///
+    /// MUST NOT be derived from user input or contain secret material.
+    /// See the module-level docs for the `code` convention.
+    pub code: &'static str,
+}
+
+impl SecurityAuditEvent {
+    /// Construct a new event with `timestamp = SystemTime::now()`.
+    ///
+    /// Callers must supply `code` as a `&'static str` literal or `pub const`.
+    /// This is the only way to construct the event, which (together with the
+    /// type system) enforces the no-free-form-payload invariant.
+    pub fn new(boundary: SecurityBoundary, decision: SecurityDecision, code: &'static str) -> Self {
+        Self {
+            boundary,
+            decision,
+            capability_id: None,
+            scope: None,
+            timestamp: SystemTime::now(),
+            code,
+        }
+    }
+
+    pub fn with_capability_id(mut self, capability_id: CapabilityId) -> Self {
+        self.capability_id = Some(capability_id);
+        self
+    }
+
+    pub fn with_scope(mut self, scope: ResourceScope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+}
+
+/// Recording surface for [`SecurityAuditEvent`].
+///
+/// **Best-effort observability.** Implementations must not panic. A sink
+/// failure must not change the outcome of the surrounding security decision;
+/// the boundary has already decided (block/allow) by the time it records.
+///
+/// `record` is **sync** by design — unlike [`AuditSink`](crate::AuditSink),
+/// security boundaries frequently fire from sync paths (predicate gates,
+/// header filters, output redaction) and we do not want adoption to require
+/// `.await` plumbing. Durable adapters can buffer / forward to async logs.
+pub trait SecurityAuditSink: Send + Sync + std::fmt::Debug {
+    fn record(&self, event: SecurityAuditEvent);
+}
+
+impl<T> SecurityAuditSink for Arc<T>
+where
+    T: SecurityAuditSink + ?Sized,
+{
+    fn record(&self, event: SecurityAuditEvent) {
+        (**self).record(event);
+    }
+}
+
+/// Drops every event. Suitable for tests and contexts that do not yet need
+/// durable security-audit recording.
+#[derive(Clone, Debug, Default)]
+pub struct NoopSecurityAuditSink;
+
+impl SecurityAuditSink for NoopSecurityAuditSink {
+    fn record(&self, _event: SecurityAuditEvent) {}
+}
+
+/// Emits each event at `tracing::debug!`.
+///
+/// `debug!` is chosen deliberately: per the repo `CLAUDE.md` REPL/TUI rule,
+/// `info!`/`warn!` corrupt the interactive display. Security-boundary
+/// decisions are not user-facing status — they are diagnostics + retention
+/// data, so they go to `debug!`. A real deployment will additionally wire a
+/// durable sink behind this (or alongside it via a multi-adapter).
+#[derive(Clone, Debug, Default)]
+pub struct TracingSecurityAuditSink;
+
+impl SecurityAuditSink for TracingSecurityAuditSink {
+    fn record(&self, event: SecurityAuditEvent) {
+        tracing::debug!(
+            target: "ironclaw::security_audit",
+            boundary = event.boundary.as_str(),
+            decision = event.decision.as_str(),
+            code = event.code,
+            capability_id = event.capability_id.as_ref().map(|c| c.as_str()),
+            "security boundary decision"
+        );
+    }
+}
+
+/// Test-only recording sink that captures every event. Not intended for
+/// production: unbounded growth, no eviction.
+#[derive(Debug, Default)]
+pub struct InMemorySecurityAuditSink {
+    events: std::sync::Mutex<Vec<SecurityAuditEvent>>,
+}
+
+impl InMemorySecurityAuditSink {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn snapshot(&self) -> Vec<SecurityAuditEvent> {
+        self.events
+            .lock()
+            .expect("InMemorySecurityAuditSink mutex poisoned")
+            .clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.events
+            .lock()
+            .expect("InMemorySecurityAuditSink mutex poisoned")
+            .len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl SecurityAuditSink for InMemorySecurityAuditSink {
+    fn record(&self, event: SecurityAuditEvent) {
+        self.events
+            .lock()
+            .expect("InMemorySecurityAuditSink mutex poisoned")
+            .push(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boundary_decision_codes_are_stable_tokens() {
+        // These string forms are part of the public surface (used in logs,
+        // dashboards, durable records). Locking them down here prevents an
+        // accidental rename from silently breaking SRE pattern-matching.
+        assert_eq!(SecurityBoundary::LeakDetector.as_str(), "leak_detector");
+        assert_eq!(
+            SecurityBoundary::NoExposureGuard.as_str(),
+            "no_exposure_guard"
+        );
+        assert_eq!(
+            SecurityBoundary::CredentialChannel.as_str(),
+            "credential_channel"
+        );
+        assert_eq!(
+            SecurityBoundary::AuthContinuation.as_str(),
+            "auth_continuation"
+        );
+        assert_eq!(SecurityBoundary::HookDeny.as_str(), "hook_deny");
+        assert_eq!(
+            SecurityBoundary::McpDirectLease.as_str(),
+            "mcp_direct_lease"
+        );
+
+        assert_eq!(SecurityDecision::Blocked.as_str(), "blocked");
+        assert_eq!(SecurityDecision::Allowed.as_str(), "allowed");
+        assert_eq!(SecurityDecision::ScopeMismatch.as_str(), "scope_mismatch");
+        assert_eq!(SecurityDecision::ReplayRejected.as_str(), "replay_rejected");
+    }
+
+    #[test]
+    fn noop_sink_drops_events() {
+        let sink = NoopSecurityAuditSink;
+        sink.record(SecurityAuditEvent::new(
+            SecurityBoundary::LeakDetector,
+            SecurityDecision::Blocked,
+            "test_code",
+        ));
+    }
+
+    #[test]
+    fn in_memory_sink_captures_events_in_order() {
+        let sink = InMemorySecurityAuditSink::new();
+        assert!(sink.is_empty());
+
+        sink.record(SecurityAuditEvent::new(
+            SecurityBoundary::LeakDetector,
+            SecurityDecision::Blocked,
+            "first",
+        ));
+        sink.record(SecurityAuditEvent::new(
+            SecurityBoundary::NoExposureGuard,
+            SecurityDecision::Allowed,
+            "second",
+        ));
+
+        let snapshot = sink.snapshot();
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(snapshot[0].code, "first");
+        assert_eq!(snapshot[0].boundary, SecurityBoundary::LeakDetector);
+        assert_eq!(snapshot[0].decision, SecurityDecision::Blocked);
+        assert_eq!(snapshot[1].code, "second");
+        assert_eq!(snapshot[1].boundary, SecurityBoundary::NoExposureGuard);
+        assert_eq!(snapshot[1].decision, SecurityDecision::Allowed);
+    }
+
+    #[test]
+    fn event_can_be_enriched_with_scope_and_capability() {
+        use ironclaw_host_api::{InvocationId, UserId};
+
+        let scope = ResourceScope::local_default(
+            UserId::new("alice").expect("valid user id"),
+            InvocationId::new(),
+        )
+        .expect("valid scope");
+        let cap = CapabilityId::new("ironclaw.echo".to_string()).expect("valid capability id");
+
+        let event = SecurityAuditEvent::new(
+            SecurityBoundary::LeakDetector,
+            SecurityDecision::Blocked,
+            "leak_redact_failed",
+        )
+        .with_capability_id(cap.clone())
+        .with_scope(scope.clone());
+
+        assert_eq!(event.capability_id.as_ref(), Some(&cap));
+        assert_eq!(event.scope.as_ref(), Some(&scope));
+    }
+
+    #[test]
+    fn arc_passthrough_records_on_inner() {
+        let sink: Arc<InMemorySecurityAuditSink> = Arc::new(InMemorySecurityAuditSink::new());
+        let handle: Arc<dyn SecurityAuditSink> = sink.clone();
+        handle.record(SecurityAuditEvent::new(
+            SecurityBoundary::HookDeny,
+            SecurityDecision::Blocked,
+            "passthrough",
+        ));
+        assert_eq!(sink.len(), 1);
+    }
+}

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -84,7 +84,8 @@ pub use invocation_services::{
     InvocationServicesResolver, LocalInvocationServicesResolver,
 };
 pub use obligations::{
-    BuiltinObligationHandler, BuiltinObligationServices, ProcessObligationLifecycleStore,
+    BuiltinObligationHandler, BuiltinObligationServices, LEAK_REDACT_FAILED_CODE,
+    ProcessObligationLifecycleStore,
 };
 use obligations::{NetworkObligationPolicyStore, RuntimeSecretInjectionStore};
 pub use planner::{ExecutionPlan, PlannerError, plan_capability};

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -1736,7 +1736,7 @@ fn dispatch_output_bytes(output: &serde_json::Value) -> Result<u64, CapabilityOb
 /// Security-audit reason code emitted when [`redact_output`] rejects output
 /// because the leak detector matched. Stable grep target for SRE pattern
 /// matching across durable security-audit logs.
-pub(crate) const LEAK_REDACT_FAILED_CODE: &str = "leak_redact_failed";
+pub const LEAK_REDACT_FAILED_CODE: &str = "leak_redact_failed";
 
 fn redact_output(
     output: serde_json::Value,

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -12,7 +12,10 @@ use ironclaw_capabilities::{
     CapabilityObligationError, CapabilityObligationFailureKind, CapabilityObligationHandler,
     CapabilityObligationOutcome, CapabilityObligationPhase, CapabilityObligationRequest,
 };
-use ironclaw_events::{AuditSink, EventSink, RuntimeEvent};
+use ironclaw_events::{
+    AuditSink, EventSink, RuntimeEvent, SecurityAuditEvent, SecurityAuditSink, SecurityBoundary,
+    SecurityDecision,
+};
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AuditEnvelope, AuditEventId, AuditStage,
     CapabilityDispatchResult, CapabilityId, DecisionSummary, EffectKind, MountView, NetworkPolicy,
@@ -961,6 +964,7 @@ fn close_reservation_once<T>(result: Result<T, ResourceError>) -> Result<(), Pro
 #[derive(Clone, Default)]
 pub struct BuiltinObligationHandler {
     audit_sink: Option<Arc<dyn AuditSink>>,
+    security_audit_sink: Option<Arc<dyn SecurityAuditSink>>,
     network_policies: Option<Arc<NetworkObligationPolicyStore>>,
     secret_store: Option<Arc<dyn SecretStore>>,
     secret_injections: Option<Arc<RuntimeSecretInjectionStore>>,
@@ -983,6 +987,17 @@ impl BuiltinObligationHandler {
 
     pub fn with_audit_sink_dyn(mut self, sink: Arc<dyn AuditSink>) -> Self {
         self.audit_sink = Some(sink);
+        self
+    }
+
+    /// Wire in a [`SecurityAuditSink`] for boundary-decision recording.
+    ///
+    /// Currently consumed by the output-redaction (leak-detector) path in
+    /// [`Self::complete_dispatch`]. Additional boundaries inside this handler
+    /// will adopt the same sink in follow-up PRs; the wiring is intentionally
+    /// optional so unconfigured callers keep working unchanged.
+    pub fn with_security_audit_sink(mut self, sink: Arc<dyn SecurityAuditSink>) -> Self {
+        self.security_audit_sink = Some(sink);
         self
     }
 
@@ -1326,7 +1341,27 @@ impl CapabilityObligationHandler for BuiltinObligationHandler {
             .iter()
             .any(|obligation| matches!(obligation, Obligation::RedactOutput))
         {
-            dispatch.output = redact_output(dispatch.output)?;
+            dispatch.output = match redact_output(dispatch.output) {
+                Ok(value) => value,
+                Err(error) => {
+                    // Leak-detector blocked: record the boundary decision
+                    // before propagating. The event is payload-free by
+                    // construction — only the boundary, decision, and a
+                    // stable code reach the sink. The original output never
+                    // leaves the type system.
+                    if let Some(sink) = &self.security_audit_sink {
+                        let event = SecurityAuditEvent::new(
+                            SecurityBoundary::LeakDetector,
+                            SecurityDecision::Blocked,
+                            LEAK_REDACT_FAILED_CODE,
+                        )
+                        .with_capability_id(request.capability_id.clone())
+                        .with_scope(request.context.resource_scope.clone());
+                        sink.record(event);
+                    }
+                    return Err(error);
+                }
+            };
         }
 
         let output_bytes = dispatch_output_bytes(&dispatch.output)?;
@@ -1698,6 +1733,11 @@ fn dispatch_output_bytes(output: &serde_json::Value) -> Result<u64, CapabilityOb
         .map_err(|_| output_obligation_failed())
 }
 
+/// Security-audit reason code emitted when [`redact_output`] rejects output
+/// because the leak detector matched. Stable grep target for SRE pattern
+/// matching across durable security-audit logs.
+pub(crate) const LEAK_REDACT_FAILED_CODE: &str = "leak_redact_failed";
+
 fn redact_output(
     output: serde_json::Value,
 ) -> Result<serde_json::Value, CapabilityObligationError> {
@@ -2013,6 +2053,167 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn leak_detector_block_records_security_audit_event_through_complete_dispatch() {
+        use ironclaw_events::{
+            InMemorySecurityAuditSink, SecurityAuditSink, SecurityBoundary, SecurityDecision,
+        };
+        use ironclaw_host_api::{ReservationStatus, ResourceReceipt, ResourceUsage, RuntimeKind};
+
+        // Build a handler with both an audit sink (unused here — we hit the
+        // redact branch, not the AuditAfter branch) and a recording
+        // security-audit sink. Other backing stores are not exercised by
+        // the redact-only path, but the handler requires them to be set
+        // for safety; we install minimal in-memory ones.
+        let security_sink: Arc<InMemorySecurityAuditSink> =
+            Arc::new(InMemorySecurityAuditSink::new());
+        let security_sink_dyn: Arc<dyn SecurityAuditSink> = security_sink.clone();
+
+        let services = BuiltinObligationServices::with_handoff_stores(
+            Arc::new(InMemoryAuditSink::new()),
+            Arc::new(NetworkObligationPolicyStore::new()),
+            Arc::new(InMemorySecretStore::new()),
+            Arc::new(RuntimeSecretInjectionStore::new()),
+            Arc::new(InMemoryResourceGovernor::new()),
+        );
+        let handler = services
+            .obligation_handler()
+            .with_security_audit_sink(security_sink_dyn);
+
+        let context = execution_context();
+        let capability_id = capability_id();
+        let estimate = ResourceEstimate::default();
+        let obligations = vec![Obligation::RedactOutput];
+
+        // An AWS access-key shaped string is a built-in BLOCK pattern in
+        // `ironclaw_safety::LeakDetector` (`AKIA[0-9A-Z]{16}`). Per the
+        // module invariant we drive the *caller* (`complete_dispatch`),
+        // not the helper, and assert the recorded event:
+        //   - boundary  == LeakDetector
+        //   - decision  == Blocked
+        //   - code      == LEAK_REDACT_FAILED_CODE
+        //   - capability_id + scope are populated
+        //   - no payload (the offending string never appears in the event)
+        let leaky_payload =
+            serde_json::Value::String("hello AKIAABCDEFGHIJKLMNOP goodbye".to_string());
+        let dispatch = CapabilityDispatchResult {
+            capability_id: capability_id.clone(),
+            provider: context.extension_id.clone(),
+            runtime: RuntimeKind::Wasm,
+            output: leaky_payload,
+            usage: ResourceUsage::default(),
+            receipt: ResourceReceipt {
+                id: ResourceReservationId::new(),
+                scope: context.resource_scope.clone(),
+                status: ReservationStatus::Released,
+                estimate: ResourceEstimate::default(),
+                actual: None,
+            },
+        };
+
+        let request = CapabilityObligationCompletionRequest {
+            phase: CapabilityObligationPhase::Invoke,
+            context: &context,
+            capability_id: &capability_id,
+            estimate: &estimate,
+            obligations: &obligations,
+            dispatch: &dispatch,
+        };
+
+        let result = handler.complete_dispatch(request).await;
+        assert!(
+            matches!(
+                result,
+                Err(CapabilityObligationError::Failed {
+                    kind: CapabilityObligationFailureKind::Output
+                })
+            ),
+            "expected output-obligation failure, got {result:?}"
+        );
+
+        let events = security_sink.snapshot();
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one boundary decision should have been recorded, got {events:?}"
+        );
+        let event = &events[0];
+        assert_eq!(event.boundary, SecurityBoundary::LeakDetector);
+        assert_eq!(event.decision, SecurityDecision::Blocked);
+        assert_eq!(event.code, LEAK_REDACT_FAILED_CODE);
+        assert_eq!(event.code, "leak_redact_failed"); // stability lock
+        assert_eq!(event.capability_id.as_ref(), Some(&capability_id));
+        assert_eq!(event.scope.as_ref(), Some(&context.resource_scope));
+
+        // The `SecurityAuditEvent` shape has no free-form payload field.
+        // That invariant is enforced at the type level by the absence of
+        // a `String` member on the struct. The check below is therefore a
+        // documentation-only assertion: it locks the field set at the
+        // value level for future readers, but the real guard is the type
+        // shape in `ironclaw_events::security_audit`.
+        //
+        //   pub struct SecurityAuditEvent {
+        //       pub boundary: SecurityBoundary,
+        //       pub decision: SecurityDecision,
+        //       pub capability_id: Option<CapabilityId>,
+        //       pub scope: Option<ResourceScope>,
+        //       pub timestamp: SystemTime,
+        //       pub code: &'static str,
+        //   }
+    }
+
+    #[tokio::test]
+    async fn leak_detector_block_without_security_sink_does_not_panic() {
+        use ironclaw_host_api::{ReservationStatus, ResourceReceipt, ResourceUsage, RuntimeKind};
+
+        let services = BuiltinObligationServices::with_handoff_stores(
+            Arc::new(InMemoryAuditSink::new()),
+            Arc::new(NetworkObligationPolicyStore::new()),
+            Arc::new(InMemorySecretStore::new()),
+            Arc::new(RuntimeSecretInjectionStore::new()),
+            Arc::new(InMemoryResourceGovernor::new()),
+        );
+        // No `.with_security_audit_sink(...)` — confirms the sink is
+        // optional and the original failure semantics are preserved.
+        let handler = services.obligation_handler();
+
+        let context = execution_context();
+        let capability_id = capability_id();
+        let estimate = ResourceEstimate::default();
+        let obligations = vec![Obligation::RedactOutput];
+        let dispatch = CapabilityDispatchResult {
+            capability_id: capability_id.clone(),
+            provider: context.extension_id.clone(),
+            runtime: RuntimeKind::Wasm,
+            output: serde_json::Value::String("leak AKIAABCDEFGHIJKLMNOP".to_string()),
+            usage: ResourceUsage::default(),
+            receipt: ResourceReceipt {
+                id: ResourceReservationId::new(),
+                scope: context.resource_scope.clone(),
+                status: ReservationStatus::Released,
+                estimate: ResourceEstimate::default(),
+                actual: None,
+            },
+        };
+
+        let result = handler
+            .complete_dispatch(CapabilityObligationCompletionRequest {
+                phase: CapabilityObligationPhase::Invoke,
+                context: &context,
+                capability_id: &capability_id,
+                estimate: &estimate,
+                obligations: &obligations,
+                dispatch: &dispatch,
+            })
+            .await;
+        assert!(matches!(
+            result,
+            Err(CapabilityObligationError::Failed {
+                kind: CapabilityObligationFailureKind::Output
+            })
+        ));
     }
 
     fn same_invocation_agent_scopes() -> (ResourceScope, ResourceScope) {


### PR DESCRIPTION
## Summary

Introduces a payload-free recording trait — `SecurityAuditSink` — for security-boundary decisions across IronClaw Reborn defense-in-depth surfaces, and adopts it at the leak-detector / output-redaction boundary inside `BuiltinObligationHandler::complete_dispatch` as a worked example. Other security boundaries will adopt the same sink in follow-up PRs (one per boundary).

## Why

Across recent PR review the same pattern kept recurring:

- **#3573** (hooks) — hook predicate / envelope denials emitted at `tracing::warn!`.
- **#3767** (NoExposureGuard) — blocked egress emitted at `tracing::warn!`.
- **#3888** (auth continuation) — `auth.rs:307` emits `warn!` on bridge rejections.
- **#3903** (credential boundary) — blocked credential handoff emits `warn!`.

Per the repo `CLAUDE.md` REPL/TUI rule:

> Logging levels matter for REPL/TUI: \`info!\` and \`warn!\` output appears in the REPL and corrupts the terminal UI. Use \`debug!\` for internal diagnostics. Background tasks must NEVER use \`info!\`.

`warn!` is the wrong substrate for these decisions. CLAUDE.md also says:

> LLM data is never deleted. All LLM output … is the most valuable data in the system. Never strip, truncate, or delete it from the database. Mark with timestamps, make filterable, but always retain.

Security-boundary decisions are exactly that class of data: they must be retained, filterable by boundary/decision/scope, and never the only signal carried on a `warn!` line. This PR introduces the substrate.

## Shape

```rust
pub enum SecurityBoundary {       // load-bearing — downstream filters key off this
    LeakDetector,
    NoExposureGuard,
    CredentialChannel,
    AuthContinuation,
    HookDeny,
    McpDirectLease,
}

pub enum SecurityDecision {
    Blocked, Allowed, ScopeMismatch, ReplayRejected,
}

pub struct SecurityAuditEvent {
    pub boundary: SecurityBoundary,
    pub decision: SecurityDecision,
    pub capability_id: Option<CapabilityId>,
    pub scope: Option<ResourceScope>,
    pub timestamp: SystemTime,
    pub code: &'static str,        // SRE grep target, never user-derived
}

pub trait SecurityAuditSink: Send + Sync + Debug {
    fn record(&self, event: SecurityAuditEvent);  // sync, best-effort
}
```

**Payload-free invariant (load-bearing).** `SecurityAuditEvent` has **no `String` "details"/"reason"/"message" field** that a careless caller could stuff a secret/header/path into. The shape carries only the boundary, decision, optional already-redaction-safe id types, a timestamp, and a `'static` reason code. The invariant is enforced at the type level — there is no constructor path that lets caller-derived bytes reach the event.

**`code: &'static str` is intentional** — it's the SRE grep target. Lowercase, snake_case, never user-derived, never PII, never a secret. New codes are added as `pub const` items in the module that owns the boundary (e.g. `LEAK_REDACT_FAILED_CODE` introduced in this PR).

**Sync trait, best-effort delivery.** Security boundaries frequently fire from sync paths (predicate gates, header filters, output redaction); we don't want adoption to require `.await` plumbing. Sink failure must not change the surrounding decision — the boundary has already decided by the time it records. Durable adapters can buffer / forward to async logs.

**Three implementations in this PR:**
- `NoopSecurityAuditSink` — drops everything; suitable for tests and not-yet-wired call sites.
- `TracingSecurityAuditSink` — emits at `tracing::debug!` (chosen deliberately to respect the CLAUDE.md REPL rule). A real deployment will additionally wire a durable sink alongside it.
- `InMemorySecurityAuditSink` — test-only recording sink.

## Worked example: leak-detector boundary

`BuiltinObligationHandler` gains an optional security audit sink via `with_security_audit_sink`. When `complete_dispatch` evaluates `Obligation::RedactOutput` and `redact_output` returns `Err` because the leak detector matched a BLOCK-class pattern (e.g. an AWS access key shaped string), the handler records:

```
SecurityAuditEvent {
    boundary: SecurityBoundary::LeakDetector,
    decision: SecurityDecision::Blocked,
    capability_id: Some(<capability id>),
    scope: Some(<resource scope>),
    timestamp: <now>,
    code: "leak_redact_failed",
}
```

before propagating the original `CapabilityObligationError::Failed { kind: Output }`. The leaky string never reaches the sink — only the metadata-shaped event does.

## Test plan

Per `.claude/rules/testing.md` ("Test Through the Caller, Not Just the Helper"), the regression coverage drives `BuiltinObligationHandler::complete_dispatch` end-to-end with a recording `SecurityAuditSink`, not `redact_output` directly:

- [x] `cargo test -p ironclaw_events` — 31 passed, 0 failed. (5 new tests under `security_audit::tests`.)
- [x] `cargo test -p ironclaw_host_runtime --lib` — 73 passed, 0 failed. (2 new tests under `obligations::tests`: `leak_detector_block_records_security_audit_event_through_complete_dispatch`, `leak_detector_block_without_security_sink_does_not_panic`.)
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p ironclaw_events -p ironclaw_host_runtime --tests --all-features` clean (zero warnings).
- [ ] 2 pre-existing failures in `crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs` (`first_party_handler_maps_egress_error_codes_to_dispatch_errors`, `first_party_handler_rejects_non_string_url_input`) are present on the base branch unchanged by this PR and are unrelated to the obligations module.

## Non-goals / follow-ups (each its own PR)

Migrating remaining `warn!`-shaped security boundaries to the sink is intentionally out of scope:

- [ ] `RebornProductWorkflowAuthContinuationDispatcher` `warn!` at `auth.rs:307` — `boundary = AuthContinuation`.
- [ ] MCP direct-lease deny path / `request_denied` — `boundary = McpDirectLease`.
- [ ] Hook predicate / envelope deny paths (#3573) — `boundary = HookDeny`.
- [ ] Credential-channel boundary blocks (#3903) — `boundary = CredentialChannel`.
- [ ] `NoExposureGuard` egress blocks once #3767 lands — `boundary = NoExposureGuard`.

Each adoption is mechanical: add a `with_security_audit_sink(...)` wiring point, record a `SecurityAuditEvent` with the right boundary/decision/code before propagating the block, and add one caller-level test that asserts the event shape (boundary, decision, code, capability/scope populated, no payload).

## Files

- `crates/ironclaw_events/src/security_audit.rs` (new) — trait, enums, three sinks, 5 unit tests.
- `crates/ironclaw_events/src/lib.rs` — re-exports.
- `crates/ironclaw_events/Cargo.toml` — adds `tracing = "0.1"` (workspace-pinned version).
- `crates/ironclaw_host_runtime/src/obligations.rs` — wires `Option<Arc<dyn SecurityAuditSink>>` into `BuiltinObligationHandler`, adopts at the `redact_output` block path, adds 2 caller-level tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)