### PR TITLE
Add Reborn product command foundation

### DIFF
--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -44,6 +44,19 @@ fn validate_token_string(
     validate_bounded_string(kind, value, max, false, false)
 }
 
+fn validate_command_name(value: &str) -> Result<(), ProductAdapterError> {
+    validate_token_string("command", value, COMMAND_MAX_BYTES)?;
+    if value
+        .chars()
+        .any(|c| c.is_whitespace() || c == '/' || c == '\\')
+    {
+        return Err(malformed(
+            "command contains unsupported whitespace or slash characters",
+        ));
+    }
+    Ok(())
+}
+
 fn validate_bounded_string(
     kind: &'static str,
     value: &str,
@@ -139,7 +152,7 @@ impl InboundCommandPayload {
     ) -> Result<Self, ProductAdapterError> {
         let command = command.into();
         let arguments = arguments.into();
-        validate_token_string("command", &command, COMMAND_MAX_BYTES)?;
+        validate_command_name(&command)?;
         validate_payload_string("command arguments", &arguments, COMMAND_ARGUMENTS_MAX_BYTES)?;
         Ok(Self {
             command,
@@ -147,6 +160,41 @@ impl InboundCommandPayload {
             trigger,
         })
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProductSlashCommandParseError {
+    #[error("slash command is empty")]
+    Empty,
+    #[error("slash command payload is invalid: {0}")]
+    InvalidPayload(String),
+}
+
+/// Parse a raw slash command into a normalized command payload. Returns
+/// `Ok(None)` when the input is ordinary user text.
+pub fn parse_product_slash_command(
+    input: &str,
+    trigger: ProductTriggerReason,
+) -> Result<Option<InboundCommandPayload>, ProductSlashCommandParseError> {
+    let trimmed = input.trim();
+    let Some(without_slash) = trimmed.strip_prefix('/') else {
+        return Ok(None);
+    };
+    let without_slash = without_slash.trim_start();
+    if without_slash.is_empty() {
+        return Err(ProductSlashCommandParseError::Empty);
+    }
+
+    let command_end = without_slash
+        .char_indices()
+        .find_map(|(idx, c)| c.is_whitespace().then_some(idx))
+        .unwrap_or(without_slash.len());
+    let command = without_slash[..command_end].to_ascii_lowercase();
+    let arguments = without_slash[command_end..].trim_start().to_string();
+
+    InboundCommandPayload::new(command, arguments, trigger)
+        .map(Some)
+        .map_err(|error| ProductSlashCommandParseError::InvalidPayload(error.to_string()))
 }
 
 #[derive(Deserialize)]
@@ -681,6 +729,12 @@ mod tests {
             )
             .is_err()
         );
+        assert!(
+            InboundCommandPayload::new("bad name", "", ProductTriggerReason::BotCommand).is_err()
+        );
+        assert!(
+            InboundCommandPayload::new("bad/name", "", ProductTriggerReason::BotCommand).is_err()
+        );
         let empty_command = serde_json::json!({
             "command": "",
             "arguments": "",
@@ -701,6 +755,13 @@ mod tests {
             "trigger": "bot_command"
         });
         assert!(serde_json::from_value::<InboundCommandPayload>(forged).is_err());
+
+        let forged_slash = serde_json::json!({
+            "command": "bad/name",
+            "arguments": "",
+            "trigger": "bot_command"
+        });
+        assert!(serde_json::from_value::<InboundCommandPayload>(forged_slash).is_err());
     }
 
     #[test]

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -189,9 +189,19 @@ pub fn parse_product_slash_command(
         .char_indices()
         .find_map(|(idx, c)| c.is_whitespace().then_some(idx))
         .unwrap_or(without_slash.len());
-    let command = without_slash[..command_end].to_ascii_lowercase();
-    let arguments = without_slash[command_end..].trim_start().to_string();
+    let command_slice = &without_slash[..command_end];
+    let arguments_slice = without_slash[command_end..].trim_start();
+    validate_command_name(command_slice)
+        .map_err(|error| ProductSlashCommandParseError::InvalidPayload(error.to_string()))?;
+    validate_payload_string(
+        "command arguments",
+        arguments_slice,
+        COMMAND_ARGUMENTS_MAX_BYTES,
+    )
+    .map_err(|error| ProductSlashCommandParseError::InvalidPayload(error.to_string()))?;
 
+    let command = command_slice.to_ascii_lowercase();
+    let arguments = arguments_slice.to_string();
     InboundCommandPayload::new(command, arguments, trigger)
         .map(Some)
         .map_err(|error| ProductSlashCommandParseError::InvalidPayload(error.to_string()))

--- a/crates/ironclaw_product_adapters/src/lib.rs
+++ b/crates/ironclaw_product_adapters/src/lib.rs
@@ -45,8 +45,9 @@ pub use inbound::{
     ApprovalDecision, ApprovalResolutionPayload, AuthResolutionPayload, AuthResolutionResult,
     InboundCommandPayload, InboundRetryDisposition, LinkedThreadActionPayload,
     ParsedProductInbound, ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload,
-    ProductRejection, ProductRejectionDisposition, ProductRejectionKind, ProductTriggerReason,
-    ProjectionSubscriptionPayload, TrustedInboundContext, UserMessagePayload,
+    ProductRejection, ProductRejectionDisposition, ProductRejectionKind,
+    ProductSlashCommandParseError, ProductTriggerReason, ProjectionSubscriptionPayload,
+    TrustedInboundContext, UserMessagePayload, parse_product_slash_command,
 };
 pub use outbound::{
     AuthPromptView, FinalReplyView, GatePromptView, ProductOutboundEnvelope,

--- a/crates/ironclaw_product_adapters/tests/product_adapter_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/product_adapter_contract.rs
@@ -447,6 +447,8 @@ fn command_payload_bounds_are_public_contract() {
     assert!(
         InboundCommandPayload::new("h".repeat(257), "", ProductTriggerReason::BotCommand).is_err()
     );
+    assert!(InboundCommandPayload::new("bad name", "", ProductTriggerReason::BotCommand).is_err());
+    assert!(InboundCommandPayload::new("bad/name", "", ProductTriggerReason::BotCommand).is_err());
 }
 
 #[test]

--- a/crates/ironclaw_product_adapters/tests/product_slash_command_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/product_slash_command_contract.rs
@@ -1,6 +1,8 @@
 //! Contract tests for shared edge slash-command parsing.
 
-use ironclaw_product_adapters::{ProductTriggerReason, parse_product_slash_command};
+use ironclaw_product_adapters::{
+    ProductSlashCommandParseError, ProductTriggerReason, parse_product_slash_command,
+};
 
 #[test]
 fn slash_parser_normalizes_command_name_and_preserves_arguments() {
@@ -30,8 +32,37 @@ fn slash_parser_rejects_empty_command() {
     let err = parse_product_slash_command("/", ProductTriggerReason::BotCommand)
         .expect_err("empty command must fail");
 
-    assert_eq!(
+    assert_eq!(err, ProductSlashCommandParseError::Empty);
+}
+
+#[test]
+fn slash_parser_rejects_invalid_command_names() {
+    for input in ["//bad", "/bad\\name"] {
+        let err = parse_product_slash_command(input, ProductTriggerReason::BotCommand)
+            .expect_err("invalid command name must fail");
+
+        assert!(matches!(
+            err,
+            ProductSlashCommandParseError::InvalidPayload(_)
+        ));
+    }
+}
+
+#[test]
+fn slash_parser_rejects_oversized_command_and_arguments_before_payload_build() {
+    let oversized_command = format!("/{}", "h".repeat(257));
+    let err = parse_product_slash_command(&oversized_command, ProductTriggerReason::BotCommand)
+        .expect_err("oversized command must fail");
+    assert!(matches!(
         err,
-        ironclaw_product_adapters::ProductSlashCommandParseError::Empty
-    );
+        ProductSlashCommandParseError::InvalidPayload(_)
+    ));
+
+    let oversized_arguments = format!("/help {}", "a".repeat(64 * 1024 + 1));
+    let err = parse_product_slash_command(&oversized_arguments, ProductTriggerReason::BotCommand)
+        .expect_err("oversized arguments must fail");
+    assert!(matches!(
+        err,
+        ProductSlashCommandParseError::InvalidPayload(_)
+    ));
 }

--- a/crates/ironclaw_product_adapters/tests/product_slash_command_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/product_slash_command_contract.rs
@@ -1,0 +1,37 @@
+//! Contract tests for shared edge slash-command parsing.
+
+use ironclaw_product_adapters::{ProductTriggerReason, parse_product_slash_command};
+
+#[test]
+fn slash_parser_normalizes_command_name_and_preserves_arguments() {
+    let payload = parse_product_slash_command(
+        "  /MODEL Claude-3.5 --reasoning high  ",
+        ProductTriggerReason::BotCommand,
+    )
+    .expect("parse")
+    .expect("slash command");
+
+    assert_eq!(payload.command, "model");
+    assert_eq!(payload.arguments, "Claude-3.5 --reasoning high");
+    assert_eq!(payload.trigger, ProductTriggerReason::BotCommand);
+}
+
+#[test]
+fn slash_parser_ignores_ordinary_user_text() {
+    let parsed =
+        parse_product_slash_command("model this as a prompt", ProductTriggerReason::DirectChat)
+            .expect("parse");
+
+    assert!(parsed.is_none());
+}
+
+#[test]
+fn slash_parser_rejects_empty_command() {
+    let err = parse_product_slash_command("/", ProductTriggerReason::BotCommand)
+        .expect_err("empty command must fail");
+
+    assert_eq!(
+        err,
+        ironclaw_product_adapters::ProductSlashCommandParseError::Empty
+    );
+}

--- a/crates/ironclaw_product_adapters/tests/review_findings_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/review_findings_contract.rs
@@ -128,6 +128,8 @@ fn command_payload_is_bounded_and_serde_validated() {
     assert!(
         InboundCommandPayload::new("h".repeat(257), "", ProductTriggerReason::BotCommand).is_err()
     );
+    assert!(InboundCommandPayload::new("bad name", "", ProductTriggerReason::BotCommand).is_err());
+    assert!(InboundCommandPayload::new("bad/name", "", ProductTriggerReason::BotCommand).is_err());
     assert!(
         InboundCommandPayload::new(
             "help",

--- a/crates/ironclaw_product_workflow/CLAUDE.md
+++ b/crates/ironclaw_product_workflow/CLAUDE.md
@@ -21,6 +21,8 @@ handling, gate routing, mission routing, and redacted acknowledgements.
 | `IdempotencyLedger` | Durable action deduplication port |
 | `InMemoryIdempotencyLedger` | Local-dev/test ledger with in-flight lease recovery semantics |
 | `ProductInboundAction` | Durable ledger record for inbound actions |
+| `ProductCommandAdmissionService` | Source/auth-aware admission port that decides whether a typed product command may execute |
+| `ProductCommandService` | Reborn-native product command execution port for already-admitted typed commands |
 | `RebornServicesApi` / `RebornServices` | Native WebChat v2 facade — stable surface beta WebUI route handlers consume in place of reaching into turn coordination, thread stores, runtime lanes, dispatchers, or capability hosts. Enforces caller ownership of the thread before any turn mutation; rejects stale or attacker-supplied `gate_ref` on denied/cancelled gate resolutions; refuses persistent (`always: true`) approvals until an approval-policy port lands |
 
 ## Dependencies
@@ -42,6 +44,14 @@ Agent-loop note: product-facing turns enter through workflow services and
 canonical turn submission. Do not shortcut directly to `AgentLoopDriver`,
 `PlannedDriver`, host runtime services, or loop host factories from adapters or
 workflow callers.
+
+Product commands are not turns. Adapters may parse slash syntax at the edge, but
+`ProductInboundPayload::Command` must enter the workflow as normalized command
+payloads. The source/auth decision belongs to `ProductCommandAdmissionService`;
+the source-agnostic command model must not know which product surface produced
+the command. Admitted commands dispatch through `ProductCommandService`, not
+`InboundTurnService`, v1 `SubmissionParser`, v1 command routers, or agent-loop
+command handlers.
 
 WebUI-facing facade methods must bind browser thread ids through
 `SessionThreadService` using a `ThreadScope` derived from the authenticated

--- a/crates/ironclaw_product_workflow/src/command_dispatch.rs
+++ b/crates/ironclaw_product_workflow/src/command_dispatch.rs
@@ -13,12 +13,15 @@ use ironclaw_product_adapters::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::action::{ActionFingerprintKey, ProductActionId};
 use crate::commands::ProductCommand;
 use crate::error::ProductWorkflowError;
 
 /// Authority-bearing command dispatch context built by the workflow.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProductCommandContext {
+    pub action_id: ProductActionId,
+    pub fingerprint: ActionFingerprintKey,
     pub adapter_id: ProductAdapterId,
     pub installation_id: AdapterInstallationId,
     pub external_actor_ref: ExternalActorRef,
@@ -29,13 +32,19 @@ pub struct ProductCommandContext {
 }
 
 impl ProductCommandContext {
-    pub fn from_envelope(envelope: &ProductInboundEnvelope) -> Result<Self, ProductWorkflowError> {
+    pub fn from_envelope(
+        envelope: &ProductInboundEnvelope,
+        action_id: ProductActionId,
+        fingerprint: ActionFingerprintKey,
+    ) -> Result<Self, ProductWorkflowError> {
         let ProductInboundPayload::Command(command) = envelope.payload() else {
             return Err(ProductWorkflowError::UnsupportedActionKind {
                 kind: "non_command".to_string(),
             });
         };
         Ok(Self {
+            action_id,
+            fingerprint,
             adapter_id: envelope.adapter_id().clone(),
             installation_id: envelope.installation_id().clone(),
             external_actor_ref: envelope.external_actor_ref().clone(),
@@ -48,6 +57,7 @@ impl ProductCommandContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ProductCommandAdmission {
     Allowed,
     Rejected(ProductRejection),

--- a/crates/ironclaw_product_workflow/src/command_dispatch.rs
+++ b/crates/ironclaw_product_workflow/src/command_dispatch.rs
@@ -1,0 +1,110 @@
+//! Workflow-owned command admission and execution ports.
+//!
+//! `commands` owns the source-agnostic command model. This module owns the
+//! authority-bearing workflow context and the service boundary that decides
+//! whether a command may execute from that context.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use ironclaw_product_adapters::{
+    AdapterInstallationId, ExternalActorRef, ExternalConversationRef, ProductAdapterId,
+    ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload, ProductRejection,
+    ProductRejectionKind, ProductTriggerReason, VerifiedAuthClaim,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::commands::ProductCommand;
+use crate::error::ProductWorkflowError;
+
+/// Authority-bearing command dispatch context built by the workflow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProductCommandContext {
+    pub adapter_id: ProductAdapterId,
+    pub installation_id: AdapterInstallationId,
+    pub external_actor_ref: ExternalActorRef,
+    pub external_conversation_ref: ExternalConversationRef,
+    pub auth_claim: VerifiedAuthClaim,
+    pub trigger: ProductTriggerReason,
+    pub received_at: DateTime<Utc>,
+}
+
+impl ProductCommandContext {
+    pub fn from_envelope(envelope: &ProductInboundEnvelope) -> Result<Self, ProductWorkflowError> {
+        let ProductInboundPayload::Command(command) = envelope.payload() else {
+            return Err(ProductWorkflowError::UnsupportedActionKind {
+                kind: "non_command".to_string(),
+            });
+        };
+        Ok(Self {
+            adapter_id: envelope.adapter_id().clone(),
+            installation_id: envelope.installation_id().clone(),
+            external_actor_ref: envelope.external_actor_ref().clone(),
+            external_conversation_ref: envelope.external_conversation_ref().clone(),
+            auth_claim: envelope.auth_claim().clone(),
+            trigger: command.trigger,
+            received_at: envelope.received_at(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProductCommandAdmission {
+    Allowed,
+    Rejected(ProductRejection),
+}
+
+#[async_trait]
+pub trait ProductCommandAdmissionService: Send + Sync {
+    async fn admit(
+        &self,
+        context: &ProductCommandContext,
+        command: &ProductCommand,
+    ) -> Result<ProductCommandAdmission, ProductWorkflowError>;
+}
+
+/// Fail-closed admission service used until a host composition supplies concrete
+/// source/auth policy.
+pub struct RejectingProductCommandAdmissionService;
+
+#[async_trait]
+impl ProductCommandAdmissionService for RejectingProductCommandAdmissionService {
+    async fn admit(
+        &self,
+        _context: &ProductCommandContext,
+        command: &ProductCommand,
+    ) -> Result<ProductCommandAdmission, ProductWorkflowError> {
+        Ok(ProductCommandAdmission::Rejected(
+            ProductRejection::permanent(
+                ProductRejectionKind::PolicyDenied,
+                format!("command routing unavailable: {}", command.name()),
+            ),
+        ))
+    }
+}
+
+#[async_trait]
+pub trait ProductCommandService: Send + Sync {
+    async fn execute(
+        &self,
+        context: ProductCommandContext,
+        command: ProductCommand,
+    ) -> Result<ProductInboundAck, ProductWorkflowError>;
+}
+
+/// Fail-closed command executor used until a host composition supplies concrete
+/// command implementations.
+pub struct RejectingProductCommandService;
+
+#[async_trait]
+impl ProductCommandService for RejectingProductCommandService {
+    async fn execute(
+        &self,
+        _context: ProductCommandContext,
+        command: ProductCommand,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        Ok(ProductInboundAck::Rejected(ProductRejection::permanent(
+            ProductRejectionKind::PolicyDenied,
+            format!("command routing unavailable: {}", command.name()),
+        )))
+    }
+}

--- a/crates/ironclaw_product_workflow/src/commands.rs
+++ b/crates/ironclaw_product_workflow/src/commands.rs
@@ -1,0 +1,106 @@
+//! Reborn-native product command contract.
+//!
+//! Slash strings are only an edge syntax. This module starts from normalized
+//! command payloads so command parsing does not depend on v1 agent routing or on
+//! the product surface that produced the command.
+
+use ironclaw_product_adapters::InboundCommandPayload;
+use serde::{Deserialize, Serialize};
+
+/// Public command inventory metadata. Policy decisions based on actor,
+/// installation, trigger, or product surface belong to `ProductCommandAdmissionService`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProductCommandDescriptor {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+}
+
+struct ProductCommandSpec {
+    descriptor: ProductCommandDescriptor,
+    parse: fn(&InboundCommandPayload) -> ProductCommand,
+}
+
+const COMMAND_SPECS: &[ProductCommandSpec] = &[
+    ProductCommandSpec {
+        descriptor: ProductCommandDescriptor {
+            name: "model",
+            aliases: &[],
+        },
+        parse: parse_model_command,
+    },
+    ProductCommandSpec {
+        descriptor: ProductCommandDescriptor {
+            name: "status",
+            aliases: &["progress"],
+        },
+        parse: parse_status_command,
+    },
+];
+
+pub fn product_command_descriptors() -> impl Iterator<Item = &'static ProductCommandDescriptor> {
+    COMMAND_SPECS.iter().map(|spec| &spec.descriptor)
+}
+
+/// Typed command family produced from a normalized command payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum ProductCommand {
+    Model { action: ProductModelCommand },
+    Status,
+    Unknown { name: String, arguments: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ProductModelCommand {
+    Status,
+    Set { model: String },
+}
+
+impl ProductCommand {
+    pub fn from_payload(payload: &InboundCommandPayload) -> Self {
+        match command_spec_for_name(&payload.command) {
+            Some(spec) => (spec.parse)(payload),
+            None => Self::Unknown {
+                name: payload.command.clone(),
+                arguments: payload.arguments.clone(),
+            },
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Model { .. } => "model",
+            Self::Status => "status",
+            Self::Unknown { name, .. } => name.as_str(),
+        }
+    }
+
+    pub fn descriptor(&self) -> Option<&'static ProductCommandDescriptor> {
+        command_spec_for_name(self.name()).map(|spec| &spec.descriptor)
+    }
+}
+
+fn command_spec_for_name(name: &str) -> Option<&'static ProductCommandSpec> {
+    COMMAND_SPECS
+        .iter()
+        .find(|spec| spec.descriptor.name == name || spec.descriptor.aliases.contains(&name))
+}
+
+fn parse_model_command(payload: &InboundCommandPayload) -> ProductCommand {
+    let model = payload.arguments.split_whitespace().next();
+    match model {
+        Some(model) => ProductCommand::Model {
+            action: ProductModelCommand::Set {
+                model: model.to_string(),
+            },
+        },
+        None => ProductCommand::Model {
+            action: ProductModelCommand::Status,
+        },
+    }
+}
+
+fn parse_status_command(_payload: &InboundCommandPayload) -> ProductCommand {
+    ProductCommand::Status
+}

--- a/crates/ironclaw_product_workflow/src/error.rs
+++ b/crates/ironclaw_product_workflow/src/error.rs
@@ -95,10 +95,6 @@ pub enum ProductWorkflowError {
         prior_outcome: ironclaw_product_adapters::ProductInboundAck,
     },
 
-    /// Command routing is not yet implemented.
-    #[error("command routing unavailable: {command}")]
-    CommandRoutingUnavailable { command: String },
-
     /// The requested action kind is not supported by this workflow version.
     #[error("unsupported action kind: {kind}")]
     UnsupportedActionKind { kind: String },
@@ -209,11 +205,6 @@ impl From<ProductWorkflowError> for ProductAdapterError {
             ProductWorkflowError::DuplicateAction { .. } => ProductAdapterError::Internal {
                 detail: RedactedString::new("duplicate action escaped workflow layer"),
             },
-            ProductWorkflowError::CommandRoutingUnavailable { command } => {
-                ProductAdapterError::Internal {
-                    detail: RedactedString::new(format!("command routing unavailable: {command}")),
-                }
-            }
             ProductWorkflowError::UnsupportedActionKind { kind } => ProductAdapterError::Internal {
                 detail: RedactedString::new(format!("unsupported action kind: {kind}")),
             },

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -28,6 +28,8 @@ mod action;
 mod auth_continuation;
 mod binding;
 mod binding_ref;
+mod command_dispatch;
+mod commands;
 mod conversation_binding;
 mod error;
 #[cfg(any(test, feature = "test-support"))]
@@ -50,6 +52,13 @@ pub use auth_continuation::ProductAuthTurnGateResumeDispatcher;
 pub use binding::{
     ConversationBindingService, ProductConversationRouteKind, ResolveBindingRequest,
     ResolvedBinding,
+};
+pub use command_dispatch::{
+    ProductCommandAdmission, ProductCommandAdmissionService, ProductCommandContext,
+    ProductCommandService, RejectingProductCommandAdmissionService, RejectingProductCommandService,
+};
+pub use commands::{
+    ProductCommand, ProductCommandDescriptor, ProductModelCommand, product_command_descriptors,
 };
 pub use conversation_binding::{
     ProductConversationBindingService, ProductInstallationKey, ProductInstallationScope,

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -128,6 +128,8 @@ impl ProductWorkflow for DefaultProductWorkflow {
             IdempotencyDecision::New(mut action) => {
                 let result = dispatch_payload(
                     &envelope,
+                    action.action_id,
+                    action.fingerprint.clone(),
                     &*self.inbound_turn_service,
                     &*self.before_inbound_policy,
                     &*self.command_admission_service,
@@ -281,6 +283,8 @@ fn projection_thread_id_from_binding(
 
 async fn dispatch_payload(
     envelope: &ProductInboundEnvelope,
+    action_id: crate::ProductActionId,
+    action_fingerprint: ActionFingerprintKey,
     inbound_turn_service: &dyn InboundTurnService,
     before_inbound_policy: &dyn BeforeInboundPolicy,
     command_admission_service: &dyn ProductCommandAdmissionService,
@@ -310,7 +314,8 @@ async fn dispatch_payload(
             }
         }
         ProductInboundPayload::Command(cmd) => {
-            let context = ProductCommandContext::from_envelope(envelope)?;
+            let context =
+                ProductCommandContext::from_envelope(envelope, action_id, action_fingerprint)?;
             let command = ProductCommand::from_payload(cmd);
             match command_admission_service.admit(&context, &command).await? {
                 ProductCommandAdmission::Allowed => {}
@@ -321,7 +326,7 @@ async fn dispatch_payload(
                 }
             }
             let ack = command_service.execute(context, command).await?;
-            let dispatch_kind = dispatch_kind_from_ack(&ack, envelope.payload())?;
+            let dispatch_kind = dispatch_kind_from_command_ack(&ack, envelope.payload())?;
             Ok(DispatchedAction { ack, dispatch_kind })
         }
         ProductInboundPayload::ApprovalResolution(_) => {
@@ -364,6 +369,23 @@ fn dispatch_kind_from_ack(
         ProductInboundAck::DeferredBusy { active_run_id, .. } => {
             Ok(ActionDispatchKind::UserMessageTurn {
                 run_id: *active_run_id,
+            })
+        }
+        ProductInboundAck::Rejected(rejection) => Ok(ActionDispatchKind::Rejected {
+            kind: rejection.kind.clone(),
+        }),
+        _ => ActionDispatchKind::try_from_payload(payload),
+    }
+}
+
+fn dispatch_kind_from_command_ack(
+    ack: &ProductInboundAck,
+    payload: &ProductInboundPayload,
+) -> Result<ActionDispatchKind, ProductWorkflowError> {
+    match ack {
+        ProductInboundAck::Accepted { .. } | ProductInboundAck::DeferredBusy { .. } => {
+            Err(ProductWorkflowError::UnsupportedActionKind {
+                kind: "turn_ack_from_product_command".into(),
             })
         }
         ProductInboundAck::Rejected(rejection) => Ok(ActionDispatchKind::Rejected {

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -21,6 +21,11 @@ use crate::binding::{
     ConversationBindingService, ProductConversationRouteKind, ResolveBindingRequest,
     ResolvedBinding,
 };
+use crate::command_dispatch::{
+    ProductCommandAdmission, ProductCommandAdmissionService, ProductCommandContext,
+    ProductCommandService, RejectingProductCommandAdmissionService, RejectingProductCommandService,
+};
+use crate::commands::ProductCommand;
 use crate::error::ProductWorkflowError;
 use crate::inbound_turn::{InboundTurnService, InboundUserMessageDispatch};
 use crate::ledger::{IdempotencyDecision, IdempotencyLedger};
@@ -34,6 +39,8 @@ pub struct DefaultProductWorkflow {
     idempotency_ledger: Arc<dyn IdempotencyLedger>,
     before_inbound_policy: Arc<dyn BeforeInboundPolicy>,
     binding_service: Arc<dyn ConversationBindingService>,
+    command_admission_service: Arc<dyn ProductCommandAdmissionService>,
+    command_service: Arc<dyn ProductCommandService>,
 }
 
 impl DefaultProductWorkflow {
@@ -47,6 +54,8 @@ impl DefaultProductWorkflow {
             idempotency_ledger,
             before_inbound_policy: Arc::new(NoopBeforeInboundPolicy),
             binding_service,
+            command_admission_service: Arc::new(RejectingProductCommandAdmissionService),
+            command_service: Arc::new(RejectingProductCommandService),
         }
     }
 
@@ -55,6 +64,22 @@ impl DefaultProductWorkflow {
         before_inbound_policy: Arc<dyn BeforeInboundPolicy>,
     ) -> Self {
         self.before_inbound_policy = before_inbound_policy;
+        self
+    }
+
+    pub fn with_product_command_admission_service(
+        mut self,
+        command_admission_service: Arc<dyn ProductCommandAdmissionService>,
+    ) -> Self {
+        self.command_admission_service = command_admission_service;
+        self
+    }
+
+    pub fn with_product_command_service(
+        mut self,
+        command_service: Arc<dyn ProductCommandService>,
+    ) -> Self {
+        self.command_service = command_service;
         self
     }
 }
@@ -105,6 +130,8 @@ impl ProductWorkflow for DefaultProductWorkflow {
                     &envelope,
                     &*self.inbound_turn_service,
                     &*self.before_inbound_policy,
+                    &*self.command_admission_service,
+                    &*self.command_service,
                 )
                 .await;
 
@@ -256,6 +283,8 @@ async fn dispatch_payload(
     envelope: &ProductInboundEnvelope,
     inbound_turn_service: &dyn InboundTurnService,
     before_inbound_policy: &dyn BeforeInboundPolicy,
+    command_admission_service: &dyn ProductCommandAdmissionService,
+    command_service: &dyn ProductCommandService,
 ) -> Result<DispatchedAction, ProductWorkflowError> {
     match envelope.payload() {
         ProductInboundPayload::UserMessage(_) => {
@@ -281,9 +310,19 @@ async fn dispatch_payload(
             }
         }
         ProductInboundPayload::Command(cmd) => {
-            Err(ProductWorkflowError::CommandRoutingUnavailable {
-                command: cmd.command.clone(),
-            })
+            let context = ProductCommandContext::from_envelope(envelope)?;
+            let command = ProductCommand::from_payload(cmd);
+            match command_admission_service.admit(&context, &command).await? {
+                ProductCommandAdmission::Allowed => {}
+                ProductCommandAdmission::Rejected(rejection) => {
+                    let ack = ProductInboundAck::Rejected(rejection);
+                    let dispatch_kind = dispatch_kind_from_ack(&ack, envelope.payload())?;
+                    return Ok(DispatchedAction { ack, dispatch_kind });
+                }
+            }
+            let ack = command_service.execute(context, command).await?;
+            let dispatch_kind = dispatch_kind_from_ack(&ack, envelope.payload())?;
+            Ok(DispatchedAction { ack, dispatch_kind })
         }
         ProductInboundPayload::ApprovalResolution(_) => {
             Err(ProductWorkflowError::UnsupportedActionKind {
@@ -387,12 +426,6 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
                 reason.clone(),
             )))
         }
-        ProductWorkflowError::CommandRoutingUnavailable { command } => {
-            Some(ProductInboundAck::Rejected(ProductRejection::permanent(
-                ProductRejectionKind::PolicyDenied,
-                format!("command routing unavailable: {command}"),
-            )))
-        }
         ProductWorkflowError::UnsupportedActionKind { kind } => {
             Some(ProductInboundAck::Rejected(ProductRejection::permanent(
                 ProductRejectionKind::PolicyDenied,
@@ -461,19 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_ack_for_error_settles_command_and_unsupported_actions() {
-        let command = terminal_ack_for_error(&ProductWorkflowError::CommandRoutingUnavailable {
-            command: "help".to_string(),
-        })
-        .expect("command routing failure is terminal");
-        assert!(matches!(
-            command,
-            ProductInboundAck::Rejected(rejection)
-                if rejection.kind == ProductRejectionKind::PolicyDenied
-                    && rejection.disposition()
-                        == ironclaw_product_adapters::ProductRejectionDisposition::Permanent
-        ));
-
+    fn terminal_ack_for_error_settles_unsupported_actions() {
         let unsupported = terminal_ack_for_error(&ProductWorkflowError::UnsupportedActionKind {
             kind: "auth_resolution".to_string(),
         })

--- a/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
@@ -1,0 +1,152 @@
+//! Contract tests for product command dispatch through the workflow facade.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_product_adapters::{
+    AdapterInstallationId, AuthRequirement, ExternalActorRef, ExternalConversationRef,
+    ExternalEventId, InboundCommandPayload, ProductAdapterId, ProductInboundAck,
+    ProductInboundEnvelope, ProductInboundPayload, ProductTriggerReason, ProductWorkflow,
+    ProtocolAuthEvidence, TrustedInboundContext,
+};
+use ironclaw_product_workflow::{
+    ActionDispatchKind, DefaultProductWorkflow, FakeConversationBindingService,
+    FakeIdempotencyLedger, FakeInboundTurnService, ProductCommand, ProductCommandAdmission,
+    ProductCommandAdmissionService, ProductCommandContext, ProductCommandService,
+    ProductModelCommand, ProductWorkflowError,
+};
+
+fn sample_command_envelope(
+    event_suffix: &str,
+    command: &str,
+    arguments: &str,
+) -> ProductInboundEnvelope {
+    let adapter_id = ProductAdapterId::new("test_adapter").expect("valid adapter");
+    let installation_id = AdapterInstallationId::new("install_alpha").expect("valid installation");
+    let evidence = ProtocolAuthEvidence::test_verified(
+        AuthRequirement::SharedSecretHeader {
+            header_name: "X-Secret".into(),
+        },
+        installation_id.as_str(),
+    );
+    let context = TrustedInboundContext::from_verified_evidence(
+        adapter_id,
+        installation_id,
+        Utc::now(),
+        &evidence,
+    )
+    .expect("verified");
+    let parsed = ironclaw_product_adapters::ParsedProductInbound::new(
+        ExternalEventId::new(format!("evt:{event_suffix}")).expect("valid event"),
+        ExternalActorRef::new("test", "user1", Option::<String>::None).expect("valid actor"),
+        ExternalConversationRef::new(None, "conv1", None, None).expect("valid conversation"),
+        ProductInboundPayload::Command(
+            InboundCommandPayload::new(command, arguments, ProductTriggerReason::BotCommand)
+                .expect("valid command"),
+        ),
+    )
+    .expect("parsed");
+
+    ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("envelope")
+}
+
+struct AllowingProductCommandAdmissionService;
+
+#[async_trait]
+impl ProductCommandAdmissionService for AllowingProductCommandAdmissionService {
+    async fn admit(
+        &self,
+        _context: &ProductCommandContext,
+        _command: &ProductCommand,
+    ) -> Result<ProductCommandAdmission, ProductWorkflowError> {
+        Ok(ProductCommandAdmission::Allowed)
+    }
+}
+
+struct RecordingProductCommandService {
+    commands: Mutex<Vec<ProductCommand>>,
+    ack: ProductInboundAck,
+}
+
+impl RecordingProductCommandService {
+    fn new(ack: ProductInboundAck) -> Self {
+        Self {
+            commands: Mutex::new(Vec::new()),
+            ack,
+        }
+    }
+
+    fn commands(&self) -> Vec<ProductCommand> {
+        self.commands.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl ProductCommandService for RecordingProductCommandService {
+    async fn execute(
+        &self,
+        _context: ProductCommandContext,
+        command: ProductCommand,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        self.commands.lock().expect("lock").push(command);
+        Ok(self.ack.clone())
+    }
+}
+
+#[tokio::test]
+async fn command_payload_dispatches_through_command_service_not_inbound_turn_service() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let admission_service = Arc::new(AllowingProductCommandAdmissionService);
+    let command_service = Arc::new(RecordingProductCommandService::new(ProductInboundAck::NoOp));
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+        .with_product_command_admission_service(admission_service)
+        .with_product_command_service(command_service.clone());
+    let envelope =
+        sample_command_envelope("command-model", "model", "gpt-5-mini --ignored-for-now");
+
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    assert!(matches!(ack, ProductInboundAck::NoOp));
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(inbound.attempt_count(), 0);
+    assert_eq!(inbound.replay_attempt_count(), 0);
+    assert_eq!(
+        command_service.commands(),
+        vec![ProductCommand::Model {
+            action: ProductModelCommand::Set {
+                model: "gpt-5-mini".to_string()
+            }
+        }]
+    );
+    let settled = ledger.settled_actions();
+    assert_eq!(settled.len(), 1);
+    assert!(matches!(
+        settled[0].dispatch_kind,
+        Some(ActionDispatchKind::Command { .. })
+    ));
+}
+
+#[tokio::test]
+async fn default_command_admission_rejects_before_command_service_executes() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let command_service = Arc::new(RecordingProductCommandService::new(ProductInboundAck::NoOp));
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+        .with_product_command_service(command_service.clone());
+    let envelope = sample_command_envelope("command-default-reject", "model", "gpt-5-mini");
+
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    assert!(matches!(
+        ack,
+        ProductInboundAck::Rejected(rejection)
+            if rejection.kind == ironclaw_product_adapters::ProductRejectionKind::PolicyDenied
+    ));
+    assert!(command_service.commands().is_empty());
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 1);
+}

--- a/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_command_workflow_contract.rs
@@ -16,6 +16,7 @@ use ironclaw_product_workflow::{
     ProductCommandAdmissionService, ProductCommandContext, ProductCommandService,
     ProductModelCommand, ProductWorkflowError,
 };
+use ironclaw_turns::{AcceptedMessageRef, TurnRunId};
 
 fn sample_command_envelope(
     event_suffix: &str,
@@ -51,30 +52,66 @@ fn sample_command_envelope(
     ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("envelope")
 }
 
-struct AllowingProductCommandAdmissionService;
+struct RecordingProductCommandAdmissionService {
+    records: Mutex<Vec<(ProductCommandContext, ProductCommand)>>,
+    result: Result<ProductCommandAdmission, ProductWorkflowError>,
+}
+
+impl RecordingProductCommandAdmissionService {
+    fn new(result: Result<ProductCommandAdmission, ProductWorkflowError>) -> Self {
+        Self {
+            records: Mutex::new(Vec::new()),
+            result,
+        }
+    }
+
+    fn allowing() -> Self {
+        Self::new(Ok(ProductCommandAdmission::Allowed))
+    }
+
+    fn failing(error: ProductWorkflowError) -> Self {
+        Self::new(Err(error))
+    }
+
+    fn records(&self) -> Vec<(ProductCommandContext, ProductCommand)> {
+        self.records.lock().expect("lock").clone()
+    }
+}
 
 #[async_trait]
-impl ProductCommandAdmissionService for AllowingProductCommandAdmissionService {
+impl ProductCommandAdmissionService for RecordingProductCommandAdmissionService {
     async fn admit(
         &self,
-        _context: &ProductCommandContext,
-        _command: &ProductCommand,
+        context: &ProductCommandContext,
+        command: &ProductCommand,
     ) -> Result<ProductCommandAdmission, ProductWorkflowError> {
-        Ok(ProductCommandAdmission::Allowed)
+        self.records
+            .lock()
+            .expect("lock")
+            .push((context.clone(), command.clone()));
+        self.result.clone()
     }
 }
 
 struct RecordingProductCommandService {
     commands: Mutex<Vec<ProductCommand>>,
-    ack: ProductInboundAck,
+    result: Result<ProductInboundAck, ProductWorkflowError>,
 }
 
 impl RecordingProductCommandService {
-    fn new(ack: ProductInboundAck) -> Self {
+    fn new(result: Result<ProductInboundAck, ProductWorkflowError>) -> Self {
         Self {
             commands: Mutex::new(Vec::new()),
-            ack,
+            result,
         }
+    }
+
+    fn with_ack(ack: ProductInboundAck) -> Self {
+        Self::new(Ok(ack))
+    }
+
+    fn failing(error: ProductWorkflowError) -> Self {
+        Self::new(Err(error))
     }
 
     fn commands(&self) -> Vec<ProductCommand> {
@@ -90,7 +127,7 @@ impl ProductCommandService for RecordingProductCommandService {
         command: ProductCommand,
     ) -> Result<ProductInboundAck, ProductWorkflowError> {
         self.commands.lock().expect("lock").push(command);
-        Ok(self.ack.clone())
+        self.result.clone()
     }
 }
 
@@ -99,8 +136,10 @@ async fn command_payload_dispatches_through_command_service_not_inbound_turn_ser
     let inbound = Arc::new(FakeInboundTurnService::new());
     let ledger = Arc::new(FakeIdempotencyLedger::new());
     let binding = Arc::new(FakeConversationBindingService::new());
-    let admission_service = Arc::new(AllowingProductCommandAdmissionService);
-    let command_service = Arc::new(RecordingProductCommandService::new(ProductInboundAck::NoOp));
+    let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
+    let command_service = Arc::new(RecordingProductCommandService::with_ack(
+        ProductInboundAck::NoOp,
+    ));
     let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
         .with_product_command_admission_service(admission_service)
         .with_product_command_service(command_service.clone());
@@ -134,7 +173,9 @@ async fn default_command_admission_rejects_before_command_service_executes() {
     let inbound = Arc::new(FakeInboundTurnService::new());
     let ledger = Arc::new(FakeIdempotencyLedger::new());
     let binding = Arc::new(FakeConversationBindingService::new());
-    let command_service = Arc::new(RecordingProductCommandService::new(ProductInboundAck::NoOp));
+    let command_service = Arc::new(RecordingProductCommandService::with_ack(
+        ProductInboundAck::NoOp,
+    ));
     let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
         .with_product_command_service(command_service.clone());
     let envelope = sample_command_envelope("command-default-reject", "model", "gpt-5-mini");
@@ -149,4 +190,156 @@ async fn default_command_admission_rejects_before_command_service_executes() {
     assert!(command_service.commands().is_empty());
     assert_eq!(inbound.accepted_count(), 0);
     assert_eq!(ledger.settled_count(), 1);
+}
+
+#[tokio::test]
+async fn command_admission_receives_authority_context_and_action_metadata() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
+    let command_service = Arc::new(RecordingProductCommandService::with_ack(
+        ProductInboundAck::NoOp,
+    ));
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+        .with_product_command_admission_service(admission_service.clone())
+        .with_product_command_service(command_service);
+    let envelope = sample_command_envelope("command-context", "status", "");
+    let expected_adapter_id = envelope.adapter_id().clone();
+    let expected_installation_id = envelope.installation_id().clone();
+    let expected_actor = envelope.external_actor_ref().clone();
+    let expected_conversation = envelope.external_conversation_ref().clone();
+    let expected_auth_claim = envelope.auth_claim().clone();
+    let expected_received_at = envelope.received_at();
+
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    assert!(matches!(ack, ProductInboundAck::NoOp));
+    let records = admission_service.records();
+    assert_eq!(records.len(), 1);
+    let (context, command) = &records[0];
+    assert_eq!(command, &ProductCommand::Status);
+    assert_eq!(context.adapter_id, expected_adapter_id);
+    assert_eq!(context.installation_id, expected_installation_id);
+    assert_eq!(context.external_actor_ref, expected_actor);
+    assert_eq!(context.external_conversation_ref, expected_conversation);
+    assert_eq!(context.auth_claim, expected_auth_claim);
+    assert_eq!(context.trigger, ProductTriggerReason::BotCommand);
+    assert_eq!(context.received_at, expected_received_at);
+
+    let settled = ledger.settled_actions();
+    assert_eq!(settled.len(), 1);
+    assert_eq!(context.action_id, settled[0].action_id);
+    assert_eq!(context.fingerprint, settled[0].fingerprint);
+}
+
+#[tokio::test]
+async fn command_admission_error_releases_idempotency_lease() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let admission_service = Arc::new(RecordingProductCommandAdmissionService::failing(
+        ProductWorkflowError::Transient {
+            reason: "admission backend unavailable".into(),
+        },
+    ));
+    let command_service = Arc::new(RecordingProductCommandService::with_ack(
+        ProductInboundAck::NoOp,
+    ));
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+        .with_product_command_admission_service(admission_service)
+        .with_product_command_service(command_service.clone());
+    let envelope = sample_command_envelope("command-admission-error", "model", "gpt-5-mini");
+
+    let err = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("transient admission error must bubble");
+
+    assert!(err.is_retryable());
+    assert!(command_service.commands().is_empty());
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.released_count(), 1);
+}
+
+#[tokio::test]
+async fn command_service_error_releases_idempotency_lease() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
+    let command_service = Arc::new(RecordingProductCommandService::failing(
+        ProductWorkflowError::Transient {
+            reason: "command backend unavailable".into(),
+        },
+    ));
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+        .with_product_command_admission_service(admission_service)
+        .with_product_command_service(command_service.clone());
+    let envelope = sample_command_envelope("command-service-error", "model", "gpt-5-mini");
+
+    let err = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("transient command error must bubble");
+
+    assert!(err.is_retryable());
+    assert_eq!(command_service.commands().len(), 1);
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.released_count(), 1);
+}
+
+#[tokio::test]
+async fn default_command_service_rejects_when_admission_is_supplied() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+        .with_product_command_admission_service(admission_service);
+    let envelope = sample_command_envelope("command-default-service-reject", "status", "");
+
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    assert!(matches!(
+        ack,
+        ProductInboundAck::Rejected(rejection)
+            if rejection.kind == ironclaw_product_adapters::ProductRejectionKind::PolicyDenied
+    ));
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 1);
+}
+
+#[tokio::test]
+async fn command_service_turn_ack_is_rejected_before_turn_dispatch_kind_is_recorded() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let admission_service = Arc::new(RecordingProductCommandAdmissionService::allowing());
+    let command_service = Arc::new(RecordingProductCommandService::with_ack(
+        ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("msg:command").expect("valid ref"),
+            submitted_run_id: TurnRunId::new(),
+        },
+    ));
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone(), binding)
+        .with_product_command_admission_service(admission_service)
+        .with_product_command_service(command_service);
+    let envelope = sample_command_envelope("command-turn-ack", "status", "");
+
+    workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("turn-shaped command ack must fail");
+
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+    let settled = ledger.settled_actions();
+    assert_eq!(settled.len(), 1);
+    assert!(matches!(
+        settled[0].dispatch_kind,
+        Some(ActionDispatchKind::Rejected { .. })
+    ));
 }

--- a/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
@@ -20,6 +20,58 @@ fn command_payload_maps_to_typed_model_command_without_v1_parser() {
 }
 
 #[test]
+fn command_payload_maps_all_declared_commands_and_unknown_fallback() {
+    let cases = [
+        (
+            "model",
+            "",
+            ProductCommand::Model {
+                action: ProductModelCommand::Status,
+            },
+            "model",
+            Some("model"),
+        ),
+        (
+            "status",
+            "",
+            ProductCommand::Status,
+            "status",
+            Some("status"),
+        ),
+        (
+            "progress",
+            "",
+            ProductCommand::Status,
+            "status",
+            Some("status"),
+        ),
+        (
+            "unknown",
+            "raw args",
+            ProductCommand::Unknown {
+                name: "unknown".to_string(),
+                arguments: "raw args".to_string(),
+            },
+            "unknown",
+            None,
+        ),
+    ];
+
+    for (name, arguments, expected, expected_name, expected_descriptor) in cases {
+        let payload = InboundCommandPayload::new(name, arguments, ProductTriggerReason::BotCommand)
+            .expect("valid command payload");
+        let command = ProductCommand::from_payload(&payload);
+
+        assert_eq!(command, expected);
+        assert_eq!(command.name(), expected_name);
+        assert_eq!(
+            command.descriptor().map(|descriptor| descriptor.name),
+            expected_descriptor
+        );
+    }
+}
+
+#[test]
 fn command_registry_declares_model_without_source_policy() {
     let model = product_command_descriptors()
         .find(|descriptor| descriptor.name == "model")

--- a/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
@@ -1,0 +1,29 @@
+//! Contract tests for the Reborn-native product command model.
+
+use ironclaw_product_adapters::{InboundCommandPayload, ProductTriggerReason};
+use ironclaw_product_workflow::{ProductCommand, ProductModelCommand, product_command_descriptors};
+
+#[test]
+fn command_payload_maps_to_typed_model_command_without_v1_parser() {
+    let payload =
+        InboundCommandPayload::new("model", "gpt-5-mini", ProductTriggerReason::BotCommand)
+            .expect("valid command");
+
+    assert_eq!(
+        ProductCommand::from_payload(&payload),
+        ProductCommand::Model {
+            action: ProductModelCommand::Set {
+                model: "gpt-5-mini".to_string(),
+            }
+        }
+    );
+}
+
+#[test]
+fn command_registry_declares_model_without_source_policy() {
+    let model = product_command_descriptors()
+        .find(|descriptor| descriptor.name == "model")
+        .expect("model descriptor");
+
+    assert!(model.aliases.is_empty());
+}


### PR DESCRIPTION
## Summary
- Add shared product-adapter slash parsing so raw `/command` text is normalized at the edge before entering workflow.
- Tighten `InboundCommandPayload::new` so all normalized command payloads reject whitespace and slash characters in command names, not only slash-parser inputs.
- Add a source-agnostic Reborn product command model for typed `/model` and `/status` command DTOs.
- Add a workflow-owned `ProductCommandAdmissionService` for source/auth-aware command admission and a separate `ProductCommandService` execution port for already-admitted commands.
- Route `ProductInboundPayload::Command` through admission + command execution, returning `ProductInboundAck` directly, with default fail-closed behavior instead of sending command payloads into `InboundTurnService`.
- Document the boundary and split command workflow coverage out of the oversized product workflow contract file.

## Scope note
This PR is the command foundation only. It does not implement the concrete `/model` mutation service or model resolver persistence yet.

## Tests
- `cargo test -p ironclaw_product_adapters --test product_slash_command_contract`
- `cargo test -p ironclaw_product_workflow --test product_commands_contract --test product_command_workflow_contract`
- `cargo test -p ironclaw_product_workflow`
- `cargo test -p ironclaw_product_adapters --features test-support,host-auth-mint`
- `cargo clippy -p ironclaw_product_workflow --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_product_adapters --features test-support,host-auth-mint --all-targets -- -D warnings`

Note: plain `cargo test -p ironclaw_product_adapters` still hits existing broader test feature-gating failures because adapter integration tests use `test-support` and `host-auth-mint` APIs.