### PR TITLE
Gate GitHub comment capability behind approval

### DIFF
--- a/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_github_comment_approval_contract.rs
@@ -1,0 +1,259 @@
+use async_trait::async_trait;
+use ironclaw_approvals::*;
+use ironclaw_authorization::*;
+use ironclaw_capabilities::*;
+use ironclaw_host_api::*;
+use ironclaw_run_state::*;
+use serde_json::json;
+
+mod support;
+use support::*;
+
+#[tokio::test]
+async fn capability_host_blocks_github_comment_issue_before_dispatch() {
+    let fixture = blocked_github_comment_fixture().await;
+
+    assert_eq!(fixture.dispatcher.dispatch_count(), 0);
+    assert!(!fixture.dispatcher.has_request());
+    let run = fixture
+        .run_state
+        .get(&fixture.scope, fixture.invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, RunStatus::BlockedApproval);
+    let approval = fixture
+        .approval_requests
+        .get(&fixture.scope, fixture.approval_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(approval.status, ApprovalStatus::Pending);
+    assert_eq!(
+        approval.request.invocation_fingerprint,
+        Some(
+            InvocationFingerprint::for_dispatch(
+                &fixture.scope,
+                &github_comment_capability_id(),
+                &fixture.estimate,
+                &fixture.input
+            )
+            .unwrap()
+        )
+    );
+}
+
+#[tokio::test]
+async fn capability_host_resumes_approved_github_comment_issue_and_dispatches_once() {
+    let fixture = approved_github_comment_fixture().await;
+    let obligation_handler = AllowAllObligationHandler;
+    let resume_authorizer = GrantAuthorizer::new();
+    let resume_host =
+        CapabilityHost::new(&fixture.registry, &fixture.dispatcher, &resume_authorizer)
+            .with_run_state(&fixture.run_state)
+            .with_approval_requests(&fixture.approval_requests)
+            .with_capability_leases(&fixture.leases)
+            .with_obligation_handler(&obligation_handler);
+
+    let result = resume_host
+        .resume_json(CapabilityResumeRequest {
+            context: fixture.context.clone(),
+            approval_request_id: fixture.approval_id,
+            capability_id: github_comment_capability_id(),
+            estimate: fixture.estimate.clone(),
+            input: fixture.input.clone(),
+            trust_decision: github_comment_trust_decision(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.dispatch.output, json!({"ok": true}));
+    assert_eq!(fixture.dispatcher.dispatch_count(), 1);
+    let request = fixture.dispatcher.take_request();
+    assert_eq!(request.capability_id, github_comment_capability_id());
+    assert_eq!(request.input, fixture.input);
+    let run = fixture
+        .run_state
+        .get(&fixture.scope, fixture.invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, RunStatus::Completed);
+    let consumed = fixture
+        .leases
+        .get(
+            &fixture.scope,
+            fixture.lease_id.expect("approved fixture has a lease"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(consumed.status, CapabilityLeaseStatus::Consumed);
+}
+
+#[tokio::test]
+async fn capability_host_rejects_mutated_github_comment_issue_replay_before_dispatch_or_claim() {
+    let fixture = approved_github_comment_fixture().await;
+    let obligation_handler = AllowAllObligationHandler;
+    let resume_authorizer = GrantAuthorizer::new();
+    let resume_host =
+        CapabilityHost::new(&fixture.registry, &fixture.dispatcher, &resume_authorizer)
+            .with_run_state(&fixture.run_state)
+            .with_approval_requests(&fixture.approval_requests)
+            .with_capability_leases(&fixture.leases)
+            .with_obligation_handler(&obligation_handler);
+
+    let err = resume_host
+        .resume_json(CapabilityResumeRequest {
+            context: fixture.context.clone(),
+            approval_request_id: fixture.approval_id,
+            capability_id: github_comment_capability_id(),
+            estimate: fixture.estimate.clone(),
+            input: json!({
+                "owner": "nearai",
+                "repo": "ironclaw",
+                "issue_number": 3806,
+                "body": "mutated approved comment"
+            }),
+            trust_decision: github_comment_trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::ApprovalFingerprintMismatch { .. }
+    ));
+    assert_eq!(fixture.dispatcher.dispatch_count(), 0);
+    assert!(!fixture.dispatcher.has_request());
+    let active = fixture
+        .leases
+        .get(
+            &fixture.scope,
+            fixture.lease_id.expect("approved fixture has a lease"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(active.status, CapabilityLeaseStatus::Active);
+}
+
+struct GitHubCommentApprovalFixture {
+    registry: ironclaw_extensions::ExtensionRegistry,
+    dispatcher: RecordingDispatcher,
+    run_state: InMemoryRunStateStore,
+    approval_requests: InMemoryApprovalRequestStore,
+    leases: InMemoryCapabilityLeaseStore,
+    context: ExecutionContext,
+    scope: ResourceScope,
+    invocation_id: InvocationId,
+    estimate: ResourceEstimate,
+    input: serde_json::Value,
+    approval_id: ApprovalRequestId,
+    lease_id: Option<CapabilityGrantId>,
+}
+
+async fn blocked_github_comment_fixture() -> GitHubCommentApprovalFixture {
+    let registry = registry_with_github_comment_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let run_state = InMemoryRunStateStore::new();
+    let approval_requests = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let block_host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({
+        "owner": "nearai",
+        "repo": "ironclaw",
+        "issue_number": 3806,
+        "body": "approved comment"
+    });
+
+    let err = block_host
+        .invoke_json(CapabilityInvocationRequest {
+            context: context.clone(),
+            capability_id: github_comment_capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+            trust_decision: github_comment_trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::AuthorizationRequiresApproval { .. }
+    ));
+    let approval_id = run_state
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .approval_request_id
+        .unwrap();
+
+    GitHubCommentApprovalFixture {
+        registry,
+        dispatcher,
+        run_state,
+        approval_requests,
+        leases,
+        context,
+        scope,
+        invocation_id,
+        estimate,
+        input,
+        approval_id,
+        lease_id: None,
+    }
+}
+
+async fn approved_github_comment_fixture() -> GitHubCommentApprovalFixture {
+    let mut fixture = blocked_github_comment_fixture().await;
+    let lease = ApprovalResolver::new(&fixture.approval_requests, &fixture.leases)
+        .approve_dispatch(
+            &fixture.scope,
+            fixture.approval_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                allowed_effects: github_comment_effects(),
+                mounts: MountView::default(),
+                network: NetworkPolicy::default(),
+                secrets: vec![SecretHandle::new("github_token").unwrap()],
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+    fixture.lease_id = Some(lease.grant.id);
+    fixture
+}
+
+fn github_comment_trust_decision() -> ironclaw_trust::TrustDecision {
+    trust_decision_with_effects(github_comment_effects())
+}
+
+fn github_comment_effects() -> Vec<EffectKind> {
+    vec![
+        EffectKind::DispatchCapability,
+        EffectKind::Network,
+        EffectKind::UseSecret,
+        EffectKind::ExternalWrite,
+    ]
+}
+
+struct AllowAllObligationHandler;
+
+#[async_trait]
+impl CapabilityObligationHandler for AllowAllObligationHandler {
+    async fn satisfy(
+        &self,
+        _request: CapabilityObligationRequest<'_>,
+    ) -> Result<(), CapabilityObligationError> {
+        Ok(())
+    }
+}

--- a/crates/ironclaw_capabilities/tests/support/mod.rs
+++ b/crates/ironclaw_capabilities/tests/support/mod.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code)]
 
-use std::sync::Mutex;
+use std::sync::{
+    Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -13,6 +16,7 @@ use serde_json::json;
 #[derive(Default)]
 pub struct RecordingDispatcher {
     request: Mutex<Option<CapabilityDispatchRequest>>,
+    dispatch_count: AtomicUsize,
 }
 
 impl RecordingDispatcher {
@@ -30,6 +34,10 @@ impl RecordingDispatcher {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .is_some()
     }
+
+    pub fn dispatch_count(&self) -> usize {
+        self.dispatch_count.load(Ordering::SeqCst)
+    }
 }
 
 #[async_trait]
@@ -38,6 +46,7 @@ impl CapabilityDispatcher for RecordingDispatcher {
         &self,
         request: CapabilityDispatchRequest,
     ) -> Result<CapabilityDispatchResult, DispatchError> {
+        self.dispatch_count.fetch_add(1, Ordering::SeqCst);
         *self
             .request
             .lock()
@@ -66,7 +75,7 @@ impl TrustAwareCapabilityDispatchAuthorizer for ApprovalAuthorizer {
     async fn authorize_dispatch_with_trust(
         &self,
         context: &ExecutionContext,
-        _descriptor: &CapabilityDescriptor,
+        descriptor: &CapabilityDescriptor,
         estimate: &ResourceEstimate,
         _trust_decision: &TrustDecision,
     ) -> Decision {
@@ -76,7 +85,7 @@ impl TrustAwareCapabilityDispatchAuthorizer for ApprovalAuthorizer {
                 correlation_id: context.correlation_id,
                 requested_by: Principal::Extension(context.extension_id.clone()),
                 action: Box::new(Action::Dispatch {
-                    capability: capability_id(),
+                    capability: descriptor.id.clone(),
                     estimated_resources: estimate.clone(),
                 }),
                 invocation_fingerprint: None,
@@ -159,6 +168,23 @@ pub fn registry_with_echo_capability() -> ExtensionRegistry {
     registry
 }
 
+pub fn registry_with_github_comment_capability() -> ExtensionRegistry {
+    let manifest = ExtensionManifest::parse(
+        GITHUB_COMMENT_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    let package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/github").unwrap(),
+    )
+    .unwrap();
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+    registry
+}
+
 pub fn execution_context(grants: CapabilitySet) -> ExecutionContext {
     ExecutionContext::local_default(
         UserId::new("user").unwrap(),
@@ -223,6 +249,10 @@ pub fn capability_id() -> CapabilityId {
     CapabilityId::new("echo.say").unwrap()
 }
 
+pub fn github_comment_capability_id() -> CapabilityId {
+    CapabilityId::new("github.comment_issue").unwrap()
+}
+
 pub fn extension_id() -> ExtensionId {
     ExtensionId::new("echo").unwrap()
 }
@@ -247,4 +277,27 @@ default_permission = "allow"
 visibility = "host_internal"
 input_schema_ref = "schemas/echo/say.input.v1.json"
 output_schema_ref = "schemas/echo/say.output.v1.json"
+"#;
+
+const GITHUB_COMMENT_MANIFEST: &str = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "github"
+name = "GitHub"
+version = "0.2.5"
+description = "GitHub issue comment test extension"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/github_tool.wasm"
+
+[[capabilities]]
+id = "github.comment_issue"
+description = "Add a comment to a GitHub issue or pull request."
+effects = ["dispatch_capability", "network", "use_secret", "external_write"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/github/comment_issue.input.v1.json"
+output_schema_ref = "schemas/github/comment_issue.output.v1.json"
+prompt_doc_ref = "prompts/github/comment_issue.md"
 "#;

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -131,7 +131,7 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
 }
 
 #[tokio::test]
-async fn github_v2_package_discovers_and_publishes_read_only_hot_catalog() {
+async fn github_v2_package_discovers_and_publishes_issue_hot_catalog() {
     let (_storage, fs) = mounted_github_package_fs();
     let registry = discover_extensions_with_default_host_api_contracts(
         &fs,
@@ -152,13 +152,24 @@ async fn github_v2_package_discovers_and_publishes_read_only_hot_catalog() {
             .iter()
             .map(|capability| capability.id.as_str())
             .collect::<Vec<_>>(),
-        vec!["github.search_issues", "github.get_issue"]
+        vec![
+            "github.search_issues",
+            "github.get_issue",
+            "github.comment_issue"
+        ]
     );
     for capability in &package.manifest.capabilities {
-        assert_eq!(
-            capability.effects,
+        let expected_effects = if capability.id.as_str() == "github.comment_issue" {
+            vec![
+                EffectKind::DispatchCapability,
+                EffectKind::Network,
+                EffectKind::UseSecret,
+                EffectKind::ExternalWrite,
+            ]
+        } else {
             vec![EffectKind::Network, EffectKind::UseSecret]
-        );
+        };
+        assert_eq!(capability.effects, expected_effects);
         assert_eq!(capability.default_permission, PermissionMode::Ask);
         assert_eq!(
             capability
@@ -173,7 +184,7 @@ async fn github_v2_package_discovers_and_publishes_read_only_hot_catalog() {
     let hot_catalog = publish_hot_capability_catalog(&fs, &registry)
         .await
         .unwrap();
-    assert_eq!(hot_catalog.capabilities.len(), 2);
+    assert_eq!(hot_catalog.capabilities.len(), 3);
 
     let search = hot_catalog
         .get(&CapabilityId::new("github.search_issues").unwrap())
@@ -211,6 +222,32 @@ async fn github_v2_package_discovers_and_publishes_read_only_hot_catalog() {
             .as_deref()
             .is_some_and(|doc| doc.contains("github.get_issue") && doc.contains("read-only"))
     );
+
+    let comment_issue = hot_catalog
+        .get(&CapabilityId::new("github.comment_issue").unwrap())
+        .unwrap();
+    assert_eq!(
+        comment_issue.descriptor.parameters_schema["required"],
+        json!(["owner", "repo", "issue_number", "body"])
+    );
+    assert_eq!(
+        comment_issue.descriptor.effects,
+        vec![
+            EffectKind::DispatchCapability,
+            EffectKind::Network,
+            EffectKind::UseSecret,
+            EffectKind::ExternalWrite,
+        ]
+    );
+    assert_eq!(
+        comment_issue.output_schema["required"],
+        json!(["id", "html_url", "body"])
+    );
+    assert!(comment_issue.prompt_doc.as_deref().is_some_and(|doc| {
+        doc.contains("github.comment_issue")
+            && doc.contains("external write")
+            && doc.contains("github_token")
+    }));
 }
 
 #[tokio::test]
@@ -384,8 +421,11 @@ fn mounted_github_package_fs() -> (tempfile::TempDir, LocalFilesystem) {
         "schemas/github/search_issues.output.v1.json",
         "schemas/github/get_issue.input.v1.json",
         "schemas/github/get_issue.output.v1.json",
+        "schemas/github/comment_issue.input.v1.json",
+        "schemas/github/comment_issue.output.v1.json",
         "prompts/github/search_issues.md",
         "prompts/github/get_issue.md",
+        "prompts/github/comment_issue.md",
     ] {
         copy_package_file(&source_root, &package_root, relative);
     }

--- a/tools-src/github-reborn/manifest.toml
+++ b/tools-src/github-reborn/manifest.toml
@@ -2,7 +2,7 @@ schema_version = "reborn.extension_manifest.v2"
 id = "github"
 name = "GitHub"
 version = "0.2.5"
-description = "Read-only GitHub issue lookup capabilities."
+description = "GitHub issue lookup and issue comment capabilities."
 trust = "third_party"
 
 [runtime]
@@ -35,4 +35,15 @@ visibility = "model"
 input_schema_ref = "schemas/github/get_issue.input.v1.json"
 output_schema_ref = "schemas/github/get_issue.output.v1.json"
 prompt_doc_ref = "prompts/github/get_issue.md"
+required_host_ports = ["host.runtime.http_egress"]
+
+[[capability_provider.tools.capabilities]]
+id = "github.comment_issue"
+description = "Add a comment to a GitHub issue or pull request."
+effects = ["dispatch_capability", "network", "use_secret", "external_write"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/github/comment_issue.input.v1.json"
+output_schema_ref = "schemas/github/comment_issue.output.v1.json"
+prompt_doc_ref = "prompts/github/comment_issue.md"
 required_host_ports = ["host.runtime.http_egress"]

--- a/tools-src/github-reborn/prompts/github/comment_issue.md
+++ b/tools-src/github-reborn/prompts/github/comment_issue.md
@@ -1,0 +1,5 @@
+Use `github.comment_issue` to add a Markdown comment to an existing GitHub issue or pull request when the repository owner, repository name, issue number, and exact comment body are known.
+
+Pass `owner`, `repo`, `issue_number`, and `body` exactly. If the user provides a GitHub issue or pull request URL, extract the owner, repository, and number before calling this capability.
+
+This capability performs an external write through the GitHub API using the host HTTP egress port. It requires approval before dispatch and requires a configured `github_token` secret, but Extension Manifest v2 does not yet define a canonical credential declaration field, so the token requirement is documented here rather than declared in the manifest.

--- a/tools-src/github-reborn/schemas/github/comment_issue.input.v1.json
+++ b/tools-src/github-reborn/schemas/github/comment_issue.input.v1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitHub comment issue input",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "owner": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Repository owner or organization."
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Repository name."
+    },
+    "issue_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Issue or pull request number."
+    },
+    "body": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 65536,
+      "description": "Markdown comment body to post."
+    }
+  },
+  "required": ["owner", "repo", "issue_number", "body"]
+}

--- a/tools-src/github-reborn/schemas/github/comment_issue.output.v1.json
+++ b/tools-src/github-reborn/schemas/github/comment_issue.output.v1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitHub comment issue output",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": { "type": "integer" },
+    "node_id": { "type": "string" },
+    "html_url": { "type": "string" },
+    "issue_url": { "type": "string" },
+    "body": { "type": "string" },
+    "user": { "type": "object" },
+    "created_at": { "type": "string" },
+    "updated_at": { "type": "string" }
+  },
+  "required": ["id", "html_url", "body"]
+}


### PR DESCRIPTION
## Summary
- add `github.comment_issue` as an explicit external-write GitHub capability
- document the required GitHub token and request/response schemas
- cover approval blocking, approved resume, lease consumption, and mutated-input replay rejection through `CapabilityHost`

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_capabilities --test capability_host_github_comment_approval_contract -- --nocapture`
- `cargo test -p ironclaw_capabilities --test capability_host_run_state_contract -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test extension_v2_lifecycle_e2e github_v2_package_discovers_and_publishes_issue_hot_catalog -- --nocapture`
- `git diff --check`

Stacked on #3910.