### PR TITLE
feat(signing): WalletConnect v2 backend (attested-signing PR9/10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1249,6 +1249,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
@@ -2529,7 +2535,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2649,6 +2655,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
  "subtle",
@@ -2735,6 +2742,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,7 +2787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4046,7 +4065,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bollard",
- "bs58",
+ "bs58 0.5.1",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -5240,6 +5259,8 @@ dependencies = [
  "ironclaw_signing_provider",
  "k256",
  "rand_core 0.6.4",
+ "relay_client",
+ "relay_rpc",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5367,7 +5388,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6193,7 +6214,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6455,6 +6476,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -7639,6 +7669,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relay_client"
+version = "0.1.0"
+source = "git+https://github.com/tracecommons/walletconnect-rs?rev=7078fd303cc521cceeed919e3d452f45eeb115e8#7078fd303cc521cceeed919e3d452f45eeb115e8"
+dependencies = [
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "pin-project",
+ "relay_rpc",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.27.0",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "relay_rpc"
+version = "0.1.0"
+source = "git+https://github.com/tracecommons/walletconnect-rs?rev=7078fd303cc521cceeed919e3d452f45eeb115e8#7078fd303cc521cceeed919e3d452f45eeb115e8"
+dependencies = [
+ "bs58 0.4.0",
+ "chrono",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek",
+ "enum-as-inner",
+ "hex",
+ "jsonwebtoken",
+ "once_cell",
+ "rand 0.8.6",
+ "regex",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "sha2 0.10.9",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7723,7 +7801,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "nanoid",
- "ordered-float",
+ "ordered-float 5.3.0",
  "pin-project-lite",
  "reqwest",
  "schemars 1.2.1",
@@ -7953,7 +8031,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8347,6 +8425,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-aux"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207f67b28fe90fb596503a9bf0bf1ea5e831e21307658e177c5dfcdfc3ab8a0a"
+dependencies = [
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8410,6 +8509,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8681,7 +8791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8984,7 +9094,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9397,6 +9507,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -9804,6 +9930,26 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -9847,7 +9993,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10806,7 +10952,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,12 @@ dependencies = [
 
 [[package]]
 name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
@@ -2024,6 +2030,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2261,6 +2268,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -4516,7 +4535,7 @@ dependencies = [
  "ironclaw_host_api",
  "ironclaw_llm",
  "ironclaw_safety",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "rand 0.10.1",
  "rand_core 0.6.4",
  "regex",
@@ -4893,12 +4912,15 @@ dependencies = [
  "ironclaw_signing_provider",
  "k256",
  "rand_core 0.6.4",
+ "relay_client",
+ "relay_rpc",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "sha3",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4955,7 +4977,7 @@ dependencies = [
  "ironclaw_reborn_openai_compat",
  "ironclaw_threads",
  "ironclaw_turns",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "lru",
  "parking_lot",
  "rand 0.10.1",
@@ -5153,6 +5175,21 @@ dependencies = [
  "serde_json",
  "unicode-general-category",
  "uuid-simd",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -5833,6 +5870,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -6695,6 +6741,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "relay_client"
+version = "0.1.0"
+source = "git+https://github.com/tracecommons/walletconnect-rs?rev=7078fd303cc521cceeed919e3d452f45eeb115e8#7078fd303cc521cceeed919e3d452f45eeb115e8"
+dependencies = [
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.2",
+ "pin-project",
+ "relay_rpc",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.27.0",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "relay_rpc"
+version = "0.1.0"
+source = "git+https://github.com/tracecommons/walletconnect-rs?rev=7078fd303cc521cceeed919e3d452f45eeb115e8#7078fd303cc521cceeed919e3d452f45eeb115e8"
+dependencies = [
+ "bs58 0.4.0",
+ "chrono",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek",
+ "enum-as-inner",
+ "hex",
+ "jsonwebtoken 9.3.1",
+ "once_cell",
+ "rand 0.8.6",
+ "regex",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "sha2 0.10.9",
+ "strum",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6820,7 +6914,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "nanoid",
- "ordered-float",
+ "ordered-float 5.3.0",
  "pin-project-lite",
  "reqwest 0.13.4",
  "schemars 1.2.1",
@@ -7327,6 +7421,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-aux"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207f67b28fe90fb596503a9bf0bf1ea5e831e21307658e177c5dfcdfc3ab8a0a"
+dependencies = [
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7406,6 +7521,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7444,7 +7570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
- "bs58",
+ "bs58 0.5.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -7729,6 +7855,28 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn 2.0.117",
 ]
 
@@ -8171,6 +8319,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.41",
+ "rustls-native-certs 0.8.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -8530,6 +8694,26 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "url",
  "utf-8",
 ]
 

--- a/crates/ironclaw_architecture/tests/attested_signing_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/attested_signing_boundaries.rs
@@ -137,14 +137,15 @@ fn attestation_crate_has_no_chain_secrets_or_webauthn_dependency() {
     );
 }
 
-/// The dependency names the external-wallet crate (PR7) must never carry. It
-/// implements the browser injected provider and holds NO key material, so it
-/// must not pull the heavy chain SDKs (`solana-sdk` / `near-primitives`) nor the
-/// key-custody crate (`ironclaw_secrets`) nor the chain-signing crate
-/// (`ironclaw_chain_signing`). It IS allowed `k256` / `ed25519-dalek` / `sha3` /
-/// `sha2` for signer recovery + ed25519 verification, plus
-/// `ironclaw_signing_provider` and `ironclaw_attestation` — so those are
-/// deliberately absent from this list.
+/// The dependency names the external-wallet crate (PR7 + PR9) must never carry.
+/// It implements the browser injected provider (PR7) and the WalletConnect v2
+/// provider (PR9) and holds NO key material, so it must not pull the heavy chain
+/// SDKs (`solana-sdk` / `near-primitives`) nor the key-custody crate
+/// (`ironclaw_secrets`) nor the chain-signing crate (`ironclaw_chain_signing`).
+/// It IS allowed `k256` / `ed25519-dalek` / `sha3` / `sha2` for signer recovery
+/// and ed25519 verification, the openssl-free WalletConnect relay fork
+/// (`relay_client` / `relay_rpc`, PR9), plus `ironclaw_signing_provider` and
+/// `ironclaw_attestation` — so those are deliberately absent from this list.
 const WALLET_EXTERNAL_FORBIDDEN_DEPENDENCY_PREFIXES: &[&str] = &[
     "solana-sdk",
     "solana-program",
@@ -188,12 +189,85 @@ fn wallet_external_crate_has_no_chain_sdk_secrets_or_chain_signing_dependency() 
 
     assert!(
         violations.is_empty(),
-        "ironclaw_wallet_external is the injected-wallet provider (PR7) and holds no key material; \
-         it must carry no chain SDK, secrets, or chain-signing dependency. Broadcasting the \
-         wallet-signed tx (ironclaw_chain_signing) is deferred to PR10. Forbidden dependencies \
+        "ironclaw_wallet_external is the external-wallet provider (PR7 + PR9) and holds no key \
+         material; it must carry no chain SDK, secrets, or chain-signing dependency. Broadcasting \
+         the wallet-signed tx (ironclaw_chain_signing) is deferred to PR10. Forbidden dependencies \
          found:\n{}\nSee docs/plans/2026-05-23-attested-signing-substrate.md.",
         violations.join("\n")
     );
+
+    // Positive assertion (PR9): the openssl-free WalletConnect relay fork IS a
+    // dependency of the external-wallet crate. This guards against the WC deps
+    // being silently dropped (which would make the provider unbuildable) and
+    // documents that `relay_client` / `relay_rpc` are the allowed transport.
+    let names: Vec<&str> = dependencies
+        .iter()
+        .filter_map(|d| d["name"].as_str())
+        .collect();
+    for expected in ["relay_client", "relay_rpc"] {
+        assert!(
+            names.contains(&expected),
+            "ironclaw_wallet_external (PR9) must depend on `{expected}` from the openssl-free \
+             WalletConnect fork (tracecommons/walletconnect-rs). Present dependencies: {names:?}"
+        );
+    }
+}
+
+/// The whole attested-signing substrate is deliberately openssl-free: every TLS
+/// path uses rustls/ring so the workspace carries no OpenSSL C dependency (no
+/// system-openssl build/runtime coupling, smaller attack surface, reproducible
+/// cross-compilation). PR9 adds the WalletConnect relay client via the
+/// openssl-free fork (`tracecommons/walletconnect-rs`, rustls default,
+/// `relay_rpc`'s `cacao` feature DISABLED — `cacao` pulls `alloy 0.3.6 → reqwest
+/// default-tls → openssl`). This test fails if anything in the workspace graph
+/// (re)introduces `openssl-sys`, against the Linux target where native-tls would
+/// otherwise resolve to openssl.
+///
+/// If this regresses after a dependency change, the fix is to disable the
+/// offending crate's openssl/native-tls feature and select rustls — NOT to
+/// silence this test.
+#[test]
+fn workspace_graph_is_openssl_free() {
+    // `cargo tree -i <pkg>` exits non-zero with "did not match any packages"
+    // when the package is absent from the graph — exactly the success case here.
+    let manifest_path = workspace_root().join("Cargo.toml");
+    let output = Command::new("cargo")
+        .args([
+            "tree",
+            "--workspace",
+            "-i",
+            "openssl-sys",
+            "--target",
+            "x86_64-unknown-linux-gnu",
+            "--manifest-path",
+        ])
+        .arg(&manifest_path)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run cargo tree: {error}"));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if output.status.success() {
+        // A zero exit with non-empty output means openssl-sys IS in the graph.
+        let listed = stdout.trim();
+        assert!(
+            listed.is_empty(),
+            "the attested-signing workspace must stay openssl-free, but `openssl-sys` is in the \
+             dependency graph (Linux target):\n{listed}\n\nThe likely culprit is a native-tls / \
+             default-tls feature — most often `relay_rpc`'s `cacao` (alloy → reqwest default-tls). \
+             Disable it and select rustls; do NOT silence this test. See \
+             docs/plans/2026-05-23-attested-signing-substrate.md."
+        );
+    } else {
+        // Non-zero exit: confirm it is the "no such package" case (openssl-sys
+        // absent = success), not a cargo invocation failure.
+        assert!(
+            stderr.contains("did not match any packages"),
+            "cargo tree failed unexpectedly while checking for openssl-sys:\nstdout: {stdout}\n\
+             stderr: {stderr}"
+        );
+    }
 }
 
 fn cargo_metadata() -> Value {

--- a/crates/ironclaw_wallet_external/Cargo.toml
+++ b/crates/ironclaw_wallet_external/Cargo.toml
@@ -35,6 +35,14 @@ ed25519-dalek = { version = "2.2.0", features = ["std"] }
 sha3 = "0.10"
 sha2 = "0.10"
 
+# WalletConnect v2 relay transport (PR9). The fork at
+# tracecommons/walletconnect-rs @ c6b528e defaults to rustls (openssl-free); we
+# take DEFAULT features for relay_client and DO NOT enable relay_rpc's `cacao`
+# feature (it pulls alloy 0.3.6 -> reqwest default-tls -> openssl). The
+# architecture boundary test `workspace_graph_is_openssl_free` enforces this.
+relay_client = { git = "https://github.com/tracecommons/walletconnect-rs", rev = "7078fd303cc521cceeed919e3d452f45eeb115e8", package = "relay_client" }
+relay_rpc = { git = "https://github.com/tracecommons/walletconnect-rs", rev = "7078fd303cc521cceeed919e3d452f45eeb115e8", package = "relay_rpc" }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 hex = "0.4"

--- a/crates/ironclaw_wallet_external/Cargo.toml
+++ b/crates/ironclaw_wallet_external/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 dist = false
 
 [dependencies]
+tracing = "0.1"
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -34,6 +35,14 @@ k256 = { version = "0.13", features = ["ecdsa"] }
 ed25519-dalek = { version = "2.2.0", features = ["std"] }
 sha3 = "0.10"
 sha2 = "0.10"
+
+# WalletConnect v2 relay transport (PR9). The fork at
+# tracecommons/walletconnect-rs @ c6b528e defaults to rustls (openssl-free); we
+# take DEFAULT features for relay_client and DO NOT enable relay_rpc's `cacao`
+# feature (it pulls alloy 0.3.6 -> reqwest default-tls -> openssl). The
+# architecture boundary test `workspace_graph_is_openssl_free` enforces this.
+relay_client = { git = "https://github.com/tracecommons/walletconnect-rs", rev = "7078fd303cc521cceeed919e3d452f45eeb115e8", package = "relay_client" }
+relay_rpc = { git = "https://github.com/tracecommons/walletconnect-rs", rev = "7078fd303cc521cceeed919e3d452f45eeb115e8", package = "relay_rpc" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/ironclaw_wallet_external/src/lib.rs
+++ b/crates/ironclaw_wallet_external/src/lib.rs
@@ -56,8 +56,14 @@
 #![forbid(unsafe_code)]
 
 mod injected;
+mod walletconnect;
 
 pub use injected::{
     InjectedProofPayload, InjectedScheme, InjectedSigningProvider, decode_injected_proof,
     encode_injected_proof,
+};
+pub use walletconnect::{
+    Caip2ChainId, Caip10Account, ChainFamily, PinnedScope, ProjectId, ProposedScope,
+    SessionBinding, SessionBindingStore, WalletConnectProofPayload, WalletConnectSigningProvider,
+    decode_walletconnect_proof, encode_walletconnect_proof, enforce_pinned_scope,
 };

--- a/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
@@ -1,0 +1,352 @@
+//! The WalletConnect v2 [`SigningProvider`] backend (attested-signing PR9).
+//!
+//! [`WalletConnectSigningProvider`] bridges a WalletConnect v2 session — driven
+//! over the openssl-free `relay_client` fork — to the attested-signing gate. It
+//! reports [`ProviderId::WalletConnect`] and [`TrustModel::ExternalWallet`] and
+//! holds **no key material**: the user's wallet renders + signs natively (true
+//! WYSIWYS). It is configured with a WalletConnect Cloud [`ProjectId`]
+//! (publishable, API-key class — injected, never hardcoded).
+//!
+//! ## Two security cores
+//!
+//! 1. **Namespace pinning** ([`namespace`]). The gate has decided exactly one
+//!    chain + one signing operation; a WC session can negotiate far broader
+//!    scope. [`PinnedScope`] derives the single CAIP-2 chain + single signing
+//!    method the gate authorizes, and every proposed/settled session scope is
+//!    checked equal to it — any superset is a [`SigningProviderError::ScopeViolation`]
+//!    (threats T17/T19).
+//! 2. **Proof verification** ([`Self::verify_resume`]). Fail-closed, in order:
+//!    pinned-scope match, hash binding (T20, both proof and recorded binding),
+//!    session + nonce binding (T18), account binding, **real signed-transaction
+//!    binding** (the proof's `signed_payload` — the exact bytes the wallet's
+//!    chain signature covers — must equal the `expected_signing_payload`
+//!    recorded at initiate from the same decoded tx), signer binding over that
+//!    real signature (T17, [`SignerMismatch`](SigningProviderError::SignerMismatch)),
+//!    then the one-shot sealed-grant CAS (T20,
+//!    [`GrantClaimFailed`](SigningProviderError::GrantClaimFailed)). The recorded
+//!    binding is consumed only on full success. Only then is a [`VerifiedProof`]
+//!    returned. A signature over a synthetic digest is never accepted.
+//!
+//! ## Scope boundary (PR9 vs PR10)
+//!
+//! PR9 implements the provider, the namespace pinning, and the full proof
+//! verification against a recorded session binding. The encrypted CAIP-25 Sign
+//! envelope round-trip over the relay (publishing the pairing proposal,
+//! subscribing for the wallet's response, decrypting the signed payload) and the
+//! verified-proof → gate handoff + broadcast are composition owned by PR10 and
+//! are marked `// PR10:`. The fork's `relay_client` provides relay transport but
+//! not the higher-level v2 Sign session layer, so the live round-trip is stubbed
+//! at the verified-proof boundary rather than reimplemented here.
+
+mod namespace;
+mod proof;
+mod session;
+mod signer;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use ironclaw_attestation::{GrantError, GrantKey, SealedGrantStore};
+use ironclaw_signing_provider::{
+    ApprovedTxHash, DecodedTransaction, InitiationOutcome, ProviderId, RenderedTx, SigningContext,
+    SigningProof, SigningProvider, SigningProviderError, TrustModel, VerifiedProof,
+};
+
+// Re-export the publishable relay-side ProjectId newtype from the fork so
+// callers configure the provider with the SDK's own type (no parallel newtype).
+pub use relay_rpc::domain::ProjectId;
+
+pub use namespace::{
+    Caip2ChainId, Caip10Account, ChainFamily, PinnedScope, ProposedScope, enforce_pinned_scope,
+};
+pub use proof::{
+    WalletConnectProofPayload, decode_walletconnect_proof, encode_walletconnect_proof,
+};
+pub use session::{SessionBinding, SessionBindingStore};
+
+/// The WalletConnect v2 signing backend.
+///
+/// Holds the injected [`ProjectId`], a sealed-grant store (for the one-shot CAS
+/// at verify time), and the per-gate [`SessionBindingStore`]. Holds **no key
+/// material**.
+pub struct WalletConnectSigningProvider {
+    project_id: ProjectId,
+    grants: Arc<dyn SealedGrantStore>,
+    bindings: Arc<SessionBindingStore>,
+}
+
+impl WalletConnectSigningProvider {
+    /// Construct over an injected [`ProjectId`] and a sealed-grant store.
+    ///
+    /// The `ProjectId` is a publishable WalletConnect Cloud API key sourced from
+    /// configuration / `ironclaw_secrets` by the composition layer (PR10) — it
+    /// is never hardcoded. Different tenants may inject different project ids;
+    /// this provider treats it as opaque per-instance config.
+    pub fn new(project_id: ProjectId, grants: Arc<dyn SealedGrantStore>) -> Self {
+        Self {
+            project_id,
+            grants,
+            bindings: Arc::new(SessionBindingStore::new()),
+        }
+    }
+
+    /// The WalletConnect Cloud project id this provider is configured with.
+    pub fn project_id(&self) -> &ProjectId {
+        &self.project_id
+    }
+
+    /// Record an expected session binding for a gate.
+    ///
+    /// In production this is populated by `initiate` once the WC session settles
+    /// over the relay (PR10 wires the live settlement). Exposed so the
+    /// composition layer — and tests — can install the binding the eventual
+    /// proof must match.
+    pub fn record_session_binding(
+        &self,
+        gate: &ironclaw_signing_provider::GateRef,
+        binding: SessionBinding,
+    ) {
+        self.bindings.record(gate, binding);
+    }
+}
+
+#[async_trait]
+impl SigningProvider for WalletConnectSigningProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::WalletConnect
+    }
+
+    fn trust_model(&self) -> TrustModel {
+        TrustModel::ExternalWallet
+    }
+
+    async fn initiate(
+        &self,
+        context: &SigningContext,
+        _decoded: &DecodedTransaction,
+        _rendered: &RenderedTx,
+        _approved_tx_hash: &ApprovedTxHash,
+    ) -> Result<InitiationOutcome, SigningProviderError> {
+        // Pin the single chain + single signing method the gate authorizes.
+        // Resolving this here — before any relay traffic — means a session can
+        // only ever be proposed at the pinned scope (T17/T19). An unsupported or
+        // malformed chain id fails closed as a ScopeViolation.
+        let pinned = PinnedScope::from_chain_id(&context.chain_id)?;
+
+        // PR10: establish the WC v2 session over the forked `relay_client`:
+        // build a pairing URI for the configured ProjectId, publish the CAIP-25
+        // session proposal pinned to `pinned.caip2_chain` + `pinned.method`,
+        // subscribe for the wallet's settlement, enforce `enforce_pinned_scope`
+        // against the SETTLED namespaces + accounts, mint a per-request nonce,
+        // derive `expected_signing_payload` from the decoded tx via the real
+        // chain encoder (the EVM EIP-2718/RLP secp256k1 sighash / the Solana
+        // message bytes — PR10/PR11; not present in this crate), and
+        // `record_session_binding(gate, SessionBinding { session_topic, account,
+        // nonce, pinned, approved_tx_hash, expected_signing_payload })`. The
+        // encrypted Sign envelope layer is not exposed by the relay_client fork,
+        // so the live round-trip is deferred to PR10. The pinned method that
+        // would be requested is `pinned.method` (e.g. eth_signTransaction /
+        // solana_signTransaction) — sign-only; broadcast is PR10.
+        let _ = (&self.project_id, pinned);
+
+        // Until PR10 wires the live pairing, signal that the ceremony proceeds
+        // out of band (the directive bytes a real session would carry — the
+        // pairing URI — are a PR10 concern).
+        Ok(InitiationOutcome::AwaitingUserAction {
+            // PR10: replace with the real WalletConnect pairing URI bytes.
+            directive: Vec::new(),
+        })
+    }
+
+    async fn verify_resume(
+        &self,
+        context: &SigningContext,
+        approved_tx_hash: &ApprovedTxHash,
+        proof: &SigningProof,
+    ) -> Result<VerifiedProof, SigningProviderError> {
+        // Only WalletConnect proofs are accepted; anything else is a routing
+        // error and fails closed.
+        let SigningProof::WalletConnectProof(bytes) = proof else {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "walletconnect provider received a non-walletconnect proof".to_string(),
+            });
+        };
+        let payload = decode_walletconnect_proof(bytes)?;
+
+        // Re-derive the pinned scope from the gate's bound chain id. A malformed
+        // / unsupported chain id fails closed (ScopeViolation) before any crypto.
+        let pinned = PinnedScope::from_chain_id(&context.chain_id)?;
+
+        // The session binding recorded at initiate. PEEKED (not yet consumed):
+        // all hash/signature validation runs against this recorded expectation
+        // first, so a malformed relay/wallet response cannot burn the binding.
+        // It is consumed (taken) only on the success path, after the one-shot
+        // grant is claimed.
+        let binding =
+            self.bindings
+                .peek(&context.gate_ref)
+                .ok_or(SigningProviderError::ProofInvalid {
+                    reason: "no recorded walletconnect session binding for this gate".to_string(),
+                })?;
+
+        // The recorded binding's pinned scope must match the gate's bound scope
+        // (defense in depth against a binding recorded under a different chain).
+        if binding.pinned != pinned {
+            return Err(SigningProviderError::ScopeViolation {
+                reason: "recorded session binding scope does not match the gate's pinned scope"
+                    .to_string(),
+            });
+        }
+
+        // 1. Hash binding (T20). The wallet's proof must carry the exact bound
+        //    hash, AND the binding recorded at initiate must have been recorded
+        //    for that same hash — neither the proof nor the binding may smuggle
+        //    a different approval.
+        if &payload.approved_tx_hash != approved_tx_hash {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof approved-tx hash does not match the bound hash".to_string(),
+            });
+        }
+        if &binding.approved_tx_hash != approved_tx_hash {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "recorded session binding hash does not match the bound hash".to_string(),
+            });
+        }
+
+        // 2. Session + nonce binding (T18): the proof must belong to the recorded
+        //    session and carry the recorded nonce. A proof minted under a
+        //    different WC session / relay key, or replayed with a stale/forged
+        //    nonce, is rejected here. This is an ADDITIONAL anti-replay layer on
+        //    top of the real chain-signature check below, not a replacement.
+        if payload.session_topic != binding.session_topic {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof session topic does not match the recorded session binding"
+                    .to_string(),
+            });
+        }
+        if payload.nonce != binding.nonce {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof nonce does not match the recorded session binding".to_string(),
+            });
+        }
+
+        // The session-bound account must equal the gate's bound account — the WC
+        // session settled on the same account the grant is bound to. Compared
+        // case-insensitively: EVM addresses are case-insensitive hex (and may be
+        // EIP-55 mixed-case as returned by the wallet/relay) and the ed25519 key
+        // accounts are hex; the authoritative signer binding is the byte-exact
+        // chain-signature check in `verify_chain_signature` below, which this
+        // string compare only guards as defense in depth.
+        let bound_account = context.key_or_account_id.as_str();
+        if !binding.account.eq_ignore_ascii_case(bound_account) {
+            return Err(SigningProviderError::SignerMismatch);
+        }
+
+        // 3. Real signed-transaction binding (#1, T20). The proof carries the
+        //    EXACT bytes the wallet's chain signature covers (`signed_payload` —
+        //    the EVM secp256k1 sighash / the Solana ed25519 message returned by
+        //    eth_signTransaction / solana_signTransaction). Bind those bytes back
+        //    to what the human approved by requiring them to equal the
+        //    `expected_signing_payload` recorded at initiate from the SAME
+        //    decoded transaction that produced `approved_tx_hash`. A wallet that
+        //    signed *different* bytes than the approved transaction is rejected
+        //    here — the synthetic-digest acceptance is gone.
+        if payload.signed_payload != binding.expected_signing_payload {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof signed payload does not match the approved transaction bytes"
+                    .to_string(),
+            });
+        }
+
+        // 4. Signer binding (T17): verify the wallet's REAL chain signature over
+        //    `signed_payload` and require the recovered/verified signer to equal
+        //    the bound account.
+        signer::verify_chain_signature(
+            pinned.family,
+            &payload.signed_payload,
+            &payload.signature,
+            payload.public_key.as_deref(),
+            bound_account,
+        )?;
+
+        // 5. One-shot grant (T20): claim the sealed grant atomically. A replay of
+        //    an already-claimed grant fails closed here.
+        let key = GrantKey::from_context(context, *approved_tx_hash);
+        self.grants.claim(&key).await.map_err(map_grant_error)?;
+
+        // Consume the binding only now that every check (incl. the durable grant
+        // CAS) has passed — a malformed earlier response never burned it.
+        let _ = self.bindings.take(&context.gate_ref);
+
+        // PR10: hand the verified proof back to the gate / runner for the
+        // deterministic post-approval continuation (broadcast via
+        // ironclaw_chain_signing). PR9 stops at the verified-proof boundary.
+        Ok(VerifiedProof::new(proof.clone()))
+    }
+}
+
+/// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
+fn map_grant_error(err: GrantError) -> SigningProviderError {
+    match err {
+        GrantError::AlreadyClaimed | GrantError::NotFound | GrantError::AlreadySealed => {
+            SigningProviderError::GrantClaimFailed
+        }
+        GrantError::Backend { reason } => SigningProviderError::Provider { reason },
+    }
+}
+
+/// Hex (de)serialization helpers shared by the proof payload fields.
+pub(crate) mod hex_bytes {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(crate) fn serialize<S: Serializer>(bytes: &[u8], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&hex_encode(bytes))
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(d)?;
+        hex_decode(&s).map_err(serde::de::Error::custom)
+    }
+
+    pub(crate) fn hex_encode(bytes: &[u8]) -> String {
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            out.push(char::from_digit((b >> 4) as u32, 16).unwrap_or('0'));
+            out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap_or('0'));
+        }
+        out
+    }
+
+    /// Decode `0x`-prefixed hex into bytes, panic-free on any input.
+    ///
+    /// Operates on **bytes**, never on `&str` byte-offset slices: a non-ASCII
+    /// even-byte input would make byte-offset slicing land on an invalid UTF-8
+    /// boundary and panic. Non-ASCII / non-hex bytes are rejected as
+    /// `ProofInvalid`-grade errors so relay/wallet-supplied hex fails closed
+    /// (#3).
+    pub(crate) fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let bytes = s.as_bytes();
+        if !bytes.len().is_multiple_of(2) {
+            return Err("odd-length hex".to_string());
+        }
+        let mut out = Vec::with_capacity(bytes.len() / 2);
+        for chunk in bytes.chunks_exact(2) {
+            let hi = nibble(chunk[0])?;
+            let lo = nibble(chunk[1])?;
+            out.push((hi << 4) | lo);
+        }
+        Ok(out)
+    }
+
+    /// Map a single ASCII hex digit byte to its nibble value.
+    fn nibble(b: u8) -> Result<u8, String> {
+        match b {
+            b'0'..=b'9' => Ok(b - b'0'),
+            b'a'..=b'f' => Ok(b - b'a' + 10),
+            b'A'..=b'F' => Ok(b - b'A' + 10),
+            other => Err(format!("invalid hex byte 0x{other:02x}")),
+        }
+    }
+}

--- a/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
@@ -1,0 +1,358 @@
+//! The WalletConnect v2 [`SigningProvider`] backend (attested-signing PR9).
+//!
+//! [`WalletConnectSigningProvider`] bridges a WalletConnect v2 session — driven
+//! over the openssl-free `relay_client` fork — to the attested-signing gate. It
+//! reports [`ProviderId::WalletConnect`] and [`TrustModel::ExternalWallet`] and
+//! holds **no key material**: the user's wallet renders + signs natively (true
+//! WYSIWYS). It is configured with a WalletConnect Cloud [`ProjectId`]
+//! (publishable, API-key class — injected, never hardcoded).
+//!
+//! ## Two security cores
+//!
+//! 1. **Namespace pinning** ([`namespace`]). The gate has decided exactly one
+//!    chain + one signing operation; a WC session can negotiate far broader
+//!    scope. [`PinnedScope`] derives the single CAIP-2 chain + single signing
+//!    method the gate authorizes, and every proposed/settled session scope is
+//!    checked equal to it — any superset is a [`SigningProviderError::ScopeViolation`]
+//!    (threats T17/T19).
+//! 2. **Proof verification** ([`Self::verify_resume`]). Fail-closed, in order:
+//!    pinned-scope match, hash binding (T20, both proof and recorded binding),
+//!    session + nonce binding (T18), account binding, **real signed-transaction
+//!    binding** (the proof's `signed_payload` — the exact bytes the wallet's
+//!    chain signature covers — must equal the `expected_signing_payload`
+//!    recorded at initiate from the same decoded tx), signer binding over that
+//!    real signature (T17, [`SignerMismatch`](SigningProviderError::SignerMismatch)),
+//!    then the one-shot sealed-grant CAS (T20,
+//!    [`GrantClaimFailed`](SigningProviderError::GrantClaimFailed)). The recorded
+//!    binding is consumed only on full success. Only then is a [`VerifiedProof`]
+//!    returned. A signature over a synthetic digest is never accepted.
+//!
+//! ## Scope boundary (PR9 vs PR10)
+//!
+//! PR9 implements the provider, the namespace pinning, and the full proof
+//! verification against a recorded session binding. The encrypted CAIP-25 Sign
+//! envelope round-trip over the relay (publishing the pairing proposal,
+//! subscribing for the wallet's response, decrypting the signed payload) and the
+//! verified-proof → gate handoff + broadcast are composition owned by PR10 and
+//! are marked `// PR10:`. The fork's `relay_client` provides relay transport but
+//! not the higher-level v2 Sign session layer, so the live round-trip is stubbed
+//! at the verified-proof boundary rather than reimplemented here.
+
+mod namespace;
+mod proof;
+mod session;
+mod signer;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use ironclaw_attestation::{GrantError, GrantKey, SealedGrantStore};
+use ironclaw_signing_provider::{
+    ApprovedTxHash, DecodedTransaction, InitiationOutcome, ProviderId, RenderedTx, SigningContext,
+    SigningProof, SigningProvider, SigningProviderError, TrustModel, VerifiedProof,
+};
+
+// Re-export the publishable relay-side ProjectId newtype from the fork so
+// callers configure the provider with the SDK's own type (no parallel newtype).
+pub use relay_rpc::domain::ProjectId;
+
+pub use namespace::{
+    Caip2ChainId, Caip10Account, ChainFamily, PinnedScope, ProposedScope, enforce_pinned_scope,
+};
+pub use proof::{
+    WalletConnectProofPayload, decode_walletconnect_proof, encode_walletconnect_proof,
+};
+pub use session::{SessionBinding, SessionBindingStore};
+
+/// The WalletConnect v2 signing backend.
+///
+/// Holds the injected [`ProjectId`], a sealed-grant store (for the one-shot CAS
+/// at verify time), and the per-gate [`SessionBindingStore`]. Holds **no key
+/// material**.
+pub struct WalletConnectSigningProvider {
+    project_id: ProjectId,
+    grants: Arc<dyn SealedGrantStore>,
+    bindings: Arc<SessionBindingStore>,
+}
+
+impl WalletConnectSigningProvider {
+    /// Construct over an injected [`ProjectId`] and a sealed-grant store.
+    ///
+    /// The `ProjectId` is a publishable WalletConnect Cloud API key sourced from
+    /// configuration / `ironclaw_secrets` by the composition layer (PR10) — it
+    /// is never hardcoded. Different tenants may inject different project ids;
+    /// this provider treats it as opaque per-instance config.
+    pub fn new(project_id: ProjectId, grants: Arc<dyn SealedGrantStore>) -> Self {
+        Self {
+            project_id,
+            grants,
+            bindings: Arc::new(SessionBindingStore::new()),
+        }
+    }
+
+    /// The WalletConnect Cloud project id this provider is configured with.
+    pub fn project_id(&self) -> &ProjectId {
+        &self.project_id
+    }
+
+    /// Record an expected session binding for a gate.
+    ///
+    /// In production this is populated by `initiate` once the WC session settles
+    /// over the relay (PR10 wires the live settlement). Exposed so the
+    /// composition layer — and tests — can install the binding the eventual
+    /// proof must match.
+    pub fn record_session_binding(
+        &self,
+        gate: &ironclaw_signing_provider::GateRef,
+        binding: SessionBinding,
+    ) {
+        self.bindings.record(gate, binding);
+    }
+}
+
+#[async_trait]
+impl SigningProvider for WalletConnectSigningProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::WalletConnect
+    }
+
+    fn trust_model(&self) -> TrustModel {
+        TrustModel::ExternalWallet
+    }
+
+    async fn initiate(
+        &self,
+        context: &SigningContext,
+        _decoded: &DecodedTransaction,
+        _rendered: &RenderedTx,
+        _approved_tx_hash: &ApprovedTxHash,
+    ) -> Result<InitiationOutcome, SigningProviderError> {
+        // Pin the single chain + single signing method the gate authorizes.
+        // Resolving this here — before any relay traffic — means a session can
+        // only ever be proposed at the pinned scope (T17/T19). An unsupported or
+        // malformed chain id fails closed as a ScopeViolation.
+        let pinned = PinnedScope::from_chain_id(&context.chain_id)?;
+
+        // PR10: establish the WC v2 session over the forked `relay_client`:
+        // build a pairing URI for the configured ProjectId, publish the CAIP-25
+        // session proposal pinned to `pinned.caip2_chain` + `pinned.method`,
+        // subscribe for the wallet's settlement, enforce `enforce_pinned_scope`
+        // against the SETTLED namespaces + accounts, mint a per-request nonce,
+        // derive `expected_signing_payload` from the decoded tx via the real
+        // chain encoder (the EVM EIP-2718/RLP secp256k1 sighash / the Solana
+        // message bytes — PR10/PR11; not present in this crate), and
+        // `record_session_binding(gate, SessionBinding { session_topic, account,
+        // nonce, pinned, approved_tx_hash, expected_signing_payload })`. The
+        // encrypted Sign envelope layer is not exposed by the relay_client fork,
+        // so the live round-trip is deferred to PR10. The pinned method that
+        // would be requested is `pinned.method` (e.g. eth_signTransaction /
+        // solana_signTransaction) — sign-only; broadcast is PR10.
+        let _ = (&self.project_id, pinned);
+
+        // Until PR10 wires the live pairing, signal that the ceremony proceeds
+        // out of band (the directive bytes a real session would carry — the
+        // pairing URI — are a PR10 concern).
+        Ok(InitiationOutcome::AwaitingUserAction {
+            // PR10: replace with the real WalletConnect pairing URI bytes.
+            directive: Vec::new(),
+        })
+    }
+
+    async fn verify_resume(
+        &self,
+        context: &SigningContext,
+        approved_tx_hash: &ApprovedTxHash,
+        proof: &SigningProof,
+    ) -> Result<VerifiedProof, SigningProviderError> {
+        // Only WalletConnect proofs are accepted; anything else is a routing
+        // error and fails closed.
+        let SigningProof::WalletConnectProof(bytes) = proof else {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "walletconnect provider received a non-walletconnect proof".to_string(),
+            });
+        };
+        let payload = decode_walletconnect_proof(bytes)?;
+
+        // Re-derive the pinned scope from the gate's bound chain id. A malformed
+        // / unsupported chain id fails closed (ScopeViolation) before any crypto.
+        let pinned = PinnedScope::from_chain_id(&context.chain_id)?;
+
+        // The session binding recorded at initiate. PEEKED (not yet consumed):
+        // all hash/signature validation runs against this recorded expectation
+        // first, so a malformed relay/wallet response cannot burn the binding.
+        // It is consumed (taken) only on the success path, after the one-shot
+        // grant is claimed.
+        let binding =
+            self.bindings
+                .peek(&context.gate_ref)
+                .ok_or(SigningProviderError::ProofInvalid {
+                    reason: "no recorded walletconnect session binding for this gate".to_string(),
+                })?;
+
+        // The recorded binding's pinned scope must match the gate's bound scope
+        // (defense in depth against a binding recorded under a different chain).
+        if binding.pinned != pinned {
+            return Err(SigningProviderError::ScopeViolation {
+                reason: "recorded session binding scope does not match the gate's pinned scope"
+                    .to_string(),
+            });
+        }
+
+        // 1. Hash binding (T20). The wallet's proof must carry the exact bound
+        //    hash, AND the binding recorded at initiate must have been recorded
+        //    for that same hash — neither the proof nor the binding may smuggle
+        //    a different approval.
+        if &payload.approved_tx_hash != approved_tx_hash {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof approved-tx hash does not match the bound hash".to_string(),
+            });
+        }
+        if &binding.approved_tx_hash != approved_tx_hash {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "recorded session binding hash does not match the bound hash".to_string(),
+            });
+        }
+
+        // 2. Session + nonce binding (T18): the proof must belong to the recorded
+        //    session and carry the recorded nonce. A proof minted under a
+        //    different WC session / relay key, or replayed with a stale/forged
+        //    nonce, is rejected here. This is an ADDITIONAL anti-replay layer on
+        //    top of the real chain-signature check below, not a replacement.
+        if payload.session_topic != binding.session_topic {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof session topic does not match the recorded session binding"
+                    .to_string(),
+            });
+        }
+        if payload.nonce != binding.nonce {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof nonce does not match the recorded session binding".to_string(),
+            });
+        }
+
+        // The session-bound account must equal the gate's bound account — the WC
+        // session settled on the same account the grant is bound to. Compared
+        // case-insensitively: EVM addresses are case-insensitive hex (and may be
+        // EIP-55 mixed-case as returned by the wallet/relay) and the ed25519 key
+        // accounts are hex; the authoritative signer binding is the byte-exact
+        // chain-signature check in `verify_chain_signature` below, which this
+        // string compare only guards as defense in depth.
+        let bound_account = context.key_or_account_id.as_str();
+        if !binding.account.eq_ignore_ascii_case(bound_account) {
+            return Err(SigningProviderError::SignerMismatch);
+        }
+
+        // 3. Real signed-transaction binding (#1, T20). The proof carries the
+        //    EXACT bytes the wallet's chain signature covers (`signed_payload` —
+        //    the EVM secp256k1 sighash / the Solana ed25519 message returned by
+        //    eth_signTransaction / solana_signTransaction). Bind those bytes back
+        //    to what the human approved by requiring them to equal the
+        //    `expected_signing_payload` recorded at initiate from the SAME
+        //    decoded transaction that produced `approved_tx_hash`. A wallet that
+        //    signed *different* bytes than the approved transaction is rejected
+        //    here — the synthetic-digest acceptance is gone.
+        if payload.signed_payload != binding.expected_signing_payload {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: "proof signed payload does not match the approved transaction bytes"
+                    .to_string(),
+            });
+        }
+
+        // 4. Signer binding (T17): verify the wallet's REAL chain signature over
+        //    `signed_payload` and require the recovered/verified signer to equal
+        //    the bound account.
+        signer::verify_chain_signature(
+            pinned.family,
+            &payload.signed_payload,
+            &payload.signature,
+            payload.public_key.as_deref(),
+            bound_account,
+        )?;
+
+        // 5. One-shot grant (T20): claim the sealed grant atomically. A replay of
+        //    an already-claimed grant fails closed here.
+        let key = GrantKey::from_context(context, *approved_tx_hash);
+        self.grants.claim(&key).await.map_err(map_grant_error)?;
+
+        // Consume the binding only now that every check (incl. the durable grant
+        // CAS) has passed — a malformed earlier response never burned it.
+        let _ = self.bindings.take(&context.gate_ref);
+
+        // PR10: hand the verified proof back to the gate / runner for the
+        // deterministic post-approval continuation (broadcast via
+        // ironclaw_chain_signing). PR9 stops at the verified-proof boundary.
+        Ok(VerifiedProof::new(
+            ProviderId::WalletConnect,
+            *approved_tx_hash,
+            proof.clone(),
+        ))
+    }
+}
+
+/// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
+fn map_grant_error(err: GrantError) -> SigningProviderError {
+    match err {
+        GrantError::AlreadyClaimed
+        | GrantError::NotFound
+        | GrantError::AlreadySealed
+        | GrantError::InvalidTimestamp { .. }
+        | GrantError::InvalidExpiry { .. } => SigningProviderError::GrantClaimFailed,
+        GrantError::Backend { reason } => SigningProviderError::Provider { reason },
+    }
+}
+
+/// Hex (de)serialization helpers shared by the proof payload fields.
+pub(crate) mod hex_bytes {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(crate) fn serialize<S: Serializer>(bytes: &[u8], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&hex_encode(bytes))
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(d)?;
+        hex_decode(&s).map_err(serde::de::Error::custom)
+    }
+
+    pub(crate) fn hex_encode(bytes: &[u8]) -> String {
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            out.push(char::from_digit((b >> 4) as u32, 16).unwrap_or('0'));
+            out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap_or('0'));
+        }
+        out
+    }
+
+    /// Decode `0x`-prefixed hex into bytes, panic-free on any input.
+    ///
+    /// Operates on **bytes**, never on `&str` byte-offset slices: a non-ASCII
+    /// even-byte input would make byte-offset slicing land on an invalid UTF-8
+    /// boundary and panic. Non-ASCII / non-hex bytes are rejected as
+    /// `ProofInvalid`-grade errors so relay/wallet-supplied hex fails closed
+    /// (#3).
+    pub(crate) fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let bytes = s.as_bytes();
+        if !bytes.len().is_multiple_of(2) {
+            return Err("odd-length hex".to_string());
+        }
+        let mut out = Vec::with_capacity(bytes.len() / 2);
+        for chunk in bytes.chunks_exact(2) {
+            let hi = nibble(chunk[0])?;
+            let lo = nibble(chunk[1])?;
+            out.push((hi << 4) | lo);
+        }
+        Ok(out)
+    }
+
+    /// Map a single ASCII hex digit byte to its nibble value.
+    fn nibble(b: u8) -> Result<u8, String> {
+        match b {
+            b'0'..=b'9' => Ok(b - b'0'),
+            b'a'..=b'f' => Ok(b - b'a' + 10),
+            b'A'..=b'F' => Ok(b - b'A' + 10),
+            other => Err(format!("invalid hex byte 0x{other:02x}")),
+        }
+    }
+}

--- a/crates/ironclaw_wallet_external/src/walletconnect/namespace.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/namespace.rs
@@ -1,0 +1,477 @@
+//! CAIP-2 chain-family resolution and WalletConnect v2 session-namespace
+//! pinning.
+//!
+//! The attested-signing gate has *already* decided exactly one chain
+//! ([`SigningContext::chain_id`](ironclaw_signing_provider::SigningContext)) and
+//! exactly one signing operation. A WalletConnect v2 session, by contrast,
+//! negotiates an arbitrarily-broad set of CAIP-2 chains, RPC methods, and events
+//! between dapp and wallet. If we let the wallet (or a compromised relay) settle
+//! a session whose scope is broader than the gate's single bound operation, a
+//! later request could sign a *different* chain or call a *different* method
+//! than the human approved — threats **T17** (chain/method scope broadening) and
+//! **T19** (multi-chain session reuse).
+//!
+//! This module derives the *single* CAIP-2 chain + *single* signing method the
+//! gate authorizes, and validates any proposed/settled session scope against it,
+//! rejecting fail-closed with
+//! [`SigningProviderError::ScopeViolation`](ironclaw_signing_provider::SigningProviderError::ScopeViolation)
+//! on any superset.
+
+use ironclaw_signing_provider::{ChainId, SigningProviderError};
+
+/// A parsed CAIP-2 chain id (`namespace:reference`).
+///
+/// Parsed via a real CAIP-2 grammar check (not a bare `split_once`): exactly one
+/// `:`, a non-empty `[-a-z0-9]{3,8}` namespace, and a non-empty
+/// `[-_a-zA-Z0-9]{1,32}` reference. Anything else is rejected fail-closed so a
+/// malformed/relay-supplied chain id can never be coerced into a family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Caip2ChainId {
+    /// The full `namespace:reference` string.
+    full: String,
+    /// Byte length of the namespace (the part before the single `:`).
+    ns_len: usize,
+}
+
+impl Caip2ChainId {
+    /// Parse and validate a CAIP-2 chain id.
+    pub fn parse(s: &str) -> Result<Self, SigningProviderError> {
+        let viol = |reason: String| SigningProviderError::ScopeViolation { reason };
+        let (ns, reference) = s.split_once(':').ok_or_else(|| {
+            viol(format!(
+                "chain id `{s}` is not a CAIP-2 `namespace:reference`"
+            ))
+        })?;
+        // Reject a second `:` (a bare split_once would silently accept it).
+        if reference.contains(':') {
+            return Err(viol(format!("chain id `{s}` has more than one `:`")));
+        }
+        if !(3..=8).contains(&ns.len())
+            || !ns
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        {
+            return Err(viol(format!(
+                "chain id `{s}` has an invalid CAIP-2 namespace"
+            )));
+        }
+        if !(1..=32).contains(&reference.len())
+            || !reference
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        {
+            return Err(viol(format!(
+                "chain id `{s}` has an invalid CAIP-2 reference"
+            )));
+        }
+        Ok(Self {
+            full: s.to_string(),
+            ns_len: ns.len(),
+        })
+    }
+
+    /// The CAIP-2 namespace (the part before the `:`), e.g. `eip155`.
+    pub fn namespace(&self) -> &str {
+        &self.full[..self.ns_len]
+    }
+
+    /// The full `namespace:reference` string.
+    pub fn as_str(&self) -> &str {
+        &self.full
+    }
+}
+
+/// A parsed CAIP-10 account id (`namespace:reference:address` =
+/// `caip2_chain:address`).
+///
+/// Binds an account to the EXACT chain it lives on. Parsing settled accounts as
+/// typed CAIP-10 (rather than treating them as raw strings) lets the verifier
+/// prove the WC account is `eip155:1:<addr>` and not the same address on another
+/// chain (#2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Caip10Account {
+    /// The CAIP-2 chain id the account lives on.
+    chain: Caip2ChainId,
+    /// The account address component (chain-specific; normalized only for the
+    /// signer comparison, not here).
+    address: String,
+}
+
+impl Caip10Account {
+    /// Parse and validate a CAIP-10 account id `caip2_chain:address`.
+    pub fn parse(s: &str) -> Result<Self, SigningProviderError> {
+        let viol = |reason: String| SigningProviderError::ScopeViolation { reason };
+        // CAIP-10 = `namespace:reference:account_address`. Split off the address
+        // (last `:` segment); the remainder must be a valid CAIP-2 chain id.
+        let (chain_part, address) = s
+            .rsplit_once(':')
+            .ok_or_else(|| viol(format!("account `{s}` is not a CAIP-10 `chain:address`")))?;
+        if address.is_empty() {
+            return Err(viol(format!(
+                "account `{s}` has an empty address component"
+            )));
+        }
+        let chain = Caip2ChainId::parse(chain_part)?;
+        Ok(Self {
+            chain,
+            address: address.to_string(),
+        })
+    }
+
+    /// The CAIP-2 chain id this account is pinned to.
+    pub fn chain_id(&self) -> &Caip2ChainId {
+        &self.chain
+    }
+
+    /// The address component (chain-specific; normalize for signer comparison).
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+}
+
+/// The wallet/crypto family a CAIP-2 chain id belongs to.
+///
+/// Determines which signing RPC method and which signer-recovery scheme apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainFamily {
+    /// EVM chains (`eip155:*`). Signs via `eth_signTransaction`; signer
+    /// recovered via secp256k1 ecrecover.
+    Evm,
+    /// Solana clusters (`solana:*`). Signs via `solana_signTransaction`; signer
+    /// is the connected ed25519 account.
+    Solana,
+}
+
+impl ChainFamily {
+    /// The single WalletConnect v2 RPC method this family uses to *sign* the
+    /// gate-bound transaction.
+    ///
+    /// We deliberately pin to the **sign**, not the **send/broadcast**, method:
+    /// broadcasting is the deterministic post-approval continuation owned by
+    /// PR10 (`ironclaw_chain_signing`), never the wallet. Pinning to the
+    /// sign-only method also narrows the relay/session attack surface (the
+    /// session is never authorized to broadcast on the user's behalf).
+    pub fn signing_method(self) -> &'static str {
+        match self {
+            ChainFamily::Evm => "eth_signTransaction",
+            ChainFamily::Solana => "solana_signTransaction",
+        }
+    }
+}
+
+/// The single chain + single method a WalletConnect session is permitted to
+/// carry for this gate. Anything broader is a [`SigningProviderError::ScopeViolation`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinnedScope {
+    /// The exact, typed CAIP-2 chain id (e.g. `eip155:1`, `solana:5eykt4...`).
+    pub caip2_chain: Caip2ChainId,
+    /// The chain family resolved from the CAIP-2 namespace.
+    pub family: ChainFamily,
+    /// The single signing RPC method permitted.
+    pub method: String,
+}
+
+impl PinnedScope {
+    /// Derive the pinned scope from the gate's bound chain id.
+    ///
+    /// The gate's [`ChainId`] is treated as a CAIP-2 chain id
+    /// (`namespace:reference`). The namespace selects the family; the full id is
+    /// the single permitted chain; the family selects the single permitted
+    /// signing method.
+    pub fn from_chain_id(chain_id: &ChainId) -> Result<Self, SigningProviderError> {
+        let caip2 = Caip2ChainId::parse(chain_id.as_str())?;
+        let family = match caip2.namespace() {
+            "eip155" => ChainFamily::Evm,
+            "solana" => ChainFamily::Solana,
+            // NEAR is explicitly unsupported on the WalletConnect provider until
+            // a real NEAR account/signature verifier exists. Fail-closed rather
+            // than accept a chain we cannot verify a signer for.
+            "near" => {
+                return Err(SigningProviderError::ScopeViolation {
+                    reason:
+                        "CAIP-2 namespace `near` is not supported by the walletconnect provider"
+                            .to_string(),
+                });
+            }
+            other => {
+                return Err(SigningProviderError::ScopeViolation {
+                    reason: format!("unsupported CAIP-2 namespace `{other}`"),
+                });
+            }
+        };
+        Ok(Self {
+            family,
+            method: family.signing_method().to_string(),
+            caip2_chain: caip2,
+        })
+    }
+
+    /// The CAIP-2 namespace (the part before the first `:`), e.g. `eip155`.
+    pub fn namespace(&self) -> &str {
+        self.caip2_chain.namespace()
+    }
+
+    /// The pinned CAIP-2 chain id as a string.
+    pub fn chain_str(&self) -> &str {
+        self.caip2_chain.as_str()
+    }
+}
+
+/// A session scope as *proposed or settled* by the wallet/relay, to be checked
+/// against the gate's [`PinnedScope`].
+///
+/// Mirrors the CAIP-25 `chains` / `methods` arrays of a single namespace.
+/// Modeled minimally here (PR9 verifies the negotiated scope; the encrypted
+/// CAIP-25 envelope round-trip over the relay is PR10).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProposedScope {
+    /// CAIP-2 chain ids the session would authorize.
+    pub chains: Vec<String>,
+    /// RPC methods the session would authorize.
+    pub methods: Vec<String>,
+    /// CAIP-10 accounts the session settled on. Each is parsed as a typed
+    /// CAIP-10 account and required to live on exactly the pinned CAIP-2 chain
+    /// (#2). Empty is permitted for a pure *proposal* (pre-settlement) but
+    /// rejected for a settled scope by [`enforce_pinned_scope`] when present.
+    pub accounts: Vec<String>,
+}
+
+/// Validate a proposed/settled session scope against the gate's pinned scope,
+/// fail-closed.
+///
+/// Rejects (T17/T19) when the proposal:
+/// * authorizes any chain other than the single pinned chain, or no chains;
+/// * authorizes any method other than the single pinned signing method, or no
+///   methods.
+///
+/// Equality — not subset — is required: the session must be scoped to *exactly*
+/// the one chain and one method the human approved. A proposal that is a strict
+/// superset (extra chains/methods) is a scope-broadening attempt and is
+/// rejected.
+pub fn enforce_pinned_scope(
+    pinned: &PinnedScope,
+    proposed: &ProposedScope,
+) -> Result<(), SigningProviderError> {
+    let viol = |reason: String| SigningProviderError::ScopeViolation { reason };
+
+    // Singleton-exact: exactly one chain and exactly one method, both equal to
+    // the pinned values. A length != 1 is either empty (authorizes nothing) or a
+    // duplicate/superset (scope broadening) — both fail closed (T17/T19).
+    if proposed.chains.len() != 1 {
+        return Err(viol(format!(
+            "session scope must authorize exactly one chain, got {}",
+            proposed.chains.len()
+        )));
+    }
+    if proposed.methods.len() != 1 {
+        return Err(viol(format!(
+            "session scope must authorize exactly one method, got {}",
+            proposed.methods.len()
+        )));
+    }
+    // Compare the chain via the typed CAIP-2 parser, not a raw string compare:
+    // a malformed chain id can never silently equal the pinned chain.
+    let proposed_chain = Caip2ChainId::parse(&proposed.chains[0])?;
+    if proposed_chain != pinned.caip2_chain {
+        return Err(viol(format!(
+            "session scope chain `{}` broadens scope beyond the pinned chain `{}`",
+            proposed.chains[0],
+            pinned.chain_str()
+        )));
+    }
+    if proposed.methods[0] != pinned.method {
+        return Err(viol(format!(
+            "session scope method `{}` broadens scope beyond the pinned method `{}`",
+            proposed.methods[0], pinned.method
+        )));
+    }
+
+    // Accounts (#2): every settled account must be a typed CAIP-10 account that
+    // lives on EXACTLY the pinned CAIP-2 chain. A `proposal` (pre-settlement)
+    // may carry no accounts; a settled scope that lists accounts must bind them
+    // all to the pinned chain.
+    for account in &proposed.accounts {
+        let parsed = Caip10Account::parse(account)?;
+        if parsed.chain_id() != &pinned.caip2_chain {
+            return Err(viol(format!(
+                "settled account `{account}` is not on the pinned chain `{}`",
+                pinned.chain_str()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_evm_family_and_method() {
+        let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+        assert_eq!(pinned.family, ChainFamily::Evm);
+        assert_eq!(pinned.method, "eth_signTransaction");
+        assert_eq!(pinned.namespace(), "eip155");
+        assert_eq!(pinned.chain_str(), "eip155:1");
+    }
+
+    #[test]
+    fn resolves_solana_family() {
+        assert_eq!(
+            PinnedScope::from_chain_id(&ChainId::new("solana:mainnet"))
+                .expect("sol")
+                .method,
+            "solana_signTransaction"
+        );
+    }
+
+    #[test]
+    fn near_is_explicitly_unsupported() {
+        let err = PinnedScope::from_chain_id(&ChainId::new("near:mainnet"))
+            .expect_err("near unsupported");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn multi_colon_chain_id_is_rejected() {
+        let err =
+            Caip2ChainId::parse("eip155:1:extra").expect_err("more than one colon must reject");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn caip10_account_wrong_chain_is_rejected() {
+        let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+        let proposed = ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            // Same address, WRONG chain.
+            accounts: vec!["eip155:137:0x00000000000000000000000000000000000000aa".to_string()],
+        };
+        let err = enforce_pinned_scope(&pinned, &proposed).expect_err("wrong-chain account");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn caip10_account_on_pinned_chain_is_accepted() {
+        let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+        let proposed = ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec!["eip155:1:0x00000000000000000000000000000000000000aa".to_string()],
+        };
+        enforce_pinned_scope(&pinned, &proposed).expect("matching-chain account accepted");
+    }
+
+    #[test]
+    fn duplicate_chain_array_is_rejected() {
+        let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+        let proposed = ProposedScope {
+            chains: vec!["eip155:1".to_string(), "eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec![],
+        };
+        let err = enforce_pinned_scope(&pinned, &proposed).expect_err("duplicate chain");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn duplicate_method_array_is_rejected() {
+        let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+        let proposed = ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec![
+                "eth_signTransaction".to_string(),
+                "eth_signTransaction".to_string(),
+            ],
+            accounts: vec![],
+        };
+        let err = enforce_pinned_scope(&pinned, &proposed).expect_err("duplicate method");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn non_caip2_chain_id_is_scope_violation() {
+        let err = PinnedScope::from_chain_id(&ChainId::new("ethereum")).expect_err("no colon");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn unsupported_namespace_is_scope_violation() {
+        let err = PinnedScope::from_chain_id(&ChainId::new("cosmos:cosmoshub-4"))
+            .expect_err("unsupported");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    fn evm_pinned() -> PinnedScope {
+        PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm")
+    }
+
+    #[test]
+    fn exact_pinned_scope_is_accepted() {
+        let proposed = ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec![],
+        };
+        enforce_pinned_scope(&evm_pinned(), &proposed).expect("exact match accepted");
+    }
+
+    #[test]
+    fn extra_chain_is_rejected_t19() {
+        let proposed = ProposedScope {
+            chains: vec!["eip155:1".to_string(), "eip155:137".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec![],
+        };
+        let err = enforce_pinned_scope(&evm_pinned(), &proposed).expect_err("extra chain");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn extra_method_is_rejected_t17() {
+        let proposed = ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec![
+                "eth_signTransaction".to_string(),
+                "eth_sendTransaction".to_string(),
+            ],
+            accounts: vec![],
+        };
+        let err = enforce_pinned_scope(&evm_pinned(), &proposed).expect_err("extra method");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn wrong_single_chain_is_rejected() {
+        let proposed = ProposedScope {
+            chains: vec!["eip155:137".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec![],
+        };
+        let err = enforce_pinned_scope(&evm_pinned(), &proposed).expect_err("wrong chain");
+        assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+    }
+
+    #[test]
+    fn empty_chains_or_methods_rejected() {
+        let no_chains = ProposedScope {
+            chains: vec![],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec![],
+        };
+        assert!(matches!(
+            enforce_pinned_scope(&evm_pinned(), &no_chains).expect_err("no chains"),
+            SigningProviderError::ScopeViolation { .. }
+        ));
+        let no_methods = ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec![],
+            accounts: vec![],
+        };
+        assert!(matches!(
+            enforce_pinned_scope(&evm_pinned(), &no_methods).expect_err("no methods"),
+            SigningProviderError::ScopeViolation { .. }
+        ));
+    }
+}

--- a/crates/ironclaw_wallet_external/src/walletconnect/proof.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/proof.rs
@@ -1,0 +1,114 @@
+//! Wire shape of the WalletConnect v2 signing proof.
+//!
+//! Serialized into the opaque [`SigningProof::WalletConnectProof`](ironclaw_signing_provider::SigningProof::WalletConnectProof)
+//! byte body. The payload echoes everything the verifier re-checks against the
+//! recorded [`SessionBinding`](super::session::SessionBinding) and the bound
+//! account — none of it is trusted on its own.
+//!
+//! The security-critical field is [`WalletConnectProofPayload::signed_payload`]:
+//! the **exact bytes the wallet's chain signature covers** (the EVM secp256k1
+//! sighash / the Solana ed25519 message), as returned by
+//! `eth_signTransaction` / `solana_signTransaction`. The verifier checks the
+//! real chain signature over *those* bytes and requires them to equal the
+//! `expected_signing_payload` recorded at `initiate` from the same decoded
+//! transaction that produced the approved hash — see
+//! [`super::WalletConnectSigningProvider::verify_resume`]. A signature over a
+//! synthetic digest is never accepted.
+
+use serde::{Deserialize, Serialize};
+
+use ironclaw_signing_provider::{ApprovedTxHash, SigningProviderError};
+
+use super::hex_bytes;
+
+/// The structured payload a WalletConnect wallet carries back from the v2
+/// signing ceremony.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WalletConnectProofPayload {
+    /// The WalletConnect session topic this proof was minted under. Must equal
+    /// the recorded session binding (T18).
+    pub session_topic: String,
+    /// The approved-tx hash the wallet attests to. Must equal the bound hash
+    /// (T20); re-checked before any signature work.
+    pub approved_tx_hash: ApprovedTxHash,
+    /// The account the wallet claims signed. Re-derived from the signature
+    /// (EVM) / checked against the public key (ed25519) and compared to the
+    /// bound account; never trusted on its own (T17).
+    pub claimed_signer: String,
+    /// Per-request nonce the wallet committed to. Must equal the recorded
+    /// binding nonce (T18).
+    #[serde(with = "hex_bytes")]
+    pub nonce: Vec<u8>,
+    /// The **exact bytes the wallet's chain signature covers** — the EVM
+    /// secp256k1 sighash / the Solana ed25519 message returned by
+    /// `eth_signTransaction` / `solana_signTransaction`. The verifier checks the
+    /// chain signature over *these* bytes and requires them to equal the
+    /// `expected_signing_payload` recorded at `initiate` from the same decoded
+    /// transaction that produced the approved hash (the binding back to what the
+    /// human approved). Never trusted on its own — a payload that does not match
+    /// the recorded expectation is rejected before any signature work (#1).
+    #[serde(with = "hex_bytes")]
+    pub signed_payload: Vec<u8>,
+    /// The chain signature over [`Self::signed_payload`]. 65 bytes (r ∥ s ∥ v)
+    /// for EVM secp256k1, 64 bytes for ed25519 families.
+    #[serde(with = "hex_bytes")]
+    pub signature: Vec<u8>,
+    /// For the ed25519 families (Solana / NEAR), the 32-byte public key the
+    /// signature verifies against (lowercase hex). Unused for EVM.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "opt_hex_bytes"
+    )]
+    pub public_key: Option<Vec<u8>>,
+}
+
+/// Serialize a [`WalletConnectProofPayload`] into opaque proof bytes.
+///
+/// Returns [`SigningProviderError::ProofInvalid`] if serialization fails rather
+/// than silently emitting an empty body — an empty `Vec` would later
+/// decode-fail with a confusing "malformed payload" error far from the real
+/// cause, so the error is surfaced at the encode site.
+pub fn encode_walletconnect_proof(
+    payload: &WalletConnectProofPayload,
+) -> Result<Vec<u8>, SigningProviderError> {
+    serde_json::to_vec(payload).map_err(|e| SigningProviderError::ProofInvalid {
+        reason: format!("failed to serialize walletconnect proof payload: {e}"),
+    })
+}
+
+/// Decode opaque proof bytes into a structured [`WalletConnectProofPayload`].
+pub fn decode_walletconnect_proof(
+    bytes: &[u8],
+) -> Result<WalletConnectProofPayload, SigningProviderError> {
+    serde_json::from_slice(bytes).map_err(|e| SigningProviderError::ProofInvalid {
+        reason: format!("malformed walletconnect proof payload: {e}"),
+    })
+}
+
+/// Hex (de)serialization helper for `Option<Vec<u8>>` proof fields.
+mod opt_hex_bytes {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(
+        bytes: &Option<Vec<u8>>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        match bytes {
+            Some(b) => s.serialize_str(&super::hex_bytes::hex_encode(b)),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<Vec<u8>>, D::Error> {
+        let opt = Option::<String>::deserialize(d)?;
+        match opt {
+            Some(s) => super::hex_bytes::hex_decode(&s)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}

--- a/crates/ironclaw_wallet_external/src/walletconnect/session.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/session.rs
@@ -1,0 +1,134 @@
+//! Per-gate WalletConnect session binding.
+//!
+//! When [`initiate`](super::WalletConnectSigningProvider) establishes a session
+//! it records, keyed by the gate, the **expected** binding the eventual proof
+//! must match: the WalletConnect session topic, the account the session settled
+//! on (within the pinned scope), and a freshly-minted per-request nonce. At
+//! [`verify_resume`](super::WalletConnectSigningProvider) time the returned
+//! proof must carry exactly this `(session_topic, account, nonce)` triple, its
+//! `signed_payload` must equal the recorded `expected_signing_payload`, and the
+//! wallet's REAL chain signature must verify over those bytes (see
+//! [`super::signer::verify_chain_signature`]).
+//!
+//! Binding the proof to the session + nonce defeats **T18** (a proof minted
+//! under a *different* WC session / relay key, or replayed with a stale nonce,
+//! is rejected) and complements the one-shot grant CAS (T20).
+//!
+//! The in-memory store here is the PR9 testable surface. Persisting the binding
+//! durably across the initiate→resume gap (so it survives process restarts and
+//! is consumed exactly once at the storage layer) is composition wiring owned by
+//! PR10.
+//!
+//! PR10/PR11 must additionally derive [`SessionBinding::expected_signing_payload`]
+//! from the decoded transaction at `initiate` using a real chain encoder (the
+//! EVM EIP-2718/RLP secp256k1 sighash, the Solana message bytes) — the exact
+//! bytes `eth_signTransaction` / `solana_signTransaction` will sign. That
+//! encoder is not present in this crate (no alloy / solana-sdk; openssl-free),
+//! so PR9 records the expected payload directly (in tests) and the verifier is
+//! exercised against a real signed-payload fixture. Until the encoder exists,
+//! `initiate` cannot populate a real expected payload, and `verify_resume` fails
+//! closed for any gate without a recorded binding.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use ironclaw_signing_provider::{ApprovedTxHash, GateRef};
+
+use super::namespace::PinnedScope;
+
+/// The expected binding a WalletConnect proof must satisfy for a given gate.
+///
+/// Recorded at `initiate` from the **same decoded transaction** that produced
+/// the approved render + [`ApprovedTxHash`]. The binding — not the proof — is
+/// the authority: the proof echoes these values, but the verifier compares the
+/// echoed values against this recorded expectation. In particular
+/// [`Self::expected_signing_payload`] is the bridge from the approved hash to
+/// the real chain signing bytes the wallet will sign (#1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionBinding {
+    /// The WalletConnect v2 session topic the proof must belong to.
+    pub session_topic: String,
+    /// The account the session settled on (must lie within the pinned scope and
+    /// equal the gate's bound account).
+    pub account: String,
+    /// Per-request nonce the wallet must commit to in its signature.
+    pub nonce: Vec<u8>,
+    /// The pinned single-chain / single-method scope for this gate.
+    pub pinned: PinnedScope,
+    /// The approved-tx hash this binding was recorded for. The verifier requires
+    /// it to equal the gate's bound hash — a binding recorded for a different
+    /// approval can never authorize this gate (#1, T20).
+    pub approved_tx_hash: ApprovedTxHash,
+    /// The **exact bytes the wallet's chain signature must cover** — the EVM
+    /// secp256k1 sighash / the Solana ed25519 message, derived at `initiate`
+    /// from the same decoded transaction that produced
+    /// [`Self::approved_tx_hash`]. The verifier requires the proof's
+    /// `signed_payload` to equal this and the chain signature to verify over it.
+    /// This is the sound substitute for recomputing the approved hash (which
+    /// `verify_resume` cannot do — it lacks the decode/render inputs): both the
+    /// hash and this payload are derived from the one decoded tx the human
+    /// approved. See `// PR10/PR11:` below.
+    pub expected_signing_payload: Vec<u8>,
+}
+
+/// In-memory store of per-gate [`SessionBinding`]s.
+///
+/// `record` inserts the expectation at `initiate`; `take` removes and returns it
+/// at `verify_resume` so a binding is consumed at most once in-process. (Durable
+/// one-shot consumption is layered by the sealed-grant CAS at verify time and by
+/// PR10's persistence.)
+#[derive(Debug, Default)]
+pub struct SessionBindingStore {
+    bindings: Mutex<HashMap<String, SessionBinding>>,
+}
+
+impl SessionBindingStore {
+    /// Construct an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the expected binding for `gate`. Overwrites any prior binding for
+    /// the same gate (a re-initiation supersedes the stale expectation).
+    ///
+    /// A poisoned mutex (a thread panicked while holding the lock) is an
+    /// unrecoverable invariant violation for this security-critical store:
+    /// silently dropping the binding would make `verify_resume` fail closed for
+    /// *every* gate with no diagnostic, so we propagate the poison by panicking
+    /// rather than masking it with a no-op.
+    pub fn record(&self, gate: &GateRef, binding: SessionBinding) {
+        let mut map = self
+            .bindings
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        map.insert(gate.as_str().to_string(), binding);
+    }
+
+    /// Return a clone of the expected binding for `gate`, if any, WITHOUT
+    /// consuming it.
+    ///
+    /// Used by the verifier to run all hash/signature validation against the
+    /// recorded expectation before the binding is consumed: a malformed relay
+    /// response must not burn the binding (the recommendation). Consumption
+    /// happens only on the success path via [`Self::take`]. Recovers from a
+    /// poisoned mutex (see [`Self::record`]) instead of silently returning
+    /// `None`, which would spuriously fail verification closed.
+    pub fn peek(&self, gate: &GateRef) -> Option<SessionBinding> {
+        let map = self
+            .bindings
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        map.get(gate.as_str()).cloned()
+    }
+
+    /// Remove and return the expected binding for `gate`, if any. Recovers from
+    /// a poisoned mutex (see [`Self::record`]) rather than silently dropping the
+    /// consume.
+    pub fn take(&self, gate: &GateRef) -> Option<SessionBinding> {
+        let mut map = self
+            .bindings
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        map.remove(gate.as_str())
+    }
+}

--- a/crates/ironclaw_wallet_external/src/walletconnect/session.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/session.rs
@@ -1,0 +1,155 @@
+//! Per-gate WalletConnect session binding.
+//!
+//! When [`initiate`](super::WalletConnectSigningProvider) establishes a session
+//! it records, keyed by the gate, the **expected** binding the eventual proof
+//! must match: the WalletConnect session topic, the account the session settled
+//! on (within the pinned scope), and a freshly-minted per-request nonce. At
+//! [`verify_resume`](super::WalletConnectSigningProvider) time the returned
+//! proof must carry exactly this `(session_topic, account, nonce)` triple, its
+//! `signed_payload` must equal the recorded `expected_signing_payload`, and the
+//! wallet's REAL chain signature must verify over those bytes (see
+//! [`super::signer::verify_chain_signature`]).
+//!
+//! Binding the proof to the session + nonce defeats **T18** (a proof minted
+//! under a *different* WC session / relay key, or replayed with a stale nonce,
+//! is rejected) and complements the one-shot grant CAS (T20).
+//!
+//! The in-memory store here is the PR9 testable surface. Persisting the binding
+//! durably across the initiate→resume gap (so it survives process restarts and
+//! is consumed exactly once at the storage layer) is composition wiring owned by
+//! PR10.
+//!
+//! PR10/PR11 must additionally derive [`SessionBinding::expected_signing_payload`]
+//! from the decoded transaction at `initiate` using a real chain encoder (the
+//! EVM EIP-2718/RLP secp256k1 sighash, the Solana message bytes) — the exact
+//! bytes `eth_signTransaction` / `solana_signTransaction` will sign. That
+//! encoder is not present in this crate (no alloy / solana-sdk; openssl-free),
+//! so PR9 records the expected payload directly (in tests) and the verifier is
+//! exercised against a real signed-payload fixture. Until the encoder exists,
+//! `initiate` cannot populate a real expected payload, and `verify_resume` fails
+//! closed for any gate without a recorded binding.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use ironclaw_signing_provider::{ApprovedTxHash, GateRef};
+
+use super::namespace::PinnedScope;
+
+/// The expected binding a WalletConnect proof must satisfy for a given gate.
+///
+/// Recorded at `initiate` from the **same decoded transaction** that produced
+/// the approved render + [`ApprovedTxHash`]. The binding — not the proof — is
+/// the authority: the proof echoes these values, but the verifier compares the
+/// echoed values against this recorded expectation. In particular
+/// [`Self::expected_signing_payload`] is the bridge from the approved hash to
+/// the real chain signing bytes the wallet will sign (#1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionBinding {
+    /// The WalletConnect v2 session topic the proof must belong to.
+    pub session_topic: String,
+    /// The account the session settled on (must lie within the pinned scope and
+    /// equal the gate's bound account).
+    pub account: String,
+    /// Per-request nonce the wallet must commit to in its signature.
+    pub nonce: Vec<u8>,
+    /// The pinned single-chain / single-method scope for this gate.
+    pub pinned: PinnedScope,
+    /// The approved-tx hash this binding was recorded for. The verifier requires
+    /// it to equal the gate's bound hash — a binding recorded for a different
+    /// approval can never authorize this gate (#1, T20).
+    pub approved_tx_hash: ApprovedTxHash,
+    /// The **exact bytes the wallet's chain signature must cover** — the EVM
+    /// secp256k1 sighash / the Solana ed25519 message, derived at `initiate`
+    /// from the same decoded transaction that produced
+    /// [`Self::approved_tx_hash`]. The verifier requires the proof's
+    /// `signed_payload` to equal this and the chain signature to verify over it.
+    /// This is the sound substitute for recomputing the approved hash (which
+    /// `verify_resume` cannot do — it lacks the decode/render inputs): both the
+    /// hash and this payload are derived from the one decoded tx the human
+    /// approved. See `// PR10/PR11:` below.
+    pub expected_signing_payload: Vec<u8>,
+}
+
+/// In-memory store of per-gate [`SessionBinding`]s.
+///
+/// `record` inserts the expectation at `initiate`; `take` removes and returns it
+/// at `verify_resume` so a binding is consumed at most once in-process. (Durable
+/// one-shot consumption is layered by the sealed-grant CAS at verify time and by
+/// PR10's persistence.)
+#[derive(Debug, Default)]
+pub struct SessionBindingStore {
+    bindings: Mutex<HashMap<String, SessionBinding>>,
+}
+
+impl SessionBindingStore {
+    /// Construct an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the expected binding for `gate`. Overwrites any prior binding for
+    /// the same gate (a re-initiation supersedes the stale expectation).
+    ///
+    /// A poisoned mutex (a thread panicked while holding the lock) is recovered
+    /// rather than propagated: this is a security-critical store on a request
+    /// path, and panicking here would take down the process, which the repo's
+    /// no-panics-in-production rule forbids. Dropping the operation silently is
+    /// equally wrong — it would make `verify_resume` fail closed for *every*
+    /// gate with no diagnostic — so the poison is recovered **loudly** and the
+    /// operation proceeds. Downstream remains fail-closed: a missing or stale
+    /// binding causes the verifier to refuse, never to accept.
+    pub fn record(&self, gate: &GateRef, binding: SessionBinding) {
+        let mut map = self
+            .bindings
+            .lock()
+            .unwrap_or_else(|poison| {
+                tracing::error!(
+                    component = "walletconnect_session_store",
+                    "session binding store mutex was poisoned; recovering the inner map.                      A thread panicked while holding this lock — bindings may be stale."
+                );
+                poison.into_inner()
+            });
+        map.insert(gate.as_str().to_string(), binding);
+    }
+
+    /// Return a clone of the expected binding for `gate`, if any, WITHOUT
+    /// consuming it.
+    ///
+    /// Used by the verifier to run all hash/signature validation against the
+    /// recorded expectation before the binding is consumed: a malformed relay
+    /// response must not burn the binding (the recommendation). Consumption
+    /// happens only on the success path via [`Self::take`]. Recovers from a
+    /// poisoned mutex (see [`Self::record`]) instead of silently returning
+    /// `None`, which would spuriously fail verification closed.
+    pub fn peek(&self, gate: &GateRef) -> Option<SessionBinding> {
+        let map = self
+            .bindings
+            .lock()
+            .unwrap_or_else(|poison| {
+                tracing::error!(
+                    component = "walletconnect_session_store",
+                    "session binding store mutex was poisoned; recovering the inner map.                      A thread panicked while holding this lock — bindings may be stale."
+                );
+                poison.into_inner()
+            });
+        map.get(gate.as_str()).cloned()
+    }
+
+    /// Remove and return the expected binding for `gate`, if any. Recovers from
+    /// a poisoned mutex (see [`Self::record`]) rather than silently dropping the
+    /// consume.
+    pub fn take(&self, gate: &GateRef) -> Option<SessionBinding> {
+        let mut map = self
+            .bindings
+            .lock()
+            .unwrap_or_else(|poison| {
+                tracing::error!(
+                    component = "walletconnect_session_store",
+                    "session binding store mutex was poisoned; recovering the inner map.                      A thread panicked while holding this lock — bindings may be stale."
+                );
+                poison.into_inner()
+            });
+        map.remove(gate.as_str())
+    }
+}

--- a/crates/ironclaw_wallet_external/src/walletconnect/signer.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/signer.rs
@@ -1,0 +1,211 @@
+//! Signer recovery / verification for WalletConnect v2 chain signatures.
+//!
+//! A WalletConnect wallet does **not** sign a synthetic attestation digest. It
+//! signs the **real transaction** via `eth_signTransaction` /
+//! `solana_signTransaction`. The proof therefore carries the exact bytes that
+//! chain signature covers ([`WalletConnectProofPayload::signed_payload`](super::proof::WalletConnectProofPayload::signed_payload)):
+//!
+//! * For EVM the `signed_payload` is the 32-byte secp256k1 sighash (the
+//!   keccak256 of the EIP-2718/RLP signing pre-image); the signer is recovered
+//!   from the 65-byte signature via `k256` ecrecover and reduced to its 20-byte
+//!   address.
+//! * For Solana/NEAR the `signed_payload` is the ed25519 message bytes; the
+//!   signature is verified against the connected ed25519 public key with the
+//!   vendored `ed25519-dalek`.
+//!
+//! In every case the resolved signer must equal the bound account
+//! ([`SignerMismatch`](ironclaw_signing_provider::SigningProviderError::SignerMismatch)).
+//! The binding from `signed_payload` back to the human-approved transaction is
+//! enforced by the caller ([`super::WalletConnectSigningProvider::verify_resume`]),
+//! which requires `signed_payload == binding.expected_signing_payload` (both
+//! derived from the same decoded tx). The session-topic + nonce binding is an
+//! additional anti-replay layer enforced by the caller, not a replacement for
+//! this real chain-signature check.
+//!
+//! The relay transport / Sign envelope crypto comes from the fork — it is never
+//! reimplemented here.
+
+use k256::ecdsa::{RecoveryId, Signature as EcSignature, VerifyingKey};
+use sha3::{Digest, Keccak256};
+
+use ed25519_dalek::{Signature as EdSignature, Verifier, VerifyingKey as EdVerifyingKey};
+
+use ironclaw_signing_provider::SigningProviderError;
+
+use super::namespace::ChainFamily;
+
+/// Verify the wallet's **real chain signature** over `signed_payload` and
+/// require the resolved signer to equal `bound_account`.
+///
+/// * `family` selects the recovery/verification scheme.
+/// * `signed_payload` is the exact bytes the chain signature covers: the
+///   32-byte EVM secp256k1 sighash, or the Solana ed25519 message bytes.
+/// * `signature` is 65 bytes (r ∥ s ∥ v) for EVM, 64 bytes for ed25519 families.
+/// * `public_key` is required (32 bytes) for the ed25519 families and ignored
+///   for EVM (the address is recovered from the signature).
+pub(super) fn verify_chain_signature(
+    family: ChainFamily,
+    signed_payload: &[u8],
+    signature: &[u8],
+    public_key: Option<&[u8]>,
+    bound_account: &str,
+) -> Result<(), SigningProviderError> {
+    match family {
+        ChainFamily::Evm => verify_evm(signed_payload, signature, bound_account),
+        ChainFamily::Solana => {
+            let pk = public_key.ok_or(SigningProviderError::ProofInvalid {
+                reason: "ed25519 walletconnect proof missing public_key".to_string(),
+            })?;
+            verify_ed25519(signed_payload, signature, pk, bound_account)
+        }
+    }
+}
+
+/// Recover the EVM signer from a 65-byte signature over the 32-byte secp256k1
+/// sighash `signed_payload` and require it to equal `bound_account`
+/// (`0x`-prefixed, case-insensitive 20-byte hex).
+fn verify_evm(
+    signed_payload: &[u8],
+    signature: &[u8],
+    bound_account: &str,
+) -> Result<(), SigningProviderError> {
+    // The EVM chain signature is over a 32-byte prehash (the EIP-2718/RLP
+    // sighash). Anything else cannot be a valid eth_signTransaction sighash and
+    // fails closed.
+    let prehash: [u8; 32] =
+        signed_payload
+            .try_into()
+            .map_err(|_| SigningProviderError::ProofInvalid {
+                reason: format!(
+                    "evm signed payload must be a 32-byte sighash, got {} bytes",
+                    signed_payload.len()
+                ),
+            })?;
+    if signature.len() != 65 {
+        return Err(SigningProviderError::ProofInvalid {
+            reason: format!("evm signature must be 65 bytes, got {}", signature.len()),
+        });
+    }
+    let sig = EcSignature::from_slice(&signature[..64]).map_err(|e| {
+        SigningProviderError::ProofInvalid {
+            reason: format!("invalid evm signature scalars: {e}"),
+        }
+    })?;
+    let rec_id = recovery_id_from_v(signature[64])?;
+    let recovered =
+        VerifyingKey::recover_from_prehash(prehash.as_slice(), &sig, rec_id).map_err(|e| {
+            SigningProviderError::ProofInvalid {
+                reason: format!("evm signer recovery failed: {e}"),
+            }
+        })?;
+    let recovered_address = address_from_verifying_key(&recovered);
+    let bound = parse_evm_address(bound_account)?;
+    if recovered_address != bound {
+        return Err(SigningProviderError::SignerMismatch);
+    }
+    Ok(())
+}
+
+/// Verify a 64-byte ed25519 signature over the message `signed_payload` against
+/// `public_key`, and require `public_key` to equal `bound_account` (lowercase
+/// 32-byte hex).
+fn verify_ed25519(
+    signed_payload: &[u8],
+    signature: &[u8],
+    public_key: &[u8],
+    bound_account: &str,
+) -> Result<(), SigningProviderError> {
+    if signature.len() != 64 {
+        return Err(SigningProviderError::ProofInvalid {
+            reason: format!(
+                "ed25519 signature must be 64 bytes, got {}",
+                signature.len()
+            ),
+        });
+    }
+    let pk_bytes: [u8; 32] =
+        public_key
+            .try_into()
+            .map_err(|_| SigningProviderError::ProofInvalid {
+                reason: format!(
+                    "ed25519 public key must be 32 bytes, got {}",
+                    public_key.len()
+                ),
+            })?;
+    // Signer binding (T17): the verifying key must equal the bound account
+    // before we trust any signature it produced.
+    let bound = parse_ed25519_pubkey(bound_account)?;
+    if pk_bytes != bound {
+        return Err(SigningProviderError::SignerMismatch);
+    }
+    let verifying_key =
+        EdVerifyingKey::from_bytes(&pk_bytes).map_err(|e| SigningProviderError::ProofInvalid {
+            reason: format!("invalid ed25519 public key: {e}"),
+        })?;
+    let sig_bytes: [u8; 64] =
+        signature
+            .try_into()
+            .map_err(|_| SigningProviderError::ProofInvalid {
+                reason: "ed25519 signature length mismatch".to_string(),
+            })?;
+    let sig = EdSignature::from_bytes(&sig_bytes);
+    verifying_key
+        .verify(signed_payload, &sig)
+        .map_err(|e| SigningProviderError::ProofInvalid {
+            reason: format!("ed25519 verification failed: {e}"),
+        })?;
+    Ok(())
+}
+
+/// Normalize the signature `v` byte to a `k256` [`RecoveryId`] (0/1, 27/28, or
+/// EIP-155 reduced to parity).
+fn recovery_id_from_v(v: u8) -> Result<RecoveryId, SigningProviderError> {
+    let parity = match v {
+        0 | 1 => v,
+        27 | 28 => v - 27,
+        v if v >= 35 => (v - 35) & 1,
+        other => {
+            return Err(SigningProviderError::ProofInvalid {
+                reason: format!("invalid evm recovery id v={other}"),
+            });
+        }
+    };
+    RecoveryId::from_byte(parity).ok_or(SigningProviderError::ProofInvalid {
+        reason: "invalid evm recovery id parity".to_string(),
+    })
+}
+
+/// `keccak256(uncompressed_pubkey[1..])[12..]`.
+fn address_from_verifying_key(key: &VerifyingKey) -> [u8; 20] {
+    let encoded = key.to_encoded_point(false);
+    let hash = Keccak256::digest(&encoded.as_bytes()[1..]);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    addr
+}
+
+/// Parse a `0x`-prefixed (case-insensitive) hex EVM address into 20 bytes.
+fn parse_evm_address(s: &str) -> Result<[u8; 20], SigningProviderError> {
+    decode_hex_fixed::<20>(s).map_err(|_| SigningProviderError::ProofInvalid {
+        reason: format!("bound account is not a 20-byte evm address: {s}"),
+    })
+}
+
+/// Parse a lowercase-hex 32-byte ed25519 public key into bytes.
+fn parse_ed25519_pubkey(s: &str) -> Result<[u8; 32], SigningProviderError> {
+    decode_hex_fixed::<32>(s).map_err(|_| SigningProviderError::ProofInvalid {
+        reason: format!("bound account is not a 32-byte ed25519 key: {s}"),
+    })
+}
+
+/// Decode `0x`-prefixed (case-insensitive) hex into a fixed-size `[u8; N]`,
+/// panic-free on any input.
+///
+/// Delegates the byte-based, panic-free nibble decoding to the shared
+/// [`super::hex_bytes::hex_decode`] (which operates on **bytes**, never on
+/// `&str` byte-offset slices, so non-ASCII even-byte input fails closed instead
+/// of panicking — #3) and then enforces the fixed length `N`.
+fn decode_hex_fixed<const N: usize>(s: &str) -> Result<[u8; N], ()> {
+    let bytes = super::hex_bytes::hex_decode(s).map_err(|_| ())?;
+    bytes.try_into().map_err(|_| ())
+}

--- a/crates/ironclaw_wallet_external/tests/walletconnect_verify_resume.rs
+++ b/crates/ironclaw_wallet_external/tests/walletconnect_verify_resume.rs
@@ -1,0 +1,1037 @@
+//! End-to-end verification tests for the WalletConnect v2
+//! [`WalletConnectSigningProvider`] security cores (attested-signing PR9).
+//!
+//! Drives the provider behind `Arc<dyn SigningProvider>` (object-safety) and
+//! through the sealed-grant store + recorded session binding, exercising the
+//! full fail-closed contract:
+//!
+//! * namespace pinning rejects scope broadening + wrong-chain CAIP-10 accounts
+//!   + duplicate scope arrays (T17/T19, #2);
+//! * a valid REAL chain signature over the REAL signed-tx payload from the
+//!   session-bound account, where that payload equals the
+//!   `expected_signing_payload` recorded at initiate → `VerifiedProof` (#1);
+//! * a tampered hash, a wrong session topic / nonce (T18), a mismatched signer
+//!   (T17), a payload that differs from the approved bytes (#1), a malformed
+//!   Unicode-hex account (#3), and a replayed / already-claimed grant (T20) all
+//!   fail closed.
+//!
+//! The relay is never contacted: the session binding `initiate` would record
+//! over the relay (PR10) — including the `expected_signing_payload` PR10/PR11's
+//! chain encoder will derive — is installed directly via `record_session_binding`,
+//! and the wallet signature is minted in-test over the exact `signed_payload`
+//! fixture the verifier checks. No synthetic attestation digest exists anymore.
+
+use std::sync::Arc;
+
+use ironclaw_attestation::{
+    ApprovedTxHash, AttestedSigningGrant, GrantKey, InMemorySealedGrantStore, SealedGrantStore,
+};
+use ironclaw_signing_provider::{
+    ActorId, ChainId, DecodedTransaction, GateRef, InitiationOutcome, KeyOrAccountId, RenderedTx,
+    RunId, ScopeId, SigningContext, SigningProof, SigningProvider, SigningProviderError, TenantId,
+    UserId,
+};
+use ironclaw_wallet_external::{
+    PinnedScope, ProjectId, ProposedScope, SessionBinding, WalletConnectProofPayload,
+    WalletConnectSigningProvider, encode_walletconnect_proof, enforce_pinned_scope,
+};
+
+use ed25519_dalek::{Signer as _, SigningKey as EdSigningKey};
+use k256::ecdsa::{SigningKey as EcSigningKey, signature::hazmat::PrehashSigner};
+use sha3::{Digest, Keccak256};
+
+const SESSION_TOPIC: &str = "a3f1c0de";
+const NONCE: &[u8] = b"nonce-001";
+
+fn project() -> ProjectId {
+    // Publishable, API-key class; injected, never hardcoded in production.
+    ProjectId::from("00000000000000000000000000000000")
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+    }
+    out
+}
+
+/// A stand-in for the EVM secp256k1 sighash a real `eth_signTransaction` would
+/// cover. In production PR10/PR11 derives this from the decoded tx via a real
+/// EIP-2718/RLP encoder; here it is a fixed 32-byte fixture the wallet signs and
+/// the binding records as `expected_signing_payload`.
+fn evm_sighash_fixture() -> [u8; 32] {
+    let mut h = Keccak256::new();
+    h.update(b"real-evm-signing-payload-fixture");
+    let out = h.finalize();
+    let mut sighash = [0u8; 32];
+    sighash.copy_from_slice(&out);
+    sighash
+}
+
+/// A stand-in for the Solana ed25519 message bytes a real
+/// `solana_signTransaction` would cover.
+fn solana_message_fixture() -> Vec<u8> {
+    b"real-solana-signing-message-fixture-bytes".to_vec()
+}
+
+// ── EVM helpers ──
+
+fn evm_key() -> EcSigningKey {
+    EcSigningKey::from_slice(&[0x11u8; 32]).expect("valid secp256k1 key")
+}
+
+fn evm_address(key: &EcSigningKey) -> [u8; 20] {
+    let vk = key.verifying_key();
+    let encoded = vk.to_encoded_point(false);
+    let hash = Keccak256::digest(&encoded.as_bytes()[1..]);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    addr
+}
+
+/// 65-byte (r ∥ s ∥ v) signature over the 32-byte sighash payload.
+fn evm_sign_payload(key: &EcSigningKey, payload: &[u8; 32]) -> Vec<u8> {
+    let (sig, recid): (k256::ecdsa::Signature, k256::ecdsa::RecoveryId) =
+        key.sign_prehash(payload.as_slice()).expect("sign");
+    let mut out = sig.to_bytes().to_vec();
+    out.push(recid.to_byte());
+    out
+}
+
+// ── Solana / ed25519 helpers ──
+
+fn ed_key() -> EdSigningKey {
+    EdSigningKey::from_bytes(&[0x22u8; 32])
+}
+
+// ── Fixtures ──
+
+fn ctx_for(account: &str, chain: &str) -> SigningContext {
+    SigningContext {
+        tenant: TenantId::new("tenant-a"),
+        user: UserId::new("user-1"),
+        scope: ScopeId::new("scope-x"),
+        actor: ActorId::new("actor-7"),
+        run_id: RunId::new("run-42"),
+        gate_ref: GateRef::new("gate:abc"),
+        chain_id: ChainId::new(chain),
+        key_or_account_id: KeyOrAccountId::new(account),
+    }
+}
+
+async fn seal_grant(store: &InMemorySealedGrantStore, ctx: &SigningContext, hash: ApprovedTxHash) {
+    let key = GrantKey::from_context(ctx, hash);
+    store
+        .seal(AttestedSigningGrant::seal(key, 1_000, None))
+        .await
+        .expect("seal");
+}
+
+/// Build a binding whose `expected_signing_payload` is the real bytes the
+/// wallet will sign, recorded at initiate from the same decoded tx as `hash`.
+fn binding_for(
+    account: &str,
+    chain: &str,
+    hash: ApprovedTxHash,
+    expected_signing_payload: Vec<u8>,
+) -> SessionBinding {
+    SessionBinding {
+        session_topic: SESSION_TOPIC.to_string(),
+        account: account.to_string(),
+        nonce: NONCE.to_vec(),
+        pinned: PinnedScope::from_chain_id(&ChainId::new(chain)).expect("pinned"),
+        approved_tx_hash: hash,
+        expected_signing_payload,
+    }
+}
+
+// ── Namespace pinning (T17/T19, #2) ──
+
+#[test]
+fn pinning_accepts_exact_scope_and_rejects_broadening() {
+    let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+    enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec!["eip155:1:0x00000000000000000000000000000000000000aa".to_string()],
+        },
+    )
+    .expect("exact scope accepted");
+
+    // Extra chain (T19).
+    assert!(matches!(
+        enforce_pinned_scope(
+            &pinned,
+            &ProposedScope {
+                chains: vec!["eip155:1".to_string(), "eip155:10".to_string()],
+                methods: vec!["eth_signTransaction".to_string()],
+                accounts: vec![],
+            },
+        )
+        .expect_err("broader chains rejected"),
+        SigningProviderError::ScopeViolation { .. }
+    ));
+
+    // Extra method (T17).
+    assert!(matches!(
+        enforce_pinned_scope(
+            &pinned,
+            &ProposedScope {
+                chains: vec!["eip155:1".to_string()],
+                methods: vec![
+                    "eth_signTransaction".to_string(),
+                    "eth_sendTransaction".to_string(),
+                ],
+                accounts: vec![],
+            },
+        )
+        .expect_err("broader methods rejected"),
+        SigningProviderError::ScopeViolation { .. }
+    ));
+}
+
+#[test]
+fn pinning_rejects_wrong_chain_caip10_account() {
+    let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+    // Same address, different chain — must be rejected (#2).
+    let err = enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec!["eip155:137:0x00000000000000000000000000000000000000aa".to_string()],
+        },
+    )
+    .expect_err("wrong-chain account rejected");
+    assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+}
+
+#[test]
+fn pinning_rejects_duplicate_scope_arrays() {
+    let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+    let dup_chain = enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string(), "eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec![],
+        },
+    )
+    .expect_err("duplicate chain rejected");
+    assert!(matches!(
+        dup_chain,
+        SigningProviderError::ScopeViolation { .. }
+    ));
+
+    let dup_method = enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec![
+                "eth_signTransaction".to_string(),
+                "eth_signTransaction".to_string(),
+            ],
+            accounts: vec![],
+        },
+    )
+    .expect_err("duplicate method rejected");
+    assert!(matches!(
+        dup_method,
+        SigningProviderError::ScopeViolation { .. }
+    ));
+}
+
+// ── verify_resume: EVM (real signed-tx payload, #1) ──
+
+fn evm_proof(
+    key: &EcSigningKey,
+    account: &str,
+    hash: ApprovedTxHash,
+    topic: &str,
+    nonce: &[u8],
+    signed_payload: Vec<u8>,
+) -> SigningProof {
+    // Sign the REAL payload bytes (the secp256k1 sighash), exactly as
+    // eth_signTransaction would. There is no synthetic attestation digest.
+    let sighash: [u8; 32] = signed_payload
+        .clone()
+        .try_into()
+        .expect("evm signed payload is a 32-byte sighash");
+    let payload = WalletConnectProofPayload {
+        session_topic: topic.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.to_string(),
+        nonce: nonce.to_vec(),
+        signed_payload,
+        signature: evm_sign_payload(key, &sighash),
+        public_key: None,
+    };
+    SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode proof"))
+}
+
+#[tokio::test]
+async fn evm_valid_proof_over_real_signed_tx_verifies() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let provider: Arc<dyn SigningProvider> = Arc::new(provider);
+    let verified = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("valid evm walletconnect proof over the real signed tx must verify");
+    assert_eq!(verified.proof(), &proof);
+}
+
+#[tokio::test]
+async fn evm_session_account_casing_mismatch_still_verifies() {
+    // EVM addresses are case-insensitive hex; the WC session may settle the
+    // account in EIP-55 mixed case while the gate stores it lowercase. The
+    // defense-in-depth account string compare must be case-insensitive so a
+    // pure-casing difference does not spuriously reject. The authoritative
+    // signer binding remains the byte-exact chain-signature recovery.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    // Binding records the SAME address but UPPER-cased (different casing only).
+    let upper_account = account.to_ascii_uppercase();
+    assert_ne!(upper_account, account);
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&upper_account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let provider: Arc<dyn SigningProvider> = Arc::new(provider);
+    let verified = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("case-only account difference must not reject a valid proof");
+    assert_eq!(verified.proof(), &proof);
+}
+
+#[tokio::test]
+async fn evm_payload_not_matching_approved_bytes_is_rejected() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let approved = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    // Binding records the APPROVED payload.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, approved.to_vec()),
+    );
+
+    // Wallet signs a DIFFERENT transaction than the approved one (the core #1
+    // attack: a validly-signed but unapproved tx). The signature is valid for
+    // the bound account over `other`, but `other != expected_signing_payload`.
+    let mut other = approved;
+    other[0] ^= 0xff;
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, other.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("signed payload != approved bytes must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_signer_not_bound_account_is_signer_mismatch() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    // Bind a different account than the key recovers to, but record the binding
+    // on the REAL signing account so the account-binding check passes and we
+    // reach the signer recovery (which must mismatch the gate's bound account).
+    let wrong = "0x00000000000000000000000000000000000000bb";
+    let ctx = ctx_for(wrong, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    let real_account = format!("0x{}", lower_hex(&evm_address(&key)));
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&real_account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(
+        &key,
+        &real_account,
+        hash,
+        SESSION_TOPIC,
+        NONCE,
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("mismatched signer must reject");
+    assert!(matches!(err, SigningProviderError::SignerMismatch));
+}
+
+#[tokio::test]
+async fn evm_tampered_hash_is_proof_invalid() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let bound_hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, bound_hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", bound_hash, signed.to_vec()),
+    );
+
+    // Wallet attests to a DIFFERENT hash than the gate bound.
+    let attested = ApprovedTxHash::from_bytes([9u8; 32]);
+    let proof = evm_proof(
+        &key,
+        &account,
+        attested,
+        SESSION_TOPIC,
+        NONCE,
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &bound_hash, &proof)
+        .await
+        .expect_err("tampered hash must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_wrong_session_topic_is_rejected_t18() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // Proof minted under a DIFFERENT session topic (relay/session compromise).
+    let proof = evm_proof(&key, &account, hash, "deadbeef", NONCE, signed.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("wrong session topic must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_wrong_nonce_is_rejected_t18() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // Proof carries a stale / forged nonce (replay defense).
+    let proof = evm_proof(
+        &key,
+        &account,
+        hash,
+        SESSION_TOPIC,
+        b"other-nonce",
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("wrong nonce must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_missing_session_binding_is_rejected() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    // No session binding recorded.
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("missing binding must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_malformed_response_does_not_burn_binding() {
+    // A malformed relay/wallet response (wrong nonce) must NOT consume the
+    // recorded binding — a subsequent valid proof must still verify (the
+    // "validate first, consume only on success" recommendation).
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // First: malformed (wrong nonce) — must fail but NOT burn the binding.
+    let bad = evm_proof(
+        &key,
+        &account,
+        hash,
+        SESSION_TOPIC,
+        b"forged-nonce",
+        signed.to_vec(),
+    );
+    assert!(matches!(
+        provider
+            .verify_resume(&ctx, &hash, &bad)
+            .await
+            .expect_err("malformed must fail"),
+        SigningProviderError::ProofInvalid { .. }
+    ));
+
+    // Then: a valid proof against the still-present binding must verify.
+    let good = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    provider
+        .verify_resume(&ctx, &hash, &good)
+        .await
+        .expect("valid proof after a malformed attempt must still verify");
+}
+
+#[tokio::test]
+async fn evm_replay_after_claim_fails_closed_t20() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = Arc::new(WalletConnectSigningProvider::new(project(), store.clone()));
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("first resume succeeds");
+
+    // Re-record the binding so the replay reaches the grant CAS (the binding is
+    // consumed on first success). The one-shot grant must still reject the replay.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("replay must fail closed");
+    assert!(matches!(err, SigningProviderError::GrantClaimFailed));
+}
+
+#[tokio::test]
+async fn evm_unsealed_grant_fails_closed() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    // No grant sealed.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("no grant must fail closed");
+    assert!(matches!(err, SigningProviderError::GrantClaimFailed));
+}
+
+#[tokio::test]
+async fn evm_malformed_unicode_hex_account_fails_closed() {
+    // A bound account carrying a non-ASCII even-byte string used to panic when
+    // the hex parser sliced &str by byte offset (#3). It must now fail closed.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    // 40-byte (20 char-pairs) string of a 2-byte multibyte char: ASCII byte
+    // length is even but slicing at odd byte offsets crosses a char boundary.
+    let bad_account = "é".repeat(20); // 40 bytes, all non-ASCII
+    assert_eq!(bad_account.len(), 40);
+    let ctx = ctx_for(&bad_account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&bad_account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(
+        &key,
+        &bad_account,
+        hash,
+        SESSION_TOPIC,
+        NONCE,
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("malformed unicode hex account must fail closed (not panic)");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn malformed_unicode_hex_in_proof_field_fails_closed() {
+    // A relay-supplied proof whose hex-encoded fields contain non-ASCII even-byte
+    // content must decode-fail (ProofInvalid), never panic (#3).
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+    let ctx = ctx_for("0x00000000000000000000000000000000000000aa", "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([1u8; 32]);
+
+    // Hand-craft JSON with a malformed-unicode hex `signature` field.
+    let json = format!(
+        r#"{{"session_topic":"{SESSION_TOPIC}","approved_tx_hash":{:?},"claimed_signer":"0x00000000000000000000000000000000000000aa","nonce":"6e6f6e6365","signed_payload":"00","signature":"éé"}}"#,
+        hash.as_bytes()
+    );
+    let proof = SigningProof::WalletConnectProof(json.into_bytes());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("malformed unicode hex in proof must fail closed (not panic)");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+// ── verify_resume: Solana (ed25519, real signed message) ──
+
+#[tokio::test]
+async fn solana_valid_proof_over_real_message_verifies() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider: Arc<dyn SigningProvider> =
+        Arc::new(WalletConnectSigningProvider::new(project(), store.clone()));
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    let account = lower_hex(&pubkey);
+    let ctx = ctx_for(&account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+
+    // Record binding via a concrete provider, then drive via the dyn handle.
+    let inner = WalletConnectSigningProvider::new(project(), store.clone());
+    inner.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+
+    // ed25519 signs the REAL message bytes, as solana_signTransaction would.
+    let sig = key.sign(&message);
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: Some(pubkey.to_vec()),
+    };
+    let proof = SigningProof::WalletConnectProof(
+        encode_walletconnect_proof(&payload).expect("encode proof"),
+    );
+
+    inner
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("valid solana walletconnect proof over the real message must verify");
+
+    // Object-safety sanity: the dyn handle is usable.
+    let _ = provider.provider_id();
+}
+
+#[tokio::test]
+async fn solana_wrong_signer_is_signer_mismatch() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    // Bind a different pubkey than the proof's.
+    let other = [0x33u8; 32];
+    let bound_account = lower_hex(&other);
+    let ctx = ctx_for(&bound_account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&bound_account, "solana:mainnet", hash, message.clone()),
+    );
+
+    let sig = key.sign(&message);
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: bound_account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: Some(pubkey.to_vec()),
+    };
+    let proof = SigningProof::WalletConnectProof(
+        encode_walletconnect_proof(&payload).expect("encode proof"),
+    );
+
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("mismatched solana signer must reject");
+    assert!(matches!(err, SigningProviderError::SignerMismatch));
+}
+
+#[tokio::test]
+async fn non_walletconnect_proof_is_rejected() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+    let ctx = ctx_for("0x00000000000000000000000000000000000000aa", "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([1u8; 32]);
+
+    let err = provider
+        .verify_resume(&ctx, &hash, &SigningProof::InjectedProof(vec![1, 2, 3]))
+        .await
+        .expect_err("non-walletconnect proof must be rejected");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn near_chain_is_unsupported_fail_closed() {
+    // NEAR is explicitly unsupported on the WC provider until a real verifier
+    // exists — initiate/verify must fail closed at scope resolution.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+    let account = "0011223344556677889900112233445566778899001122334455667788990011";
+    let ctx = ctx_for(account, "near:mainnet");
+    let hash = ApprovedTxHash::from_bytes([1u8; 32]);
+    // A well-formed (decodable) proof so resolution reaches scope pinning, which
+    // is where NEAR is rejected.
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.to_string(),
+        nonce: NONCE.to_vec(),
+        signed_payload: vec![0u8; 32],
+        signature: vec![0u8; 64],
+        public_key: Some(vec![0u8; 32]),
+    };
+    let proof = SigningProof::WalletConnectProof(
+        encode_walletconnect_proof(&payload).expect("encode proof"),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("near must fail closed");
+    assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+}
+
+// ── Crypto-field error paths (henrypark review: explicit fail-closed coverage) ──
+
+#[tokio::test]
+async fn evm_signed_payload_wrong_length_is_proof_invalid() {
+    // verify_evm requires the signed_payload to be exactly the 32-byte sighash.
+    // A wrong-length payload (here 31 bytes) must fail closed as ProofInvalid.
+    // The binding records the SAME wrong-length payload so the earlier
+    // payload-match check passes and we actually reach verify_evm's length gate.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let short_payload = vec![0xabu8; 31]; // not 32 bytes
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, short_payload.clone()),
+    );
+
+    // A syntactically-valid 65-byte signature; verify_evm rejects on the
+    // payload length before signature recovery is attempted.
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: short_payload,
+        signature: vec![0u8; 65],
+        public_key: None,
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("non-32-byte evm signed payload must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_invalid_recovery_id_v_is_proof_invalid() {
+    // recovery_id_from_v rejects v bytes outside {0,1,27,28,>=35}. A 65-byte
+    // signature whose v byte is, e.g., 5 must fail closed as ProofInvalid.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // Valid r∥s scalars, but an out-of-range v byte.
+    let mut signature = evm_sign_payload(&key, &signed);
+    signature[64] = 5; // invalid recovery id
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: signed.to_vec(),
+        signature,
+        public_key: None,
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("invalid evm recovery id v must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn solana_missing_public_key_is_proof_invalid() {
+    // verify_chain_signature for the ed25519 family requires public_key; a
+    // Solana proof with public_key=None must fail closed as ProofInvalid.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    let account = lower_hex(&pubkey);
+    let ctx = ctx_for(&account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+
+    let sig = key.sign(&message);
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: None, // missing — must fail closed
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("solana proof missing public_key must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn solana_wrong_length_crypto_fields_is_proof_invalid() {
+    // verify_ed25519 rejects non-64-byte signatures and non-32-byte public keys.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    let account = lower_hex(&pubkey);
+    let ctx = ctx_for(&account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+
+    // Case 1: wrong-length signature (63 bytes).
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+    let short_sig = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message.clone(),
+        signature: vec![0u8; 63],
+        public_key: Some(pubkey.to_vec()),
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&short_sig).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("non-64-byte ed25519 signature must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+
+    // Case 2: wrong-length public key (31 bytes). The bound account is the real
+    // pubkey hex so we reach verify_ed25519, where the 32-byte check fails.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+    let sig = key.sign(&message);
+    let short_pk = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: Some(vec![0u8; 31]),
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&short_pk).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("non-32-byte ed25519 public key must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn initiate_returns_awaiting_user_action() {
+    // initiate pins the scope (no relay traffic in PR9) and signals the ceremony
+    // proceeds out of band via AwaitingUserAction.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+
+    let account = "0x00000000000000000000000000000000000000aa";
+    let ctx = ctx_for(account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let decoded = DecodedTransaction::from_opaque(vec![1u8, 2, 3]);
+    let rendered = RenderedTx::from_opaque(vec![4u8, 5, 6]);
+
+    let outcome = provider
+        .initiate(&ctx, &decoded, &rendered, &hash)
+        .await
+        .expect("initiate over a pinnable chain must succeed");
+    assert!(matches!(
+        outcome,
+        InitiationOutcome::AwaitingUserAction { .. }
+    ));
+}
+
+#[tokio::test]
+async fn initiate_unsupported_chain_fails_closed() {
+    // initiate must fail closed (ScopeViolation) for a chain it cannot pin
+    // (NEAR is unsupported on the WC provider in PR9).
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+
+    let ctx = ctx_for("near-account.near", "near:mainnet");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let decoded = DecodedTransaction::from_opaque(vec![1u8]);
+    let rendered = RenderedTx::from_opaque(vec![2u8]);
+
+    let err = provider
+        .initiate(&ctx, &decoded, &rendered, &hash)
+        .await
+        .expect_err("unsupported chain must fail closed at scope pinning");
+    assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+}
+
+#[tokio::test]
+async fn object_safe_behind_dyn_arc() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider: Arc<dyn SigningProvider> =
+        Arc::new(WalletConnectSigningProvider::new(project(), store));
+    assert_eq!(
+        provider.provider_id(),
+        ironclaw_signing_provider::ProviderId::WalletConnect
+    );
+    assert_eq!(
+        provider.trust_model(),
+        ironclaw_signing_provider::TrustModel::ExternalWallet
+    );
+}

--- a/crates/ironclaw_wallet_external/tests/walletconnect_verify_resume.rs
+++ b/crates/ironclaw_wallet_external/tests/walletconnect_verify_resume.rs
@@ -1,0 +1,1037 @@
+//! End-to-end verification tests for the WalletConnect v2
+//! [`WalletConnectSigningProvider`] security cores (attested-signing PR9).
+//!
+//! Drives the provider behind `Arc<dyn SigningProvider>` (object-safety) and
+//! through the sealed-grant store + recorded session binding, exercising the
+//! full fail-closed contract:
+//!
+//! * namespace pinning rejects scope broadening + wrong-chain CAIP-10 accounts
+//!   + duplicate scope arrays (T17/T19, #2);
+//! * a valid REAL chain signature over the REAL signed-tx payload from the
+//!   session-bound account, where that payload equals the
+//!   `expected_signing_payload` recorded at initiate → `VerifiedProof` (#1);
+//! * a tampered hash, a wrong session topic / nonce (T18), a mismatched signer
+//!   (T17), a payload that differs from the approved bytes (#1), a malformed
+//!   Unicode-hex account (#3), and a replayed / already-claimed grant (T20) all
+//!   fail closed.
+//!
+//! The relay is never contacted: the session binding `initiate` would record
+//! over the relay (PR10) — including the `expected_signing_payload` PR10/PR11's
+//! chain encoder will derive — is installed directly via `record_session_binding`,
+//! and the wallet signature is minted in-test over the exact `signed_payload`
+//! fixture the verifier checks. No synthetic attestation digest exists anymore.
+
+use std::sync::Arc;
+
+use ironclaw_attestation::{
+    ApprovedTxHash, AttestedSigningGrant, GrantKey, InMemorySealedGrantStore, SealedGrantStore,
+};
+use ironclaw_signing_provider::{
+    ActorId, ChainId, DecodedTransaction, GateRef, InitiationOutcome, KeyOrAccountId, RenderedTx,
+    RunId, ScopeId, SigningContext, SigningProof, SigningProvider, SigningProviderError, TenantId,
+    UserId,
+};
+use ironclaw_wallet_external::{
+    PinnedScope, ProjectId, ProposedScope, SessionBinding, WalletConnectProofPayload,
+    WalletConnectSigningProvider, encode_walletconnect_proof, enforce_pinned_scope,
+};
+
+use ed25519_dalek::{Signer as _, SigningKey as EdSigningKey};
+use k256::ecdsa::{SigningKey as EcSigningKey, signature::hazmat::PrehashSigner};
+use sha3::{Digest, Keccak256};
+
+const SESSION_TOPIC: &str = "a3f1c0de";
+const NONCE: &[u8] = b"nonce-001";
+
+fn project() -> ProjectId {
+    // Publishable, API-key class; injected, never hardcoded in production.
+    ProjectId::from("00000000000000000000000000000000")
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        out.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+    }
+    out
+}
+
+/// A stand-in for the EVM secp256k1 sighash a real `eth_signTransaction` would
+/// cover. In production PR10/PR11 derives this from the decoded tx via a real
+/// EIP-2718/RLP encoder; here it is a fixed 32-byte fixture the wallet signs and
+/// the binding records as `expected_signing_payload`.
+fn evm_sighash_fixture() -> [u8; 32] {
+    let mut h = Keccak256::new();
+    h.update(b"real-evm-signing-payload-fixture");
+    let out = h.finalize();
+    let mut sighash = [0u8; 32];
+    sighash.copy_from_slice(&out);
+    sighash
+}
+
+/// A stand-in for the Solana ed25519 message bytes a real
+/// `solana_signTransaction` would cover.
+fn solana_message_fixture() -> Vec<u8> {
+    b"real-solana-signing-message-fixture-bytes".to_vec()
+}
+
+// ── EVM helpers ──
+
+fn evm_key() -> EcSigningKey {
+    EcSigningKey::from_slice(&[0x11u8; 32]).expect("valid secp256k1 key")
+}
+
+fn evm_address(key: &EcSigningKey) -> [u8; 20] {
+    let vk = key.verifying_key();
+    let encoded = vk.to_encoded_point(false);
+    let hash = Keccak256::digest(&encoded.as_bytes()[1..]);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    addr
+}
+
+/// 65-byte (r ∥ s ∥ v) signature over the 32-byte sighash payload.
+fn evm_sign_payload(key: &EcSigningKey, payload: &[u8; 32]) -> Vec<u8> {
+    let (sig, recid): (k256::ecdsa::Signature, k256::ecdsa::RecoveryId) =
+        key.sign_prehash(payload.as_slice()).expect("sign");
+    let mut out = sig.to_bytes().to_vec();
+    out.push(recid.to_byte());
+    out
+}
+
+// ── Solana / ed25519 helpers ──
+
+fn ed_key() -> EdSigningKey {
+    EdSigningKey::from_bytes(&[0x22u8; 32])
+}
+
+// ── Fixtures ──
+
+fn ctx_for(account: &str, chain: &str) -> SigningContext {
+    SigningContext {
+        tenant: TenantId::new("tenant-a"),
+        user: UserId::new("user-1"),
+        scope: ScopeId::new("scope-x"),
+        actor: ActorId::new("actor-7"),
+        run_id: RunId::new("run-42"),
+        gate_ref: GateRef::new("gate:abc"),
+        chain_id: ChainId::new(chain),
+        key_or_account_id: KeyOrAccountId::new(account),
+    }
+}
+
+async fn seal_grant(store: &InMemorySealedGrantStore, ctx: &SigningContext, hash: ApprovedTxHash) {
+    let key = GrantKey::from_context(ctx, hash);
+    store
+        .seal(AttestedSigningGrant::new(key, 1_000, None).expect("valid grant"))
+        .await
+        .expect("seal");
+}
+
+/// Build a binding whose `expected_signing_payload` is the real bytes the
+/// wallet will sign, recorded at initiate from the same decoded tx as `hash`.
+fn binding_for(
+    account: &str,
+    chain: &str,
+    hash: ApprovedTxHash,
+    expected_signing_payload: Vec<u8>,
+) -> SessionBinding {
+    SessionBinding {
+        session_topic: SESSION_TOPIC.to_string(),
+        account: account.to_string(),
+        nonce: NONCE.to_vec(),
+        pinned: PinnedScope::from_chain_id(&ChainId::new(chain)).expect("pinned"),
+        approved_tx_hash: hash,
+        expected_signing_payload,
+    }
+}
+
+// ── Namespace pinning (T17/T19, #2) ──
+
+#[test]
+fn pinning_accepts_exact_scope_and_rejects_broadening() {
+    let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+    enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec!["eip155:1:0x00000000000000000000000000000000000000aa".to_string()],
+        },
+    )
+    .expect("exact scope accepted");
+
+    // Extra chain (T19).
+    assert!(matches!(
+        enforce_pinned_scope(
+            &pinned,
+            &ProposedScope {
+                chains: vec!["eip155:1".to_string(), "eip155:10".to_string()],
+                methods: vec!["eth_signTransaction".to_string()],
+                accounts: vec![],
+            },
+        )
+        .expect_err("broader chains rejected"),
+        SigningProviderError::ScopeViolation { .. }
+    ));
+
+    // Extra method (T17).
+    assert!(matches!(
+        enforce_pinned_scope(
+            &pinned,
+            &ProposedScope {
+                chains: vec!["eip155:1".to_string()],
+                methods: vec![
+                    "eth_signTransaction".to_string(),
+                    "eth_sendTransaction".to_string(),
+                ],
+                accounts: vec![],
+            },
+        )
+        .expect_err("broader methods rejected"),
+        SigningProviderError::ScopeViolation { .. }
+    ));
+}
+
+#[test]
+fn pinning_rejects_wrong_chain_caip10_account() {
+    let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+    // Same address, different chain — must be rejected (#2).
+    let err = enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec!["eip155:137:0x00000000000000000000000000000000000000aa".to_string()],
+        },
+    )
+    .expect_err("wrong-chain account rejected");
+    assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+}
+
+#[test]
+fn pinning_rejects_duplicate_scope_arrays() {
+    let pinned = PinnedScope::from_chain_id(&ChainId::new("eip155:1")).expect("evm");
+    let dup_chain = enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string(), "eip155:1".to_string()],
+            methods: vec!["eth_signTransaction".to_string()],
+            accounts: vec![],
+        },
+    )
+    .expect_err("duplicate chain rejected");
+    assert!(matches!(
+        dup_chain,
+        SigningProviderError::ScopeViolation { .. }
+    ));
+
+    let dup_method = enforce_pinned_scope(
+        &pinned,
+        &ProposedScope {
+            chains: vec!["eip155:1".to_string()],
+            methods: vec![
+                "eth_signTransaction".to_string(),
+                "eth_signTransaction".to_string(),
+            ],
+            accounts: vec![],
+        },
+    )
+    .expect_err("duplicate method rejected");
+    assert!(matches!(
+        dup_method,
+        SigningProviderError::ScopeViolation { .. }
+    ));
+}
+
+// ── verify_resume: EVM (real signed-tx payload, #1) ──
+
+fn evm_proof(
+    key: &EcSigningKey,
+    account: &str,
+    hash: ApprovedTxHash,
+    topic: &str,
+    nonce: &[u8],
+    signed_payload: Vec<u8>,
+) -> SigningProof {
+    // Sign the REAL payload bytes (the secp256k1 sighash), exactly as
+    // eth_signTransaction would. There is no synthetic attestation digest.
+    let sighash: [u8; 32] = signed_payload
+        .clone()
+        .try_into()
+        .expect("evm signed payload is a 32-byte sighash");
+    let payload = WalletConnectProofPayload {
+        session_topic: topic.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.to_string(),
+        nonce: nonce.to_vec(),
+        signed_payload,
+        signature: evm_sign_payload(key, &sighash),
+        public_key: None,
+    };
+    SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode proof"))
+}
+
+#[tokio::test]
+async fn evm_valid_proof_over_real_signed_tx_verifies() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let provider: Arc<dyn SigningProvider> = Arc::new(provider);
+    let verified = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("valid evm walletconnect proof over the real signed tx must verify");
+    assert_eq!(verified.proof(), &proof);
+}
+
+#[tokio::test]
+async fn evm_session_account_casing_mismatch_still_verifies() {
+    // EVM addresses are case-insensitive hex; the WC session may settle the
+    // account in EIP-55 mixed case while the gate stores it lowercase. The
+    // defense-in-depth account string compare must be case-insensitive so a
+    // pure-casing difference does not spuriously reject. The authoritative
+    // signer binding remains the byte-exact chain-signature recovery.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    // Binding records the SAME address but UPPER-cased (different casing only).
+    let upper_account = account.to_ascii_uppercase();
+    assert_ne!(upper_account, account);
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&upper_account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let provider: Arc<dyn SigningProvider> = Arc::new(provider);
+    let verified = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("case-only account difference must not reject a valid proof");
+    assert_eq!(verified.proof(), &proof);
+}
+
+#[tokio::test]
+async fn evm_payload_not_matching_approved_bytes_is_rejected() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let approved = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    // Binding records the APPROVED payload.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, approved.to_vec()),
+    );
+
+    // Wallet signs a DIFFERENT transaction than the approved one (the core #1
+    // attack: a validly-signed but unapproved tx). The signature is valid for
+    // the bound account over `other`, but `other != expected_signing_payload`.
+    let mut other = approved;
+    other[0] ^= 0xff;
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, other.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("signed payload != approved bytes must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_signer_not_bound_account_is_signer_mismatch() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    // Bind a different account than the key recovers to, but record the binding
+    // on the REAL signing account so the account-binding check passes and we
+    // reach the signer recovery (which must mismatch the gate's bound account).
+    let wrong = "0x00000000000000000000000000000000000000bb";
+    let ctx = ctx_for(wrong, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    let real_account = format!("0x{}", lower_hex(&evm_address(&key)));
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&real_account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(
+        &key,
+        &real_account,
+        hash,
+        SESSION_TOPIC,
+        NONCE,
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("mismatched signer must reject");
+    assert!(matches!(err, SigningProviderError::SignerMismatch));
+}
+
+#[tokio::test]
+async fn evm_tampered_hash_is_proof_invalid() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let bound_hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, bound_hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", bound_hash, signed.to_vec()),
+    );
+
+    // Wallet attests to a DIFFERENT hash than the gate bound.
+    let attested = ApprovedTxHash::from_bytes([9u8; 32]);
+    let proof = evm_proof(
+        &key,
+        &account,
+        attested,
+        SESSION_TOPIC,
+        NONCE,
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &bound_hash, &proof)
+        .await
+        .expect_err("tampered hash must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_wrong_session_topic_is_rejected_t18() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // Proof minted under a DIFFERENT session topic (relay/session compromise).
+    let proof = evm_proof(&key, &account, hash, "deadbeef", NONCE, signed.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("wrong session topic must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_wrong_nonce_is_rejected_t18() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // Proof carries a stale / forged nonce (replay defense).
+    let proof = evm_proof(
+        &key,
+        &account,
+        hash,
+        SESSION_TOPIC,
+        b"other-nonce",
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("wrong nonce must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_missing_session_binding_is_rejected() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    // No session binding recorded.
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("missing binding must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_malformed_response_does_not_burn_binding() {
+    // A malformed relay/wallet response (wrong nonce) must NOT consume the
+    // recorded binding — a subsequent valid proof must still verify (the
+    // "validate first, consume only on success" recommendation).
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // First: malformed (wrong nonce) — must fail but NOT burn the binding.
+    let bad = evm_proof(
+        &key,
+        &account,
+        hash,
+        SESSION_TOPIC,
+        b"forged-nonce",
+        signed.to_vec(),
+    );
+    assert!(matches!(
+        provider
+            .verify_resume(&ctx, &hash, &bad)
+            .await
+            .expect_err("malformed must fail"),
+        SigningProviderError::ProofInvalid { .. }
+    ));
+
+    // Then: a valid proof against the still-present binding must verify.
+    let good = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    provider
+        .verify_resume(&ctx, &hash, &good)
+        .await
+        .expect("valid proof after a malformed attempt must still verify");
+}
+
+#[tokio::test]
+async fn evm_replay_after_claim_fails_closed_t20() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = Arc::new(WalletConnectSigningProvider::new(project(), store.clone()));
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("first resume succeeds");
+
+    // Re-record the binding so the replay reaches the grant CAS (the binding is
+    // consumed on first success). The one-shot grant must still reject the replay.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("replay must fail closed");
+    assert!(matches!(err, SigningProviderError::GrantClaimFailed));
+}
+
+#[tokio::test]
+async fn evm_unsealed_grant_fails_closed() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    // No grant sealed.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(&key, &account, hash, SESSION_TOPIC, NONCE, signed.to_vec());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("no grant must fail closed");
+    assert!(matches!(err, SigningProviderError::GrantClaimFailed));
+}
+
+#[tokio::test]
+async fn evm_malformed_unicode_hex_account_fails_closed() {
+    // A bound account carrying a non-ASCII even-byte string used to panic when
+    // the hex parser sliced &str by byte offset (#3). It must now fail closed.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    // 40-byte (20 char-pairs) string of a 2-byte multibyte char: ASCII byte
+    // length is even but slicing at odd byte offsets crosses a char boundary.
+    let bad_account = "é".repeat(20); // 40 bytes, all non-ASCII
+    assert_eq!(bad_account.len(), 40);
+    let ctx = ctx_for(&bad_account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&bad_account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    let proof = evm_proof(
+        &key,
+        &bad_account,
+        hash,
+        SESSION_TOPIC,
+        NONCE,
+        signed.to_vec(),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("malformed unicode hex account must fail closed (not panic)");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn malformed_unicode_hex_in_proof_field_fails_closed() {
+    // A relay-supplied proof whose hex-encoded fields contain non-ASCII even-byte
+    // content must decode-fail (ProofInvalid), never panic (#3).
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+    let ctx = ctx_for("0x00000000000000000000000000000000000000aa", "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([1u8; 32]);
+
+    // Hand-craft JSON with a malformed-unicode hex `signature` field.
+    let json = format!(
+        r#"{{"session_topic":"{SESSION_TOPIC}","approved_tx_hash":{:?},"claimed_signer":"0x00000000000000000000000000000000000000aa","nonce":"6e6f6e6365","signed_payload":"00","signature":"éé"}}"#,
+        hash.as_bytes()
+    );
+    let proof = SigningProof::WalletConnectProof(json.into_bytes());
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("malformed unicode hex in proof must fail closed (not panic)");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+// ── verify_resume: Solana (ed25519, real signed message) ──
+
+#[tokio::test]
+async fn solana_valid_proof_over_real_message_verifies() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider: Arc<dyn SigningProvider> =
+        Arc::new(WalletConnectSigningProvider::new(project(), store.clone()));
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    let account = lower_hex(&pubkey);
+    let ctx = ctx_for(&account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+
+    // Record binding via a concrete provider, then drive via the dyn handle.
+    let inner = WalletConnectSigningProvider::new(project(), store.clone());
+    inner.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+
+    // ed25519 signs the REAL message bytes, as solana_signTransaction would.
+    let sig = key.sign(&message);
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: Some(pubkey.to_vec()),
+    };
+    let proof = SigningProof::WalletConnectProof(
+        encode_walletconnect_proof(&payload).expect("encode proof"),
+    );
+
+    inner
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect("valid solana walletconnect proof over the real message must verify");
+
+    // Object-safety sanity: the dyn handle is usable.
+    let _ = provider.provider_id();
+}
+
+#[tokio::test]
+async fn solana_wrong_signer_is_signer_mismatch() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    // Bind a different pubkey than the proof's.
+    let other = [0x33u8; 32];
+    let bound_account = lower_hex(&other);
+    let ctx = ctx_for(&bound_account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&bound_account, "solana:mainnet", hash, message.clone()),
+    );
+
+    let sig = key.sign(&message);
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: bound_account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: Some(pubkey.to_vec()),
+    };
+    let proof = SigningProof::WalletConnectProof(
+        encode_walletconnect_proof(&payload).expect("encode proof"),
+    );
+
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("mismatched solana signer must reject");
+    assert!(matches!(err, SigningProviderError::SignerMismatch));
+}
+
+#[tokio::test]
+async fn non_walletconnect_proof_is_rejected() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+    let ctx = ctx_for("0x00000000000000000000000000000000000000aa", "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([1u8; 32]);
+
+    let err = provider
+        .verify_resume(&ctx, &hash, &SigningProof::InjectedProof(vec![1, 2, 3]))
+        .await
+        .expect_err("non-walletconnect proof must be rejected");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn near_chain_is_unsupported_fail_closed() {
+    // NEAR is explicitly unsupported on the WC provider until a real verifier
+    // exists — initiate/verify must fail closed at scope resolution.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+    let account = "0011223344556677889900112233445566778899001122334455667788990011";
+    let ctx = ctx_for(account, "near:mainnet");
+    let hash = ApprovedTxHash::from_bytes([1u8; 32]);
+    // A well-formed (decodable) proof so resolution reaches scope pinning, which
+    // is where NEAR is rejected.
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.to_string(),
+        nonce: NONCE.to_vec(),
+        signed_payload: vec![0u8; 32],
+        signature: vec![0u8; 64],
+        public_key: Some(vec![0u8; 32]),
+    };
+    let proof = SigningProof::WalletConnectProof(
+        encode_walletconnect_proof(&payload).expect("encode proof"),
+    );
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("near must fail closed");
+    assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+}
+
+// ── Crypto-field error paths (henrypark review: explicit fail-closed coverage) ──
+
+#[tokio::test]
+async fn evm_signed_payload_wrong_length_is_proof_invalid() {
+    // verify_evm requires the signed_payload to be exactly the 32-byte sighash.
+    // A wrong-length payload (here 31 bytes) must fail closed as ProofInvalid.
+    // The binding records the SAME wrong-length payload so the earlier
+    // payload-match check passes and we actually reach verify_evm's length gate.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let short_payload = vec![0xabu8; 31]; // not 32 bytes
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, short_payload.clone()),
+    );
+
+    // A syntactically-valid 65-byte signature; verify_evm rejects on the
+    // payload length before signature recovery is attempted.
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: short_payload,
+        signature: vec![0u8; 65],
+        public_key: None,
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("non-32-byte evm signed payload must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn evm_invalid_recovery_id_v_is_proof_invalid() {
+    // recovery_id_from_v rejects v bytes outside {0,1,27,28,>=35}. A 65-byte
+    // signature whose v byte is, e.g., 5 must fail closed as ProofInvalid.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = evm_key();
+    let account = format!("0x{}", lower_hex(&evm_address(&key)));
+    let ctx = ctx_for(&account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let signed = evm_sighash_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "eip155:1", hash, signed.to_vec()),
+    );
+
+    // Valid r∥s scalars, but an out-of-range v byte.
+    let mut signature = evm_sign_payload(&key, &signed);
+    signature[64] = 5; // invalid recovery id
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: signed.to_vec(),
+        signature,
+        public_key: None,
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("invalid evm recovery id v must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn solana_missing_public_key_is_proof_invalid() {
+    // verify_chain_signature for the ed25519 family requires public_key; a
+    // Solana proof with public_key=None must fail closed as ProofInvalid.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    let account = lower_hex(&pubkey);
+    let ctx = ctx_for(&account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+
+    let sig = key.sign(&message);
+    let payload = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: None, // missing — must fail closed
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&payload).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("solana proof missing public_key must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn solana_wrong_length_crypto_fields_is_proof_invalid() {
+    // verify_ed25519 rejects non-64-byte signatures and non-32-byte public keys.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store.clone());
+
+    let key = ed_key();
+    let pubkey = key.verifying_key().to_bytes();
+    let account = lower_hex(&pubkey);
+    let ctx = ctx_for(&account, "solana:mainnet");
+    let hash = ApprovedTxHash::from_bytes([5u8; 32]);
+    let message = solana_message_fixture();
+    seal_grant(&store, &ctx, hash).await;
+
+    // Case 1: wrong-length signature (63 bytes).
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+    let short_sig = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message.clone(),
+        signature: vec![0u8; 63],
+        public_key: Some(pubkey.to_vec()),
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&short_sig).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("non-64-byte ed25519 signature must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+
+    // Case 2: wrong-length public key (31 bytes). The bound account is the real
+    // pubkey hex so we reach verify_ed25519, where the 32-byte check fails.
+    provider.record_session_binding(
+        &ctx.gate_ref,
+        binding_for(&account, "solana:mainnet", hash, message.clone()),
+    );
+    let sig = key.sign(&message);
+    let short_pk = WalletConnectProofPayload {
+        session_topic: SESSION_TOPIC.to_string(),
+        approved_tx_hash: hash,
+        claimed_signer: account.clone(),
+        nonce: NONCE.to_vec(),
+        signed_payload: message,
+        signature: sig.to_bytes().to_vec(),
+        public_key: Some(vec![0u8; 31]),
+    };
+    let proof =
+        SigningProof::WalletConnectProof(encode_walletconnect_proof(&short_pk).expect("encode"));
+    let err = provider
+        .verify_resume(&ctx, &hash, &proof)
+        .await
+        .expect_err("non-32-byte ed25519 public key must fail closed");
+    assert!(matches!(err, SigningProviderError::ProofInvalid { .. }));
+}
+
+#[tokio::test]
+async fn initiate_returns_awaiting_user_action() {
+    // initiate pins the scope (no relay traffic in PR9) and signals the ceremony
+    // proceeds out of band via AwaitingUserAction.
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+
+    let account = "0x00000000000000000000000000000000000000aa";
+    let ctx = ctx_for(account, "eip155:1");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let decoded = DecodedTransaction::from_opaque(vec![1u8, 2, 3]);
+    let rendered = RenderedTx::from_opaque(vec![4u8, 5, 6]);
+
+    let outcome = provider
+        .initiate(&ctx, &decoded, &rendered, &hash)
+        .await
+        .expect("initiate over a pinnable chain must succeed");
+    assert!(matches!(
+        outcome,
+        InitiationOutcome::AwaitingUserAction { .. }
+    ));
+}
+
+#[tokio::test]
+async fn initiate_unsupported_chain_fails_closed() {
+    // initiate must fail closed (ScopeViolation) for a chain it cannot pin
+    // (NEAR is unsupported on the WC provider in PR9).
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider = WalletConnectSigningProvider::new(project(), store);
+
+    let ctx = ctx_for("near-account.near", "near:mainnet");
+    let hash = ApprovedTxHash::from_bytes([7u8; 32]);
+    let decoded = DecodedTransaction::from_opaque(vec![1u8]);
+    let rendered = RenderedTx::from_opaque(vec![2u8]);
+
+    let err = provider
+        .initiate(&ctx, &decoded, &rendered, &hash)
+        .await
+        .expect_err("unsupported chain must fail closed at scope pinning");
+    assert!(matches!(err, SigningProviderError::ScopeViolation { .. }));
+}
+
+#[tokio::test]
+async fn object_safe_behind_dyn_arc() {
+    let store = Arc::new(InMemorySealedGrantStore::new());
+    let provider: Arc<dyn SigningProvider> =
+        Arc::new(WalletConnectSigningProvider::new(project(), store));
+    assert_eq!(
+        provider.provider_id(),
+        ironclaw_signing_provider::ProviderId::WalletConnect
+    );
+    assert_eq!(
+        provider.trust_model(),
+        ironclaw_signing_provider::TrustModel::ExternalWallet
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -71,4 +71,7 @@ allow-git = [
     # Pulls in ruff_* crates from astral-sh/ruff at a pinned revision.
     "https://github.com/pydantic/monty.git",
     "https://github.com/astral-sh/ruff.git",
+    # First-party WalletConnect v2 fork (tracecommons/walletconnect-rs) — provides
+    # relay_client/relay_rpc for the attested-signing external-wallet backend.
+    "https://github.com/tracecommons/walletconnect-rs",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -62,4 +62,7 @@ allow-git = [
     # Pulls in ruff_* crates from samuelcolvin/ruff at a pinned revision.
     "https://github.com/pydantic/monty.git",
     "https://github.com/samuelcolvin/ruff.git",
+    # First-party WalletConnect v2 fork (tracecommons/walletconnect-rs) — provides
+    # relay_client/relay_rpc for the attested-signing external-wallet backend.
+    "https://github.com/tracecommons/walletconnect-rs",
 ]


### PR DESCRIPTION
> **Rebased onto current `main` (attested-signing cascade, 2026-07-23).** The stack was 1184 commits behind (merge base 2026-05-24). Tracking issue: #6532.
>
> Inline review threads may have re-anchored or orphaned from the force-push. Reviewers: the "Cascade changes" section states exactly what the rebase altered beyond the original work.

## What this PR is
WalletConnect v2 backend in `ironclaw_wallet_external`, over the openssl-free fork `tracecommons/walletconnect-rs` (`relay_client`/`relay_rpc`, `cacao` deliberately disabled).

## Cascade changes
- **The openssl-free fork pin was re-verified against current dependencies** — this was the flagged risk for this hop. The workspace still resolves and `workspace_graph_is_openssl_free` **passes with the WalletConnect fork in the tree**.
- **`deny.toml` rebuilt as `main`'s + the fork allowance.** The branch's copy had a stale `allow-git` entry (`astral-sh/ruff.git`); `main` currently uses `samuelcolvin/ruff.git`. Taking `main`'s file and appending only the `tracecommons/walletconnect-rs` line avoids reverting main-side policy drift.
- Adopted the round-2 API: **`VerifiedProof::new` is now 3-arg** `(ProviderId::WalletConnect, *approved_tx_hash, proof)` — binding the provider and the approved hash into the proof is what makes it unforgeable; the old 1-arg form would have dropped that. Plus the `GrantError::InvalidTimestamp/InvalidExpiry` fail-closed mapping.

## Verification
15 + 20 + 27 crate tests pass; **boundary test green including `workspace_graph_is_openssl_free`**; clippy clean.
