### PR TITLE
Address tool failure taxonomy review feedback

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/coding/paths.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/paths.rs
@@ -222,7 +222,7 @@ pub(super) fn filesystem_error(error: FilesystemError) -> CodingCapabilityError 
             CodingCapabilityError::new(RuntimeDispatchErrorKind::FilesystemDenied)
         }
         FilesystemError::NotFound { .. } => operation_error(),
-        FilesystemError::Backend { .. } => {
+        FilesystemError::Backend { .. } | FilesystemError::BackendInfrastructure { .. } => {
             CodingCapabilityError::new(RuntimeDispatchErrorKind::Backend)
         }
         // The unified record/index/CAS variants are surfaced when a backend

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -290,7 +290,7 @@ fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
         RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
         RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
-        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode,
+        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OperationFailed,
         RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
             RuntimeDispatchErrorKind::OutputTooLarge
         }

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -949,7 +949,7 @@ async fn builtin_http_maps_runtime_egress_errors_by_source() {
                 request_bytes: 4,
                 response_bytes: 1024,
             },
-            RuntimeFailureKind::InvalidOutput,
+            RuntimeFailureKind::OperationFailed,
         ),
     ];
 

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -213,6 +213,30 @@ async fn builtin_coding_grep_fails_on_explicit_file_read_error() {
 }
 
 #[tokio::test]
+async fn builtin_coding_grep_treats_backend_infrastructure_as_backend_failure() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("fail.rs"), "needle\n").unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
+    let runtime = runtime_with_filesystem(ReadInfrastructureFailureFilesystem {
+        inner: filesystem,
+        fail_suffix: "/fail.rs",
+    });
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let error = invoke_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({"path": "/workspace/fail.rs", "pattern": "needle"}),
+        context,
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::Backend);
+}
+
+#[tokio::test]
 async fn builtin_coding_list_fails_when_visited_entry_budget_is_exceeded() {
     let temp = tempfile::tempdir().unwrap();
     let (_filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
@@ -406,6 +430,40 @@ impl RootFilesystem for ReadFailureFilesystem {
                 path: path.clone(),
                 operation: FilesystemOperation::ReadFile,
                 reason: "injected read failure".to_string(),
+            });
+        }
+        self.inner.read_file(path).await
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.inner.write_file(path, bytes).await
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.create_dir_all(path).await
+    }
+}
+
+struct ReadInfrastructureFailureFilesystem {
+    inner: LocalFilesystem,
+    fail_suffix: &'static str,
+}
+
+#[async_trait]
+impl RootFilesystem for ReadInfrastructureFailureFilesystem {
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        if path.as_str().ends_with(self.fail_suffix) {
+            return Err(FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::ReadFile,
+                reason: "injected read infrastructure failure".to_string(),
             });
         }
         self.inner.read_file(path).await

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -210,7 +210,7 @@ async fn first_party_handler_maps_egress_error_codes_to_dispatch_errors() {
                 request_bytes: 11,
                 response_bytes: 22,
             },
-            RuntimeFailureKind::InvalidOutput,
+            RuntimeFailureKind::OperationFailed,
         ),
         (
             RuntimeHttpEgressError::Response {
@@ -218,7 +218,7 @@ async fn first_party_handler_maps_egress_error_codes_to_dispatch_errors() {
                 request_bytes: 11,
                 response_bytes: 4097,
             },
-            RuntimeFailureKind::InvalidOutput,
+            RuntimeFailureKind::OutputTooLarge,
         ),
     ];
 
@@ -328,11 +328,11 @@ fn http_error_kind_maps_all_reason_codes() {
         ),
         (
             RuntimeHttpEgressReasonCode::ResponseError,
-            RuntimeDispatchErrorKind::OutputDecode,
+            RuntimeDispatchErrorKind::OperationFailed,
         ),
         (
             RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded,
-            RuntimeDispatchErrorKind::OutputDecode,
+            RuntimeDispatchErrorKind::OutputTooLarge,
         ),
     ];
 
@@ -759,9 +759,9 @@ fn http_error_kind(reason: RuntimeHttpEgressReasonCode) -> RuntimeDispatchErrorK
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
         RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
         RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
-        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode,
+        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OperationFailed,
         RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
-            RuntimeDispatchErrorKind::OutputDecode
+            RuntimeDispatchErrorKind::OutputTooLarge
         }
     }
 }


### PR DESCRIPTION
## Summary
- Map first-party HTTP `ResponseError` to `OperationFailed` so host response handling failures remain model-visible instead of aborting as invalid output.
- Keep response body limit failures aligned with production `OutputTooLarge` behavior in the runtime contract fixture.
- Map coding-tool `FilesystemError::BackendInfrastructure` to backend failures and cover it through the host-runtime coding-tool caller test.

## Review feedback addressed
- Follow-up to #4014 review: https://github.com/nearai/ironclaw/pull/4014#pullrequestreview-4353606133
- The WASM guest trap path was left unchanged: only guest-reported operation errors map to `OperationFailed`; runtime execution errors still go through `wasm_error_kind`.
- The sanitized operation-reason suggestion was left for a narrower follow-up because the current dispatch surface carries only stable failure kinds; threading per-operation reasons would require a broader host API/error-shape change.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test -p ironclaw_host_runtime --test first_party_runtime_contract`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test -p ironclaw_host_runtime --test first_party_coding_tools`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_http_maps_runtime_egress_errors_by_source`