### PR TITLE
test: cover approval invocation fingerprints

### DIFF
--- a/crates/ironclaw_host_api/src/approval.rs
+++ b/crates/ironclaw_host_api/src/approval.rs
@@ -175,3 +175,85 @@ pub enum FileActionKind {
     Write,
     Delete,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{InvocationId, ResourceEstimate, TenantId, UserId};
+    use serde_json::json;
+
+    fn scope() -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant").unwrap(),
+            user_id: UserId::new("user").unwrap(),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    #[test]
+    fn invocation_fingerprint_canonicalizes_nested_object_key_order() {
+        let scope = scope();
+        let capability = CapabilityId::new("echo.say").unwrap();
+        let left = json!({
+            "z": 1,
+            "nested": {
+                "b": [3, {"y": true, "x": false}],
+                "a": "first"
+            }
+        });
+        let right = json!({
+            "nested": {
+                "a": "first",
+                "b": [3, {"x": false, "y": true}]
+            },
+            "z": 1
+        });
+
+        let first = InvocationFingerprint::for_dispatch(
+            &scope,
+            &capability,
+            &ResourceEstimate::default(),
+            &left,
+        )
+        .unwrap();
+        let second = InvocationFingerprint::for_dispatch(
+            &scope,
+            &capability,
+            &ResourceEstimate::default(),
+            &right,
+        )
+        .unwrap();
+
+        assert_eq!(first, second);
+        assert!(first.as_str().starts_with("sha256:"));
+        assert_eq!(first.as_str().len(), "sha256:".len() + 64);
+    }
+
+    #[test]
+    fn invocation_fingerprint_separates_dispatch_and_spawn_actions() {
+        let scope = scope();
+        let capability = CapabilityId::new("echo.say").unwrap();
+        let input = json!({"message": "same payload"});
+
+        let dispatch = InvocationFingerprint::for_dispatch(
+            &scope,
+            &capability,
+            &ResourceEstimate::default(),
+            &input,
+        )
+        .unwrap();
+        let spawn = InvocationFingerprint::for_spawn(
+            &scope,
+            &capability,
+            &ResourceEstimate::default(),
+            &input,
+        )
+        .unwrap();
+
+        assert_ne!(dispatch, spawn);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds focused regression coverage for approval invocation fingerprints in `ironclaw_host_api`.
- Verifies semantically identical JSON inputs produce the same fingerprint even when nested object key order differs.
- Verifies `dispatch` and `spawn_capability` approvals do not share fingerprints for the same scope, capability, estimate, and input.


## Change Type

- [x] Security

## Linked Issue

None.

## Validation

<!-- How did you verify this works? -->

- [x] `cargo +1.92.0 fmt -p ironclaw_host_api -- --check`
- [x] `cargo +1.92.0 clippy -p ironclaw_host_api --lib --tests --all-features -- -D warnings`
- [x] `cargo +1.92.0 build -p ironclaw_host_api --all-features`
- [x] `cargo +1.92.0 test -p ironclaw_host_api --lib invocation_fingerprint`
- [x] Relevant tests pass:
  - `approval::tests::invocation_fingerprint_canonicalizes_nested_object_key_order`
  - `approval::tests::invocation_fingerprint_separates_dispatch_and_spawn_actions`
 
- [ ] Workspace-wide cargo commands were not run locally due to resource limits; CI should provide full workspace coverage.
## Security Impact

Test-only change covering approval/tool-execution security semantics. The production approval, sandbox, authorization, network, secret, and file-access paths are unchanged.

## Database Impact

None.

## Blast Radius

Limited to `crates/ironclaw_host_api/src/approval.rs` test coverage. Runtime behavior should not change.

## Rollback Plan

Revert this PR. Since it is test-only, rollback should not affect runtime behavior or persisted state.

## Review Follow-Through

Reviewer judgment requested on whether this is the right minimum proof for approval replay semantics, especially the dispatch/spawn separation boundary. Workspace-wide validation was intentionally deferred to CI because local full-workspace cargo commands exhaust available resources.



---

**Review track**: A
