### PR TITLE
fix(tools): HTTP response error is recoverable, not a run-aborting output-contract violation (regression from #4014)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,16 +3454,6 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
-dependencies = [
- "log",
- "markup5ever 0.38.0",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
@@ -5448,17 +5438,17 @@ dependencies = [
 
 [[package]]
 name = "kuchikikiki"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73885c6a3cefdf7a1db0327cefbe4b9b72cac94cae4b19ede4fa492d8af02a0"
+checksum = "14683223e533503d404478bfd32826a4cba1b4906034ff74135404372390e87b"
 dependencies = [
  "bitflags 2.11.1",
  "crc",
  "cssparser",
- "html5ever 0.38.0",
+ "html5ever 0.36.1",
  "indexmap 2.14.0",
  "precomputed-hash",
- "selectors 0.35.0",
+ "selectors",
 ]
 
 [[package]]
@@ -5836,17 +5826,6 @@ checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
 dependencies = [
  "log",
  "tendril 0.4.3",
- "web_atoms",
-]
-
-[[package]]
-name = "markup5ever"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
-dependencies = [
- "log",
- "tendril 0.5.0",
  "web_atoms",
 ]
 
@@ -8094,7 +8073,7 @@ dependencies = [
  "getopts",
  "html5ever 0.36.1",
  "precomputed-hash",
- "selectors 0.33.0",
+ "selectors",
  "tendril 0.4.3",
 ]
 
@@ -8184,25 +8163,6 @@ name = "selectors"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
-dependencies = [
- "bitflags 2.11.1",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash 2.1.2",
- "servo_arc",
- "smallvec",
-]
-
-[[package]]
-name = "selectors"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",

--- a/crates/ironclaw_agent_loop/src/executor/mapping.rs
+++ b/crates/ironclaw_agent_loop/src/executor/mapping.rs
@@ -169,3 +169,36 @@ pub(super) fn honor_retry_alteration(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Invariant: an operational capability failure (e.g. a remote HTTP error response,
+    /// which the first-party HTTP runtime classifies as `OperationFailed`) must be a
+    /// recoverable, model-visible error class — never the run-aborting `Permanent` class.
+    /// A remote HTTP response error must never abort the entire agent run. See the #4014
+    /// regression where `ResponseError` was mapped through `InvalidOutput -> Permanent`.
+    #[test]
+    fn operation_failed_is_recoverable_not_run_aborting() {
+        let class = capability_error_class(&CapabilityFailureKind::OperationFailed);
+        assert_eq!(class, CapabilityErrorClass::OperationFailed);
+        assert_ne!(
+            class,
+            CapabilityErrorClass::Permanent,
+            "operational failures must stay recoverable and model-visible, not abort the run"
+        );
+    }
+
+    /// Counterpart invariant: genuine output-contract violations (e.g. a WASM tool
+    /// returning a malformed result -> `InvalidOutput`) remain `Permanent`/run-aborting.
+    /// This guards against over-correcting the #4014 fix and silently downgrading real
+    /// contract violations to recoverable.
+    #[test]
+    fn invalid_output_remains_run_aborting() {
+        assert_eq!(
+            capability_error_class(&CapabilityFailureKind::InvalidOutput),
+            CapabilityErrorClass::Permanent
+        );
+    }
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -290,9 +290,16 @@ fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
         RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
         RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
-        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode,
+        // A remote HTTP error response is an operational failure surfaced to the model
+        // (retry, try a different endpoint, tell the user), not a fatal violation of our
+        // own output contract. Mapping it to OutputDecode/InvalidOutput would classify it
+        // as Permanent and abort the entire agent run.
+        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OperationFailed,
+        // An oversized remote response body is likewise an operational/remote condition,
+        // not a violation of our own output contract, so it must stay recoverable and
+        // model-visible rather than aborting the run.
         RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
-            RuntimeDispatchErrorKind::OutputTooLarge
+            RuntimeDispatchErrorKind::OperationFailed
         }
     };
     tracing::debug!(

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -294,10 +294,26 @@ fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
         // (retry, try a different endpoint, tell the user), not a fatal violation of our
         // own output contract. Mapping it to OutputDecode/InvalidOutput would classify it
         // as Permanent and abort the entire agent run.
+        //
+        // Note: `response_leak_blocked` (the leak detector found unredactable secrets in
+        // the response, synthesized as `RuntimeHttpEgressError::Response` in
+        // sanitize_runtime_response in lib.rs) also rides this recoverable `ResponseError`
+        // path, since reason_code() only special-cases `response_body_limit_exceeded`. This
+        // is safe — the leak detector re-runs and re-blocks on any re-issued request, so
+        // nothing leaks — but it can produce a bounded retry loop (the model re-requests and
+        // re-triggers the block, capped by the loop's global iteration limit). Giving
+        // `response_leak_blocked` a dedicated Permanent reason code so the run aborts instead
+        // of spinning is the documented follow-up.
         RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OperationFailed,
         // An oversized remote response body is likewise an operational/remote condition,
         // not a violation of our own output contract, so it must stay recoverable and
         // model-visible rather than aborting the run.
+        //
+        // This intentionally diverges from a guest exceeding its own declared output
+        // (`OutputTooLarge`), which stays Permanent and aborts: an oversized *remote* body is
+        // an operational/remote condition, whereas a guest overflowing its declared output is
+        // a genuine contract violation. The two "output too large" paths therefore differ in
+        // fatality by design, not oversight.
         RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
             RuntimeDispatchErrorKind::OperationFailed
         }

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -1343,6 +1343,10 @@ fn sanitize_runtime_response(
         if exact_redacted.contains("[REDACTED]") {
             redaction_applied = true;
         }
+        // `response_leak_blocked` rides the recoverable `ResponseError` path (reason_code()
+        // only special-cases response_body_limit_exceeded). Safe — the detector re-blocks any
+        // re-issued request — but can spin a bounded retry loop; a dedicated Permanent reason
+        // code is the documented follow-up. See first_party_tools/http.rs http_error().
         let cleaned = detector.scan_and_clean(&exact_redacted).map_err(|_| {
             RuntimeHttpEgressError::Response {
                 reason: "response_leak_blocked".to_string(),
@@ -1362,6 +1366,10 @@ fn sanitize_runtime_response(
     if exact_body_redacted {
         redaction_applied = true;
     }
+    // `response_leak_blocked` rides the recoverable `ResponseError` path (reason_code() only
+    // special-cases response_body_limit_exceeded). Safe — the detector re-blocks any re-issued
+    // request — but can spin a bounded retry loop; a dedicated Permanent reason code is the
+    // documented follow-up. See first_party_tools/http.rs http_error().
     let cleaned =
         detector
             .scan_and_clean(&exact_redacted)

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -933,7 +933,9 @@ async fn builtin_http_maps_runtime_egress_errors_by_source() {
                 request_bytes: 4,
                 response_bytes: 1024,
             },
-            RuntimeFailureKind::OutputTooLarge,
+            // An oversized remote response body is operational/remote, not our own
+            // output-contract violation, so it must stay recoverable and model-visible.
+            RuntimeFailureKind::OperationFailed,
         ),
         (
             RuntimeHttpEgressError::Response {
@@ -941,7 +943,7 @@ async fn builtin_http_maps_runtime_egress_errors_by_source() {
                 request_bytes: 4,
                 response_bytes: 1024,
             },
-            RuntimeFailureKind::OutputTooLarge,
+            RuntimeFailureKind::OperationFailed,
         ),
         (
             RuntimeHttpEgressError::Response {
@@ -949,7 +951,10 @@ async fn builtin_http_maps_runtime_egress_errors_by_source() {
                 request_bytes: 4,
                 response_bytes: 1024,
             },
-            RuntimeFailureKind::InvalidOutput,
+            // A remote HTTP error response is an operational failure surfaced to the
+            // model (retry / different endpoint / tell the user), never a run-aborting
+            // violation of our own output contract. Regression guard for #4014.
+            RuntimeFailureKind::OperationFailed,
         ),
     ];
 

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -210,7 +210,9 @@ async fn first_party_handler_maps_egress_error_codes_to_dispatch_errors() {
                 request_bytes: 11,
                 response_bytes: 22,
             },
-            RuntimeFailureKind::InvalidOutput,
+            // A remote HTTP error response is operational and model-visible, never a
+            // run-aborting output-contract violation.
+            RuntimeFailureKind::OperationFailed,
         ),
         (
             RuntimeHttpEgressError::Response {
@@ -218,7 +220,9 @@ async fn first_party_handler_maps_egress_error_codes_to_dispatch_errors() {
                 request_bytes: 11,
                 response_bytes: 4097,
             },
-            RuntimeFailureKind::InvalidOutput,
+            // An oversized remote response body is likewise operational, not a violation
+            // of our own output contract, so it stays recoverable.
+            RuntimeFailureKind::OperationFailed,
         ),
     ];
 
@@ -328,11 +332,11 @@ fn http_error_kind_maps_all_reason_codes() {
         ),
         (
             RuntimeHttpEgressReasonCode::ResponseError,
-            RuntimeDispatchErrorKind::OutputDecode,
+            RuntimeDispatchErrorKind::OperationFailed,
         ),
         (
             RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded,
-            RuntimeDispatchErrorKind::OutputDecode,
+            RuntimeDispatchErrorKind::OperationFailed,
         ),
     ];
 
@@ -759,9 +763,11 @@ fn http_error_kind(reason: RuntimeHttpEgressReasonCode) -> RuntimeDispatchErrorK
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
         RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
         RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
-        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode,
+        // Remote HTTP error responses and oversized bodies are operational/remote
+        // failures surfaced to the model, never fatal output-contract violations.
+        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OperationFailed,
         RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
-            RuntimeDispatchErrorKind::OutputDecode
+            RuntimeDispatchErrorKind::OperationFailed
         }
     }
 }


### PR DESCRIPTION
## Regression

#4014 (`16bb43d5b`, *Classify recoverable tool operation failures*) introduced a **run-terminating regression**: a host-side HTTP **response error from a remote server now aborts the entire agent run**, where it was previously a model-visible, recoverable tool error that let the loop continue.

#4014 did **not** touch the `http.rs` `ResponseError → OutputDecode` mapping (that mapping predates it). The regression came from #4014 flipping the **downstream** `OutputDecode` classification in `production.rs` from `InvalidInput` (recoverable) to `InvalidOutput` (Permanent/abort), which turned the pre-existing `ResponseError → OutputDecode` mapping into a run-aborting path.

### Verified chain (pre-fix)

1. `crates/ironclaw_host_runtime/src/first_party_tools/http.rs` — `RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode` (predates #4014, unchanged by it)
2. `crates/ironclaw_host_runtime/src/production.rs` — `OutputDecode => RuntimeFailureKind::InvalidOutput` (**this is what #4014 changed**: it was `OutputDecode => InvalidInput` before)
3. `crates/ironclaw_agent_loop/src/executor/mapping.rs` — `InvalidOutput | … | Permanent => CapabilityErrorClass::Permanent` (the **abort** class)

So post-#4014 it flows `ResponseError → OutputDecode → InvalidOutput → Permanent → abort`. Pre-#4014 the same `ResponseError → OutputDecode` mapping flowed `OutputDecode → InvalidInput → InputInvalid →` a model-visible `ToolErrorResult` and the loop continued.

`RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => OutputTooLarge` shares the same shape: `OutputTooLarge => RuntimeFailureKind::OutputTooLarge => CapabilityErrorClass::Permanent` (abort).

## Semantic rationale: operational vs. output-contract

`RuntimeHttpEgressError::Response { .. }` means **the remote returned an error response** (or an oversized body) — an **operational/remote** failure the model should see and react to (retry, try a different endpoint, tell the user). It is **not** a violation of *our own* output contract. A genuine output-contract violation is e.g. a WASM tool returning a malformed result (`InvalidResult`), which legitimately maps `OutputDecode → InvalidOutput → Permanent → abort`.

#4014 itself added the correct recoverable class for exactly this case: `RuntimeDispatchErrorKind::OperationFailed => RuntimeFailureKind::OperationFailed => CapabilityErrorClass::OperationFailed` (recoverable, model-visible). The HTTP mappings simply weren't pointed at it.

## Fix

- `http.rs`: `ResponseError` and `ResponseBodyLimitExceeded` now map to `RuntimeDispatchErrorKind::OperationFailed` (recoverable, model-visible) instead of `OutputDecode` / `OutputTooLarge` (Permanent/abort).
- **Left `OutputDecode → InvalidOutput → Permanent → abort` intact** for genuine output-contract violations (e.g. WASM `InvalidResult`). `production.rs` and `mapping.rs` mappings are untouched.

Verified downstream class after the fix: `ResponseError → OperationFailed → RuntimeFailureKind::OperationFailed → CapabilityFailureKind::OperationFailed → CapabilityErrorClass::OperationFailed` (recoverable; the recovery strategy turns this into a model-visible tool error, not an abort).

## Tests

- Corrected the contract tests that pinned the abort (`first_party_runtime_contract.rs`, `first_party_builtin_tools.rs`) to assert the **intended safe** mapping (`OperationFailed`) and the recoverable end-to-end `RuntimeFailureKind::OperationFailed`, not merely whatever the code now does.
- Added regression invariants in `crates/ironclaw_agent_loop/src/executor/mapping.rs`:
  - `operation_failed_is_recoverable_not_run_aborting` — phrased as "a remote HTTP response error never aborts the run" so it can't be silently downgraded later.
  - `invalid_output_remains_run_aborting` — guards against over-correcting and downgrading genuine contract violations.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all --tests --examples --all-features -- -D warnings` — exit 0
- `cargo test -p ironclaw_host_runtime -p ironclaw_agent_loop` — green incl. corrected + new tests.
  - Pre-existing, env-dependent failures in `github_wasm_runtime_contract.rs` (`first-party GitHub WASM must be built: NotFound` + `FilesystemDenied`) reproduce identically on the clean base (`16bb43d5b`) and are unrelated to this change.

## Context

This is another instance of the **regression-pinning test** pattern — a test that asserted the buggy behavior and locked it in. See systemic issue #4017 and proposal #4019. Regression source: #4014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
