### PR TITLE
Wire WebUI projection stream to turn lifecycle prompts

### DIFF
--- a/crates/ironclaw_event_streams/src/types.rs
+++ b/crates/ironclaw_event_streams/src/types.rs
@@ -240,6 +240,26 @@ impl ProjectionSubscription {
         }
     }
 
+    pub fn try_next_buffered(&mut self) -> Option<ProjectionStreamItem> {
+        if self.terminated {
+            return None;
+        }
+        if let Some(item) = self.pending_terminal.take() {
+            return self.observe_terminal_item(item);
+        }
+        match self.terminal_receiver.try_recv() {
+            Ok(item) => return self.observe_terminal_item(item),
+            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {}
+        }
+        match self.receiver.try_recv() {
+            Ok(item) => self.observe_item(Some(item)),
+            Err(mpsc::error::TryRecvError::Empty) => None,
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                self.observe_item_or_terminal_on_close(None)
+            }
+        }
+    }
+
     fn observe_item_or_terminal_on_close(
         &mut self,
         item: Option<ProjectionStreamItem>,
@@ -335,4 +355,52 @@ fn with_observed_terminal_cursor(
 
 pub fn keep_alive_item() -> ProjectionStreamItem {
     ProjectionStreamItem::KeepAlive
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_next_buffered_returns_ready_item_without_waiting() {
+        let (sender, receiver) = mpsc::channel(2);
+        let (_terminal_sender, terminal_receiver) = mpsc::channel(1);
+        sender.try_send(ProjectionStreamItem::KeepAlive).unwrap();
+        let mut subscription = ProjectionSubscription::new(
+            receiver,
+            terminal_receiver,
+            ProjectionStreamAdmissionPermit::detached(),
+        );
+
+        assert!(matches!(
+            subscription.try_next_buffered(),
+            Some(ProjectionStreamItem::KeepAlive)
+        ));
+        assert!(subscription.try_next_buffered().is_none());
+    }
+
+    #[test]
+    fn try_next_buffered_defers_terminal_item_until_buffered_items_drain() {
+        let (sender, receiver) = mpsc::channel(2);
+        let (terminal_sender, terminal_receiver) = mpsc::channel(1);
+        sender.try_send(ProjectionStreamItem::KeepAlive).unwrap();
+        terminal_sender
+            .try_send(ProjectionStreamItem::KeepAlive)
+            .unwrap();
+        let mut subscription = ProjectionSubscription::new(
+            receiver,
+            terminal_receiver,
+            ProjectionStreamAdmissionPermit::detached(),
+        );
+
+        assert!(matches!(
+            subscription.try_next_buffered(),
+            Some(ProjectionStreamItem::KeepAlive)
+        ));
+        assert!(matches!(
+            subscription.try_next_buffered(),
+            Some(ProjectionStreamItem::KeepAlive)
+        ));
+        assert!(subscription.try_next_buffered().is_none());
+    }
 }

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -219,6 +219,7 @@ pub enum ProductOutboundPayload {
     AuthPrompt(AuthPromptView),
     ProjectionSnapshot { state: ProductProjectionState },
     ProjectionUpdate { state: ProductProjectionState },
+    KeepAlive,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -98,12 +98,12 @@ impl ProjectionStream for WebuiRunStatusProjectionStream {
         request: ProjectionSubscriptionRequest,
     ) -> Result<Vec<ProductOutboundEnvelope>, ProductAdapterError> {
         let projection_scope = runtime_projection_scope(&request.actor, &request.scope);
-        let mut cursor = request
+        let origin_cursor = request
             .after_cursor
             .map(|cursor| parse_webui_projection_cursor(cursor.as_str()))
             .transpose()?
             .unwrap_or_default();
-        validate_webui_projection_cursor_scope(&cursor, &request.scope)?;
+        validate_webui_projection_cursor_scope(&origin_cursor, &request.scope)?;
         let mut subscription = self
             .manager
             .subscribe(ProjectionSubscribeRequest {
@@ -113,40 +113,37 @@ impl ProjectionStream for WebuiRunStatusProjectionStream {
                 target: ProjectionTarget::Thread {
                     thread_id: request.scope.thread_id.clone(),
                 },
-                after_cursor: cursor.runtime.clone(),
+                after_cursor: origin_cursor.runtime.clone(),
                 limit: WEBUI_PROJECTION_PAGE_LIMIT,
                 capabilities: SubscriberCapabilities::default(),
             })
             .await
             .map_err(map_event_stream_error)?;
 
-        let mut payloads = Vec::new();
+        let mut batch = WebuiProjectionBatch::new(origin_cursor);
         if let Some(item) = subscription.next().await
             && let Some((runtime_cursor, payload)) = item_to_payload(item, &request.scope)?
         {
-            cursor.runtime = Some(runtime_cursor);
-            payloads.push((cursor.clone(), payload));
+            batch.push_runtime(runtime_cursor, payload);
         }
 
-        let turn_after = cursor.turn.clone();
+        let turn_after = batch.cursor().turn.clone();
         let turn_drain = self.turn_events.drain(&request.scope, turn_after).await?;
         for TurnEventPayload {
             cursor: turn_cursor,
             payload,
         } in turn_drain.payloads
         {
-            cursor.turn = Some(turn_cursor.clone());
-            payloads.push((cursor.clone(), payload));
+            batch.push_turn(turn_cursor, payload);
         }
         if let Some(next_cursor) = turn_drain.next_cursor
-            && cursor.turn.as_ref() != Some(&next_cursor)
+            && batch.cursor().turn.as_ref() != Some(&next_cursor)
         {
-            cursor.turn = Some(next_cursor);
-            payloads.push((cursor.clone(), ProductOutboundPayload::KeepAlive));
+            batch.push_turn(next_cursor, ProductOutboundPayload::KeepAlive);
         }
 
-        payloads
-            .into_iter()
+        batch
+            .into_payloads()
             .map(|(cursor, payload)| {
                 envelope_to_outbound(
                     product_cursor_from_webui_cursor(&cursor)?,
@@ -157,6 +154,44 @@ impl ProjectionStream for WebuiRunStatusProjectionStream {
                 )
             })
             .collect()
+    }
+}
+
+struct WebuiProjectionBatch {
+    cursor: WebuiProjectionCursor,
+    payloads: Vec<(WebuiProjectionCursor, ProductOutboundPayload)>,
+}
+
+impl WebuiProjectionBatch {
+    fn new(cursor: WebuiProjectionCursor) -> Self {
+        Self {
+            cursor,
+            payloads: Vec::new(),
+        }
+    }
+
+    fn cursor(&self) -> &WebuiProjectionCursor {
+        &self.cursor
+    }
+
+    fn push_runtime(&mut self, cursor: EventProjectionCursor, payload: ProductOutboundPayload) {
+        self.cursor.runtime = Some(cursor);
+        self.push(payload);
+    }
+
+    fn push_turn(&mut self, cursor: TurnEventProjectionCursor, payload: ProductOutboundPayload) {
+        self.cursor.turn = Some(cursor);
+        self.push(payload);
+    }
+
+    fn push(&mut self, payload: ProductOutboundPayload) {
+        self.payloads.push((self.cursor.clone(), payload));
+    }
+
+    fn into_payloads(
+        self,
+    ) -> impl Iterator<Item = (WebuiProjectionCursor, ProductOutboundPayload)> {
+        self.payloads.into_iter()
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -21,7 +21,13 @@ use ironclaw_product_adapters::{
     ProjectionCursor as ProductProjectionCursor, ProjectionStream, ProjectionSubscriptionRequest,
     RedactedString,
 };
-use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
+use ironclaw_turns::{
+    ReplyTargetBindingRef, TurnActor, TurnCoordinator, TurnEventProjectionCursor,
+    TurnEventProjectionSource, TurnRunId, TurnScope,
+};
+
+mod turn_events;
+use turn_events::{TurnEventBridge, TurnEventPayload};
 
 const WEBUI_PROJECTION_PAGE_LIMIT: usize = 256;
 const WEBUI_PROJECTION_ADAPTER_ID: &str = "webui_v2";
@@ -30,13 +36,24 @@ const WEBUI_PROJECTION_INSTALLATION_ID: &str = "webui_v2.local";
 #[derive(Clone)]
 pub(crate) struct RebornProjectionServices {
     event_stream_manager: Arc<EventStreamManager>,
+    turn_events: TurnEventBridge,
     webui_reply_target_binding_ref: ReplyTargetBindingRef,
 }
 
 impl RebornProjectionServices {
+    pub(crate) fn with_turn_events(
+        mut self,
+        turn_event_source: Arc<dyn TurnEventProjectionSource>,
+        turn_coordinator: Arc<dyn TurnCoordinator>,
+    ) -> Self {
+        self.turn_events = TurnEventBridge::enabled(turn_event_source, turn_coordinator);
+        self
+    }
+
     pub(crate) fn webui_event_stream(&self) -> Arc<dyn ProjectionStream> {
         Arc::new(WebuiRunStatusProjectionStream {
             manager: Arc::clone(&self.event_stream_manager),
+            turn_events: self.turn_events.clone(),
             reply_target_binding_ref: self.webui_reply_target_binding_ref.clone(),
         })
     }
@@ -58,6 +75,7 @@ pub(crate) fn build_reborn_projection_services(
     ));
     RebornProjectionServices {
         event_stream_manager,
+        turn_events: TurnEventBridge::default(),
         webui_reply_target_binding_ref,
     }
 }
@@ -69,6 +87,7 @@ pub(crate) fn build_reborn_projection_services(
 /// until the browser event schema grows a first-class timeline-entry mapper.
 struct WebuiRunStatusProjectionStream {
     manager: Arc<EventStreamManager>,
+    turn_events: TurnEventBridge,
     reply_target_binding_ref: ReplyTargetBindingRef,
 }
 
@@ -79,10 +98,12 @@ impl ProjectionStream for WebuiRunStatusProjectionStream {
         request: ProjectionSubscriptionRequest,
     ) -> Result<Vec<ProductOutboundEnvelope>, ProductAdapterError> {
         let projection_scope = runtime_projection_scope(&request.actor, &request.scope);
-        let after_cursor = request
+        let mut cursor = request
             .after_cursor
-            .map(|cursor| parse_event_projection_cursor(cursor.as_str()))
-            .transpose()?;
+            .map(|cursor| parse_webui_projection_cursor(cursor.as_str()))
+            .transpose()?
+            .unwrap_or_default();
+        validate_webui_projection_cursor_scope(&cursor, &request.scope)?;
         let mut subscription = self
             .manager
             .subscribe(ProjectionSubscribeRequest {
@@ -92,23 +113,50 @@ impl ProjectionStream for WebuiRunStatusProjectionStream {
                 target: ProjectionTarget::Thread {
                     thread_id: request.scope.thread_id.clone(),
                 },
-                after_cursor,
+                after_cursor: cursor.runtime.clone(),
                 limit: WEBUI_PROJECTION_PAGE_LIMIT,
                 capabilities: SubscriberCapabilities::default(),
             })
             .await
             .map_err(map_event_stream_error)?;
 
-        match subscription.next().await {
-            Some(item) => item_to_outbound(
-                item,
-                &request.scope,
-                &request.actor,
-                &self.reply_target_binding_ref,
-            )
-            .map(|item| item.into_iter().collect()),
-            None => Ok(Vec::new()),
+        let mut payloads = Vec::new();
+        if let Some(item) = subscription.next().await
+            && let Some((runtime_cursor, payload)) = item_to_payload(item, &request.scope)?
+        {
+            cursor.runtime = Some(runtime_cursor);
+            payloads.push((cursor.clone(), payload));
         }
+
+        let turn_after = cursor.turn.clone();
+        let turn_drain = self.turn_events.drain(&request.scope, turn_after).await?;
+        for TurnEventPayload {
+            cursor: turn_cursor,
+            payload,
+        } in turn_drain.payloads
+        {
+            cursor.turn = Some(turn_cursor.clone());
+            payloads.push((cursor.clone(), payload));
+        }
+        if let Some(next_cursor) = turn_drain.next_cursor
+            && cursor.turn.as_ref() != Some(&next_cursor)
+        {
+            cursor.turn = Some(next_cursor);
+            payloads.push((cursor.clone(), ProductOutboundPayload::KeepAlive));
+        }
+
+        payloads
+            .into_iter()
+            .map(|(cursor, payload)| {
+                envelope_to_outbound(
+                    product_cursor_from_webui_cursor(&cursor)?,
+                    payload,
+                    &request.scope,
+                    &request.actor,
+                    &self.reply_target_binding_ref,
+                )
+            })
+            .collect()
     }
 }
 
@@ -128,46 +176,77 @@ fn runtime_projection_scope(actor: &TurnActor, scope: &TurnScope) -> EventProjec
     }
 }
 
-fn parse_event_projection_cursor(
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct WebuiProjectionCursor {
+    runtime: Option<EventProjectionCursor>,
+    turn: Option<TurnEventProjectionCursor>,
+}
+
+fn parse_webui_projection_cursor(
     cursor: &str,
-) -> Result<EventProjectionCursor, ProductAdapterError> {
-    serde_json::from_str(cursor).map_err(|_| ProductAdapterError::InvalidIdentifier {
-        kind: "projection_cursor",
-        reason: "must be a WebUI projection cursor".to_string(),
+) -> Result<WebuiProjectionCursor, ProductAdapterError> {
+    if let Ok(parsed) = serde_json::from_str::<WebuiProjectionCursor>(cursor)
+        && (parsed.runtime.is_some() || parsed.turn.is_some())
+    {
+        return Ok(parsed);
+    }
+    let runtime = serde_json::from_str::<EventProjectionCursor>(cursor).map_err(|_| {
+        ProductAdapterError::InvalidIdentifier {
+            kind: "projection_cursor",
+            reason: "must be a WebUI projection cursor".to_string(),
+        }
+    })?;
+    Ok(WebuiProjectionCursor {
+        runtime: Some(runtime),
+        turn: None,
     })
 }
 
-fn item_to_outbound(
+fn validate_webui_projection_cursor_scope(
+    cursor: &WebuiProjectionCursor,
+    scope: &TurnScope,
+) -> Result<(), ProductAdapterError> {
+    if let Some(turn) = cursor.turn.as_ref()
+        && &turn.scope != scope
+    {
+        return Err(ProductAdapterError::InvalidIdentifier {
+            kind: "projection_cursor",
+            reason: "turn cursor scope does not match subscription scope".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn product_cursor_from_webui_cursor(
+    cursor: &WebuiProjectionCursor,
+) -> Result<ProductProjectionCursor, ProductAdapterError> {
+    ProductProjectionCursor::new(
+        serde_json::to_string(cursor).map_err(|_| internal_projection_error("cursor encode"))?,
+    )
+}
+
+fn item_to_payload(
     item: ProjectionStreamItem,
     scope: &TurnScope,
-    actor: &TurnActor,
-    reply_target_binding_ref: &ReplyTargetBindingRef,
-) -> Result<Option<ProductOutboundEnvelope>, ProductAdapterError> {
+) -> Result<Option<(EventProjectionCursor, ProductOutboundPayload)>, ProductAdapterError> {
     match item {
-        ProjectionStreamItem::Snapshot(envelope) => envelope_to_outbound(
-            envelope.cursor(),
-            snapshot_state(scope, snapshot_from_envelope(envelope)?)?
-                .map(|state| ProductOutboundPayload::ProjectionSnapshot { state }),
-            scope,
-            actor,
-            reply_target_binding_ref,
-        ),
-        ProjectionStreamItem::Update(envelope) => envelope_to_outbound(
-            envelope.cursor(),
-            replay_state(scope, replay_from_envelope(envelope.as_ref())?)?
-                .map(|state| ProductOutboundPayload::ProjectionUpdate { state }),
-            scope,
-            actor,
-            reply_target_binding_ref,
-        ),
-        ProjectionStreamItem::RebaseRequired { snapshot, .. } => envelope_to_outbound(
-            snapshot.cursor(),
-            snapshot_state(scope, snapshot_from_envelope(*snapshot)?)?
-                .map(|state| ProductOutboundPayload::ProjectionSnapshot { state }),
-            scope,
-            actor,
-            reply_target_binding_ref,
-        ),
+        ProjectionStreamItem::Snapshot(envelope) => {
+            let cursor = envelope.cursor();
+            Ok(snapshot_state(scope, snapshot_from_envelope(envelope)?)?
+                .map(|state| (cursor, ProductOutboundPayload::ProjectionSnapshot { state })))
+        }
+        ProjectionStreamItem::Update(envelope) => {
+            let cursor = envelope.cursor();
+            Ok(
+                replay_state(scope, replay_from_envelope(envelope.as_ref())?)?
+                    .map(|state| (cursor, ProductOutboundPayload::ProjectionUpdate { state })),
+            )
+        }
+        ProjectionStreamItem::RebaseRequired { snapshot, .. } => {
+            let cursor = snapshot.cursor();
+            Ok(snapshot_state(scope, snapshot_from_envelope(*snapshot)?)?
+                .map(|state| (cursor, ProductOutboundPayload::ProjectionSnapshot { state })))
+        }
         ProjectionStreamItem::Lagged { .. } => Err(ProductAdapterError::WorkflowRejected {
             kind: ProductWorkflowRejectionKind::Unavailable,
             status_code: 503,
@@ -232,18 +311,12 @@ fn run_status_projection_state(
 }
 
 fn envelope_to_outbound(
-    cursor: EventProjectionCursor,
-    payload: Option<ProductOutboundPayload>,
+    projection_cursor: ProductProjectionCursor,
+    payload: ProductOutboundPayload,
     scope: &TurnScope,
     actor: &TurnActor,
     reply_target_binding_ref: &ReplyTargetBindingRef,
-) -> Result<Option<ProductOutboundEnvelope>, ProductAdapterError> {
-    let Some(payload) = payload else {
-        return Ok(None);
-    };
-    let projection_cursor = ProductProjectionCursor::new(
-        serde_json::to_string(&cursor).map_err(|_| internal_projection_error("cursor encode"))?,
-    )?;
+) -> Result<ProductOutboundEnvelope, ProductAdapterError> {
     let adapter_id = ProductAdapterId::new(WEBUI_PROJECTION_ADAPTER_ID)?;
     let installation_id = AdapterInstallationId::new(WEBUI_PROJECTION_INSTALLATION_ID)?;
     let target = ProductOutboundTarget::new(
@@ -255,13 +328,13 @@ fn envelope_to_outbound(
             None::<String>,
         )?),
     );
-    Ok(Some(ProductOutboundEnvelope::new(
+    Ok(ProductOutboundEnvelope::new(
         adapter_id,
         installation_id,
         target,
         projection_cursor,
         payload,
-    )))
+    ))
 }
 
 fn run_status_wire(status: RunProjectionStatus) -> &'static str {
@@ -312,236 +385,4 @@ fn internal_projection_error(detail: &'static str) -> ProductAdapterError {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    use ironclaw_events::{InMemoryDurableEventLog, RuntimeEvent};
-    use ironclaw_host_api::{
-        AgentId, CapabilityId, InvocationId, ResourceScope, TenantId, ThreadId, UserId,
-    };
-    use ironclaw_product_adapters::{ProductOutboundEnvelope, ProductOutboundPayload};
-
-    #[tokio::test]
-    async fn webui_event_stream_drains_run_status_projection_from_event_stream_manager() {
-        let tenant_id = TenantId::new("webui-events-tenant").unwrap();
-        let user_id = UserId::new("webui-events-user").unwrap();
-        let agent_id = AgentId::new("webui-events-agent").unwrap();
-        let thread_id = ThreadId::new("webui-events-thread").unwrap();
-        let invocation_id = InvocationId::new();
-        let event_log = Arc::new(InMemoryDurableEventLog::new());
-        event_log
-            .append(RuntimeEvent::model_started(
-                ResourceScope {
-                    tenant_id: tenant_id.clone(),
-                    user_id: user_id.clone(),
-                    agent_id: Some(agent_id.clone()),
-                    project_id: None,
-                    mission_id: None,
-                    thread_id: Some(thread_id.clone()),
-                    invocation_id,
-                },
-                CapabilityId::new("loop.model").unwrap(),
-            ))
-            .await
-            .unwrap();
-
-        let event_log: Arc<dyn DurableEventLog> = event_log;
-        let actor = TurnActor::new(user_id);
-        let services = build_reborn_projection_services(
-            event_log,
-            ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
-        );
-        let events = services
-            .webui_event_stream()
-            .drain(ProjectionSubscriptionRequest {
-                actor,
-                scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
-                after_cursor: None,
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(events.len(), 1);
-        let ProductOutboundPayload::ProjectionSnapshot { state } = events[0].payload() else {
-            panic!("expected projection snapshot");
-        };
-        assert_eq!(state.items.len(), 1);
-        assert!(matches!(
-            state.items[0],
-            ProductProjectionItem::RunStatus { ref status, .. } if status == "running"
-        ));
-    }
-
-    #[tokio::test]
-    async fn webui_event_stream_resumes_after_serialized_projection_cursor() {
-        let tenant_id = TenantId::new("webui-events-tenant").unwrap();
-        let user_id = UserId::new("webui-events-user").unwrap();
-        let agent_id = AgentId::new("webui-events-agent").unwrap();
-        let thread_id = ThreadId::new("webui-events-thread").unwrap();
-        let first_run = InvocationId::new();
-        let second_run = InvocationId::new();
-        let event_log = Arc::new(InMemoryDurableEventLog::new());
-        event_log
-            .append(RuntimeEvent::model_started(
-                resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, first_run),
-                CapabilityId::new("loop.model").unwrap(),
-            ))
-            .await
-            .unwrap();
-
-        let event_log_dyn: Arc<dyn DurableEventLog> = event_log.clone();
-        let actor = TurnActor::new(user_id.clone());
-        let services = build_reborn_projection_services(
-            event_log_dyn,
-            ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
-        );
-        let first = services
-            .webui_event_stream()
-            .drain(ProjectionSubscriptionRequest {
-                actor: actor.clone(),
-                scope: TurnScope::new(
-                    tenant_id.clone(),
-                    Some(agent_id.clone()),
-                    None,
-                    thread_id.clone(),
-                ),
-                after_cursor: None,
-            })
-            .await
-            .unwrap();
-
-        event_log
-            .append(RuntimeEvent::model_started(
-                resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, second_run),
-                CapabilityId::new("loop.model").unwrap(),
-            ))
-            .await
-            .unwrap();
-        let resumed = services
-            .webui_event_stream()
-            .drain(ProjectionSubscriptionRequest {
-                actor,
-                scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
-                after_cursor: Some(first[0].projection_cursor().clone()),
-            })
-            .await
-            .unwrap();
-
-        assert!(contains_run_status(&resumed, second_run, "running"));
-        assert!(!contains_run_status(&resumed, first_run, "running"));
-    }
-
-    #[tokio::test]
-    async fn webui_event_stream_uses_request_actor_for_projection_scope() {
-        let tenant_id = TenantId::new("webui-events-tenant").unwrap();
-        let owner_user_id = UserId::new("webui-events-owner").unwrap();
-        let other_user_id = UserId::new("webui-events-other").unwrap();
-        let agent_id = AgentId::new("webui-events-agent").unwrap();
-        let thread_id = ThreadId::new("webui-events-thread").unwrap();
-        let event_log = Arc::new(InMemoryDurableEventLog::new());
-        event_log
-            .append(RuntimeEvent::model_started(
-                resource_scope(
-                    &tenant_id,
-                    &owner_user_id,
-                    &agent_id,
-                    &thread_id,
-                    InvocationId::new(),
-                ),
-                CapabilityId::new("loop.model").unwrap(),
-            ))
-            .await
-            .unwrap();
-
-        let event_log: Arc<dyn DurableEventLog> = event_log;
-        let services = build_reborn_projection_services(
-            event_log,
-            ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
-        );
-        let events = services
-            .webui_event_stream()
-            .drain(ProjectionSubscriptionRequest {
-                actor: TurnActor::new(other_user_id),
-                scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
-                after_cursor: None,
-            })
-            .await
-            .unwrap();
-
-        assert!(
-            events.is_empty(),
-            "projection stream must not read another user's event stream through a hidden runtime actor"
-        );
-    }
-
-    #[tokio::test]
-    async fn webui_event_stream_rejects_malformed_projection_cursor() {
-        let tenant_id = TenantId::new("webui-events-tenant").unwrap();
-        let user_id = UserId::new("webui-events-user").unwrap();
-        let agent_id = AgentId::new("webui-events-agent").unwrap();
-        let thread_id = ThreadId::new("webui-events-thread").unwrap();
-        let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
-        let actor = TurnActor::new(user_id);
-        let services = build_reborn_projection_services(
-            event_log,
-            ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
-        );
-
-        let error = services
-            .webui_event_stream()
-            .drain(ProjectionSubscriptionRequest {
-                actor,
-                scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
-                after_cursor: Some(ProductProjectionCursor::new("not-json").unwrap()),
-            })
-            .await
-            .unwrap_err();
-
-        assert!(matches!(
-            error,
-            ProductAdapterError::InvalidIdentifier {
-                kind: "projection_cursor",
-                ..
-            }
-        ));
-    }
-
-    fn resource_scope(
-        tenant_id: &TenantId,
-        user_id: &UserId,
-        agent_id: &AgentId,
-        thread_id: &ThreadId,
-        invocation_id: InvocationId,
-    ) -> ResourceScope {
-        ResourceScope {
-            tenant_id: tenant_id.clone(),
-            user_id: user_id.clone(),
-            agent_id: Some(agent_id.clone()),
-            project_id: None,
-            mission_id: None,
-            thread_id: Some(thread_id.clone()),
-            invocation_id,
-        }
-    }
-
-    fn contains_run_status(
-        events: &[ProductOutboundEnvelope],
-        invocation_id: InvocationId,
-        expected_status: &str,
-    ) -> bool {
-        let expected_run_id = TurnRunId::from_uuid(invocation_id.as_uuid());
-        events.iter().any(|event| match event.payload() {
-            ProductOutboundPayload::ProjectionSnapshot { state }
-            | ProductOutboundPayload::ProjectionUpdate { state } => {
-                state.items.iter().any(|item| {
-                    matches!(
-                        item,
-                        ProductProjectionItem::RunStatus { run_id, status }
-                            if *run_id == expected_run_id && status == expected_status
-                    )
-                })
-            }
-            _ => false,
-        })
-    }
-}
+mod tests;

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -121,10 +121,14 @@ impl ProjectionStream for WebuiRunStatusProjectionStream {
             .map_err(map_event_stream_error)?;
 
         let mut batch = WebuiProjectionBatch::new(origin_cursor);
-        if let Some(item) = subscription.next().await
-            && let Some((runtime_cursor, payload)) = item_to_payload(item, &request.scope)?
-        {
-            batch.push_runtime(runtime_cursor, payload);
+        if let Some(item) = subscription.next().await {
+            batch.push_runtime_item(item, &request.scope)?;
+            for _ in 1..WEBUI_PROJECTION_PAGE_LIMIT {
+                let Some(item) = subscription.try_next_buffered() else {
+                    break;
+                };
+                batch.push_runtime_item(item, &request.scope)?;
+            }
         }
 
         let turn_after = batch.cursor().turn.clone();
@@ -177,6 +181,17 @@ impl WebuiProjectionBatch {
     fn push_runtime(&mut self, cursor: EventProjectionCursor, payload: ProductOutboundPayload) {
         self.cursor.runtime = Some(cursor);
         self.push(payload);
+    }
+
+    fn push_runtime_item(
+        &mut self,
+        item: ProjectionStreamItem,
+        scope: &TurnScope,
+    ) -> Result<(), ProductAdapterError> {
+        if let Some((cursor, payload)) = item_to_payload(item, scope)? {
+            self.push_runtime(cursor, payload);
+        }
+        Ok(())
     }
 
     fn push_turn(&mut self, cursor: TurnEventProjectionCursor, payload: ProductOutboundPayload) {

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -1,3 +1,4 @@
+use super::turn_events::WEBUI_TURN_EVENT_PAGE_LIMIT;
 use super::*;
 
 use async_trait::async_trait;
@@ -311,6 +312,124 @@ async fn webui_event_stream_emits_keepalive_when_only_turn_cursor_advances() {
             TurnEventCursor(1)
         ))
     );
+}
+
+#[tokio::test]
+async fn webui_event_stream_reads_past_filtered_turn_event_pages() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let run_id = TurnRunId::new();
+    let mut events = (1..=WEBUI_TURN_EVENT_PAGE_LIMIT as u64)
+        .map(|cursor| TurnLifecycleEvent {
+            cursor: TurnEventCursor(cursor),
+            scope: scope.clone(),
+            run_id,
+            status: TurnStatus::Running,
+            kind: TurnEventKind::RunnerHeartbeat,
+            sanitized_reason: None,
+        })
+        .collect::<Vec<_>>();
+    events.push(TurnLifecycleEvent {
+        cursor: TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1),
+        scope: scope.clone(),
+        run_id,
+        status: TurnStatus::BlockedAuth,
+        kind: TurnEventKind::Blocked,
+        sanitized_reason: Some("GitHub authentication required".to_string()),
+    });
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    )
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource { events }),
+        Arc::new(FakeTurnCoordinator {
+            state: turn_run_state(
+                &scope,
+                &user_id,
+                run_id,
+                TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1),
+            ),
+        }),
+    );
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        events[0].payload(),
+        ProductOutboundPayload::AuthPrompt(prompt)
+            if prompt.turn_run_id == run_id
+                && prompt.body == "GitHub authentication required"
+    ));
+}
+
+#[tokio::test]
+async fn webui_event_stream_does_not_prompt_for_stale_blocked_event() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let run_id = TurnRunId::new();
+    let mut state = turn_run_state(&scope, &user_id, run_id, TurnEventCursor(1));
+    state.event_cursor = TurnEventCursor(2);
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    )
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                run_id,
+                status: TurnStatus::BlockedAuth,
+                kind: TurnEventKind::Blocked,
+                sanitized_reason: Some("stale auth gate".to_string()),
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator { state }),
+    );
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        events[0].payload(),
+        ProductOutboundPayload::ProjectionUpdate { .. }
+    ));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/projection/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests.rs
@@ -1,0 +1,519 @@
+use super::*;
+
+use async_trait::async_trait;
+use ironclaw_events::{InMemoryDurableEventLog, RuntimeEvent};
+use ironclaw_host_api::{
+    AgentId, CapabilityId, InvocationId, ResourceScope, TenantId, ThreadId, UserId,
+};
+use ironclaw_product_adapters::{ProductOutboundEnvelope, ProductOutboundPayload};
+use ironclaw_turns::{
+    AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor as TurnEventCursor,
+    GateRef, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,
+    RunProfileVersion, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnError,
+    TurnEventKind, TurnEventPage, TurnLifecycleEvent, TurnRunState, TurnStatus,
+};
+
+#[tokio::test]
+async fn webui_event_stream_drains_run_status_projection_from_event_stream_manager() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let invocation_id = InvocationId::new();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    event_log
+        .append(RuntimeEvent::model_started(
+            ResourceScope {
+                tenant_id: tenant_id.clone(),
+                user_id: user_id.clone(),
+                agent_id: Some(agent_id.clone()),
+                project_id: None,
+                mission_id: None,
+                thread_id: Some(thread_id.clone()),
+                invocation_id,
+            },
+            CapabilityId::new("loop.model").unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    let event_log: Arc<dyn DurableEventLog> = event_log;
+    let actor = TurnActor::new(user_id);
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    );
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    let ProductOutboundPayload::ProjectionSnapshot { state } = events[0].payload() else {
+        panic!("expected projection snapshot");
+    };
+    assert_eq!(state.items.len(), 1);
+    assert!(matches!(
+        state.items[0],
+        ProductProjectionItem::RunStatus { ref status, .. } if status == "running"
+    ));
+}
+
+#[tokio::test]
+async fn webui_event_stream_resumes_after_serialized_projection_cursor() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let first_run = InvocationId::new();
+    let second_run = InvocationId::new();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    event_log
+        .append(RuntimeEvent::model_started(
+            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, first_run),
+            CapabilityId::new("loop.model").unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    let event_log_dyn: Arc<dyn DurableEventLog> = event_log.clone();
+    let actor = TurnActor::new(user_id.clone());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    );
+    let first = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: actor.clone(),
+            scope: TurnScope::new(
+                tenant_id.clone(),
+                Some(agent_id.clone()),
+                None,
+                thread_id.clone(),
+            ),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    event_log
+        .append(RuntimeEvent::model_started(
+            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, second_run),
+            CapabilityId::new("loop.model").unwrap(),
+        ))
+        .await
+        .unwrap();
+    let resumed = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
+            after_cursor: Some(first[0].projection_cursor().clone()),
+        })
+        .await
+        .unwrap();
+
+    assert!(contains_run_status(&resumed, second_run, "running"));
+    assert!(!contains_run_status(&resumed, first_run, "running"));
+}
+
+#[tokio::test]
+async fn webui_event_stream_resumes_mixed_batch_without_skipping_turn_event() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let runtime_run = InvocationId::new();
+    let turn_run = TurnRunId::new();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    event_log
+        .append(RuntimeEvent::model_started(
+            resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, runtime_run),
+            CapabilityId::new("loop.model").unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let event_log_dyn: Arc<dyn DurableEventLog> = event_log;
+    let actor = TurnActor::new(user_id.clone());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    )
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                run_id: turn_run,
+                status: TurnStatus::BlockedAuth,
+                kind: TurnEventKind::Blocked,
+                sanitized_reason: Some("GitHub authentication required".to_string()),
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1)),
+        }),
+    );
+
+    let first = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: actor.clone(),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(first.len(), 2);
+    assert!(matches!(
+        first[0].payload(),
+        ProductOutboundPayload::ProjectionSnapshot { .. }
+    ));
+    assert!(matches!(
+        first[1].payload(),
+        ProductOutboundPayload::AuthPrompt(_)
+    ));
+
+    let resumed = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: Some(first[0].projection_cursor().clone()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(resumed.len(), 1);
+    assert!(matches!(
+        resumed[0].payload(),
+        ProductOutboundPayload::AuthPrompt(prompt)
+            if prompt.turn_run_id == turn_run
+                && prompt.auth_request_ref == "gate:auth-required"
+    ));
+}
+
+#[tokio::test]
+async fn webui_event_stream_rejects_foreign_composite_turn_cursor() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_a = ThreadId::new("webui-events-thread-a").unwrap();
+    let thread_b = ThreadId::new("webui-events-thread-b").unwrap();
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let scope_a = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_a.clone(),
+    );
+    let scope_b = TurnScope::new(tenant_id, Some(agent_id), None, thread_b);
+    let cursor = product_cursor_from_webui_cursor(&WebuiProjectionCursor {
+        runtime: None,
+        turn: Some(TurnEventProjectionCursor::for_scope(
+            scope_a,
+            TurnEventCursor(10),
+        )),
+    })
+    .unwrap();
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    );
+
+    let error = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope: scope_b,
+            after_cursor: Some(cursor),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ProductAdapterError::InvalidIdentifier {
+            kind: "projection_cursor",
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn webui_event_stream_emits_keepalive_when_only_turn_cursor_advances() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let run_id = TurnRunId::new();
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    )
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                run_id,
+                status: TurnStatus::Running,
+                kind: TurnEventKind::RunnerHeartbeat,
+                sanitized_reason: None,
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: turn_run_state(&scope, &user_id, run_id, TurnEventCursor(1)),
+        }),
+    );
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        events[0].payload(),
+        ProductOutboundPayload::KeepAlive
+    ));
+    let parsed = parse_webui_projection_cursor(events[0].projection_cursor().as_str()).unwrap();
+    assert_eq!(
+        parsed.turn,
+        Some(TurnEventProjectionCursor::for_scope(
+            scope,
+            TurnEventCursor(1)
+        ))
+    );
+}
+
+#[tokio::test]
+async fn webui_event_stream_uses_request_actor_for_projection_scope() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let owner_user_id = UserId::new("webui-events-owner").unwrap();
+    let other_user_id = UserId::new("webui-events-other").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    event_log
+        .append(RuntimeEvent::model_started(
+            resource_scope(
+                &tenant_id,
+                &owner_user_id,
+                &agent_id,
+                &thread_id,
+                InvocationId::new(),
+            ),
+            CapabilityId::new("loop.model").unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    let event_log: Arc<dyn DurableEventLog> = event_log;
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    );
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(other_user_id),
+            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        events.is_empty(),
+        "projection stream must not read another user's event stream through a hidden runtime actor"
+    );
+}
+
+#[tokio::test]
+async fn webui_event_stream_rejects_malformed_projection_cursor() {
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-thread").unwrap();
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let actor = TurnActor::new(user_id);
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    );
+
+    let error = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope: TurnScope::new(tenant_id, Some(agent_id), None, thread_id),
+            after_cursor: Some(ProductProjectionCursor::new("not-json").unwrap()),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ProductAdapterError::InvalidIdentifier {
+            kind: "projection_cursor",
+            ..
+        }
+    ));
+}
+
+fn resource_scope(
+    tenant_id: &TenantId,
+    user_id: &UserId,
+    agent_id: &AgentId,
+    thread_id: &ThreadId,
+    invocation_id: InvocationId,
+) -> ResourceScope {
+    ResourceScope {
+        tenant_id: tenant_id.clone(),
+        user_id: user_id.clone(),
+        agent_id: Some(agent_id.clone()),
+        project_id: None,
+        mission_id: None,
+        thread_id: Some(thread_id.clone()),
+        invocation_id,
+    }
+}
+
+fn contains_run_status(
+    events: &[ProductOutboundEnvelope],
+    invocation_id: InvocationId,
+    expected_status: &str,
+) -> bool {
+    let expected_run_id = TurnRunId::from_uuid(invocation_id.as_uuid());
+    events.iter().any(|event| match event.payload() {
+        ProductOutboundPayload::ProjectionSnapshot { state }
+        | ProductOutboundPayload::ProjectionUpdate { state } => state.items.iter().any(|item| {
+            matches!(
+                item,
+                ProductProjectionItem::RunStatus { run_id, status }
+                    if *run_id == expected_run_id && status == expected_status
+            )
+        }),
+        _ => false,
+    })
+}
+
+struct FakeTurnEventSource {
+    events: Vec<TurnLifecycleEvent>,
+}
+
+#[async_trait]
+impl TurnEventProjectionSource for FakeTurnEventSource {
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        after: Option<TurnEventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        let after = after.unwrap_or_default();
+        let mut events = self
+            .events
+            .iter()
+            .filter(|event| &event.scope == scope && event.cursor > after)
+            .cloned()
+            .collect::<Vec<_>>();
+        events.sort_by_key(|event| event.cursor);
+        let truncated = events.len() > limit;
+        if truncated {
+            events.truncate(limit);
+        }
+        let next_cursor = events.last().map(|event| event.cursor).unwrap_or(after);
+        Ok(TurnEventPage {
+            entries: events,
+            next_cursor,
+            truncated,
+            rebase_required: None,
+        })
+    }
+}
+
+struct FakeTurnCoordinator {
+    state: TurnRunState,
+}
+
+#[async_trait]
+impl TurnCoordinator for FakeTurnCoordinator {
+    async fn submit_turn(
+        &self,
+        _request: SubmitTurnRequest,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        unreachable!("projection tests only read run state")
+    }
+
+    async fn resume_turn(
+        &self,
+        _request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        unreachable!("projection tests only read run state")
+    }
+
+    async fn cancel_run(&self, _request: CancelRunRequest) -> Result<CancelRunResponse, TurnError> {
+        unreachable!("projection tests only read run state")
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        if request.scope == self.state.scope && request.run_id == self.state.run_id {
+            Ok(self.state.clone())
+        } else {
+            Err(TurnError::ScopeNotFound)
+        }
+    }
+}
+
+fn turn_run_state(
+    scope: &TurnScope,
+    user_id: &UserId,
+    run_id: TurnRunId,
+    cursor: TurnEventCursor,
+) -> TurnRunState {
+    TurnRunState {
+        scope: scope.clone(),
+        actor: Some(TurnActor::new(user_id.clone())),
+        turn_id: ironclaw_turns::TurnId::new(),
+        run_id,
+        status: TurnStatus::BlockedAuth,
+        accepted_message_ref: AcceptedMessageRef::new("message:auth-required").unwrap(),
+        source_binding_ref: SourceBindingRef::new("source:auth-required").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth-required").unwrap(),
+        resolved_run_profile_id: RunProfileId::default_profile(),
+        resolved_run_profile_version: RunProfileVersion::new(1),
+        resolved_model_route: None,
+        received_at: chrono::Utc::now(),
+        checkpoint_id: None,
+        gate_ref: Some(GateRef::new("gate:auth-required").unwrap()),
+        failure: None,
+        event_cursor: cursor,
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -1,0 +1,501 @@
+use std::sync::Arc;
+
+use ironclaw_product_adapters::{
+    AuthPromptView, GatePromptView, ProductAdapterError, ProductOutboundPayload,
+    ProductProjectionItem, ProductProjectionState, ProductWorkflowRejectionKind, RedactedString,
+};
+use ironclaw_turns::{
+    GetRunStateRequest, TurnCoordinator, TurnError, TurnEventKind, TurnEventProjectionCursor,
+    TurnEventProjectionSource, TurnLifecycleEvent, TurnScope, TurnStatus,
+};
+
+const WEBUI_TURN_EVENT_PAGE_LIMIT: usize = 256;
+
+pub(super) struct TurnEventPayload {
+    pub(super) cursor: TurnEventProjectionCursor,
+    pub(super) payload: ProductOutboundPayload,
+}
+
+pub(super) struct TurnEventDrain {
+    pub(super) next_cursor: Option<TurnEventProjectionCursor>,
+    pub(super) payloads: Vec<TurnEventPayload>,
+}
+
+#[derive(Clone, Default)]
+pub(super) enum TurnEventBridge {
+    #[default]
+    Disabled,
+    Enabled {
+        source: Arc<dyn TurnEventProjectionSource>,
+        coordinator: Arc<dyn TurnCoordinator>,
+    },
+}
+
+impl TurnEventBridge {
+    pub(super) fn enabled(
+        source: Arc<dyn TurnEventProjectionSource>,
+        coordinator: Arc<dyn TurnCoordinator>,
+    ) -> Self {
+        Self::Enabled {
+            source,
+            coordinator,
+        }
+    }
+
+    pub(super) async fn drain(
+        &self,
+        scope: &TurnScope,
+        after: Option<TurnEventProjectionCursor>,
+    ) -> Result<TurnEventDrain, ProductAdapterError> {
+        let Self::Enabled {
+            source,
+            coordinator,
+        } = self
+        else {
+            return Ok(TurnEventDrain {
+                next_cursor: after,
+                payloads: Vec::new(),
+            });
+        };
+        let mut after_event = match after.as_ref() {
+            Some(cursor) if &cursor.scope == scope => Some(cursor.event),
+            Some(_) => {
+                return Err(ProductAdapterError::InvalidIdentifier {
+                    kind: "projection_cursor",
+                    reason: "turn cursor scope does not match subscription scope".to_string(),
+                });
+            }
+            None => None,
+        };
+        let mut payloads = Vec::new();
+        let mut next_cursor;
+        loop {
+            let page = source
+                .read_turn_events_after(scope, after_event, WEBUI_TURN_EVENT_PAGE_LIMIT)
+                .await
+                .map_err(|_| ProductAdapterError::WorkflowRejected {
+                    kind: ProductWorkflowRejectionKind::Unavailable,
+                    status_code: 503,
+                    retryable: true,
+                    reason: RedactedString::new("turn event projection source unavailable"),
+                })?;
+            if page.rebase_required.is_some() {
+                return Err(ProductAdapterError::WorkflowRejected {
+                    kind: ProductWorkflowRejectionKind::Unavailable,
+                    status_code: 503,
+                    retryable: true,
+                    reason: RedactedString::new("turn event projection rebase required; reconnect"),
+                });
+            }
+            let next_event = page.next_cursor;
+            next_cursor = Some(TurnEventProjectionCursor::for_scope(
+                scope.clone(),
+                next_event,
+            ));
+            for event in page.entries {
+                if let Some(payload) =
+                    turn_event_payload(coordinator.as_ref(), event.clone(), scope).await?
+                {
+                    payloads.push(TurnEventPayload {
+                        cursor: TurnEventProjectionCursor::for_scope(scope.clone(), event.cursor),
+                        payload,
+                    });
+                }
+            }
+            if !payloads.is_empty() || !page.truncated || after_event == Some(next_event) {
+                break;
+            }
+            after_event = Some(next_event);
+        }
+        Ok(TurnEventDrain {
+            next_cursor,
+            payloads,
+        })
+    }
+}
+
+async fn turn_event_payload(
+    coordinator: &dyn TurnCoordinator,
+    event: TurnLifecycleEvent,
+    scope: &TurnScope,
+) -> Result<Option<ProductOutboundPayload>, ProductAdapterError> {
+    if matches!(event.kind, TurnEventKind::Blocked)
+        && let Some(prompt) = blocked_prompt_payload(coordinator, &event, scope).await?
+    {
+        return Ok(Some(prompt));
+    }
+    if projects_run_status(&event.kind) {
+        return Ok(Some(ProductOutboundPayload::ProjectionUpdate {
+            state: turn_event_projection_state(scope, &event)?,
+        }));
+    }
+    Ok(None)
+}
+
+async fn blocked_prompt_payload(
+    coordinator: &dyn TurnCoordinator,
+    event: &TurnLifecycleEvent,
+    scope: &TurnScope,
+) -> Result<Option<ProductOutboundPayload>, ProductAdapterError> {
+    let state = match coordinator
+        .get_run_state(GetRunStateRequest {
+            scope: scope.clone(),
+            run_id: event.run_id,
+        })
+        .await
+    {
+        Ok(state) => state,
+        Err(TurnError::ScopeNotFound) => return Ok(None),
+        Err(_) => {
+            return Err(ProductAdapterError::WorkflowTransient {
+                reason: RedactedString::new("turn gate state lookup failed"),
+            });
+        }
+    };
+    if state.status != event.status || state.event_cursor != event.cursor {
+        return Ok(None);
+    }
+    let Some(gate_ref) = state.gate_ref else {
+        return Ok(None);
+    };
+    let gate_ref = gate_ref.as_str().to_string();
+    match event.status {
+        TurnStatus::BlockedAuth => Ok(Some(ProductOutboundPayload::AuthPrompt(AuthPromptView {
+            turn_run_id: event.run_id,
+            auth_request_ref: gate_ref,
+            headline: "Authentication required".to_string(),
+            body: event
+                .sanitized_reason
+                .clone()
+                .unwrap_or_else(|| "Authenticate to continue this run.".to_string()),
+        }))),
+        TurnStatus::BlockedApproval | TurnStatus::BlockedResource => {
+            Ok(Some(ProductOutboundPayload::GatePrompt(GatePromptView {
+                turn_run_id: event.run_id,
+                gate_ref,
+                headline: match event.status {
+                    TurnStatus::BlockedApproval => "Approval required",
+                    TurnStatus::BlockedResource => "Resource unavailable",
+                    _ => unreachable!(),
+                }
+                .to_string(),
+                body: event
+                    .sanitized_reason
+                    .clone()
+                    .unwrap_or_else(|| "Resolve this gate to continue the run.".to_string()),
+            })))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn projects_run_status(kind: &TurnEventKind) -> bool {
+    matches!(
+        kind,
+        &TurnEventKind::Submitted
+            | &TurnEventKind::Resumed
+            | &TurnEventKind::RunnerClaimed
+            | &TurnEventKind::RecoveryRequired
+            | &TurnEventKind::Blocked
+            | &TurnEventKind::CancelRequested
+            | &TurnEventKind::Cancelled
+            | &TurnEventKind::Completed
+            | &TurnEventKind::Failed
+    )
+}
+
+fn turn_event_projection_state(
+    scope: &TurnScope,
+    event: &TurnLifecycleEvent,
+) -> Result<ProductProjectionState, ProductAdapterError> {
+    ProductProjectionState::new(
+        scope.thread_id.to_string(),
+        vec![ProductProjectionItem::RunStatus {
+            run_id: event.run_id,
+            status: turn_status_wire(event.status).to_string(),
+        }],
+    )
+}
+
+fn turn_status_wire(status: TurnStatus) -> &'static str {
+    match status {
+        TurnStatus::Queued => "queued",
+        TurnStatus::Running => "running",
+        TurnStatus::BlockedApproval => "blocked_approval",
+        TurnStatus::BlockedAuth => "blocked_auth",
+        TurnStatus::BlockedResource => "blocked_resource",
+        TurnStatus::RecoveryRequired => "recovery_required",
+        TurnStatus::CancelRequested => "cancel_requested",
+        TurnStatus::Completed => "completed",
+        TurnStatus::Cancelled => "cancelled",
+        TurnStatus::Failed => "failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
+    use ironclaw_turns::{
+        AcceptedMessageRef, CancelRunRequest, CancelRunResponse, GateRef, ReplyTargetBindingRef,
+        ResumeTurnRequest, ResumeTurnResponse, RunProfileId, RunProfileVersion, SourceBindingRef,
+        SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnEventPage, TurnId, TurnRunId,
+        TurnRunState, events::EventCursor as TurnEventCursor,
+    };
+
+    struct FakeTurnEventSource {
+        events: Vec<TurnLifecycleEvent>,
+    }
+
+    #[async_trait]
+    impl TurnEventProjectionSource for FakeTurnEventSource {
+        async fn read_turn_events_after(
+            &self,
+            scope: &TurnScope,
+            after: Option<TurnEventCursor>,
+            limit: usize,
+        ) -> Result<TurnEventPage, TurnError> {
+            let after = after.unwrap_or_default();
+            let mut events = self
+                .events
+                .iter()
+                .filter(|event| &event.scope == scope && event.cursor > after)
+                .cloned()
+                .collect::<Vec<_>>();
+            events.sort_by_key(|event| event.cursor);
+            let truncated = events.len() > limit;
+            if truncated {
+                events.truncate(limit);
+            }
+            let next_cursor = events.last().map(|event| event.cursor).unwrap_or(after);
+            Ok(TurnEventPage {
+                entries: events,
+                next_cursor,
+                truncated,
+                rebase_required: None,
+            })
+        }
+    }
+
+    struct FakeTurnCoordinator {
+        state: TurnRunState,
+    }
+
+    #[async_trait]
+    impl TurnCoordinator for FakeTurnCoordinator {
+        async fn submit_turn(
+            &self,
+            _request: SubmitTurnRequest,
+        ) -> Result<SubmitTurnResponse, TurnError> {
+            unreachable!("projection tests only read run state")
+        }
+
+        async fn resume_turn(
+            &self,
+            _request: ResumeTurnRequest,
+        ) -> Result<ResumeTurnResponse, TurnError> {
+            unreachable!("projection tests only read run state")
+        }
+
+        async fn cancel_run(
+            &self,
+            _request: CancelRunRequest,
+        ) -> Result<CancelRunResponse, TurnError> {
+            unreachable!("projection tests only read run state")
+        }
+
+        async fn get_run_state(
+            &self,
+            request: GetRunStateRequest,
+        ) -> Result<TurnRunState, TurnError> {
+            if request.scope == self.state.scope && request.run_id == self.state.run_id {
+                Ok(self.state.clone())
+            } else {
+                Err(TurnError::ScopeNotFound)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_projects_blocked_auth_turn_event_as_prompt() {
+        let user_id = UserId::new("webui-events-user").unwrap();
+        let scope = TurnScope::new(
+            TenantId::new("webui-events-tenant").unwrap(),
+            Some(AgentId::new("webui-events-agent").unwrap()),
+            None,
+            ThreadId::new("webui-events-thread").unwrap(),
+        );
+        let run_id = TurnRunId::new();
+        let bridge = TurnEventBridge::enabled(
+            Arc::new(FakeTurnEventSource {
+                events: vec![TurnLifecycleEvent {
+                    cursor: TurnEventCursor(1),
+                    scope: scope.clone(),
+                    run_id,
+                    status: TurnStatus::BlockedAuth,
+                    kind: TurnEventKind::Blocked,
+                    sanitized_reason: Some("GitHub authentication required".to_string()),
+                }],
+            }),
+            Arc::new(FakeTurnCoordinator {
+                state: TurnRunState {
+                    scope: scope.clone(),
+                    actor: Some(TurnActor::new(user_id)),
+                    turn_id: TurnId::new(),
+                    run_id,
+                    status: TurnStatus::BlockedAuth,
+                    accepted_message_ref: AcceptedMessageRef::new("message:auth-required").unwrap(),
+                    source_binding_ref: SourceBindingRef::new("source:auth-required").unwrap(),
+                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth-required")
+                        .unwrap(),
+                    resolved_run_profile_id: RunProfileId::default_profile(),
+                    resolved_run_profile_version: RunProfileVersion::new(1),
+                    resolved_model_route: None,
+                    received_at: chrono::Utc::now(),
+                    checkpoint_id: None,
+                    gate_ref: Some(GateRef::new("gate:auth-required").unwrap()),
+                    failure: None,
+                    event_cursor: TurnEventCursor(1),
+                },
+            }),
+        );
+        let drain = bridge.drain(&scope, None).await.unwrap();
+        let payloads = drain.payloads;
+
+        assert!(payloads.iter().any(|payload| match payload {
+            TurnEventPayload {
+                cursor,
+                payload: ProductOutboundPayload::AuthPrompt(prompt),
+            } =>
+                cursor.event == TurnEventCursor(1)
+                    && cursor.scope == scope
+                    && prompt.turn_run_id == run_id
+                    && prompt.auth_request_ref == "gate:auth-required"
+                    && prompt.body == "GitHub authentication required",
+            _ => false,
+        }));
+        assert_eq!(payloads.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn bridge_reads_past_filtered_heartbeat_pages() {
+        let user_id = UserId::new("webui-events-user").unwrap();
+        let scope = TurnScope::new(
+            TenantId::new("webui-events-tenant").unwrap(),
+            Some(AgentId::new("webui-events-agent").unwrap()),
+            None,
+            ThreadId::new("webui-events-thread").unwrap(),
+        );
+        let run_id = TurnRunId::new();
+        let mut events = (1..=WEBUI_TURN_EVENT_PAGE_LIMIT as u64)
+            .map(|cursor| TurnLifecycleEvent {
+                cursor: TurnEventCursor(cursor),
+                scope: scope.clone(),
+                run_id,
+                status: TurnStatus::Running,
+                kind: TurnEventKind::RunnerHeartbeat,
+                sanitized_reason: None,
+            })
+            .collect::<Vec<_>>();
+        events.push(TurnLifecycleEvent {
+            cursor: TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1),
+            scope: scope.clone(),
+            run_id,
+            status: TurnStatus::BlockedAuth,
+            kind: TurnEventKind::Blocked,
+            sanitized_reason: Some("GitHub authentication required".to_string()),
+        });
+        let bridge = TurnEventBridge::enabled(
+            Arc::new(FakeTurnEventSource { events }),
+            Arc::new(FakeTurnCoordinator {
+                state: TurnRunState {
+                    scope: scope.clone(),
+                    actor: Some(TurnActor::new(user_id)),
+                    turn_id: TurnId::new(),
+                    run_id,
+                    status: TurnStatus::BlockedAuth,
+                    accepted_message_ref: AcceptedMessageRef::new("message:auth-required").unwrap(),
+                    source_binding_ref: SourceBindingRef::new("source:auth-required").unwrap(),
+                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth-required")
+                        .unwrap(),
+                    resolved_run_profile_id: RunProfileId::default_profile(),
+                    resolved_run_profile_version: RunProfileVersion::new(1),
+                    resolved_model_route: None,
+                    received_at: chrono::Utc::now(),
+                    checkpoint_id: None,
+                    gate_ref: Some(GateRef::new("gate:auth-required").unwrap()),
+                    failure: None,
+                    event_cursor: TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1),
+                },
+            }),
+        );
+        let drain = bridge.drain(&scope, None).await.unwrap();
+        let payloads = drain.payloads;
+
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(drain.next_cursor, Some(payloads[0].cursor.clone()));
+        assert_eq!(
+            payloads[0].cursor.event,
+            TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1)
+        );
+        assert!(matches!(
+            payloads[0].payload,
+            ProductOutboundPayload::AuthPrompt(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn bridge_does_not_project_prompt_for_stale_blocked_event() {
+        let user_id = UserId::new("webui-events-user").unwrap();
+        let scope = TurnScope::new(
+            TenantId::new("webui-events-tenant").unwrap(),
+            Some(AgentId::new("webui-events-agent").unwrap()),
+            None,
+            ThreadId::new("webui-events-thread").unwrap(),
+        );
+        let run_id = TurnRunId::new();
+        let bridge = TurnEventBridge::enabled(
+            Arc::new(FakeTurnEventSource {
+                events: vec![TurnLifecycleEvent {
+                    cursor: TurnEventCursor(1),
+                    scope: scope.clone(),
+                    run_id,
+                    status: TurnStatus::BlockedAuth,
+                    kind: TurnEventKind::Blocked,
+                    sanitized_reason: Some("stale auth gate".to_string()),
+                }],
+            }),
+            Arc::new(FakeTurnCoordinator {
+                state: TurnRunState {
+                    scope: scope.clone(),
+                    actor: Some(TurnActor::new(user_id)),
+                    turn_id: TurnId::new(),
+                    run_id,
+                    status: TurnStatus::BlockedAuth,
+                    accepted_message_ref: AcceptedMessageRef::new("message:auth-required").unwrap(),
+                    source_binding_ref: SourceBindingRef::new("source:auth-required").unwrap(),
+                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth-required")
+                        .unwrap(),
+                    resolved_run_profile_id: RunProfileId::default_profile(),
+                    resolved_run_profile_version: RunProfileVersion::new(1),
+                    resolved_model_route: None,
+                    received_at: chrono::Utc::now(),
+                    checkpoint_id: None,
+                    gate_ref: Some(GateRef::new("gate:new-auth-required").unwrap()),
+                    failure: None,
+                    event_cursor: TurnEventCursor(2),
+                },
+            }),
+        );
+        let drain = bridge.drain(&scope, None).await.unwrap();
+        let payloads = drain.payloads;
+
+        assert_eq!(payloads.len(), 1);
+        assert!(matches!(
+            payloads[0].payload,
+            ProductOutboundPayload::ProjectionUpdate { .. }
+        ));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -127,7 +127,12 @@ async fn blocked_prompt_payload(
     {
         Ok(state) => state,
         Err(TurnError::ScopeNotFound) => return Ok(None),
-        Err(_) => {
+        Err(error) => {
+            tracing::debug!(
+                %error,
+                run_id = %event.run_id,
+                "turn gate state lookup failed during WebUI projection"
+            );
             return Err(ProductAdapterError::WorkflowTransient {
                 reason: RedactedString::new("turn gate state lookup failed"),
             });

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -6,10 +6,11 @@ use ironclaw_product_adapters::{
 };
 use ironclaw_turns::{
     GetRunStateRequest, TurnCoordinator, TurnError, TurnEventKind, TurnEventProjectionCursor,
+    TurnEventProjectionError, TurnEventProjectionRequest, TurnEventProjectionService,
     TurnEventProjectionSource, TurnLifecycleEvent, TurnScope, TurnStatus,
 };
 
-const WEBUI_TURN_EVENT_PAGE_LIMIT: usize = 256;
+pub(super) const WEBUI_TURN_EVENT_PAGE_LIMIT: usize = 256;
 
 pub(super) struct TurnEventPayload {
     pub(super) cursor: TurnEventProjectionCursor,
@@ -26,7 +27,7 @@ pub(super) enum TurnEventBridge {
     #[default]
     Disabled,
     Enabled {
-        source: Arc<dyn TurnEventProjectionSource>,
+        service: Arc<TurnEventProjectionService<dyn TurnEventProjectionSource>>,
         coordinator: Arc<dyn TurnCoordinator>,
     },
 }
@@ -37,7 +38,7 @@ impl TurnEventBridge {
         coordinator: Arc<dyn TurnCoordinator>,
     ) -> Self {
         Self::Enabled {
-            source,
+            service: Arc::new(TurnEventProjectionService::new(source)),
             coordinator,
         }
     }
@@ -48,7 +49,7 @@ impl TurnEventBridge {
         after: Option<TurnEventProjectionCursor>,
     ) -> Result<TurnEventDrain, ProductAdapterError> {
         let Self::Enabled {
-            source,
+            service,
             coordinator,
         } = self
         else {
@@ -57,55 +58,37 @@ impl TurnEventBridge {
                 payloads: Vec::new(),
             });
         };
-        let mut after_event = match after.as_ref() {
-            Some(cursor) if &cursor.scope == scope => Some(cursor.event),
-            Some(_) => {
-                return Err(ProductAdapterError::InvalidIdentifier {
-                    kind: "projection_cursor",
-                    reason: "turn cursor scope does not match subscription scope".to_string(),
-                });
-            }
-            None => None,
-        };
+        let mut after_cursor = after;
         let mut payloads = Vec::new();
         let mut next_cursor;
         loop {
-            let page = source
-                .read_turn_events_after(scope, after_event, WEBUI_TURN_EVENT_PAGE_LIMIT)
+            let page = service
+                .updates(TurnEventProjectionRequest {
+                    scope: scope.clone(),
+                    after: after_cursor.clone(),
+                    limit: WEBUI_TURN_EVENT_PAGE_LIMIT,
+                })
                 .await
-                .map_err(|_| ProductAdapterError::WorkflowRejected {
-                    kind: ProductWorkflowRejectionKind::Unavailable,
-                    status_code: 503,
-                    retryable: true,
-                    reason: RedactedString::new("turn event projection source unavailable"),
-                })?;
-            if page.rebase_required.is_some() {
-                return Err(ProductAdapterError::WorkflowRejected {
-                    kind: ProductWorkflowRejectionKind::Unavailable,
-                    status_code: 503,
-                    retryable: true,
-                    reason: RedactedString::new("turn event projection rebase required; reconnect"),
-                });
-            }
-            let next_event = page.next_cursor;
-            next_cursor = Some(TurnEventProjectionCursor::for_scope(
-                scope.clone(),
-                next_event,
-            ));
+                .map_err(map_turn_event_projection_error)?;
+            next_cursor = Some(page.next_cursor.clone());
             for event in page.entries {
-                if let Some(payload) =
-                    turn_event_payload(coordinator.as_ref(), event.clone(), scope).await?
-                {
+                if let Some(payload) = turn_event_payload(coordinator.as_ref(), &event).await? {
                     payloads.push(TurnEventPayload {
-                        cursor: TurnEventProjectionCursor::for_scope(scope.clone(), event.cursor),
+                        cursor: TurnEventProjectionCursor::for_scope(
+                            event.scope.clone(),
+                            event.cursor,
+                        ),
                         payload,
                     });
                 }
             }
-            if !payloads.is_empty() || !page.truncated || after_event == Some(next_event) {
+            if !payloads.is_empty()
+                || !page.truncated
+                || after_cursor.as_ref() == Some(&page.next_cursor)
+            {
                 break;
             }
-            after_event = Some(next_event);
+            after_cursor = Some(page.next_cursor);
         }
         Ok(TurnEventDrain {
             next_cursor,
@@ -116,17 +99,16 @@ impl TurnEventBridge {
 
 async fn turn_event_payload(
     coordinator: &dyn TurnCoordinator,
-    event: TurnLifecycleEvent,
-    scope: &TurnScope,
+    event: &TurnLifecycleEvent,
 ) -> Result<Option<ProductOutboundPayload>, ProductAdapterError> {
     if matches!(event.kind, TurnEventKind::Blocked)
-        && let Some(prompt) = blocked_prompt_payload(coordinator, &event, scope).await?
+        && let Some(prompt) = blocked_prompt_payload(coordinator, event).await?
     {
         return Ok(Some(prompt));
     }
     if projects_run_status(&event.kind) {
         return Ok(Some(ProductOutboundPayload::ProjectionUpdate {
-            state: turn_event_projection_state(scope, &event)?,
+            state: turn_event_projection_state(event)?,
         }));
     }
     Ok(None)
@@ -135,11 +117,10 @@ async fn turn_event_payload(
 async fn blocked_prompt_payload(
     coordinator: &dyn TurnCoordinator,
     event: &TurnLifecycleEvent,
-    scope: &TurnScope,
 ) -> Result<Option<ProductOutboundPayload>, ProductAdapterError> {
     let state = match coordinator
         .get_run_state(GetRunStateRequest {
-            scope: scope.clone(),
+            scope: event.scope.clone(),
             run_id: event.run_id,
         })
         .await
@@ -169,47 +150,50 @@ async fn blocked_prompt_payload(
                 .clone()
                 .unwrap_or_else(|| "Authenticate to continue this run.".to_string()),
         }))),
-        TurnStatus::BlockedApproval | TurnStatus::BlockedResource => {
-            Ok(Some(ProductOutboundPayload::GatePrompt(GatePromptView {
-                turn_run_id: event.run_id,
-                gate_ref,
-                headline: match event.status {
-                    TurnStatus::BlockedApproval => "Approval required",
-                    TurnStatus::BlockedResource => "Resource unavailable",
-                    _ => unreachable!(),
-                }
-                .to_string(),
-                body: event
-                    .sanitized_reason
-                    .clone()
-                    .unwrap_or_else(|| "Resolve this gate to continue the run.".to_string()),
-            })))
+        TurnStatus::BlockedApproval => Ok(Some(gate_prompt(event, gate_ref, "Approval required"))),
+        TurnStatus::BlockedResource => {
+            Ok(Some(gate_prompt(event, gate_ref, "Resource unavailable")))
         }
         _ => Ok(None),
     }
 }
 
+fn gate_prompt(
+    event: &TurnLifecycleEvent,
+    gate_ref: String,
+    headline: &'static str,
+) -> ProductOutboundPayload {
+    ProductOutboundPayload::GatePrompt(GatePromptView {
+        turn_run_id: event.run_id,
+        gate_ref,
+        headline: headline.to_string(),
+        body: event
+            .sanitized_reason
+            .clone()
+            .unwrap_or_else(|| "Resolve this gate to continue the run.".to_string()),
+    })
+}
+
 fn projects_run_status(kind: &TurnEventKind) -> bool {
     matches!(
         kind,
-        &TurnEventKind::Submitted
-            | &TurnEventKind::Resumed
-            | &TurnEventKind::RunnerClaimed
-            | &TurnEventKind::RecoveryRequired
-            | &TurnEventKind::Blocked
-            | &TurnEventKind::CancelRequested
-            | &TurnEventKind::Cancelled
-            | &TurnEventKind::Completed
-            | &TurnEventKind::Failed
+        TurnEventKind::Submitted
+            | TurnEventKind::Resumed
+            | TurnEventKind::RunnerClaimed
+            | TurnEventKind::RecoveryRequired
+            | TurnEventKind::Blocked
+            | TurnEventKind::CancelRequested
+            | TurnEventKind::Cancelled
+            | TurnEventKind::Completed
+            | TurnEventKind::Failed
     )
 }
 
 fn turn_event_projection_state(
-    scope: &TurnScope,
     event: &TurnLifecycleEvent,
 ) -> Result<ProductProjectionState, ProductAdapterError> {
     ProductProjectionState::new(
-        scope.thread_id.to_string(),
+        event.scope.thread_id.to_string(),
         vec![ProductProjectionItem::RunStatus {
             run_id: event.run_id,
             status: turn_status_wire(event.status).to_string(),
@@ -232,270 +216,32 @@ fn turn_status_wire(status: TurnStatus) -> &'static str {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use async_trait::async_trait;
-    use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
-    use ironclaw_turns::{
-        AcceptedMessageRef, CancelRunRequest, CancelRunResponse, GateRef, ReplyTargetBindingRef,
-        ResumeTurnRequest, ResumeTurnResponse, RunProfileId, RunProfileVersion, SourceBindingRef,
-        SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnEventPage, TurnId, TurnRunId,
-        TurnRunState, events::EventCursor as TurnEventCursor,
-    };
-
-    struct FakeTurnEventSource {
-        events: Vec<TurnLifecycleEvent>,
-    }
-
-    #[async_trait]
-    impl TurnEventProjectionSource for FakeTurnEventSource {
-        async fn read_turn_events_after(
-            &self,
-            scope: &TurnScope,
-            after: Option<TurnEventCursor>,
-            limit: usize,
-        ) -> Result<TurnEventPage, TurnError> {
-            let after = after.unwrap_or_default();
-            let mut events = self
-                .events
-                .iter()
-                .filter(|event| &event.scope == scope && event.cursor > after)
-                .cloned()
-                .collect::<Vec<_>>();
-            events.sort_by_key(|event| event.cursor);
-            let truncated = events.len() > limit;
-            if truncated {
-                events.truncate(limit);
-            }
-            let next_cursor = events.last().map(|event| event.cursor).unwrap_or(after);
-            Ok(TurnEventPage {
-                entries: events,
-                next_cursor,
-                truncated,
-                rebase_required: None,
-            })
-        }
-    }
-
-    struct FakeTurnCoordinator {
-        state: TurnRunState,
-    }
-
-    #[async_trait]
-    impl TurnCoordinator for FakeTurnCoordinator {
-        async fn submit_turn(
-            &self,
-            _request: SubmitTurnRequest,
-        ) -> Result<SubmitTurnResponse, TurnError> {
-            unreachable!("projection tests only read run state")
-        }
-
-        async fn resume_turn(
-            &self,
-            _request: ResumeTurnRequest,
-        ) -> Result<ResumeTurnResponse, TurnError> {
-            unreachable!("projection tests only read run state")
-        }
-
-        async fn cancel_run(
-            &self,
-            _request: CancelRunRequest,
-        ) -> Result<CancelRunResponse, TurnError> {
-            unreachable!("projection tests only read run state")
-        }
-
-        async fn get_run_state(
-            &self,
-            request: GetRunStateRequest,
-        ) -> Result<TurnRunState, TurnError> {
-            if request.scope == self.state.scope && request.run_id == self.state.run_id {
-                Ok(self.state.clone())
-            } else {
-                Err(TurnError::ScopeNotFound)
+fn map_turn_event_projection_error(error: TurnEventProjectionError) -> ProductAdapterError {
+    match error {
+        TurnEventProjectionError::InvalidRequest { reason } => {
+            ProductAdapterError::InvalidIdentifier {
+                kind: "projection_cursor",
+                reason: reason.to_string(),
             }
         }
-    }
-
-    #[tokio::test]
-    async fn bridge_projects_blocked_auth_turn_event_as_prompt() {
-        let user_id = UserId::new("webui-events-user").unwrap();
-        let scope = TurnScope::new(
-            TenantId::new("webui-events-tenant").unwrap(),
-            Some(AgentId::new("webui-events-agent").unwrap()),
-            None,
-            ThreadId::new("webui-events-thread").unwrap(),
-        );
-        let run_id = TurnRunId::new();
-        let bridge = TurnEventBridge::enabled(
-            Arc::new(FakeTurnEventSource {
-                events: vec![TurnLifecycleEvent {
-                    cursor: TurnEventCursor(1),
-                    scope: scope.clone(),
-                    run_id,
-                    status: TurnStatus::BlockedAuth,
-                    kind: TurnEventKind::Blocked,
-                    sanitized_reason: Some("GitHub authentication required".to_string()),
-                }],
-            }),
-            Arc::new(FakeTurnCoordinator {
-                state: TurnRunState {
-                    scope: scope.clone(),
-                    actor: Some(TurnActor::new(user_id)),
-                    turn_id: TurnId::new(),
-                    run_id,
-                    status: TurnStatus::BlockedAuth,
-                    accepted_message_ref: AcceptedMessageRef::new("message:auth-required").unwrap(),
-                    source_binding_ref: SourceBindingRef::new("source:auth-required").unwrap(),
-                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth-required")
-                        .unwrap(),
-                    resolved_run_profile_id: RunProfileId::default_profile(),
-                    resolved_run_profile_version: RunProfileVersion::new(1),
-                    resolved_model_route: None,
-                    received_at: chrono::Utc::now(),
-                    checkpoint_id: None,
-                    gate_ref: Some(GateRef::new("gate:auth-required").unwrap()),
-                    failure: None,
-                    event_cursor: TurnEventCursor(1),
-                },
-            }),
-        );
-        let drain = bridge.drain(&scope, None).await.unwrap();
-        let payloads = drain.payloads;
-
-        assert!(payloads.iter().any(|payload| match payload {
-            TurnEventPayload {
-                cursor,
-                payload: ProductOutboundPayload::AuthPrompt(prompt),
-            } =>
-                cursor.event == TurnEventCursor(1)
-                    && cursor.scope == scope
-                    && prompt.turn_run_id == run_id
-                    && prompt.auth_request_ref == "gate:auth-required"
-                    && prompt.body == "GitHub authentication required",
-            _ => false,
-        }));
-        assert_eq!(payloads.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn bridge_reads_past_filtered_heartbeat_pages() {
-        let user_id = UserId::new("webui-events-user").unwrap();
-        let scope = TurnScope::new(
-            TenantId::new("webui-events-tenant").unwrap(),
-            Some(AgentId::new("webui-events-agent").unwrap()),
-            None,
-            ThreadId::new("webui-events-thread").unwrap(),
-        );
-        let run_id = TurnRunId::new();
-        let mut events = (1..=WEBUI_TURN_EVENT_PAGE_LIMIT as u64)
-            .map(|cursor| TurnLifecycleEvent {
-                cursor: TurnEventCursor(cursor),
-                scope: scope.clone(),
-                run_id,
-                status: TurnStatus::Running,
-                kind: TurnEventKind::RunnerHeartbeat,
-                sanitized_reason: None,
-            })
-            .collect::<Vec<_>>();
-        events.push(TurnLifecycleEvent {
-            cursor: TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1),
-            scope: scope.clone(),
-            run_id,
-            status: TurnStatus::BlockedAuth,
-            kind: TurnEventKind::Blocked,
-            sanitized_reason: Some("GitHub authentication required".to_string()),
-        });
-        let bridge = TurnEventBridge::enabled(
-            Arc::new(FakeTurnEventSource { events }),
-            Arc::new(FakeTurnCoordinator {
-                state: TurnRunState {
-                    scope: scope.clone(),
-                    actor: Some(TurnActor::new(user_id)),
-                    turn_id: TurnId::new(),
-                    run_id,
-                    status: TurnStatus::BlockedAuth,
-                    accepted_message_ref: AcceptedMessageRef::new("message:auth-required").unwrap(),
-                    source_binding_ref: SourceBindingRef::new("source:auth-required").unwrap(),
-                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth-required")
-                        .unwrap(),
-                    resolved_run_profile_id: RunProfileId::default_profile(),
-                    resolved_run_profile_version: RunProfileVersion::new(1),
-                    resolved_model_route: None,
-                    received_at: chrono::Utc::now(),
-                    checkpoint_id: None,
-                    gate_ref: Some(GateRef::new("gate:auth-required").unwrap()),
-                    failure: None,
-                    event_cursor: TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1),
-                },
-            }),
-        );
-        let drain = bridge.drain(&scope, None).await.unwrap();
-        let payloads = drain.payloads;
-
-        assert_eq!(payloads.len(), 1);
-        assert_eq!(drain.next_cursor, Some(payloads[0].cursor.clone()));
-        assert_eq!(
-            payloads[0].cursor.event,
-            TurnEventCursor(WEBUI_TURN_EVENT_PAGE_LIMIT as u64 + 1)
-        );
-        assert!(matches!(
-            payloads[0].payload,
-            ProductOutboundPayload::AuthPrompt(_)
-        ));
-    }
-
-    #[tokio::test]
-    async fn bridge_does_not_project_prompt_for_stale_blocked_event() {
-        let user_id = UserId::new("webui-events-user").unwrap();
-        let scope = TurnScope::new(
-            TenantId::new("webui-events-tenant").unwrap(),
-            Some(AgentId::new("webui-events-agent").unwrap()),
-            None,
-            ThreadId::new("webui-events-thread").unwrap(),
-        );
-        let run_id = TurnRunId::new();
-        let bridge = TurnEventBridge::enabled(
-            Arc::new(FakeTurnEventSource {
-                events: vec![TurnLifecycleEvent {
-                    cursor: TurnEventCursor(1),
-                    scope: scope.clone(),
-                    run_id,
-                    status: TurnStatus::BlockedAuth,
-                    kind: TurnEventKind::Blocked,
-                    sanitized_reason: Some("stale auth gate".to_string()),
-                }],
-            }),
-            Arc::new(FakeTurnCoordinator {
-                state: TurnRunState {
-                    scope: scope.clone(),
-                    actor: Some(TurnActor::new(user_id)),
-                    turn_id: TurnId::new(),
-                    run_id,
-                    status: TurnStatus::BlockedAuth,
-                    accepted_message_ref: AcceptedMessageRef::new("message:auth-required").unwrap(),
-                    source_binding_ref: SourceBindingRef::new("source:auth-required").unwrap(),
-                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth-required")
-                        .unwrap(),
-                    resolved_run_profile_id: RunProfileId::default_profile(),
-                    resolved_run_profile_version: RunProfileVersion::new(1),
-                    resolved_model_route: None,
-                    received_at: chrono::Utc::now(),
-                    checkpoint_id: None,
-                    gate_ref: Some(GateRef::new("gate:new-auth-required").unwrap()),
-                    failure: None,
-                    event_cursor: TurnEventCursor(2),
-                },
-            }),
-        );
-        let drain = bridge.drain(&scope, None).await.unwrap();
-        let payloads = drain.payloads;
-
-        assert_eq!(payloads.len(), 1);
-        assert!(matches!(
-            payloads[0].payload,
-            ProductOutboundPayload::ProjectionUpdate { .. }
-        ));
+        TurnEventProjectionError::RebaseRequired {
+            requested,
+            earliest,
+        } if requested.scope != earliest.scope => ProductAdapterError::InvalidIdentifier {
+            kind: "projection_cursor",
+            reason: "turn cursor scope does not match subscription scope".to_string(),
+        },
+        TurnEventProjectionError::RebaseRequired { .. } => ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::Unavailable,
+            status_code: 503,
+            retryable: true,
+            reason: RedactedString::new("turn event projection rebase required; reconnect"),
+        },
+        TurnEventProjectionError::Source { .. } => ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::Unavailable,
+            status_code: 503,
+            retryable: true,
+            reason: RedactedString::new("turn event projection source unavailable"),
+        },
     }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -62,8 +62,8 @@ use ironclaw_threads::{
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, GetRunStateRequest, IdempotencyKey,
     ReplyTargetBindingRef, RunProfileResolutionRequest, SanitizedCancelReason, SourceBindingRef,
-    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnRunId,
-    TurnScope, TurnStatus,
+    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError,
+    TurnEventProjectionSource, TurnRunId, TurnScope, TurnStatus,
     run_profile::{LoopHostMilestoneSink, LoopRunContext, PromptMode},
 };
 
@@ -846,14 +846,12 @@ pub async fn build_reborn_runtime(
         })?;
     let default_run_profile_id = default_resolved_run_profile.profile_id.as_str().to_string();
     let planned_turn_coordinator: Arc<dyn TurnCoordinator> = composition.coordinator.clone();
+    let turn_event_source: Arc<dyn TurnEventProjectionSource> = turn_state_store.clone();
     let projection_services = build_reborn_projection_services(
         Arc::clone(&event_log),
         validated_identity.reply_target_binding_ref.clone(),
     )
-    .with_turn_events(
-        Arc::clone(&turn_state_store) as Arc<_>,
-        Arc::clone(&planned_turn_coordinator),
-    );
+    .with_turn_events(turn_event_source, Arc::clone(&planned_turn_coordinator));
     services.turn_coordinator = Some(Arc::clone(&planned_turn_coordinator));
 
     let worker_cancel = CancellationToken::new();

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -786,10 +786,6 @@ pub async fn build_reborn_runtime(
     // Local-dev WebUI projections are process-local today; production fanout
     // will swap this for a retained durable log owned by the host runtime.
     let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
-    let projection_services = build_reborn_projection_services(
-        Arc::clone(&event_log),
-        validated_identity.reply_target_binding_ref.clone(),
-    );
     let milestone_thread_scope = ThreadScope {
         owner_user_id: Some(actor_user_id.clone()),
         ..thread_scope.clone()
@@ -850,6 +846,14 @@ pub async fn build_reborn_runtime(
         })?;
     let default_run_profile_id = default_resolved_run_profile.profile_id.as_str().to_string();
     let planned_turn_coordinator: Arc<dyn TurnCoordinator> = composition.coordinator.clone();
+    let projection_services = build_reborn_projection_services(
+        Arc::clone(&event_log),
+        validated_identity.reply_target_binding_ref.clone(),
+    )
+    .with_turn_events(
+        Arc::clone(&turn_state_store) as Arc<_>,
+        Arc::clone(&planned_turn_coordinator),
+    );
     services.turn_coordinator = Some(Arc::clone(&planned_turn_coordinator));
 
     let worker_cancel = CancellationToken::new();

--- a/crates/ironclaw_telegram_v2_adapter/src/adapter.rs
+++ b/crates/ironclaw_telegram_v2_adapter/src/adapter.rs
@@ -292,7 +292,8 @@ impl ProductAdapter for TelegramV2Adapter {
                 return Ok(ProductRenderOutcome::Deferred);
             }
             ProductOutboundPayload::ProjectionSnapshot { .. }
-            | ProductOutboundPayload::ProjectionUpdate { .. } => {
+            | ProductOutboundPayload::ProjectionUpdate { .. }
+            | ProductOutboundPayload::KeepAlive => {
                 // Telegram never consumes projection subscriptions; the
                 // workflow should not route these to a Telegram installation.
                 record_status(

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -142,14 +142,14 @@ pub trait TurnEventProjectionSource: Send + Sync {
 
 pub struct TurnEventProjectionService<S>
 where
-    S: TurnEventProjectionSource,
+    S: TurnEventProjectionSource + ?Sized,
 {
     source: Arc<S>,
 }
 
 impl<S> TurnEventProjectionService<S>
 where
-    S: TurnEventProjectionSource,
+    S: TurnEventProjectionSource + ?Sized,
 {
     pub fn new(source: Arc<S>) -> Self {
         Self { source }

--- a/crates/ironclaw_webui_v2/src/schema.rs
+++ b/crates/ironclaw_webui_v2/src/schema.rs
@@ -117,6 +117,7 @@ impl From<ProductOutboundPayload> for WebChatV2Event {
                 Self::ProjectionSnapshot { state }
             }
             ProductOutboundPayload::ProjectionUpdate { state } => Self::ProjectionUpdate { state },
+            ProductOutboundPayload::KeepAlive => Self::KeepAlive,
         }
     }
 }

--- a/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
@@ -220,6 +220,7 @@ fn outbound_payload_mapping_covers_every_browser_event_variant() {
             },
             "projection_update",
         ),
+        (ProductOutboundPayload::KeepAlive, "keep_alive"),
     ];
 
     for (payload, expected_type) in cases {


### PR DESCRIPTION
## Summary
- Wire the Reborn WebUI projection stream to the turn lifecycle projection source and coordinator.
- Emit WebUI auth/gate prompt payloads for blocked turn events by resolving gate refs through scoped run-state lookup.
- Use a composite WebUI cursor so runtime projection and turn-event cursors drain together without re-emitting frames.
- Extract turn-event projection bridging into a dedicated module to keep the projection service file from becoming a monolith.

## Review fixes
- Avoided putting gate refs on generic turn lifecycle events; WebUI prompt refs are resolved only through the authenticated WebUI projection path.
- Fixed composite cursor handling so each outbound envelope carries the cursor corresponding to the event that produced it.
- Avoided run-status spam from runner heartbeat events and emitted a single prompt frame for blocked auth/approval/resource gates.

## Tests
- `cargo test -p ironclaw_reborn_composition webui_event_stream --lib`
- `cargo test -p ironclaw_reborn_composition turn_event --lib`
- `cargo test -p ironclaw_reborn_composition local_dev_runtime_webui_bundle_reuses_thread_and_turn_facades --lib`
- `cargo test -p ironclaw_turns --tests`
- `cargo check -p ironclaw_reborn_composition -p ironclaw_turns`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`