### PR TITLE
refactor(hooks): make PredicateStateBackend a stable public async contract (durable backend PR 1/4)

### DIFF
--- a/crates/ironclaw_hooks/Cargo.toml
+++ b/crates/ironclaw_hooks/Cargo.toml
@@ -13,6 +13,11 @@ default = []
 # on-trusted-path invariant. Intended exclusively as a `dev-dependency` feature
 # for hook authors writing predicate tests outside `ironclaw_reborn`.
 test-support = []
+# Exposes the `predicate_state::contract` trait-level test harness so
+# out-of-crate durable backends (durable-backend PRs 2/3 — Postgres,
+# libSQL) can run the same `PredicateStateBackend` contract suite against
+# their impl. Mirrors `ironclaw_memory`'s `contract-tests` feature.
+contract-tests = []
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_hooks/src/evaluator.rs
+++ b/crates/ironclaw_hooks/src/evaluator.rs
@@ -21,8 +21,9 @@
 
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 
 use crate::identity::HookId;
@@ -120,23 +121,23 @@ impl PredicateEvaluator {
 
     /// Evaluate `spec` against the given context. Mutates internal counters
     /// for stateful predicates.
-    pub fn evaluate(
+    pub async fn evaluate(
         &self,
         hook_id: HookId,
         spec: &HookPredicateSpec,
         ctx: &BeforeCapabilityHookContext,
     ) -> EvaluatorDecision {
-        self.evaluate_at(hook_id, spec, ctx, Instant::now())
+        self.evaluate_at(hook_id, spec, ctx, Utc::now()).await
     }
 
     /// Test-only variant accepting an explicit `now` so sliding-window tests
     /// don't depend on real wall-clock progress.
-    pub fn evaluate_at(
+    pub async fn evaluate_at(
         &self,
         hook_id: HookId,
         spec: &HookPredicateSpec,
         ctx: &BeforeCapabilityHookContext,
-        now: Instant,
+        now: DateTime<Utc>,
     ) -> EvaluatorDecision {
         match spec {
             HookPredicateSpec::DenyCapability { when, reason } => {
@@ -185,6 +186,7 @@ impl PredicateEvaluator {
                         let count = match self
                             .backend
                             .record_invocation(&key, &event_id, now, window_dur)
+                            .await
                         {
                             Ok(c) => c,
                             Err(error) => {
@@ -248,6 +250,7 @@ impl PredicateEvaluator {
                         let sum = match self
                             .backend
                             .record_value(&key, &event_id, now, value, window_dur)
+                            .await
                         {
                             Ok(s) => s,
                             Err(error) => {
@@ -439,8 +442,15 @@ mod tests {
         )
     }
 
-    #[test]
-    fn deny_capability_fires_on_match() {
+    /// Fixed wall-clock base for deterministic sliding-window tests. The
+    /// evaluator clock is now `DateTime<Utc>` (serializable) rather than
+    /// `Instant`.
+    fn base() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_700_000_000, 0).expect("valid fixed timestamp")
+    }
+
+    #[tokio::test]
+    async fn deny_capability_fires_on_match() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::DenyCapability {
             when: CapabilityPredicate::NameEquals {
@@ -448,7 +458,9 @@ mod tests {
             },
             reason: "shell disabled".to_string(),
         };
-        let denied = evaluator.evaluate(hook_id(), &spec, &ctx("shell.exec"));
+        let denied = evaluator
+            .evaluate(hook_id(), &spec, &ctx("shell.exec"))
+            .await;
         assert_eq!(
             denied,
             EvaluatorDecision::Deny {
@@ -457,12 +469,14 @@ mod tests {
             }
         );
 
-        let allowed = evaluator.evaluate(hook_id(), &spec, &ctx("memory.read"));
+        let allowed = evaluator
+            .evaluate(hook_id(), &spec, &ctx("memory.read"))
+            .await;
         assert_eq!(allowed, EvaluatorDecision::Allow);
     }
 
-    #[test]
-    fn nested_predicate_matches_correctly() {
+    #[tokio::test]
+    async fn nested_predicate_matches_correctly() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::DenyCapability {
             when: CapabilityPredicate::All {
@@ -485,15 +499,21 @@ mod tests {
             reason: "wallet locked".to_string(),
         };
         assert!(matches!(
-            evaluator.evaluate(hook_id(), &spec, &ctx("wallet.sign")),
+            evaluator
+                .evaluate(hook_id(), &spec, &ctx("wallet.sign"))
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
         assert_eq!(
-            evaluator.evaluate(hook_id(), &spec, &ctx("wallet.balance")),
+            evaluator
+                .evaluate(hook_id(), &spec, &ctx("wallet.balance"))
+                .await,
             EvaluatorDecision::Allow
         );
         assert_eq!(
-            evaluator.evaluate(hook_id(), &spec, &ctx("memory.read")),
+            evaluator
+                .evaluate(hook_id(), &spec, &ctx("memory.read"))
+                .await,
             EvaluatorDecision::Allow
         );
     }
@@ -504,8 +524,8 @@ mod tests {
     /// invocation, even if all other context (capability, args, hook,
     /// timestamp) is bit-identical — because that's the very case durable
     /// backends face on retry/replay.
-    #[test]
-    fn duplicate_caller_event_id_is_deduped_in_invocation_count() {
+    #[tokio::test]
+    async fn duplicate_caller_event_id_is_deduped_in_invocation_count() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::RateOrValueCap {
             when: CapabilityPredicate::NameEquals {
@@ -524,17 +544,21 @@ mod tests {
         )
         .expect("fixture id passes format validation");
         let ctx_with_id = ctx("cap.x").with_caller_event_id(stable_id);
-        let now = Instant::now();
+        let now = base();
 
         // First evaluation with the stable id — counted.
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx_with_id, now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx_with_id, now)
+                .await,
             EvaluatorDecision::Allow
         );
         // Replay with the same caller_event_id — backend dedupes, count
         // remains 1, still under the cap of 2.
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx_with_id, now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx_with_id, now)
+                .await,
             EvaluatorDecision::Allow
         );
         // A second logical invocation gets a different stable id and counts
@@ -545,7 +569,9 @@ mod tests {
         .expect("fixture id passes format validation");
         let ctx_second = ctx("cap.x").with_caller_event_id(second_id);
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx_second, now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx_second, now)
+                .await,
             EvaluatorDecision::Allow
         );
         // A third logical invocation crosses the cap.
@@ -556,7 +582,9 @@ mod tests {
         .expect("fixture id passes format validation");
         let ctx_third = ctx("cap.x").with_caller_event_id(third_id);
         assert!(matches!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx_third, now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx_third, now)
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
 
@@ -565,18 +593,22 @@ mod tests {
         let plain = PredicateEvaluator::new();
         for _ in 0..2 {
             assert_eq!(
-                plain.evaluate_at(hook_id(), &spec, &ctx("cap.x"), now),
+                plain
+                    .evaluate_at(hook_id(), &spec, &ctx("cap.x"), now)
+                    .await,
                 EvaluatorDecision::Allow
             );
         }
         assert!(matches!(
-            plain.evaluate_at(hook_id(), &spec, &ctx("cap.x"), now),
+            plain
+                .evaluate_at(hook_id(), &spec, &ctx("cap.x"), now)
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
     }
 
-    #[test]
-    fn invocation_count_cap_denies_after_limit() {
+    #[tokio::test]
+    async fn invocation_count_cap_denies_after_limit() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::RateOrValueCap {
             when: CapabilityPredicate::NameEquals {
@@ -590,12 +622,16 @@ mod tests {
                 reason: "rate cap".to_string(),
             },
         };
-        let now = Instant::now();
+        let now = base();
         for _ in 0..3 {
-            let outcome = evaluator.evaluate_at(hook_id(), &spec, &ctx("cap.x"), now);
+            let outcome = evaluator
+                .evaluate_at(hook_id(), &spec, &ctx("cap.x"), now)
+                .await;
             assert_eq!(outcome, EvaluatorDecision::Allow);
         }
-        let blocked = evaluator.evaluate_at(hook_id(), &spec, &ctx("cap.x"), now);
+        let blocked = evaluator
+            .evaluate_at(hook_id(), &spec, &ctx("cap.x"), now)
+            .await;
         assert_eq!(
             blocked,
             EvaluatorDecision::Deny {
@@ -605,8 +641,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn invocation_count_resets_after_window_expires() {
+    #[tokio::test]
+    async fn invocation_count_resets_after_window_expires() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::RateOrValueCap {
             when: CapabilityPredicate::Always,
@@ -618,34 +654,40 @@ mod tests {
                 reason: "exceeded".to_string(),
             },
         };
-        let start = Instant::now();
+        let start = base();
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx("cap.x"), start),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx("cap.x"), start)
+                .await,
             EvaluatorDecision::Allow
         );
         assert!(matches!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx("cap.x"),
-                start + Duration::from_secs(1)
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx("cap.x"),
+                    start + chrono::Duration::seconds(1)
+                )
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
         // After the window expires, both prior entries are trimmed.
         assert_eq!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx("cap.x"),
-                start + Duration::from_secs(20)
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx("cap.x"),
+                    start + chrono::Duration::seconds(20)
+                )
+                .await,
             EvaluatorDecision::Allow
         );
     }
 
-    #[test]
-    fn invocation_count_partitions_by_capability_name() {
+    #[tokio::test]
+    async fn invocation_count_partitions_by_capability_name() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::RateOrValueCap {
             when: CapabilityPredicate::NameStartsWith {
@@ -659,19 +701,25 @@ mod tests {
                 reason: "exceeded".to_string(),
             },
         };
-        let now = Instant::now();
+        let now = base();
         // shell.run hits its cap.
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx("shell.run"), now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx("shell.run"), now)
+                .await,
             EvaluatorDecision::Allow
         );
         assert!(matches!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx("shell.run"), now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx("shell.run"), now)
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
         // shell.exec has its own counter.
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx("shell.exec"), now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx("shell.exec"), now)
+                .await,
             EvaluatorDecision::Allow
         );
     }
@@ -703,160 +751,188 @@ mod tests {
         }
     }
 
-    #[test]
-    fn numeric_sum_denies_after_total_exceeds_max() {
+    #[tokio::test]
+    async fn numeric_sum_denies_after_total_exceeds_max() {
         let evaluator = PredicateEvaluator::new();
         let spec = numeric_sum_spec("100", "amount", "1h");
-        let now = Instant::now();
+        let now = base();
         // 40 + 40 = 80, under cap
         assert_eq!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"amount": "40"})),
-                now,
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"amount": "40"})),
+                    now,
+                )
+                .await,
             EvaluatorDecision::Allow,
         );
         assert_eq!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"amount": "40"})),
-                now,
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"amount": "40"})),
+                    now,
+                )
+                .await,
             EvaluatorDecision::Allow,
         );
         // Third spend pushes 120 > 100.
         assert!(matches!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"amount": "40"})),
-                now,
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"amount": "40"})),
+                    now,
+                )
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
     }
 
-    #[test]
-    fn numeric_sum_fails_closed_with_unresolved_args() {
+    #[tokio::test]
+    async fn numeric_sum_fails_closed_with_unresolved_args() {
         let evaluator = PredicateEvaluator::new();
         let spec = numeric_sum_spec("100", "amount", "1h");
         // Unresolved args -> Deny, even though the cap is enormous relative to nothing.
         assert!(matches!(
-            evaluator.evaluate(hook_id(), &spec, &ctx("wallet.spend")),
+            evaluator
+                .evaluate(hook_id(), &spec, &ctx("wallet.spend"))
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
     }
 
-    #[test]
-    fn numeric_sum_fails_closed_with_missing_field() {
+    #[tokio::test]
+    async fn numeric_sum_fails_closed_with_missing_field() {
         let evaluator = PredicateEvaluator::new();
         let spec = numeric_sum_spec("100", "amount", "1h");
         assert!(matches!(
-            evaluator.evaluate(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"other": "5"})),
-            ),
+            evaluator
+                .evaluate(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"other": "5"})),
+                )
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
     }
 
-    #[test]
-    fn numeric_sum_resets_after_window() {
+    #[tokio::test]
+    async fn numeric_sum_resets_after_window() {
         let evaluator = PredicateEvaluator::new();
         let spec = numeric_sum_spec("50", "amount", "10s");
-        let start = Instant::now();
+        let start = base();
         // First call: 40 <= 50, allow.
         assert_eq!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"amount": 40})),
-                start,
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"amount": 40})),
+                    start,
+                )
+                .await,
             EvaluatorDecision::Allow,
         );
         // Second call within window: 40 + 40 = 80 > 50, deny.
         assert!(matches!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"amount": 40})),
-                start + Duration::from_secs(1),
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"amount": 40})),
+                    start + chrono::Duration::seconds(1),
+                )
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
         // After window: prior entries trimmed; only the new 40 counts.
         assert_eq!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"amount": 40})),
-                start + Duration::from_secs(20),
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"amount": 40})),
+                    start + chrono::Duration::seconds(20),
+                )
+                .await,
             EvaluatorDecision::Allow,
         );
     }
 
-    #[test]
-    fn numeric_sum_partitions_by_tenant() {
+    #[tokio::test]
+    async fn numeric_sum_partitions_by_tenant() {
         let evaluator = PredicateEvaluator::new();
         let spec = numeric_sum_spec("50", "amount", "1h");
-        let now = Instant::now();
+        let now = base();
         let alpha = TenantId::new("alpha").expect("ok");
         let beta = TenantId::new("beta").expect("ok");
         // alpha: 30 + 30 = 60 > 50 -> second spend denied.
         assert_eq!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args_for_tenant(
-                    alpha.clone(),
-                    "wallet.spend",
-                    serde_json::json!({"amount": 30}),
-                ),
-                now,
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args_for_tenant(
+                        alpha.clone(),
+                        "wallet.spend",
+                        serde_json::json!({"amount": 30}),
+                    ),
+                    now,
+                )
+                .await,
             EvaluatorDecision::Allow,
         );
         assert!(matches!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args_for_tenant(
-                    alpha,
-                    "wallet.spend",
-                    serde_json::json!({"amount": 30}),
-                ),
-                now,
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args_for_tenant(
+                        alpha,
+                        "wallet.spend",
+                        serde_json::json!({"amount": 30}),
+                    ),
+                    now,
+                )
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
         // beta has its own bucket and is unaffected by alpha's spend.
         assert_eq!(
-            evaluator.evaluate_at(
-                hook_id(),
-                &spec,
-                &ctx_with_args_for_tenant(beta, "wallet.spend", serde_json::json!({"amount": 30}),),
-                now,
-            ),
+            evaluator
+                .evaluate_at(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args_for_tenant(
+                        beta,
+                        "wallet.spend",
+                        serde_json::json!({"amount": 30}),
+                    ),
+                    now,
+                )
+                .await,
             EvaluatorDecision::Allow,
         );
     }
 
-    #[test]
-    fn numeric_sum_fails_closed_with_unparseable_max() {
+    #[tokio::test]
+    async fn numeric_sum_fails_closed_with_unparseable_max() {
         let evaluator = PredicateEvaluator::new();
         let spec = numeric_sum_spec("not-a-number", "amount", "1h");
         assert!(matches!(
-            evaluator.evaluate(
-                hook_id(),
-                &spec,
-                &ctx_with_args("wallet.spend", serde_json::json!({"amount": 1})),
-            ),
+            evaluator
+                .evaluate(
+                    hook_id(),
+                    &spec,
+                    &ctx_with_args("wallet.spend", serde_json::json!({"amount": 1})),
+                )
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
     }
@@ -883,8 +959,8 @@ mod tests {
         assert_eq!(parse_window("™"), None);
     }
 
-    #[test]
-    fn invocation_counter_partitions_by_tenant() {
+    #[tokio::test]
+    async fn invocation_counter_partitions_by_tenant() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::RateOrValueCap {
             when: CapabilityPredicate::Always,
@@ -897,7 +973,7 @@ mod tests {
             },
         };
 
-        let now = Instant::now();
+        let now = base();
         let alpha = ironclaw_host_api::TenantId::new("alpha").expect("ok");
         let beta = ironclaw_host_api::TenantId::new("beta").expect("ok");
 
@@ -908,16 +984,22 @@ mod tests {
 
         // Alpha hits the cap with one allowed call and a second deny.
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx_alpha, now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx_alpha, now)
+                .await,
             EvaluatorDecision::Allow
         );
         assert!(matches!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx_alpha, now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx_alpha, now)
+                .await,
             EvaluatorDecision::Deny { .. }
         ));
         // Beta is a separate tenant and must NOT inherit alpha's counter.
         assert_eq!(
-            evaluator.evaluate_at(hook_id(), &spec, &ctx_beta, now),
+            evaluator
+                .evaluate_at(hook_id(), &spec, &ctx_beta, now)
+                .await,
             EvaluatorDecision::Allow,
             "tenants must not share rate-cap counters"
         );
@@ -942,8 +1024,8 @@ mod tests {
         assert_eq!(evaluator.evictions_observed(), 0);
     }
 
-    #[test]
-    fn unparseable_window_fails_closed() {
+    #[tokio::test]
+    async fn unparseable_window_fails_closed() {
         let evaluator = PredicateEvaluator::new();
         let spec = HookPredicateSpec::RateOrValueCap {
             when: CapabilityPredicate::Always,
@@ -956,7 +1038,7 @@ mod tests {
             },
         };
         assert!(matches!(
-            evaluator.evaluate(hook_id(), &spec, &ctx("cap.x")),
+            evaluator.evaluate(hook_id(), &spec, &ctx("cap.x")).await,
             EvaluatorDecision::Deny { .. }
         ));
     }
@@ -967,17 +1049,17 @@ mod tests {
     /// more invocation through `evaluate_at`. The backend returns
     /// `WindowOverflow`, which the evaluator must translate into the
     /// restrictive `on_exceeded` action (DENY), never `Allow`.
-    #[test]
-    fn numeric_sum_backend_overflow_surfaces_as_deny_through_evaluator() {
+    #[tokio::test]
+    async fn numeric_sum_backend_overflow_surfaces_as_deny_through_evaluator() {
         use crate::predicate_state::{
             InMemoryPredicateStateBackend, MAX_SAMPLES_PER_KEY, PredicateEventId, ValueKey,
         };
         use rust_decimal::Decimal;
-        use std::time::{Duration, Instant};
+        use std::time::Duration;
 
         let backend = Arc::new(InMemoryPredicateStateBackend::new());
         let hid = hook_id();
-        let t0 = Instant::now();
+        let t0 = base();
         let window = Duration::from_secs(3600);
         let field = "amount";
         let capability = "cap.spend";
@@ -993,10 +1075,11 @@ mod tests {
                 .record_value(
                     &key,
                     &PredicateEventId::new_unchecked(format!("seed-{i}")),
-                    t0 + Duration::from_millis(i as u64),
+                    t0 + chrono::Duration::milliseconds(i as i64),
                     Decimal::from(1),
                     window,
                 )
+                .await
                 .expect("seed insert ok");
         }
 
@@ -1017,7 +1100,9 @@ mod tests {
             },
         };
         let ctx = ctx_with_args(capability, serde_json::json!({ "amount": 1 }));
-        let decision = evaluator.evaluate_at(hook_id(), &spec, &ctx, t0 + Duration::from_secs(1));
+        let decision = evaluator
+            .evaluate_at(hook_id(), &spec, &ctx, t0 + chrono::Duration::seconds(1))
+            .await;
         assert!(
             matches!(decision, EvaluatorDecision::Deny { .. }),
             "backend WindowOverflow must fail closed as DENY, got {decision:?}"

--- a/crates/ironclaw_hooks/src/installed_hook.rs
+++ b/crates/ironclaw_hooks/src/installed_hook.rs
@@ -61,7 +61,7 @@ impl RestrictedBeforeCapabilityHook for PredicateBackedBeforeCapabilityHook {
         // `&'static str` — so we can surface a richer model-visible label
         // (`hook_rate_limit`, `hook_value_cap`, ...) without opening a
         // free-form text channel.
-        match self.evaluator.evaluate(self.hook_id, &self.spec, ctx) {
+        match self.evaluator.evaluate(self.hook_id, &self.spec, ctx).await {
             EvaluatorDecision::Allow => {
                 // The predicate did not match — the hook has no opinion. The
                 // dispatcher recognizes `pass()` as a no-opinion contribution

--- a/crates/ironclaw_hooks/src/predicate_state.rs
+++ b/crates/ironclaw_hooks/src/predicate_state.rs
@@ -7,20 +7,20 @@
 //! (Postgres-backed, libSQL-backed) implement the same trait so the
 //! evaluator's predicate logic stays backend-agnostic.
 //!
-//! # Visibility
+//! # Visibility — stable public contract
 //!
-//! The backend trait and the in-memory impl are intentionally
-//! `pub(crate)` until the durable contract is stable. The trait's `now:
-//! Instant` is correct for the in-memory backend but not serializable
-//! across processes, so a future durable trait will accept
-//! `chrono::DateTime<Utc>` (see successor doc 03-persistent-counter.md).
-//! Holding the public surface back until then avoids shipping a public
-//! API we know we'll break (serrrfirat MED on PR #3635).
+//! [`PredicateStateBackend`] and its supporting types ([`InvocationKey`],
+//! [`ValueKey`], [`PredicateBackendError`]) are **public** and form the
+//! stable contract that durable backends (Postgres-backed, libSQL-backed)
+//! implement out-of-crate. The contract was widened from `pub(crate)` in
+//! the durable-backend split (PR 1/4): the trait is now `async` (durable
+//! backends are async; a sync trait would force `block_on` on the dispatch
+//! hot path) and the clock is [`chrono::DateTime<Utc>`] rather than
+//! [`Instant`] (`Instant` is not serializable across processes).
 //!
-//! [`PredicateEventId`] stays `pub` because it flows through
-//! [`BeforeCapabilityHookContext::caller_event_id`] on the public hook
-//! surface; only the backend trait and its keys/error type are crate-
-//! internal until the durable contract is ready.
+//! Backends are exercised against the shared [`contract`] harness so every
+//! impl is proven to honor the same isolation / dedup / window invariants
+//! by construction, not per-impl.
 //!
 //! # Why a trait
 //!
@@ -43,20 +43,28 @@
 //! letting the cap drift past `max`. Implementations must hold a
 //! single lock / transaction across the write + read.
 //!
-//! # Sync trait, monotonic clock
+//! # Async trait, serializable clock
 //!
-//! The trait is **synchronous** in this PR to minimize call-site churn.
-//! [`Instant`] is monotonic (process-local) and is the right clock for
-//! the in-memory backend; durable backends will accept a
-//! [`std::time::SystemTime`]-based companion via a separate trait or
-//! adapter (tracked in the scope doc) since `Instant` cannot be
-//! serialized across processes.
+//! The trait is **async** ([`async_trait`]) so durable backends can do
+//! `tokio-postgres` / libSQL I/O without blocking the dispatch hot path.
+//! The in-memory backend completes synchronously inside the async body.
+//!
+//! The clock is [`chrono::DateTime<Utc>`] rather than [`Instant`]: a
+//! serializable wall-clock timestamp is required for durable rows that
+//! survive process restarts and are written by one host and read by
+//! another. Window trimming is age-based — an entry is trimmed when its
+//! timestamp is strictly older than `now - window`. Because
+//! `DateTime<Utc>` arithmetic saturates rather than panicking, the
+//! `Instant::checked_sub` underflow hazard of the prior design does not
+//! arise.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use ironclaw_host_api::TenantId;
 use rust_decimal::Decimal;
 
@@ -65,7 +73,7 @@ use crate::identity::HookId;
 /// Identity of an invocation-history bucket. The `tenant_id` field is
 /// the trust boundary — one tenant's counter must never affect another's.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct InvocationKey {
+pub struct InvocationKey {
     pub hook_id: HookId,
     pub tenant_id: TenantId,
     pub capability: String,
@@ -74,7 +82,7 @@ pub(crate) struct InvocationKey {
 /// Identity of a value-sum-history bucket. Extends [`InvocationKey`]
 /// with the numeric field path the predicate is summing over.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct ValueKey {
+pub struct ValueKey {
     pub hook_id: HookId,
     pub tenant_id: TenantId,
     pub capability: String,
@@ -248,7 +256,7 @@ impl PredicateEventId {
 /// transient failures (connection lost, DB unavailable); the in-memory
 /// backend never returns errors.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum PredicateBackendError {
+pub enum PredicateBackendError {
     #[error("predicate state backend is unavailable: {0}")]
     #[allow(dead_code)] // populated by future durable backends; in-memory is infallible
     Unavailable(String),
@@ -277,7 +285,7 @@ pub(crate) enum PredicateBackendError {
 /// Backend for the predicate evaluator's sliding-window state.
 ///
 /// Each method is bracketed by `now` so tests can drive a deterministic
-/// clock; production callers pass [`Instant::now()`].
+/// clock; production callers pass [`Utc::now()`].
 ///
 /// # Atomicity contract
 ///
@@ -328,27 +336,28 @@ pub(crate) enum PredicateBackendError {
 /// (henrypark133 security note on PR #3635). Threat-model finding D5a
 /// also captures the high-cardinality-key LRU-eviction variant that lets
 /// an attacker reset another tenant's counter on the in-memory backend.
-pub(crate) trait PredicateStateBackend: Send + Sync {
+#[async_trait]
+pub trait PredicateStateBackend: Send + Sync {
     /// Record an invocation at `now` against `key` (idempotent against
     /// `event_id`) and return the resulting in-window count after
     /// trimming entries older than `window`. Atomic against concurrent
     /// writers.
-    fn record_invocation(
+    async fn record_invocation(
         &self,
         key: &InvocationKey,
         event_id: &PredicateEventId,
-        now: Instant,
+        now: DateTime<Utc>,
         window: Duration,
     ) -> Result<u32, PredicateBackendError>;
 
     /// Record a numeric value at `now` against `key` (idempotent
     /// against `event_id`) and return the resulting in-window sum
     /// after trimming. Atomic against concurrent writers.
-    fn record_value(
+    async fn record_value(
         &self,
         key: &ValueKey,
         event_id: &PredicateEventId,
-        now: Instant,
+        now: DateTime<Utc>,
         value: Decimal,
         window: Duration,
     ) -> Result<Decimal, PredicateBackendError>;
@@ -367,7 +376,7 @@ pub(crate) trait PredicateStateBackend: Send + Sync {
     /// backend PR) so trait-object callers don't break when the durable
     /// impl lands — henrypark133 important #5 on PR #3635.
     #[allow(dead_code)] // operator reaper hook for future durable backends
-    fn evict_older_than(&self, _cutoff: Instant) -> Result<u64, PredicateBackendError> {
+    async fn evict_older_than(&self, _cutoff: DateTime<Utc>) -> Result<u64, PredicateBackendError> {
         Ok(0)
     }
 }
@@ -389,7 +398,7 @@ pub(crate) trait PredicateStateBackend: Send + Sync {
 ///   become a zombie LRU-skip.
 #[derive(Debug, Default)]
 struct InvocationBucket {
-    entries: VecDeque<(Instant, PredicateEventId)>,
+    entries: VecDeque<(DateTime<Utc>, PredicateEventId)>,
     dedup_ids: HashSet<PredicateEventId>,
 }
 
@@ -400,7 +409,7 @@ impl InvocationBucket {
         }
     }
 
-    fn push_back(&mut self, ts: Instant, event_id: PredicateEventId) {
+    fn push_back(&mut self, ts: DateTime<Utc>, event_id: PredicateEventId) {
         self.dedup_ids.insert(event_id.clone());
         self.entries.push_back((ts, event_id));
     }
@@ -416,7 +425,7 @@ impl InvocationBucket {
 /// two ways the deque mutates.
 #[derive(Debug, Default)]
 struct ValueBucket {
-    entries: VecDeque<(Instant, Decimal, PredicateEventId)>,
+    entries: VecDeque<(DateTime<Utc>, Decimal, PredicateEventId)>,
     dedup_ids: HashSet<PredicateEventId>,
     running_sum: Decimal,
 }
@@ -429,7 +438,7 @@ impl ValueBucket {
         }
     }
 
-    fn push_back(&mut self, ts: Instant, value: Decimal, event_id: PredicateEventId) {
+    fn push_back(&mut self, ts: DateTime<Utc>, value: Decimal, event_id: PredicateEventId) {
         self.dedup_ids.insert(event_id.clone());
         self.running_sum += value;
         self.entries.push_back((ts, value, event_id));
@@ -443,7 +452,7 @@ impl ValueBucket {
 ///
 /// State is per-instance; cross-process consistency + restart survival
 /// require a durable backend (separate PR).
-pub(crate) struct InMemoryPredicateStateBackend {
+pub struct InMemoryPredicateStateBackend {
     invocation_history: Mutex<HashMap<InvocationKey, InvocationBucket>>,
     value_history: Mutex<HashMap<ValueKey, ValueBucket>>,
     evictions: AtomicU64,
@@ -503,12 +512,28 @@ impl Default for InMemoryPredicateStateBackend {
     }
 }
 
+/// Compute the sliding-window cutoff `now - window` as a wall-clock
+/// timestamp. `window` is a [`std::time::Duration`] (always non-negative);
+/// `chrono::Duration::from_std` only fails if the window exceeds chrono's
+/// `i64`-millisecond range (~292 million years), which no parsed predicate
+/// window can reach — in that pathological case we saturate to `now`,
+/// meaning nothing is trimmed (conservative for a rate/value cap). Unlike
+/// the prior `Instant::checked_sub`, `DateTime<Utc>` subtraction never
+/// panics or underflows.
+fn window_cutoff(now: DateTime<Utc>, window: Duration) -> DateTime<Utc> {
+    match chrono::Duration::from_std(window) {
+        Ok(d) => now.checked_sub_signed(d).unwrap_or(now),
+        Err(_) => now,
+    }
+}
+
+#[async_trait]
 impl PredicateStateBackend for InMemoryPredicateStateBackend {
-    fn record_invocation(
+    async fn record_invocation(
         &self,
         key: &InvocationKey,
         event_id: &PredicateEventId,
-        now: Instant,
+        now: DateTime<Utc>,
         window: Duration,
     ) -> Result<u32, PredicateBackendError> {
         // Single-lock atomic record-and-read (codex Critical: must not
@@ -539,21 +564,17 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
             }
         }
         let bucket = history.entry(key.clone()).or_default();
-        // Trim entries outside the window by AGE, not by an absolute
-        // cutoff. `now.checked_sub(window)` underflows the monotonic clock
-        // when `window` exceeds the representable past (e.g. a 24h window
-        // shortly after boot), and the old `unwrap_or(now)` then collapsed
-        // the cutoff to `now`, trimming every valid prior entry — a long
-        // window behaved like a zero-width one (codex review on PR #3635,
-        // Bug 2). Comparing each entry's age against `window` is correct
-        // regardless of how far back `now - window` would be; future
-        // timestamps (`ts > now`, possible only via a test clock) yield
-        // `None` age and are treated as fresh, never trimmed.
+        // Trim entries outside the window using a wall-clock cutoff. With
+        // the `DateTime<Utc>` clock, `window_cutoff` computes `now - window`
+        // via saturating `chrono` arithmetic, so the `Instant::checked_sub`
+        // underflow that collapsed long windows to "only now" (codex review
+        // on PR #3635, Bug 2) cannot arise — year-2026 minus any realistic
+        // window stays well above `DateTime::MIN`. The strict `<` keeps an
+        // entry exactly at the cutoff in-window. Trimming via `pop_front`
+        // keeps the `dedup_ids` set in sync.
+        let cutoff = window_cutoff(now, window);
         while let Some((front_ts, _)) = bucket.entries.front() {
-            let trim = now
-                .checked_duration_since(*front_ts)
-                .is_some_and(|age| age > window);
-            if trim {
+            if *front_ts < cutoff {
                 bucket.pop_front();
             } else {
                 break;
@@ -598,11 +619,11 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
         Ok(count)
     }
 
-    fn record_value(
+    async fn record_value(
         &self,
         key: &ValueKey,
         event_id: &PredicateEventId,
-        now: Instant,
+        now: DateTime<Utc>,
         value: Decimal,
         window: Duration,
     ) -> Result<Decimal, PredicateBackendError> {
@@ -622,13 +643,11 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
             }
         }
         let bucket = history.entry(key.clone()).or_default();
-        // Trim by AGE, not an absolute cutoff — see `record_invocation`
-        // for the underflow rationale (codex review on PR #3635, Bug 2).
+        // Wall-clock cutoff trim — see `record_invocation` for why the
+        // `DateTime<Utc>` clock removes the Bug 2 underflow hazard.
+        let cutoff = window_cutoff(now, window);
         while let Some((ts, _, _)) = bucket.entries.front() {
-            let trim = now
-                .checked_duration_since(*ts)
-                .is_some_and(|age| age > window);
-            if trim {
+            if *ts < cutoff {
                 bucket.pop_front();
             } else {
                 break;
@@ -685,7 +704,7 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
     /// is hitting those keys (henrypark133 MED on PR #3635 5-19 review:
     /// the default no-op was misleading because callers expected it to
     /// reclaim memory).
-    fn evict_older_than(&self, cutoff: Instant) -> Result<u64, PredicateBackendError> {
+    async fn evict_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64, PredicateBackendError> {
         let mut dropped: u64 = 0;
         {
             let mut history = match self.invocation_history.lock() {
@@ -828,6 +847,433 @@ fn evict_lru_value_for_tenant(
     }
 }
 
+/// Trait-level contract test harness for [`PredicateStateBackend`].
+///
+/// This establishes the **scaffolding pattern** (mirrors
+/// `ironclaw_memory::contract_tests`, #3918): every invariant the trait
+/// promises is defined once here as a `pub async fn` taking a factory
+/// closure, and every impl wires the suite once. Durable backends added
+/// in the durable-backend split (PRs 2/3 — Postgres, libSQL) drop into
+/// the same suite so isolation / dedup / window / atomicity invariants
+/// are proven for every impl by construction, not per-impl.
+///
+/// The in-memory backend is wired below via [`contract_test!`]; that is
+/// the proof that the harness shape works with one backend before the
+/// durable impls land.
+///
+/// Gated on `any(test, feature = "contract-tests")` so out-of-crate
+/// durable backends can depend on `ironclaw_hooks` with the
+/// `contract-tests` feature and run the same suite against their impl.
+#[cfg(any(test, feature = "contract-tests"))]
+pub mod contract {
+    use super::*;
+
+    use crate::identity::{ExtensionId, HookLocalId, HookVersion};
+
+    /// Factory closure shape every contract takes. Must return a fresh,
+    /// empty backend — contracts assume nothing leaks between calls.
+    fn hook_id() -> HookId {
+        HookId::derive(
+            &ExtensionId::new("ext").expect("ext id is valid"),
+            "1.0",
+            &HookLocalId::new("h").expect("hook local id is valid"),
+            HookVersion::ONE,
+        )
+    }
+
+    fn tenant_named(name: &str) -> TenantId {
+        TenantId::new(name).expect("valid tenant id")
+    }
+
+    fn ev(s: &str) -> PredicateEventId {
+        PredicateEventId::new_unchecked(s)
+    }
+
+    fn inv_key(tenant: &str, capability: &str) -> InvocationKey {
+        InvocationKey {
+            hook_id: hook_id(),
+            tenant_id: tenant_named(tenant),
+            capability: capability.to_string(),
+        }
+    }
+
+    fn val_key(tenant: &str, capability: &str, field: &str) -> ValueKey {
+        ValueKey {
+            hook_id: hook_id(),
+            tenant_id: tenant_named(tenant),
+            capability: capability.to_string(),
+            field: field.to_string(),
+        }
+    }
+
+    /// Shared fixed wall-clock base so contracts are deterministic.
+    fn base() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_700_000_000, 0).expect("valid fixed timestamp")
+    }
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        base() + chrono::Duration::seconds(secs)
+    }
+
+    /// Contract: invocations within the window accumulate.
+    pub async fn invocation_counts_within_window<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let key = inv_key("alpha", "cap.x");
+        let c1 = backend
+            .record_invocation(&key, &ev("e1"), at(0), Duration::from_secs(60))
+            .await
+            .expect("ok");
+        let c2 = backend
+            .record_invocation(&key, &ev("e2"), at(1), Duration::from_secs(60))
+            .await
+            .expect("ok");
+        assert_eq!(c1, 1);
+        assert_eq!(c2, 2);
+    }
+
+    /// Contract: entries older than the window are trimmed.
+    pub async fn invocation_trims_outside_window<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let key = inv_key("alpha", "cap.x");
+        let _ = backend
+            .record_invocation(&key, &ev("e1"), at(0), Duration::from_secs(10))
+            .await
+            .expect("ok");
+        let count = backend
+            .record_invocation(&key, &ev("e2"), at(100), Duration::from_secs(10))
+            .await
+            .expect("ok");
+        assert_eq!(count, 1, "earlier entry should be trimmed");
+    }
+
+    /// Contract: numeric values within the window sum.
+    pub async fn value_sums_within_window<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let key = val_key("alpha", "cap.x", "amount");
+        let s1 = backend
+            .record_value(
+                &key,
+                &ev("e1"),
+                at(0),
+                Decimal::from(50),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("ok");
+        let s2 = backend
+            .record_value(
+                &key,
+                &ev("e2"),
+                at(1),
+                Decimal::from(75),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("ok");
+        assert_eq!(s1, Decimal::from(50));
+        assert_eq!(s2, Decimal::from(125));
+    }
+
+    /// Contract: one tenant's counter never inherits another's increments.
+    pub async fn tenant_isolation<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let alpha = inv_key("alpha", "cap.x");
+        let beta = inv_key("beta", "cap.x");
+        for e in ["e1", "e2", "e3"] {
+            backend
+                .record_invocation(&alpha, &ev(e), at(0), Duration::from_secs(60))
+                .await
+                .expect("ok");
+        }
+        let beta_count = backend
+            .record_invocation(&beta, &ev("b1"), at(0), Duration::from_secs(60))
+            .await
+            .expect("ok");
+        assert_eq!(
+            beta_count, 1,
+            "tenant β's counter must not inherit α's increments"
+        );
+    }
+
+    /// Contract: re-emitting a recorded `event_id` is a no-op against the
+    /// invocation count (replay refusal — load-bearing, codex Critical on
+    /// PR #3635).
+    pub async fn duplicate_event_id_is_noop_for_invocations<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let key = inv_key("alpha", "cap.x");
+        let c1 = backend
+            .record_invocation(&key, &ev("event-A"), at(0), Duration::from_secs(60))
+            .await
+            .expect("ok");
+        let c2 = backend
+            .record_invocation(&key, &ev("event-A"), at(1), Duration::from_secs(60))
+            .await
+            .expect("ok");
+        let c3 = backend
+            .record_invocation(&key, &ev("event-B"), at(2), Duration::from_secs(60))
+            .await
+            .expect("ok");
+        assert_eq!(c1, 1);
+        assert_eq!(c2, 1, "duplicate event-A must not increment");
+        assert_eq!(c3, 2, "distinct event-B advances the count");
+    }
+
+    /// Contract: replayed `event_id` is a no-op against the value sum.
+    pub async fn duplicate_event_id_is_noop_for_values<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let key = val_key("alpha", "cap.x", "amount");
+        let s1 = backend
+            .record_value(
+                &key,
+                &ev("event-A"),
+                at(0),
+                Decimal::from(50),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("ok");
+        let s2 = backend
+            .record_value(
+                &key,
+                &ev("event-A"),
+                at(1),
+                Decimal::from(50),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("ok");
+        let s3 = backend
+            .record_value(
+                &key,
+                &ev("event-B"),
+                at(2),
+                Decimal::from(75),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("ok");
+        assert_eq!(s1, Decimal::from(50));
+        assert_eq!(
+            s2,
+            Decimal::from(50),
+            "duplicate event-A must not double-count"
+        );
+        assert_eq!(s3, Decimal::from(125));
+    }
+
+    /// Contract: an entry whose timestamp equals the cutoff is RETAINED
+    /// (`< cutoff` trim, not `<=`).
+    pub async fn invocation_retains_entry_at_exact_window_cutoff<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let key = inv_key("alpha", "cap.boundary");
+        let window = Duration::from_secs(60);
+        let _ = backend
+            .record_invocation(&key, &ev("e-at-t0"), at(0), window)
+            .await
+            .expect("ok");
+        let at_cutoff = backend
+            .record_invocation(&key, &ev("e-at-boundary"), at(60), window)
+            .await
+            .expect("ok");
+        assert_eq!(
+            at_cutoff, 2,
+            "entry whose timestamp equals the cutoff is retained (< cutoff, not <=)"
+        );
+    }
+
+    /// Contract: dedup is isolated across the invocation and value maps —
+    /// the same `event_id` in both must not collide.
+    pub async fn event_id_dedup_isolated_across_maps<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let inv = inv_key("alpha", "cap.cross");
+        let val = val_key("alpha", "cap.cross", "amount");
+        let shared = ev("shared-event-id");
+        let inv_count = backend
+            .record_invocation(&inv, &shared, at(0), Duration::from_secs(60))
+            .await
+            .expect("ok");
+        let val_sum = backend
+            .record_value(
+                &val,
+                &shared,
+                at(0),
+                Decimal::from(42),
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("ok");
+        assert_eq!(
+            inv_count, 1,
+            "value map's dedup must not pre-empt invocation"
+        );
+        assert_eq!(
+            val_sum,
+            Decimal::from(42),
+            "invocation map's dedup must not pre-empt value"
+        );
+    }
+
+    /// Contract: the per-key sample cap is FAIL CLOSED. Filling a single
+    /// key past [`MAX_SAMPLES_PER_KEY`] with distinct in-window event ids
+    /// must return [`PredicateBackendError::WindowOverflow`] rather than
+    /// silently evicting the oldest sample (PR #3635 followup / #3929). The
+    /// evaluator maps this `Err` to the restrictive `on_exceeded` action, so
+    /// overflow surfaces as DENY, never a silent Allow. Every backend —
+    /// in-memory and durable — must honor this by construction.
+    pub async fn record_invocation_overflow_is_fail_closed<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let key = inv_key("alpha", "cap.hot");
+        let window = Duration::from_secs(3600);
+        // Space samples by 1ms so all `MAX_SAMPLES_PER_KEY` stay inside the
+        // 1h window (seconds-spacing would push the earliest out of window
+        // before the cap is reached).
+        let at_ms = |ms: i64| base() + chrono::Duration::milliseconds(ms);
+        // Fill exactly to the cap with distinct in-window ids — all succeed.
+        for i in 0..MAX_SAMPLES_PER_KEY {
+            let count = backend
+                .record_invocation(&key, &ev(&format!("e-{i}")), at_ms(i as i64), window)
+                .await
+                .expect("inserts up to the cap succeed");
+            assert_eq!(count as usize, i + 1);
+        }
+        // The next distinct in-window id must fail closed, not silent-evict.
+        let result = backend
+            .record_invocation(
+                &key,
+                &ev("e-overflow"),
+                at_ms(MAX_SAMPLES_PER_KEY as i64),
+                window,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(PredicateBackendError::WindowOverflow { .. })),
+            "hitting the per-key cap must fail closed, got {result:?}"
+        );
+        // A replay of an in-window id at the cap dedups to a no-op (returns
+        // the unchanged count) rather than overflowing — replay refusal must
+        // survive the cap boundary.
+        let replay = backend
+            .record_invocation(
+                &key,
+                &ev("e-0"),
+                at_ms(MAX_SAMPLES_PER_KEY as i64 + 1),
+                window,
+            )
+            .await
+            .expect("replay of an in-window id must dedup, not overflow");
+        assert_eq!(
+            replay as usize, MAX_SAMPLES_PER_KEY,
+            "replay at the cap is a no-op against the count"
+        );
+    }
+
+    /// Run every contract against `factory`. Per-impl test files invoke
+    /// this via [`contract_test!`].
+    #[macro_export]
+    macro_rules! predicate_backend_contract_test {
+        ($label:ident, $factory:expr) => {
+            mod $label {
+                #[tokio::test]
+                async fn invocation_counts_within_window() {
+                    $crate::predicate_state::contract::invocation_counts_within_window($factory)
+                        .await;
+                }
+                #[tokio::test]
+                async fn invocation_trims_outside_window() {
+                    $crate::predicate_state::contract::invocation_trims_outside_window($factory)
+                        .await;
+                }
+                #[tokio::test]
+                async fn value_sums_within_window() {
+                    $crate::predicate_state::contract::value_sums_within_window($factory).await;
+                }
+                #[tokio::test]
+                async fn tenant_isolation() {
+                    $crate::predicate_state::contract::tenant_isolation($factory).await;
+                }
+                #[tokio::test]
+                async fn duplicate_event_id_is_noop_for_invocations() {
+                    $crate::predicate_state::contract::duplicate_event_id_is_noop_for_invocations(
+                        $factory,
+                    )
+                    .await;
+                }
+                #[tokio::test]
+                async fn duplicate_event_id_is_noop_for_values() {
+                    $crate::predicate_state::contract::duplicate_event_id_is_noop_for_values(
+                        $factory,
+                    )
+                    .await;
+                }
+                #[tokio::test]
+                async fn invocation_retains_entry_at_exact_window_cutoff() {
+                    $crate::predicate_state::contract::invocation_retains_entry_at_exact_window_cutoff(
+                        $factory,
+                    )
+                    .await;
+                }
+                #[tokio::test]
+                async fn event_id_dedup_isolated_across_maps() {
+                    $crate::predicate_state::contract::event_id_dedup_isolated_across_maps($factory)
+                        .await;
+                }
+                #[tokio::test]
+                async fn record_invocation_overflow_is_fail_closed() {
+                    $crate::predicate_state::contract::record_invocation_overflow_is_fail_closed(
+                        $factory,
+                    )
+                    .await;
+                }
+            }
+        };
+    }
+}
+
+// Wire the in-memory backend through the shared contract suite. This is
+// the proof that the harness shape works with one backend before the
+// durable impls (PRs 2/3) drop in.
+#[cfg(test)]
+crate::predicate_backend_contract_test!(
+    in_memory,
+    crate::predicate_state::InMemoryPredicateStateBackend::new
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -850,6 +1296,22 @@ mod tests {
     fn ev(s: &str) -> PredicateEventId {
         // Test fixture ids are well-formed; use unchecked.
         PredicateEventId::new_unchecked(s)
+    }
+
+    /// Fixed wall-clock base so window arithmetic is deterministic. The
+    /// clock is now `DateTime<Utc>` (serializable across processes) rather
+    /// than `Instant`; `+ chrono::Duration` advances it without the
+    /// `Instant::checked_sub` underflow hazard of the prior design.
+    fn base() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_700_000_000, 0).expect("valid fixed timestamp")
+    }
+
+    fn at_secs(secs: i64) -> DateTime<Utc> {
+        base() + chrono::Duration::seconds(secs)
+    }
+
+    fn at_millis(ms: i64) -> DateTime<Utc> {
+        base() + chrono::Duration::milliseconds(ms)
     }
 
     /// serrrfirat MEDIUM regression on PR #3635: caller-facing
@@ -889,11 +1351,7 @@ mod tests {
 
     /// henrypark133 LOW on PR #3635 5-19 review (equality-oracle closure):
     /// two calls with bit-identical `(hook_id_bytes, capability_name)` must
-    /// produce DISTINCT synth ids. Otherwise the 64-char hex output would be
-    /// an equality oracle: an observer of two event ids could correlate
-    /// "same hook + same capability" across tenants. The process-global
-    /// counter + thread-local nonce in the hash input must drive divergence
-    /// even when the caller's inputs collide.
+    /// produce DISTINCT synth ids.
     #[test]
     fn synth_diverges_on_identical_inputs() {
         let a = PredicateEventId::synth(b"hookid-bytes", "cap.x");
@@ -916,245 +1374,36 @@ mod tests {
         );
     }
 
-    #[test]
-    fn in_memory_invocation_counts_within_window() {
-        let backend = InMemoryPredicateStateBackend::new();
-        let key = InvocationKey {
-            hook_id: hook_id(),
-            tenant_id: tenant(),
-            capability: "cap.x".to_string(),
-        };
-        let now = Instant::now();
-        let count_1 = backend
-            .record_invocation(&key, &ev("e1"), now, Duration::from_secs(60))
-            .expect("ok");
-        let count_2 = backend
-            .record_invocation(
-                &key,
-                &ev("e2"),
-                now + Duration::from_secs(1),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        assert_eq!(count_1, 1);
-        assert_eq!(count_2, 2);
-    }
-
-    #[test]
-    fn in_memory_invocation_trims_outside_window() {
-        let backend = InMemoryPredicateStateBackend::new();
-        let key = InvocationKey {
-            hook_id: hook_id(),
-            tenant_id: tenant(),
-            capability: "cap.x".to_string(),
-        };
-        let t0 = Instant::now();
-        let _ = backend
-            .record_invocation(&key, &ev("e1"), t0, Duration::from_secs(10))
-            .expect("ok");
-        let count = backend
-            .record_invocation(
-                &key,
-                &ev("e2"),
-                t0 + Duration::from_secs(100),
-                Duration::from_secs(10),
-            )
-            .expect("ok");
-        assert_eq!(count, 1, "earlier entry should be trimmed");
-    }
-
-    #[test]
-    fn in_memory_value_sums_within_window() {
-        let backend = InMemoryPredicateStateBackend::new();
-        let key = ValueKey {
-            hook_id: hook_id(),
-            tenant_id: tenant(),
-            capability: "cap.x".to_string(),
-            field: "amount".to_string(),
-        };
-        let now = Instant::now();
-        let sum_1 = backend
-            .record_value(
-                &key,
-                &ev("e1"),
-                now,
-                Decimal::from(50),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        let sum_2 = backend
-            .record_value(
-                &key,
-                &ev("e2"),
-                now + Duration::from_secs(1),
-                Decimal::from(75),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        assert_eq!(sum_1, Decimal::from(50));
-        assert_eq!(sum_2, Decimal::from(125));
-    }
-
-    #[test]
-    fn in_memory_tenant_isolation() {
-        let backend = InMemoryPredicateStateBackend::new();
-        let alpha_key = InvocationKey {
-            hook_id: hook_id(),
-            tenant_id: TenantId::new("alpha").expect("ok"),
-            capability: "cap.x".to_string(),
-        };
-        let beta_key = InvocationKey {
-            hook_id: hook_id(),
-            tenant_id: TenantId::new("beta").expect("ok"),
-            capability: "cap.x".to_string(),
-        };
-        let now = Instant::now();
-        backend
-            .record_invocation(&alpha_key, &ev("e1"), now, Duration::from_secs(60))
-            .expect("ok");
-        backend
-            .record_invocation(&alpha_key, &ev("e2"), now, Duration::from_secs(60))
-            .expect("ok");
-        backend
-            .record_invocation(&alpha_key, &ev("e3"), now, Duration::from_secs(60))
-            .expect("ok");
-        let beta_count = backend
-            .record_invocation(&beta_key, &ev("b1"), now, Duration::from_secs(60))
-            .expect("ok");
-        assert_eq!(
-            beta_count, 1,
-            "tenant β's counter must not inherit α's increments"
-        );
-    }
-
-    /// Replay refusal: re-emitting the same `event_id` against an
-    /// already-recorded invocation must NOT increment the count.
-    /// Load-bearing for safe replay across host restarts (codex
-    /// Critical on PR #3635).
-    #[test]
-    fn in_memory_duplicate_event_id_is_a_noop_for_invocations() {
-        let backend = InMemoryPredicateStateBackend::new();
-        let key = InvocationKey {
-            hook_id: hook_id(),
-            tenant_id: tenant(),
-            capability: "cap.x".to_string(),
-        };
-        let now = Instant::now();
-        let count_1 = backend
-            .record_invocation(&key, &ev("event-A"), now, Duration::from_secs(60))
-            .expect("ok");
-        let count_2 = backend
-            .record_invocation(
-                &key,
-                &ev("event-A"),
-                now + Duration::from_secs(1),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        let count_3 = backend
-            .record_invocation(
-                &key,
-                &ev("event-B"),
-                now + Duration::from_secs(2),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        assert_eq!(count_1, 1);
-        assert_eq!(count_2, 1, "duplicate event-A must not increment");
-        assert_eq!(count_3, 2, "distinct event-B advances the count");
-    }
-
-    #[test]
-    fn in_memory_duplicate_event_id_is_a_noop_for_values() {
-        let backend = InMemoryPredicateStateBackend::new();
-        let key = ValueKey {
-            hook_id: hook_id(),
-            tenant_id: tenant(),
-            capability: "cap.x".to_string(),
-            field: "amount".to_string(),
-        };
-        let now = Instant::now();
-        let sum_1 = backend
-            .record_value(
-                &key,
-                &ev("event-A"),
-                now,
-                Decimal::from(50),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        let sum_2 = backend
-            .record_value(
-                &key,
-                &ev("event-A"),
-                now + Duration::from_secs(1),
-                Decimal::from(50),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        let sum_3 = backend
-            .record_value(
-                &key,
-                &ev("event-B"),
-                now + Duration::from_secs(2),
-                Decimal::from(75),
-                Duration::from_secs(60),
-            )
-            .expect("ok");
-        assert_eq!(sum_1, Decimal::from(50));
-        assert_eq!(
-            sum_2,
-            Decimal::from(50),
-            "duplicate event-A must not double-count the value"
-        );
-        assert_eq!(sum_3, Decimal::from(125));
-    }
-
     /// codex P1 #1 regression: dedup memory must be tied to the window,
     /// not a fixed-size ring. Under high-throughput keys (>256 distinct
     /// in-window events), an event re-emitted from far back in the
-    /// window was previously silently re-counted because its event-id
-    /// had aged out of the `recent_ids` ring. Now dedup checks against
-    /// every in-window entry, so this can't happen.
-    #[test]
-    fn dedup_memory_covers_full_window_under_high_throughput() {
+    /// window must still be deduped.
+    #[tokio::test]
+    async fn dedup_memory_covers_full_window_under_high_throughput() {
         let backend = InMemoryPredicateStateBackend::new();
         let key = InvocationKey {
             hook_id: hook_id(),
             tenant_id: tenant(),
             capability: "cap.busy".to_string(),
         };
-        let t0 = Instant::now();
         let window = Duration::from_secs(3600);
-        // Push 512 distinct events into the bucket within the window.
-        // The old implementation capped the dedup ring at 256, so
-        // event-0's id had aged out — a replay would have silently
-        // counted again. With the new design (dedup vs in-window
-        // entries), every replay is a no-op.
-        for i in 0..512u32 {
+        for i in 0..512i64 {
             let _ = backend
-                .record_invocation(
-                    &key,
-                    &ev(&format!("event-{i}")),
-                    t0 + Duration::from_millis(i as u64),
-                    window,
-                )
+                .record_invocation(&key, &ev(&format!("event-{i}")), at_millis(i), window)
+                .await
                 .expect("ok");
         }
         let count_after_inserts = backend
-            .record_invocation(
-                &key,
-                &ev("event-fresh"),
-                t0 + Duration::from_secs(1),
-                window,
-            )
+            .record_invocation(&key, &ev("event-fresh"), at_secs(1), window)
+            .await
             .expect("ok");
         assert_eq!(count_after_inserts, 513);
 
-        // Replay the FIRST event id — should be a no-op because
-        // event-0's timestamp is still in the window.
+        // Replay the FIRST event id — should be a no-op because event-0's
+        // timestamp is still in the window.
         let count_after_replay = backend
-            .record_invocation(&key, &ev("event-0"), t0 + Duration::from_secs(2), window)
+            .record_invocation(&key, &ev("event-0"), at_secs(2), window)
+            .await
             .expect("ok");
         assert_eq!(
             count_after_replay, 513,
@@ -1162,22 +1411,10 @@ mod tests {
         );
     }
 
-    /// codex P1 #2: in the prior design, `recent_ids` was a separate
-    /// ring from `entries`. A duplicate-replay after the window expired
-    /// would trim `entries` to empty, then the duplicate check would
-    /// hit `recent_ids` (still populated) and skip the new entry —
-    /// leaving the bucket empty AND retained, where the LRU search
-    /// filtered it out as a zombie. The new design dedupes against
-    /// `entries` directly, so once `entries` is empty there are no
-    /// dedup hits and the call adds a fresh entry. The unreachable-by-
-    /// record-flow empty-bucket case is still defended at the LRU
-    /// level (see `lru_evicts_empty_buckets_first`).
-    ///
-    /// LRU defense-in-depth: even if some path leaves an empty bucket,
-    /// the LRU eviction must prefer it as the first victim instead of
-    /// skipping it (which would let zombies accumulate).
-    #[test]
-    fn lru_evicts_empty_buckets_first() {
+    /// codex P1 #2 / LRU defense-in-depth: even if some path leaves an
+    /// empty bucket, the LRU eviction must prefer it as the first victim.
+    #[tokio::test]
+    async fn lru_evicts_empty_buckets_first() {
         let backend = InMemoryPredicateStateBackend::new();
         let empty_key = InvocationKey {
             hook_id: hook_id(),
@@ -1189,16 +1426,13 @@ mod tests {
             tenant_id: tenant(),
             capability: "cap.live".to_string(),
         };
-        // Manually craft an empty bucket alongside a live one to
-        // simulate the bug condition.
         {
             let mut map = backend.invocation_history.lock().expect("ok");
             map.insert(empty_key.clone(), InvocationBucket::default());
             let mut live = InvocationBucket::default();
-            live.entries.push_back((Instant::now(), ev("live-evt")));
+            live.entries.push_back((at_secs(0), ev("live-evt")));
             map.insert(live_key.clone(), live);
         }
-        // Force an LRU pass.
         {
             let mut map = backend.invocation_history.lock().expect("ok");
             evict_lru_invocation(&mut map, &backend.evictions);
@@ -1215,21 +1449,11 @@ mod tests {
         assert_eq!(backend.evictions_observed(), 1);
     }
 
-    /// henrypark133 missing-coverage on PR #3635: drive the LRU eviction
-    /// path through the **public** `record_invocation` API. A single
-    /// tenant inserting more than [`MAX_KEYS_PER_TENANT`] distinct keys
-    /// triggers the per-tenant eviction path (henrypark133 MED on PR
-    /// #3635 5-19 review); the global [`MAX_HISTORY_KEYS`] cap is still
-    /// the outer bound but the per-tenant quota fires first when a
-    /// single tenant is the noisy one.
-    #[test]
-    fn per_tenant_quota_holds_single_tenant_at_its_cap() {
+    /// henrypark133 missing-coverage on PR #3635: drive the per-tenant
+    /// eviction path through the public `record_invocation` API.
+    #[tokio::test]
+    async fn per_tenant_quota_holds_single_tenant_at_its_cap() {
         let backend = InMemoryPredicateStateBackend::new();
-        let now = Instant::now();
-        // Insert MAX_KEYS_PER_TENANT + 1 distinct keys for a single
-        // tenant via the public API. The (MAX_KEYS_PER_TENANT + 1)th
-        // record_invocation must trigger the per-tenant eviction so the
-        // map never exceeds MAX_KEYS_PER_TENANT for that tenant.
         for i in 0..=MAX_KEYS_PER_TENANT {
             let key = InvocationKey {
                 hook_id: hook_id(),
@@ -1237,7 +1461,13 @@ mod tests {
                 capability: format!("cap.{i}"),
             };
             let _ = backend
-                .record_invocation(&key, &ev(&format!("e{i}")), now, Duration::from_secs(60))
+                .record_invocation(
+                    &key,
+                    &ev(&format!("e{i}")),
+                    at_secs(0),
+                    Duration::from_secs(60),
+                )
+                .await
                 .expect("record ok");
         }
         let map = backend.invocation_history.lock().expect("lock ok");
@@ -1253,30 +1483,29 @@ mod tests {
         );
     }
 
-    /// henrypark133 MED on PR #3635 5-19 review: the per-tenant quota
-    /// must guarantee that a noisy tenant cannot evict another tenant's
-    /// bucket. Tenant α fills its quota; tenant β's prior bucket must
-    /// survive.
-    #[test]
-    fn per_tenant_quota_isolates_tenants_from_each_other() {
+    /// henrypark133 MED on PR #3635 5-19 review: the per-tenant quota must
+    /// guarantee that a noisy tenant cannot evict another tenant's bucket.
+    #[tokio::test]
+    async fn per_tenant_quota_isolates_tenants_from_each_other() {
         let backend = InMemoryPredicateStateBackend::new();
-        let now = Instant::now();
         let alpha = TenantId::new("alpha").expect("ok");
         let beta = TenantId::new("beta").expect("ok");
 
-        // β records first so its bucket is the "oldest" in the global
-        // map by insertion order. Without the per-tenant quota, α's
-        // overflow would evict β's bucket as the global LRU victim.
         let beta_key = InvocationKey {
             hook_id: hook_id(),
             tenant_id: beta.clone(),
             capability: "beta.cap".to_string(),
         };
         backend
-            .record_invocation(&beta_key, &ev("beta-evt"), now, Duration::from_secs(60))
+            .record_invocation(
+                &beta_key,
+                &ev("beta-evt"),
+                at_secs(0),
+                Duration::from_secs(60),
+            )
+            .await
             .expect("ok");
 
-        // α then floods past its per-tenant cap.
         for i in 0..=MAX_KEYS_PER_TENANT {
             let key = InvocationKey {
                 hook_id: hook_id(),
@@ -1287,14 +1516,13 @@ mod tests {
                 .record_invocation(
                     &key,
                     &ev(&format!("alpha-e{i}")),
-                    now + Duration::from_millis(i as u64 + 1),
+                    at_millis(i as i64 + 1),
                     Duration::from_secs(60),
                 )
+                .await
                 .expect("ok");
         }
 
-        // β's bucket must still be present — α's overflow evicted its
-        // own oldest-front bucket, not β's.
         let map = backend.invocation_history.lock().expect("ok");
         assert!(
             map.contains_key(&beta_key),
@@ -1307,15 +1535,11 @@ mod tests {
         );
     }
 
-    /// henrypark133 MED on PR #3635 5-19 review: `evict_older_than` was
-    /// previously a no-op `Ok(0)` default. The in-memory backend now
-    /// implements it to drop entries whose timestamp is strictly older
-    /// than the cutoff and remove buckets that become empty. Operator
-    /// reaper tasks rely on this to reclaim memory from idle keys.
-    #[test]
-    fn evict_older_than_drops_expired_entries_and_empty_buckets() {
+    /// henrypark133 MED on PR #3635 5-19 review: `evict_older_than` drops
+    /// entries strictly older than the cutoff and removes empty buckets.
+    #[tokio::test]
+    async fn evict_older_than_drops_expired_entries_and_empty_buckets() {
         let backend = InMemoryPredicateStateBackend::new();
-        let t0 = Instant::now();
         let window = Duration::from_secs(3600);
 
         let stale_key = InvocationKey {
@@ -1328,20 +1552,21 @@ mod tests {
             tenant_id: tenant(),
             capability: "cap.live".to_string(),
         };
-        // Two stale entries that should be reaped.
         backend
-            .record_invocation(&stale_key, &ev("s1"), t0, window)
+            .record_invocation(&stale_key, &ev("s1"), at_secs(0), window)
+            .await
             .expect("ok");
         backend
-            .record_invocation(&stale_key, &ev("s2"), t0 + Duration::from_secs(1), window)
+            .record_invocation(&stale_key, &ev("s2"), at_secs(1), window)
+            .await
             .expect("ok");
-        // One live entry from later in time.
         backend
-            .record_invocation(&live_key, &ev("l1"), t0 + Duration::from_secs(120), window)
+            .record_invocation(&live_key, &ev("l1"), at_secs(120), window)
+            .await
             .expect("ok");
 
-        let cutoff = t0 + Duration::from_secs(60);
-        let dropped = backend.evict_older_than(cutoff).expect("evict ok");
+        let cutoff = at_secs(60);
+        let dropped = backend.evict_older_than(cutoff).await.expect("evict ok");
         assert_eq!(dropped, 2, "two stale entries must be dropped");
 
         let map = backend.invocation_history.lock().expect("ok");
@@ -1356,13 +1581,10 @@ mod tests {
     }
 
     /// henrypark133 HIGH on PR #3635 5-19 review: NumericSum sums must be
-    /// O(1) per call via an incrementally-maintained `running_sum`. The
-    /// observable contract is unchanged, but the invariant is that
-    /// `running_sum` matches the deque sum after every push/pop. This
-    /// test exercises mixed insert + window-trim + replay scenarios and
-    /// confirms the reported sum tracks the actual deque content.
-    #[test]
-    fn numeric_sum_running_sum_matches_deque_after_trim_and_replay() {
+    /// O(1) via an incrementally-maintained `running_sum`; the invariant
+    /// is that `running_sum` matches the deque sum after every push/pop.
+    #[tokio::test]
+    async fn numeric_sum_running_sum_matches_deque_after_trim_and_replay() {
         let backend = InMemoryPredicateStateBackend::new();
         let key = ValueKey {
             hook_id: hook_id(),
@@ -1371,45 +1593,30 @@ mod tests {
             field: "amount".to_string(),
         };
         let window = Duration::from_secs(60);
-        let t0 = Instant::now();
 
         let s1 = backend
-            .record_value(&key, &ev("v1"), t0, Decimal::from(10), window)
+            .record_value(&key, &ev("v1"), at_secs(0), Decimal::from(10), window)
+            .await
             .expect("ok");
         assert_eq!(s1, Decimal::from(10));
 
         let s2 = backend
-            .record_value(
-                &key,
-                &ev("v2"),
-                t0 + Duration::from_secs(1),
-                Decimal::from(25),
-                window,
-            )
+            .record_value(&key, &ev("v2"), at_secs(1), Decimal::from(25), window)
+            .await
             .expect("ok");
         assert_eq!(s2, Decimal::from(35));
 
         // Replay v1: dedup, sum unchanged.
         let s_replay = backend
-            .record_value(
-                &key,
-                &ev("v1"),
-                t0 + Duration::from_secs(2),
-                Decimal::from(10),
-                window,
-            )
+            .record_value(&key, &ev("v1"), at_secs(2), Decimal::from(10), window)
+            .await
             .expect("ok");
         assert_eq!(s_replay, Decimal::from(35), "replay must not double-count");
 
         // Advance past window so both prior entries trim.
         let s_after_trim = backend
-            .record_value(
-                &key,
-                &ev("v3"),
-                t0 + Duration::from_secs(120),
-                Decimal::from(7),
-                window,
-            )
+            .record_value(&key, &ev("v3"), at_secs(120), Decimal::from(7), window)
+            .await
             .expect("ok");
         assert_eq!(
             s_after_trim,
@@ -1422,8 +1629,8 @@ mod tests {
     /// behavior. The trim condition is `front_ts < cutoff`, so an entry
     /// recorded at exactly `cutoff` is RETAINED, not trimmed. Pin that
     /// boundary so a future refactor to `<=` would fail loud.
-    #[test]
-    fn in_memory_invocation_retains_entry_at_exact_window_cutoff() {
+    #[tokio::test]
+    async fn in_memory_invocation_retains_entry_at_exact_window_cutoff() {
         let backend = InMemoryPredicateStateBackend::new();
         let key = InvocationKey {
             hook_id: hook_id(),
@@ -1431,28 +1638,26 @@ mod tests {
             capability: "cap.boundary".to_string(),
         };
         let window = Duration::from_secs(60);
-        let t0 = Instant::now();
+        let t0 = at_secs(0);
         // Record at t0.
         let _ = backend
             .record_invocation(&key, &ev("e-at-t0"), t0, window)
+            .await
             .expect("ok");
         // At t0 + window, the cutoff is exactly t0; t0 is NOT strictly less
         // than t0, so the original entry must still be in-window.
         let count_at_exact_cutoff = backend
-            .record_invocation(&key, &ev("e-at-boundary"), t0 + window, window)
+            .record_invocation(&key, &ev("e-at-boundary"), at_secs(60), window)
+            .await
             .expect("ok");
         assert_eq!(
             count_at_exact_cutoff, 2,
             "entry whose timestamp equals the cutoff is retained (< cutoff trim, not <=)"
         );
-        // One nanosecond past the cutoff, the original entry IS trimmed.
+        // One millisecond past the cutoff, the original entry IS trimmed.
         let count_just_past = backend
-            .record_invocation(
-                &key,
-                &ev("e-just-past"),
-                t0 + window + Duration::from_nanos(1),
-                window,
-            )
+            .record_invocation(&key, &ev("e-just-past"), at_millis(60_001), window)
+            .await
             .expect("ok");
         // After the just-past call: e-at-t0 is now strictly older than
         // cutoff and gets trimmed; e-at-boundary and e-just-past remain.
@@ -1467,8 +1672,8 @@ mod tests {
     /// `record_invocation` and `record_value` must NOT collide — the two
     /// maps key on disjoint types (`InvocationKey` vs `ValueKey`), so
     /// dedup in one must not suppress the other.
-    #[test]
-    fn event_id_dedup_is_isolated_across_invocation_and_value_maps() {
+    #[tokio::test]
+    async fn event_id_dedup_is_isolated_across_invocation_and_value_maps() {
         let backend = InMemoryPredicateStateBackend::new();
         let inv_key = InvocationKey {
             hook_id: hook_id(),
@@ -1482,9 +1687,10 @@ mod tests {
             field: "amount".to_string(),
         };
         let shared = ev("shared-event-id");
-        let now = Instant::now();
+        let now = at_secs(0);
         let inv_count = backend
             .record_invocation(&inv_key, &shared, now, Duration::from_secs(60))
+            .await
             .expect("ok");
         let val_sum = backend
             .record_value(
@@ -1494,6 +1700,7 @@ mod tests {
                 Decimal::from(42),
                 Duration::from_secs(60),
             )
+            .await
             .expect("ok");
         assert_eq!(
             inv_count, 1,
@@ -1507,6 +1714,7 @@ mod tests {
         // Replay each — within its own map the shared id is now a dup.
         let inv_count_replay = backend
             .record_invocation(&inv_key, &shared, now, Duration::from_secs(60))
+            .await
             .expect("ok");
         let val_sum_replay = backend
             .record_value(
@@ -1516,6 +1724,7 @@ mod tests {
                 Decimal::from(42),
                 Duration::from_secs(60),
             )
+            .await
             .expect("ok");
         assert_eq!(inv_count_replay, 1, "intra-map dedup still works");
         assert_eq!(
@@ -1525,10 +1734,6 @@ mod tests {
         );
     }
 
-    /// henrypark133 missing-coverage on PR #3635: prove the atomic
-    /// record-and-read contract holds under concurrent writers. N threads
-    /// each call `record_invocation` once with a distinct `event_id`; the
-    /// final observed count must equal N (no lost-update race).
     /// Threat-model finding **D5** regression: an attacker that triggers a
     /// hot capability with a very large declared window can otherwise force
     /// the backend to retain every invocation in the window, exhausting
@@ -1545,38 +1750,28 @@ mod tests {
     /// evaluator treats as a fail-closed DENY. Validation rejects count
     /// thresholds above the cap at install time so a well-formed
     /// `InvocationCount` cap never reaches overflow.
-    #[test]
-    fn record_invocation_returns_window_overflow_at_cap_not_silent_drop() {
+    #[tokio::test]
+    async fn record_invocation_returns_window_overflow_at_cap_not_silent_drop() {
         let backend = InMemoryPredicateStateBackend::new();
         let key = InvocationKey {
             hook_id: hook_id(),
             tenant_id: tenant(),
             capability: "cap.hot".to_string(),
         };
-        let t0 = Instant::now();
-        // Window large enough that no entry trims for time; the cap is the
-        // only thing keeping the bucket bounded.
         let window = Duration::from_secs(3600);
         // Fill exactly to the cap — these must all succeed.
         for i in 0..MAX_SAMPLES_PER_KEY {
             let count = backend
-                .record_invocation(
-                    &key,
-                    &ev(&format!("evt-{i}")),
-                    t0 + Duration::from_millis(i as u64),
-                    window,
-                )
+                .record_invocation(&key, &ev(&format!("evt-{i}")), at_millis(i as i64), window)
+                .await
                 .expect("inserts up to the cap succeed");
             assert_eq!(count as usize, i + 1);
         }
         // The next distinct in-window event would push past the cap. It must
         // fail closed (WindowOverflow), NOT silently evict the oldest sample.
-        let result = backend.record_invocation(
-            &key,
-            &ev("evt-overflow"),
-            t0 + Duration::from_secs(1),
-            window,
-        );
+        let result = backend
+            .record_invocation(&key, &ev("evt-overflow"), at_secs(1), window)
+            .await;
         assert!(
             matches!(result, Err(PredicateBackendError::WindowOverflow { .. })),
             "hitting the per-key cap must fail closed, got {result:?}"
@@ -1594,8 +1789,8 @@ mod tests {
     /// only sample bound. Hitting it must fail closed with
     /// [`PredicateBackendError::WindowOverflow`] rather than silently
     /// undercounting the sum by evicting in-window samples.
-    #[test]
-    fn numeric_sum_window_overflow_returns_deny_not_silent_allow() {
+    #[tokio::test]
+    async fn numeric_sum_window_overflow_returns_deny_not_silent_allow() {
         let backend = InMemoryPredicateStateBackend::new();
         let key = ValueKey {
             hook_id: hook_id(),
@@ -1603,7 +1798,6 @@ mod tests {
             capability: "cap.spend".to_string(),
             field: "amount".to_string(),
         };
-        let t0 = Instant::now();
         let window = Duration::from_secs(3600);
         let value = Decimal::from(3);
         for i in 0..MAX_SAMPLES_PER_KEY {
@@ -1611,19 +1805,16 @@ mod tests {
                 .record_value(
                     &key,
                     &ev(&format!("v-{i}")),
-                    t0 + Duration::from_millis(i as u64),
+                    at_millis(i as i64),
                     value,
                     window,
                 )
+                .await
                 .expect("inserts up to the cap succeed");
         }
-        let result = backend.record_value(
-            &key,
-            &ev("v-overflow"),
-            t0 + Duration::from_secs(1),
-            value,
-            window,
-        );
+        let result = backend
+            .record_value(&key, &ev("v-overflow"), at_secs(1), value, window)
+            .await;
         assert!(
             matches!(result, Err(PredicateBackendError::WindowOverflow { .. })),
             "NumericSum at the per-key cap must fail closed (overflow), got {result:?}"
@@ -1633,6 +1824,11 @@ mod tests {
         let history = backend.value_history.lock().expect("lock");
         let bucket = history.get(&key).expect("bucket retained");
         assert_eq!(bucket.entries.len(), MAX_SAMPLES_PER_KEY);
+        let deque_sum: Decimal = bucket.entries.iter().map(|(_, v, _)| *v).sum();
+        assert_eq!(
+            bucket.running_sum, deque_sum,
+            "running_sum must stay in sync with deque content"
+        );
         assert_eq!(
             bucket.running_sum,
             Decimal::from(MAX_SAMPLES_PER_KEY as u64) * value,
@@ -1645,25 +1841,20 @@ mod tests {
     /// (and report the unchanged count) rather than being treated as a
     /// fresh event. The dedup-id lifecycle is the logical window, not a
     /// fixed ring that the cap can silently shrink.
-    #[test]
-    fn dedup_id_survives_cap_eviction_within_window() {
+    #[tokio::test]
+    async fn dedup_id_survives_cap_eviction_within_window() {
         let backend = InMemoryPredicateStateBackend::new();
         let key = InvocationKey {
             hook_id: hook_id(),
             tenant_id: tenant(),
             capability: "cap.replay".to_string(),
         };
-        let t0 = Instant::now();
         let window = Duration::from_secs(3600);
         // Saturate the bucket to the cap.
         for i in 0..MAX_SAMPLES_PER_KEY {
             backend
-                .record_invocation(
-                    &key,
-                    &ev(&format!("evt-{i}")),
-                    t0 + Duration::from_millis(i as u64),
-                    window,
-                )
+                .record_invocation(&key, &ev(&format!("evt-{i}")), at_millis(i as i64), window)
+                .await
                 .expect("ok");
         }
         // Replaying the FIRST (oldest) in-window id must be a no-op: it is
@@ -1671,7 +1862,8 @@ mod tests {
         // honored even at the cap boundary. A fresh count is returned, NOT
         // an overflow, because no new sample is added.
         let count = backend
-            .record_invocation(&key, &ev("evt-0"), t0 + Duration::from_secs(2), window)
+            .record_invocation(&key, &ev("evt-0"), at_secs(2), window)
+            .await
             .expect("replay of in-window id must dedup, not overflow");
         assert_eq!(
             count as usize, MAX_SAMPLES_PER_KEY,
@@ -1679,69 +1871,76 @@ mod tests {
         );
     }
 
-    /// codex review (PR #3635 followup) — Bug 2: a window longer than the
-    /// monotonic clock's representable past previously collapsed the cutoff
-    /// to `now` (via `now.checked_sub(window).unwrap_or(now)`), trimming
-    /// every prior in-window entry — a 24h window after recent boot behaved
-    /// like a zero-width window. Trimming by age (`now - ts > window`)
-    /// instead of an absolute cutoff fixes this: prior entries inside the
-    /// window are retained even when `now - window` underflows.
-    #[test]
-    fn record_invocation_with_long_window_does_not_zero_cutoff() {
+    /// codex review (PR #3635 followup) — Bug 2: a long window must not
+    /// collapse to "only now". Under the prior `Instant` clock,
+    /// `now.checked_sub(window).unwrap_or(now)` underflowed the monotonic
+    /// clock for a 24h window shortly after boot and collapsed the cutoff to
+    /// `now`, trimming every prior in-window entry. The `DateTime<Utc>` clock
+    /// (PR #3927) computes `now - window` via saturating `chrono` arithmetic
+    /// — a wall-clock instant minus 24h cannot underflow — so the cutoff is a
+    /// real prior timestamp and in-window entries are retained. This test
+    /// pins that intent against the new clock.
+    #[tokio::test]
+    async fn record_invocation_with_long_window_does_not_zero_cutoff() {
         let backend = InMemoryPredicateStateBackend::new();
         let key = InvocationKey {
             hook_id: hook_id(),
             tenant_id: tenant(),
             capability: "cap.longwindow".to_string(),
         };
-        // `now` is a fresh Instant; `now - 24h` underflows the monotonic
-        // clock shortly after process/boot start. Two events a few ms apart
-        // are both well within a 24h window and must both be counted.
-        let now = Instant::now();
+        // Two events a few ms apart are both well within a 24h window and
+        // must both be counted; the long window must not collapse the cutoff.
+        let now = at_secs(0);
         let window = Duration::from_secs(24 * 3600);
         backend
             .record_invocation(&key, &ev("first"), now, window)
+            .await
             .expect("ok");
         let count = backend
-            .record_invocation(&key, &ev("second"), now + Duration::from_millis(5), window)
+            .record_invocation(&key, &ev("second"), at_millis(5), window)
+            .await
             .expect("ok");
         assert_eq!(
             count, 2,
-            "a long window must retain prior in-window entries even when now - window underflows"
+            "a long window must retain prior in-window entries; the cutoff must not collapse to now"
         );
     }
 
-    #[test]
-    fn in_memory_record_invocation_is_atomic_under_concurrent_writers() {
+    /// henrypark133 missing-coverage on PR #3635: prove the atomic
+    /// record-and-read contract holds under concurrent writers. N tasks
+    /// each call `record_invocation` once with a distinct `event_id`; the
+    /// final observed count must equal N (no lost-update race).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn record_invocation_is_atomic_under_concurrent_writers() {
         use std::sync::Arc as StdArc;
-        use std::thread;
         let backend = StdArc::new(InMemoryPredicateStateBackend::new());
         let key = InvocationKey {
             hook_id: hook_id(),
             tenant_id: tenant(),
             capability: "cap.concurrent".to_string(),
         };
-        let now = Instant::now();
+        let now = at_secs(0);
         const N: usize = 32;
-        let handles: Vec<_> = (0..N)
-            .map(|i| {
-                let backend = StdArc::clone(&backend);
-                let key = key.clone();
-                let ev = ev(&format!("event-{i}"));
-                thread::spawn(move || {
-                    backend
-                        .record_invocation(&key, &ev, now, Duration::from_secs(60))
-                        .expect("ok")
-                })
-            })
-            .collect();
+        let mut handles = Vec::with_capacity(N);
+        for i in 0..N {
+            let backend = StdArc::clone(&backend);
+            let key = key.clone();
+            let ev = ev(&format!("event-{i}"));
+            handles.push(tokio::spawn(async move {
+                backend
+                    .record_invocation(&key, &ev, now, Duration::from_secs(60))
+                    .await
+                    .expect("ok")
+            }));
+        }
         for h in handles {
-            h.join().expect("thread joined");
+            h.await.expect("task joined");
         }
         // Re-read via a no-op record with a duplicate id to observe the
         // final count without inserting a new entry.
         let final_count = backend
             .record_invocation(&key, &ev("event-0"), now, Duration::from_secs(60))
+            .await
             .expect("ok");
         assert_eq!(
             final_count as usize, N,


### PR DESCRIPTION
## What

PR **1 of 4** in the durable predicate-state-backend split. This PR widens the contract only — it establishes the stable public surface that the durable Postgres/libSQL backends (PRs 2-4, to follow) will implement out-of-crate. **No durable backends in this PR.**

Successor to #3635, which added `PredicateStateBackend` + `InMemoryPredicateStateBackend` as intentionally `pub(crate)` until the durable contract stabilized.

## Surface changes

1. **`pub` visibility** — `PredicateStateBackend`, `InvocationKey`, `ValueKey`, `PredicateBackendError` are now `pub` (were `pub(crate)`). The "intentionally pub(crate)" rustdoc is replaced with a stable-contract note.
2. **`async` trait** — converted to `#[async_trait]`. Both target durable backends (`tokio-postgres`, libSQL) are async; a sync trait would force `block_on` on the dispatch hot path. `PredicateEvaluator::evaluate`/`evaluate_at` become `async`; the sole production caller (`PredicateBackedBeforeCapabilityHook::evaluate`, already `async`) ripples to `.await` cleanly.
3. **`chrono::DateTime<Utc>` clock** — the trait's `now:` arg changes from `std::time::Instant` to `DateTime<Utc>`. `Instant` is not serializable across processes; durable rows need a wall-clock timestamp. The in-memory backend now stores `DateTime<Utc>`; window trimming stays age-based (`front_ts < now - window`).
4. **Contract-test harness scaffold** — new feature-gated (`contract-tests`) `predicate_state::contract` module of `pub async fn` contracts, each taking a backend factory closure, plus a `predicate_backend_contract_test!` macro. Mirrors `ironclaw_memory::contract_tests` (#3918). The in-memory backend is wired through the suite as `predicate_state::in_memory::*`, proving the harness shape works with one backend so PRs 2/3 can drop in durable impls.

## In-memory behavior unchanged

This is a pure contract-shape refactor. The in-memory backend's semantics (tenant-keyed sliding windows, replay dedup, per-tenant LRU quota, per-key sample cap, running-sum invariant, atomic record-and-read) are unchanged apart from the clock-type adaptation. All prior unit tests are preserved, converted to async + `DateTime<Utc>` fixtures.

## Coordination with the in-flight #3635 bugfix

A concurrent `hooks-predicate-state-bugfix` was expected to fix two Codex-flagged bugs in this same file. **As of this PR it is NOT on origin** (no branch, no open PR). Notes:

- **`Instant::checked_sub` underflow → superseded.** Changing the clock to `DateTime<Utc>` removes this hazard entirely: `DateTime<Utc>` subtraction saturates rather than underflowing. Age-based trimming still makes sense and is preserved (`window_cutoff` helper computes `now - window` safely via `chrono::Duration::from_std`).
- **Cap-eviction overflow fix → preserve it.** If the bugfix adds a fail-closed overflow shape (e.g. a `WindowOverflow` variant on `PredicateBackendError`), it must be kept as part of the now-**public** `PredicateBackendError`. 

**Merge ordering:** if `hooks-predicate-state-bugfix` lands first, **rebase this PR onto it** so the public `PredicateBackendError` carries its overflow variant — do not clobber the security fix. If this lands first, fold the overflow variant into the public enum in that PR.

## Validation

- `cargo fmt --all` clean
- `cargo clippy -p ironclaw_hooks -p ironclaw_reborn --benches --tests --examples --all-features` — zero warnings
- `cargo test -p ironclaw_hooks` — 250 unit + 1 + 6 integration pass (incl. 8 `predicate_state::in_memory::*` contract tests)
- `cargo test -p ironclaw_reborn` — all pass
- Full `cargo build --workspace` clean — blast radius confined to `ironclaw_hooks` + `ironclaw_reborn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)