### PR TITLE
feat(auth): add google oauth protocol helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "hex",
  "ironclaw_host_api",
  "secrecy",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4136,11 +4136,13 @@ name = "ironclaw_auth"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "ironclaw_host_api",
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/ironclaw_auth/Cargo.toml
+++ b/crates/ironclaw_auth/Cargo.toml
@@ -13,10 +13,12 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
 subtle = "2"
 thiserror = "2"
 url = "2"

--- a/crates/ironclaw_auth/Cargo.toml
+++ b/crates/ironclaw_auth/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 async-trait = "0.1"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
+hex = "0.4"
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -48,8 +48,9 @@ pub use interaction::{
 pub use oauth::{
     GOOGLE_AUTHORIZATION_ENDPOINT, GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_CALENDAR_READONLY_SCOPE,
     GOOGLE_GMAIL_MODIFY_SCOPE, GOOGLE_GMAIL_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
-    GOOGLE_PROVIDER_ID, GOOGLE_TOKEN_ENDPOINT, OAuthAuthorizeUrlRequest, OAuthTokenResponse,
-    PkceCodeChallenge, authorization_code_hash, build_authorization_url,
+    GOOGLE_PROVIDER_ID, GOOGLE_TOKEN_ENDPOINT, OAuthAuthorizationEndpoint,
+    OAuthAuthorizeUrlRequest, OAuthClientId, OAuthExtraParam, OAuthRedirectUri, OAuthState,
+    OAuthTokenResponse, PkceCodeChallenge, authorization_code_hash, build_authorization_url,
     build_google_authorization_url, opaque_state_hash, pkce_s256_challenge, pkce_verifier_hash,
     scope_text,
 };

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -15,6 +15,7 @@ mod fakes;
 mod flow;
 mod ids;
 mod interaction;
+mod oauth;
 mod provider;
 mod scope;
 
@@ -43,6 +44,14 @@ pub use ids::{
 };
 pub use interaction::{
     AuthInteractionService, ManualTokenSetupRequest, SecretSubmitRequest, SecretSubmitResult,
+};
+pub use oauth::{
+    GOOGLE_AUTHORIZATION_ENDPOINT, GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_CALENDAR_READONLY_SCOPE,
+    GOOGLE_GMAIL_MODIFY_SCOPE, GOOGLE_GMAIL_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
+    GOOGLE_PROVIDER_ID, GOOGLE_TOKEN_ENDPOINT, OAuthAuthorizeUrlRequest, OAuthTokenResponse,
+    PkceCodeChallenge, authorization_code_hash, build_authorization_url,
+    build_google_authorization_url, opaque_state_hash, pkce_s256_challenge, pkce_verifier_hash,
+    scope_text,
 };
 pub use provider::{
     AuthProviderClient, OAuthAuthorizationCode, OAuthProviderCallbackRequest,

--- a/crates/ironclaw_auth/src/oauth.rs
+++ b/crates/ironclaw_auth/src/oauth.rs
@@ -180,6 +180,13 @@ pub fn build_authorization_url(
             "oauth authorization endpoint host is required",
         ));
     }
+    for (name, _) in url.query_pairs() {
+        if is_reserved_authorize_param(name.as_ref()) {
+            return Err(AuthProductError::invalid_request(
+                "oauth authorization endpoint must not predefine reserved query parameters",
+            ));
+        }
+    }
 
     {
         let mut pairs = url.query_pairs_mut();
@@ -192,7 +199,7 @@ pub fn build_authorization_url(
             .append_pair("code_challenge", request.code_challenge.as_str())
             .append_pair("code_challenge_method", "S256");
         for (name, value) in request.extra_params {
-            validate_authorize_fragment("oauth query parameter name", name)?;
+            validate_extra_param_name(name)?;
             validate_authorize_fragment("oauth query parameter value", value)?;
             pairs.append_pair(name, value);
         }
@@ -207,14 +214,14 @@ pub fn build_google_authorization_url(
     state: &str,
     code_challenge: &PkceCodeChallenge,
     scopes: &[ProviderScope],
-    allowed_hosted_domain: Option<&str>,
+    hosted_domain_hint: Option<&str>,
 ) -> Result<OAuthAuthorizationUrl, AuthProductError> {
     let mut extra_params = vec![
         ("access_type", "offline"),
         ("prompt", "consent"),
         ("include_granted_scopes", "true"),
     ];
-    if let Some(hosted_domain) = allowed_hosted_domain {
+    if let Some(hosted_domain) = hosted_domain_hint {
         validate_authorize_fragment("google hosted domain", hosted_domain)?;
         extra_params.push(("hd", hosted_domain));
     }
@@ -264,4 +271,27 @@ fn validate_authorize_fragment(label: &'static str, value: &str) -> Result<(), A
         )));
     }
     Ok(())
+}
+
+fn validate_extra_param_name(name: &str) -> Result<(), AuthProductError> {
+    validate_authorize_fragment("oauth query parameter name", name)?;
+    if is_reserved_authorize_param(name) {
+        return Err(AuthProductError::invalid_request(
+            "oauth query parameter name is reserved",
+        ));
+    }
+    Ok(())
+}
+
+fn is_reserved_authorize_param(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "client_id"
+            | "redirect_uri"
+            | "response_type"
+            | "scope"
+            | "state"
+            | "code_challenge"
+            | "code_challenge_method"
+    )
 }

--- a/crates/ironclaw_auth/src/oauth.rs
+++ b/crates/ironclaw_auth/src/oauth.rs
@@ -1,0 +1,233 @@
+use std::fmt;
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use secrecy::{ExposeSecret, SecretString};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::{
+    AuthProductError, AuthorizationCodeHash, OAuthAuthorizationCode, OAuthAuthorizationUrl,
+    OpaqueStateHash, PkceVerifierHash, PkceVerifierSecret, ProviderScope,
+};
+
+pub const GOOGLE_PROVIDER_ID: &str = "google";
+pub const GOOGLE_AUTHORIZATION_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+pub const GOOGLE_TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+
+pub const GOOGLE_CALENDAR_READONLY_SCOPE: &str =
+    "https://www.googleapis.com/auth/calendar.readonly";
+pub const GOOGLE_CALENDAR_EVENTS_SCOPE: &str = "https://www.googleapis.com/auth/calendar.events";
+pub const GOOGLE_GMAIL_READONLY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.readonly";
+pub const GOOGLE_GMAIL_SEND_SCOPE: &str = "https://www.googleapis.com/auth/gmail.send";
+pub const GOOGLE_GMAIL_MODIFY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.modify";
+
+/// URL-safe S256 PKCE code challenge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PkceCodeChallenge(String);
+
+impl PkceCodeChallenge {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PkceCodeChallenge {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Provider authorization URL input. This is protocol-only: callers still own
+/// durable auth-flow records, callback routing, and provider exchange.
+#[derive(Debug, Clone)]
+pub struct OAuthAuthorizeUrlRequest<'a> {
+    pub authorization_endpoint: &'a str,
+    pub client_id: &'a str,
+    pub redirect_uri: &'a str,
+    pub state: &'a str,
+    pub code_challenge: &'a PkceCodeChallenge,
+    pub scopes: &'a [ProviderScope],
+    pub extra_params: &'a [(&'a str, &'a str)],
+}
+
+/// Redacted token-response projection after provider exchange. It can be used
+/// by provider clients before converting token material into secret handles.
+#[derive(Clone)]
+pub struct OAuthTokenResponse {
+    pub access_token: SecretString,
+    pub refresh_token: Option<SecretString>,
+    pub scopes: Vec<ProviderScope>,
+    pub expires_in_seconds: Option<u64>,
+}
+
+impl fmt::Debug for OAuthTokenResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OAuthTokenResponse")
+            .field("access_token", &"[REDACTED]")
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("scopes", &self.scopes)
+            .field("expires_in_seconds", &self.expires_in_seconds)
+            .finish()
+    }
+}
+
+impl OAuthTokenResponse {
+    pub fn new(
+        access_token: SecretString,
+        refresh_token: Option<SecretString>,
+        scope_text: Option<&str>,
+        expires_in_seconds: Option<u64>,
+    ) -> Result<Self, AuthProductError> {
+        if access_token.expose_secret().trim().is_empty() {
+            return Err(AuthProductError::invalid_request(
+                "oauth access token must not be empty",
+            ));
+        }
+        if refresh_token
+            .as_ref()
+            .is_some_and(|token| token.expose_secret().trim().is_empty())
+        {
+            return Err(AuthProductError::invalid_request(
+                "oauth refresh token must not be empty",
+            ));
+        }
+        let scopes = scope_text
+            .unwrap_or_default()
+            .split_whitespace()
+            .map(ProviderScope::new)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            access_token,
+            refresh_token,
+            scopes,
+            expires_in_seconds,
+        })
+    }
+}
+
+pub fn opaque_state_hash(state: &str) -> Result<OpaqueStateHash, AuthProductError> {
+    OpaqueStateHash::new(sha256_hex(state))
+}
+
+pub fn pkce_verifier_hash(
+    verifier: &PkceVerifierSecret,
+) -> Result<PkceVerifierHash, AuthProductError> {
+    PkceVerifierHash::new(sha256_hex(verifier.expose_secret()))
+}
+
+pub fn authorization_code_hash(
+    code: &OAuthAuthorizationCode,
+) -> Result<AuthorizationCodeHash, AuthProductError> {
+    AuthorizationCodeHash::new(sha256_hex(code.expose_secret()))
+}
+
+pub fn pkce_s256_challenge(verifier: &PkceVerifierSecret) -> PkceCodeChallenge {
+    PkceCodeChallenge(URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.expose_secret().as_bytes())))
+}
+
+pub fn build_authorization_url(
+    request: OAuthAuthorizeUrlRequest<'_>,
+) -> Result<OAuthAuthorizationUrl, AuthProductError> {
+    validate_authorize_fragment("oauth client id", request.client_id)?;
+    validate_authorize_fragment("oauth redirect uri", request.redirect_uri)?;
+    validate_authorize_fragment("oauth state", request.state)?;
+
+    let mut url = Url::parse(request.authorization_endpoint).map_err(|_| {
+        AuthProductError::invalid_request("oauth authorization endpoint must be an absolute url")
+    })?;
+    if url.scheme() != "https" {
+        return Err(AuthProductError::invalid_request(
+            "oauth authorization endpoint must use https",
+        ));
+    }
+    if url.host_str().is_none() {
+        return Err(AuthProductError::invalid_request(
+            "oauth authorization endpoint host is required",
+        ));
+    }
+
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs
+            .append_pair("client_id", request.client_id)
+            .append_pair("redirect_uri", request.redirect_uri)
+            .append_pair("response_type", "code")
+            .append_pair("scope", &scope_text(request.scopes))
+            .append_pair("state", request.state)
+            .append_pair("code_challenge", request.code_challenge.as_str())
+            .append_pair("code_challenge_method", "S256");
+        for (name, value) in request.extra_params {
+            validate_authorize_fragment("oauth query parameter name", name)?;
+            validate_authorize_fragment("oauth query parameter value", value)?;
+            pairs.append_pair(name, value);
+        }
+    }
+
+    OAuthAuthorizationUrl::new(url.to_string())
+}
+
+pub fn build_google_authorization_url(
+    client_id: &str,
+    redirect_uri: &str,
+    state: &str,
+    code_challenge: &PkceCodeChallenge,
+    scopes: &[ProviderScope],
+    allowed_hosted_domain: Option<&str>,
+) -> Result<OAuthAuthorizationUrl, AuthProductError> {
+    let mut extra_params = vec![
+        ("access_type", "offline"),
+        ("prompt", "consent"),
+        ("include_granted_scopes", "true"),
+    ];
+    if let Some(hosted_domain) = allowed_hosted_domain {
+        extra_params.push(("hd", hosted_domain));
+    }
+    build_authorization_url(OAuthAuthorizeUrlRequest {
+        authorization_endpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
+        client_id,
+        redirect_uri,
+        state,
+        code_challenge,
+        scopes,
+        extra_params: &extra_params,
+    })
+}
+
+pub fn scope_text(scopes: &[ProviderScope]) -> String {
+    scopes
+        .iter()
+        .map(ProviderScope::as_str)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sha256_hex(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}
+
+fn validate_authorize_fragment(label: &'static str, value: &str) -> Result<(), AuthProductError> {
+    if value.trim().is_empty() {
+        return Err(AuthProductError::invalid_request(format!(
+            "{label} must not be empty"
+        )));
+    }
+    if value
+        .chars()
+        .any(|character| character == '\0' || character.is_control())
+    {
+        return Err(AuthProductError::invalid_request(format!(
+            "{label} must not contain NUL/control characters"
+        )));
+    }
+    Ok(())
+}

--- a/crates/ironclaw_auth/src/oauth.rs
+++ b/crates/ironclaw_auth/src/oauth.rs
@@ -1,3 +1,11 @@
+//! OAuth protocol helpers shared by Reborn product auth providers.
+//!
+//! This module intentionally owns only protocol-level pieces: Google OAuth
+//! constants, PKCE challenge construction, authorization URL assembly, and
+//! redacted provider token projections. Durable flow state, callback routing,
+//! provider exchange, and credential storage remain owned by the product auth
+//! services in this crate.
+
 use std::fmt;
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -10,15 +18,23 @@ use crate::{
     OpaqueStateHash, PkceVerifierHash, PkceVerifierSecret, ProviderScope,
 };
 
+/// Reborn auth provider id for Google OAuth accounts.
 pub const GOOGLE_PROVIDER_ID: &str = "google";
+/// Google OAuth 2.0 authorization endpoint.
 pub const GOOGLE_AUTHORIZATION_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+/// Google OAuth 2.0 token endpoint.
 pub const GOOGLE_TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
 
+/// Read-only access to Google Calendar calendars and events.
 pub const GOOGLE_CALENDAR_READONLY_SCOPE: &str =
     "https://www.googleapis.com/auth/calendar.readonly";
+/// Read/write access to Google Calendar events.
 pub const GOOGLE_CALENDAR_EVENTS_SCOPE: &str = "https://www.googleapis.com/auth/calendar.events";
+/// Read-only access to Gmail messages and metadata.
 pub const GOOGLE_GMAIL_READONLY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.readonly";
+/// Permission to send Gmail messages.
 pub const GOOGLE_GMAIL_SEND_SCOPE: &str = "https://www.googleapis.com/auth/gmail.send";
+/// Permission to modify Gmail messages and drafts.
 pub const GOOGLE_GMAIL_MODIFY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.modify";
 
 /// URL-safe S256 PKCE code challenge.
@@ -39,7 +55,7 @@ impl fmt::Display for PkceCodeChallenge {
 
 /// Provider authorization URL input. This is protocol-only: callers still own
 /// durable auth-flow records, callback routing, and provider exchange.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OAuthAuthorizeUrlRequest<'a> {
     pub authorization_endpoint: &'a str,
     pub client_id: &'a str,
@@ -48,6 +64,21 @@ pub struct OAuthAuthorizeUrlRequest<'a> {
     pub code_challenge: &'a PkceCodeChallenge,
     pub scopes: &'a [ProviderScope],
     pub extra_params: &'a [(&'a str, &'a str)],
+}
+
+impl fmt::Debug for OAuthAuthorizeUrlRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OAuthAuthorizeUrlRequest")
+            .field("authorization_endpoint", &self.authorization_endpoint)
+            .field("client_id", &"[REDACTED]")
+            .field("redirect_uri", &self.redirect_uri)
+            .field("state", &"[REDACTED]")
+            .field("code_challenge", &"[REDACTED]")
+            .field("scopes", &self.scopes)
+            .field("extra_params", &self.extra_params)
+            .finish()
+    }
 }
 
 /// Redacted token-response projection after provider exchange. It can be used
@@ -184,6 +215,7 @@ pub fn build_google_authorization_url(
         ("include_granted_scopes", "true"),
     ];
     if let Some(hosted_domain) = allowed_hosted_domain {
+        validate_authorize_fragment("google hosted domain", hosted_domain)?;
         extra_params.push(("hd", hosted_domain));
     }
     build_authorization_url(OAuthAuthorizeUrlRequest {
@@ -206,6 +238,8 @@ pub fn scope_text(scopes: &[ProviderScope]) -> String {
 }
 
 fn sha256_hex(value: &str) -> String {
+    // Digest newtypes expose constant-time comparison for callback/state checks;
+    // this helper only constructs the canonical 64-character lowercase hex text.
     let digest = Sha256::digest(value.as_bytes());
     let mut output = String::with_capacity(64);
     for byte in digest {

--- a/crates/ironclaw_auth/src/oauth.rs
+++ b/crates/ironclaw_auth/src/oauth.rs
@@ -247,13 +247,7 @@ pub fn scope_text(scopes: &[ProviderScope]) -> String {
 fn sha256_hex(value: &str) -> String {
     // Digest newtypes expose constant-time comparison for callback/state checks;
     // this helper only constructs the canonical 64-character lowercase hex text.
-    let digest = Sha256::digest(value.as_bytes());
-    let mut output = String::with_capacity(64);
-    for byte in digest {
-        use std::fmt::Write as _;
-        let _ = write!(output, "{byte:02x}");
-    }
-    output
+    hex::encode(Sha256::digest(value.as_bytes()))
 }
 
 fn validate_authorize_fragment(label: &'static str, value: &str) -> Result<(), AuthProductError> {

--- a/crates/ironclaw_auth/src/oauth.rs
+++ b/crates/ironclaw_auth/src/oauth.rs
@@ -141,19 +141,21 @@ impl OAuthTokenResponse {
 }
 
 pub fn opaque_state_hash(state: &str) -> Result<OpaqueStateHash, AuthProductError> {
-    OpaqueStateHash::new(sha256_hex(state))
+    OpaqueStateHash::new(hex::encode(Sha256::digest(state.as_bytes())))
 }
 
 pub fn pkce_verifier_hash(
     verifier: &PkceVerifierSecret,
 ) -> Result<PkceVerifierHash, AuthProductError> {
-    PkceVerifierHash::new(sha256_hex(verifier.expose_secret()))
+    PkceVerifierHash::new(hex::encode(Sha256::digest(
+        verifier.expose_secret().as_bytes(),
+    )))
 }
 
 pub fn authorization_code_hash(
     code: &OAuthAuthorizationCode,
 ) -> Result<AuthorizationCodeHash, AuthProductError> {
-    AuthorizationCodeHash::new(sha256_hex(code.expose_secret()))
+    AuthorizationCodeHash::new(hex::encode(Sha256::digest(code.expose_secret().as_bytes())))
 }
 
 pub fn pkce_s256_challenge(verifier: &PkceVerifierSecret) -> PkceCodeChallenge {
@@ -242,12 +244,6 @@ pub fn scope_text(scopes: &[ProviderScope]) -> String {
         .map(ProviderScope::as_str)
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn sha256_hex(value: &str) -> String {
-    // Digest newtypes expose constant-time comparison for callback/state checks;
-    // this helper only constructs the canonical 64-character lowercase hex text.
-    hex::encode(Sha256::digest(value.as_bytes()))
 }
 
 fn validate_authorize_fragment(label: &'static str, value: &str) -> Result<(), AuthProductError> {

--- a/crates/ironclaw_auth/src/oauth.rs
+++ b/crates/ironclaw_auth/src/oauth.rs
@@ -53,17 +53,180 @@ impl fmt::Display for PkceCodeChallenge {
     }
 }
 
+/// Validated OAuth authorization endpoint.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OAuthAuthorizationEndpoint(String);
+
+impl OAuthAuthorizationEndpoint {
+    pub fn new(value: impl Into<String>) -> Result<Self, AuthProductError> {
+        let value = value.into();
+        let url = Url::parse(&value).map_err(|_| {
+            AuthProductError::invalid_request(
+                "oauth authorization endpoint must be an absolute url",
+            )
+        })?;
+        if url.scheme() != "https" {
+            return Err(AuthProductError::invalid_request(
+                "oauth authorization endpoint must use https",
+            ));
+        }
+        if url.host_str().is_none() {
+            return Err(AuthProductError::invalid_request(
+                "oauth authorization endpoint host is required",
+            ));
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(AuthProductError::invalid_request(
+                "oauth authorization endpoint must not include userinfo",
+            ));
+        }
+        for (name, _) in url.query_pairs() {
+            if is_reserved_authorize_param(name.as_ref()) {
+                return Err(AuthProductError::invalid_request(
+                    "oauth authorization endpoint must not predefine reserved query parameters",
+                ));
+            }
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OAuthAuthorizationEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Validated OAuth client id.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OAuthClientId(String);
+
+impl OAuthClientId {
+    pub fn new(value: impl Into<String>) -> Result<Self, AuthProductError> {
+        let value = value.into();
+        validate_authorize_fragment("oauth client id", &value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OAuthClientId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[REDACTED]")
+    }
+}
+
+/// Validated OAuth redirect URI.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OAuthRedirectUri(String);
+
+impl OAuthRedirectUri {
+    pub fn new(value: impl Into<String>) -> Result<Self, AuthProductError> {
+        let value = value.into();
+        validate_authorize_fragment("oauth redirect uri", &value)?;
+        let url = Url::parse(&value)
+            .map_err(|_| AuthProductError::invalid_request("oauth redirect uri must be a url"))?;
+        let is_loopback_http = url.scheme() == "http"
+            && url
+                .host_str()
+                .is_some_and(|host| matches!(host, "localhost" | "127.0.0.1" | "[::1]"));
+        if url.scheme() != "https" && !is_loopback_http {
+            return Err(AuthProductError::invalid_request(
+                "oauth redirect uri must use https unless it targets loopback localhost",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OAuthRedirectUri {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Validated opaque OAuth state value.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OAuthState(String);
+
+impl OAuthState {
+    pub fn new(value: impl Into<String>) -> Result<Self, AuthProductError> {
+        let value = value.into();
+        validate_authorize_fragment("oauth state", &value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OAuthState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[REDACTED]")
+    }
+}
+
+/// Validated provider-specific OAuth authorization query parameter.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OAuthExtraParam {
+    name: String,
+    value: String,
+}
+
+impl OAuthExtraParam {
+    pub fn new(
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, AuthProductError> {
+        let name = name.into();
+        let value = value.into();
+        validate_extra_param_name(&name)?;
+        validate_authorize_fragment("oauth query parameter value", &value)?;
+        Ok(Self { name, value })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl fmt::Debug for OAuthExtraParam {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OAuthExtraParam")
+            .field("name", &self.name)
+            .field("value", &"[REDACTED]")
+            .finish()
+    }
+}
+
 /// Provider authorization URL input. This is protocol-only: callers still own
 /// durable auth-flow records, callback routing, and provider exchange.
 #[derive(Clone)]
 pub struct OAuthAuthorizeUrlRequest<'a> {
-    pub authorization_endpoint: &'a str,
-    pub client_id: &'a str,
-    pub redirect_uri: &'a str,
-    pub state: &'a str,
+    pub authorization_endpoint: &'a OAuthAuthorizationEndpoint,
+    pub client_id: &'a OAuthClientId,
+    pub redirect_uri: &'a OAuthRedirectUri,
+    pub state: &'a OAuthState,
     pub code_challenge: &'a PkceCodeChallenge,
     pub scopes: &'a [ProviderScope],
-    pub extra_params: &'a [(&'a str, &'a str)],
+    pub extra_params: &'a [OAuthExtraParam],
 }
 
 impl fmt::Debug for OAuthAuthorizeUrlRequest<'_> {
@@ -165,45 +328,21 @@ pub fn pkce_s256_challenge(verifier: &PkceVerifierSecret) -> PkceCodeChallenge {
 pub fn build_authorization_url(
     request: OAuthAuthorizeUrlRequest<'_>,
 ) -> Result<OAuthAuthorizationUrl, AuthProductError> {
-    validate_authorize_fragment("oauth client id", request.client_id)?;
-    validate_authorize_fragment("oauth redirect uri", request.redirect_uri)?;
-    validate_authorize_fragment("oauth state", request.state)?;
-
-    let mut url = Url::parse(request.authorization_endpoint).map_err(|_| {
+    let mut url = Url::parse(request.authorization_endpoint.as_str()).map_err(|_| {
         AuthProductError::invalid_request("oauth authorization endpoint must be an absolute url")
     })?;
-    if url.scheme() != "https" {
-        return Err(AuthProductError::invalid_request(
-            "oauth authorization endpoint must use https",
-        ));
-    }
-    if url.host_str().is_none() {
-        return Err(AuthProductError::invalid_request(
-            "oauth authorization endpoint host is required",
-        ));
-    }
-    for (name, _) in url.query_pairs() {
-        if is_reserved_authorize_param(name.as_ref()) {
-            return Err(AuthProductError::invalid_request(
-                "oauth authorization endpoint must not predefine reserved query parameters",
-            ));
-        }
-    }
-
     {
         let mut pairs = url.query_pairs_mut();
         pairs
-            .append_pair("client_id", request.client_id)
-            .append_pair("redirect_uri", request.redirect_uri)
+            .append_pair("client_id", request.client_id.as_str())
+            .append_pair("redirect_uri", request.redirect_uri.as_str())
             .append_pair("response_type", "code")
             .append_pair("scope", &scope_text(request.scopes))
-            .append_pair("state", request.state)
+            .append_pair("state", request.state.as_str())
             .append_pair("code_challenge", request.code_challenge.as_str())
             .append_pair("code_challenge_method", "S256");
-        for (name, value) in request.extra_params {
-            validate_extra_param_name(name)?;
-            validate_authorize_fragment("oauth query parameter value", value)?;
-            pairs.append_pair(name, value);
+        for param in request.extra_params {
+            pairs.append_pair(param.name(), param.value());
         }
     }
 
@@ -218,20 +357,24 @@ pub fn build_google_authorization_url(
     scopes: &[ProviderScope],
     hosted_domain_hint: Option<&str>,
 ) -> Result<OAuthAuthorizationUrl, AuthProductError> {
+    let authorization_endpoint = OAuthAuthorizationEndpoint::new(GOOGLE_AUTHORIZATION_ENDPOINT)?;
+    let client_id = OAuthClientId::new(client_id)?;
+    let redirect_uri = OAuthRedirectUri::new(redirect_uri)?;
+    let state = OAuthState::new(state)?;
     let mut extra_params = vec![
-        ("access_type", "offline"),
-        ("prompt", "consent"),
-        ("include_granted_scopes", "true"),
+        OAuthExtraParam::new("access_type", "offline")?,
+        OAuthExtraParam::new("prompt", "consent")?,
+        OAuthExtraParam::new("include_granted_scopes", "true")?,
     ];
     if let Some(hosted_domain) = hosted_domain_hint {
         validate_authorize_fragment("google hosted domain", hosted_domain)?;
-        extra_params.push(("hd", hosted_domain));
+        extra_params.push(OAuthExtraParam::new("hd", hosted_domain)?);
     }
     build_authorization_url(OAuthAuthorizeUrlRequest {
-        authorization_endpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
-        client_id,
-        redirect_uri,
-        state,
+        authorization_endpoint: &authorization_endpoint,
+        client_id: &client_id,
+        redirect_uri: &redirect_uri,
+        state: &state,
         code_challenge,
         scopes,
         extra_params: &extra_params,

--- a/crates/ironclaw_auth/tests/auth_product_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract.rs
@@ -8,5 +8,7 @@ mod credential_account_contract;
 mod manual_token_contract;
 #[path = "auth_product_contract/oauth_flow_contract.rs"]
 mod oauth_flow_contract;
+#[path = "auth_product_contract/oauth_helpers_contract.rs"]
+mod oauth_helpers_contract;
 #[path = "auth_product_contract/serde_redaction_contract.rs"]
 mod serde_redaction_contract;

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -1,9 +1,10 @@
 use super::common::*;
 use ironclaw_auth::{
     GOOGLE_AUTHORIZATION_ENDPOINT, GOOGLE_CALENDAR_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
-    OAuthAuthorizationCode, OAuthAuthorizeUrlRequest, OAuthTokenResponse, PkceCodeChallenge,
-    PkceVerifierSecret, build_authorization_url, build_google_authorization_url, opaque_state_hash,
-    pkce_s256_challenge, pkce_verifier_hash, scope_text,
+    OAuthAuthorizationCode, OAuthAuthorizationEndpoint, OAuthAuthorizeUrlRequest, OAuthClientId,
+    OAuthExtraParam, OAuthRedirectUri, OAuthState, OAuthTokenResponse, PkceCodeChallenge,
+    PkceVerifierSecret, ProviderScope, build_authorization_url, build_google_authorization_url,
+    opaque_state_hash, pkce_s256_challenge, pkce_verifier_hash, scope_text,
 };
 use secrecy::ExposeSecret;
 
@@ -12,23 +13,45 @@ fn verifier_challenge() -> PkceCodeChallenge {
     pkce_s256_challenge(&verifier)
 }
 
-fn valid_scopes() -> Vec<ironclaw_auth::ProviderScope> {
+fn valid_scopes() -> Vec<ProviderScope> {
     provider_scopes(&[GOOGLE_CALENDAR_READONLY_SCOPE])
 }
 
-fn valid_authorization_request<'a>(
-    challenge: &'a PkceCodeChallenge,
-    scopes: &'a [ironclaw_auth::ProviderScope],
-    extra_params: &'a [(&'a str, &'a str)],
-) -> OAuthAuthorizeUrlRequest<'a> {
-    OAuthAuthorizeUrlRequest {
-        authorization_endpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
-        client_id: "client-id.apps.googleusercontent.com",
-        redirect_uri: "http://127.0.0.1:5555/oauth/callback/google",
-        state: "opaque-state",
-        code_challenge: challenge,
-        scopes,
-        extra_params,
+struct ValidAuthorizationRequest {
+    authorization_endpoint: OAuthAuthorizationEndpoint,
+    client_id: OAuthClientId,
+    redirect_uri: OAuthRedirectUri,
+    state: OAuthState,
+    code_challenge: PkceCodeChallenge,
+    scopes: Vec<ProviderScope>,
+    extra_params: Vec<OAuthExtraParam>,
+}
+
+impl ValidAuthorizationRequest {
+    fn new(scopes: Vec<ProviderScope>, extra_params: Vec<OAuthExtraParam>) -> Self {
+        Self {
+            authorization_endpoint: OAuthAuthorizationEndpoint::new(GOOGLE_AUTHORIZATION_ENDPOINT)
+                .unwrap(),
+            client_id: OAuthClientId::new("client-id.apps.googleusercontent.com").unwrap(),
+            redirect_uri: OAuthRedirectUri::new("http://127.0.0.1:5555/oauth/callback/google")
+                .unwrap(),
+            state: OAuthState::new("opaque-state").unwrap(),
+            code_challenge: verifier_challenge(),
+            scopes,
+            extra_params,
+        }
+    }
+
+    fn request(&self) -> OAuthAuthorizeUrlRequest<'_> {
+        OAuthAuthorizeUrlRequest {
+            authorization_endpoint: &self.authorization_endpoint,
+            client_id: &self.client_id,
+            redirect_uri: &self.redirect_uri,
+            state: &self.state,
+            code_challenge: &self.code_challenge,
+            scopes: &self.scopes,
+            extra_params: &self.extra_params,
+        }
     }
 }
 
@@ -68,20 +91,13 @@ fn pkce_s256_challenge_uses_url_safe_base64_without_padding() {
 
 #[test]
 fn authorization_url_builder_sets_core_oauth_parameters() {
-    let verifier = PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap();
-    let challenge = pkce_s256_challenge(&verifier);
     let scopes = provider_scopes(&[GOOGLE_CALENDAR_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE]);
+    let request = ValidAuthorizationRequest::new(
+        scopes,
+        vec![OAuthExtraParam::new("access_type", "offline").unwrap()],
+    );
 
-    let url = build_authorization_url(OAuthAuthorizeUrlRequest {
-        authorization_endpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
-        client_id: "client-id.apps.googleusercontent.com",
-        redirect_uri: "http://127.0.0.1:5555/oauth/callback/google",
-        state: "opaque-state",
-        code_challenge: &challenge,
-        scopes: &scopes,
-        extra_params: &[("access_type", "offline")],
-    })
-    .unwrap();
+    let url = build_authorization_url(request.request()).unwrap();
     let parsed = url::Url::parse(url.as_str()).unwrap();
 
     assert_eq!(parsed.scheme(), "https");
@@ -94,7 +110,8 @@ fn authorization_url_builder_sets_core_oauth_parameters() {
     assert!(
         query
             .iter()
-            .any(|(name, value)| name == "code_challenge" && value == challenge.as_str())
+            .any(|(name, value)| name == "code_challenge"
+                && value == request.code_challenge.as_str())
     );
     assert!(
         query
@@ -212,177 +229,102 @@ fn token_response_rejects_invalid_scope() {
 
 #[test]
 fn authorization_url_request_debug_redacts_sensitive_fields() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-    let request = valid_authorization_request(&challenge, &scopes, &[]);
+    let request = ValidAuthorizationRequest::new(
+        valid_scopes(),
+        vec![OAuthExtraParam::new("login_hint", "ada@example.com").unwrap()],
+    );
+    let authorize_request = request.request();
 
-    let debug = format!("{request:?}");
+    let debug = format!("{authorize_request:?}");
 
     assert!(!debug.contains("client-id.apps.googleusercontent.com"));
     assert!(!debug.contains("opaque-state"));
-    assert!(!debug.contains(challenge.as_str()));
+    assert!(!debug.contains(request.code_challenge.as_str()));
+    assert!(!debug.contains("ada@example.com"));
+    assert!(debug.contains("login_hint"));
     assert!(debug.contains("[REDACTED]"));
 }
 
 #[test]
 fn build_authorization_url_rejects_empty_client_id() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        client_id: "",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthClientId::new(""));
 }
 
 #[test]
 fn build_authorization_url_rejects_empty_redirect_uri() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        redirect_uri: "",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthRedirectUri::new(""));
 }
 
 #[test]
 fn build_authorization_url_rejects_empty_state() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        state: "",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthState::new(""));
 }
 
 #[test]
 fn build_authorization_url_rejects_invalid_endpoint() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        authorization_endpoint: "not a url",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthAuthorizationEndpoint::new("not a url"));
 }
 
 #[test]
 fn authorization_url_builder_rejects_non_https_scheme() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        authorization_endpoint: "http://accounts.google.com/o/oauth2/v2/auth",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthAuthorizationEndpoint::new(
+        "http://accounts.google.com/o/oauth2/v2/auth",
+    ));
 }
 
 #[test]
 fn build_authorization_url_rejects_missing_host() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        authorization_endpoint: "https://",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthAuthorizationEndpoint::new("https://"));
 }
 
 #[test]
 fn build_authorization_url_rejects_userinfo_endpoint() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        authorization_endpoint: "https://user:pass@accounts.google.com/o/oauth2/v2/auth",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthAuthorizationEndpoint::new(
+        "https://user:pass@accounts.google.com/o/oauth2/v2/auth",
+    ));
 }
 
 #[test]
 fn build_authorization_url_rejects_reserved_endpoint_query_param() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        authorization_endpoint: "https://accounts.google.com/o/oauth2/v2/auth?state=predefined",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthAuthorizationEndpoint::new(
+        "https://accounts.google.com/o/oauth2/v2/auth?state=predefined",
+    ));
 }
 
 #[test]
 fn build_authorization_url_rejects_empty_param_name() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(valid_authorization_request(
-        &challenge,
-        &scopes,
-        &[("", "value")],
-    )));
+    assert_invalid_request(OAuthExtraParam::new("", "value"));
 }
 
 #[test]
 fn build_authorization_url_rejects_empty_param_value() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(valid_authorization_request(
-        &challenge,
-        &scopes,
-        &[("login_hint", "")],
-    )));
+    assert_invalid_request(OAuthExtraParam::new("login_hint", ""));
 }
 
 #[test]
 fn validate_authorize_fragment_rejects_control_chars() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(valid_authorization_request(
-        &challenge,
-        &scopes,
-        &[("login_hint", "bad\u{0000}value")],
-    )));
+    assert_invalid_request(OAuthExtraParam::new("login_hint", "bad\u{0000}value"));
 }
 
 #[test]
 fn authorization_url_builder_rejects_control_characters() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
-        state: "opaque\nstate",
-        ..valid_authorization_request(&challenge, &scopes, &[])
-    }));
+    assert_invalid_request(OAuthState::new("opaque\nstate"));
 }
 
 #[test]
 fn build_authorization_url_rejects_reserved_extra_param_name() {
-    let challenge = verifier_challenge();
-    let scopes = valid_scopes();
-
-    assert_invalid_request(build_authorization_url(valid_authorization_request(
-        &challenge,
-        &scopes,
-        &[("state", "override")],
-    )));
-    assert_invalid_request(build_authorization_url(valid_authorization_request(
-        &challenge,
-        &scopes,
-        &[("redirect_uri", "https://attacker.example/callback")],
-    )));
+    assert_invalid_request(OAuthExtraParam::new("state", "override"));
+    assert_invalid_request(OAuthExtraParam::new(
+        "redirect_uri",
+        "https://attacker.example/callback",
+    ));
 }
 
 #[test]
 fn authorization_url_builder_handles_empty_scopes_and_extra_params() {
-    let challenge = verifier_challenge();
-    let scopes = Vec::new();
+    let request = ValidAuthorizationRequest::new(Vec::new(), Vec::new());
 
-    let url =
-        build_authorization_url(valid_authorization_request(&challenge, &scopes, &[])).unwrap();
+    let url = build_authorization_url(request.request()).unwrap();
     let parsed = url::Url::parse(url.as_str()).unwrap();
     let query = parsed.query_pairs().collect::<Vec<_>>();
 

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -205,7 +205,7 @@ fn authorization_url_request_debug_redacts_sensitive_fields() {
 }
 
 #[test]
-fn authorization_url_builder_rejects_missing_core_fields() {
+fn build_authorization_url_rejects_empty_client_id() {
     let challenge = verifier_challenge();
     let scopes = valid_scopes();
 
@@ -213,10 +213,24 @@ fn authorization_url_builder_rejects_missing_core_fields() {
         client_id: "",
         ..valid_authorization_request(&challenge, &scopes, &[])
     }));
+}
+
+#[test]
+fn build_authorization_url_rejects_empty_redirect_uri() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
         redirect_uri: "",
         ..valid_authorization_request(&challenge, &scopes, &[])
     }));
+}
+
+#[test]
+fn build_authorization_url_rejects_empty_state() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
         state: "",
         ..valid_authorization_request(&challenge, &scopes, &[])
@@ -224,7 +238,7 @@ fn authorization_url_builder_rejects_missing_core_fields() {
 }
 
 #[test]
-fn authorization_url_builder_rejects_bad_endpoint_urls() {
+fn build_authorization_url_rejects_invalid_endpoint() {
     let challenge = verifier_challenge();
     let scopes = valid_scopes();
 
@@ -232,14 +246,46 @@ fn authorization_url_builder_rejects_bad_endpoint_urls() {
         authorization_endpoint: "not a url",
         ..valid_authorization_request(&challenge, &scopes, &[])
     }));
+}
+
+#[test]
+fn build_authorization_url_rejects_http_endpoint() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
         authorization_endpoint: "http://accounts.google.com/o/oauth2/v2/auth",
         ..valid_authorization_request(&challenge, &scopes, &[])
     }));
+}
+
+#[test]
+fn build_authorization_url_rejects_missing_host() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        authorization_endpoint: "https://",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+}
+
+#[test]
+fn build_authorization_url_rejects_userinfo_endpoint() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
         authorization_endpoint: "https://user:pass@accounts.google.com/o/oauth2/v2/auth",
         ..valid_authorization_request(&challenge, &scopes, &[])
     }));
+}
+
+#[test]
+fn build_authorization_url_rejects_reserved_endpoint_query_param() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
         authorization_endpoint: "https://accounts.google.com/o/oauth2/v2/auth?state=predefined",
         ..valid_authorization_request(&challenge, &scopes, &[])
@@ -247,7 +293,7 @@ fn authorization_url_builder_rejects_bad_endpoint_urls() {
 }
 
 #[test]
-fn authorization_url_builder_rejects_bad_extra_params() {
+fn build_authorization_url_rejects_empty_param_name() {
     let challenge = verifier_challenge();
     let scopes = valid_scopes();
 
@@ -256,16 +302,37 @@ fn authorization_url_builder_rejects_bad_extra_params() {
         &scopes,
         &[("", "value")],
     )));
+}
+
+#[test]
+fn build_authorization_url_rejects_empty_param_value() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(valid_authorization_request(
         &challenge,
         &scopes,
         &[("login_hint", "")],
     )));
+}
+
+#[test]
+fn validate_authorize_fragment_rejects_control_chars() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(valid_authorization_request(
         &challenge,
         &scopes,
         &[("login_hint", "bad\u{0000}value")],
     )));
+}
+
+#[test]
+fn build_authorization_url_rejects_reserved_extra_param_name() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
     assert_invalid_request(build_authorization_url(valid_authorization_request(
         &challenge,
         &scopes,

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -144,6 +144,26 @@ fn google_authorization_url_includes_google_offline_consent_defaults() {
 }
 
 #[test]
+fn google_authorization_url_omits_hd_when_hosted_domain_is_none() {
+    let verifier = PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap();
+    let challenge = pkce_s256_challenge(&verifier);
+    let scopes = provider_scopes(&[GOOGLE_GMAIL_SEND_SCOPE]);
+
+    let url = build_google_authorization_url(
+        "client-id.apps.googleusercontent.com",
+        "http://127.0.0.1:5555/oauth/callback/google",
+        "opaque-state",
+        &challenge,
+        &scopes,
+        None,
+    )
+    .unwrap();
+    let parsed = url::Url::parse(url.as_str()).unwrap();
+
+    assert!(!parsed.query_pairs().any(|(name, _)| name == "hd"));
+}
+
+#[test]
 fn token_response_projects_scopes_and_redacts_debug() {
     let response = OAuthTokenResponse::new(
         secret("access-token"),
@@ -329,6 +349,17 @@ fn validate_authorize_fragment_rejects_control_chars() {
 }
 
 #[test]
+fn authorization_url_builder_rejects_control_characters() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        state: "opaque\nstate",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+}
+
+#[test]
 fn build_authorization_url_rejects_reserved_extra_param_name() {
     let challenge = verifier_challenge();
     let scopes = valid_scopes();
@@ -361,6 +392,11 @@ fn authorization_url_builder_handles_empty_scopes_and_extra_params() {
             .any(|(name, value)| name == "scope" && value.is_empty())
     );
     assert!(!query.iter().any(|(name, _)| name == "access_type"));
+}
+
+#[test]
+fn scope_text_returns_empty_string_for_empty_scopes() {
+    assert!(scope_text(&[]).is_empty());
 }
 
 #[test]

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -1,0 +1,141 @@
+use super::common::*;
+use ironclaw_auth::{
+    GOOGLE_AUTHORIZATION_ENDPOINT, GOOGLE_CALENDAR_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
+    OAuthAuthorizationCode, OAuthAuthorizeUrlRequest, OAuthTokenResponse, PkceVerifierSecret,
+    build_authorization_url, build_google_authorization_url, opaque_state_hash,
+    pkce_s256_challenge, pkce_verifier_hash, scope_text,
+};
+use secrecy::ExposeSecret;
+
+#[test]
+fn oauth_hash_helpers_emit_valid_stable_digests_without_raw_material() {
+    let verifier = PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap();
+    let code = OAuthAuthorizationCode::new(secret("raw-auth-code")).unwrap();
+
+    let state_hash = opaque_state_hash("opaque-state").unwrap();
+    let verifier_hash = pkce_verifier_hash(&verifier).unwrap();
+    let code_hash = ironclaw_auth::authorization_code_hash(&code).unwrap();
+
+    assert_eq!(state_hash.as_str().len(), 64);
+    assert_eq!(verifier_hash.as_str().len(), 64);
+    assert_eq!(code_hash.as_str().len(), 64);
+    assert_ne!(state_hash.as_str(), "opaque-state");
+    assert_ne!(verifier_hash.as_str(), "raw-pkce-verifier");
+    assert_ne!(code_hash.as_str(), "raw-auth-code");
+}
+
+#[test]
+fn pkce_s256_challenge_uses_url_safe_base64_without_padding() {
+    let verifier = PkceVerifierSecret::new(secret("correct horse battery staple")).unwrap();
+
+    let challenge = pkce_s256_challenge(&verifier);
+
+    assert!(!challenge.as_str().contains('='));
+    assert!(!challenge.as_str().contains('+'));
+    assert!(!challenge.as_str().contains('/'));
+    assert_eq!(challenge.as_str().len(), 43);
+}
+
+#[test]
+fn authorization_url_builder_sets_core_oauth_parameters() {
+    let verifier = PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap();
+    let challenge = pkce_s256_challenge(&verifier);
+    let scopes = provider_scopes(&[GOOGLE_CALENDAR_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE]);
+
+    let url = build_authorization_url(OAuthAuthorizeUrlRequest {
+        authorization_endpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
+        client_id: "client-id.apps.googleusercontent.com",
+        redirect_uri: "http://127.0.0.1:5555/oauth/callback/google",
+        state: "opaque-state",
+        code_challenge: &challenge,
+        scopes: &scopes,
+        extra_params: &[("access_type", "offline")],
+    })
+    .unwrap();
+    let parsed = url::Url::parse(url.as_str()).unwrap();
+
+    assert_eq!(parsed.scheme(), "https");
+    assert_eq!(parsed.host_str(), Some("accounts.google.com"));
+    let query = parsed.query_pairs().collect::<Vec<_>>();
+    assert!(query.iter().any(|(name, value)| {
+        name == "scope"
+            && value == "https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/gmail.send"
+    }));
+    assert!(
+        query
+            .iter()
+            .any(|(name, value)| name == "code_challenge" && value == challenge.as_str())
+    );
+    assert!(
+        query
+            .iter()
+            .any(|(name, value)| name == "code_challenge_method" && value == "S256")
+    );
+}
+
+#[test]
+fn google_authorization_url_includes_google_offline_consent_defaults() {
+    let verifier = PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap();
+    let challenge = pkce_s256_challenge(&verifier);
+    let scopes = provider_scopes(&[GOOGLE_GMAIL_SEND_SCOPE]);
+
+    let url = build_google_authorization_url(
+        "client-id.apps.googleusercontent.com",
+        "http://127.0.0.1:5555/oauth/callback/google",
+        "opaque-state",
+        &challenge,
+        &scopes,
+        Some("near.ai"),
+    )
+    .unwrap();
+    let parsed = url::Url::parse(url.as_str()).unwrap();
+    let query = parsed.query_pairs().collect::<Vec<_>>();
+
+    assert!(
+        query
+            .iter()
+            .any(|(name, value)| name == "access_type" && value == "offline")
+    );
+    assert!(
+        query
+            .iter()
+            .any(|(name, value)| name == "prompt" && value == "consent")
+    );
+    assert!(
+        query
+            .iter()
+            .any(|(name, value)| name == "include_granted_scopes" && value == "true")
+    );
+    assert!(
+        query
+            .iter()
+            .any(|(name, value)| name == "hd" && value == "near.ai")
+    );
+}
+
+#[test]
+fn token_response_projects_scopes_and_redacts_debug() {
+    let response = OAuthTokenResponse::new(
+        secret("access-token"),
+        Some(secret("refresh-token")),
+        Some("https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar.readonly"),
+        Some(3600),
+    )
+    .unwrap();
+
+    assert_eq!(response.access_token.expose_secret(), "access-token");
+    assert_eq!(
+        scope_text(&response.scopes),
+        "https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar.readonly"
+    );
+    let debug = format!("{response:?}");
+    assert!(!debug.contains("access-token"));
+    assert!(!debug.contains("refresh-token"));
+}
+
+#[test]
+fn token_response_rejects_empty_token_material() {
+    let error = OAuthTokenResponse::new(secret(""), None, None, None).unwrap_err();
+
+    assert_eq!(error.code(), AuthErrorCode::InvalidRequest);
+}

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -236,6 +236,14 @@ fn authorization_url_builder_rejects_bad_endpoint_urls() {
         authorization_endpoint: "http://accounts.google.com/o/oauth2/v2/auth",
         ..valid_authorization_request(&challenge, &scopes, &[])
     }));
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        authorization_endpoint: "https://user:pass@accounts.google.com/o/oauth2/v2/auth",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        authorization_endpoint: "https://accounts.google.com/o/oauth2/v2/auth?state=predefined",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
 }
 
 #[test]
@@ -258,6 +266,34 @@ fn authorization_url_builder_rejects_bad_extra_params() {
         &scopes,
         &[("login_hint", "bad\u{0000}value")],
     )));
+    assert_invalid_request(build_authorization_url(valid_authorization_request(
+        &challenge,
+        &scopes,
+        &[("state", "override")],
+    )));
+    assert_invalid_request(build_authorization_url(valid_authorization_request(
+        &challenge,
+        &scopes,
+        &[("redirect_uri", "https://attacker.example/callback")],
+    )));
+}
+
+#[test]
+fn authorization_url_builder_handles_empty_scopes_and_extra_params() {
+    let challenge = verifier_challenge();
+    let scopes = Vec::new();
+
+    let url =
+        build_authorization_url(valid_authorization_request(&challenge, &scopes, &[])).unwrap();
+    let parsed = url::Url::parse(url.as_str()).unwrap();
+    let query = parsed.query_pairs().collect::<Vec<_>>();
+
+    assert!(
+        query
+            .iter()
+            .any(|(name, value)| name == "scope" && value.is_empty())
+    );
+    assert!(!query.iter().any(|(name, _)| name == "access_type"));
 }
 
 #[test]

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -269,7 +269,7 @@ fn build_authorization_url_rejects_invalid_endpoint() {
 }
 
 #[test]
-fn build_authorization_url_rejects_http_endpoint() {
+fn authorization_url_builder_rejects_non_https_scheme() {
     let challenge = verifier_challenge();
     let scopes = valid_scopes();
 

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_helpers_contract.rs
@@ -1,11 +1,41 @@
 use super::common::*;
 use ironclaw_auth::{
     GOOGLE_AUTHORIZATION_ENDPOINT, GOOGLE_CALENDAR_READONLY_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
-    OAuthAuthorizationCode, OAuthAuthorizeUrlRequest, OAuthTokenResponse, PkceVerifierSecret,
-    build_authorization_url, build_google_authorization_url, opaque_state_hash,
+    OAuthAuthorizationCode, OAuthAuthorizeUrlRequest, OAuthTokenResponse, PkceCodeChallenge,
+    PkceVerifierSecret, build_authorization_url, build_google_authorization_url, opaque_state_hash,
     pkce_s256_challenge, pkce_verifier_hash, scope_text,
 };
 use secrecy::ExposeSecret;
+
+fn verifier_challenge() -> PkceCodeChallenge {
+    let verifier = PkceVerifierSecret::new(secret("raw-pkce-verifier")).unwrap();
+    pkce_s256_challenge(&verifier)
+}
+
+fn valid_scopes() -> Vec<ironclaw_auth::ProviderScope> {
+    provider_scopes(&[GOOGLE_CALENDAR_READONLY_SCOPE])
+}
+
+fn valid_authorization_request<'a>(
+    challenge: &'a PkceCodeChallenge,
+    scopes: &'a [ironclaw_auth::ProviderScope],
+    extra_params: &'a [(&'a str, &'a str)],
+) -> OAuthAuthorizeUrlRequest<'a> {
+    OAuthAuthorizeUrlRequest {
+        authorization_endpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
+        client_id: "client-id.apps.googleusercontent.com",
+        redirect_uri: "http://127.0.0.1:5555/oauth/callback/google",
+        state: "opaque-state",
+        code_challenge: challenge,
+        scopes,
+        extra_params,
+    }
+}
+
+fn assert_invalid_request<T>(result: Result<T, ironclaw_auth::AuthProductError>) {
+    let error = result.err().expect("request should be invalid");
+    assert_eq!(error.code(), AuthErrorCode::InvalidRequest);
+}
 
 #[test]
 fn oauth_hash_helpers_emit_valid_stable_digests_without_raw_material() {
@@ -138,4 +168,109 @@ fn token_response_rejects_empty_token_material() {
     let error = OAuthTokenResponse::new(secret(""), None, None, None).unwrap_err();
 
     assert_eq!(error.code(), AuthErrorCode::InvalidRequest);
+}
+
+#[test]
+fn token_response_rejects_empty_refresh_token() {
+    assert_invalid_request(OAuthTokenResponse::new(
+        secret("access-token"),
+        Some(secret("")),
+        None,
+        None,
+    ));
+}
+
+#[test]
+fn token_response_rejects_invalid_scope() {
+    assert_invalid_request(OAuthTokenResponse::new(
+        secret("access-token"),
+        None,
+        Some("valid-scope \0invalid"),
+        None,
+    ));
+}
+
+#[test]
+fn authorization_url_request_debug_redacts_sensitive_fields() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+    let request = valid_authorization_request(&challenge, &scopes, &[]);
+
+    let debug = format!("{request:?}");
+
+    assert!(!debug.contains("client-id.apps.googleusercontent.com"));
+    assert!(!debug.contains("opaque-state"));
+    assert!(!debug.contains(challenge.as_str()));
+    assert!(debug.contains("[REDACTED]"));
+}
+
+#[test]
+fn authorization_url_builder_rejects_missing_core_fields() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        client_id: "",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        redirect_uri: "",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        state: "",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+}
+
+#[test]
+fn authorization_url_builder_rejects_bad_endpoint_urls() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        authorization_endpoint: "not a url",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+    assert_invalid_request(build_authorization_url(OAuthAuthorizeUrlRequest {
+        authorization_endpoint: "http://accounts.google.com/o/oauth2/v2/auth",
+        ..valid_authorization_request(&challenge, &scopes, &[])
+    }));
+}
+
+#[test]
+fn authorization_url_builder_rejects_bad_extra_params() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
+    assert_invalid_request(build_authorization_url(valid_authorization_request(
+        &challenge,
+        &scopes,
+        &[("", "value")],
+    )));
+    assert_invalid_request(build_authorization_url(valid_authorization_request(
+        &challenge,
+        &scopes,
+        &[("login_hint", "")],
+    )));
+    assert_invalid_request(build_authorization_url(valid_authorization_request(
+        &challenge,
+        &scopes,
+        &[("login_hint", "bad\u{0000}value")],
+    )));
+}
+
+#[test]
+fn google_authorization_url_rejects_invalid_hosted_domain() {
+    let challenge = verifier_challenge();
+    let scopes = valid_scopes();
+
+    assert_invalid_request(build_google_authorization_url(
+        "client-id.apps.googleusercontent.com",
+        "http://127.0.0.1:5555/oauth/callback/google",
+        "opaque-state",
+        &challenge,
+        &scopes,
+        Some("near.ai\nexample.com"),
+    ));
 }

--- a/docs/plans/2026-05-24-gsuite-reborn-port-map.md
+++ b/docs/plans/2026-05-24-gsuite-reborn-port-map.md
@@ -10,7 +10,9 @@ extension boundaries.
 - `crates/ironclaw_auth` owns product auth flows, callback claim/fail/complete,
   credential accounts, provider exchange contracts, and in-memory fakes.
 - `crates/ironclaw_first_party_extensions` owns concrete first-party userland
-  extension code and narrow ports.
+  extension behavior, package descriptors, and host-bundled handlers.
+- `crates/ironclaw_first_party_extension_ports` owns loop-facing adapter and
+  port contracts for first-party extension activation/execution surfaces.
 - `crates/ironclaw_reborn_composition` wires built-in first-party packages,
   handler registries, product auth ports, secret stores, and runtime HTTP
   egress.
@@ -49,12 +51,15 @@ extension boundaries.
 
 ## Deferred Issue Hooks
 
-- Composition wiring should reference #3939, #3944, #3955, #3904, and #3949.
-- Shim/live harness should reference #3944, #3955, and #3903.
-- Closeout should reference old GSuite PRs #3893-#3898.
+- Composition wiring should reference #3967 and blocking PRs #3939, #3944,
+  #3955, #3904, and #3949.
+- Shim/live harness should reference #3968 and blocking PRs #3944, #3955, and
+  #3903.
+- Closeout should reference #3969 and old GSuite PRs #3893-#3898.
 
 ## Target Verification
 
 - Phase 2: `cargo test -p ironclaw_auth`
 - Phase 3/4: `cargo test -p ironclaw_first_party_extensions`
+- Port contract changes: `cargo test -p ironclaw_first_party_extension_ports`
 - Dependency changes: `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`

--- a/docs/plans/2026-05-24-gsuite-reborn-port-map.md
+++ b/docs/plans/2026-05-24-gsuite-reborn-port-map.md
@@ -1,0 +1,60 @@
+# GSuite Reborn Port Map
+
+This plan supersedes the old Google phase worktrees and PRs #3893-#3898. The
+replacement stack starts from `origin/reborn-integration` at `38b8a9210` and
+ports only the pieces that still fit the current Reborn auth and first-party
+extension boundaries.
+
+## Current Base
+
+- `crates/ironclaw_auth` owns product auth flows, callback claim/fail/complete,
+  credential accounts, provider exchange contracts, and in-memory fakes.
+- `crates/ironclaw_first_party_extensions` owns concrete first-party userland
+  extension code and narrow ports.
+- `crates/ironclaw_reborn_composition` wires built-in first-party packages,
+  handler registries, product auth ports, secret stores, and runtime HTTP
+  egress.
+- `crates/ironclaw_host_runtime` owns host runtime authority,
+  `FirstPartyCapabilityHandler`, `FirstPartyCapabilityRegistry`, and built-in
+  first-party dispatch.
+
+## Phase Source Decisions
+
+| Old source | Decision | Replacement owner |
+| --- | --- | --- |
+| Phase 1 `crates/ironclaw_oauth` | Rewrite, do not port as a crate | `crates/ironclaw_auth::oauth` helpers |
+| Phase 2 blocked-auth resume path | Drop for this stack | Already covered by current product auth continuation flow |
+| Phase 3 Google provider scaffold | Rewrite | `ironclaw_auth` provider helper plus `ironclaw_first_party_extensions::gsuite` |
+| Phase 4 composition wiring | Defer | GitHub issue blocked on composition/manifest PRs |
+| Phase 5 Calendar package | Port/adapt | `crates/ironclaw_first_party_extensions::gsuite::calendar` |
+| Phase 6 Gmail package | Port/adapt | `crates/ironclaw_first_party_extensions::gsuite::gmail` |
+| Phase 7 UI prompts | Defer | Follow-up UI issue only if backend needs it |
+| Phase 8 live harness | Defer | GitHub issue for ignored/manual live tests |
+
+## Port Rules
+
+- Do not recreate `ironclaw_oauth` or `ironclaw_native_extensions`.
+- Keep OAuth callback authority on:
+  `RebornProductAuthServices::handle_oauth_callback -> AuthFlowManager`.
+- Validate callback flow, scope, state, provider, and PKCE before provider
+  exchange.
+- Store and select Google credentials through `CredentialAccountService`.
+- GSuite handlers must use `RuntimeHttpEgress`; they must not own direct HTTP
+  transports.
+- Credential injection must use the selected account `SecretHandle`, not a
+  process-wide `google_oauth_token` constant.
+- Keep Calendar and Gmail package descriptors under first-party extension code;
+  composition decides when to register them into the host package/handler
+  registries.
+
+## Deferred Issue Hooks
+
+- Composition wiring should reference #3939, #3944, #3955, #3904, and #3949.
+- Shim/live harness should reference #3944, #3955, and #3903.
+- Closeout should reference old GSuite PRs #3893-#3898.
+
+## Target Verification
+
+- Phase 2: `cargo test -p ironclaw_auth`
+- Phase 3/4: `cargo test -p ironclaw_first_party_extensions`
+- Dependency changes: `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`


### PR DESCRIPTION
## Summary

This is phase 2 of the replacement GSuite Reborn stack. It folds the OAuth protocol substrate into the existing `ironclaw_auth` crate instead of adding a standalone `ironclaw_oauth` crate.

The goal is to provide the Google OAuth constants and protocol helpers that later GSuite phases need while keeping product auth ownership in the crate that already owns auth flows, credential accounts, callback state, provider exchange contracts, and test fakes.

## Stack

1. `gsuite/phase-1-port-map` -> `reborn-integration`
2. This PR: `gsuite/phase-2-auth-google-oauth` -> `gsuite/phase-1-port-map`
3. `gsuite/phase-3-first-party-gsuite-core` -> `gsuite/phase-2-auth-google-oauth`
4. `gsuite/phase-4-rest-of-gsuite` -> `gsuite/phase-3-first-party-gsuite-core`

## What Changed

- Adds `crates/ironclaw_auth/src/oauth.rs`.
- Re-exports OAuth helpers from `crates/ironclaw_auth/src/lib.rs`.
- Adds dependencies needed for protocol helper behavior:
  - `base64`
  - `sha2`
- Adds auth product contract tests for OAuth helper behavior.

## OAuth Helper Surface

This phase adds:

- Google provider and endpoint constants.
- Calendar/Gmail OAuth scope constants.
- PKCE S256 challenge construction.
- Authorization URL builders, including a Google-specific helper.
- Stable hash helpers for state, PKCE verifier, and authorization code values.
- Scope string normalization via `scope_text`.
- A redaction-conscious `OAuthTokenResponse` type that intentionally does not derive serde serialization.

## Important Design Decisions

- No new `ironclaw_oauth` crate. OAuth protocol helpers live under `ironclaw_auth::oauth` because `ironclaw_auth` already owns product auth flows and credential account contracts.
- Token response handling remains conservative. The token response type does not serialize by default so future product surfaces do not accidentally leak OAuth token material.
- This phase does not wire Google into product composition. It only adds the reusable protocol helpers and tests.

## Deferred Work Tracked Separately

- #3967: Composition wiring after active manifest/composition/runtime PRs settle.
- #3968: Live harness and additional shim coverage.
- #3969: Close superseded old phase PRs, including the old standalone `ironclaw_oauth` PR.

## Verification

- `cargo test -p ironclaw_auth`

Expected result from local verification: all `ironclaw_auth` tests pass, including the new OAuth helper contract tests.
