### PR TITLE
Add Reborn setup marker skill parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,6 +4366,7 @@ dependencies = [
  "ironclaw_turns",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/ironclaw_first_party_extensions/Cargo.toml
+++ b/crates/ironclaw_first_party_extensions/Cargo.toml
@@ -19,6 +19,7 @@ ironclaw_loop_support = { path = "../ironclaw_loop_support" }
 ironclaw_skills = { path = "../ironclaw_skills" }
 ironclaw_turns = { path = "../ironclaw_turns" }
 thiserror = "2"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_first_party_extensions/src/activation.rs
+++ b/crates/ironclaw_first_party_extensions/src/activation.rs
@@ -710,7 +710,7 @@ fn candidates_with_unsatisfied_setup_markers<'a>(
                 .activation
                 .setup_marker
                 .as_ref()
-                .map_or(true, |marker| !satisfied_setup_markers.contains(marker))
+                .is_none_or(|marker| !satisfied_setup_markers.contains(marker))
         })
         .collect()
 }

--- a/crates/ironclaw_first_party_extensions/src/activation.rs
+++ b/crates/ironclaw_first_party_extensions/src/activation.rs
@@ -168,9 +168,20 @@ where
 {
     bundle_source: Arc<S>,
     config: SkillActivationSelectorConfig,
+    setup_marker_source: Option<Arc<dyn SetupMarkerSource>>,
     messages_by_run: Mutex<HashMap<SkillActivationMessageKey, SkillActivationMessage>>,
     activation_cache: Mutex<HashMap<ActivationCandidateCacheKey, CachedActivationCandidate>>,
     plans_by_run: Mutex<HashMap<(TurnScope, TurnRunId), CapturedSkillActivationPlan>>,
+}
+
+/// Source of already-satisfied setup markers for one-time setup skills.
+#[async_trait]
+pub trait SetupMarkerSource: std::fmt::Debug + Send + Sync {
+    async fn satisfied_setup_markers(
+        &self,
+        run_context: &LoopRunContext,
+        markers: &HashSet<String>,
+    ) -> Result<HashSet<String>, SkillActivationSelectionError>;
 }
 
 impl<S> SelectableSkillContextSource<S>
@@ -181,10 +192,16 @@ where
         Self {
             bundle_source,
             config,
+            setup_marker_source: None,
             messages_by_run: Mutex::new(HashMap::new()),
             activation_cache: Mutex::new(HashMap::new()),
             plans_by_run: Mutex::new(HashMap::new()),
         }
+    }
+
+    pub fn with_setup_marker_source(mut self, source: Arc<dyn SetupMarkerSource>) -> Self {
+        self.setup_marker_source = Some(source);
+        self
     }
 
     pub fn record_user_message(
@@ -351,9 +368,39 @@ where
         let candidates = self
             .load_activation_candidates(run_context, &descriptors)
             .await?;
-        let selection = select_skill_activations(message, &candidates, &self.config)?;
+        let satisfied_setup_markers = self
+            .satisfied_setup_markers(run_context, &candidates)
+            .await?;
+        let selection =
+            select_skill_activations(message, &candidates, &self.config, &satisfied_setup_markers)?;
         let plan = activation_plan_for_candidates(selection);
         Ok((plan, candidates))
+    }
+
+    async fn satisfied_setup_markers(
+        &self,
+        run_context: &LoopRunContext,
+        candidates: &[ActivationCandidate],
+    ) -> Result<HashSet<String>, SkillActivationSelectionError> {
+        let markers = candidates
+            .iter()
+            .filter_map(|candidate| {
+                candidate
+                    .loaded
+                    .manifest
+                    .activation
+                    .setup_marker
+                    .as_ref()
+                    .cloned()
+            })
+            .collect::<HashSet<_>>();
+        if markers.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let Some(source) = self.setup_marker_source.as_deref() else {
+            return Ok(HashSet::new());
+        };
+        source.satisfied_setup_markers(run_context, &markers).await
     }
 
     async fn load_activation_candidates(
@@ -576,6 +623,7 @@ fn select_skill_activations(
     message: &str,
     candidates: &[ActivationCandidate],
     config: &SkillActivationSelectorConfig,
+    satisfied_setup_markers: &HashSet<String>,
 ) -> Result<SkillActivationSelection, SkillActivationSelectionError> {
     let loaded_skills: Vec<LoadedSkill> = candidates.iter().map(|c| c.loaded.clone()).collect();
     let mention_normalized_message = normalize_dollar_skill_mentions(message);
@@ -615,7 +663,7 @@ fn select_skill_activations(
         &loaded_skills,
         remaining_slots,
         remaining_tokens,
-        &HashSet::new(),
+        satisfied_setup_markers,
     );
     feedback.extend(outcome.notes);
 

--- a/crates/ironclaw_first_party_extensions/src/activation.rs
+++ b/crates/ironclaw_first_party_extensions/src/activation.rs
@@ -176,7 +176,7 @@ where
 
 /// Source of already-satisfied setup markers for one-time setup skills.
 #[async_trait]
-pub trait SetupMarkerSource: std::fmt::Debug + Send + Sync {
+pub(crate) trait SetupMarkerSource: std::fmt::Debug + Send + Sync {
     async fn satisfied_setup_markers(
         &self,
         run_context: &LoopRunContext,
@@ -199,7 +199,7 @@ where
         }
     }
 
-    pub fn with_setup_marker_source<T>(mut self, source: Arc<T>) -> Self
+    pub(crate) fn with_setup_marker_source<T>(mut self, source: Arc<T>) -> Self
     where
         T: SetupMarkerSource + 'static,
     {

--- a/crates/ironclaw_first_party_extensions/src/activation.rs
+++ b/crates/ironclaw_first_party_extensions/src/activation.rs
@@ -199,7 +199,10 @@ where
         }
     }
 
-    pub fn with_setup_marker_source(mut self, source: Arc<dyn SetupMarkerSource>) -> Self {
+    pub fn with_setup_marker_source<T>(mut self, source: Arc<T>) -> Self
+    where
+        T: SetupMarkerSource + 'static,
+    {
         self.setup_marker_source = Some(source);
         self
     }
@@ -625,12 +628,15 @@ fn select_skill_activations(
     config: &SkillActivationSelectorConfig,
     satisfied_setup_markers: &HashSet<String>,
 ) -> Result<SkillActivationSelection, SkillActivationSelectionError> {
-    let loaded_skills: Vec<LoadedSkill> = candidates.iter().map(|c| c.loaded.clone()).collect();
+    let active_candidates =
+        candidates_with_unsatisfied_setup_markers(candidates, satisfied_setup_markers);
+    let loaded_skills: Vec<LoadedSkill> =
+        active_candidates.iter().map(|c| c.loaded.clone()).collect();
     let mention_normalized_message = normalize_dollar_skill_mentions(message);
     let (explicit, rewritten_message) =
         extract_skill_mentions(&mention_normalized_message, &loaded_skills);
     let explicit_names = extract_explicit_skill_names(message);
-    validate_explicit_mentions_are_unambiguous(&explicit_names, candidates)?;
+    validate_explicit_mentions_are_unambiguous(&explicit_names, &active_candidates)?;
 
     let mut activations = Vec::new();
     let mut selected_keys = HashSet::new();
@@ -639,7 +645,7 @@ fn select_skill_activations(
     let mut remaining_tokens = config.max_context_tokens;
 
     for skill in explicit {
-        let candidate = candidate_for_loaded_skill(skill, candidates)?;
+        let candidate = candidate_for_loaded_skill(skill, &active_candidates)?;
         let key = (
             candidate.descriptor.id().source_kind(),
             candidate.loaded.manifest.name.clone(),
@@ -668,7 +674,7 @@ fn select_skill_activations(
     feedback.extend(outcome.notes);
 
     for skill in outcome.selected {
-        let candidate = candidate_for_loaded_skill(skill, candidates)?;
+        let candidate = candidate_for_loaded_skill(skill, &active_candidates)?;
         let key = (
             candidate.descriptor.id().source_kind(),
             candidate.loaded.manifest.name.clone(),
@@ -682,7 +688,7 @@ fn select_skill_activations(
         }
     }
 
-    validate_selected_names_are_unambiguous(&activations, candidates)?;
+    validate_selected_names_are_unambiguous(&activations)?;
 
     Ok(SkillActivationSelection {
         activations,
@@ -691,9 +697,27 @@ fn select_skill_activations(
     })
 }
 
+fn candidates_with_unsatisfied_setup_markers<'a>(
+    candidates: &'a [ActivationCandidate],
+    satisfied_setup_markers: &HashSet<String>,
+) -> Vec<&'a ActivationCandidate> {
+    candidates
+        .iter()
+        .filter(|candidate| {
+            candidate
+                .loaded
+                .manifest
+                .activation
+                .setup_marker
+                .as_ref()
+                .map_or(true, |marker| !satisfied_setup_markers.contains(marker))
+        })
+        .collect()
+}
+
 fn candidate_for_loaded_skill<'a>(
     skill: &LoadedSkill,
-    candidates: &'a [ActivationCandidate],
+    candidates: &'a [&ActivationCandidate],
 ) -> Result<&'a ActivationCandidate, SkillActivationSelectionError> {
     candidates
         .iter()
@@ -702,11 +726,12 @@ fn candidate_for_loaded_skill<'a>(
                 && candidate.loaded.source == skill.source
         })
         .ok_or(SkillActivationSelectionError::Internal)
+        .copied()
 }
 
 fn validate_explicit_mentions_are_unambiguous(
     explicit_names: &[String],
-    candidates: &[ActivationCandidate],
+    candidates: &[&ActivationCandidate],
 ) -> Result<(), SkillActivationSelectionError> {
     for name in explicit_names {
         let sources: Vec<SkillSourceKind> = candidates
@@ -727,7 +752,6 @@ fn validate_explicit_mentions_are_unambiguous(
 
 fn validate_selected_names_are_unambiguous(
     activations: &[SkillActivationRequest],
-    _candidates: &[ActivationCandidate],
 ) -> Result<(), SkillActivationSelectionError> {
     let mut sources_by_name: HashMap<&str, HashSet<SkillSourceKind>> = HashMap::new();
     for activation in activations {
@@ -930,6 +954,11 @@ mod tests {
         reads: std::sync::atomic::AtomicUsize,
     }
 
+    #[derive(Debug)]
+    struct StaticSetupMarkerSource {
+        satisfied_markers: HashSet<String>,
+    }
+
     impl StaticSkillBundleSource {
         fn new(skills: Vec<(SkillSourceKind, &str, &str)>) -> Self {
             let mut descriptors = Vec::new();
@@ -970,6 +999,17 @@ mod tests {
                 first: first.into_bytes(),
                 second: second.into_bytes(),
                 reads: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl StaticSetupMarkerSource {
+        fn new(satisfied_markers: &[&str]) -> Self {
+            Self {
+                satisfied_markers: satisfied_markers
+                    .iter()
+                    .map(|marker| marker.to_string())
+                    .collect(),
             }
         }
     }
@@ -1036,6 +1076,20 @@ mod tests {
             } else {
                 Ok(self.second.clone())
             }
+        }
+    }
+
+    #[async_trait]
+    impl SetupMarkerSource for StaticSetupMarkerSource {
+        async fn satisfied_setup_markers(
+            &self,
+            _run_context: &LoopRunContext,
+            markers: &HashSet<String>,
+        ) -> Result<HashSet<String>, SkillActivationSelectionError> {
+            Ok(markers
+                .intersection(&self.satisfied_markers)
+                .cloned()
+                .collect())
         }
     }
 
@@ -1167,6 +1221,41 @@ mod tests {
                 .as_ref()
                 .expect("skill context")
                 .contains("CODE_REVIEW_SENTINEL")
+        );
+    }
+
+    #[tokio::test]
+    async fn selector_suppresses_explicit_skill_when_setup_marker_is_satisfied() {
+        let source = Arc::new(StaticSkillBundleSource::new(vec![(
+            SkillSourceKind::User,
+            "setup-helper",
+            &skill_md_with_activation(
+                "setup-helper",
+                "  keywords: [\"setup-helper\"]\n  setup_marker: \"markers/setup-helper.done\"",
+                "SETUP_HELPER_SENTINEL",
+            ),
+        )]));
+        let setup_markers = Arc::new(StaticSetupMarkerSource::new(&["markers/setup-helper.done"]));
+        let selectable =
+            SelectableSkillContextSource::new(source, SkillActivationSelectorConfig::default())
+                .with_setup_marker_source(setup_markers);
+        let context = run_context().await;
+        selectable
+            .record_user_message(
+                context.scope.clone(),
+                accepted_message_ref(&context),
+                "$setup-helper",
+            )
+            .expect("record message");
+
+        let selected = selectable
+            .load_skill_context_candidates(&context)
+            .await
+            .expect("selection succeeds");
+
+        assert!(
+            selected.is_empty(),
+            "setup markers must suppress explicit and natural-language activation"
         );
     }
 

--- a/crates/ironclaw_first_party_extensions/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/src/lib.rs
@@ -13,8 +13,8 @@ mod skills;
 
 pub use activation::{
     DEFAULT_MAX_ACTIVE_SKILLS, DEFAULT_MAX_SKILL_CONTEXT_TOKENS, SelectableSkillContextSource,
-    SkillActivationMode, SkillActivationPlan, SkillActivationRequest, SkillActivationSelection,
-    SkillActivationSelectionError, SkillActivationSelectorConfig,
+    SetupMarkerSource, SkillActivationMode, SkillActivationPlan, SkillActivationRequest,
+    SkillActivationSelection, SkillActivationSelectionError, SkillActivationSelectorConfig,
 };
 pub use assets::{SkillBundleAsset, SkillBundleAssetReadError, SkillBundleAssetReader};
 pub use error::FirstPartySkillsExtensionError;

--- a/crates/ironclaw_first_party_extensions/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/src/lib.rs
@@ -14,8 +14,8 @@ mod skills;
 
 pub use activation::{
     DEFAULT_MAX_ACTIVE_SKILLS, DEFAULT_MAX_SKILL_CONTEXT_TOKENS, SelectableSkillContextSource,
-    SetupMarkerSource, SkillActivationMode, SkillActivationPlan, SkillActivationRequest,
-    SkillActivationSelection, SkillActivationSelectionError, SkillActivationSelectorConfig,
+    SkillActivationMode, SkillActivationPlan, SkillActivationRequest, SkillActivationSelection,
+    SkillActivationSelectionError, SkillActivationSelectorConfig,
 };
 pub use assets::{SkillBundleAsset, SkillBundleAssetReadError, SkillBundleAssetReader};
 pub use error::FirstPartySkillsExtensionError;

--- a/crates/ironclaw_first_party_extensions/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/src/lib.rs
@@ -9,6 +9,7 @@ mod activation;
 mod assets;
 mod error;
 mod execution;
+mod setup_markers;
 mod skills;
 
 pub use activation::{
@@ -24,4 +25,6 @@ pub use ironclaw_skills::{
     SkillManagementContext, SkillManagementError, SkillManagementErrorKind, SkillRemoveRequest,
     SkillRemoveResult, SkillSummary, install_skill, list_skills, remove_skill,
 };
-pub use skills::{FirstPartySkillsExtension, FirstPartySkillsExtensionHandles};
+pub use skills::{
+    FirstPartySelectableSkillsRuntime, FirstPartySkillsExtension, FirstPartySkillsExtensionHandles,
+};

--- a/crates/ironclaw_first_party_extensions/src/setup_markers.rs
+++ b/crates/ironclaw_first_party_extensions/src/setup_markers.rs
@@ -1,0 +1,97 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_filesystem::{FilesystemError, RootFilesystem, ScopedFilesystem};
+use ironclaw_host_api::ScopedPath;
+use ironclaw_turns::run_profile::LoopRunContext;
+
+use crate::{SetupMarkerSource, SkillActivationSelectionError};
+
+pub(crate) struct FilesystemSetupMarkerSource<F>
+where
+    F: RootFilesystem + 'static,
+{
+    filesystem: Arc<ScopedFilesystem<F>>,
+}
+
+impl<F> std::fmt::Debug for FilesystemSetupMarkerSource<F>
+where
+    F: RootFilesystem + 'static,
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FilesystemSetupMarkerSource")
+            .field("filesystem", &self.filesystem)
+            .finish()
+    }
+}
+
+impl<F> FilesystemSetupMarkerSource<F>
+where
+    F: RootFilesystem + 'static,
+{
+    pub(crate) fn new(filesystem: Arc<ScopedFilesystem<F>>) -> Self {
+        Self { filesystem }
+    }
+}
+
+#[async_trait]
+impl<F> SetupMarkerSource for FilesystemSetupMarkerSource<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn satisfied_setup_markers(
+        &self,
+        run_context: &LoopRunContext,
+        markers: &HashSet<String>,
+    ) -> Result<HashSet<String>, SkillActivationSelectionError> {
+        let scope = run_context.scope.to_resource_scope();
+        let mut satisfied = HashSet::new();
+        for marker in markers {
+            let Some(path) = workspace_setup_marker_path(marker) else {
+                continue;
+            };
+            match self.filesystem.stat(&scope, &path).await {
+                Ok(_) => {
+                    satisfied.insert(marker.clone());
+                }
+                Err(FilesystemError::NotFound { .. }) => {}
+                Err(_) => return Err(SkillActivationSelectionError::SourceUnavailable),
+            }
+        }
+        Ok(satisfied)
+    }
+}
+
+fn workspace_setup_marker_path(marker: &str) -> Option<ScopedPath> {
+    let marker = marker.trim_start_matches('/');
+    if marker.is_empty() {
+        tracing::debug!("ignoring empty skill setup marker");
+        return None;
+    }
+    match ScopedPath::new(format!("/workspace/{marker}")) {
+        Ok(path) => Some(path),
+        Err(reason) => {
+            tracing::debug!(%marker, %reason, "ignoring invalid skill setup marker");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_setup_marker_path_ignores_invalid_markers() {
+        assert!(workspace_setup_marker_path("").is_none());
+        assert!(workspace_setup_marker_path("../escape").is_none());
+        assert_eq!(
+            workspace_setup_marker_path("/markers/setup.done")
+                .expect("valid setup marker path")
+                .as_str(),
+            "/workspace/markers/setup.done"
+        );
+    }
+}

--- a/crates/ironclaw_first_party_extensions/src/setup_markers.rs
+++ b/crates/ironclaw_first_party_extensions/src/setup_markers.rs
@@ -6,7 +6,7 @@ use ironclaw_filesystem::{FilesystemError, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::ScopedPath;
 use ironclaw_turns::run_profile::LoopRunContext;
 
-use crate::{SetupMarkerSource, SkillActivationSelectionError};
+use crate::{SkillActivationSelectionError, activation::SetupMarkerSource};
 
 pub(crate) struct FilesystemSetupMarkerSource<F>
 where

--- a/crates/ironclaw_first_party_extensions/src/setup_markers.rs
+++ b/crates/ironclaw_first_party_extensions/src/setup_markers.rs
@@ -2,11 +2,14 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::{StreamExt, stream};
 use ironclaw_filesystem::{FilesystemError, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::ScopedPath;
 use ironclaw_turns::run_profile::LoopRunContext;
 
 use crate::{SkillActivationSelectionError, activation::SetupMarkerSource};
+
+const MAX_CONCURRENT_SETUP_MARKER_STATS: usize = 16;
 
 pub(crate) struct FilesystemSetupMarkerSource<F>
 where
@@ -47,19 +50,31 @@ where
         markers: &HashSet<String>,
     ) -> Result<HashSet<String>, SkillActivationSelectionError> {
         let scope = run_context.scope.to_resource_scope();
-        let mut satisfied = HashSet::new();
-        for marker in markers {
-            let Some(path) = workspace_setup_marker_path(marker) else {
-                continue;
-            };
-            match self.filesystem.stat(&scope, &path).await {
-                Ok(_) => {
-                    satisfied.insert(marker.clone());
+        let filesystem = Arc::clone(&self.filesystem);
+        let satisfied = stream::iter(markers.iter().cloned())
+            .map(|marker| {
+                let filesystem = Arc::clone(&filesystem);
+                let scope = scope.clone();
+                async move {
+                    let path = workspace_setup_marker_path(&marker)?;
+                    match filesystem.stat(&scope, &path).await {
+                        Ok(_) => Some(marker),
+                        Err(FilesystemError::NotFound { .. }) => None,
+                        Err(error) => {
+                            tracing::debug!(
+                                %marker,
+                                %error,
+                                "treating unavailable skill setup marker as unsatisfied"
+                            );
+                            None
+                        }
+                    }
                 }
-                Err(FilesystemError::NotFound { .. }) => {}
-                Err(_) => return Err(SkillActivationSelectionError::SourceUnavailable),
-            }
-        }
+            })
+            .buffer_unordered(MAX_CONCURRENT_SETUP_MARKER_STATS)
+            .filter_map(|marker| async move { marker })
+            .collect::<HashSet<_>>()
+            .await;
         Ok(satisfied)
     }
 }
@@ -82,6 +97,38 @@ fn workspace_setup_marker_path(marker: &str) -> Option<ScopedPath> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
+    use ironclaw_host_api::{AgentId, MountView, ProjectId, TenantId};
+    use ironclaw_turns::{
+        AcceptedMessageRef, TurnActor, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            InMemoryRunProfileResolver, RunProfileResolutionRequest, RunProfileResolver,
+        },
+    };
+
+    async fn run_context() -> LoopRunContext {
+        let resolved = InMemoryRunProfileResolver::default()
+            .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+            .await
+            .expect("run profile resolves");
+        LoopRunContext::new(
+            TurnScope::new(
+                TenantId::new("tenant-a").expect("valid tenant"),
+                Some(AgentId::new("agent-a").expect("valid agent")),
+                Some(ProjectId::new("project-a").expect("valid project")),
+                ironclaw_host_api::ThreadId::new("thread-a").expect("valid thread"),
+            ),
+            TurnId::new(),
+            TurnRunId::new(),
+            resolved,
+        )
+        .with_accepted_message_ref(
+            AcceptedMessageRef::new("msg:setup-marker").expect("valid message ref"),
+        )
+        .with_actor(TurnActor::new(
+            ironclaw_host_api::UserId::new("user-a").expect("valid user"),
+        ))
+    }
 
     #[test]
     fn workspace_setup_marker_path_ignores_invalid_markers() {
@@ -93,5 +140,22 @@ mod tests {
                 .as_str(),
             "/workspace/markers/setup.done"
         );
+    }
+
+    #[tokio::test]
+    async fn filesystem_setup_marker_source_treats_stat_errors_as_unsatisfied() {
+        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+            Arc::new(InMemoryBackend::default()),
+            MountView::new(Vec::new()).expect("empty mount view"),
+        ));
+        let source = FilesystemSetupMarkerSource::new(filesystem);
+        let markers = HashSet::from(["markers/setup.done".to_string()]);
+
+        let satisfied = source
+            .satisfied_setup_markers(&run_context().await, &markers)
+            .await
+            .expect("marker probe errors should not fail activation");
+
+        assert!(satisfied.is_empty());
     }
 }

--- a/crates/ironclaw_first_party_extensions/src/skills.rs
+++ b/crates/ironclaw_first_party_extensions/src/skills.rs
@@ -9,7 +9,7 @@ use ironclaw_loop_support::{
 
 use crate::{
     SelectableSkillContextSource, SkillActivationSelectorConfig, SkillExecutionAdapter,
-    error::FirstPartySkillsExtensionError,
+    error::FirstPartySkillsExtensionError, setup_markers::FilesystemSetupMarkerSource,
 };
 
 const SYSTEM_SKILLS_ROOT: &str = "/system/skills";
@@ -104,9 +104,69 @@ where
 {
     bundle_source: Arc<FilesystemSkillBundleSource<F>>,
     context_source: Arc<SkillBundleContextSource<FilesystemSkillBundleSource<F>>>,
-    default_selectable_context_source:
-        Arc<SelectableSkillContextSource<FilesystemSkillBundleSource<F>>>,
+    default_selectable_runtime: FirstPartySelectableSkillsRuntime<F>,
+}
+
+pub struct FirstPartySelectableSkillsRuntime<F>
+where
+    F: RootFilesystem + 'static,
+{
+    activation_source: Arc<SelectableSkillContextSource<FilesystemSkillBundleSource<F>>>,
     execution_adapter: Arc<SkillExecutionAdapter<FilesystemSkillBundleSource<F>>>,
+}
+
+impl<F> Clone for FirstPartySelectableSkillsRuntime<F>
+where
+    F: RootFilesystem + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            activation_source: Arc::clone(&self.activation_source),
+            execution_adapter: Arc::clone(&self.execution_adapter),
+        }
+    }
+}
+
+impl<F> std::fmt::Debug for FirstPartySelectableSkillsRuntime<F>
+where
+    F: RootFilesystem + 'static,
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FirstPartySelectableSkillsRuntime")
+            .field("activation_source", &self.activation_source)
+            .field("execution_adapter", &self.execution_adapter)
+            .finish()
+    }
+}
+
+impl<F> FirstPartySelectableSkillsRuntime<F>
+where
+    F: RootFilesystem + 'static,
+{
+    fn new(
+        activation_source: Arc<SelectableSkillContextSource<FilesystemSkillBundleSource<F>>>,
+        execution_adapter: Arc<SkillExecutionAdapter<FilesystemSkillBundleSource<F>>>,
+    ) -> Self {
+        Self {
+            activation_source,
+            execution_adapter,
+        }
+    }
+
+    pub fn host_skill_context_source(&self) -> Arc<dyn HostSkillContextSource> {
+        self.activation_source.clone()
+    }
+
+    pub fn activation_source(
+        &self,
+    ) -> Arc<SelectableSkillContextSource<FilesystemSkillBundleSource<F>>> {
+        Arc::clone(&self.activation_source)
+    }
+
+    pub fn execution_adapter(&self) -> Arc<SkillExecutionAdapter<FilesystemSkillBundleSource<F>>> {
+        Arc::clone(&self.execution_adapter)
+    }
 }
 
 impl<F> std::fmt::Debug for FirstPartySkillsExtension<F>
@@ -144,11 +204,14 @@ where
         let execution_adapter = Arc::new(SkillExecutionAdapter::new(Arc::clone(
             &default_selectable_context_source,
         )));
+        let default_selectable_runtime = FirstPartySelectableSkillsRuntime::new(
+            default_selectable_context_source,
+            execution_adapter,
+        );
         Ok(Self {
             bundle_source,
             context_source,
-            default_selectable_context_source,
-            execution_adapter,
+            default_selectable_runtime,
         })
     }
 
@@ -169,7 +232,7 @@ where
         config: SkillActivationSelectorConfig,
     ) -> Arc<SelectableSkillContextSource<FilesystemSkillBundleSource<F>>> {
         if config == SkillActivationSelectorConfig::default() {
-            return Arc::clone(&self.default_selectable_context_source);
+            return self.default_selectable_runtime.activation_source();
         }
         Arc::new(SelectableSkillContextSource::new(
             Arc::clone(&self.bundle_source),
@@ -177,10 +240,41 @@ where
         ))
     }
 
+    pub fn selectable_skill_runtime(
+        &self,
+        config: SkillActivationSelectorConfig,
+    ) -> FirstPartySelectableSkillsRuntime<F> {
+        if config == SkillActivationSelectorConfig::default() {
+            return self.default_selectable_runtime.clone();
+        }
+        let activation_source = self.selectable_skill_context_source(config);
+        let execution_adapter =
+            Arc::new(SkillExecutionAdapter::new(Arc::clone(&activation_source)));
+        FirstPartySelectableSkillsRuntime::new(activation_source, execution_adapter)
+    }
+
+    pub fn selectable_skill_runtime_with_setup_markers<W>(
+        &self,
+        config: SkillActivationSelectorConfig,
+        workspace_filesystem: Arc<ScopedFilesystem<W>>,
+    ) -> FirstPartySelectableSkillsRuntime<F>
+    where
+        W: RootFilesystem + 'static,
+    {
+        let setup_marker_source = Arc::new(FilesystemSetupMarkerSource::new(workspace_filesystem));
+        let activation_source = Arc::new(
+            SelectableSkillContextSource::new(Arc::clone(&self.bundle_source), config)
+                .with_setup_marker_source(setup_marker_source),
+        );
+        let execution_adapter =
+            Arc::new(SkillExecutionAdapter::new(Arc::clone(&activation_source)));
+        FirstPartySelectableSkillsRuntime::new(activation_source, execution_adapter)
+    }
+
     pub fn skill_execution_adapter(
         &self,
     ) -> Arc<SkillExecutionAdapter<FilesystemSkillBundleSource<F>>> {
-        Arc::clone(&self.execution_adapter)
+        self.default_selectable_runtime.execution_adapter()
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -654,10 +654,11 @@ fn readiness_for(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_filesystem::FilesystemError;
     use ironclaw_host_api::{
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
-        ExecutionContext, ExtensionId, GrantConstraints, NetworkPolicy, Principal,
-        ResourceEstimate, RuntimeKind, TrustClass, UserId,
+        ExecutionContext, ExtensionId, GrantConstraints, InvocationId, NetworkPolicy, Principal,
+        ResourceEstimate, ResourceScope, RuntimeKind, ScopedPath, TrustClass, UserId,
     };
     use ironclaw_host_runtime::{
         RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind,
@@ -680,6 +681,52 @@ mod tests {
         assert!(services.product_auth.is_some());
         assert!(services.local_runtime.is_some());
         assert_eq!(services.readiness.state, RebornReadinessState::DevOnly);
+    }
+
+    #[tokio::test]
+    async fn local_dev_setup_marker_workspace_filesystem_is_read_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_root = dir.path().join("local-dev");
+        let marker_path = storage_root.join("workspace/markers/setup.done");
+        std::fs::create_dir_all(marker_path.parent().expect("marker parent"))
+            .expect("marker directory");
+        std::fs::write(&marker_path, "done").expect("marker file");
+        let services = build_reborn_services(RebornBuildInput::local_dev(
+            "local-dev-marker-workspace-owner",
+            storage_root,
+        ))
+        .await
+        .expect("local-dev services build");
+        let local_runtime = services
+            .local_runtime
+            .as_ref()
+            .expect("local-dev runtime substrate");
+        let scope = ResourceScope::local_default(
+            UserId::new("local-dev-marker-user").expect("valid user"),
+            InvocationId::new(),
+        )
+        .expect("valid resource scope");
+
+        let stat = local_runtime
+            .workspace_filesystem
+            .stat(
+                &scope,
+                &ScopedPath::new("/workspace/markers/setup.done").expect("valid marker path"),
+            )
+            .await
+            .expect("marker stat succeeds");
+        assert_eq!(stat.len, 4);
+
+        let error = local_runtime
+            .workspace_filesystem
+            .write_file(
+                &scope,
+                &ScopedPath::new("/workspace/markers/new.done").expect("valid marker path"),
+                b"done",
+            )
+            .await
+            .expect_err("setup marker workspace filesystem should be read-only");
+        assert!(matches!(error, FilesystemError::PermissionDenied { .. }));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -47,6 +47,7 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) loop_checkpoint_store: Arc<InMemoryLoopCheckpointStore>,
     pub(crate) thread_service: Arc<InMemorySessionThreadService>,
     pub(crate) skill_filesystem: Arc<ScopedFilesystem<LocalFilesystem>>,
+    pub(crate) workspace_filesystem: Arc<ScopedFilesystem<LocalFilesystem>>,
 }
 
 impl std::fmt::Debug for RebornServices {
@@ -158,6 +159,10 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         Arc::clone(&filesystem),
         local_dev_skill_mount_view()?,
     ));
+    let workspace_filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::clone(&filesystem),
+        local_dev_workspace_mount_view()?,
+    ));
 
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
@@ -168,6 +173,7 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         loop_checkpoint_store: Arc::new(InMemoryLoopCheckpointStore::default()),
         thread_service: Arc::new(InMemorySessionThreadService::default()),
         skill_filesystem,
+        workspace_filesystem,
     });
 
     let mut services = HostRuntimeServices::new(
@@ -264,6 +270,23 @@ fn local_dev_skill_mount_view() -> Result<MountView, RebornBuildError> {
         grant("/tenant-shared/skills", "/projects/tenant-shared/skills")?,
         grant("/system/skills", "/projects/system/skills")?,
     ])
+    .map_err(|error| RebornBuildError::InvalidConfig {
+        reason: error.to_string(),
+    })
+}
+
+fn local_dev_workspace_mount_view() -> Result<MountView, RebornBuildError> {
+    MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").map_err(|error| RebornBuildError::InvalidConfig {
+            reason: error.to_string(),
+        })?,
+        VirtualPath::new("/projects/workspace").map_err(|error| {
+            RebornBuildError::InvalidConfig {
+                reason: error.to_string(),
+            }
+        })?,
+        MountPermissions::read_only(),
+    )])
     .map_err(|error| RebornBuildError::InvalidConfig {
         reason: error.to_string(),
     })

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -20,7 +20,7 @@
 //! property that satisfies the "narrow Reborn public surface" requirement
 //! pinned by `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -32,13 +32,14 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use ironclaw_events::{DurableEventLog, InMemoryDurableEventLog, RuntimeEvent};
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::{FilesystemError, LocalFilesystem, ScopedFilesystem};
 use ironclaw_first_party_extensions::{
     FirstPartySkillsExtension, FirstPartySkillsExtensionHandles, SelectableSkillContextSource,
-    SkillActivationSelectorConfig, SkillExecutionAdapter,
+    SetupMarkerSource, SkillActivationSelectionError, SkillActivationSelectorConfig,
+    SkillExecutionAdapter,
 };
 use ironclaw_host_api::{
-    AgentId, CapabilityId, InvocationId, ResourceScope, TenantId, ThreadId, UserId,
+    AgentId, CapabilityId, InvocationId, ResourceScope, ScopedPath, TenantId, ThreadId, UserId,
 };
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
@@ -890,6 +891,34 @@ struct LocalDevSkillContextSource {
     execution_adapter: Arc<LocalDevSkillExecutionAdapter>,
 }
 
+#[derive(Debug)]
+struct LocalDevWorkspaceSetupMarkerSource {
+    filesystem: Arc<ScopedFilesystem<LocalFilesystem>>,
+}
+
+#[async_trait::async_trait]
+impl SetupMarkerSource for LocalDevWorkspaceSetupMarkerSource {
+    async fn satisfied_setup_markers(
+        &self,
+        run_context: &LoopRunContext,
+        markers: &HashSet<String>,
+    ) -> Result<HashSet<String>, SkillActivationSelectionError> {
+        let scope = run_context.scope.to_resource_scope();
+        let mut satisfied = HashSet::new();
+        for marker in markers {
+            let path = workspace_setup_marker_path(marker)?;
+            match self.filesystem.stat(&scope, &path).await {
+                Ok(_) => {
+                    satisfied.insert(marker.clone());
+                }
+                Err(FilesystemError::NotFound { .. }) => {}
+                Err(_) => return Err(SkillActivationSelectionError::SourceUnavailable),
+            }
+        }
+        Ok(satisfied)
+    }
+}
+
 fn local_dev_filesystem_skill_context_source(
     local_runtime: &crate::factory::RebornLocalRuntimeServices,
     tenant_id: &TenantId,
@@ -906,15 +935,33 @@ fn local_dev_filesystem_skill_context_source(
     .map_err(|reason| RebornRuntimeError::InvalidArgument {
         reason: format!("first-party skills extension source: {reason}"),
     })?;
-    let activation_source =
-        extension.selectable_skill_context_source(SkillActivationSelectorConfig::default());
+    let setup_marker_source: Arc<dyn SetupMarkerSource> =
+        Arc::new(LocalDevWorkspaceSetupMarkerSource {
+            filesystem: Arc::clone(&local_runtime.workspace_filesystem),
+        });
+    let activation_source = Arc::new(
+        SelectableSkillContextSource::new(
+            extension.bundle_source(),
+            SkillActivationSelectorConfig::default(),
+        )
+        .with_setup_marker_source(setup_marker_source),
+    );
     let source: Arc<dyn HostSkillContextSource> = activation_source.clone();
-    let execution_adapter = extension.skill_execution_adapter();
+    let execution_adapter = Arc::new(SkillExecutionAdapter::new(Arc::clone(&activation_source)));
     Ok(LocalDevSkillContextSource {
         source,
         activation_source,
         execution_adapter,
     })
+}
+
+fn workspace_setup_marker_path(marker: &str) -> Result<ScopedPath, SkillActivationSelectionError> {
+    let marker = marker.trim_start_matches('/');
+    if marker.is_empty() {
+        return Err(SkillActivationSelectionError::ParseFailed);
+    }
+    ScopedPath::new(format!("/workspace/{marker}"))
+        .map_err(|_| SkillActivationSelectionError::ParseFailed)
 }
 
 struct ValidatedRuntimeIdentity {
@@ -1372,6 +1419,17 @@ mod tests {
     fn skill_md(name: &str, description: &str, prompt: &str) -> String {
         format!(
             "---\nname: {name}\ndescription: {description}\nactivation:\n  keywords: [\"{name}\"]\n---\n\n{prompt}"
+        )
+    }
+
+    fn skill_md_with_setup_marker(
+        name: &str,
+        description: &str,
+        marker: &str,
+        prompt: &str,
+    ) -> String {
+        format!(
+            "---\nname: {name}\ndescription: {description}\nactivation:\n  keywords: [\"{name}\"]\n  setup_marker: \"{marker}\"\n---\n\n{prompt}"
         )
     }
 
@@ -2019,6 +2077,81 @@ mod tests {
                 .is_empty(),
             "ambiguous explicit skill should fail before model dispatch"
         );
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn local_dev_runtime_suppresses_setup_skill_when_workspace_marker_exists() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let storage_root = root.path().join("local-dev");
+        std::fs::create_dir_all(storage_root.join("skills/setup-helper")).expect("user skill dir");
+        std::fs::create_dir_all(storage_root.join("workspace/markers")).expect("marker dir");
+        std::fs::write(
+            storage_root.join("skills/setup-helper/SKILL.md"),
+            skill_md_with_setup_marker(
+                "setup-helper",
+                "setup helper description",
+                "markers/setup-helper.done",
+                "SETUP_HELPER_PROMPT_SENTINEL",
+            ),
+        )
+        .expect("write setup helper skill");
+        std::fs::write(
+            storage_root.join("workspace/markers/setup-helper.done"),
+            "done",
+        )
+        .expect("write setup marker");
+        let requests = Arc::new(StdMutex::new(Vec::new()));
+        let gateway = Arc::new(RecordingGateway {
+            reply: "setup marker ok".to_string(),
+            requests: Arc::clone(&requests),
+        });
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev("runtime-setup-marker-owner", storage_root)
+                .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-setup-marker-tenant".to_string(),
+            agent_id: "runtime-setup-marker-agent".to_string(),
+            source_binding_id: "runtime-setup-marker-source".to_string(),
+            reply_target_binding_id: "runtime-setup-marker-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: Duration::from_millis(10),
+            max_total: Duration::from_secs(3),
+        })
+        .with_model_gateway_override(gateway);
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let conversation = runtime.new_conversation().await.expect("conversation");
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            runtime.execute_skill_message(&conversation, "please run setup-helper"),
+        )
+        .await
+        .expect("skill execution should finish")
+        .expect("skill execution should succeed");
+
+        assert_eq!(result.reply.status, TurnStatus::Completed);
+        assert!(result.plan.activations().is_empty());
+        let skill_messages = {
+            let requests = requests
+                .lock()
+                .expect("recording gateway requests lock poisoned");
+            requests[0]
+                .messages
+                .iter()
+                .filter(|message| {
+                    message.role == HostManagedModelMessageRole::System
+                        && message
+                            .content_ref
+                            .as_str()
+                            .starts_with("msg:snippet.skill.")
+                })
+                .count()
+        };
+        assert_eq!(skill_messages, 0);
 
         runtime.shutdown().await.expect("runtime shutdown");
     }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2110,6 +2110,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn local_dev_runtime_activates_setup_skill_when_workspace_marker_is_absent() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let storage_root = root.path().join("local-dev");
+        std::fs::create_dir_all(storage_root.join("skills/setup-helper")).expect("user skill dir");
+        std::fs::write(
+            storage_root.join("skills/setup-helper/SKILL.md"),
+            skill_md_with_setup_marker(
+                "setup-helper",
+                "setup helper description",
+                "markers/setup-helper.done",
+                "SETUP_HELPER_PROMPT_SENTINEL",
+            ),
+        )
+        .expect("write setup helper skill");
+        let requests = Arc::new(StdMutex::new(Vec::new()));
+        let gateway = Arc::new(RecordingGateway {
+            reply: "setup marker absent ok".to_string(),
+            requests: Arc::clone(&requests),
+        });
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev("runtime-setup-marker-absent-owner", storage_root)
+                .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-setup-marker-absent-tenant".to_string(),
+            agent_id: "runtime-setup-marker-absent-agent".to_string(),
+            source_binding_id: "runtime-setup-marker-absent-source".to_string(),
+            reply_target_binding_id: "runtime-setup-marker-absent-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: Duration::from_millis(10),
+            max_total: Duration::from_secs(3),
+        })
+        .with_model_gateway_override(gateway);
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let conversation = runtime.new_conversation().await.expect("conversation");
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            runtime.execute_skill_message(&conversation, "$setup-helper"),
+        )
+        .await
+        .expect("skill execution should finish")
+        .expect("skill execution should succeed");
+
+        assert_eq!(result.reply.status, TurnStatus::Completed);
+        assert_eq!(result.plan.activations().len(), 1);
+        assert_eq!(result.plan.activations()[0].name, "setup-helper");
+        let skill_context = {
+            let requests = requests
+                .lock()
+                .expect("recording gateway requests lock poisoned");
+            requests[0]
+                .messages
+                .iter()
+                .filter(|message| {
+                    message.role == HostManagedModelMessageRole::System
+                        && message
+                            .content_ref
+                            .as_str()
+                            .starts_with("msg:snippet.skill.")
+                })
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        assert!(skill_context.contains("setup helper description"));
+        assert!(skill_context.contains("SETUP_HELPER_PROMPT_SENTINEL"));
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
     async fn local_dev_runtime_rejects_workspace_overlapping_default_skill_roots() {
         let root = tempfile::tempdir().expect("tempdir");
         let storage_root = root.path().join("local-dev");

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -79,7 +79,7 @@ pub use skills::{
     RebornSkillExecutionPlan, RebornSkillExecutionResult, RebornSkillSourceKind,
 };
 
-use skills::{LocalDevWorkspaceSetupMarkerSource, skill_asset_error};
+use skills::skill_asset_error;
 
 #[cfg(feature = "root-llm-provider")]
 use crate::runtime_input::{ResolvedRebornLlm, ResolvedRebornLlmSource};
@@ -906,22 +906,14 @@ fn local_dev_filesystem_skill_context_source(
     .map_err(|reason| RebornRuntimeError::InvalidArgument {
         reason: format!("first-party skills extension source: {reason}"),
     })?;
-    let setup_marker_source = Arc::new(LocalDevWorkspaceSetupMarkerSource::new(Arc::clone(
-        &local_runtime.workspace_filesystem,
-    )));
-    let activation_source = Arc::new(
-        SelectableSkillContextSource::new(
-            extension.bundle_source(),
-            SkillActivationSelectorConfig::default(),
-        )
-        .with_setup_marker_source(setup_marker_source),
+    let selectable_skills = extension.selectable_skill_runtime_with_setup_markers(
+        SkillActivationSelectorConfig::default(),
+        Arc::clone(&local_runtime.workspace_filesystem),
     );
-    let source: Arc<dyn HostSkillContextSource> = activation_source.clone();
-    let execution_adapter = Arc::new(SkillExecutionAdapter::new(Arc::clone(&activation_source)));
     Ok(LocalDevSkillContextSource {
-        source,
-        activation_source,
-        execution_adapter,
+        source: selectable_skills.host_skill_context_source(),
+        activation_source: selectable_skills.activation_source(),
+        execution_adapter: selectable_skills.execution_adapter(),
     })
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -20,7 +20,7 @@
 //! property that satisfies the "narrow Reborn public surface" requirement
 //! pinned by `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -32,14 +32,13 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use ironclaw_events::{DurableEventLog, InMemoryDurableEventLog, RuntimeEvent};
-use ironclaw_filesystem::{FilesystemError, LocalFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_first_party_extensions::{
     FirstPartySkillsExtension, FirstPartySkillsExtensionHandles, SelectableSkillContextSource,
-    SetupMarkerSource, SkillActivationSelectionError, SkillActivationSelectorConfig,
-    SkillExecutionAdapter,
+    SkillActivationSelectorConfig, SkillExecutionAdapter,
 };
 use ironclaw_host_api::{
-    AgentId, CapabilityId, InvocationId, ResourceScope, ScopedPath, TenantId, ThreadId, UserId,
+    AgentId, CapabilityId, InvocationId, ResourceScope, TenantId, ThreadId, UserId,
 };
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
@@ -80,7 +79,7 @@ pub use skills::{
     RebornSkillExecutionPlan, RebornSkillExecutionResult, RebornSkillSourceKind,
 };
 
-use skills::skill_asset_error;
+use skills::{LocalDevWorkspaceSetupMarkerSource, skill_asset_error};
 
 #[cfg(feature = "root-llm-provider")]
 use crate::runtime_input::{ResolvedRebornLlm, ResolvedRebornLlmSource};
@@ -891,34 +890,6 @@ struct LocalDevSkillContextSource {
     execution_adapter: Arc<LocalDevSkillExecutionAdapter>,
 }
 
-#[derive(Debug)]
-struct LocalDevWorkspaceSetupMarkerSource {
-    filesystem: Arc<ScopedFilesystem<LocalFilesystem>>,
-}
-
-#[async_trait::async_trait]
-impl SetupMarkerSource for LocalDevWorkspaceSetupMarkerSource {
-    async fn satisfied_setup_markers(
-        &self,
-        run_context: &LoopRunContext,
-        markers: &HashSet<String>,
-    ) -> Result<HashSet<String>, SkillActivationSelectionError> {
-        let scope = run_context.scope.to_resource_scope();
-        let mut satisfied = HashSet::new();
-        for marker in markers {
-            let path = workspace_setup_marker_path(marker)?;
-            match self.filesystem.stat(&scope, &path).await {
-                Ok(_) => {
-                    satisfied.insert(marker.clone());
-                }
-                Err(FilesystemError::NotFound { .. }) => {}
-                Err(_) => return Err(SkillActivationSelectionError::SourceUnavailable),
-            }
-        }
-        Ok(satisfied)
-    }
-}
-
 fn local_dev_filesystem_skill_context_source(
     local_runtime: &crate::factory::RebornLocalRuntimeServices,
     tenant_id: &TenantId,
@@ -935,10 +906,9 @@ fn local_dev_filesystem_skill_context_source(
     .map_err(|reason| RebornRuntimeError::InvalidArgument {
         reason: format!("first-party skills extension source: {reason}"),
     })?;
-    let setup_marker_source: Arc<dyn SetupMarkerSource> =
-        Arc::new(LocalDevWorkspaceSetupMarkerSource {
-            filesystem: Arc::clone(&local_runtime.workspace_filesystem),
-        });
+    let setup_marker_source = Arc::new(LocalDevWorkspaceSetupMarkerSource::new(Arc::clone(
+        &local_runtime.workspace_filesystem,
+    )));
     let activation_source = Arc::new(
         SelectableSkillContextSource::new(
             extension.bundle_source(),
@@ -953,15 +923,6 @@ fn local_dev_filesystem_skill_context_source(
         activation_source,
         execution_adapter,
     })
-}
-
-fn workspace_setup_marker_path(marker: &str) -> Result<ScopedPath, SkillActivationSelectionError> {
-    let marker = marker.trim_start_matches('/');
-    if marker.is_empty() {
-        return Err(SkillActivationSelectionError::ParseFailed);
-    }
-    ScopedPath::new(format!("/workspace/{marker}"))
-        .map_err(|_| SkillActivationSelectionError::ParseFailed)
 }
 
 struct ValidatedRuntimeIdentity {
@@ -2082,7 +2043,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_dev_runtime_suppresses_setup_skill_when_workspace_marker_exists() {
+    async fn local_dev_runtime_suppresses_explicit_setup_skill_when_workspace_marker_exists() {
         let root = tempfile::tempdir().expect("tempdir");
         let storage_root = root.path().join("local-dev");
         std::fs::create_dir_all(storage_root.join("skills/setup-helper")).expect("user skill dir");
@@ -2127,7 +2088,7 @@ mod tests {
         let conversation = runtime.new_conversation().await.expect("conversation");
         let result = tokio::time::timeout(
             Duration::from_secs(3),
-            runtime.execute_skill_message(&conversation, "please run setup-helper"),
+            runtime.execute_skill_message(&conversation, "$setup-helper"),
         )
         .await
         .expect("skill execution should finish")

--- a/crates/ironclaw_reborn_composition/src/runtime/skills.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/skills.rs
@@ -1,13 +1,8 @@
-use std::collections::HashSet;
-use std::sync::Arc;
-
-use ironclaw_filesystem::{FilesystemError, LocalFilesystem, ScopedFilesystem};
 use ironclaw_first_party_extensions::{
-    SetupMarkerSource, SkillActivationMode as FirstPartySkillActivationMode, SkillActivationPlan,
-    SkillActivationRequest as FirstPartySkillActivationRequest, SkillActivationSelectionError,
+    SkillActivationMode as FirstPartySkillActivationMode, SkillActivationPlan,
+    SkillActivationRequest as FirstPartySkillActivationRequest,
     SkillBundleAsset as FirstPartySkillBundleAsset, SkillBundleAssetReadError, SkillExecutionPlan,
 };
-use ironclaw_host_api::ScopedPath;
 use ironclaw_loop_support::{SkillBundleId, SkillBundleSource, SkillSourceKind};
 use ironclaw_turns::run_profile::LoopRunContext;
 
@@ -206,72 +201,4 @@ impl From<FirstPartySkillBundleAsset> for RebornSkillAsset {
 
 pub(super) fn skill_asset_error(error: SkillBundleAssetReadError) -> RebornRuntimeError {
     RebornRuntimeError::SkillExecution(error.to_string())
-}
-
-#[derive(Debug)]
-pub(super) struct LocalDevWorkspaceSetupMarkerSource {
-    filesystem: Arc<ScopedFilesystem<LocalFilesystem>>,
-}
-
-impl LocalDevWorkspaceSetupMarkerSource {
-    pub(super) fn new(filesystem: Arc<ScopedFilesystem<LocalFilesystem>>) -> Self {
-        Self { filesystem }
-    }
-}
-
-#[async_trait::async_trait]
-impl SetupMarkerSource for LocalDevWorkspaceSetupMarkerSource {
-    async fn satisfied_setup_markers(
-        &self,
-        run_context: &LoopRunContext,
-        markers: &HashSet<String>,
-    ) -> Result<HashSet<String>, SkillActivationSelectionError> {
-        let scope = run_context.scope.to_resource_scope();
-        let mut satisfied = HashSet::new();
-        for marker in markers {
-            let Some(path) = workspace_setup_marker_path(marker) else {
-                continue;
-            };
-            match self.filesystem.stat(&scope, &path).await {
-                Ok(_) => {
-                    satisfied.insert(marker.clone());
-                }
-                Err(FilesystemError::NotFound { .. }) => {}
-                Err(_) => return Err(SkillActivationSelectionError::SourceUnavailable),
-            }
-        }
-        Ok(satisfied)
-    }
-}
-
-fn workspace_setup_marker_path(marker: &str) -> Option<ScopedPath> {
-    let marker = marker.trim_start_matches('/');
-    if marker.is_empty() {
-        tracing::debug!("ignoring empty skill setup marker");
-        return None;
-    }
-    match ScopedPath::new(format!("/workspace/{marker}")) {
-        Ok(path) => Some(path),
-        Err(reason) => {
-            tracing::debug!(%marker, %reason, "ignoring invalid skill setup marker");
-            None
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn workspace_setup_marker_path_ignores_invalid_markers() {
-        assert!(workspace_setup_marker_path("").is_none());
-        assert!(workspace_setup_marker_path("../escape").is_none());
-        assert_eq!(
-            workspace_setup_marker_path("/markers/setup.done")
-                .expect("valid setup marker path")
-                .as_str(),
-            "/workspace/markers/setup.done"
-        );
-    }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime/skills.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/skills.rs
@@ -1,8 +1,13 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use ironclaw_filesystem::{FilesystemError, LocalFilesystem, ScopedFilesystem};
 use ironclaw_first_party_extensions::{
-    SkillActivationMode as FirstPartySkillActivationMode, SkillActivationPlan,
-    SkillActivationRequest as FirstPartySkillActivationRequest,
+    SetupMarkerSource, SkillActivationMode as FirstPartySkillActivationMode, SkillActivationPlan,
+    SkillActivationRequest as FirstPartySkillActivationRequest, SkillActivationSelectionError,
     SkillBundleAsset as FirstPartySkillBundleAsset, SkillBundleAssetReadError, SkillExecutionPlan,
 };
+use ironclaw_host_api::ScopedPath;
 use ironclaw_loop_support::{SkillBundleId, SkillBundleSource, SkillSourceKind};
 use ironclaw_turns::run_profile::LoopRunContext;
 
@@ -201,4 +206,72 @@ impl From<FirstPartySkillBundleAsset> for RebornSkillAsset {
 
 pub(super) fn skill_asset_error(error: SkillBundleAssetReadError) -> RebornRuntimeError {
     RebornRuntimeError::SkillExecution(error.to_string())
+}
+
+#[derive(Debug)]
+pub(super) struct LocalDevWorkspaceSetupMarkerSource {
+    filesystem: Arc<ScopedFilesystem<LocalFilesystem>>,
+}
+
+impl LocalDevWorkspaceSetupMarkerSource {
+    pub(super) fn new(filesystem: Arc<ScopedFilesystem<LocalFilesystem>>) -> Self {
+        Self { filesystem }
+    }
+}
+
+#[async_trait::async_trait]
+impl SetupMarkerSource for LocalDevWorkspaceSetupMarkerSource {
+    async fn satisfied_setup_markers(
+        &self,
+        run_context: &LoopRunContext,
+        markers: &HashSet<String>,
+    ) -> Result<HashSet<String>, SkillActivationSelectionError> {
+        let scope = run_context.scope.to_resource_scope();
+        let mut satisfied = HashSet::new();
+        for marker in markers {
+            let Some(path) = workspace_setup_marker_path(marker) else {
+                continue;
+            };
+            match self.filesystem.stat(&scope, &path).await {
+                Ok(_) => {
+                    satisfied.insert(marker.clone());
+                }
+                Err(FilesystemError::NotFound { .. }) => {}
+                Err(_) => return Err(SkillActivationSelectionError::SourceUnavailable),
+            }
+        }
+        Ok(satisfied)
+    }
+}
+
+fn workspace_setup_marker_path(marker: &str) -> Option<ScopedPath> {
+    let marker = marker.trim_start_matches('/');
+    if marker.is_empty() {
+        tracing::debug!("ignoring empty skill setup marker");
+        return None;
+    }
+    match ScopedPath::new(format!("/workspace/{marker}")) {
+        Ok(path) => Some(path),
+        Err(reason) => {
+            tracing::debug!(%marker, %reason, "ignoring invalid skill setup marker");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_setup_marker_path_ignores_invalid_markers() {
+        assert!(workspace_setup_marker_path("").is_none());
+        assert!(workspace_setup_marker_path("../escape").is_none());
+        assert_eq!(
+            workspace_setup_marker_path("/markers/setup.done")
+                .expect("valid setup marker path")
+                .as_str(),
+            "/workspace/markers/setup.done"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add a setup-marker source hook to Reborn first-party skill activation
- wire local-dev skill selection to check satisfied setup markers through a read-only /workspace scoped filesystem
- add a Reborn runtime regression proving a setup skill is not injected after its workspace marker exists

## Tests
- cargo check -p ironclaw_first_party_extensions -p ironclaw_reborn_composition
- cargo test -p ironclaw_first_party_extensions activation::
- cargo test -p ironclaw_reborn_composition local_dev_runtime_suppresses_setup_skill_when_workspace_marker_exists
- cargo test -p ironclaw_reborn_composition local_dev_runtime_wires_filesystem_skills_by_default_to_model_calls
- cargo test -p ironclaw_reborn_composition execute_skill_message_returns_plan_and_reads_active_bundle_assets
- cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold
- git diff --check