### PR TITLE
Improve Reborn model error diagnostics

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor.rs
+++ b/crates/ironclaw_agent_loop/src/executor.rs
@@ -52,8 +52,10 @@ use turn_stop::{StopInput, StopStage, StopStep};
 
 use async_trait::async_trait;
 use ironclaw_turns::{
-    LoopCancelledReasonKind, LoopExit,
-    run_profile::{AgentLoopDriverHost, LoopInputAckToken},
+    LoopCancelledReasonKind, LoopDiagnosticRef, LoopExit,
+    run_profile::{
+        AgentLoopDriverHost, AgentLoopHostErrorKind, LoopInputAckToken, LoopSafeSummary,
+    },
 };
 
 use crate::{
@@ -88,6 +90,13 @@ pub trait AgentLoopExecutor: Send + Sync {
 pub enum AgentLoopExecutorError {
     #[error("host port returned an unrecoverable error: {stage:?}")]
     HostUnavailable { stage: HostStage },
+    #[error("host port returned an unrecoverable error: {stage:?} ({kind:?}: {safe_summary})")]
+    HostUnavailableWithDiagnostics {
+        stage: HostStage,
+        kind: AgentLoopHostErrorKind,
+        safe_summary: LoopSafeSummary,
+        diagnostic_ref: Option<LoopDiagnosticRef>,
+    },
     #[error("planner returned a contract violation: {detail}")]
     PlannerContract { detail: &'static str },
     #[error("checkpoint write failed at {stage:?}")]

--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -3,7 +3,7 @@ use ironclaw_turns::{
     LoopExit, LoopFailureKind,
     run_profile::{
         AgentLoopHostErrorKind, LoopDriverNoteKind, LoopModelCapabilityView, LoopModelRequest,
-        LoopProgressEvent,
+        LoopProgressEvent, LoopSafeSummary,
     },
 };
 
@@ -76,8 +76,12 @@ impl ExecutorStage<ModelInput> for ModelStage {
                         return Err(AgentLoopExecutorError::Cancelled);
                     }
                     let Some(class) = model_error_class(&error) else {
-                        return Err(AgentLoopExecutorError::HostUnavailable {
+                        return Err(AgentLoopExecutorError::HostUnavailableWithDiagnostics {
                             stage: HostStage::Model,
+                            kind: error.kind,
+                            safe_summary: LoopSafeSummary::new(error.safe_summary)
+                                .unwrap_or_else(|_| LoopSafeSummary::model_gateway_failed()),
+                            diagnostic_ref: error.diagnostic_ref,
                         });
                     };
                     if !recorded_failure {

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -1,12 +1,12 @@
 use ironclaw_turns::{
-    LoopCancelledReasonKind, LoopCompletionKind, LoopExit, LoopFailureKind, LoopGateRef,
-    LoopResultRef,
+    LoopCancelledReasonKind, LoopCompletionKind, LoopDiagnosticRef, LoopExit, LoopFailureKind,
+    LoopGateRef, LoopResultRef,
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, CapabilityCallCandidate, CapabilityFailureKind,
         CapabilityInputRef, CapabilityOutcome, CapabilityResultMessage, LoopCancelReasonKind,
         LoopCheckpointKind, LoopInput, LoopInputAckToken, LoopInputBatch, LoopInputCursor,
-        LoopInterruptKind, LoopProcessRef, LoopRunInfoPort, ParentLoopOutput, ProcessHandleSummary,
-        ProviderToolCallReplay, VisibleCapabilityRequest,
+        LoopInterruptKind, LoopProcessRef, LoopRunInfoPort, LoopSafeSummary, ParentLoopOutput,
+        ProcessHandleSummary, ProviderToolCallReplay, VisibleCapabilityRequest,
     },
 };
 
@@ -990,6 +990,35 @@ async fn model_retry_success_clears_recovery_state() {
     assert!(matches!(exit, LoopExit::Completed(_)));
     assert_eq!(host.model_requests().len(), 2);
     assert_eq!(final_staged_state(&host).recovery_state, Default::default());
+}
+
+#[tokio::test]
+async fn model_unrecoverable_host_error_preserves_sanitized_diagnostics() {
+    let diagnostic_ref = LoopDiagnosticRef::new("diag:model-credentials").expect("valid");
+    let host = MockHost::new(Vec::new()).with_model_errors(vec![
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::CredentialUnavailable,
+            "model credentials are unavailable",
+        )
+        .with_diagnostic_ref(diagnostic_ref),
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let error = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect_err("credential errors should stop before a loop exit");
+
+    assert_eq!(
+        error,
+        AgentLoopExecutorError::HostUnavailableWithDiagnostics {
+            stage: HostStage::Model,
+            kind: AgentLoopHostErrorKind::CredentialUnavailable,
+            safe_summary: LoopSafeSummary::new("model credentials are unavailable").expect("safe"),
+            diagnostic_ref: Some(LoopDiagnosticRef::new("diag:model-credentials").expect("valid")),
+        }
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -227,6 +227,23 @@ pub(crate) fn map_executor_error(error: AgentLoopExecutorError) -> AgentLoopDriv
         AgentLoopExecutorError::HostUnavailable { stage } => AgentLoopDriverError::Unavailable {
             reason: format!("{}: unavailable", host_stage_name(stage)),
         },
+        AgentLoopExecutorError::HostUnavailableWithDiagnostics {
+            stage,
+            kind,
+            safe_summary,
+            diagnostic_ref,
+        } => {
+            tracing::warn!(
+                stage = ?stage,
+                kind = ?kind,
+                diagnostic_ref = ?diagnostic_ref,
+                safe_summary = %safe_summary,
+                "planned driver host stage unavailable"
+            );
+            AgentLoopDriverError::Unavailable {
+                reason: format!("{}: {safe_summary}", host_stage_name(stage)),
+            }
+        }
         AgentLoopExecutorError::PlannerContract { detail } => AgentLoopDriverError::Failed {
             reason_kind: format!("driver_bug:{detail}"),
         },
@@ -315,8 +332,9 @@ mod tests {
             LoopDriverId, LoopInputAckToken, LoopInputBatch, LoopInputCursor, LoopInputPort,
             LoopModelPort, LoopModelRequest, LoopModelResponse, LoopProgressEvent,
             LoopProgressPort, LoopPromptBundle, LoopPromptBundleRequest, LoopPromptPort,
-            LoopRunContext, LoopRunInfoPort, LoopTranscriptPort, StageCheckpointPayloadRequest,
-            UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
+            LoopRunContext, LoopRunInfoPort, LoopSafeSummary, LoopTranscriptPort,
+            StageCheckpointPayloadRequest, UpdateAssistantDraft, VisibleCapabilityRequest,
+            VisibleCapabilitySurface,
         },
     };
     use std::sync::Mutex;
@@ -399,6 +417,23 @@ mod tests {
             mapped,
             AgentLoopDriverError::Failed {
                 reason_kind: "interrupted_unexpectedly".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn executor_host_diagnostics_map_to_actionable_unavailable_reason() {
+        let mapped = map_executor_error(AgentLoopExecutorError::HostUnavailableWithDiagnostics {
+            stage: HostStage::Model,
+            kind: AgentLoopHostErrorKind::CredentialUnavailable,
+            safe_summary: LoopSafeSummary::new("model credentials are unavailable").expect("safe"),
+            diagnostic_ref: None,
+        });
+
+        assert_eq!(
+            mapped,
+            AgentLoopDriverError::Unavailable {
+                reason: "Model: model credentials are unavailable".to_string()
             }
         );
     }


### PR DESCRIPTION
## Summary
- Preserve sanitized model host error diagnostics when the planned loop cannot recover from a model-stage host error.
- Log the host stage, host error kind, safe summary, and diagnostic ref at the planned-driver boundary.
- Surface actionable driver unavailable reasons such as `Model: model credentials are unavailable` instead of only `Model: unavailable`.

## Tests
- `cargo fmt --check`
- `cargo test -p ironclaw_agent_loop model_unrecoverable_host_error_preserves_sanitized_diagnostics`
- `cargo test -p ironclaw_reborn executor_host_diagnostics_map_to_actionable_unavailable_reason`
- `cargo test -p ironclaw_agent_loop`
- `cargo test -p ironclaw_reborn`
- `git diff --check`