### PR TITLE
[codex] Implement Reborn scoped thread listing

### DIFF
--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -499,6 +499,12 @@ struct ScriptedThreadService {
 }
 
 impl ScriptedThreadService {
+    fn without_list_threads_override() -> Self {
+        // Intentionally do not override SessionThreadService::list_threads_for_scope;
+        // tests using this constructor exercise the trait's fail-closed default.
+        Self::backend_history()
+    }
+
     fn backend_history() -> Self {
         Self {
             behavior: ScriptedThreadBehavior::BackendHistory,
@@ -2716,7 +2722,7 @@ fn facade_source_avoids_forbidden_runtime_dependencies() {
 #[tokio::test]
 async fn list_threads_unimplemented_backend_returns_service_unavailable() {
     let services = RebornServices::new(
-        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(ScriptedThreadService::without_list_threads_override()),
         Arc::new(FakeTurnCoordinator::default()),
     );
 
@@ -2744,4 +2750,55 @@ async fn list_threads_unimplemented_backend_returns_service_unavailable() {
         "wire code must be snake_case `unavailable`; got: {json}"
     );
     assert_eq!(json["retryable"], true);
+}
+
+#[tokio::test]
+async fn list_threads_returns_threads_owned_by_authenticated_caller() {
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(FakeTurnCoordinator::default()),
+    );
+    create_thread_for(&services, caller(), "thread-list-alpha").await;
+    create_thread_for(&services, caller(), "thread-list-beta").await;
+    create_thread_for(
+        &services,
+        caller_for_user("user-other"),
+        "thread-list-other",
+    )
+    .await;
+
+    let first = services
+        .list_threads(
+            caller(),
+            WebUiListThreadsRequest {
+                limit: Some(1),
+                cursor: None,
+            },
+        )
+        .await
+        .expect("list owned threads");
+    assert_eq!(first.threads.len(), 1);
+    assert!(first.next_cursor.is_some());
+
+    let second = services
+        .list_threads(
+            caller(),
+            WebUiListThreadsRequest {
+                limit: Some(10),
+                cursor: first.next_cursor,
+            },
+        )
+        .await
+        .expect("list next page");
+    assert_eq!(second.threads.len(), 1);
+    assert!(second.next_cursor.is_none());
+
+    let mut listed_ids: Vec<_> = first
+        .threads
+        .iter()
+        .chain(second.threads.iter())
+        .map(|thread| thread.thread_id.as_str())
+        .collect();
+    listed_ids.sort();
+    assert_eq!(listed_ids, vec!["thread-list-alpha", "thread-list-beta"]);
 }

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -224,8 +224,8 @@ pub struct ThreadHistoryRequest {
 ///
 /// Pagination is opaque: `cursor` is whatever value the backend
 /// returned as `next_cursor` in a prior response. Stores that have
-/// no enumeration support today return an empty list + `None`
-/// cursor, which is the default trait impl on `SessionThreadService`.
+/// no enumeration support fail closed through the default
+/// `SessionThreadService` implementation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListThreadsForScopeRequest {
     pub scope: ThreadScope,

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -35,23 +35,27 @@
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex, OnceLock, Weak},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{
-    CasExpectation, ContentType, Entry, FilesystemError, FilesystemOperation, RecordVersion,
-    RootFilesystem, ScopedFilesystem,
+    CasExpectation, ContentType, Entry, FileType, FilesystemError, FilesystemOperation, Filter,
+    IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page, RecordVersion, RootFilesystem,
+    ScopedFilesystem,
 };
 use ironclaw_host_api::{HostApiError, ResourceScope, ScopedPath, ThreadId};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::identifiers::SummaryArtifactId;
+use crate::listing::{ThreadListEntry, paginate_thread_entries};
 use crate::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageReplay,
     AppendAssistantDraftRequest, AppendToolResultReferenceRequest, ContextMessage, ContextMessages,
-    ContextWindow, CreateSummaryArtifactRequest, EnsureThreadRequest, LoadContextMessagesRequest,
-    LoadContextWindowRequest, MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
+    ContextWindow, CreateSummaryArtifactRequest, EnsureThreadRequest, ListThreadsForScopeRequest,
+    ListThreadsForScopeResponse, LoadContextMessagesRequest, LoadContextWindowRequest,
+    MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
     ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadRecord,
     SessionThreadService, SummaryArtifact, ThreadHistory, ThreadHistoryRequest, ThreadMessageId,
     ThreadMessageRecord, ThreadScope, ToolResultReferenceEnvelope, UpdateAssistantDraftRequest,
@@ -70,6 +74,8 @@ struct StoredThreadRecord {
     #[serde(flatten)]
     record: SessionThreadRecord,
     next_sequence: u64,
+    #[serde(default)]
+    updated_at_unix_ms: i64,
 }
 
 /// On-disk inbound idempotency record. Includes the originating scope so
@@ -114,7 +120,16 @@ where
 
     fn thread_entry(record: &StoredThreadRecord) -> Result<Entry, SessionThreadError> {
         let body = serialize_pretty(record)?;
-        Ok(Entry::bytes(body).with_content_type(ContentType::json()))
+        Ok(Entry::bytes(body)
+            .with_content_type(ContentType::json())
+            .with_indexed(
+                index_key_thread_scope(),
+                IndexValue::Text(thread_scope_index_value(&record.record.scope)),
+            )
+            .with_indexed(
+                index_key_updated_at_unix_ms(),
+                IndexValue::I64(record.updated_at_unix_ms),
+            ))
     }
 
     fn message_entry(record: &ThreadMessageRecord) -> Result<Entry, SessionThreadError> {
@@ -287,6 +302,97 @@ where
         Ok(None)
     }
 
+    async fn list_thread_entries_via_index(
+        &self,
+        thread_scope: &ThreadScope,
+        resource_scope: &ResourceScope,
+        root: &ScopedPath,
+    ) -> Result<Vec<ThreadListEntry>, FilesystemError> {
+        self.filesystem
+            .ensure_index(
+                resource_scope,
+                root,
+                &IndexSpec::new(
+                    index_name_thread_scope(),
+                    vec![index_key_thread_scope()],
+                    IndexKind::Exact,
+                ),
+            )
+            .await?;
+        let filter = Filter::Eq {
+            key: index_key_thread_scope(),
+            value: IndexValue::Text(thread_scope_index_value(thread_scope)),
+        };
+
+        let mut entries = Vec::new();
+        let mut offset = 0_u64;
+        loop {
+            let page = Page::new(offset, Page::MAX_LIMIT);
+            let page_entries = match self
+                .filesystem
+                .query(resource_scope, root, &filter, page)
+                .await
+            {
+                Ok(page_entries) => page_entries,
+                Err(error) if is_not_found(&error) => return Ok(Vec::new()),
+                Err(error) => return Err(error),
+            };
+            let received = page_entries.len();
+            for entry in page_entries {
+                let stored = serde_json::from_slice::<StoredThreadRecord>(&entry.entry.body)
+                    .map_err(|error| FilesystemError::Backend {
+                        path: entry.path.clone(),
+                        operation: FilesystemOperation::Query,
+                        reason: format!("thread record deserialization failed: {error}"),
+                    })?;
+                if stored.record.scope == *thread_scope {
+                    entries.push(ThreadListEntry::new(
+                        stored.record,
+                        stored.updated_at_unix_ms,
+                    ));
+                }
+            }
+            if received < Page::MAX_LIMIT as usize {
+                break;
+            }
+            offset = offset.saturating_add(received as u64);
+        }
+        Ok(entries)
+    }
+
+    async fn list_thread_entries_via_dir(
+        &self,
+        thread_scope: &ThreadScope,
+        resource_scope: &ResourceScope,
+        root: &ScopedPath,
+    ) -> Result<Vec<ThreadListEntry>, SessionThreadError> {
+        let entries = match self.filesystem.list_dir(resource_scope, root).await {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+
+        let mut threads = Vec::new();
+        for entry in entries {
+            if entry.file_type != FileType::Directory {
+                continue;
+            }
+            let thread_id = ThreadId::new(entry.name.clone()).map_err(|error| {
+                SessionThreadError::Backend(format!(
+                    "invalid stored thread id under {}: {error}",
+                    root.as_str()
+                ))
+            })?;
+            if let Some((stored, _)) = self.read_thread_versioned(thread_scope, &thread_id).await? {
+                threads.push(ThreadListEntry::new(
+                    stored.record,
+                    stored.updated_at_unix_ms,
+                ));
+            }
+        }
+        Ok(threads)
+    }
+
     /// Read-modify-write the `next_sequence` counter on the thread record
     /// with optimistic CAS and bounded retry. Returns the sequence
     /// assigned to the caller (i.e. `next_sequence` before the bump) plus
@@ -306,6 +412,7 @@ where
                 })?;
             let assigned = stored.next_sequence;
             stored.next_sequence = assigned + 1;
+            stored.updated_at_unix_ms = unix_millis_now();
             let entry = Self::thread_entry(&stored)?;
             match put_with_cas(
                 self.filesystem.as_ref(),
@@ -323,6 +430,41 @@ where
         }
         Err(SessionThreadError::Backend(format!(
             "filesystem CAS retries exhausted reserving thread sequence at {}",
+            path.as_str()
+        )))
+    }
+
+    async fn touch_thread_updated_at(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        let path = thread_record_path(scope, thread_id)?;
+        for _ in 0..FILESYSTEM_CAS_RETRIES {
+            let (mut stored, version) = self
+                .read_thread_versioned(scope, thread_id)
+                .await?
+                .ok_or_else(|| SessionThreadError::UnknownThread {
+                    thread_id: thread_id.clone(),
+                })?;
+            stored.updated_at_unix_ms = unix_millis_now();
+            let entry = Self::thread_entry(&stored)?;
+            match put_with_cas(
+                self.filesystem.as_ref(),
+                &scope.to_resource_scope(),
+                &path,
+                entry,
+                CasExpectation::Version(version),
+            )
+            .await
+            {
+                Ok(()) => return Ok(()),
+                Err(PutError::VersionMismatch) => continue,
+                Err(PutError::Other(error)) => return Err(error),
+            }
+        }
+        Err(SessionThreadError::Backend(format!(
+            "filesystem CAS retries exhausted touching thread updated_at at {}",
             path.as_str()
         )))
     }
@@ -357,7 +499,10 @@ where
             )
             .await
             {
-                Ok(()) => return Ok(message),
+                Ok(()) => {
+                    self.touch_thread_updated_at(scope, thread_id).await?;
+                    return Ok(message);
+                }
                 Err(PutError::VersionMismatch) => continue,
                 Err(PutError::Other(error)) => return Err(error),
             }
@@ -411,6 +556,7 @@ where
         let stored = StoredThreadRecord {
             record: record.clone(),
             next_sequence: 1,
+            updated_at_unix_ms: unix_millis_now(),
         };
         let entry = Self::thread_entry(&stored)?;
         let resource_scope = record.scope.to_resource_scope();
@@ -961,6 +1107,35 @@ where
         Ok(thread.record)
     }
 
+    async fn list_threads_for_scope(
+        &self,
+        request: ListThreadsForScopeRequest,
+    ) -> Result<ListThreadsForScopeResponse, SessionThreadError> {
+        let root = scope_threads_root(&request.scope)?;
+        let resource_scope = request.scope.to_resource_scope();
+        match self
+            .list_thread_entries_via_index(&request.scope, &resource_scope, &root)
+            .await
+        {
+            Ok(entries) => Ok(paginate_thread_entries(
+                entries,
+                request.limit,
+                request.cursor.as_deref(),
+            )),
+            Err(error) if is_unsupported(&error) => {
+                let entries = self
+                    .list_thread_entries_via_dir(&request.scope, &resource_scope, &root)
+                    .await?;
+                Ok(paginate_thread_entries(
+                    entries,
+                    request.limit,
+                    request.cursor.as_deref(),
+                ))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
     async fn create_summary_artifact(
         &self,
         request: CreateSummaryArtifactRequest,
@@ -1030,7 +1205,11 @@ where
         )
         .await
         {
-            Ok(()) => Ok(artifact),
+            Ok(()) => {
+                self.touch_thread_updated_at(&request.scope, &request.thread_id)
+                    .await?;
+                Ok(artifact)
+            }
             Err(PutError::VersionMismatch) => Err(SessionThreadError::Backend(format!(
                 "filesystem CAS Absent rejected new summary artifact at {}",
                 path.as_str()
@@ -1098,6 +1277,10 @@ fn thread_record_path(
         "{}/thread.json",
         thread_root_string(scope, thread_id)
     ))
+}
+
+fn scope_threads_root(scope: &ThreadScope) -> Result<ScopedPath, SessionThreadError> {
+    scoped_path(&format!("{}/threads", scope_axes_string(scope)))
 }
 
 fn messages_root(
@@ -1179,6 +1362,28 @@ fn scope_axes_string(scope: &ThreadScope) -> String {
     base
 }
 
+fn thread_scope_index_value(scope: &ThreadScope) -> String {
+    scope_axes_string(scope)
+}
+
+fn index_name_thread_scope() -> IndexName {
+    IndexName::new("thread_scope").unwrap_or_else(|_| {
+        unreachable!("thread index name `thread_scope` must be a simple identifier")
+    })
+}
+
+fn index_key_thread_scope() -> IndexKey {
+    IndexKey::new("thread_scope").unwrap_or_else(|_| {
+        unreachable!("thread index key `thread_scope` must be a simple identifier")
+    })
+}
+
+fn index_key_updated_at_unix_ms() -> IndexKey {
+    IndexKey::new("updated_at_unix_ms").unwrap_or_else(|_| {
+        unreachable!("thread index key `updated_at_unix_ms` must be a simple identifier")
+    })
+}
+
 fn scoped_path(raw: &str) -> Result<ScopedPath, SessionThreadError> {
     ScopedPath::new(raw).map_err(invalid_path)
 }
@@ -1224,6 +1429,17 @@ where
 
 fn is_not_found(error: &FilesystemError) -> bool {
     matches!(error, FilesystemError::NotFound { .. })
+}
+
+fn is_unsupported(error: &FilesystemError) -> bool {
+    matches!(error, FilesystemError::Unsupported { .. })
+}
+
+fn unix_millis_now() -> i64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    }
 }
 
 // ── Transcript helpers (shared semantics) ──────────────────────
@@ -1445,7 +1661,8 @@ async fn put_with_cas<F>(
 where
     F: RootFilesystem,
 {
-    let fallback_entry = entry.clone();
+    let fallback_entry =
+        Entry::bytes(entry.body.clone()).with_content_type(entry.content_type.clone());
     match filesystem.put(scope, path, entry, cas).await {
         Ok(_) => Ok(()),
         Err(FilesystemError::VersionMismatch { .. }) => Err(PutError::VersionMismatch),

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
@@ -9,11 +10,13 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use crate::identifiers::SummaryArtifactId;
+use crate::listing::{ThreadListEntry, paginate_thread_entries};
 use crate::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageReplay,
     AppendAssistantDraftRequest, AppendToolResultReferenceRequest, ContextMessage, ContextMessages,
-    ContextWindow, CreateSummaryArtifactRequest, EnsureThreadRequest, LoadContextMessagesRequest,
-    LoadContextWindowRequest, MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
+    ContextWindow, CreateSummaryArtifactRequest, EnsureThreadRequest, ListThreadsForScopeRequest,
+    ListThreadsForScopeResponse, LoadContextMessagesRequest, LoadContextWindowRequest,
+    MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
     ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadRecord,
     SessionThreadService, SummaryArtifact, ThreadHistory, ThreadHistoryRequest, ThreadMessageId,
     ThreadMessageRecord, ThreadScope, ToolResultReferenceEnvelope, UpdateAssistantDraftRequest,
@@ -36,6 +39,7 @@ struct StoredThread {
     messages: Vec<ThreadMessageRecord>,
     summary_artifacts: Vec<SummaryArtifact>,
     next_sequence: u64,
+    updated_at_unix_ms: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -93,6 +97,7 @@ impl SessionThreadService for InMemorySessionThreadService {
                 messages: Vec::new(),
                 summary_artifacts: Vec::new(),
                 next_sequence: 1,
+                updated_at_unix_ms: unix_millis_now(),
             },
         );
         Ok(record)
@@ -139,6 +144,7 @@ impl SessionThreadService for InMemorySessionThreadService {
         let message_id = ThreadMessageId::new();
         let sequence = thread.next_sequence;
         thread.next_sequence += 1;
+        touch_thread(thread);
         thread.messages.push(ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),
@@ -219,12 +225,16 @@ impl SessionThreadService for InMemorySessionThreadService {
         turn_run_id: String,
     ) -> Result<ThreadMessageRecord, SessionThreadError> {
         let mut state = self.state.lock().await;
-        let message = get_message_mut(&mut state, scope, thread_id, message_id)?;
-        ensure_user_accepted(message, "mark_message_submitted")?;
-        message.status = MessageStatus::Submitted;
-        message.turn_id = Some(turn_id);
-        message.turn_run_id = Some(turn_run_id);
-        Ok(message.clone())
+        let message = {
+            let message = get_message_mut(&mut state, scope, thread_id, message_id)?;
+            ensure_user_accepted(message, "mark_message_submitted")?;
+            message.status = MessageStatus::Submitted;
+            message.turn_id = Some(turn_id);
+            message.turn_run_id = Some(turn_run_id);
+            message.clone()
+        };
+        touch_thread(get_thread_mut(&mut state, scope, thread_id)?);
+        Ok(message)
     }
 
     async fn mark_message_deferred_busy(
@@ -234,12 +244,16 @@ impl SessionThreadService for InMemorySessionThreadService {
         message_id: ThreadMessageId,
     ) -> Result<ThreadMessageRecord, SessionThreadError> {
         let mut state = self.state.lock().await;
-        let message = get_message_mut(&mut state, scope, thread_id, message_id)?;
-        ensure_user_accepted(message, "mark_message_deferred_busy")?;
-        message.status = MessageStatus::DeferredBusy;
-        message.turn_id = None;
-        message.turn_run_id = None;
-        Ok(message.clone())
+        let message = {
+            let message = get_message_mut(&mut state, scope, thread_id, message_id)?;
+            ensure_user_accepted(message, "mark_message_deferred_busy")?;
+            message.status = MessageStatus::DeferredBusy;
+            message.turn_id = None;
+            message.turn_run_id = None;
+            message.clone()
+        };
+        touch_thread(get_thread_mut(&mut state, scope, thread_id)?);
+        Ok(message)
     }
 
     async fn append_assistant_draft(
@@ -272,6 +286,7 @@ impl SessionThreadService for InMemorySessionThreadService {
             redaction_ref: None,
         };
         thread.next_sequence += 1;
+        touch_thread(thread);
         thread.messages.push(message.clone());
         Ok(message)
     }
@@ -306,7 +321,9 @@ impl SessionThreadService for InMemorySessionThreadService {
                     }
                 }
             }
-            return Ok(existing.clone());
+            let message = existing.clone();
+            touch_thread(thread);
+            return Ok(message);
         }
         if let Some(provider_call) = &provider_call {
             provider_call
@@ -332,6 +349,7 @@ impl SessionThreadService for InMemorySessionThreadService {
             redaction_ref: None,
         };
         thread.next_sequence += 1;
+        touch_thread(thread);
         thread.messages.push(message.clone());
         Ok(message)
     }
@@ -341,15 +359,23 @@ impl SessionThreadService for InMemorySessionThreadService {
         request: UpdateAssistantDraftRequest,
     ) -> Result<ThreadMessageRecord, SessionThreadError> {
         let mut state = self.state.lock().await;
-        let message = get_message_mut(
+        let message = {
+            let message = get_message_mut(
+                &mut state,
+                &request.scope,
+                &request.thread_id,
+                request.message_id,
+            )?;
+            ensure_draft(message)?;
+            message.content = Some(request.content.into_text());
+            message.clone()
+        };
+        touch_thread(get_thread_mut(
             &mut state,
             &request.scope,
             &request.thread_id,
-            request.message_id,
-        )?;
-        ensure_draft(message)?;
-        message.content = Some(request.content.into_text());
-        Ok(message.clone())
+        )?);
+        Ok(message)
     }
 
     async fn finalize_assistant_message(
@@ -360,11 +386,15 @@ impl SessionThreadService for InMemorySessionThreadService {
         content: MessageContent,
     ) -> Result<ThreadMessageRecord, SessionThreadError> {
         let mut state = self.state.lock().await;
-        let message = get_message_mut(&mut state, scope, thread_id, message_id)?;
-        ensure_draft(message)?;
-        message.status = MessageStatus::Finalized;
-        message.content = Some(content.into_text());
-        Ok(message.clone())
+        let message = {
+            let message = get_message_mut(&mut state, scope, thread_id, message_id)?;
+            ensure_draft(message)?;
+            message.status = MessageStatus::Finalized;
+            message.content = Some(content.into_text());
+            message.clone()
+        };
+        touch_thread(get_thread_mut(&mut state, scope, thread_id)?);
+        Ok(message)
     }
 
     async fn redact_message(
@@ -372,17 +402,25 @@ impl SessionThreadService for InMemorySessionThreadService {
         request: RedactMessageRequest,
     ) -> Result<ThreadMessageRecord, SessionThreadError> {
         let mut state = self.state.lock().await;
-        let message = get_message_mut(
+        let message = {
+            let message = get_message_mut(
+                &mut state,
+                &request.scope,
+                &request.thread_id,
+                request.message_id,
+            )?;
+            message.status = MessageStatus::Redacted;
+            message.content = None;
+            message.tool_result_provider_call = None;
+            message.redaction_ref = Some(request.redaction_ref);
+            message.clone()
+        };
+        touch_thread(get_thread_mut(
             &mut state,
             &request.scope,
             &request.thread_id,
-            request.message_id,
-        )?;
-        message.status = MessageStatus::Redacted;
-        message.content = None;
-        message.tool_result_provider_call = None;
-        message.redaction_ref = Some(request.redaction_ref);
-        Ok(message.clone())
+        )?);
+        Ok(message)
     }
 
     async fn load_context_window(
@@ -434,6 +472,24 @@ impl SessionThreadService for InMemorySessionThreadService {
         let state = self.state.lock().await;
         let thread = get_thread(&state, &request.scope, &request.thread_id)?;
         Ok(thread.record.clone())
+    }
+
+    async fn list_threads_for_scope(
+        &self,
+        request: ListThreadsForScopeRequest,
+    ) -> Result<ListThreadsForScopeResponse, SessionThreadError> {
+        let state = self.state.lock().await;
+        let threads: Vec<_> = state
+            .threads
+            .values()
+            .filter(|thread| thread.record.scope == request.scope)
+            .map(|thread| ThreadListEntry::new(thread.record.clone(), thread.updated_at_unix_ms))
+            .collect();
+        Ok(paginate_thread_entries(
+            threads,
+            request.limit,
+            request.cursor.as_deref(),
+        ))
     }
 
     async fn create_summary_artifact(
@@ -488,6 +544,7 @@ impl SessionThreadService for InMemorySessionThreadService {
             model_context_policy: request.model_context_policy,
         };
         thread.summary_artifacts.push(artifact.clone());
+        touch_thread(thread);
         Ok(artifact)
     }
 }
@@ -495,6 +552,17 @@ impl SessionThreadService for InMemorySessionThreadService {
 fn generated_thread_id() -> Result<ThreadId, SessionThreadError> {
     ThreadId::new(Uuid::new_v4().to_string())
         .map_err(|error| SessionThreadError::GeneratedThreadId(error.to_string()))
+}
+
+fn touch_thread(thread: &mut StoredThread) {
+    thread.updated_at_unix_ms = unix_millis_now();
+}
+
+fn unix_millis_now() -> i64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    }
 }
 
 fn get_thread<'a>(

--- a/crates/ironclaw_threads/src/lib.rs
+++ b/crates/ironclaw_threads/src/lib.rs
@@ -14,6 +14,7 @@ mod error;
 mod filesystem_service;
 mod identifiers;
 mod in_memory;
+mod listing;
 mod service;
 mod tool_result_reference;
 

--- a/crates/ironclaw_threads/src/listing.rs
+++ b/crates/ironclaw_threads/src/listing.rs
@@ -1,0 +1,181 @@
+use serde::{Deserialize, Serialize};
+
+use crate::contract::{ListThreadsForScopeResponse, SessionThreadRecord};
+
+const LIST_THREADS_DEFAULT_LIMIT: usize = 100;
+const LIST_THREADS_MAX_LIMIT: usize = 500;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ThreadListEntry {
+    pub(crate) record: SessionThreadRecord,
+    pub(crate) updated_at_unix_ms: i64,
+}
+
+impl ThreadListEntry {
+    pub(crate) fn new(record: SessionThreadRecord, updated_at_unix_ms: i64) -> Self {
+        Self {
+            record,
+            updated_at_unix_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ThreadListCursor {
+    updated_at_unix_ms: i64,
+    thread_id: String,
+}
+
+pub(crate) fn paginate_thread_entries(
+    mut entries: Vec<ThreadListEntry>,
+    limit: Option<u32>,
+    cursor: Option<&str>,
+) -> ListThreadsForScopeResponse {
+    entries.sort_by(|left, right| {
+        right
+            .updated_at_unix_ms
+            .cmp(&left.updated_at_unix_ms)
+            .then_with(|| {
+                left.record
+                    .thread_id
+                    .as_str()
+                    .cmp(right.record.thread_id.as_str())
+            })
+    });
+
+    let limit = clamp_list_threads_limit(limit);
+    let start = page_start(&entries, cursor);
+    let mut page: Vec<_> = entries.into_iter().skip(start).take(limit + 1).collect();
+    let next_cursor = if page.len() > limit {
+        page.truncate(limit);
+        page.last().and_then(encode_cursor)
+    } else {
+        None
+    };
+    ListThreadsForScopeResponse {
+        threads: page.into_iter().map(|entry| entry.record).collect(),
+        next_cursor,
+    }
+}
+
+fn page_start(entries: &[ThreadListEntry], cursor: Option<&str>) -> usize {
+    let Some(cursor) = cursor.filter(|cursor| !cursor.is_empty()) else {
+        return 0;
+    };
+    match serde_json::from_str::<ThreadListCursor>(cursor) {
+        Ok(cursor) => entries
+            .iter()
+            .position(|entry| is_after_cursor(entry, &cursor))
+            .unwrap_or(entries.len()),
+        Err(_) => entries
+            .iter()
+            .position(|entry| entry.record.thread_id.as_str() == cursor)
+            .map(|index| index + 1)
+            .unwrap_or(entries.len()),
+    }
+}
+
+fn is_after_cursor(entry: &ThreadListEntry, cursor: &ThreadListCursor) -> bool {
+    entry.updated_at_unix_ms < cursor.updated_at_unix_ms
+        || (entry.updated_at_unix_ms == cursor.updated_at_unix_ms
+            && entry.record.thread_id.as_str() > cursor.thread_id.as_str())
+}
+
+fn encode_cursor(entry: &ThreadListEntry) -> Option<String> {
+    serde_json::to_string(&ThreadListCursor {
+        updated_at_unix_ms: entry.updated_at_unix_ms,
+        thread_id: entry.record.thread_id.as_str().to_string(),
+    })
+    .ok()
+}
+
+fn clamp_list_threads_limit(limit: Option<u32>) -> usize {
+    limit
+        .unwrap_or(LIST_THREADS_DEFAULT_LIMIT as u32)
+        .clamp(1, LIST_THREADS_MAX_LIMIT as u32) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+
+    use crate::{SessionThreadRecord, ThreadScope};
+
+    use super::{ThreadListEntry, paginate_thread_entries};
+
+    #[test]
+    fn pagination_sorts_by_updated_at_before_limiting_and_cursoring() {
+        let first = paginate_thread_entries(
+            vec![
+                entry("thread-c", 10),
+                entry("thread-a", 30),
+                entry("thread-b", 20),
+            ],
+            Some(2),
+            None,
+        );
+        assert_eq!(thread_ids(&first.threads), vec!["thread-a", "thread-b"]);
+        assert!(first.next_cursor.is_some());
+
+        let second = paginate_thread_entries(
+            vec![
+                entry("thread-c", 10),
+                entry("thread-a", 30),
+                entry("thread-b", 20),
+            ],
+            Some(2),
+            first.next_cursor.as_deref(),
+        );
+        assert_eq!(thread_ids(&second.threads), vec!["thread-c"]);
+        assert!(second.next_cursor.is_none());
+    }
+
+    #[test]
+    fn pagination_cursor_survives_deleted_cursor_item() {
+        let first = paginate_thread_entries(
+            vec![
+                entry("thread-c", 10),
+                entry("thread-a", 30),
+                entry("thread-b", 20),
+            ],
+            Some(2),
+            None,
+        );
+
+        let second = paginate_thread_entries(
+            vec![entry("thread-c", 10), entry("thread-a", 30)],
+            Some(2),
+            first.next_cursor.as_deref(),
+        );
+
+        assert_eq!(thread_ids(&second.threads), vec!["thread-c"]);
+        assert!(second.next_cursor.is_none());
+    }
+
+    fn entry(thread_id: &str, updated_at_unix_ms: i64) -> ThreadListEntry {
+        ThreadListEntry::new(record(thread_id), updated_at_unix_ms)
+    }
+
+    fn record(thread_id: &str) -> SessionThreadRecord {
+        SessionThreadRecord {
+            scope: ThreadScope {
+                tenant_id: TenantId::new("tenant-listing").unwrap(),
+                agent_id: AgentId::new("agent-listing").unwrap(),
+                project_id: Some(ProjectId::new("project-listing").unwrap()),
+                owner_user_id: Some(UserId::new("user-listing").unwrap()),
+                mission_id: None,
+            },
+            thread_id: ThreadId::new(thread_id).unwrap(),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        }
+    }
+
+    fn thread_ids(records: &[SessionThreadRecord]) -> Vec<&str> {
+        records
+            .iter()
+            .map(|record| record.thread_id.as_str())
+            .collect()
+    }
+}

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -21,6 +21,9 @@ use ironclaw_threads::{
     ThreadHistoryRequest, ThreadScope, UpdateAssistantDraftRequest,
 };
 
+mod support;
+use support::{assert_two_page_thread_listing, seed_listable_threads};
+
 #[tokio::test]
 async fn durable_history_round_trips_through_filesystem_store() {
     let backend = Arc::new(InMemoryBackend::new());
@@ -165,6 +168,20 @@ async fn filesystem_session_thread_service_isolates_two_tenants_with_same_user_p
         replay.is_none(),
         "tenant B must NOT replay tenant A's inbound idempotency record"
     );
+}
+
+#[tokio::test]
+async fn filesystem_store_lists_threads_for_exact_scope_after_reopen() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-a", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let owned_scope = scope("fs-list-owned");
+    let thread_ids =
+        seed_listable_threads(&service, &owned_scope, scope("fs-list-other"), "fs-list").await;
+
+    let scoped = scoped_threads_fs_at(backend, "tenant-a", "alice");
+    let reopened = FilesystemSessionThreadService::new(scoped);
+    assert_two_page_thread_listing(&reopened, owned_scope, thread_ids).await;
 }
 
 #[tokio::test]

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -9,6 +9,9 @@ use ironclaw_threads::{
     ToolResultSafeSummary, UpdateAssistantDraftRequest,
 };
 
+mod support;
+use support::{assert_two_page_thread_listing, seed_listable_threads};
+
 fn scope(label: &str) -> ThreadScope {
     ThreadScope {
         tenant_id: TenantId::new(format!("tenant-{label}")).unwrap(),
@@ -1438,6 +1441,16 @@ async fn read_thread_rejects_cross_scope_lookup_with_unknown_thread() {
         matches!(&err, ironclaw_threads::SessionThreadError::UnknownThread { thread_id } if thread_id == &thread.thread_id),
         "cross-scope read_thread must collapse to UnknownThread, got: {err:?}"
     );
+}
+
+#[tokio::test]
+async fn list_threads_for_scope_returns_only_owned_threads_and_paginates() {
+    let service = InMemorySessionThreadService::default();
+    let owned_scope = scope("list-owned");
+    let thread_ids =
+        seed_listable_threads(&service, &owned_scope, scope("list-other"), "list").await;
+
+    assert_two_page_thread_listing(&service, owned_scope, thread_ids).await;
 }
 
 #[test]

--- a/crates/ironclaw_threads/tests/support/mod.rs
+++ b/crates/ironclaw_threads/tests/support/mod.rs
@@ -1,0 +1,87 @@
+use ironclaw_host_api::ThreadId;
+use ironclaw_threads::{
+    EnsureThreadRequest, ListThreadsForScopeRequest, ListThreadsForScopeResponse,
+    SessionThreadService, ThreadScope,
+};
+
+pub async fn seed_listable_threads(
+    service: &impl SessionThreadService,
+    owned_scope: &ThreadScope,
+    other_scope: ThreadScope,
+    prefix: &str,
+) -> [String; 3] {
+    let thread_ids = [
+        format!("thread-{prefix}-a"),
+        format!("thread-{prefix}-b"),
+        format!("thread-{prefix}-c"),
+    ];
+
+    for thread_id in &thread_ids {
+        service
+            .ensure_thread(EnsureThreadRequest {
+                scope: owned_scope.clone(),
+                thread_id: Some(ThreadId::new(thread_id.clone()).unwrap()),
+                created_by_actor_id: "actor-a".into(),
+                title: Some(thread_id.clone()),
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+    }
+    service
+        .ensure_thread(EnsureThreadRequest {
+            scope: other_scope,
+            thread_id: Some(ThreadId::new(format!("thread-{prefix}-other")).unwrap()),
+            created_by_actor_id: "actor-b".into(),
+            title: Some("other".into()),
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    thread_ids
+}
+
+pub async fn assert_two_page_thread_listing(
+    service: &impl SessionThreadService,
+    scope: ThreadScope,
+    expected_ids: [String; 3],
+) {
+    let first = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope: scope.clone(),
+            limit: Some(2),
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(first.threads.len(), 2);
+    assert!(first.next_cursor.is_some());
+
+    let second = service
+        .list_threads_for_scope(ListThreadsForScopeRequest {
+            scope,
+            limit: Some(2),
+            cursor: first.next_cursor.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(second.threads.len(), 1);
+    assert!(second.next_cursor.is_none());
+
+    let mut actual_ids = listed_thread_ids(&first);
+    actual_ids.extend(listed_thread_ids(&second));
+    actual_ids.sort();
+
+    let mut expected_ids = expected_ids.to_vec();
+    expected_ids.sort();
+    assert_eq!(actual_ids, expected_ids);
+}
+
+fn listed_thread_ids(response: &ListThreadsForScopeResponse) -> Vec<String> {
+    response
+        .threads
+        .iter()
+        .map(|thread| thread.thread_id.as_str().to_string())
+        .collect()
+}


### PR DESCRIPTION
## Summary
- Implement `list_threads_for_scope` for the in-memory Reborn session thread service.
- Implement scoped durable enumeration for `FilesystemSessionThreadService` so historical persisted threads can be returned by `GET /api/webchat/v2/threads`.
- Share cursor/limit pagination semantics and add backend plus facade regression coverage.

## Root Cause
`SessionThreadService::list_threads_for_scope` intentionally failed closed by default, so the WebChat v2 list-threads route returned `503 service_unavailable` whenever the active backend did not override enumeration.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_threads list_threads_for_scope`
- `cargo test -p ironclaw_threads filesystem_store_lists_threads_for_exact_scope_after_reopen`
- `cargo test -p ironclaw_product_workflow list_threads`
- `cargo test -p ironclaw_webui_v2 list_threads`