### PR TITLE
[codex] Fix model retry prompt grant renewal

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -59,24 +59,18 @@ impl ExecutorStage<ModelInput> for ModelStage {
             CancelCheck::Continue(state) => *state,
             CancelCheck::Exit(exit) => return Ok(ModelStep::Exit(exit)),
         };
+        let surface_version = input.surface_version;
+        let capability_view = input.capability_view;
         let mut request = LoopModelRequest {
             messages: input.messages,
-            surface_version: Some(input.surface_version),
+            surface_version: Some(surface_version.clone()),
             model_preference,
-            capability_view: Some(input.capability_view),
+            capability_view: Some(capability_view.clone()),
         };
-        let visible_capability_count = request
-            .capability_view
-            .as_ref()
-            .map(|view| view.visible_capability_ids.len())
-            .unwrap_or(0);
+        let visible_capability_count = capability_view.visible_capability_ids.len();
         debug!(
             iteration = state.iteration,
-            surface_version = request
-                .surface_version
-                .as_ref()
-                .map(|version| version.as_str())
-                .unwrap_or("<none>"),
+            surface_version = surface_version.as_str(),
             visible_capability_count,
             model_preference = request
                 .model_preference
@@ -166,8 +160,8 @@ impl ExecutorStage<ModelInput> for ModelStage {
                             let messages = build_prompt_bundle_for_surface(
                                 ctx,
                                 &state,
-                                request.surface_version.clone(),
-                                request.capability_view.clone(),
+                                surface_version.clone(),
+                                capability_view.clone(),
                             )
                             .await?;
                             match CheckpointStage.cancel_if_requested(ctx, state).await? {

--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -13,6 +13,7 @@ use crate::{
     strategies::{ModelErrorSummary, RecoveryOutcome},
 };
 
+use super::prompt::build_prompt_bundle_for_surface;
 use super::{
     AgentLoopExecutorError, CancelCheck, CheckpointStage, ExecutorStage, HostStage,
     MAX_MODEL_RETRIES, StageContext, failed_exit, honor_retry_alteration, model_error_class,
@@ -58,7 +59,7 @@ impl ExecutorStage<ModelInput> for ModelStage {
             CancelCheck::Continue(state) => *state,
             CancelCheck::Exit(exit) => return Ok(ModelStep::Exit(exit)),
         };
-        let request = LoopModelRequest {
+        let mut request = LoopModelRequest {
             messages: input.messages,
             surface_version: Some(input.surface_version),
             model_preference,
@@ -162,6 +163,18 @@ impl ExecutorStage<ModelInput> for ModelStage {
                                     })?,
                                 )
                                 .await;
+                            let messages = build_prompt_bundle_for_surface(
+                                ctx,
+                                &state,
+                                request.surface_version.clone(),
+                                request.capability_view.clone(),
+                            )
+                            .await?;
+                            match CheckpointStage.cancel_if_requested(ctx, state).await? {
+                                CancelCheck::Continue(next) => state = *next,
+                                CancelCheck::Exit(exit) => return Ok(ModelStep::Exit(exit)),
+                            }
+                            request.messages = messages;
                         }
                         RecoveryOutcome::SkipResult { .. } => {
                             return Err(AgentLoopExecutorError::PlannerContract {

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use ironclaw_turns::{
     LoopExit,
     run_profile::{
-        LoopModelCapabilityView, LoopProgressEvent, VisibleCapabilityRequest,
-        VisibleCapabilitySurface,
+        CapabilitySurfaceVersion, LoopModelCapabilityView, LoopModelMessage, LoopProgressEvent,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
 };
 use tracing::debug;
@@ -96,10 +96,13 @@ impl ExecutorStage<PromptInput> for PromptStage {
             CancelCheck::Exit(exit) => return Ok(PromptStep::Exit(exit)),
         };
 
-        let mut context_request = ctx.planner.context().plan_context_request(&state).await;
-        context_request.surface_version = Some(surface.version.clone());
-        context_request.capability_view = Some(capability_view.clone());
-        let prompt_mode = context_request.mode;
+        let messages = build_prompt_bundle_for_surface(
+            ctx,
+            &state,
+            Some(surface.version.clone()),
+            Some(capability_view.clone()),
+        )
+        .await?;
         state = match CheckpointStage
             .cancel_if_requested_after_pending_input_ack(ctx, state, &mut pending_input_ack)
             .await?
@@ -107,41 +110,47 @@ impl ExecutorStage<PromptInput> for PromptStage {
             CancelCheck::Continue(state) => *state,
             CancelCheck::Exit(exit) => return Ok(PromptStep::Exit(exit)),
         };
-        let prompt_bundle = ctx
-            .host
-            .build_prompt_bundle(context_request)
-            .await
-            .map_err(|_| AgentLoopExecutorError::HostUnavailable {
-                stage: HostStage::Prompt,
-            })?;
-        CheckpointStage
-            .emit_progress(
-                ctx,
-                LoopProgressEvent::PromptBundleBuilt {
-                    iteration: state.iteration,
-                    bundle_ref: prompt_bundle.bundle_ref.clone(),
-                    mode: prompt_mode,
-                    surface_version: prompt_bundle.surface_version.clone(),
-                    message_count: prompt_bundle.messages.len() as u32,
-                    identity_message_count: prompt_bundle.identity_message_count,
-                    instruction_snippet_count: prompt_bundle.instruction_snippet_count,
-                },
-            )
-            .await;
-        state = match CheckpointStage
-            .cancel_if_requested_after_pending_input_ack(ctx, state, &mut pending_input_ack)
-            .await?
-        {
-            CancelCheck::Continue(state) => *state,
-            CancelCheck::Exit(exit) => return Ok(PromptStep::Exit(exit)),
-        };
-
         Ok(PromptStep::Prepared(Box::new(PromptOutput {
             state,
             pending_input_ack,
             surface,
-            messages: prompt_bundle.messages,
+            messages,
             capability_view,
         })))
     }
+}
+
+pub(super) async fn build_prompt_bundle_for_surface(
+    ctx: StageContext<'_>,
+    state: &LoopExecutionState,
+    surface_version: Option<CapabilitySurfaceVersion>,
+    capability_view: Option<LoopModelCapabilityView>,
+) -> Result<Vec<LoopModelMessage>, AgentLoopExecutorError> {
+    let mut context_request = ctx.planner.context().plan_context_request(state).await;
+    context_request.surface_version = surface_version;
+    context_request.capability_view = capability_view;
+    let prompt_mode = context_request.mode;
+    let prompt_bundle = ctx
+        .host
+        .build_prompt_bundle(context_request)
+        .await
+        .map_err(|_| AgentLoopExecutorError::HostUnavailable {
+            stage: HostStage::Prompt,
+        })?;
+    CheckpointStage
+        .emit_progress(
+            ctx,
+            LoopProgressEvent::PromptBundleBuilt {
+                iteration: state.iteration,
+                bundle_ref: prompt_bundle.bundle_ref.clone(),
+                mode: prompt_mode,
+                surface_version: prompt_bundle.surface_version.clone(),
+                message_count: prompt_bundle.messages.len() as u32,
+                identity_message_count: prompt_bundle.identity_message_count,
+                instruction_snippet_count: prompt_bundle.instruction_snippet_count,
+            },
+        )
+        .await;
+
+    Ok(prompt_bundle.messages)
 }

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -99,8 +99,8 @@ impl ExecutorStage<PromptInput> for PromptStage {
         let messages = build_prompt_bundle_for_surface(
             ctx,
             &state,
-            Some(surface.version.clone()),
-            Some(capability_view.clone()),
+            surface.version.clone(),
+            capability_view.clone(),
         )
         .await?;
         state = match CheckpointStage
@@ -123,12 +123,12 @@ impl ExecutorStage<PromptInput> for PromptStage {
 pub(super) async fn build_prompt_bundle_for_surface(
     ctx: StageContext<'_>,
     state: &LoopExecutionState,
-    surface_version: Option<CapabilitySurfaceVersion>,
-    capability_view: Option<LoopModelCapabilityView>,
+    surface_version: CapabilitySurfaceVersion,
+    capability_view: LoopModelCapabilityView,
 ) -> Result<Vec<LoopModelMessage>, AgentLoopExecutorError> {
     let mut context_request = ctx.planner.context().plan_context_request(state).await;
-    context_request.surface_version = surface_version;
-    context_request.capability_view = capability_view;
+    context_request.surface_version = Some(surface_version);
+    context_request.capability_view = Some(capability_view);
     let prompt_mode = context_request.mode;
     let prompt_bundle = ctx
         .host

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -975,11 +975,12 @@ async fn model_request_uses_current_visible_surface_not_prompt_bundle_version() 
 
 #[tokio::test]
 async fn model_retry_success_clears_recovery_state() {
-    let host =
-        MockHost::new(vec![reply_response()]).with_model_errors(vec![AgentLoopHostError::new(
+    let host = MockHost::new(vec![reply_response()])
+        .with_model_errors(vec![AgentLoopHostError::new(
             AgentLoopHostErrorKind::Unavailable,
             "model unavailable",
-        )]);
+        )])
+        .with_prompt_surface_version(Some(stale_surface_version()));
     let executor = CanonicalAgentLoopExecutor;
     let state = LoopExecutionState::initial_for_run(host.run_context());
 
@@ -989,7 +990,15 @@ async fn model_retry_success_clears_recovery_state() {
         .expect("execute");
 
     assert!(matches!(exit, LoopExit::Completed(_)));
-    assert_eq!(host.model_requests().len(), 2);
+    let requests = host.model_requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].surface_version, Some(surface_version()));
+    assert_eq!(requests[1].surface_version, Some(surface_version()));
+    assert_eq!(
+        host.prompt_requests().len(),
+        2,
+        "model retry must request a fresh host-built prompt bundle"
+    );
     assert_eq!(final_staged_state(&host).recovery_state, Default::default());
 }
 

--- a/crates/ironclaw_agent_loop/src/executor/tests/cancellation.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/cancellation.rs
@@ -434,6 +434,27 @@ async fn model_cancelled_returns_cancelled_without_retry() {
 }
 
 #[tokio::test]
+async fn cancellation_after_retry_prompt_rebuild_skips_second_model_call() {
+    let host = MockHost::new(vec![reply_response()])
+        .with_model_errors(vec![AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Unavailable,
+            "model unavailable",
+        )])
+        .cancel_after_prompt_bundle(2);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Cancelled(_)));
+    assert_eq!(host.prompt_requests().len(), 2);
+    assert_eq!(host.model_requests().len(), 1);
+}
+
+#[tokio::test]
 async fn capability_cancelled_returns_cancelled_exit_without_retry() {
     let host = MockHost::new(vec![calls_response()]).with_batch_outcomes(vec![
         ironclaw_turns::run_profile::CapabilityBatchOutcome {

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -58,6 +58,7 @@ pub(super) struct MockHost {
     fail_progress_port: bool,
     cancellation: Arc<Mutex<Option<LoopCancellationSignal>>>,
     cancel_after_poll_inputs: Arc<Mutex<bool>>,
+    cancel_after_prompt_bundle_count: Arc<Mutex<Option<usize>>>,
     cancel_after_checkpoint: Arc<Mutex<Option<LoopCheckpointKind>>>,
     cancel_after_model_response: Arc<Mutex<bool>>,
     cancel_after_batch_invocation: Arc<Mutex<bool>>,
@@ -90,6 +91,7 @@ impl MockHost {
             fail_progress_port: false,
             cancellation: Arc::new(Mutex::new(None)),
             cancel_after_poll_inputs: Arc::new(Mutex::new(false)),
+            cancel_after_prompt_bundle_count: Arc::new(Mutex::new(None)),
             cancel_after_checkpoint: Arc::new(Mutex::new(None)),
             cancel_after_model_response: Arc::new(Mutex::new(false)),
             cancel_after_batch_invocation: Arc::new(Mutex::new(false)),
@@ -206,6 +208,11 @@ impl MockHost {
 
     pub(super) fn cancel_after_poll_inputs(self) -> Self {
         *self.cancel_after_poll_inputs.lock().expect("lock") = true;
+        self
+    }
+
+    pub(super) fn cancel_after_prompt_bundle(self, count: usize) -> Self {
+        *self.cancel_after_prompt_bundle_count.lock().expect("lock") = Some(count);
         self
     }
 
@@ -339,7 +346,7 @@ impl ironclaw_turns::run_profile::LoopPromptPort for MockHost {
                 "prompt bundle unavailable",
             ));
         }
-        Ok(LoopPromptBundle {
+        let bundle = LoopPromptBundle {
             bundle_ref: LoopPromptBundleRef::for_run(&self.context, "bundle").expect("valid"),
             messages: vec![LoopModelMessage {
                 role: "user".to_string(),
@@ -349,7 +356,26 @@ impl ironclaw_turns::run_profile::LoopPromptPort for MockHost {
             instruction_fingerprint: None,
             identity_message_count: 0,
             instruction_snippet_count: 0,
-        })
+        };
+        let should_cancel = {
+            let mut remaining = self.cancel_after_prompt_bundle_count.lock().expect("lock");
+            match remaining.as_mut() {
+                Some(count) => {
+                    *count = count.saturating_sub(1);
+                    if *count == 0 {
+                        *remaining = None;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                None => false,
+            }
+        };
+        if should_cancel {
+            self.request_cancellation(LoopCancelReasonKind::UserRequested);
+        }
+        Ok(bundle)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes Reborn model retries so each retry asks the host for a fresh prompt bundle/grant instead of reusing the model request built from the first bundle.

The previous retry path could hit the host's one-shot prompt-bundle authority: the first failed model attempt consumes the latest prompt grant, then the retry reuses the same message refs and surfaces `InvalidInvocation: model request has no host-built prompt bundle` instead of retrying through the normal host prompt path.

## What changed

- Extracted canonical prompt-bundle materialization into `build_prompt_bundle_for_surface` inside the prompt stage module.
- Reused that helper from `ModelStage` before retrying a model request.
- Preserved the already-resolved visible surface version and capability view for retry requests.
- Added cancellation coverage so a cancellation observed after retry prompt rebuild prevents a second model stream.
- Added regression assertions that model retry performs a second prompt-bundle build and keeps the visible surface version.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_agent_loop model_retry_success_clears_recovery_state`
- `cargo test -p ironclaw_agent_loop cancellation_after_retry_prompt_rebuild_skips_second_model_call`
- `cargo test -p ironclaw_turns --test agent_loop_host_contract prompt_bundle_authority_consumes_grant_after_successful_model_authorization`

Before rebasing onto latest `origin/reborn-integration`, the full `cargo test -p ironclaw_agent_loop` suite also passed.