### PR TITLE
[codex] Log raw Reborn errors before safe summaries

### DIFF
--- a/crates/ironclaw_loop_support/src/cancellation_port.rs
+++ b/crates/ironclaw_loop_support/src/cancellation_port.rs
@@ -392,10 +392,13 @@ impl TurnRunWakeNotifier for TurnStateRunCancellationFactory {
     }
 }
 
-fn turn_state_error_to_host_error(_error: ironclaw_turns::TurnError) -> AgentLoopHostError {
-    AgentLoopHostError::new(
+fn turn_state_error_to_host_error(error: ironclaw_turns::TurnError) -> AgentLoopHostError {
+    crate::raw_agent_loop_host_error(
+        "turn_state_cancellation",
+        "build_cancellation_handle",
         AgentLoopHostErrorKind::Unavailable,
         "turn state was unavailable while building cancellation handle",
+        error,
     )
 }
 

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -1401,7 +1401,14 @@ fn provider_tool_call_input_ref(
         )
     })?;
     let arguments = serde_json::to_string(&tool_call.arguments).map_err(|error| {
-        AgentLoopHostError::new(AgentLoopHostErrorKind::InvalidInvocation, error.to_string())
+        let safe_summary = error.to_string();
+        crate::raw_agent_loop_host_error(
+            "capability_provider_tool_call",
+            "serialize_arguments",
+            AgentLoopHostErrorKind::InvalidInvocation,
+            safe_summary,
+            error,
+        )
     })?;
     let payload = format!(
         "provider-tool-input\nrun={}\nprovider={}\nmodel={}\nturn={}\ncall={}\ntool={}\narguments={}",
@@ -1601,16 +1608,25 @@ fn blocked_summary(reason: RuntimeBlockedReason) -> &'static str {
 
 fn host_runtime_error(error: HostRuntimeError) -> AgentLoopHostError {
     match error {
-        HostRuntimeError::InvalidRequest { reason } => AgentLoopHostError::new(
+        HostRuntimeError::InvalidRequest { reason } => crate::raw_agent_loop_host_error(
+            "host_runtime_capability",
+            "invoke",
             AgentLoopHostErrorKind::InvalidInvocation,
-            runtime_safe_summary(Some(reason), "host runtime rejected capability request"),
+            runtime_safe_summary(
+                Some(reason.clone()),
+                "host runtime rejected capability request",
+            ),
+            reason,
         ),
-        HostRuntimeError::Unavailable { reason } => AgentLoopHostError::new(
+        HostRuntimeError::Unavailable { reason } => crate::raw_agent_loop_host_error(
+            "host_runtime_capability",
+            "invoke",
             AgentLoopHostErrorKind::Unavailable,
             runtime_safe_summary(
-                Some(reason),
+                Some(reason.clone()),
                 "host runtime capability service is unavailable",
             ),
+            reason,
         ),
     }
 }

--- a/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/provider_validation.rs
@@ -56,7 +56,14 @@ pub(super) fn validate_provider_arguments(
 }
 
 fn invalid_invocation(error: ProviderValidationError) -> AgentLoopHostError {
-    AgentLoopHostError::new(AgentLoopHostErrorKind::InvalidInvocation, error.to_string())
+    let safe_summary = error.to_string();
+    crate::raw_agent_loop_host_error(
+        "capability_provider_validation",
+        "validate_provider_arguments",
+        AgentLoopHostErrorKind::InvalidInvocation,
+        safe_summary,
+        error,
+    )
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
+++ b/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
@@ -373,12 +373,26 @@ fn ensure_unique_source_kinds(
 
 fn map_file_read_error(error: FilesystemError) -> SkillBundleSourceError {
     if is_not_found(&error) {
+        tracing::warn!(
+            component = "filesystem_skill_bundle_source",
+            operation = "read_file",
+            error = %error,
+            error_debug = ?error,
+            "filesystem skill bundle read error mapped to not found"
+        );
         return SkillBundleSourceError::FileNotFound;
     }
     map_filesystem_error(error)
 }
 
 fn map_filesystem_error(error: FilesystemError) -> SkillBundleSourceError {
+    tracing::warn!(
+        component = "filesystem_skill_bundle_source",
+        operation = "map_filesystem_error",
+        error = %error,
+        error_debug = ?error,
+        "filesystem skill bundle error mapped to safe source error"
+    );
     match error {
         FilesystemError::PermissionDenied { .. } => SkillBundleSourceError::PermissionDenied,
         // Kept for API completeness: some callers route filesystem errors through

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -177,7 +177,7 @@ pub enum HostIdentityContextBuildError {
 
 impl HostIdentityContextBuildError {
     pub fn into_host_error(self) -> AgentLoopHostError {
-        let kind = match self {
+        let kind = match &self {
             Self::SourceUnavailable => AgentLoopHostErrorKind::Unavailable,
             Self::UnknownIdentityFile | Self::InvalidIdentityFile | Self::PolicyDenied => {
                 AgentLoopHostErrorKind::PolicyDenied

--- a/crates/ironclaw_loop_support/src/input_port.rs
+++ b/crates/ironclaw_loop_support/src/input_port.rs
@@ -132,6 +132,13 @@ fn validate_cursor_for_run(
 }
 
 fn host_queue_error_into_host_error(error: HostInputQueueError) -> AgentLoopHostError {
+    tracing::warn!(
+        component = "host_input_queue",
+        operation = "map_queue_error",
+        error = %error,
+        error_debug = ?error,
+        "host input queue error mapped to safe host error"
+    );
     match error {
         HostInputQueueError::Unavailable { reason } => {
             AgentLoopHostError::new(AgentLoopHostErrorKind::Unavailable, reason)

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -100,6 +100,44 @@ use serde::{Deserialize, Serialize};
 const EMPTY_SURFACE_VERSION: &str = "empty:v1";
 const LOOP_SYSTEM_ROLE: &str = "system";
 
+pub fn raw_agent_loop_host_error(
+    component: &'static str,
+    operation: &'static str,
+    kind: AgentLoopHostErrorKind,
+    safe_summary: impl Into<String>,
+    raw_detail: impl std::fmt::Display,
+) -> AgentLoopHostError {
+    let safe_summary = safe_summary.into();
+    tracing::warn!(
+        component,
+        operation,
+        kind = ?kind,
+        safe_summary = %safe_summary,
+        raw_detail = %raw_detail,
+        "agent loop host error mapped to safe summary"
+    );
+    AgentLoopHostError::new(kind, safe_summary)
+}
+
+pub fn raw_host_managed_model_error(
+    component: &'static str,
+    operation: &'static str,
+    kind: HostManagedModelErrorKind,
+    safe_summary: impl Into<String>,
+    raw_detail: impl std::fmt::Display,
+) -> HostManagedModelError {
+    let safe_summary = safe_summary.into();
+    tracing::warn!(
+        component,
+        operation,
+        kind = ?kind,
+        safe_summary = %safe_summary,
+        raw_detail = %raw_detail,
+        "host-managed model error mapped to safe summary"
+    );
+    HostManagedModelError::safe(kind, safe_summary)
+}
+
 /// Thread-backed context adapter for text-only Reborn loops.
 #[derive(Clone)]
 pub struct ThreadBackedLoopContextPort<S>
@@ -1624,17 +1662,23 @@ fn empty_capability_error() -> AgentLoopHostError {
     )
 }
 
-fn context_read_error(_error: SessionThreadError) -> AgentLoopHostError {
-    AgentLoopHostError::new(
+fn context_read_error(error: SessionThreadError) -> AgentLoopHostError {
+    raw_agent_loop_host_error(
+        "thread_context",
+        "read_context",
         AgentLoopHostErrorKind::Unavailable,
         "thread context is unavailable",
+        error,
     )
 }
 
-fn transcript_write_error(_error: SessionThreadError) -> AgentLoopHostError {
-    AgentLoopHostError::new(
+fn transcript_write_error(error: SessionThreadError) -> AgentLoopHostError {
+    raw_agent_loop_host_error(
+        "thread_transcript",
+        "write_transcript",
         AgentLoopHostErrorKind::TranscriptWriteFailed,
         "assistant transcript write failed",
+        error,
     )
 }
 

--- a/crates/ironclaw_loop_support/src/skill_bundle_context_source.rs
+++ b/crates/ironclaw_loop_support/src/skill_bundle_context_source.rs
@@ -122,6 +122,13 @@ where
 fn skill_bundle_source_error_to_context_error(
     error: SkillBundleSourceError,
 ) -> HostSkillContextBuildError {
+    tracing::warn!(
+        component = "skill_bundle_context_source",
+        operation = "map_source_error",
+        error = %error,
+        error_debug = ?error,
+        "skill bundle source error mapped to safe skill context error"
+    );
     // Collapse bundle-source internals into the public-safe context error taxonomy:
     // unavailable, parse/policy failure, budget exhaustion, or internal bug.
     match error {

--- a/crates/ironclaw_loop_support/src/skill_context.rs
+++ b/crates/ironclaw_loop_support/src/skill_context.rs
@@ -198,6 +198,13 @@ fn skill_trust_level(trust: SkillTrust) -> SkillTrustLevel {
 }
 
 fn skill_context_error_to_host_error(error: SkillContextError) -> AgentLoopHostError {
+    tracing::warn!(
+        component = "skill_context",
+        operation = "map_context_error",
+        error = %error,
+        error_debug = ?error,
+        "skill context error mapped to safe host error"
+    );
     let build_error = match error {
         SkillContextError::TrustDataMissing => HostSkillContextBuildError::TrustDataMissing,
         SkillContextError::VisibilityDataMissing => {

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -1839,6 +1839,13 @@ fn is_legacy_text_only_driver_key(key: &LoopDriverRegistryKey) -> bool {
 }
 
 fn model_route_error_to_host_error(error: ModelRouteError) -> RebornLoopDriverHostError {
+    tracing::warn!(
+        component = "model_route",
+        operation = "resolve_route",
+        error = %error,
+        error_debug = ?error,
+        "model route error mapped to safe host error"
+    );
     RebornLoopDriverHostError::InvalidRequest {
         reason: format!("model route resolution failed: {}", error.kind().as_str()),
     }
@@ -1847,6 +1854,13 @@ fn model_route_error_to_host_error(error: ModelRouteError) -> RebornLoopDriverHo
 fn capability_resolve_error_to_host_error(
     error: CapabilityResolveError,
 ) -> RebornLoopDriverHostError {
+    tracing::warn!(
+        component = "capability_surface_profile",
+        operation = "resolve_profile",
+        error = %error,
+        error_debug = ?error,
+        "capability surface resolution error mapped to safe host error"
+    );
     let reason = match error {
         CapabilityResolveError::Unavailable { .. } => "capability surface profile is unavailable",
         CapabilityResolveError::Internal { .. } => {
@@ -1901,39 +1915,65 @@ fn validate_thread_scope(
 }
 
 fn turn_error_to_host_error(error: TurnError) -> AgentLoopHostError {
-    match error {
-        TurnError::Unauthorized => AgentLoopHostError::new(
+    match &error {
+        TurnError::Unauthorized => ironclaw_loop_support::raw_agent_loop_host_error(
+            "checkpoint_state",
+            "access",
             AgentLoopHostErrorKind::Unauthorized,
             "checkpoint state access was unauthorized",
+            &error,
         ),
-        TurnError::InvalidRequest { .. } => AgentLoopHostError::new(
+        TurnError::InvalidRequest { .. } => ironclaw_loop_support::raw_agent_loop_host_error(
+            "checkpoint_state",
+            "request",
             AgentLoopHostErrorKind::InvalidInvocation,
             "checkpoint state request is invalid",
+            &error,
         ),
-        TurnError::Unavailable { .. } => AgentLoopHostError::new(
+        TurnError::Unavailable { .. } => ironclaw_loop_support::raw_agent_loop_host_error(
+            "checkpoint_state",
+            "store",
             AgentLoopHostErrorKind::Unavailable,
             "checkpoint state store is unavailable",
+            &error,
         ),
-        TurnError::ScopeNotFound => AgentLoopHostError::new(
+        TurnError::ScopeNotFound => ironclaw_loop_support::raw_agent_loop_host_error(
+            "checkpoint_state",
+            "scope_lookup",
             AgentLoopHostErrorKind::CheckpointRejected,
             "checkpoint state scope was not found for this loop run",
+            &error,
         ),
-        TurnError::Conflict { .. } => AgentLoopHostError::new(
+        TurnError::Conflict { .. } => ironclaw_loop_support::raw_agent_loop_host_error(
+            "checkpoint_state",
+            "write",
             AgentLoopHostErrorKind::CheckpointRejected,
             "checkpoint state write conflicted with current turn state",
+            &error,
         ),
-        TurnError::InvalidTransition { .. } => AgentLoopHostError::new(
+        TurnError::InvalidTransition { .. } => ironclaw_loop_support::raw_agent_loop_host_error(
+            "checkpoint_state",
+            "write",
             AgentLoopHostErrorKind::CheckpointRejected,
             "checkpoint state write was invalid for current turn state",
+            &error,
         ),
-        TurnError::LeaseMismatch => AgentLoopHostError::new(
+        TurnError::LeaseMismatch => ironclaw_loop_support::raw_agent_loop_host_error(
+            "checkpoint_state",
+            "write",
             AgentLoopHostErrorKind::CheckpointRejected,
             "checkpoint state write lease no longer matches current run",
+            &error,
         ),
-        TurnError::ThreadBusy(_) | TurnError::AdmissionRejected(_) => AgentLoopHostError::new(
-            AgentLoopHostErrorKind::Unavailable,
-            "checkpoint state store returned unsupported turn admission status",
-        ),
+        TurnError::ThreadBusy(_) | TurnError::AdmissionRejected(_) => {
+            ironclaw_loop_support::raw_agent_loop_host_error(
+                "checkpoint_state",
+                "admission",
+                AgentLoopHostErrorKind::Unavailable,
+                "checkpoint state store returned unsupported turn admission status",
+                &error,
+            )
+        }
     }
 }
 

--- a/crates/ironclaw_reborn/src/milestone_events.rs
+++ b/crates/ironclaw_reborn/src/milestone_events.rs
@@ -304,10 +304,13 @@ fn capability_id(value: &'static str) -> Result<CapabilityId, AgentLoopHostError
     })
 }
 
-fn durable_event_error(_error: EventError) -> AgentLoopHostError {
-    AgentLoopHostError::new(
+fn durable_event_error(error: EventError) -> AgentLoopHostError {
+    ironclaw_loop_support::raw_agent_loop_host_error(
+        "loop_milestone_events",
+        "append_event",
         AgentLoopHostErrorKind::Unavailable,
         "loop milestone event log is unavailable",
+        error,
     )
 }
 

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -1073,10 +1073,13 @@ fn validate_provider_replay_identity(
     provider_call: &ProviderToolCallReferenceEnvelope,
     expected: &ProviderReplayIdentity,
 ) -> Result<(), HostManagedModelError> {
-    provider_call.validate().map_err(|_| {
-        HostManagedModelError::safe(
+    provider_call.validate().map_err(|error| {
+        ironclaw_loop_support::raw_host_managed_model_error(
+            "provider_tool_replay",
+            "validate_provider_call",
             HostManagedModelErrorKind::InvalidRequest,
             "provider tool-call replay metadata is invalid",
+            error,
         )
     })?;
     if provider_call.provider_id != expected.provider_id
@@ -1099,10 +1102,13 @@ fn tool_result_replay_message(
     message: &HostManagedModelMessage,
 ) -> Result<ToolResultReplayMessage, HostManagedModelError> {
     let envelope: ToolResultReferenceEnvelope =
-        serde_json::from_str(&message.content).map_err(|_| {
-            HostManagedModelError::safe(
+        serde_json::from_str(&message.content).map_err(|error| {
+            ironclaw_loop_support::raw_host_managed_model_error(
+                "tool_result_replay",
+                "decode_transcript_envelope",
                 HostManagedModelErrorKind::InvalidRequest,
                 "tool result reference transcript content is invalid",
+                error,
             )
         })?;
     Ok(ToolResultReplayMessage {
@@ -1153,6 +1159,13 @@ fn provider_tool_call_from_reference(
 }
 
 fn map_provider_error(error: LlmError) -> HostManagedModelError {
+    tracing::warn!(
+        component = "model_provider",
+        operation = "complete",
+        error = %error,
+        error_debug = ?error,
+        "reborn model provider error mapped to safe summary"
+    );
     match error {
         LlmError::ContextLengthExceeded { .. } => HostManagedModelError::safe(
             HostManagedModelErrorKind::BudgetExceeded,

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -667,7 +667,14 @@ impl LoopCapabilityPortFactory for ProductLiveLoopCapabilityPortFactory {
 }
 
 fn adapter_error(error: ProductLivePlannedRuntimeAdapterError) -> AgentLoopHostError {
-    AgentLoopHostError::new(AgentLoopHostErrorKind::InvalidInvocation, error.to_string())
+    let safe_summary = error.to_string();
+    ironclaw_loop_support::raw_agent_loop_host_error(
+        "product_live_planned_runtime_adapter",
+        "build_capability_port",
+        AgentLoopHostErrorKind::InvalidInvocation,
+        safe_summary,
+        error,
+    )
 }
 
 struct StaticCapabilitySurfaceResolver {

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -398,6 +398,13 @@ fn run_status_wire(status: RunProjectionStatus) -> &'static str {
 }
 
 fn map_event_stream_error(error: EventProjectionStreamError) -> ProductAdapterError {
+    tracing::warn!(
+        component = "event_projection_stream",
+        operation = "map_stream_error",
+        error = %error,
+        error_debug = ?error,
+        "event projection stream error mapped to product adapter error"
+    );
     match error {
         EventProjectionStreamError::InvalidRequest { reason } => {
             ProductAdapterError::InvalidIdentifier {

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -222,6 +222,13 @@ fn turn_status_wire(status: TurnStatus) -> &'static str {
 }
 
 fn map_turn_event_projection_error(error: TurnEventProjectionError) -> ProductAdapterError {
+    tracing::warn!(
+        component = "turn_event_projection",
+        operation = "map_projection_error",
+        error = %error,
+        error_debug = ?error,
+        "turn event projection error mapped to product adapter error"
+    );
     match error {
         TurnEventProjectionError::InvalidRequest { reason } => {
             ProductAdapterError::InvalidIdentifier {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1371,7 +1371,8 @@ mod tests {
     }
 
     fn model_capability_error(error: impl std::fmt::Display) -> HostManagedModelError {
-        HostManagedModelError::safe(HostManagedModelErrorKind::Unavailable, error.to_string())
+        let safe_summary = error.to_string();
+        HostManagedModelError::safe(HostManagedModelErrorKind::Unavailable, safe_summary)
     }
 
     fn skill_md(name: &str, description: &str, prompt: &str) -> String {

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -232,10 +232,13 @@ impl StagedValueStore {
 fn staged_value_bytes(value: &serde_json::Value) -> Result<usize, AgentLoopHostError> {
     serde_json::to_vec(value)
         .map(|bytes| bytes.len())
-        .map_err(|_| {
-            AgentLoopHostError::new(
+        .map_err(|error| {
+            ironclaw_loop_support::raw_agent_loop_host_error(
+                "local_dev_capability_io",
+                "measure_payload",
                 AgentLoopHostErrorKind::InvalidInvocation,
                 "capability payload could not be measured",
+                error,
             )
         })
 }
@@ -360,10 +363,13 @@ fn hydrate_tool_result_messages(
             continue;
         }
         let mut envelope: ToolResultReferenceEnvelope = serde_json::from_str(&message.content)
-            .map_err(|_| {
-                HostManagedModelError::safe(
+            .map_err(|error| {
+                ironclaw_loop_support::raw_host_managed_model_error(
+                    "local_dev_model_replay",
+                    "decode_tool_result_envelope",
                     HostManagedModelErrorKind::InvalidRequest,
                     "tool result reference transcript content is invalid",
+                    error,
                 )
             })?;
         let output = capability_io
@@ -373,16 +379,23 @@ fn hydrate_tool_result_messages(
             continue;
         };
         envelope.safe_summary = ToolResultSafeSummary::new(model_visible_tool_output(&output))
-            .map_err(|_| {
-                HostManagedModelError::safe(
+            .map_err(|error| {
+                ironclaw_loop_support::raw_host_managed_model_error(
+                    "local_dev_model_replay",
+                    "sanitize_tool_result",
                     HostManagedModelErrorKind::InvalidRequest,
                     "tool result output could not be represented safely for model replay",
+                    error,
                 )
             })?;
         message.content = serde_json::to_string(&envelope).map_err(|error| {
-            HostManagedModelError::safe(
+            let safe_summary = error.to_string();
+            ironclaw_loop_support::raw_host_managed_model_error(
+                "local_dev_model_replay",
+                "encode_tool_result_envelope",
                 HostManagedModelErrorKind::InvalidRequest,
-                error.to_string(),
+                safe_summary,
+                error,
             )
         })?;
     }
@@ -699,8 +712,17 @@ fn capability_io_error() -> AgentLoopHostError {
     )
 }
 
-fn host_api_agent_loop_error(error: impl std::fmt::Display) -> AgentLoopHostError {
-    AgentLoopHostError::new(AgentLoopHostErrorKind::InvalidInvocation, error.to_string())
+fn host_api_agent_loop_error(
+    error: impl std::fmt::Debug + std::fmt::Display,
+) -> AgentLoopHostError {
+    let safe_summary = error.to_string();
+    ironclaw_loop_support::raw_agent_loop_host_error(
+        "local_dev_host_api",
+        "validate_local_dev_runtime_input",
+        AgentLoopHostErrorKind::InvalidInvocation,
+        safe_summary,
+        format!("{error:?}"),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add shared helpers for logging raw details before mapping errors to safe summaries
- wire raw-detail warn logs through Reborn model, loop-support, local-dev, projection, checkpoint, and capability adapter mappings
- preserve existing safe-summary surfaces while making Rust logs useful for debugging

## Validation
- cargo fmt --check
- cargo check -p ironclaw_reborn --features root-llm-provider
- cargo check -p ironclaw_reborn_composition
- cargo test -p ironclaw_loop_support model_port_replaces_invalid_gateway_safe_summary_with_stable_summary
- cargo test -p ironclaw_reborn --test llm_gateway --features root-llm-provider gateway_sanitizes_provider_errors