### PR TITLE
test: cover obligation canonicalization

### DIFF
--- a/crates/ironclaw_host_api/src/decision.rs
+++ b/crates/ironclaw_host_api/src/decision.rs
@@ -195,3 +195,56 @@ impl Obligation {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn obligations_are_canonicalized_into_runtime_evaluation_order() {
+        let reservation_id = ResourceReservationId::new();
+        let obligations = Obligations::new(vec![
+            Obligation::AuditAfter,
+            Obligation::AuditBefore,
+            Obligation::ReserveResources { reservation_id },
+            Obligation::EnforceOutputLimit { bytes: 1024 },
+        ])
+        .unwrap();
+
+        assert_eq!(
+            obligations.as_slice(),
+            &[
+                Obligation::ReserveResources { reservation_id },
+                Obligation::AuditBefore,
+                Obligation::EnforceOutputLimit { bytes: 1024 },
+                Obligation::AuditAfter,
+            ]
+        );
+    }
+
+    #[test]
+    fn obligations_reject_duplicate_or_conflicting_same_kind_entries() {
+        let err = Obligations::new(vec![
+            Obligation::EnforceOutputLimit { bytes: 1024 },
+            Obligation::EnforceOutputLimit { bytes: 2048 },
+        ])
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("duplicate or conflicting EnforceOutputLimit")
+        );
+    }
+
+    #[test]
+    fn obligations_deserialization_fails_closed_on_duplicate_kinds() {
+        let value = serde_json::json!([
+            {"type": "audit_before"},
+            {"type": "audit_before"}
+        ]);
+
+        let err = serde_json::from_value::<Obligations>(value).unwrap_err();
+
+        assert!(err.to_string().contains("duplicate or conflicting"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds focused host API tests for obligation normalization on allowed decisions.
- Verifies obligations are canonicalized into the runtime evaluation order before handlers consume them.
- Verifies duplicate or conflicting same-kind obligations fail closed through both direct construction and JSON deserialization.

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->


- [x] Tests

## Linked Issue

None.

## Validation

<!-- How did you verify this works? -->

- [x] `cargo +1.92.0 fmt -p ironclaw_host_api -- --check`
- [x] `cargo +1.92.0 clippy -p ironclaw_host_api --lib --tests --all-features -- -D warnings`
- [x] `cargo +1.92.0 build -p ironclaw_host_api --all-features`
- [x] `cargo +1.92.0 test -p ironclaw_host_api --lib obligations_`
- [ ] Manual testing: not applicable; this is test-only coverage for host API decision contracts.

## Security Impact

No production behavior changes. The added tests strengthen proof around fail-closed handling for authorization obligations, which are security-relevant because they carry runtime enforcement requirements such as audit, resource, network, output, secret, and mount controls.

## Database Impact

None.

## Blast Radius

Limited to `crates/ironclaw_host_api/src/decision.rs` unit tests. The covered contract is important because future changes to obligation ordering or duplicate handling could affect runtime enforcement, but this PR does not change runtime code.

## Rollback Plan

Revert the test-only commit if the added assertions prove incompatible with the intended host API contract.

## Review Follow-Through

Reviewer judgment requested on whether these are the right invariants for obligation handling: deterministic runtime order, one obligation per kind, and deserialization rejecting ambiguous input before side effects can occur.

---

**Review track**: A (docs/tests/chore)
