### PR TITLE
Resolve built-in capability schemas on visible surfaces

### DIFF
--- a/crates/ironclaw_extensions/src/registry.rs
+++ b/crates/ironclaw_extensions/src/registry.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use ironclaw_host_api::{CapabilityDescriptor, CapabilityId, ExtensionId};
 
-use crate::{ExtensionError, ExtensionPackage};
+use crate::{ExtensionError, ExtensionPackage, ManifestSource};
 
 /// Registry of validated extension packages and declared capabilities.
 #[derive(Debug, Default)]
@@ -188,10 +188,31 @@ pub(crate) fn validate_package_consistency(
             ),
         });
     }
-    if package.capabilities != expected.capabilities {
+    // Host-bundled packages may pre-resolve manifest schema refs into concrete
+    // descriptors; all other descriptor fields must still match the manifest.
+    if package.capabilities != expected.capabilities
+        && !host_bundled_capabilities_match_except_parameters_schema(package, &expected)
+    {
         return Err(ExtensionError::InvalidManifest {
             reason: "package capability descriptors do not match manifest declarations".to_string(),
         });
     }
     Ok(())
+}
+
+fn host_bundled_capabilities_match_except_parameters_schema(
+    package: &ExtensionPackage,
+    expected: &ExtensionPackage,
+) -> bool {
+    if package.manifest.source != ManifestSource::HostBundled
+        || package.capabilities.len() != expected.capabilities.len()
+    {
+        return false;
+    }
+
+    let mut normalized = package.capabilities.clone();
+    for (actual, expected) in normalized.iter_mut().zip(&expected.capabilities) {
+        actual.parameters_schema = expected.parameters_schema.clone();
+    }
+    normalized == expected.capabilities
 }

--- a/crates/ironclaw_extensions/src/registry.rs
+++ b/crates/ironclaw_extensions/src/registry.rs
@@ -4,6 +4,8 @@ use ironclaw_host_api::{CapabilityDescriptor, CapabilityId, ExtensionId};
 
 use crate::{ExtensionError, ExtensionPackage, ManifestSource};
 
+const BUILTIN_FIRST_PARTY_EXTENSION_ID: &str = "builtin";
+
 /// Registry of validated extension packages and declared capabilities.
 #[derive(Debug, Default)]
 pub struct ExtensionRegistry {
@@ -188,8 +190,8 @@ pub(crate) fn validate_package_consistency(
             ),
         });
     }
-    // Host-bundled packages may pre-resolve manifest schema refs into concrete
-    // descriptors; all other descriptor fields must still match the manifest.
+    // The built-in first-party package may pre-resolve manifest schema refs into
+    // concrete descriptors; all other descriptor fields must still match.
     if package.capabilities != expected.capabilities
         && !host_bundled_capabilities_match_except_parameters_schema(package, &expected)
     {
@@ -205,6 +207,7 @@ fn host_bundled_capabilities_match_except_parameters_schema(
     expected: &ExtensionPackage,
 ) -> bool {
     if package.manifest.source != ManifestSource::HostBundled
+        || package.id.as_str() != BUILTIN_FIRST_PARTY_EXTENSION_ID
         || package.capabilities.len() != expected.capabilities.len()
     {
         return false;

--- a/crates/ironclaw_extensions/src/registry.rs
+++ b/crates/ironclaw_extensions/src/registry.rs
@@ -2,9 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use ironclaw_host_api::{CapabilityDescriptor, CapabilityId, ExtensionId};
 
-use crate::{ExtensionError, ExtensionPackage, ManifestSource};
-
-const BUILTIN_FIRST_PARTY_EXTENSION_ID: &str = "builtin";
+use crate::{ExtensionError, ExtensionPackage};
 
 /// Registry of validated extension packages and declared capabilities.
 #[derive(Debug, Default)]
@@ -190,32 +188,10 @@ pub(crate) fn validate_package_consistency(
             ),
         });
     }
-    // The built-in first-party package may pre-resolve manifest schema refs into
-    // concrete descriptors; all other descriptor fields must still match.
-    if package.capabilities != expected.capabilities
-        && !host_bundled_capabilities_match_except_parameters_schema(package, &expected)
-    {
+    if package.capabilities != expected.capabilities {
         return Err(ExtensionError::InvalidManifest {
             reason: "package capability descriptors do not match manifest declarations".to_string(),
         });
     }
     Ok(())
-}
-
-fn host_bundled_capabilities_match_except_parameters_schema(
-    package: &ExtensionPackage,
-    expected: &ExtensionPackage,
-) -> bool {
-    if package.manifest.source != ManifestSource::HostBundled
-        || package.id.as_str() != BUILTIN_FIRST_PARTY_EXTENSION_ID
-        || package.capabilities.len() != expected.capabilities.len()
-    {
-        return false;
-    }
-
-    let mut normalized = package.capabilities.clone();
-    for (actual, expected) in normalized.iter_mut().zip(&expected.capabilities) {
-        actual.parameters_schema = expected.parameters_schema.clone();
-    }
-    normalized == expected.capabilities
 }

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -94,7 +94,7 @@ fn registry_rejects_installed_package_with_mutated_parameters_schema() {
 }
 
 #[test]
-fn registry_allows_host_bundled_package_with_resolved_parameters_schema() {
+fn registry_rejects_host_bundled_non_builtin_package_with_mutated_parameters_schema() {
     let manifest = ExtensionManifest::parse(
         WASM_MANIFEST,
         ManifestSource::HostBundled,
@@ -111,11 +111,39 @@ fn registry_allows_host_bundled_package_with_resolved_parameters_schema() {
         "additionalProperties": false
     });
 
+    let err = ExtensionRegistry::new().insert(package).unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::InvalidManifest { reason } if reason.contains("capability descriptors")
+    ));
+}
+
+#[test]
+fn registry_allows_builtin_host_bundled_package_with_resolved_parameters_schema() {
+    let manifest = ExtensionManifest::parse(
+        &WASM_MANIFEST
+            .replace("id = \"echo\"", "id = \"builtin\"")
+            .replace("id = \"echo.say\"", "id = \"builtin.say\""),
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    let mut package = package_from_manifest(manifest, "builtin");
+    package.capabilities[0].parameters_schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "message": { "type": "string" }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    });
+
     let mut registry = ExtensionRegistry::new();
     registry.insert(package).unwrap();
 
     let descriptor = registry
-        .get_capability(&CapabilityId::new("echo.say").unwrap())
+        .get_capability(&CapabilityId::new("builtin.say").unwrap())
         .unwrap();
     assert_eq!(
         descriptor.parameters_schema,
@@ -128,6 +156,28 @@ fn registry_allows_host_bundled_package_with_resolved_parameters_schema() {
             "additionalProperties": false
         })
     );
+}
+
+#[test]
+fn registry_rejects_builtin_host_bundled_package_with_mutated_non_schema_descriptor_fields() {
+    let manifest = ExtensionManifest::parse(
+        &WASM_MANIFEST
+            .replace("id = \"echo\"", "id = \"builtin\"")
+            .replace("id = \"echo.say\"", "id = \"builtin.say\""),
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    let mut package = package_from_manifest(manifest, "builtin");
+    package.capabilities[0].parameters_schema = serde_json::json!({"type": "object"});
+    package.capabilities[0].default_permission = PermissionMode::Ask;
+
+    let err = ExtensionRegistry::new().insert(package).unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::InvalidManifest { reason } if reason.contains("capability descriptors")
+    ));
 }
 
 #[test]

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -81,6 +81,56 @@ fn package_trust_policy_input_rejects_mutated_public_descriptors() {
 }
 
 #[test]
+fn registry_rejects_installed_package_with_mutated_parameters_schema() {
+    let mut package = package_from_manifest(parse_manifest(WASM_MANIFEST), "echo");
+    package.capabilities[0].parameters_schema = serde_json::json!({"type": "object"});
+
+    let err = ExtensionRegistry::new().insert(package).unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::InvalidManifest { reason } if reason.contains("capability descriptors")
+    ));
+}
+
+#[test]
+fn registry_allows_host_bundled_package_with_resolved_parameters_schema() {
+    let manifest = ExtensionManifest::parse(
+        WASM_MANIFEST,
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    let mut package = package_from_manifest(manifest, "echo");
+    package.capabilities[0].parameters_schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "message": { "type": "string" }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    });
+
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+
+    let descriptor = registry
+        .get_capability(&CapabilityId::new("echo.say").unwrap())
+        .unwrap();
+    assert_eq!(
+        descriptor.parameters_schema,
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "message": { "type": "string" }
+            },
+            "required": ["message"],
+            "additionalProperties": false
+        })
+    );
+}
+
+#[test]
 fn script_and_mcp_runtime_metadata_stays_declarative() {
     let script = parse_manifest(SCRIPT_MANIFEST);
     assert_eq!(script.runtime_kind(), RuntimeKind::Script);

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -121,15 +121,7 @@ fn registry_rejects_host_bundled_non_builtin_package_with_mutated_parameters_sch
 
 #[test]
 fn registry_allows_builtin_host_bundled_package_with_resolved_parameters_schema() {
-    let manifest = ExtensionManifest::parse(
-        &WASM_MANIFEST
-            .replace("id = \"echo\"", "id = \"builtin\"")
-            .replace("id = \"echo.say\"", "id = \"builtin.say\""),
-        ManifestSource::HostBundled,
-        &HostPortCatalog::empty(),
-    )
-    .unwrap();
-    let mut package = package_from_manifest(manifest, "builtin");
+    let mut package = builtin_host_bundled_echo_package();
     package.capabilities[0].parameters_schema = serde_json::json!({
         "type": "object",
         "properties": {
@@ -160,15 +152,7 @@ fn registry_allows_builtin_host_bundled_package_with_resolved_parameters_schema(
 
 #[test]
 fn registry_rejects_builtin_host_bundled_package_with_mutated_non_schema_descriptor_fields() {
-    let manifest = ExtensionManifest::parse(
-        &WASM_MANIFEST
-            .replace("id = \"echo\"", "id = \"builtin\"")
-            .replace("id = \"echo.say\"", "id = \"builtin.say\""),
-        ManifestSource::HostBundled,
-        &HostPortCatalog::empty(),
-    )
-    .unwrap();
-    let mut package = package_from_manifest(manifest, "builtin");
+    let mut package = builtin_host_bundled_echo_package();
     package.capabilities[0].parameters_schema = serde_json::json!({"type": "object"});
     package.capabilities[0].default_permission = PermissionMode::Ask;
 
@@ -178,6 +162,18 @@ fn registry_rejects_builtin_host_bundled_package_with_mutated_non_schema_descrip
         err,
         ExtensionError::InvalidManifest { reason } if reason.contains("capability descriptors")
     ));
+}
+
+fn builtin_host_bundled_echo_package() -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(
+        &WASM_MANIFEST
+            .replace("id = \"echo\"", "id = \"builtin\"")
+            .replace("id = \"echo.say\"", "id = \"builtin.say\""),
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    package_from_manifest(manifest, "builtin")
 }
 
 #[test]

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -94,7 +94,7 @@ fn registry_rejects_installed_package_with_mutated_parameters_schema() {
 }
 
 #[test]
-fn registry_rejects_host_bundled_non_builtin_package_with_mutated_parameters_schema() {
+fn registry_rejects_host_bundled_package_with_mutated_parameters_schema() {
     let manifest = ExtensionManifest::parse(
         WASM_MANIFEST,
         ManifestSource::HostBundled,
@@ -117,63 +117,6 @@ fn registry_rejects_host_bundled_non_builtin_package_with_mutated_parameters_sch
         err,
         ExtensionError::InvalidManifest { reason } if reason.contains("capability descriptors")
     ));
-}
-
-#[test]
-fn registry_allows_builtin_host_bundled_package_with_resolved_parameters_schema() {
-    let mut package = builtin_host_bundled_echo_package();
-    package.capabilities[0].parameters_schema = serde_json::json!({
-        "type": "object",
-        "properties": {
-            "message": { "type": "string" }
-        },
-        "required": ["message"],
-        "additionalProperties": false
-    });
-
-    let mut registry = ExtensionRegistry::new();
-    registry.insert(package).unwrap();
-
-    let descriptor = registry
-        .get_capability(&CapabilityId::new("builtin.say").unwrap())
-        .unwrap();
-    assert_eq!(
-        descriptor.parameters_schema,
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "message": { "type": "string" }
-            },
-            "required": ["message"],
-            "additionalProperties": false
-        })
-    );
-}
-
-#[test]
-fn registry_rejects_builtin_host_bundled_package_with_mutated_non_schema_descriptor_fields() {
-    let mut package = builtin_host_bundled_echo_package();
-    package.capabilities[0].parameters_schema = serde_json::json!({"type": "object"});
-    package.capabilities[0].default_permission = PermissionMode::Ask;
-
-    let err = ExtensionRegistry::new().insert(package).unwrap_err();
-
-    assert!(matches!(
-        err,
-        ExtensionError::InvalidManifest { reason } if reason.contains("capability descriptors")
-    ));
-}
-
-fn builtin_host_bundled_echo_package() -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse(
-        &WASM_MANIFEST
-            .replace("id = \"echo\"", "id = \"builtin\"")
-            .replace("id = \"echo.say\"", "id = \"builtin.say\""),
-        ManifestSource::HostBundled,
-        &HostPortCatalog::empty(),
-    )
-    .unwrap();
-    package_from_manifest(manifest, "builtin")
 }
 
 #[test]

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -23,10 +23,11 @@ use ironclaw_first_party_extensions::coding::{
     CodingCapabilityError, CodingCapabilityKind, CodingCapabilityRequest, CodingCapabilityState,
 };
 use ironclaw_host_api::{
-    CapabilityId, CapabilityProfileSchemaRef, EffectKind, ExtensionId, HostApiError,
-    PermissionMode, RequestedTrustClass, ResourceCeiling, ResourceEstimate, ResourceProfile,
-    ResourceUsage, RuntimeDispatchErrorKind, TrustClass, VirtualPath,
+    CapabilityDescriptor, CapabilityId, CapabilityProfileSchemaRef, EffectKind, ExtensionId,
+    HostApiError, PermissionMode, RequestedTrustClass, ResourceCeiling, ResourceEstimate,
+    ResourceProfile, ResourceUsage, RuntimeDispatchErrorKind, TrustClass, VirtualPath,
 };
+use serde_json::{Value, json};
 
 use crate::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
@@ -206,6 +207,198 @@ fn first_party_capability_manifest(
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),
         resource_profile,
+    })
+}
+
+pub(crate) fn resolve_builtin_input_schema_ref(descriptor: &mut CapabilityDescriptor) {
+    if descriptor.provider.as_str() != BUILTIN_FIRST_PARTY_PROVIDER {
+        return;
+    }
+    let Some(reference) = descriptor
+        .parameters_schema
+        .get("$ref")
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    if let Some(schema) = builtin_input_schema(reference) {
+        descriptor.parameters_schema = schema;
+    }
+}
+
+fn builtin_input_schema(reference: &str) -> Option<Value> {
+    Some(match reference {
+        "schemas/builtin/echo.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "message": { "type": "string", "description": "Message to echo" }
+            },
+            "required": ["message"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/time.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["now", "parse", "convert", "format", "diff"],
+                    "description": "Time operation to perform. Defaults to now."
+                },
+                "input": { "type": "string", "description": "Timestamp input for parse, convert, format, or diff" },
+                "timestamp": { "type": "string", "description": "Alias for input" },
+                "timestamp2": { "type": "string", "description": "Second timestamp for diff" },
+                "timezone": { "type": "string", "description": "IANA timezone name" },
+                "from_timezone": { "type": "string", "description": "IANA timezone for interpreting the input" },
+                "to_timezone": { "type": "string", "description": "IANA timezone for conversion output" },
+                "format": { "type": "string", "description": "chrono format string for format operation" },
+                "format_string": { "type": "string", "description": "Alias for format" }
+            },
+            "additionalProperties": false
+        }),
+        "schemas/builtin/json.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["parse", "stringify", "query", "validate"]
+                },
+                "data": { "description": "JSON string or JSON value to process" },
+                "path": { "type": "string", "description": "Dot/bracket path for query operation" }
+            },
+            "required": ["operation", "data"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/http.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "url": { "type": "string", "description": "Absolute HTTP or HTTPS URL" },
+                "method": {
+                    "type": "string",
+                    "enum": ["get", "post", "put", "patch", "delete", "head"],
+                    "description": "HTTP method. Defaults to get."
+                },
+                "headers": {
+                    "description": "HTTP headers as an object or array of {name,value} entries"
+                },
+                "body": { "description": "String or JSON request body" },
+                "body_base64": { "type": "string", "description": "Base64-encoded request body" },
+                "response_body_limit": { "type": "integer", "minimum": 1 },
+                "timeout_ms": { "type": "integer", "minimum": 1 }
+            },
+            "required": ["url"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/shell.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string", "description": "Shell command to execute" },
+                "workdir": { "type": "string", "description": "Optional scoped working directory" },
+                "timeout": { "type": "integer", "minimum": 1, "description": "Timeout in seconds" }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/read_file.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped path to read" },
+                "offset": { "type": "integer", "minimum": 0, "description": "1-based starting line; 0 starts at the beginning" },
+                "limit": { "type": "integer", "minimum": 0, "description": "Maximum lines to return" }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/write_file.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped path to write" },
+                "content": { "type": "string", "description": "Complete file content" }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/list_dir.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped directory path. Defaults to the workspace root." },
+                "recursive": { "type": "boolean", "description": "Whether to list recursively" },
+                "max_depth": { "type": "integer", "minimum": 0, "description": "Maximum recursive depth" }
+            },
+            "additionalProperties": false
+        }),
+        "schemas/builtin/glob.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "pattern": { "type": "string", "description": "Glob pattern relative to path" },
+                "path": { "type": "string", "description": "Scoped root path. Defaults to the workspace root." },
+                "max_results": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["pattern"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/grep.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "pattern": { "type": "string", "description": "Regular expression to search for" },
+                "path": { "type": "string", "description": "Scoped file or directory path. Defaults to the workspace root." },
+                "glob": { "type": "string", "description": "Optional glob filter relative to path" },
+                "type_filter": { "type": "string", "description": "Optional file type filter" },
+                "output_mode": {
+                    "type": "string",
+                    "enum": ["content", "files_with_matches", "count"],
+                    "description": "Output mode. Defaults to files_with_matches."
+                },
+                "case_insensitive": { "type": "boolean" },
+                "multiline": { "type": "boolean" },
+                "context": { "type": "integer", "minimum": 0 },
+                "before_context": { "type": "integer", "minimum": 0 },
+                "after_context": { "type": "integer", "minimum": 0 },
+                "head_limit": { "type": "integer", "minimum": 0 },
+                "offset": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["pattern"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/apply_patch.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped file path to patch" },
+                "old_string": { "type": "string", "description": "Exact text to replace" },
+                "new_string": { "type": "string", "description": "Replacement text" },
+                "replace_all": { "type": "boolean", "description": "Replace every match instead of exactly one" }
+            },
+            "required": ["path", "old_string", "new_string"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/skill_list.input.v1.json" => json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        }),
+        "schemas/builtin/skill_install.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Optional skill name to use for the installed SKILL.md document"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Raw SKILL.md content to install"
+                }
+            },
+            "required": ["content"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/skill_remove.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "description": "Name of the installed skill to remove" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        }),
+        _ => return None,
     })
 }
 

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -8,6 +8,7 @@
 mod echo;
 mod http;
 mod json;
+mod schemas;
 mod shell;
 mod skill_management;
 mod time;
@@ -23,16 +24,17 @@ use ironclaw_first_party_extensions::coding::{
     CodingCapabilityError, CodingCapabilityKind, CodingCapabilityRequest, CodingCapabilityState,
 };
 use ironclaw_host_api::{
-    CapabilityDescriptor, CapabilityId, CapabilityProfileSchemaRef, EffectKind, ExtensionId,
-    HostApiError, PermissionMode, RequestedTrustClass, ResourceCeiling, ResourceEstimate,
-    ResourceProfile, ResourceUsage, RuntimeDispatchErrorKind, TrustClass, VirtualPath,
+    CapabilityId, CapabilityProfileSchemaRef, EffectKind, ExtensionId, HostApiError,
+    PermissionMode, RequestedTrustClass, ResourceCeiling, ResourceEstimate, ResourceProfile,
+    ResourceUsage, RuntimeDispatchErrorKind, TrustClass, VirtualPath,
 };
-use serde_json::{Value, json};
 
 use crate::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
     FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
 };
+
+use self::schemas::resolve_builtin_package_input_schemas;
 
 pub use echo::ECHO_CAPABILITY_ID;
 pub use http::HTTP_CAPABILITY_ID;
@@ -116,7 +118,7 @@ const CODING_CAPABILITIES: &[CodingCapabilityMetadata] = &[
 /// Create the host-assigned package that declares built-in first-party
 /// capabilities for the capability surface.
 pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError> {
-    ExtensionPackage::from_manifest(
+    let mut package = ExtensionPackage::from_manifest(
         ExtensionManifest {
             schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
             id: ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER)?,
@@ -146,7 +148,9 @@ pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError>
             },
         },
         VirtualPath::new("/system/extensions/builtin")?,
-    )
+    )?;
+    resolve_builtin_package_input_schemas(&mut package)?;
+    Ok(package)
 }
 
 fn coding_manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {
@@ -207,198 +211,6 @@ fn first_party_capability_manifest(
         required_host_ports: Vec::new(),
         runtime_credentials: Vec::new(),
         resource_profile,
-    })
-}
-
-pub(crate) fn resolve_builtin_input_schema_ref(descriptor: &mut CapabilityDescriptor) {
-    if descriptor.provider.as_str() != BUILTIN_FIRST_PARTY_PROVIDER {
-        return;
-    }
-    let Some(reference) = descriptor
-        .parameters_schema
-        .get("$ref")
-        .and_then(Value::as_str)
-    else {
-        return;
-    };
-    if let Some(schema) = builtin_input_schema(reference) {
-        descriptor.parameters_schema = schema;
-    }
-}
-
-fn builtin_input_schema(reference: &str) -> Option<Value> {
-    Some(match reference {
-        "schemas/builtin/echo.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "message": { "type": "string", "description": "Message to echo" }
-            },
-            "required": ["message"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/time.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "operation": {
-                    "type": "string",
-                    "enum": ["now", "parse", "convert", "format", "diff"],
-                    "description": "Time operation to perform. Defaults to now."
-                },
-                "input": { "type": "string", "description": "Timestamp input for parse, convert, format, or diff" },
-                "timestamp": { "type": "string", "description": "Alias for input" },
-                "timestamp2": { "type": "string", "description": "Second timestamp for diff" },
-                "timezone": { "type": "string", "description": "IANA timezone name" },
-                "from_timezone": { "type": "string", "description": "IANA timezone for interpreting the input" },
-                "to_timezone": { "type": "string", "description": "IANA timezone for conversion output" },
-                "format": { "type": "string", "description": "chrono format string for format operation" },
-                "format_string": { "type": "string", "description": "Alias for format" }
-            },
-            "additionalProperties": false
-        }),
-        "schemas/builtin/json.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "operation": {
-                    "type": "string",
-                    "enum": ["parse", "stringify", "query", "validate"]
-                },
-                "data": { "description": "JSON string or JSON value to process" },
-                "path": { "type": "string", "description": "Dot/bracket path for query operation" }
-            },
-            "required": ["operation", "data"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/http.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "url": { "type": "string", "description": "Absolute HTTP or HTTPS URL" },
-                "method": {
-                    "type": "string",
-                    "enum": ["get", "post", "put", "patch", "delete", "head"],
-                    "description": "HTTP method. Defaults to get."
-                },
-                "headers": {
-                    "description": "HTTP headers as an object or array of {name,value} entries"
-                },
-                "body": { "description": "String or JSON request body" },
-                "body_base64": { "type": "string", "description": "Base64-encoded request body" },
-                "response_body_limit": { "type": "integer", "minimum": 1 },
-                "timeout_ms": { "type": "integer", "minimum": 1 }
-            },
-            "required": ["url"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/shell.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "command": { "type": "string", "description": "Shell command to execute" },
-                "workdir": { "type": "string", "description": "Optional scoped working directory" },
-                "timeout": { "type": "integer", "minimum": 1, "description": "Timeout in seconds" }
-            },
-            "required": ["command"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/read_file.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Scoped path to read" },
-                "offset": { "type": "integer", "minimum": 0, "description": "1-based starting line; 0 starts at the beginning" },
-                "limit": { "type": "integer", "minimum": 0, "description": "Maximum lines to return" }
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/write_file.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Scoped path to write" },
-                "content": { "type": "string", "description": "Complete file content" }
-            },
-            "required": ["path", "content"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/list_dir.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Scoped directory path. Defaults to the workspace root." },
-                "recursive": { "type": "boolean", "description": "Whether to list recursively" },
-                "max_depth": { "type": "integer", "minimum": 0, "description": "Maximum recursive depth" }
-            },
-            "additionalProperties": false
-        }),
-        "schemas/builtin/glob.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "pattern": { "type": "string", "description": "Glob pattern relative to path" },
-                "path": { "type": "string", "description": "Scoped root path. Defaults to the workspace root." },
-                "max_results": { "type": "integer", "minimum": 0 }
-            },
-            "required": ["pattern"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/grep.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "pattern": { "type": "string", "description": "Regular expression to search for" },
-                "path": { "type": "string", "description": "Scoped file or directory path. Defaults to the workspace root." },
-                "glob": { "type": "string", "description": "Optional glob filter relative to path" },
-                "type_filter": { "type": "string", "description": "Optional file type filter" },
-                "output_mode": {
-                    "type": "string",
-                    "enum": ["content", "files_with_matches", "count"],
-                    "description": "Output mode. Defaults to files_with_matches."
-                },
-                "case_insensitive": { "type": "boolean" },
-                "multiline": { "type": "boolean" },
-                "context": { "type": "integer", "minimum": 0 },
-                "before_context": { "type": "integer", "minimum": 0 },
-                "after_context": { "type": "integer", "minimum": 0 },
-                "head_limit": { "type": "integer", "minimum": 0 },
-                "offset": { "type": "integer", "minimum": 0 }
-            },
-            "required": ["pattern"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/apply_patch.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Scoped file path to patch" },
-                "old_string": { "type": "string", "description": "Exact text to replace" },
-                "new_string": { "type": "string", "description": "Replacement text" },
-                "replace_all": { "type": "boolean", "description": "Replace every match instead of exactly one" }
-            },
-            "required": ["path", "old_string", "new_string"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/skill_list.input.v1.json" => json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        }),
-        "schemas/builtin/skill_install.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Optional skill name to use for the installed SKILL.md document"
-                },
-                "content": {
-                    "type": "string",
-                    "description": "Raw SKILL.md content to install"
-                }
-            },
-            "required": ["content"],
-            "additionalProperties": false
-        }),
-        "schemas/builtin/skill_remove.input.v1.json" => json!({
-            "type": "object",
-            "properties": {
-                "name": { "type": "string", "description": "Name of the installed skill to remove" }
-            },
-            "required": ["name"],
-            "additionalProperties": false
-        }),
-        _ => return None,
     })
 }
 

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
 };
 
-use self::schemas::resolve_builtin_package_input_schemas;
+pub(crate) use self::schemas::resolve_builtin_input_schema_ref;
 
 pub use echo::ECHO_CAPABILITY_ID;
 pub use http::HTTP_CAPABILITY_ID;
@@ -118,7 +118,7 @@ const CODING_CAPABILITIES: &[CodingCapabilityMetadata] = &[
 /// Create the host-assigned package that declares built-in first-party
 /// capabilities for the capability surface.
 pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError> {
-    let mut package = ExtensionPackage::from_manifest(
+    ExtensionPackage::from_manifest(
         ExtensionManifest {
             schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
             id: ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER)?,
@@ -148,9 +148,7 @@ pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError>
             },
         },
         VirtualPath::new("/system/extensions/builtin")?,
-    )?;
-    resolve_builtin_package_input_schemas(&mut package)?;
-    Ok(package)
+    )
 }
 
 fn coding_manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -1,0 +1,205 @@
+use ironclaw_extensions::{ExtensionError, ExtensionPackage};
+use serde_json::{Value, json};
+
+pub(super) fn resolve_builtin_package_input_schemas(
+    package: &mut ExtensionPackage,
+) -> Result<(), ExtensionError> {
+    for descriptor in &mut package.capabilities {
+        let Some(reference) = descriptor
+            .parameters_schema
+            .get("$ref")
+            .and_then(Value::as_str)
+        else {
+            return Err(ExtensionError::InvalidManifest {
+                reason: format!(
+                    "built-in capability {} must declare an input schema ref",
+                    descriptor.id
+                ),
+            });
+        };
+        descriptor.parameters_schema =
+            builtin_input_schema(reference).ok_or_else(|| ExtensionError::InvalidManifest {
+                reason: format!(
+                    "built-in capability {} references unknown input schema {}",
+                    descriptor.id, reference
+                ),
+            })?;
+    }
+    Ok(())
+}
+
+fn builtin_input_schema(reference: &str) -> Option<Value> {
+    Some(match reference {
+        "schemas/builtin/echo.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "message": { "type": "string", "description": "Message to echo" }
+            },
+            "required": ["message"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/time.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["now", "parse", "convert", "format", "diff"],
+                    "description": "Time operation to perform. Defaults to now."
+                },
+                "input": { "type": "string", "description": "Timestamp input for parse, convert, format, or diff" },
+                "timestamp": { "type": "string", "description": "Alias for input" },
+                "timestamp2": { "type": "string", "description": "Second timestamp for diff" },
+                "timezone": { "type": "string", "description": "IANA timezone name" },
+                "from_timezone": { "type": "string", "description": "IANA timezone for interpreting the input" },
+                "to_timezone": { "type": "string", "description": "IANA timezone for conversion output" },
+                "format": { "type": "string", "description": "chrono format string for format operation" },
+                "format_string": { "type": "string", "description": "Alias for format" }
+            },
+            "additionalProperties": false
+        }),
+        "schemas/builtin/json.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["parse", "stringify", "query", "validate"]
+                },
+                "data": { "description": "JSON string or JSON value to process" },
+                "path": { "type": "string", "description": "Dot/bracket path for query operation" }
+            },
+            "required": ["operation", "data"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/http.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "url": { "type": "string", "description": "Absolute HTTP or HTTPS URL" },
+                "method": {
+                    "type": "string",
+                    "enum": ["get", "post", "put", "patch", "delete", "head"],
+                    "description": "HTTP method. Defaults to get."
+                },
+                "headers": {
+                    "description": "HTTP headers as an object or array of {name,value} entries"
+                },
+                "body": { "description": "String or JSON request body" },
+                "body_base64": { "type": "string", "description": "Base64-encoded request body" },
+                "response_body_limit": { "type": "integer", "minimum": 1 },
+                "timeout_ms": { "type": "integer", "minimum": 1 }
+            },
+            "required": ["url"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/shell.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string", "description": "Shell command to execute" },
+                "workdir": { "type": "string", "description": "Optional scoped working directory" },
+                "timeout": { "type": "integer", "minimum": 1, "description": "Timeout in seconds" }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/read_file.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped path to read" },
+                "offset": { "type": "integer", "minimum": 0, "description": "1-based starting line; 0 starts at the beginning" },
+                "limit": { "type": "integer", "minimum": 0, "description": "Maximum lines to return" }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/write_file.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped path to write" },
+                "content": { "type": "string", "description": "Complete file content" }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/list_dir.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped directory path. Defaults to the workspace root." },
+                "recursive": { "type": "boolean", "description": "Whether to list recursively" },
+                "max_depth": { "type": "integer", "minimum": 0, "description": "Maximum recursive depth" }
+            },
+            "additionalProperties": false
+        }),
+        "schemas/builtin/glob.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "pattern": { "type": "string", "description": "Glob pattern relative to path" },
+                "path": { "type": "string", "description": "Scoped root path. Defaults to the workspace root." },
+                "max_results": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["pattern"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/grep.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "pattern": { "type": "string", "description": "Regular expression to search for" },
+                "path": { "type": "string", "description": "Scoped file or directory path. Defaults to the workspace root." },
+                "glob": { "type": "string", "description": "Optional glob filter relative to path" },
+                "type_filter": { "type": "string", "description": "Optional file type filter" },
+                "output_mode": {
+                    "type": "string",
+                    "enum": ["content", "files_with_matches", "count"],
+                    "description": "Output mode. Defaults to files_with_matches."
+                },
+                "case_insensitive": { "type": "boolean" },
+                "multiline": { "type": "boolean" },
+                "context": { "type": "integer", "minimum": 0 },
+                "before_context": { "type": "integer", "minimum": 0 },
+                "after_context": { "type": "integer", "minimum": 0 },
+                "head_limit": { "type": "integer", "minimum": 0 },
+                "offset": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["pattern"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/apply_patch.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Scoped file path to patch" },
+                "old_string": { "type": "string", "description": "Exact text to replace" },
+                "new_string": { "type": "string", "description": "Replacement text" },
+                "replace_all": { "type": "boolean", "description": "Replace every match instead of exactly one" }
+            },
+            "required": ["path", "old_string", "new_string"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/skill_list.input.v1.json" => json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        }),
+        "schemas/builtin/skill_install.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Optional skill name to use for the installed SKILL.md document"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Raw SKILL.md content to install"
+                }
+            },
+            "required": ["content"],
+            "additionalProperties": false
+        }),
+        "schemas/builtin/skill_remove.input.v1.json" => json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "description": "Name of the installed skill to remove" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        }),
+        _ => return None,
+    })
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -1,34 +1,6 @@
-use ironclaw_extensions::{ExtensionError, ExtensionPackage};
 use serde_json::{Value, json};
 
-pub(super) fn resolve_builtin_package_input_schemas(
-    package: &mut ExtensionPackage,
-) -> Result<(), ExtensionError> {
-    for descriptor in &mut package.capabilities {
-        let Some(reference) = descriptor
-            .parameters_schema
-            .get("$ref")
-            .and_then(Value::as_str)
-        else {
-            return Err(ExtensionError::InvalidManifest {
-                reason: format!(
-                    "built-in capability {} must declare an input schema ref",
-                    descriptor.id
-                ),
-            });
-        };
-        descriptor.parameters_schema =
-            builtin_input_schema(reference).ok_or_else(|| ExtensionError::InvalidManifest {
-                reason: format!(
-                    "built-in capability {} references unknown input schema {}",
-                    descriptor.id, reference
-                ),
-            })?;
-    }
-    Ok(())
-}
-
-fn builtin_input_schema(reference: &str) -> Option<Value> {
+pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value> {
     Some(match reference {
         "schemas/builtin/echo.input.v1.json" => json!({
             "type": "object",

--- a/crates/ironclaw_host_runtime/src/surface.rs
+++ b/crates/ironclaw_host_runtime/src/surface.rs
@@ -213,7 +213,10 @@ fn surface_descriptor(
         .and_then(Value::as_str)
         .map(str::to_string)
     else {
-        return Ok(descriptor);
+        return Err(HostRuntimeError::invalid_request(format!(
+            "built-in capability {} must publish from an input schema ref",
+            descriptor.id
+        )));
     };
     descriptor.parameters_schema =
         resolve_builtin_input_schema_ref(&reference).ok_or_else(|| {

--- a/crates/ironclaw_host_runtime/src/surface.rs
+++ b/crates/ironclaw_host_runtime/src/surface.rs
@@ -9,6 +9,7 @@ use serde_json::{Value, json};
 
 use crate::{
     CapabilitySurfaceVersion, HostRuntimeError, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    first_party_tools::{BUILTIN_FIRST_PARTY_PROVIDER, resolve_builtin_input_schema_ref},
     plan_capability,
 };
 
@@ -180,7 +181,7 @@ impl<'a> CapabilityCatalog<'a> {
             };
 
             capabilities.push(VisibleCapability {
-                descriptor: descriptor.clone(),
+                descriptor: surface_descriptor(descriptor)?,
                 access,
                 estimated_resources: estimate,
             });
@@ -197,6 +198,31 @@ impl<'a> CapabilityCatalog<'a> {
             capabilities,
         })
     }
+}
+
+fn surface_descriptor(
+    descriptor: &CapabilityDescriptor,
+) -> Result<CapabilityDescriptor, HostRuntimeError> {
+    let mut descriptor = descriptor.clone();
+    if descriptor.provider.as_str() != BUILTIN_FIRST_PARTY_PROVIDER {
+        return Ok(descriptor);
+    }
+    let Some(reference) = descriptor
+        .parameters_schema
+        .get("$ref")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return Ok(descriptor);
+    };
+    descriptor.parameters_schema =
+        resolve_builtin_input_schema_ref(&reference).ok_or_else(|| {
+            HostRuntimeError::invalid_request(format!(
+                "built-in capability {} references unknown input schema {}",
+                descriptor.id, reference
+            ))
+        })?;
+    Ok(descriptor)
 }
 
 fn surface_version(

--- a/crates/ironclaw_host_runtime/src/surface.rs
+++ b/crates/ironclaw_host_runtime/src/surface.rs
@@ -9,7 +9,7 @@ use serde_json::{Value, json};
 
 use crate::{
     CapabilitySurfaceVersion, HostRuntimeError, VisibleCapabilityRequest, VisibleCapabilitySurface,
-    plan_capability,
+    first_party_tools::resolve_builtin_input_schema_ref, plan_capability,
 };
 
 const ALL_RUNTIME_KINDS: &[RuntimeKind] = &[
@@ -179,8 +179,11 @@ impl<'a> CapabilityCatalog<'a> {
                 Decision::RequireApproval { .. } | Decision::Deny { .. } => continue,
             };
 
+            let mut descriptor = descriptor.clone();
+            resolve_builtin_input_schema_ref(&mut descriptor);
+
             capabilities.push(VisibleCapability {
-                descriptor: descriptor.clone(),
+                descriptor,
                 access,
                 estimated_resources: estimate,
             });

--- a/crates/ironclaw_host_runtime/src/surface.rs
+++ b/crates/ironclaw_host_runtime/src/surface.rs
@@ -9,7 +9,7 @@ use serde_json::{Value, json};
 
 use crate::{
     CapabilitySurfaceVersion, HostRuntimeError, VisibleCapabilityRequest, VisibleCapabilitySurface,
-    first_party_tools::resolve_builtin_input_schema_ref, plan_capability,
+    plan_capability,
 };
 
 const ALL_RUNTIME_KINDS: &[RuntimeKind] = &[
@@ -179,11 +179,8 @@ impl<'a> CapabilityCatalog<'a> {
                 Decision::RequireApproval { .. } | Decision::Deny { .. } => continue,
             };
 
-            let mut descriptor = descriptor.clone();
-            resolve_builtin_input_schema_ref(&mut descriptor);
-
             capabilities.push(VisibleCapability {
-                descriptor,
+                descriptor: descriptor.clone(),
                 access,
                 estimated_resources: estimate,
             });

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -400,14 +400,12 @@ async fn visible_surface_uses_caller_provider_trust_not_host_trust_policy() {
 #[tokio::test]
 async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
     let package = builtin_first_party_package().unwrap();
-    for descriptor in &package.capabilities {
-        assert!(
-            descriptor.parameters_schema.get("$ref").is_none(),
-            "{} should be registered with a concrete input schema, got {:?}",
-            descriptor.id,
-            descriptor.parameters_schema
-        );
-    }
+    assert!(
+        package
+            .capabilities
+            .iter()
+            .all(|descriptor| descriptor.parameters_schema.get("$ref").is_some())
+    );
 
     let mut registry = ExtensionRegistry::new();
     registry.insert(package.clone()).unwrap();
@@ -429,6 +427,14 @@ async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
 
     assert_eq!(surface.capabilities.len(), package.capabilities.len());
     for capability in &surface.capabilities {
+        jsonschema::validator_for(&capability.descriptor.parameters_schema).unwrap_or_else(
+            |error| {
+                panic!(
+                    "{} should expose a valid JSON schema: {error}",
+                    capability.descriptor.id
+                )
+            },
+        );
         assert!(
             capability
                 .descriptor

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -399,10 +399,19 @@ async fn visible_surface_uses_caller_provider_trust_not_host_trust_policy() {
 
 #[tokio::test]
 async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
+    let package = builtin_first_party_package().unwrap();
+    assert_eq!(package.capabilities.len(), 14);
+    for descriptor in &package.capabilities {
+        assert!(
+            descriptor.parameters_schema.get("$ref").is_none(),
+            "{} should be registered with a concrete input schema, got {:?}",
+            descriptor.id,
+            descriptor.parameters_schema
+        );
+    }
+
     let mut registry = ExtensionRegistry::new();
-    registry
-        .insert(builtin_first_party_package().unwrap())
-        .unwrap();
+    registry.insert(package).unwrap();
     let runtime = runtime_with(registry, Arc::new(GrantAuthorizer));
     let builtin_effects = vec![
         EffectKind::DispatchCapability,

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -25,7 +25,7 @@ use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime,
     MAX_HOT_PROMPT_BYTES, MAX_HOT_SCHEMA_BYTES, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
     RuntimeFailureKind, SurfaceKind, VisibleCapabilityAccess, VisibleCapabilityRequest,
-    VisibleCapabilitySurface, publish_hot_capability_catalog,
+    VisibleCapabilitySurface, builtin_first_party_package, publish_hot_capability_catalog,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -395,6 +395,74 @@ async fn visible_surface_uses_caller_provider_trust_not_host_trust_policy() {
         .unwrap();
 
     assert_eq!(visible_ids(&surface), vec![capability_id("echo.say")]);
+}
+
+#[tokio::test]
+async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(builtin_first_party_package().unwrap())
+        .unwrap();
+    let runtime = runtime_with(registry, Arc::new(GrantAuthorizer));
+    let builtin_effects = vec![
+        EffectKind::DispatchCapability,
+        EffectKind::ReadFilesystem,
+        EffectKind::WriteFilesystem,
+        EffectKind::Network,
+        EffectKind::SpawnProcess,
+        EffectKind::ExecuteCode,
+    ];
+    let context = context_with_grants([
+        (capability_id("builtin.echo"), builtin_effects.clone()),
+        (capability_id("builtin.time"), builtin_effects.clone()),
+        (capability_id("builtin.json"), builtin_effects.clone()),
+        (capability_id("builtin.http"), builtin_effects.clone()),
+        (capability_id("builtin.shell"), builtin_effects.clone()),
+        (capability_id("builtin.read_file"), builtin_effects.clone()),
+        (capability_id("builtin.write_file"), builtin_effects.clone()),
+        (capability_id("builtin.list_dir"), builtin_effects.clone()),
+        (capability_id("builtin.glob"), builtin_effects.clone()),
+        (capability_id("builtin.grep"), builtin_effects.clone()),
+        (
+            capability_id("builtin.apply_patch"),
+            builtin_effects.clone(),
+        ),
+        (capability_id("builtin.skill_list"), builtin_effects.clone()),
+        (
+            capability_id("builtin.skill_install"),
+            builtin_effects.clone(),
+        ),
+        (
+            capability_id("builtin.skill_remove"),
+            builtin_effects.clone(),
+        ),
+    ]);
+
+    let surface = runtime
+        .visible_capabilities(request_with_provider_trust(
+            context,
+            [("builtin", builtin_effects)],
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(surface.capabilities.len(), 14);
+    for capability in &surface.capabilities {
+        assert!(
+            capability
+                .descriptor
+                .parameters_schema
+                .get("$ref")
+                .is_none(),
+            "{} should expose a concrete input schema, got {:?}",
+            capability.descriptor.id,
+            capability.descriptor.parameters_schema
+        );
+    }
+    assert_schema_has_property(&surface, "builtin.glob", "pattern");
+    assert_schema_has_property(&surface, "builtin.grep", "pattern");
+    assert_schema_has_property(&surface, "builtin.skill_install", "content");
+    assert_schema_has_property(&surface, "builtin.skill_install", "name");
 }
 
 #[tokio::test]
@@ -1278,6 +1346,27 @@ fn trust_decision_for(allowed_effects: Vec<EffectKind>) -> TrustDecision {
         provenance: TrustProvenance::Default,
         evaluated_at: Utc::now(),
     }
+}
+
+fn assert_schema_has_property(
+    surface: &VisibleCapabilitySurface,
+    capability: &str,
+    property: &str,
+) {
+    let schema = &surface
+        .capabilities
+        .iter()
+        .find(|entry| entry.descriptor.id == capability_id(capability))
+        .unwrap_or_else(|| panic!("{capability} should be visible"))
+        .descriptor
+        .parameters_schema;
+    assert!(
+        schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|properties| properties.contains_key(property)),
+        "{capability} schema should expose property {property}, got {schema:?}"
+    );
 }
 
 fn visible_ids(surface: &VisibleCapabilitySurface) -> Vec<CapabilityId> {

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -400,7 +400,6 @@ async fn visible_surface_uses_caller_provider_trust_not_host_trust_policy() {
 #[tokio::test]
 async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
     let package = builtin_first_party_package().unwrap();
-    assert_eq!(package.capabilities.len(), 14);
     for descriptor in &package.capabilities {
         assert!(
             descriptor.parameters_schema.get("$ref").is_none(),
@@ -411,51 +410,24 @@ async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
     }
 
     let mut registry = ExtensionRegistry::new();
-    registry.insert(package).unwrap();
+    registry.insert(package.clone()).unwrap();
     let runtime = runtime_with(registry, Arc::new(GrantAuthorizer));
-    let builtin_effects = vec![
-        EffectKind::DispatchCapability,
-        EffectKind::ReadFilesystem,
-        EffectKind::WriteFilesystem,
-        EffectKind::Network,
-        EffectKind::SpawnProcess,
-        EffectKind::ExecuteCode,
-    ];
-    let context = context_with_grants([
-        (capability_id("builtin.echo"), builtin_effects.clone()),
-        (capability_id("builtin.time"), builtin_effects.clone()),
-        (capability_id("builtin.json"), builtin_effects.clone()),
-        (capability_id("builtin.http"), builtin_effects.clone()),
-        (capability_id("builtin.shell"), builtin_effects.clone()),
-        (capability_id("builtin.read_file"), builtin_effects.clone()),
-        (capability_id("builtin.write_file"), builtin_effects.clone()),
-        (capability_id("builtin.list_dir"), builtin_effects.clone()),
-        (capability_id("builtin.glob"), builtin_effects.clone()),
-        (capability_id("builtin.grep"), builtin_effects.clone()),
-        (
-            capability_id("builtin.apply_patch"),
-            builtin_effects.clone(),
-        ),
-        (capability_id("builtin.skill_list"), builtin_effects.clone()),
-        (
-            capability_id("builtin.skill_install"),
-            builtin_effects.clone(),
-        ),
-        (
-            capability_id("builtin.skill_remove"),
-            builtin_effects.clone(),
-        ),
-    ]);
+    let context = context_with_grant_entries(
+        package
+            .capabilities
+            .iter()
+            .map(|descriptor| (descriptor.id.clone(), descriptor.effects.clone())),
+    );
 
     let surface = runtime
         .visible_capabilities(request_with_provider_trust(
             context,
-            [("builtin", builtin_effects)],
+            [("builtin", combined_descriptor_effects(&package))],
         ))
         .await
         .unwrap();
 
-    assert_eq!(surface.capabilities.len(), 14);
+    assert_eq!(surface.capabilities.len(), package.capabilities.len());
     for capability in &surface.capabilities {
         assert!(
             capability
@@ -1357,6 +1329,18 @@ fn trust_decision_for(allowed_effects: Vec<EffectKind>) -> TrustDecision {
     }
 }
 
+fn combined_descriptor_effects(package: &ExtensionPackage) -> Vec<EffectKind> {
+    let mut effects = Vec::new();
+    for descriptor in &package.capabilities {
+        for effect in &descriptor.effects {
+            if !effects.contains(effect) {
+                effects.push(*effect);
+            }
+        }
+    }
+    effects
+}
+
 fn assert_schema_has_property(
     surface: &VisibleCapabilitySurface,
     capability: &str,
@@ -1614,6 +1598,12 @@ fn trust_policy_for<const N: usize>(
 
 fn context_with_grants<const N: usize>(
     grants: [(CapabilityId, Vec<EffectKind>); N],
+) -> ExecutionContext {
+    context_with_grant_entries(grants)
+}
+
+fn context_with_grant_entries(
+    grants: impl IntoIterator<Item = (CapabilityId, Vec<EffectKind>)>,
 ) -> ExecutionContext {
     let grants = CapabilitySet {
         grants: grants

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -654,6 +654,14 @@ async fn local_dev_adapter_registers_provider_tool_calls_as_run_scoped_inputs() 
         .into_iter()
         .find(|definition| definition.capability_id == capability_id)
         .expect("builtin echo should be advertised as a provider tool");
+    assert!(
+        tool_definition
+            .parameters
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|properties| properties.contains_key("message")),
+        "provider tool definitions should receive resolved built-in input schemas"
+    );
 
     let provider_tool_call = ProviderToolCall {
         provider_id: "nearai".to_string(),

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -742,19 +742,20 @@ async fn local_dev_adapter_exposes_skill_install_provider_tool_schema_requires_s
     let run_context = loop_run_context("provider-skill-install").await;
     let io = Arc::new(ProductLiveCapabilityIo::default());
     let capability_id = capability_id(SKILL_INSTALL_CAPABILITY_ID);
+    let user_id = UserId::new("user-provider-skill-install").unwrap();
     let adapters = ProductLivePlannedRuntimeAdapters::from_services(
         &services,
         ProductLivePlannedRuntimeAdapterConfig {
             capability_authority_resolver: authority_resolver(
                 ProductLiveVisibleCapabilityRequestConfig::new(
-                    UserId::new("user-provider-skill-install").unwrap(),
+                    user_id.clone(),
                     RuntimeKind::FirstParty,
                     TrustClass::FirstParty,
                     SurfaceKind::new("agent_loop").unwrap(),
                     CapabilitySurfacePolicy::allow_all(),
                 )
                 .with_grants(grants_for_principal_with_effects(
-                    Principal::User(UserId::new("user-provider-skill-install").unwrap()),
+                    Principal::User(user_id),
                     [SKILL_INSTALL_CAPABILITY_ID],
                     vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
                 ))

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -11,7 +11,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, ECHO_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, SHELL_CAPABILITY_ID,
-    SurfaceKind, VisibleCapabilityRequest as HostVisibleCapabilityRequest,
+    SKILL_INSTALL_CAPABILITY_ID, SurfaceKind,
+    VisibleCapabilityRequest as HostVisibleCapabilityRequest,
 };
 use ironclaw_loop_support::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
@@ -726,6 +727,85 @@ async fn local_dev_adapter_registers_provider_tool_calls_as_run_scoped_inputs() 
         io.result_for_ref(&run_context, &completed.result_ref)
             .unwrap(),
         serde_json::json!("hello from provider tool")
+    );
+}
+
+#[tokio::test]
+async fn local_dev_adapter_exposes_skill_install_provider_tool_schema_requires_string_content() {
+    let root = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(RebornBuildInput::local_dev(
+        "provider-skill-install-owner",
+        root.path().join("local-dev"),
+    ))
+    .await
+    .unwrap();
+    let run_context = loop_run_context("provider-skill-install").await;
+    let io = Arc::new(ProductLiveCapabilityIo::default());
+    let capability_id = capability_id(SKILL_INSTALL_CAPABILITY_ID);
+    let adapters = ProductLivePlannedRuntimeAdapters::from_services(
+        &services,
+        ProductLivePlannedRuntimeAdapterConfig {
+            capability_authority_resolver: authority_resolver(
+                ProductLiveVisibleCapabilityRequestConfig::new(
+                    UserId::new("user-provider-skill-install").unwrap(),
+                    RuntimeKind::FirstParty,
+                    TrustClass::FirstParty,
+                    SurfaceKind::new("agent_loop").unwrap(),
+                    CapabilitySurfacePolicy::allow_all(),
+                )
+                .with_grants(grants_for_principal_with_effects(
+                    Principal::User(UserId::new("user-provider-skill-install").unwrap()),
+                    [SKILL_INSTALL_CAPABILITY_ID],
+                    vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
+                ))
+                .with_provider_trust_for_effects(
+                    ExtensionId::new("builtin").unwrap(),
+                    EffectiveTrustClass::user_trusted(),
+                    vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
+                ),
+            ),
+            capability_input_resolver: io.clone(),
+            capability_result_writer: io,
+            capability_allow_set: capability_allowlist([capability_id.clone()]),
+            ..adapter_config()
+        },
+    )
+    .unwrap();
+    let capability_port = adapters
+        .capability_factory
+        .create_capability_port(&run_context)
+        .await
+        .unwrap();
+    capability_port
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+    let tool_definition = capability_port
+        .tool_definitions()
+        .unwrap()
+        .into_iter()
+        .find(|definition| definition.capability_id == capability_id)
+        .expect("builtin skill_install should be advertised as a provider tool");
+
+    let properties = tool_definition
+        .parameters
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .expect("skill_install schema should expose object properties");
+    assert_eq!(
+        properties
+            .get("content")
+            .and_then(|schema| schema.get("type")),
+        Some(&serde_json::json!("string")),
+        "skill_install content input should be advertised as a string"
+    );
+    assert!(
+        tool_definition
+            .parameters
+            .get("required")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|required| required.iter().any(|field| field == "content")),
+        "skill_install content input should be required"
     );
 }
 


### PR DESCRIPTION
## Summary
- resolve built-in capability `parameters_schema` `` values to concrete JSON schemas before publishing visible capability surfaces
- add concrete input schemas for the built-in first-party tools, including `builtin.skill_install` requiring string `content`
- cover both host-runtime visible surfaces and Reborn product-live provider tool definitions

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_host_runtime visible_surface_resolves_builtin_first_party_input_schema_refs -- --nocapture`
- `cargo test -p ironclaw_reborn_composition local_dev_adapter_registers_provider_tool_calls_as_run_scoped_inputs -- --nocapture`
- `cargo check -p ironclaw_reborn_composition`
- `git diff --check`