### PR TITLE
hooks: address henrypark approval-with-followup items from #3911/#3912/#3913

### DIFF
--- a/crates/ironclaw_hooks/src/identity.rs
+++ b/crates/ironclaw_hooks/src/identity.rs
@@ -212,8 +212,29 @@ impl ExtensionId {
         &self.0
     }
 
-    pub fn into_string(self) -> String {
+    /// Canonical newtype-template accessor for taking the inner string by
+    /// value. Prefer this over [`Self::into_string`] in new code.
+    pub fn into_inner(self) -> String {
         self.0
+    }
+
+    /// Legacy alias retained for callers that predate the canonical
+    /// `into_inner` convention from `.claude/rules/types.md`. New code
+    /// should use [`Self::into_inner`].
+    pub fn into_string(self) -> String {
+        self.into_inner()
+    }
+}
+
+impl AsRef<str> for ExtensionId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<ExtensionId> for String {
+    fn from(id: ExtensionId) -> Self {
+        id.0
     }
 }
 
@@ -271,8 +292,29 @@ impl HookLocalId {
         &self.0
     }
 
-    pub fn into_string(self) -> String {
+    /// Canonical newtype-template accessor for taking the inner string by
+    /// value. Prefer this over [`Self::into_string`] in new code.
+    pub fn into_inner(self) -> String {
         self.0
+    }
+
+    /// Legacy alias retained for callers that predate the canonical
+    /// `into_inner` convention from `.claude/rules/types.md`. New code
+    /// should use [`Self::into_inner`].
+    pub fn into_string(self) -> String {
+        self.into_inner()
+    }
+}
+
+impl AsRef<str> for HookLocalId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<HookLocalId> for String {
+    fn from(id: HookLocalId) -> Self {
+        id.0
     }
 }
 
@@ -356,7 +398,16 @@ mod tests {
     #[test]
     fn builtin_id_distinct_from_extension_id() {
         // Use a `.`-separated local id, which is permitted by the segment
-        // grammar (mirroring host-api's `validate_name_segment`).
+        // grammar (mirroring host-api's `validate_name_segment`). The
+        // original fixture used `"path::module"` for the installed local id,
+        // but the post-#3912 segment grammar disallows `:` characters
+        // anywhere in a `HookLocalId`, so we substitute the equivalent
+        // legal value `"path.module"`. The assertion's intent — that the
+        // builtin and installed digests are distinct for any pair of
+        // syntactically legal ids — is unchanged; `HookId::for_builtin`
+        // accepts a free-form canonical path (not a `HookLocalId`) so the
+        // builtin side can still carry the original `"path::module"`
+        // shape.
         let installed = HookId::derive(
             &ext("builtin"),
             "x",

--- a/crates/ironclaw_hooks/src/manifest.rs
+++ b/crates/ironclaw_hooks/src/manifest.rs
@@ -220,9 +220,12 @@ impl HookManifestEntry {
     /// (trust class assignment, scope grant matching, hook-id pinning all
     /// happen later in the installer).
     pub fn validate(&self) -> Result<(), HookManifestValidationError> {
-        if self.id.as_str().is_empty() {
-            return Err(HookManifestValidationError("hook id is empty".to_string()));
-        }
+        // Note: the previous empty-id guard here is unreachable now that
+        // `HookLocalId::new` rejects empty strings at construction time
+        // (see `crates/ironclaw_hooks/src/identity.rs`), so manifest
+        // deserialization fails before this method is ever called. Removed
+        // per henrypark133 review of PR #3912 (finding L1).
+        //
         // Phase × Trust: a manifest hook is always Installed, so it cannot
         // register at Validation or Authorization.
         if matches!(self.phase, HookPhase::Validation | HookPhase::Authorization) {

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -192,13 +192,19 @@ impl HookedLoopCapabilityPort {
         };
         // Defense-in-depth: even when the resolver's `size_hint`
         // returned `None`, refuse to expose payloads larger than the cap
-        // to predicate evaluation. `serde_json::to_vec` is the cheapest
-        // stable way to measure the materialized byte cost.
-        match serde_json::to_vec(&value) {
-            Ok(bytes) if (bytes.len() as u64) > MAX_PREDICATE_INPUT_BYTES => {
+        // to predicate evaluation. We measure the serialized byte cost
+        // by streaming into a counting writer rather than calling
+        // `serde_json::to_vec` and discarding the buffer — avoids one
+        // `Vec<u8>` allocation per resolved invocation on the happy
+        // path (henrypark133 review L1 on PR #3913). `SanitizedArguments::from_json`
+        // sanitizes the in-memory `serde_json::Value` directly; it does
+        // not re-serialize, so handing it the unmodified `value` is the
+        // cheapest path.
+        match serialized_len(&value) {
+            Ok(bytes) if bytes > MAX_PREDICATE_INPUT_BYTES => {
                 tracing::debug!(
                     capability = %invocation.capability_id,
-                    size_bytes = bytes.len(),
+                    size_bytes = bytes,
                     cap_bytes = MAX_PREDICATE_INPUT_BYTES,
                     "materialized capability input exceeds MAX_PREDICATE_INPUT_BYTES; failing closed"
                 );
@@ -522,6 +528,28 @@ fn fail_closed_gate_ref_unavailable(sanitized_reason: &str) -> CapabilityOutcome
             .expect("hook_gate_ref_unavailable is a valid loop-safe identifier"), // safety: literal ASCII identifier, validated by LoopGateRef constructor contract
         safe_summary: sanitized_reason.to_string(),
     })
+}
+
+/// Counts the JSON-serialized byte length of `value` without allocating
+/// an intermediate `Vec<u8>`. `serde_json::to_writer` writes into a
+/// trivial `std::io::Write` impl that only increments a counter, so the
+/// happy-path measurement skips one buffer allocation and one
+/// `Vec<u8>::drop` per resolved invocation (henrypark133 review L1 on
+/// PR #3913).
+fn serialized_len(value: &serde_json::Value) -> Result<u64, serde_json::Error> {
+    struct CountingWriter(u64);
+    impl std::io::Write for CountingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0 = self.0.saturating_add(buf.len() as u64);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut writer = CountingWriter(0);
+    serde_json::to_writer(&mut writer, value)?;
+    Ok(writer.0)
 }
 
 /// Stable digest of capability arguments for hook context. The middleware

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -427,18 +427,13 @@ impl LoopCapabilityPort for HookedLoopCapabilityPort {
                         // to surface; drop it.
                         None
                     } else {
-                        match inner_outcomes.pop() {
-                            Some(inner) => Some((inner, provider)),
-                            None => {
-                                // Inner port stopped early (its own
-                                // suspension) and consumed fewer
-                                // outcomes than we queued. Drop
-                                // remaining Pending slots and continue
-                                // — observers on any trailing Resolved
-                                // slots must still fire.
-                                None
-                            }
-                        }
+                        // `pop()` returns `None` when the inner port
+                        // stopped early (its own suspension) and
+                        // consumed fewer outcomes than we queued. Drop
+                        // pending slots without an outcome and continue
+                        // — observers on any trailing Resolved slots
+                        // must still fire.
+                        inner_outcomes.pop().map(|inner| (inner, provider))
                     }
                 }
             };
@@ -1679,6 +1674,131 @@ mod tests {
         );
     }
 
+    /// henrypark133 L2 on PR #3913: when several BeforeCapability hooks
+    /// share a scope+provider, `before_capability_needs_input` must
+    /// return `true` as soon as ANY active binding's hook reports
+    /// `needs_input() = true`. The short-circuit doesn't depend on which
+    /// hook the trait's default lives on, so a mixed pair (one false,
+    /// one true) must still cause `resolve_arguments` to be called by
+    /// the middleware. Drive the whole path via `invoke_capability` and
+    /// an instrumented resolver to confirm the call actually happens.
+    #[tokio::test]
+    async fn before_capability_needs_input_returns_true_when_any_active_binding_needs_input() {
+        struct NoInputHook;
+        #[async_trait]
+        impl RestrictedBeforeCapabilityHook for NoInputHook {
+            async fn evaluate(
+                &self,
+                _ctx: &BeforeCapabilityHookContext,
+                sink: &mut dyn RestrictedGateSink,
+            ) {
+                sink.pass();
+            }
+            fn needs_input(&self) -> bool {
+                false
+            }
+        }
+
+        struct NeedsInputHook;
+        #[async_trait]
+        impl RestrictedBeforeCapabilityHook for NeedsInputHook {
+            async fn evaluate(
+                &self,
+                _ctx: &BeforeCapabilityHookContext,
+                sink: &mut dyn RestrictedGateSink,
+            ) {
+                sink.pass();
+            }
+            fn needs_input(&self) -> bool {
+                true
+            }
+        }
+
+        // Two BeforeCapability bindings on the same scope. One opts
+        // out of input access; the other opts in. The dispatcher's
+        // input-needed probe must short-circuit to true on the second
+        // binding regardless of registration order.
+        let no_input_id = HookId::derive(
+            &ExtensionId::new("ext").expect("valid"),
+            "1.0",
+            &HookLocalId::new("no-input").expect("valid"),
+            HookVersion::ONE,
+        );
+        let needs_input_id = HookId::derive(
+            &ExtensionId::new("ext").expect("valid"),
+            "1.0",
+            &HookLocalId::new("needs-input").expect("valid"),
+            HookVersion::ONE,
+        );
+        let mut registry = HookRegistry::new();
+        registry
+            .insert(HookBinding {
+                hook_id: no_input_id,
+                hook_version: HookVersion::ONE,
+                trust_class: HookTrustClass::Installed,
+                phase: HookPhase::Policy,
+                priority: HookPriority::DEFAULT,
+                point: HookPointSpec::BeforeCapability,
+                owning_extension: None,
+                scope: HookBindingScope::Global,
+                poisoned: false,
+            })
+            .expect("insert no_input");
+        registry
+            .insert(HookBinding {
+                hook_id: needs_input_id,
+                hook_version: HookVersion::ONE,
+                trust_class: HookTrustClass::Installed,
+                phase: HookPhase::Policy,
+                priority: HookPriority::DEFAULT,
+                point: HookPointSpec::BeforeCapability,
+                owning_extension: None,
+                scope: HookBindingScope::Global,
+                poisoned: false,
+            })
+            .expect("insert needs_input");
+        let mut dispatcher = HookDispatcher::new(registry);
+        dispatcher.install_before_capability(
+            no_input_id,
+            BeforeCapabilityHookImpl::Restricted(Box::new(NoInputHook)),
+        );
+        dispatcher.install_before_capability(
+            needs_input_id,
+            BeforeCapabilityHookImpl::Restricted(Box::new(NeedsInputHook)),
+        );
+
+        // First half: probe directly via the dispatcher's
+        // `before_capability_needs_input` API.
+        let dispatcher = Arc::new(dispatcher);
+        assert!(
+            dispatcher.before_capability_needs_input(None),
+            "with a mixed pair (one needs_input=false, one needs_input=true) the \
+             dispatcher must return true so the middleware materializes input",
+        );
+
+        // Second half: drive `invoke_capability` end-to-end with an
+        // instrumented resolver. The middleware must consult `resolve`
+        // because at least one active binding needs input — confirming
+        // the short-circuit is wired all the way through the call site,
+        // not just the helper.
+        let resolver = Arc::new(ProbingResolver::new(serde_json::json!({"amount": 1})));
+        let inner = Arc::new(AlwaysCompletedPort::new());
+        let wrapped = HookedLoopCapabilityPort::new(inner, dispatcher, tenant())
+            .with_resolver(Arc::clone(&resolver) as Arc<_>);
+
+        let _ = wrapped
+            .invoke_capability(invocation("cap.x"))
+            .await
+            .expect("ok");
+
+        assert_eq!(
+            resolver.resolve_calls(),
+            1,
+            "resolver must be called exactly once when at least one active \
+             binding's hook reports needs_input()=true",
+        );
+    }
+
     /// henrypark133 M1 on PR #3911: in the merged-batch path, when an
     /// allowed (Pending) entry precedes a hook-resolved suspension entry
     /// and `stop_on_first_suspension` is true, the merge loop must still
@@ -1802,7 +1922,10 @@ mod tests {
             "alpha was hook-allowed and inner produced a Completed outcome",
         );
         assert!(
-            matches!(outcome.outcomes[1], CapabilityOutcome::ApprovalRequired { .. }),
+            matches!(
+                outcome.outcomes[1],
+                CapabilityOutcome::ApprovalRequired { .. }
+            ),
             "beta was hook-resolved to ApprovalRequired",
         );
         assert!(

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -390,21 +390,54 @@ impl LoopCapabilityPort for HookedLoopCapabilityPort {
 
         // Merge: walk slots in order, splicing inner outcomes into pending
         // slots. Dispatch AfterCapability observer per merged entry.
+        //
+        // Suspension handling preserves the per-entry observer contract
+        // from PR #3573 (serrrfirat P2 #3): a hook-resolved suspension
+        // slot that follows an allowed slot must still fire its
+        // observer, and must still surface in `outcomes`, even when
+        // `stop_on_first_suspension` is set. The pre-fix loop seeded
+        // `stopped_on_suspension` from `stopped_in_preflight` and broke
+        // on the first iteration, dropping any trailing Resolved
+        // suspension slot — see the
+        // `batch_invocation_fires_observer_for_hook_suspended_entry_after_allowed_entry_with_stop_on_first_suspension`
+        // regression test (henrypark133 review M1 on PR #3911).
+        //
+        // Today the loop runs to completion when only Resolved
+        // (hook-resolved) entries remain — every observer fires and
+        // every outcome is pushed — and only breaks early when a
+        // Pending slot has no inner outcome (inner port stopped on its
+        // own suspension and consumed fewer outcomes than we queued).
         let mut outcomes = Vec::with_capacity(slots.len());
         let mut stopped_on_suspension = stopped_in_preflight;
+        let mut pending_after_stop = false;
         for slot in slots {
-            let (outcome, provider) = match slot {
-                Slot::Resolved { outcome, provider } => (outcome, provider),
-                Slot::Pending { provider } => match inner_outcomes.pop() {
-                    Some(inner) => (inner, provider),
-                    None => {
-                        // Inner port stopped early (suspension) and consumed
-                        // fewer outcomes than we queued. Remaining pending
-                        // slots have no outcome — drop them, matching the
-                        // pre-refactor sequential break-out semantics.
-                        break;
+            let outcome_and_provider = match slot {
+                Slot::Resolved { outcome, provider } => Some((outcome, provider)),
+                Slot::Pending { provider } => {
+                    if pending_after_stop {
+                        // We already stopped on a prior suspension and
+                        // queued no work for the inner port past that
+                        // point. A trailing Pending slot has no outcome
+                        // to surface; drop it.
+                        None
+                    } else {
+                        match inner_outcomes.pop() {
+                            Some(inner) => Some((inner, provider)),
+                            None => {
+                                // Inner port stopped early (its own
+                                // suspension) and consumed fewer
+                                // outcomes than we queued. Drop
+                                // remaining Pending slots and continue
+                                // — observers on any trailing Resolved
+                                // slots must still fire.
+                                None
+                            }
+                        }
                     }
-                },
+                }
+            };
+            let Some((outcome, provider)) = outcome_and_provider else {
+                continue;
             };
             let _ = self
                 .dispatcher
@@ -416,11 +449,9 @@ impl LoopCapabilityPort for HookedLoopCapabilityPort {
                 .await;
             if outcome.is_suspension() && stop_on_first_suspension {
                 stopped_on_suspension = true;
+                pending_after_stop = true;
             }
             outcomes.push(outcome);
-            if stopped_on_suspension {
-                break;
-            }
         }
         if inner_stopped {
             stopped_on_suspension = true;
@@ -1618,5 +1649,163 @@ mod tests {
             size_hint_seq < resolve_seq,
             "size_hint (seq {size_hint_seq}) must be consulted before resolve (seq {resolve_seq}) so oversized inputs never get materialized"
         );
+    }
+
+    /// henrypark133 M1 on PR #3911: in the merged-batch path, when an
+    /// allowed (Pending) entry precedes a hook-resolved suspension entry
+    /// and `stop_on_first_suspension` is true, the merge loop must still
+    /// fire the `AfterCapability` observer for the suspension slot. The
+    /// pre-fix loop initialized `stopped_on_suspension` from
+    /// `stopped_in_preflight` and broke after the first iteration —
+    /// dropping the observer for the trailing Resolved suspension slot
+    /// and losing it from `outcomes` entirely. This pins the fixed
+    /// behavior: every slot's observer fires and every Resolved slot
+    /// surfaces in `outcomes`, even when `stop_on_first_suspension` is
+    /// set and the suspension appears after an allowed entry.
+    #[tokio::test]
+    async fn batch_invocation_fires_observer_for_hook_suspended_entry_after_allowed_entry_with_stop_on_first_suspension()
+     {
+        use crate::points::ObserverHookContext;
+        use crate::sink::{ObserverHook, ObserverSink};
+
+        /// Allows `cap.alpha`, pauses `cap.beta` for approval. The
+        /// mixed-batch scenario the merge loop has to handle correctly.
+        struct SelectivePauseHook;
+        #[async_trait]
+        impl RestrictedBeforeCapabilityHook for SelectivePauseHook {
+            async fn evaluate(
+                &self,
+                ctx: &BeforeCapabilityHookContext,
+                sink: &mut dyn RestrictedGateSink,
+            ) {
+                if ctx.capability_name == "cap.beta" {
+                    sink.pause_approval("needs approval");
+                } else {
+                    sink.pass();
+                }
+            }
+        }
+
+        struct CountingObserver {
+            seen: Arc<Mutex<u32>>,
+        }
+        #[async_trait]
+        impl ObserverHook for CountingObserver {
+            async fn observe(&self, _ctx: &ObserverHookContext, _sink: &mut dyn ObserverSink) {
+                *self.seen.lock().expect("not poisoned") += 1;
+            }
+        }
+
+        // Set up a dispatcher with both the gating hook AND an
+        // AfterCapability observer so we can count per-entry observer
+        // dispatch.
+        let gating_id = HookId::derive(
+            &ExtensionId::new("ext").expect("valid ExtensionId in test"),
+            "1.0",
+            &HookLocalId::new("selective-pause").expect("valid HookLocalId in test"),
+            HookVersion::ONE,
+        );
+        let gating_binding = HookBinding {
+            hook_id: gating_id,
+            hook_version: HookVersion::ONE,
+            trust_class: HookTrustClass::Installed,
+            phase: HookPhase::Policy,
+            priority: HookPriority::DEFAULT,
+            point: HookPointSpec::BeforeCapability,
+            owning_extension: None,
+            scope: HookBindingScope::Global,
+            poisoned: false,
+        };
+
+        let observer_id = HookId::for_builtin("test::after_cap_mixed_susp", HookVersion::ONE);
+        let observer_binding = HookBinding {
+            hook_id: observer_id,
+            hook_version: HookVersion::ONE,
+            trust_class: HookTrustClass::Builtin,
+            phase: HookPhase::Telemetry,
+            priority: HookPriority::DEFAULT,
+            point: HookPointSpec::AfterCapability,
+            owning_extension: None,
+            scope: HookBindingScope::Global,
+            poisoned: false,
+        };
+
+        let mut registry = HookRegistry::new();
+        registry.insert(gating_binding).expect("insert gating");
+        registry.insert(observer_binding).expect("insert observer");
+        let mut dispatcher = HookDispatcher::new(registry);
+        dispatcher.install_before_capability(
+            gating_id,
+            BeforeCapabilityHookImpl::Restricted(Box::new(SelectivePauseHook)),
+        );
+        let seen = Arc::new(Mutex::new(0u32));
+        dispatcher.install_observer_impl(
+            observer_id,
+            crate::dispatch::ObserverHookImpl::Any(Box::new(CountingObserver {
+                seen: seen.clone(),
+            })),
+        );
+
+        let inner = Arc::new(AlwaysCompletedPort::new());
+        let wrapped = HookedLoopCapabilityPort::new(inner.clone(), Arc::new(dispatcher), tenant())
+            .with_gate_ref_factory(Arc::new(UuidHookGateRefFactory));
+
+        // alpha (hook-allowed → Pending) precedes beta (hook-suspension
+        // → Resolved). `stop_on_first_suspension` is true so the bug
+        // path: the merge loop sees `stopped_in_preflight = true` from
+        // Phase 1 (beta was the suspension trigger), pushes alpha, then
+        // breaks before reaching beta's slot — dropping beta's observer
+        // and outcome.
+        let batch = CapabilityBatchInvocation {
+            invocations: vec![invocation("cap.alpha"), invocation("cap.beta")],
+            stop_on_first_suspension: true,
+        };
+        let outcome = wrapped.invoke_capability_batch(batch).await.expect("ok");
+
+        assert_eq!(
+            outcome.outcomes.len(),
+            2,
+            "merged outcomes must contain both entries: the hook-allowed alpha \
+             (from inner) and the hook-suspended beta (from hook resolution). \
+             Pre-fix this dropped beta to a length of 1.",
+        );
+        assert!(
+            matches!(outcome.outcomes[0], CapabilityOutcome::Completed(_)),
+            "alpha was hook-allowed and inner produced a Completed outcome",
+        );
+        assert!(
+            matches!(outcome.outcomes[1], CapabilityOutcome::ApprovalRequired { .. }),
+            "beta was hook-resolved to ApprovalRequired",
+        );
+        assert!(
+            outcome.stopped_on_suspension,
+            "stop_on_first_suspension was set and a suspension surfaced",
+        );
+        assert_eq!(
+            *seen.lock().expect("not poisoned"),
+            2,
+            "AfterCapability observer must fire for BOTH entries — the \
+             hook-allowed alpha AND the hook-resolved suspension beta. \
+             Pre-fix the merge loop broke before firing beta's observer.",
+        );
+        // No inner work for beta — the hook short-circuited it. The
+        // inner test port's `invoke_capability_batch` impl delegates
+        // per-entry to `invoke_capability`, so `calls()` counts the
+        // entries the inner port saw; only alpha should appear.
+        let calls = inner.calls();
+        assert_eq!(
+            calls.len(),
+            1,
+            "only alpha must reach the inner port; beta was hook-suspended",
+        );
+        assert_eq!(calls[0].as_str(), "cap.alpha");
+        let batch_calls = inner.batch_calls();
+        assert_eq!(
+            batch_calls.len(),
+            1,
+            "the inner port must be batched-called exactly once with just alpha",
+        );
+        assert_eq!(batch_calls[0].len(), 1);
+        assert_eq!(batch_calls[0][0].as_str(), "cap.alpha");
     }
 }


### PR DESCRIPTION
Consolidates henrypark133 approval-with-followup feedback from three merged hooks PRs. Each item is in its own commit; the only behavioral change is the M1 observer-loss fix on #3911.

## #3911 (merged)

- **M1 — fix(hooks): fire AfterCapability observer for hook-suspended entries after allowed entries.** In `HookedLoopCapabilityPort::invoke_capability_batch`, the merge loop initialized `stopped_on_suspension` from `stopped_in_preflight` and broke after the first iteration. When the batch was `[A=Pending(hook-allowed), B=Resolved(hook-suspension)]` with `stop_on_first_suspension = true`, slot B's `AfterCapability` observer never fired and B never surfaced in `outcomes` — violating the per-entry observer contract from PR #3573 (serrrfirat P2 #3). Fix: keep walking the slot vec so every observer fires and every Resolved outcome is pushed; only `Pending` slots are dropped after a stop. (Commit `3a077e9`.)

- **M2 — test:** new regression `batch_invocation_fires_observer_for_hook_suspended_entry_after_allowed_entry_with_stop_on_first_suspension` verifies the fix and the mixed-batch contract end-to-end. Written TDD: confirmed the test fails on the pre-fix code (`outcomes.len() == 1`) before the merge-loop change was applied. (Commit `3a077e9`.)

## #3912 (merged) — commit `471cf0f`

- **L1:** removed the unreachable `if self.id.as_str().is_empty()` guard in `HookManifestEntry::validate` — `HookLocalId::new` now rejects empty strings at construction, so manifest deserialization fails before `validate()` runs.
- **L2:** added `impl AsRef<str>` and `impl From<Self> for String` to `ExtensionId` and `HookLocalId`, plus a canonical `into_inner()` method, matching the newtype template in `.claude/rules/types.md`. `into_string()` is retained as a thin alias so no downstream callers break; new code should use `into_inner()`.
- **L3:** added a comment in `builtin_id_distinct_from_extension_id` documenting why the test fixture substitutes `"path.module"` for the original `"path::module"` (the post-#3912 segment grammar disallows `:` in `HookLocalId`).

## #3913 (merged)

- **L1 — perf(hooks): reuse serialized argument bytes in lazy resolve.** `resolve_arguments` previously called `serde_json::to_vec(&value)` purely to measure the payload's byte length and then dropped the `Vec<u8>`; `SanitizedArguments::from_json` does not re-serialize on the happy path. Replaced with a counting `io::Write` adapter (`serialized_len`) that streams `serde_json::to_writer` into a u64 counter — saves one Vec<u8> allocation + matching drop per resolved invocation. Behavior identical: same JSON encoding rules, same cap check, same fail-closed on serialization error. (Commit `e6530a8`.)

- **L2 — test:** new `before_capability_needs_input_returns_true_when_any_active_binding_needs_input` installs two BeforeCapability bindings on the same scope (one `needs_input()=false`, one `needs_input()=true`), then asserts (a) the dispatcher's probe returns true and (b) driving `invoke_capability` with an instrumented `ProbingResolver` causes `resolve` to be called exactly once — pinning the short-circuit through the call site, not just the helper. (Commit `bf12ce9`.)

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo test -p ironclaw_hooks -p ironclaw_reborn`
  - `ironclaw_hooks`: 213 passed (was 211; +1 M1 regression, +1 L2 short-circuit test)
  - `ironclaw_reborn`: all green
- [x] TDD verified for M1: the new M2 test fails on the pre-fix merge-loop code (`outcomes.len() = 1, expected 2`) and passes after the fix.

## Notes / out of scope

- The original L1 task description for #3913 suggested adding a `SanitizedArguments::from_json_bytes` constructor that reuses the measured bytes. After tracing the code path, the existing `from_json` sanitizes the in-memory `serde_json::Value` directly (no re-serialize), so the actual perf win was avoiding the throwaway `Vec<u8>` — implemented via the counting-writer instead, which is local to `capability_port.rs` and avoids churning `SanitizedArguments`' API.
- `ExtensionId::into_string` and `HookLocalId::into_string` are kept as aliases. No callers currently use them, but the alias is the conservative path; a follow-up could mark them `#[deprecated]` or delete them outright once the rest of the workspace finishes migrating to `into_inner`.