### PR TITLE
Add Reborn secrets keychain support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,6 +5040,8 @@ dependencies = [
  "ironclaw_host_api",
  "rand 0.8.6",
  "secrecy",
+ "secret-service",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/ironclaw_secrets/Cargo.toml
+++ b/crates/ironclaw_secrets/Cargo.toml
@@ -25,5 +25,11 @@ tokio = { version = "1", features = ["macros", "rt", "sync"] }
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = "3"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+secret-service = { version = "4", features = ["rt-tokio-crypto-rust"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_secrets/src/keychain.rs
+++ b/crates/ironclaw_secrets/src/keychain.rs
@@ -1,0 +1,383 @@
+//! OS keychain integration for secrets master key storage.
+//!
+//! Provides platform-specific keychain support:
+//! - macOS: security-framework (Keychain Services)
+//! - Linux: secret-service (GNOME Keyring, KWallet)
+//!
+//! # Example
+//!
+//! ```ignore
+//! use ironclaw_secrets::keychain::{store_master_key, get_master_key, delete_master_key};
+//!
+//! // Generate and store a new master key
+//! let key = generate_master_key();
+//! store_master_key(&key)?;
+//!
+//! // Later, retrieve it
+//! let key = get_master_key()?;
+//! ```
+
+use crate::SecretError;
+
+/// Environment variable checked before the OS keychain.
+pub const SECRETS_MASTER_KEY_ENV: &str = "SECRETS_MASTER_KEY";
+
+/// Service name for keychain entries.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+const SERVICE_NAME: &str = "ironclaw";
+
+/// Account name for the master key.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+const MASTER_KEY_ACCOUNT: &str = "master_key";
+
+/// Generate a random 32-byte master key.
+pub fn generate_master_key() -> Vec<u8> {
+    use rand::RngCore;
+    use rand::rngs::OsRng;
+    let mut key = vec![0u8; 32];
+    OsRng.fill_bytes(&mut key);
+    key
+}
+
+/// Generate a master key as a hex string.
+pub fn generate_master_key_hex() -> String {
+    let bytes = generate_master_key();
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+/// Resolve an existing master key from the environment or OS keychain.
+///
+/// This mirrors the v1 lookup order without auto-generating new material:
+/// an explicitly set `SECRETS_MASTER_KEY` wins, otherwise the OS keychain is
+/// consulted. Empty environment values are ignored. Callers that require
+/// production durability should fail closed when this returns `None`.
+pub async fn resolve_master_key() -> Option<String> {
+    if let Some(env_key) = std::env::var(SECRETS_MASTER_KEY_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Some(env_key);
+    }
+
+    get_master_key()
+        .await
+        .ok()
+        .map(|bytes| bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+#[cfg(test)]
+fn resolve_master_key_inner(
+    env_key: Option<String>,
+    keychain_key: Option<Vec<u8>>,
+) -> Option<String> {
+    if let Some(env_key) = env_key.filter(|value| !value.trim().is_empty()) {
+        return Some(env_key);
+    }
+
+    keychain_key.map(|bytes| bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+// ============================================================================
+// macOS implementation using security-framework
+// ============================================================================
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use security_framework::passwords::{
+        delete_generic_password, get_generic_password, set_generic_password,
+    };
+
+    use super::*;
+
+    /// Store the master key in the macOS Keychain.
+    pub async fn store_master_key(key: &[u8]) -> Result<(), SecretError> {
+        // Convert to hex for storage (keychain prefers strings)
+        let key_hex: String = key.iter().map(|b| format!("{:02x}", b)).collect();
+
+        set_generic_password(SERVICE_NAME, MASTER_KEY_ACCOUNT, key_hex.as_bytes())
+            .map_err(|e| SecretError::KeychainError(format!("Failed to store in keychain: {}", e)))
+    }
+
+    /// Retrieve the master key from the macOS Keychain.
+    pub async fn get_master_key() -> Result<Vec<u8>, SecretError> {
+        let password = get_generic_password(SERVICE_NAME, MASTER_KEY_ACCOUNT).map_err(|e| {
+            SecretError::KeychainError(format!("Failed to get from keychain: {}", e))
+        })?;
+
+        // Parse hex string back to bytes
+        let hex_str = String::from_utf8(password)
+            .map_err(|_| SecretError::KeychainError("Invalid UTF-8 in keychain".to_string()))?;
+
+        hex_to_bytes(&hex_str)
+    }
+
+    /// Delete the master key from the macOS Keychain.
+    pub async fn delete_master_key() -> Result<(), SecretError> {
+        delete_generic_password(SERVICE_NAME, MASTER_KEY_ACCOUNT).map_err(|e| {
+            SecretError::KeychainError(format!("Failed to delete from keychain: {}", e))
+        })
+    }
+
+    /// Check if a master key exists in the keychain.
+    pub async fn has_master_key() -> bool {
+        get_generic_password(SERVICE_NAME, MASTER_KEY_ACCOUNT).is_ok()
+    }
+}
+
+// ============================================================================
+// Linux implementation using secret-service
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use secret_service::{EncryptionType, SecretService};
+
+    use super::*;
+
+    /// Store the master key in the Linux secret service (GNOME Keyring, KWallet).
+    pub async fn store_master_key(key: &[u8]) -> Result<(), SecretError> {
+        let ss = SecretService::connect(EncryptionType::Dh)
+            .await
+            .map_err(|e| {
+                SecretError::KeychainError(format!("Failed to connect to secret service: {}", e))
+            })?;
+
+        let collection = ss
+            .get_default_collection()
+            .await
+            .map_err(|e| SecretError::KeychainError(format!("Failed to get collection: {}", e)))?;
+
+        // Unlock if needed
+        if collection.is_locked().await.unwrap_or(true) {
+            collection.unlock().await.map_err(|e| {
+                SecretError::KeychainError(format!("Failed to unlock collection: {}", e))
+            })?;
+        }
+
+        // Convert to hex for storage
+        let key_hex: String = key.iter().map(|b| format!("{:02x}", b)).collect();
+
+        collection
+            .create_item(
+                &format!("{} master key", SERVICE_NAME),
+                [("service", SERVICE_NAME), ("account", MASTER_KEY_ACCOUNT)]
+                    .into_iter()
+                    .collect(),
+                key_hex.as_bytes(),
+                true, // Replace if exists
+                "text/plain",
+            )
+            .await
+            .map_err(|e| SecretError::KeychainError(format!("Failed to create secret: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Retrieve the master key from the Linux secret service.
+    pub async fn get_master_key() -> Result<Vec<u8>, SecretError> {
+        let ss = SecretService::connect(EncryptionType::Dh)
+            .await
+            .map_err(|e| {
+                SecretError::KeychainError(format!("Failed to connect to secret service: {}", e))
+            })?;
+
+        let items = ss
+            .search_items(
+                [("service", SERVICE_NAME), ("account", MASTER_KEY_ACCOUNT)]
+                    .into_iter()
+                    .collect(),
+            )
+            .await
+            .map_err(|e| SecretError::KeychainError(format!("Failed to search: {}", e)))?;
+
+        let item = items
+            .unlocked
+            .first()
+            .or(items.locked.first())
+            .ok_or_else(|| SecretError::KeychainError("Master key not found".to_string()))?;
+
+        // Unlock if needed
+        if item.is_locked().await.unwrap_or(true) {
+            item.unlock()
+                .await
+                .map_err(|e| SecretError::KeychainError(format!("Failed to unlock: {}", e)))?;
+        }
+
+        let secret = item
+            .get_secret()
+            .await
+            .map_err(|e| SecretError::KeychainError(format!("Failed to get secret: {}", e)))?;
+
+        let hex_str = String::from_utf8(secret)
+            .map_err(|_| SecretError::KeychainError("Invalid UTF-8 in secret".to_string()))?;
+
+        hex_to_bytes(&hex_str)
+    }
+
+    /// Delete the master key from the Linux secret service.
+    pub async fn delete_master_key() -> Result<(), SecretError> {
+        let ss = SecretService::connect(EncryptionType::Dh)
+            .await
+            .map_err(|e| {
+                SecretError::KeychainError(format!("Failed to connect to secret service: {}", e))
+            })?;
+
+        let items = ss
+            .search_items(
+                [("service", SERVICE_NAME), ("account", MASTER_KEY_ACCOUNT)]
+                    .into_iter()
+                    .collect(),
+            )
+            .await
+            .map_err(|e| SecretError::KeychainError(format!("Failed to search: {}", e)))?;
+
+        for item in items.unlocked.iter().chain(items.locked.iter()) {
+            item.delete()
+                .await
+                .map_err(|e| SecretError::KeychainError(format!("Failed to delete: {}", e)))?;
+        }
+
+        Ok(())
+    }
+
+    /// Check if a master key exists in the secret service.
+    pub async fn has_master_key() -> bool {
+        let ss = match SecretService::connect(EncryptionType::Dh).await {
+            Ok(ss) => ss,
+            Err(_) => return false,
+        };
+
+        let items = match ss
+            .search_items(
+                [("service", SERVICE_NAME), ("account", MASTER_KEY_ACCOUNT)]
+                    .into_iter()
+                    .collect(),
+            )
+            .await
+        {
+            Ok(items) => items,
+            Err(_) => return false,
+        };
+
+        !items.unlocked.is_empty() || !items.locked.is_empty()
+    }
+}
+
+// ============================================================================
+// Fallback for unsupported platforms
+// ============================================================================
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+mod platform {
+    use super::*;
+
+    pub async fn store_master_key(_key: &[u8]) -> Result<(), SecretError> {
+        Err(SecretError::KeychainError(
+            "Keychain not supported on this platform. Use SECRETS_MASTER_KEY env var.".to_string(),
+        ))
+    }
+
+    pub async fn get_master_key() -> Result<Vec<u8>, SecretError> {
+        Err(SecretError::KeychainError(
+            "Keychain not supported on this platform. Use SECRETS_MASTER_KEY env var.".to_string(),
+        ))
+    }
+
+    pub async fn delete_master_key() -> Result<(), SecretError> {
+        Err(SecretError::KeychainError(
+            "Keychain not supported on this platform".to_string(),
+        ))
+    }
+
+    pub async fn has_master_key() -> bool {
+        false
+    }
+}
+
+// Re-export platform-specific functions
+pub use platform::{delete_master_key, get_master_key, has_master_key, store_master_key};
+
+/// Parse a hex string to bytes.
+#[cfg(any(target_os = "macos", target_os = "linux", test))]
+fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, SecretError> {
+    if !hex.len().is_multiple_of(2) {
+        return Err(SecretError::KeychainError(
+            "Invalid hex string length".to_string(),
+        ));
+    }
+
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .map_err(|_| SecretError::KeychainError("Invalid hex character".to_string()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_master_key() {
+        let key = generate_master_key();
+        assert_eq!(key.len(), 32);
+
+        // Should be different each time
+        let key2 = generate_master_key();
+        assert_ne!(key, key2);
+    }
+
+    #[test]
+    fn test_generate_master_key_hex() {
+        let hex = generate_master_key_hex();
+        assert_eq!(hex.len(), 64); // 32 bytes * 2 hex chars
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_hex_to_bytes() {
+        let result = hex_to_bytes("deadbeef").unwrap();
+        assert_eq!(result, vec![0xde, 0xad, 0xbe, 0xef]);
+
+        let result = hex_to_bytes("00ff").unwrap();
+        assert_eq!(result, vec![0x00, 0xff]);
+    }
+
+    #[test]
+    fn test_hex_to_bytes_invalid() {
+        assert!(hex_to_bytes("abc").is_err()); // Odd length
+        assert!(hex_to_bytes("gg").is_err()); // Invalid chars
+    }
+
+    #[test]
+    fn resolve_master_key_prefers_env_key() {
+        let env = Some("env-master-key".to_string());
+        let keychain = Some(vec![0xbb; 32]);
+
+        let resolved = resolve_master_key_inner(env, keychain).unwrap();
+
+        assert_eq!(resolved, "env-master-key");
+    }
+
+    #[test]
+    fn resolve_master_key_uses_keychain_when_env_is_absent() {
+        let resolved = resolve_master_key_inner(None, Some(vec![0xbb; 32])).unwrap();
+
+        assert_eq!(resolved, "bb".repeat(32));
+    }
+
+    #[test]
+    fn resolve_master_key_ignores_blank_env_key() {
+        let resolved = resolve_master_key_inner(Some(" \t ".to_string()), Some(vec![0xab; 32]))
+            .expect("keychain key should be used");
+
+        assert_eq!(resolved, "ab".repeat(32));
+    }
+
+    #[test]
+    fn resolve_master_key_returns_none_without_env_or_keychain() {
+        assert_eq!(resolve_master_key_inner(None, None), None);
+    }
+}

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod crypto;
 mod filesystem_store;
+pub mod keychain;
 mod legacy_store;
 
 pub use filesystem_store::{FilesystemCredentialBroker, FilesystemSecretStore};


### PR DESCRIPTION
## Summary
- add `ironclaw_secrets::keychain` with macOS/Linux OS keychain support for secrets master keys
- add env-first `SECRETS_MASTER_KEY` resolution with OS keychain fallback in the Reborn secrets crate
- keep v1 `src/secrets/*` untouched while preserving the same lookup semantics in `ironclaw_secrets`

## Validation
- `cargo fmt --check -p ironclaw_secrets`
- `cargo test -p ironclaw_secrets keychain -- --nocapture`
- `cargo test -p ironclaw_secrets -- --nocapture`

## Stack
- Base PR: this PR, keychain support only
- Follow-up PR: Reborn production composition wiring and `github_token` helper, based on this branch