### PR TITLE
[codex] Wire HTTP into Reborn local dev

### DIFF
--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -13,10 +13,11 @@ use ironclaw_host_api::{
 };
 use ironclaw_host_runtime::{
     APPLY_PATCH_CAPABILITY_ID, CapabilitySurfacePolicy, ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID,
-    GREP_CAPABILITY_ID, HostRuntime, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID,
-    READ_FILE_CAPABILITY_ID, SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID,
-    SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SurfaceKind, TIME_CAPABILITY_ID,
-    VisibleCapabilityRequest as HostVisibleCapabilityRequest, WRITE_FILE_CAPABILITY_ID,
+    GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HostRuntime, JSON_CAPABILITY_ID,
+    LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, SHELL_CAPABILITY_ID,
+    SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SurfaceKind,
+    TIME_CAPABILITY_ID, VisibleCapabilityRequest as HostVisibleCapabilityRequest,
+    WRITE_FILE_CAPABILITY_ID,
 };
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
@@ -542,12 +543,15 @@ fn local_dev_builtin_grants(
 enum LocalDevCapabilityKind {
     Workspace,
     AmbientShell,
+    Network,
     SkillManagement,
 }
 
 fn local_dev_capability_kind(capability_id: &str) -> LocalDevCapabilityKind {
     if capability_id == SHELL_CAPABILITY_ID {
         LocalDevCapabilityKind::AmbientShell
+    } else if capability_id == HTTP_CAPABILITY_ID {
+        LocalDevCapabilityKind::Network
     } else if capability_id == SKILL_LIST_CAPABILITY_ID
         || capability_id == SKILL_INSTALL_CAPABILITY_ID
         || capability_id == SKILL_REMOVE_CAPABILITY_ID
@@ -587,6 +591,15 @@ fn local_dev_grant_constraints(
             expires_at: None,
             max_invocations: None,
         },
+        LocalDevCapabilityKind::Network => GrantConstraints {
+            allowed_effects: local_dev_network_allowed_effects(),
+            mounts: MountView::default(),
+            network: local_dev_shell_network_policy(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
         LocalDevCapabilityKind::Workspace => GrantConstraints {
             allowed_effects: local_dev_allowed_effects(),
             mounts: workspace_mounts.clone(),
@@ -608,11 +621,12 @@ fn local_dev_grant_constraints(
     }
 }
 
-fn local_dev_builtin_capability_ids() -> [&'static str; 13] {
+fn local_dev_builtin_capability_ids() -> [&'static str; 14] {
     [
         ECHO_CAPABILITY_ID,
         TIME_CAPABILITY_ID,
         JSON_CAPABILITY_ID,
+        HTTP_CAPABILITY_ID,
         SHELL_CAPABILITY_ID,
         READ_FILE_CAPABILITY_ID,
         WRITE_FILE_CAPABILITY_ID,
@@ -624,6 +638,10 @@ fn local_dev_builtin_capability_ids() -> [&'static str; 13] {
         SKILL_INSTALL_CAPABILITY_ID,
         SKILL_REMOVE_CAPABILITY_ID,
     ]
+}
+
+fn local_dev_network_allowed_effects() -> Vec<EffectKind> {
+    vec![EffectKind::DispatchCapability, EffectKind::Network]
 }
 
 fn local_dev_allowed_effects() -> Vec<EffectKind> {
@@ -843,7 +861,7 @@ mod tests {
     }
 
     #[test]
-    fn local_dev_builtin_surface_grants_shell_as_ambient_escape_hatch() {
+    fn local_dev_builtin_surface_grants_capability_classes() {
         let capability_ids = local_dev_builtin_capability_ids();
 
         assert!(capability_ids.contains(&WRITE_FILE_CAPABILITY_ID));
@@ -852,6 +870,7 @@ mod tests {
         assert!(capability_ids.contains(&SKILL_INSTALL_CAPABILITY_ID));
         assert!(capability_ids.contains(&SKILL_REMOVE_CAPABILITY_ID));
         assert!(capability_ids.contains(&SHELL_CAPABILITY_ID));
+        assert!(capability_ids.contains(&HTTP_CAPABILITY_ID));
         assert_eq!(
             local_dev_allowed_effects(),
             vec![
@@ -921,6 +940,17 @@ mod tests {
         assert!(shell_grant.constraints.mounts.mounts.is_empty());
         assert_eq!(
             shell_grant.constraints.network,
+            local_dev_shell_network_policy()
+        );
+
+        let http_grant = grant_for(HTTP_CAPABILITY_ID);
+        assert_eq!(
+            http_grant.constraints.allowed_effects,
+            vec![EffectKind::DispatchCapability, EffectKind::Network]
+        );
+        assert!(http_grant.constraints.mounts.mounts.is_empty());
+        assert_eq!(
+            http_grant.constraints.network,
             local_dev_shell_network_policy()
         );
 

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -417,6 +417,37 @@ fn auth_scope(user: &str) -> ironclaw_auth::AuthProductScope {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn local_dev_runtime_policy_exposes_http_capability() {
+    let dir = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(
+        RebornBuildInput::local_dev("test-owner", dir.path().to_path_buf())
+            .with_runtime_policy(local_only_runtime_policy()),
+    )
+    .await
+    .unwrap();
+    let runtime = services
+        .host_runtime
+        .expect("local dev exposes host runtime");
+
+    let surface = runtime
+        .visible_capabilities(local_dev_builtin_visible_request())
+        .await
+        .unwrap();
+    let visible_ids = surface
+        .capabilities
+        .iter()
+        .map(|capability| capability.descriptor.id.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(visible_ids.contains(&"builtin.echo"));
+    assert!(
+        visible_ids.contains(&"builtin.http"),
+        "local-dev facade should expose host HTTP when the runtime policy allows network"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn local_dev_runtime_policy_hides_http_capability() {
     let dir = tempfile::tempdir().unwrap();
     let services = build_reborn_services(


### PR DESCRIPTION
## Summary

- Add `builtin.http` to the Reborn local-dev builtin capability grant set.
- Grant HTTP only dispatch + network effects, with no filesystem mounts, using the existing local-dev egress policy.
- Add facade coverage proving local-dev exposes HTTP when network is allowed and hides it when network is denied.

## Validation

- `cargo fmt`
- `CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition local_dev_builtin_surface_grants_capability_classes --features libsql`
- `CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition local_dev_runtime_policy_ --features libsql`

## Target

Base branch is `reborn-integration`; head branch is `codex/reborn-localdev-http`.