### PR TITLE
docs(reborn): map gsuite port phases

### DIFF
--- a/docs/plans/2026-05-24-gsuite-reborn-port-map.md
+++ b/docs/plans/2026-05-24-gsuite-reborn-port-map.md
@@ -10,7 +10,9 @@ extension boundaries.
 - `crates/ironclaw_auth` owns product auth flows, callback claim/fail/complete,
   credential accounts, provider exchange contracts, and in-memory fakes.
 - `crates/ironclaw_first_party_extensions` owns concrete first-party userland
-  extension code and narrow ports.
+  extension behavior, package descriptors, and host-bundled handlers.
+- `crates/ironclaw_first_party_extension_ports` owns loop-facing adapter and
+  port contracts for first-party extension activation/execution surfaces.
 - `crates/ironclaw_reborn_composition` wires built-in first-party packages,
   handler registries, product auth ports, secret stores, and runtime HTTP
   egress.
@@ -49,12 +51,15 @@ extension boundaries.
 
 ## Deferred Issue Hooks
 
-- Composition wiring should reference #3939, #3944, #3955, #3904, and #3949.
-- Shim/live harness should reference #3944, #3955, and #3903.
-- Closeout should reference old GSuite PRs #3893-#3898.
+- Composition wiring should reference #3967 and blocking PRs #3939, #3944,
+  #3955, #3904, and #3949.
+- Shim/live harness should reference #3968 and blocking PRs #3944, #3955, and
+  #3903.
+- Closeout should reference #3969 and old GSuite PRs #3893-#3898.
 
 ## Target Verification
 
 - Phase 2: `cargo test -p ironclaw_auth`
 - Phase 3/4: `cargo test -p ironclaw_first_party_extensions`
+- Port contract changes: `cargo test -p ironclaw_first_party_extension_ports`
 - Dependency changes: `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`

--- a/docs/plans/2026-05-24-gsuite-reborn-port-map.md
+++ b/docs/plans/2026-05-24-gsuite-reborn-port-map.md
@@ -1,0 +1,60 @@
+# GSuite Reborn Port Map
+
+This plan supersedes the old Google phase worktrees and PRs #3893-#3898. The
+replacement stack starts from `origin/reborn-integration` at `38b8a9210` and
+ports only the pieces that still fit the current Reborn auth and first-party
+extension boundaries.
+
+## Current Base
+
+- `crates/ironclaw_auth` owns product auth flows, callback claim/fail/complete,
+  credential accounts, provider exchange contracts, and in-memory fakes.
+- `crates/ironclaw_first_party_extensions` owns concrete first-party userland
+  extension code and narrow ports.
+- `crates/ironclaw_reborn_composition` wires built-in first-party packages,
+  handler registries, product auth ports, secret stores, and runtime HTTP
+  egress.
+- `crates/ironclaw_host_runtime` owns host runtime authority,
+  `FirstPartyCapabilityHandler`, `FirstPartyCapabilityRegistry`, and built-in
+  first-party dispatch.
+
+## Phase Source Decisions
+
+| Old source | Decision | Replacement owner |
+| --- | --- | --- |
+| Phase 1 `crates/ironclaw_oauth` | Rewrite, do not port as a crate | `crates/ironclaw_auth::oauth` helpers |
+| Phase 2 blocked-auth resume path | Drop for this stack | Already covered by current product auth continuation flow |
+| Phase 3 Google provider scaffold | Rewrite | `ironclaw_auth` provider helper plus `ironclaw_first_party_extensions::gsuite` |
+| Phase 4 composition wiring | Defer | GitHub issue blocked on composition/manifest PRs |
+| Phase 5 Calendar package | Port/adapt | `crates/ironclaw_first_party_extensions::gsuite::calendar` |
+| Phase 6 Gmail package | Port/adapt | `crates/ironclaw_first_party_extensions::gsuite::gmail` |
+| Phase 7 UI prompts | Defer | Follow-up UI issue only if backend needs it |
+| Phase 8 live harness | Defer | GitHub issue for ignored/manual live tests |
+
+## Port Rules
+
+- Do not recreate `ironclaw_oauth` or `ironclaw_native_extensions`.
+- Keep OAuth callback authority on:
+  `RebornProductAuthServices::handle_oauth_callback -> AuthFlowManager`.
+- Validate callback flow, scope, state, provider, and PKCE before provider
+  exchange.
+- Store and select Google credentials through `CredentialAccountService`.
+- GSuite handlers must use `RuntimeHttpEgress`; they must not own direct HTTP
+  transports.
+- Credential injection must use the selected account `SecretHandle`, not a
+  process-wide `google_oauth_token` constant.
+- Keep Calendar and Gmail package descriptors under first-party extension code;
+  composition decides when to register them into the host package/handler
+  registries.
+
+## Deferred Issue Hooks
+
+- Composition wiring should reference #3939, #3944, #3955, #3904, and #3949.
+- Shim/live harness should reference #3944, #3955, and #3903.
+- Closeout should reference old GSuite PRs #3893-#3898.
+
+## Target Verification
+
+- Phase 2: `cargo test -p ironclaw_auth`
+- Phase 3/4: `cargo test -p ironclaw_first_party_extensions`
+- Dependency changes: `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`


### PR DESCRIPTION
## Summary

This is phase 1 of the replacement GSuite Reborn stack. It adds a port map that documents how the old Google/OAuth phase worktrees and PRs should be folded into the current `reborn-integration` architecture.

The key decision is that we should not merge the obsolete crate layout from the old stack as-is. The replacement stack keeps OAuth protocol helpers inside `crates/ironclaw_auth`, keeps concrete Google Calendar/Gmail tools under `crates/ironclaw_first_party_extensions`, and defers composition/live-harness work until the active base PRs settle.

## Stack

1. This PR: `gsuite/phase-1-port-map` -> `reborn-integration`
2. `gsuite/phase-2-auth-google-oauth` -> `gsuite/phase-1-port-map`
3. `gsuite/phase-3-first-party-gsuite-core` -> `gsuite/phase-2-auth-google-oauth`
4. `gsuite/phase-4-rest-of-gsuite` -> `gsuite/phase-3-first-party-gsuite-core`

## What Changed

- Adds `docs/plans/2026-05-24-gsuite-reborn-port-map.md`.
- Maps old phase PRs/worktrees #3893-#3898 to the new Reborn owners.
- Captures the core ownership decisions:
  - Do not recreate `ironclaw_oauth`.
  - Do not recreate `ironclaw_native_extensions`.
  - Put OAuth protocol helpers under `ironclaw_auth::oauth`.
  - Put Google Calendar/Gmail native tools under `ironclaw_first_party_extensions::gsuite`.
  - Use `CredentialAccountService` for Google credential selection/storage.
  - Use `RuntimeHttpEgress` for Google API calls; handlers must not own direct HTTP transports.
  - Use selected account `SecretHandle`s instead of a process-wide `google_oauth_token` constant.

## Why This Shape

The old phase stack predates the merged Reborn auth and first-party extension crates. Merging it directly would reintroduce ownership that the current architecture has moved elsewhere. This document is the coordination anchor for reviewers so later phases can be reviewed against the intended boundaries rather than the obsolete branch layout.

## Deferred Work Tracked Separately

- #3967: Wire GSuite first-party extensions into Reborn composition.
- #3968: Add shim/live harness coverage for GSuite.
- #3969: Close the superseded old GSuite phase PR stack and remove old worktrees once replacement PRs are reviewed.

## Verification

- Multi-agent code review was run on this phase using `gpt-5.3-codex-spark` for the available reviewers.
- Reviewers returning zero findings: security, bugs, performance/concurrency, tests, conventions, local-patterns.
- Maintainability was reviewed locally after the Spark usage limit was reached; no actionable findings.
- No code tests are required for this docs-only phase.
