### PR TITLE
[codex] Add model-visible tool error recovery

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/capabilities.rs
+++ b/crates/ironclaw_agent_loop/src/executor/capabilities.rs
@@ -325,7 +325,7 @@ impl CapabilityStage {
                 .on_capability_error(&state, &summary)
                 .await
             {
-                RecoveryOutcome::SkipResult { recovery } => {
+                RecoveryOutcome::ToolErrorResult { recovery } => {
                     state.recovery_state = recovery;
                     append_capability_error_ref(ctx.host, &mut state, &call, &summary).await?;
                     match CheckpointStage.cancel_if_requested(ctx, state).await? {

--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -170,9 +170,9 @@ impl ExecutorStage<ModelInput> for ModelStage {
                             }
                             request.messages = messages;
                         }
-                        RecoveryOutcome::SkipResult { .. } => {
+                        RecoveryOutcome::ToolErrorResult { .. } => {
                             return Err(AgentLoopExecutorError::PlannerContract {
-                                detail: "SkipResult on model error",
+                                detail: "ToolErrorResult on model error",
                             });
                         }
                         RecoveryOutcome::Abort {

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -1346,3 +1346,51 @@ async fn denied_provider_call_appends_failure_tool_result_for_replay() {
         vec![result_ref, appended[1].result_ref.clone()]
     );
 }
+
+#[tokio::test]
+async fn invalid_provider_tool_input_appends_failure_tool_result_for_replay() {
+    let host = MockHost::new(vec![provider_calls_response(), reply_response()])
+        .with_batch_outcomes(vec![ironclaw_turns::run_profile::CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::Failed(
+                ironclaw_turns::run_profile::CapabilityFailure {
+                    error_kind: CapabilityFailureKind::InvalidInput,
+                    safe_summary: "invalid input".to_string(),
+                },
+            )],
+            stopped_on_suspension: false,
+        }]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    let appended = host.appended_result_refs();
+    assert_eq!(appended.len(), 1);
+    assert_eq!(appended[0].safe_summary, "invalid input");
+    assert!(
+        appended[0]
+            .result_ref
+            .as_str()
+            .starts_with("result:provider-error-turn_1-call_1")
+    );
+    let provider_call = appended[0]
+        .provider_call
+        .as_ref()
+        .expect("provider replay metadata");
+    assert_eq!(provider_call.provider_turn_id, "turn_1");
+    assert_eq!(provider_call.provider_call_id, "call_1");
+    assert_eq!(provider_call.provider_tool_name, "demo__echo");
+    match exit {
+        LoopExit::Completed(completed) => {
+            assert_eq!(completed.result_refs, vec![appended[0].result_ref.clone()]);
+        }
+        other => panic!("expected completed, got {other:?}"),
+    }
+    assert_eq!(
+        final_staged_state(&host).result_refs,
+        vec![appended[0].result_ref.clone()]
+    );
+}

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -135,7 +135,8 @@ pub(crate) enum ModelErrorClass {
 /// - `Retry` — re-issue (the executor decides whether call-level or
 ///   iteration-level retry from `scope`; `alter` carries the strategy's
 ///   prompt/model hint).
-/// - `SkipResult` — drop this result and continue the batch.
+/// - `ToolErrorResult` — append a model-visible tool error result and continue
+///   the capability batch.
 /// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -146,7 +147,7 @@ pub(crate) enum RecoveryOutcome {
         scope: RetryScope,
         alter: Option<RetryAlteration>,
     },
-    SkipResult {
+    ToolErrorResult {
         recovery: RecoveryStrategyState,
     },
     Abort {
@@ -170,9 +171,9 @@ pub(crate) enum RetryScope {
 /// exponential backoff.
 ///
 /// This strategy:
-/// - Skips `PolicyDenied` so the model can try another authorized tool without
-///   consuming retry budget.
-/// - Aborts immediately on `Permanent`, `InputInvalid`, and `ContentFiltered`.
+/// - Turns `PolicyDenied` and `InputInvalid` into model-visible tool error
+///   results without consuming retry budget.
+/// - Aborts immediately on `Permanent` and `ContentFiltered`.
 /// - Retries capability/model transient, unavailable, and internal errors up
 ///   to [`Self::max_attempts_per_class`] times with `Backoff`.
 /// - Retries `ContextOverflow` at iteration scope with `ShrinkContext`.
@@ -199,15 +200,15 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
     ) -> RecoveryOutcome {
         let kind = capability_error_to_failure_kind(err.class);
         match err.class {
-            CapabilityErrorClass::PolicyDenied => RecoveryOutcome::SkipResult {
-                recovery: state.recovery_state.cleared_attempts(),
-            },
-            CapabilityErrorClass::Permanent | CapabilityErrorClass::InputInvalid => {
-                RecoveryOutcome::Abort {
+            class if capability_error_is_model_visible_tool_failure(class) => {
+                RecoveryOutcome::ToolErrorResult {
                     recovery: state.recovery_state.cleared_attempts(),
-                    failure_kind: kind,
                 }
             }
+            CapabilityErrorClass::Permanent => RecoveryOutcome::Abort {
+                recovery: state.recovery_state.cleared_attempts(),
+                failure_kind: kind,
+            },
             CapabilityErrorClass::Transient
             | CapabilityErrorClass::Unavailable
             | CapabilityErrorClass::Internal => {
@@ -230,6 +231,10 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
                     },
                 )
             }
+            _ => RecoveryOutcome::Abort {
+                recovery: state.recovery_state.cleared_attempts(),
+                failure_kind: LoopFailureKind::DriverBug,
+            },
         }
     }
 
@@ -284,6 +289,13 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
             }
         }
     }
+}
+
+fn capability_error_is_model_visible_tool_failure(class: CapabilityErrorClass) -> bool {
+    matches!(
+        class,
+        CapabilityErrorClass::PolicyDenied | CapabilityErrorClass::InputInvalid
+    )
 }
 
 fn retry_or_abort(
@@ -636,15 +648,15 @@ mod tests {
     }
 
     #[test]
-    fn recovery_outcome_skip_result_carries_recovery_slot() {
-        let outcome = RecoveryOutcome::SkipResult {
+    fn recovery_outcome_tool_error_result_carries_recovery_slot() {
+        let outcome = RecoveryOutcome::ToolErrorResult {
             recovery: sample_recovery(),
         };
         let value = serde_json::to_value(&outcome).expect("serialize");
         let restored: RecoveryOutcome = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, outcome);
         match restored {
-            RecoveryOutcome::SkipResult { recovery } => {
+            RecoveryOutcome::ToolErrorResult { recovery } => {
                 assert_eq!(recovery, sample_recovery())
             }
             other => panic!("unexpected variant: {other:?}"),
@@ -828,7 +840,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn capability_input_invalid_aborts_immediately() {
+        async fn capability_input_invalid_becomes_tool_error_result() {
             let strategy = DefaultRecoveryStrategy::default();
             let state = state_with_no_attempts();
 
@@ -836,11 +848,16 @@ mod tests {
                 .on_capability_error(&state, &cap_err(CapabilityErrorClass::InputInvalid))
                 .await;
 
-            assert!(matches!(outcome, RecoveryOutcome::Abort { .. }));
+            match outcome {
+                RecoveryOutcome::ToolErrorResult { recovery } => {
+                    assert_eq!(recovery, RecoveryStrategyState::default());
+                }
+                other => panic!("expected ToolErrorResult, got {other:?}"),
+            }
         }
 
         #[tokio::test]
-        async fn capability_policy_denied_skips_result() {
+        async fn capability_policy_denied_becomes_tool_error_result() {
             let strategy = DefaultRecoveryStrategy::default();
             let state = state_with_no_attempts();
 
@@ -849,10 +866,10 @@ mod tests {
                 .await;
 
             match outcome {
-                RecoveryOutcome::SkipResult { recovery } => {
+                RecoveryOutcome::ToolErrorResult { recovery } => {
                     assert_eq!(recovery, RecoveryStrategyState::default());
                 }
-                other => panic!("expected SkipResult, got {other:?}"),
+                other => panic!("expected ToolErrorResult, got {other:?}"),
             }
         }
 
@@ -1002,8 +1019,8 @@ mod tests {
             let outcome = strategy
                 .on_capability_error(&state, &cap_err(CapabilityErrorClass::PolicyDenied))
                 .await;
-            let RecoveryOutcome::SkipResult { recovery } = outcome else {
-                panic!("expected policy denied skip");
+            let RecoveryOutcome::ToolErrorResult { recovery } = outcome else {
+                panic!("expected policy denied tool error result");
             };
 
             let mut next = LoopExecutionState::initial_for_run(&test_run_context());


### PR DESCRIPTION
## Summary

- Add an explicit `RecoveryOutcome::ToolErrorResult` for model-visible tool failures.
- Route capability `PolicyDenied` and `InputInvalid` through a centralized `capability_error_is_model_visible_tool_failure` predicate.
- Keep permanent, transient, unavailable, and internal failures on the existing abort/retry control-plane path.
- Add executor coverage proving invalid provider tool input appends replay metadata so the next model turn can recover.

## Root Cause

Malformed model-generated tool calls, such as invalid `builtin.apply_patch` arguments, were mapped to `InputInvalid`. The default recovery strategy aborted immediately, so the model never received a tool-result error it could use to correct the call or tell the user what failed.

## Design

The boundary is now explicit: capability failures that should be visible to the model become `ToolErrorResult`, while host/control-plane failures remain retry-or-abort decisions. This avoids per-built-in-tool classification and gives follow-up work a single central predicate to broaden when more safe tool-domain failures are identified.

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_agent_loop capability_input_invalid_becomes_tool_error_result`
- `cargo test -p ironclaw_agent_loop invalid_provider_tool_input_appends_failure_tool_result_for_replay`
- `git diff --check`
