### PR TITLE
Add debug tracing for Reborn capability dispatch

### DIFF
--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -9,7 +9,7 @@ use ironclaw_run_state::{
     ApprovalRequestStore, ApprovalStatus, RunStart, RunStateApprovalStore, RunStateError,
     RunStateStore, RunStatus,
 };
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::helpers::{
     CapabilityActionKind, approval_not_approved_error_kind, capability_lease_error_kind,
@@ -132,6 +132,15 @@ where
         self
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, request),
+        fields(
+            invocation_id = %request.context.invocation_id,
+            capability_id = %request.capability_id,
+            scope = ?request.context.resource_scope,
+        )
+    )]
     pub async fn invoke_json(
         &self,
         request: CapabilityInvocationRequest,
@@ -140,11 +149,13 @@ where
         let capability_id = request.capability_id.clone();
         let scope = request.context.resource_scope.clone();
         if request.context.validate().is_err() {
+            debug!("capability invocation rejected invalid execution context");
             return Err(CapabilityInvocationError::AuthorizationDenied {
                 capability: request.capability_id,
                 reason: DenyReason::InternalInvariantViolation,
             });
         }
+        debug!("capability invocation started");
 
         let invocation_fingerprint = invocation_fingerprint_for_kind(
             CapabilityActionKind::Dispatch,
@@ -166,9 +177,11 @@ where
                     scope: scope.clone(),
                 })
                 .await?;
+            debug!("capability run state started");
         }
 
         let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+            debug!("capability invocation failed before authorization: unknown capability");
             fail_run_if_configured(self.run_state, &scope, invocation_id, "UnknownCapability")
                 .await;
             return Err(CapabilityInvocationError::UnknownCapability {
@@ -192,6 +205,10 @@ where
                 obligations: allowed_obligations,
             } => {
                 let allowed_obligations = allowed_obligations.into_vec();
+                debug!(
+                    obligation_count = allowed_obligations.len(),
+                    "capability authorization allowed dispatch"
+                );
                 match self
                     .prepare_obligations(
                         CapabilityObligationPhase::Invoke,
@@ -205,8 +222,13 @@ where
                     Ok(outcome) => {
                         obligations = allowed_obligations;
                         obligation_outcome = outcome;
+                        debug!("capability invoke obligations prepared");
                     }
                     Err(error) => {
+                        debug!(
+                            error_kind = obligation_invocation_error_kind(&error),
+                            "capability invoke obligation preparation failed"
+                        );
                         fail_run_if_configured(
                             self.run_state,
                             &scope,
@@ -219,6 +241,10 @@ where
                 }
             }
             Decision::Deny { reason } => {
+                debug!(
+                    reason = ?reason,
+                    "capability authorization denied dispatch"
+                );
                 fail_run_if_configured(
                     self.run_state,
                     &scope,
@@ -234,6 +260,11 @@ where
             Decision::RequireApproval {
                 request: mut approval,
             } => {
+                let approval_request_id = approval.id;
+                debug!(
+                    approval_request_id = %approval_request_id,
+                    "capability authorization requires approval"
+                );
                 if let Err(error) = validate_approval_request_matches_invocation(
                     &approval,
                     &request.context,
@@ -241,6 +272,10 @@ where
                     &request.estimate,
                     CapabilityActionKind::Dispatch,
                 ) {
+                    debug!(
+                        approval_request_id = %approval_request_id,
+                        "capability approval request did not match invocation"
+                    );
                     fail_run_if_configured(
                         self.run_state,
                         &scope,
@@ -253,6 +288,10 @@ where
 
                 if let Some(existing) = &approval.invocation_fingerprint {
                     if existing != &invocation_fingerprint {
+                        debug!(
+                            approval_request_id = %approval_request_id,
+                            "capability approval fingerprint mismatch"
+                        );
                         fail_run_if_configured(
                             self.run_state,
                             &scope,
@@ -279,6 +318,10 @@ where
                                 )
                                 .await
                             {
+                                debug!(
+                                    approval_request_id = %approval_request_id,
+                                    "capability approval block failed in combined store"
+                                );
                                 fail_run_if_configured(
                                     Some(run_state),
                                     &scope,
@@ -288,12 +331,20 @@ where
                                 .await;
                                 return Err(CapabilityInvocationError::from(error));
                             }
+                            debug!(
+                                approval_request_id = %approval_request_id,
+                                "capability approval persisted and run state blocked"
+                            );
                         } else {
                             let approval_id = approval.id;
                             if let Err(error) = approval_requests
                                 .save_pending(scope.clone(), approval.clone())
                                 .await
                             {
+                                debug!(
+                                    approval_request_id = %approval_id,
+                                    "capability approval request persistence failed"
+                                );
                                 fail_run_if_configured(
                                     Some(run_state),
                                     &scope,
@@ -307,6 +358,10 @@ where
                                 .block_approval(&scope, invocation_id, approval)
                                 .await
                             {
+                                debug!(
+                                    approval_request_id = %approval_id,
+                                    "capability run state approval block failed"
+                                );
                                 if let Err(discard_error) =
                                     approval_requests.discard_pending(&scope, approval_id).await
                                 {
@@ -326,9 +381,18 @@ where
                                 .await;
                                 return Err(CapabilityInvocationError::from(error));
                             }
+                            debug!(
+                                approval_request_id = %approval_id,
+                                "capability approval persisted and run state blocked"
+                            );
                         }
                     }
                     (Some(run_state), None) => {
+                        debug!(
+                            approval_request_id = %approval_request_id,
+                            store = "approval_requests",
+                            "capability approval cannot block because store is missing"
+                        );
                         fail_run_if_configured(
                             Some(run_state),
                             &scope,
@@ -342,12 +406,22 @@ where
                         });
                     }
                     (None, Some(_)) => {
+                        debug!(
+                            approval_request_id = %approval_request_id,
+                            store = "run_state",
+                            "capability approval cannot block because store is missing"
+                        );
                         return Err(CapabilityInvocationError::ApprovalStoreMissing {
                             capability: request.capability_id,
                             store: "run_state",
                         });
                     }
                     (None, None) => {
+                        debug!(
+                            approval_request_id = %approval_request_id,
+                            store = "run_state and approval_requests",
+                            "capability approval cannot block because stores are missing"
+                        );
                         return Err(CapabilityInvocationError::ApprovalStoreMissing {
                             capability: request.capability_id,
                             store: "run_state and approval_requests",
@@ -360,6 +434,7 @@ where
             }
         }
 
+        debug!("capability dispatch starting");
         let dispatch = match self
             .dispatcher
             .dispatch_json(CapabilityDispatchRequest {
@@ -372,8 +447,19 @@ where
             })
             .await
         {
-            Ok(dispatch) => dispatch,
+            Ok(dispatch) => {
+                debug!(
+                    provider = %dispatch.provider,
+                    runtime = ?dispatch.runtime,
+                    "capability dispatch completed"
+                );
+                dispatch
+            }
             Err(error) => {
+                debug!(
+                    dispatch_failure_kind = %error.failure_kind(),
+                    "capability dispatch failed"
+                );
                 self.abort_obligations(
                     CapabilityObligationPhase::Invoke,
                     &request.context,
@@ -401,6 +487,10 @@ where
         {
             Ok(dispatch) => dispatch,
             Err(error) => {
+                debug!(
+                    error_kind = obligation_invocation_error_kind(&error),
+                    "capability invoke obligation completion failed"
+                );
                 let cleanup_outcome = CapabilityObligationOutcome::default();
                 self.abort_obligations(
                     CapabilityObligationPhase::Invoke,
@@ -431,8 +521,10 @@ where
                 "dispatch",
             )
             .await;
+            debug!("capability run state completed");
         }
 
+        debug!("capability invocation completed");
         Ok(CapabilityInvocationResult { dispatch })
     }
 

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -187,6 +187,14 @@ where
         self
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, request),
+        fields(
+            capability_id = %request.capability_id,
+            scope = ?request.scope,
+        )
+    )]
     pub async fn dispatch_json(
         &self,
         request: CapabilityDispatchRequest,
@@ -357,6 +365,15 @@ where
     }
 
     async fn emit_event(&self, event: RuntimeEvent) -> Result<(), DispatchError> {
+        tracing::debug!(
+            event_kind = ?event.kind,
+            capability_id = %event.capability_id,
+            provider = event.provider.as_ref().map(|provider| provider.as_str()).unwrap_or(""),
+            runtime = ?event.runtime,
+            output_bytes = event.output_bytes,
+            error_kind = event.error_kind.as_deref().unwrap_or(""),
+            "runtime dispatcher observed event"
+        );
         if let Some(sink) = self.event_sink.as_ref() {
             let _ = sink.as_ref().emit(event).await;
         }

--- a/crates/ironclaw_first_party_extensions/src/skills.rs
+++ b/crates/ironclaw_first_party_extensions/src/skills.rs
@@ -64,6 +64,11 @@ impl SkillManagementCapabilityError {
     }
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(request),
+    fields(kind = ?request.kind, scope = ?request.scope)
+)]
 pub async fn dispatch(
     request: &SkillManagementCapabilityRequest<'_>,
 ) -> Result<Value, SkillManagementCapabilityError> {
@@ -74,17 +79,30 @@ pub async fn dispatch(
     }
 }
 
+#[tracing::instrument(level = "debug", skip(request))]
 async fn dispatch_list(
     request: &SkillManagementCapabilityRequest<'_>,
 ) -> Result<Value, SkillManagementCapabilityError> {
     let context = management_context(request)?;
     let skills = list_skills(&context).await.map_err(capability_error)?;
+    tracing::debug!(
+        skill_count = skills.len(),
+        "skill management list completed"
+    );
     Ok(json!({
         "skills": Value::from_iter(skills.iter().map(skill_summary_json)),
         "count": skills.len(),
     }))
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(request),
+    fields(
+        has_content = request.input.get("content").is_some(),
+        has_requested_name = request.input.get("name").is_some(),
+    )
+)]
 async fn dispatch_install(
     request: &SkillManagementCapabilityRequest<'_>,
 ) -> Result<Value, SkillManagementCapabilityError> {
@@ -92,12 +110,20 @@ async fn dispatch_install(
         .input
         .get("content")
         .and_then(Value::as_str)
-        .ok_or_else(input_error)?;
+        .ok_or_else(|| {
+            tracing::debug!("skill management install missing string content input");
+            input_error()
+        })?;
     let name = request.input.get("name").and_then(Value::as_str);
     let context = management_context(request)?;
     let installed = install_skill(&context, SkillInstallRequest { name, content })
         .await
         .map_err(capability_error)?;
+    tracing::debug!(
+        skill_name = %installed.name,
+        scoped_path = %installed.scoped_path,
+        "skill management install completed"
+    );
 
     Ok(json!({
         "installed": true,
@@ -106,6 +132,11 @@ async fn dispatch_install(
     }))
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(request),
+    fields(has_name = request.input.get("name").is_some())
+)]
 async fn dispatch_remove(
     request: &SkillManagementCapabilityRequest<'_>,
 ) -> Result<Value, SkillManagementCapabilityError> {
@@ -113,11 +144,18 @@ async fn dispatch_remove(
         .input
         .get("name")
         .and_then(Value::as_str)
-        .ok_or_else(input_error)?;
+        .ok_or_else(|| {
+            tracing::debug!("skill management remove missing string name input");
+            input_error()
+        })?;
     let context = management_context(request)?;
     let removed = remove_skill(&context, SkillRemoveRequest { name })
         .await
         .map_err(capability_error)?;
+    tracing::debug!(
+        skill_name = %removed.name,
+        "skill management remove completed"
+    );
 
     Ok(json!({
         "removed": true,
@@ -129,6 +167,7 @@ fn management_context(
     request: &SkillManagementCapabilityRequest<'_>,
 ) -> Result<SkillManagementContext, SkillManagementCapabilityError> {
     let Some(mounts) = request.mounts else {
+        tracing::debug!("skill management request missing filesystem mounts");
         return Err(SkillManagementCapabilityError::new(
             RuntimeDispatchErrorKind::FilesystemDenied,
         ));
@@ -157,6 +196,7 @@ fn input_error() -> SkillManagementCapabilityError {
 }
 
 fn capability_error(error: SkillManagementError) -> SkillManagementCapabilityError {
+    let skill_error_kind = error.kind();
     let kind = match error.kind() {
         SkillManagementErrorKind::InvalidInput => RuntimeDispatchErrorKind::InputEncode,
         SkillManagementErrorKind::FilesystemDenied => RuntimeDispatchErrorKind::FilesystemDenied,
@@ -165,5 +205,10 @@ fn capability_error(error: SkillManagementError) -> SkillManagementCapabilityErr
         | SkillManagementErrorKind::InvalidSkill => RuntimeDispatchErrorKind::Guest,
         SkillManagementErrorKind::Resource => RuntimeDispatchErrorKind::Resource,
     };
+    tracing::debug!(
+        skill_management_error_kind = ?skill_error_kind,
+        runtime_dispatch_error_kind = %kind,
+        "skill management error mapped to runtime dispatch error"
+    );
     SkillManagementCapabilityError::new(kind)
 }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/skill_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/skill_management.rs
@@ -99,5 +99,9 @@ impl FirstPartyCapabilityHandler for SkillManagementToolHandler {
 }
 
 fn skill_management_error(error: SkillManagementCapabilityError) -> FirstPartyCapabilityError {
+    tracing::debug!(
+        runtime_dispatch_error_kind = %error.kind(),
+        "skill management error mapped to first-party capability error"
+    );
     FirstPartyCapabilityError::new(error.kind())
 }

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -206,10 +206,19 @@ where
     F: RootFilesystem,
     G: ResourceGovernor,
 {
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, request),
+        fields(
+            capability_id = %request.capability_id,
+            scope = ?request.scope,
+        )
+    )]
     async fn dispatch_json(
         &self,
         request: RuntimeAdapterRequest<'_, F, G>,
     ) -> Result<RuntimeAdapterResult, DispatchError> {
+        tracing::debug!("first-party runtime adapter dispatch started");
         let Some(handler) = self.registry.get(request.capability_id) else {
             if let Some(reservation) = request.resource_reservation
                 && let Err(error) = request.governor.release(reservation.id)
@@ -220,6 +229,7 @@ where
                     "failed to release prepared resource reservation after missing first-party handler"
                 );
             }
+            tracing::debug!("first-party runtime adapter missing handler");
             return Err(DispatchError::FirstParty {
                 kind: RuntimeDispatchErrorKind::UndeclaredCapability,
             });
@@ -227,6 +237,10 @@ where
 
         let plan =
             plan_capability(request.descriptor, request.runtime_policy).map_err(|error| {
+                tracing::debug!(
+                    error_kind = %planner_error_kind(&error),
+                    "first-party runtime adapter policy planning failed"
+                );
                 if let Some(reservation) = &request.resource_reservation {
                     release_first_party_reservation(request.governor, reservation.id);
                 }
@@ -234,6 +248,13 @@ where
                     kind: planner_error_kind(&error),
                 }
             })?;
+        tracing::debug!(
+            filesystem_backend = ?plan.filesystem_backend,
+            process_backend = ?plan.process_backend,
+            network_mode = ?plan.network_mode,
+            secret_mode = ?plan.secret_mode,
+            "first-party runtime adapter policy plan resolved"
+        );
         let services = self
             .invocation_services
             .resolve(InvocationServicesResolutionRequest {
@@ -242,22 +263,40 @@ where
                 mounts: request.mounts.as_ref(),
             })
             .map_err(|error| {
+                tracing::debug!(
+                    error_kind = %error.kind(),
+                    "first-party runtime adapter service resolution failed"
+                );
                 if let Some(reservation) = &request.resource_reservation {
                     release_first_party_reservation(request.governor, reservation.id);
                 }
                 DispatchError::FirstParty { kind: error.kind() }
             })?;
+        tracing::debug!("first-party runtime adapter services resolved");
 
+        let used_prepared_reservation = request.resource_reservation.is_some();
         let reservation = match request.resource_reservation {
             Some(reservation) => reservation,
             None => request
                 .governor
                 .reserve(request.scope.clone(), request.estimate.clone())
-                .map_err(|_| DispatchError::FirstParty {
-                    kind: RuntimeDispatchErrorKind::Resource,
+                .map_err(|_| {
+                    tracing::debug!("first-party runtime adapter resource reservation failed");
+                    DispatchError::FirstParty {
+                        kind: RuntimeDispatchErrorKind::Resource,
+                    }
                 })?,
         };
+        tracing::debug!(
+            reservation_id = %reservation.id,
+            used_prepared_reservation,
+            "first-party runtime adapter resource reservation ready"
+        );
 
+        tracing::debug!(
+            reservation_id = %reservation.id,
+            "first-party runtime adapter invoking handler"
+        );
         let result = match AssertUnwindSafe(handler.dispatch(FirstPartyCapabilityRequest {
             capability_id: request.capability_id.clone(),
             scope: request.scope.clone(),
@@ -271,6 +310,11 @@ where
         {
             Ok(Ok(result)) => result,
             Ok(Err(error)) => {
+                tracing::debug!(
+                    reservation_id = %reservation.id,
+                    error_kind = %error.kind(),
+                    "first-party runtime adapter handler failed"
+                );
                 account_or_release_failed_first_party_execution(
                     request.governor,
                     reservation.id,
@@ -279,6 +323,10 @@ where
                 return Err(DispatchError::FirstParty { kind: error.kind() });
             }
             Err(_) => {
+                tracing::debug!(
+                    reservation_id = %reservation.id,
+                    "first-party runtime adapter handler panicked"
+                );
                 release_first_party_reservation(request.governor, reservation.id);
                 return Err(DispatchError::FirstParty {
                     kind: RuntimeDispatchErrorKind::Backend,
@@ -288,14 +336,24 @@ where
 
         let output_bytes = serde_json::to_vec(&result.output)
             .map(|bytes| bytes.len() as u64)
-            .map_err(|_| DispatchError::FirstParty {
-                kind: RuntimeDispatchErrorKind::OutputDecode,
+            .map_err(|_| {
+                tracing::debug!(
+                    reservation_id = %reservation.id,
+                    "first-party runtime adapter output serialization failed"
+                );
+                DispatchError::FirstParty {
+                    kind: RuntimeDispatchErrorKind::OutputDecode,
+                }
             })?;
         let mut usage = result.usage;
         usage.output_bytes = usage.output_bytes.max(output_bytes);
         let receipt = match request.governor.reconcile(reservation.id, usage.clone()) {
             Ok(receipt) => receipt,
             Err(_) => {
+                tracing::debug!(
+                    reservation_id = %reservation.id,
+                    "first-party runtime adapter resource reconcile failed"
+                );
                 if let Err(release_error) = request.governor.release(reservation.id) {
                     tracing::warn!(
                         reservation_id = %reservation.id,
@@ -308,6 +366,11 @@ where
                 });
             }
         };
+        tracing::debug!(
+            reservation_id = %reservation.id,
+            output_bytes,
+            "first-party runtime adapter dispatch completed"
+        );
 
         Ok(RuntimeAdapterResult {
             output: result.output,

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -147,31 +147,53 @@ pub struct SkillRemoveResult {
     pub name: String,
 }
 
+#[tracing::instrument(level = "debug", skip(context))]
 pub async fn list_skills(
     context: &SkillManagementContext,
 ) -> Result<Vec<SkillSummary>, SkillManagementError> {
     let mut skills = Vec::new();
     skills.extend(list_skill_root(context, SYSTEM_SKILLS_ROOT, SkillSource::System).await?);
     skills.extend(list_skill_root(context, USER_SKILLS_ROOT, SkillSource::User).await?);
+    tracing::debug!(skill_count = skills.len(), "skill management listed skills");
     Ok(skills)
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(context, request),
+    fields(
+        requested_name = request.name.unwrap_or("<none>"),
+        content_bytes = request.content.len(),
+    )
+)]
 pub async fn install_skill(
     context: &SkillManagementContext,
     request: SkillInstallRequest<'_>,
 ) -> Result<SkillInstallResult, SkillManagementError> {
+    tracing::debug!("skill install started");
     if request.content.len() as u64 > MAX_PROMPT_FILE_SIZE {
+        tracing::debug!(
+            max_bytes = MAX_PROMPT_FILE_SIZE,
+            "skill install rejected oversized content"
+        );
         return Err(SkillManagementError::new(
             SkillManagementErrorKind::Resource,
         ));
     }
 
     let normalized = normalize_line_endings(request.content);
-    let parsed = parse_skill_md(&normalized)
-        .map_err(|_| SkillManagementError::new(SkillManagementErrorKind::InvalidInput))?;
+    let parsed = parse_skill_md(&normalized).map_err(|_| {
+        tracing::debug!("skill install failed to parse SKILL.md content");
+        SkillManagementError::new(SkillManagementErrorKind::InvalidInput)
+    })?;
     if let Some(requested_name) = request.name
         && requested_name != parsed.manifest.name
     {
+        tracing::debug!(
+            requested_name,
+            parsed_name = %parsed.manifest.name,
+            "skill install rejected name mismatch"
+        );
         return Err(SkillManagementError::new(
             SkillManagementErrorKind::InvalidInput,
         ));
@@ -181,12 +203,19 @@ pub async fn install_skill(
     let skill_dir = skill_root_scoped_path(USER_SKILLS_ROOT, &skill_name)?;
     let skill_path = skill_scoped_path(USER_SKILLS_ROOT, &skill_name, SKILL_FILE_NAME)?;
 
+    log_skill_filesystem_phase("stat_existing", &skill_name, &skill_path);
     if stat_optional(context, &skill_path).await?.is_some() {
+        tracing::debug!(
+            skill_name = %skill_name,
+            scoped_path = %skill_path,
+            "skill install rejected existing skill"
+        );
         return Err(SkillManagementError::new(
             SkillManagementErrorKind::Conflict,
         ));
     }
 
+    log_skill_filesystem_phase("create_dir_all", &skill_name, &skill_dir);
     context
         .filesystem
         .create_dir_all(&context.scope, &skill_dir)
@@ -195,15 +224,30 @@ pub async fn install_skill(
             FilesystemError::Unsupported {
                 operation: FilesystemOperation::CreateDirAll,
                 ..
-            } => Ok(()),
+            } => {
+                log_skill_filesystem_phase("create_dir_all_unsupported", &skill_name, &skill_dir);
+                Ok(())
+            }
             other => Err(other),
         })
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            log_skill_filesystem_phase("create_dir_all_failed", &skill_name, &skill_dir);
+            filesystem_error(error)
+        })?;
+    log_skill_filesystem_phase("write_file", &skill_name, &skill_path);
     context
         .filesystem
         .write_file(&context.scope, &skill_path, normalized.as_bytes())
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            log_skill_filesystem_phase("write_file_failed", &skill_name, &skill_path);
+            filesystem_error(error)
+        })?;
+    tracing::debug!(
+        skill_name = %skill_name,
+        scoped_path = %skill_path,
+        "skill install completed"
+    );
 
     Ok(SkillInstallResult {
         name: skill_name.clone(),
@@ -211,44 +255,76 @@ pub async fn install_skill(
     })
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(context, request),
+    fields(skill_name = %request.name)
+)]
 pub async fn remove_skill(
     context: &SkillManagementContext,
     request: SkillRemoveRequest<'_>,
 ) -> Result<SkillRemoveResult, SkillManagementError> {
+    tracing::debug!("skill remove started");
     if !validate_skill_name(request.name) {
+        tracing::debug!("skill remove rejected invalid name");
         return Err(SkillManagementError::new(
             SkillManagementErrorKind::InvalidInput,
         ));
     }
     let skill_dir = skill_root_scoped_path(USER_SKILLS_ROOT, request.name)?;
     let skill_path = skill_scoped_path(USER_SKILLS_ROOT, request.name, SKILL_FILE_NAME)?;
+    log_skill_filesystem_phase("stat_existing", request.name, &skill_path);
     if stat_optional(context, &skill_path).await?.is_none() {
+        tracing::debug!(
+            scoped_path = %skill_path,
+            "skill remove could not find installed skill"
+        );
         return Err(SkillManagementError::new(
             SkillManagementErrorKind::NotFound,
         ));
     }
+    log_skill_filesystem_phase("delete_dir", request.name, &skill_dir);
     context
         .filesystem
         .delete(&context.scope, &skill_dir)
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            log_skill_filesystem_phase("delete_dir_failed", request.name, &skill_dir);
+            filesystem_error(error)
+        })?;
+    tracing::debug!("skill remove completed");
     Ok(SkillRemoveResult {
         name: request.name.to_string(),
     })
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(context),
+    fields(scoped_root = %scoped_root, source = source.as_str())
+)]
 async fn list_skill_root(
     context: &SkillManagementContext,
     scoped_root: &str,
     source: SkillSource,
 ) -> Result<Vec<SkillSummary>, SkillManagementError> {
+    tracing::debug!("skill management listing skill root");
     let root = ScopedPath::new(scoped_root)
         .map_err(|_| SkillManagementError::new(SkillManagementErrorKind::InvalidInput))?;
     let entries = match context.filesystem.list_dir(&context.scope, &root).await {
         Ok(entries) => entries,
-        Err(FilesystemError::NotFound { .. }) => return Ok(Vec::new()),
-        Err(FilesystemError::PermissionDenied { .. }) => return Ok(Vec::new()),
-        Err(error) if is_unmounted_scoped_root(&error) => return Ok(Vec::new()),
+        Err(FilesystemError::NotFound { .. }) => {
+            tracing::debug!("skill management skill root not found");
+            return Ok(Vec::new());
+        }
+        Err(FilesystemError::PermissionDenied { .. }) => {
+            tracing::debug!("skill management skill root permission denied");
+            return Ok(Vec::new());
+        }
+        Err(error) if is_unmounted_scoped_root(&error) => {
+            tracing::debug!("skill management skill root is not mounted");
+            return Ok(Vec::new());
+        }
         Err(error) => return Err(filesystem_error(error)),
     };
 
@@ -266,6 +342,10 @@ async fn list_skill_root(
             skills.push(skill);
         }
     }
+    tracing::debug!(
+        skill_count = skills.len(),
+        "skill management listed skill root"
+    );
     Ok(skills)
 }
 
@@ -277,8 +357,18 @@ async fn read_skill_summary(
     let Some(content) = read_skill_file(context, path).await? else {
         return Ok(None);
     };
-    let parsed = parse_skill_md(&content)
-        .map_err(|_| SkillManagementError::new(SkillManagementErrorKind::InvalidSkill))?;
+    let parsed = parse_skill_md(&content).map_err(|_| {
+        tracing::debug!(
+            scoped_path = %path,
+            "skill management failed to parse skill summary"
+        );
+        SkillManagementError::new(SkillManagementErrorKind::InvalidSkill)
+    })?;
+    tracing::debug!(
+        scoped_path = %path,
+        skill_name = %parsed.manifest.name,
+        "skill management parsed skill summary"
+    );
     Ok(Some(SkillSummary {
         name: parsed.manifest.name,
         version: parsed.manifest.version,
@@ -328,7 +418,10 @@ async fn stat_optional(
     match context.filesystem.stat(&context.scope, path).await {
         Ok(stat) => Ok(Some(stat)),
         Err(FilesystemError::NotFound { .. }) => Ok(None),
-        Err(error) => Err(filesystem_error(error)),
+        Err(error) => {
+            tracing::debug!(scoped_path = %path, "skill management stat failed");
+            Err(filesystem_error(error))
+        }
     }
 }
 
@@ -341,21 +434,46 @@ async fn read_skill_file(
         None => return Ok(None),
     };
     if stat.file_type != FileType::File || stat.sensitive {
+        tracing::debug!(
+            scoped_path = %path,
+            file_type = ?stat.file_type,
+            sensitive = stat.sensitive,
+            "skill management skipped non-readable skill file"
+        );
         return Ok(None);
     }
     let Some(bytes) = context
         .filesystem
         .read_bytes_bounded(&context.scope, path, MAX_PROMPT_FILE_SIZE as usize)
         .await
-        .map_err(filesystem_error)?
+        .map_err(|error| {
+            tracing::debug!(scoped_path = %path, "skill management failed to read skill file");
+            filesystem_error(error)
+        })?
     else {
+        tracing::debug!(
+            scoped_path = %path,
+            max_bytes = MAX_PROMPT_FILE_SIZE,
+            "skill management skill file exceeded read bound"
+        );
         return Err(SkillManagementError::new(
             SkillManagementErrorKind::Resource,
         ));
     };
-    String::from_utf8(bytes)
-        .map(Some)
-        .map_err(|_| SkillManagementError::new(SkillManagementErrorKind::InvalidSkill))
+    let content = String::from_utf8(bytes).map_err(|_| {
+        tracing::debug!(scoped_path = %path, "skill management skill file is not UTF-8");
+        SkillManagementError::new(SkillManagementErrorKind::InvalidSkill)
+    })?;
+    Ok(Some(content))
+}
+
+fn log_skill_filesystem_phase(phase: &'static str, skill_name: &str, scoped_path: &ScopedPath) {
+    tracing::debug!(
+        phase,
+        skill_name = %skill_name,
+        scoped_path = %scoped_path,
+        "skill management filesystem phase"
+    );
 }
 
 fn filesystem_error(error: FilesystemError) -> SkillManagementError {


### PR DESCRIPTION
## Summary
- Add debug breadcrumbs across Reborn capability invocation, authorization, approval blocking, dispatch, and run-state completion.
- Add dispatcher and first-party runtime adapter debug logs for runtime selection, handler execution, reservation/reconcile phases, and redacted failure kinds.
- Add skill-management debug tracing for list/install/remove phases without logging raw skill content or tool input.

## Verification
- `cargo fmt --check`
- `cargo check -p ironclaw_capabilities -p ironclaw_dispatcher -p ironclaw_host_runtime -p ironclaw_skills`
- `cargo test -p ironclaw_skills management::tests::`
- `cargo test -p ironclaw_reborn_composition local_dev_skill_management_invokes_through_first_party_runtime`
- `cargo clippy -p ironclaw_capabilities -p ironclaw_dispatcher -p ironclaw_host_runtime -p ironclaw_skills --all-targets -- -D warnings`