### PR TITLE
Add Reborn model boundary debug tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,6 +4114,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/ironclaw_agent_loop/Cargo.toml
+++ b/crates/ironclaw_agent_loop/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_jcs = "0.2"
 thiserror = "2"
+tracing = "0.1"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/crates/ironclaw_agent_loop/src/executor/canonical.rs
+++ b/crates/ironclaw_agent_loop/src/executor/canonical.rs
@@ -2,6 +2,7 @@ use ironclaw_turns::{
     LoopExit,
     run_profile::{AgentLoopDriverHost, LoopProgressEvent, ParentLoopOutput},
 };
+use tracing::debug;
 
 use crate::{family::LoopFamily, state::LoopExecutionState, strategies::TurnEndKind};
 
@@ -191,6 +192,10 @@ impl DefaultExecutorPipeline {
 
             match completed_kind {
                 TurnEndKind::ReplyOnly => {
+                    debug!(
+                        iteration = state.iteration,
+                        "agent loop handling reply-only turn end"
+                    );
                     match self
                         .input
                         .process(
@@ -211,6 +216,10 @@ impl DefaultExecutorPipeline {
                             state = *next;
                             pending_input_ack = ack;
                             if drained {
+                                debug!(
+                                    iteration = state.iteration,
+                                    "agent loop continuing after queued follow-up input"
+                                );
                                 state.iteration = state.iteration.saturating_add(1);
                                 continue;
                             }
@@ -227,6 +236,11 @@ impl DefaultExecutorPipeline {
                             },
                         )
                         .await?;
+                    debug!(
+                        iteration = checked.state.iteration,
+                        checkpoint_id = %checked.checkpoint_id.as_uuid(),
+                        "agent loop exiting after reply-only model output"
+                    );
                     pending_input_ack.ack(host).await?;
                     return completed_exit(host, checked.state, Some(checked.checkpoint_id));
                 }

--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -6,6 +6,7 @@ use ironclaw_turns::{
         LoopProgressEvent, LoopSafeSummary,
     },
 };
+use tracing::debug;
 
 use crate::{
     state::{CheckpointKind, LoopExecutionState},
@@ -63,11 +64,50 @@ impl ExecutorStage<ModelInput> for ModelStage {
             model_preference,
             capability_view: Some(input.capability_view),
         };
+        let visible_capability_count = request
+            .capability_view
+            .as_ref()
+            .map(|view| view.visible_capability_ids.len())
+            .unwrap_or(0);
+        debug!(
+            iteration = state.iteration,
+            surface_version = request
+                .surface_version
+                .as_ref()
+                .map(|version| version.as_str())
+                .unwrap_or("<none>"),
+            visible_capability_count,
+            model_preference = request
+                .model_preference
+                .as_ref()
+                .map(|profile| profile.as_str())
+                .unwrap_or("<none>"),
+            message_count = request.messages.len(),
+            "agent loop model request prepared"
+        );
 
         let mut recorded_failure = false;
         for _ in 0..MAX_MODEL_RETRIES {
             match ctx.host.stream_model(request.clone()).await {
                 Ok(response) => {
+                    match &response.output {
+                        ironclaw_turns::run_profile::ParentLoopOutput::AssistantReply(reply) => {
+                            debug!(
+                                iteration = state.iteration,
+                                response_kind = "assistant_reply",
+                                content_bytes = reply.content.len(),
+                                "agent loop model response classified"
+                            );
+                        }
+                        ironclaw_turns::run_profile::ParentLoopOutput::CapabilityCalls(calls) => {
+                            debug!(
+                                iteration = state.iteration,
+                                response_kind = "capability_calls",
+                                capability_call_count = calls.len(),
+                                "agent loop model response classified"
+                            );
+                        }
+                    }
                     state.recovery_state = state.recovery_state.cleared_attempts();
                     return Ok(ModelStep::Response(Box::new(state), response));
                 }

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -6,6 +6,7 @@ use ironclaw_turns::{
         VisibleCapabilitySurface,
     },
 };
+use tracing::debug;
 
 use crate::state::LoopExecutionState;
 
@@ -64,6 +65,21 @@ impl ExecutorStage<PromptInput> for PromptStage {
                 stage: HostStage::Capability,
             })?;
         apply_capability_filter(&mut surface, &surface_filter);
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let visible_capability_sample = surface
+                .descriptors
+                .iter()
+                .take(20)
+                .map(|descriptor| descriptor.capability_id.as_str())
+                .collect::<Vec<_>>();
+            debug!(
+                iteration = state.iteration,
+                surface_version = %surface.version,
+                visible_capability_count = surface.descriptors.len(),
+                visible_capability_sample = ?visible_capability_sample,
+                "agent loop prompt capability surface prepared"
+            );
+        }
         let capability_view = LoopModelCapabilityView {
             visible_capability_ids: surface
                 .descriptors

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -38,6 +38,7 @@ use ironclaw_turns::{
         PromptMode, ProviderToolCall, ProviderToolDefinition,
     },
 };
+use tracing::debug;
 
 use crate::model_routes::{
     ModelRoute, ModelRouteError, ModelRouteErrorKind, ModelRouteProviderKey, ModelRouteResolver,
@@ -717,6 +718,15 @@ fn validate_replay_identity_text(
     Ok(())
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(provider, completion, capabilities, replay_identity),
+    fields(
+        provider_id = %replay_identity.provider_id,
+        provider_model_id = %replay_identity.provider_model_id,
+        provider_turn_scope = provider_turn_scope.as_deref().unwrap_or("model_call=unknown"),
+    )
+)]
 async fn complete_model_request<P>(
     provider: &P,
     completion: CompletionRequest,
@@ -731,6 +741,18 @@ where
         let tool_definitions = capabilities
             .tool_definitions()
             .map_err(map_capability_host_error)?;
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let tool_name_sample = tool_definitions
+                .iter()
+                .take(20)
+                .map(|definition| definition.name.as_str())
+                .collect::<Vec<_>>();
+            debug!(
+                tool_definition_count = tool_definitions.len(),
+                tool_name_sample = ?tool_name_sample,
+                "reborn model gateway resolved provider tool definitions"
+            );
+        }
         if !tool_definitions.is_empty() {
             let tool_request = ToolCompletionRequest::from_completion_request(
                 completion,
@@ -739,6 +761,7 @@ where
                     .map(provider_tool_definition_to_llm)
                     .collect(),
             );
+            debug!("reborn model gateway dispatching tool-capable provider request");
             let response = provider
                 .complete_with_tools(tool_request)
                 .await
@@ -753,12 +776,24 @@ where
             )
             .await;
         }
+        debug!(
+            "reborn model gateway falling back to text-only provider request because no provider tool definitions were available"
+        );
+    } else {
+        debug!(
+            "reborn model gateway dispatching text-only provider request because no capability port was supplied"
+        );
     }
 
     let response = provider
         .complete(completion)
         .await
         .map_err(map_provider_error)?;
+    debug!(
+        finish_reason = ?response.finish_reason,
+        content_bytes = response.content.len(),
+        "reborn model gateway received text-only provider response"
+    );
     response_to_host_reply(response)
 }
 
@@ -770,12 +805,36 @@ fn provider_tool_definition_to_llm(definition: ProviderToolDefinition) -> ToolDe
     }
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip(response, capabilities, replay_identity),
+    fields(
+        provider_id = %replay_identity.provider_id,
+        provider_model_id = %replay_identity.provider_model_id,
+        provider_turn_scope,
+    )
+)]
 async fn tool_response_to_host(
     response: ToolCompletionResponse,
     capabilities: Arc<dyn ironclaw_turns::run_profile::LoopCapabilityPort>,
     provider_turn_scope: &str,
     replay_identity: &ProviderReplayIdentity,
 ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        let tool_call_name_sample = response
+            .tool_calls
+            .iter()
+            .take(20)
+            .map(|tool_call| tool_call.name.as_str())
+            .collect::<Vec<_>>();
+        debug!(
+            finish_reason = ?response.finish_reason,
+            tool_call_count = response.tool_calls.len(),
+            tool_call_name_sample = ?tool_call_name_sample,
+            content_bytes = response.content.as_ref().map(|content| content.len()).unwrap_or(0),
+            "reborn model gateway received tool-capable provider response"
+        );
+    }
     if !response.tool_calls.is_empty()
         && matches!(
             response.finish_reason,
@@ -824,6 +883,10 @@ async fn tool_response_to_host(
                 .map_err(map_capability_host_error)?;
             candidates.push(candidate);
         }
+        debug!(
+            capability_call_count = candidates.len(),
+            "reborn model gateway classified provider response as capability calls"
+        );
         return Ok(HostManagedModelResponse::capability_calls(
             candidates,
             response.content.unwrap_or_default(),
@@ -831,9 +894,14 @@ async fn tool_response_to_host(
     }
 
     match response.finish_reason {
-        FinishReason::Stop => Ok(HostManagedModelResponse::assistant_reply(
-            response.content.unwrap_or_default(),
-        )),
+        FinishReason::Stop => {
+            let content = response.content.unwrap_or_default();
+            debug!(
+                content_bytes = content.len(),
+                "reborn model gateway classified tool-capable provider response as assistant reply"
+            );
+            Ok(HostManagedModelResponse::assistant_reply(content))
+        }
         FinishReason::Length => Err(HostManagedModelError::safe(
             HostManagedModelErrorKind::BudgetExceeded,
             "model response was truncated before completion",

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -322,6 +322,10 @@ impl TurnRunnerWorker {
             runner_id = ?self.runner_id,
             run_id = ?run_id,
             status = ?status,
+            resolved_run_profile_id = claimed.resolved_run_profile.profile_id.as_str(),
+            resolved_run_profile_version = claimed.resolved_run_profile.profile_version.as_u64(),
+            loop_driver_id = claimed.resolved_run_profile.loop_driver.id.as_str(),
+            loop_driver_version = claimed.resolved_run_profile.loop_driver.version.as_u64(),
             "claimed turn run"
         );
 
@@ -403,6 +407,14 @@ impl TurnRunnerWorker {
         })?;
 
         let driver = registered.driver();
+        debug!(
+            runner_id = ?self.runner_id,
+            run_id = %claimed.state.run_id,
+            resolved_run_profile_id = claimed.resolved_run_profile.profile_id.as_str(),
+            loop_driver_id = descriptor.id.as_str(),
+            loop_driver_version = descriptor.version.as_u64(),
+            "reborn turn runner resolved loop driver"
+        );
 
         // Create host for this run
         let host = self

--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -175,6 +175,20 @@ where
                 self.run_profile_resolver.as_ref(),
             )
             .await?;
+        let SubmitTurnResponse::Accepted {
+            run_id,
+            status,
+            resolved_run_profile_id,
+            resolved_run_profile_version,
+            ..
+        } = &response;
+        debug!(
+            run_id = %run_id,
+            status = ?status,
+            resolved_run_profile_id = resolved_run_profile_id.as_str(),
+            resolved_run_profile_version = resolved_run_profile_version.as_u64(),
+            "turn coordinator accepted turn with resolved run profile"
+        );
         notify_queued_run_best_effort(self.wake_notifier.as_ref(), submit_wake(scope, &response));
         Ok(response)
     }


### PR DESCRIPTION
## Summary
- Add debug tracing around Reborn turn submission/profile resolution and loop driver selection.
- Add prompt/model boundary logs for visible capability counts, model response classification, and reply-only exits.
- Add model gateway logs for tool-definition availability, provider request mode, finish reason, tool-call count, and assistant-vs-capability classification.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_agent_loop`
- `cargo test -p ironclaw_reborn_composition local_dev_runtime_exposes_host_runtime_capabilities_to_model_calls --lib`
- `cargo test -p ironclaw_reborn default_planned_driver_smoke --test planned_driver_e2e`
- `cargo test -p ironclaw_turns submit --test turn_coordinator_contract`