### PR TITLE
fix(secrets): stop tests from prompting for OS keychain access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -312,5 +312,15 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # `[identity].installation_tenant` in `config.toml`.
 # IRONCLAW_REBORN_WEBUI_USER_ID=reborn-cli-operator
 
+# ─── Test / CI: OS keychain ────────────────────────────────────────────
+# Set to "1" to stop the secrets master-key lookup from touching the real OS
+# keychain (macOS Keychain / Linux Secret Service). Without it, a test or
+# tool run that resolves the master key while SECRETS_MASTER_KEY is unset
+# pops a macOS Keychain authorization dialog (or blocks on a locked Secret
+# Service). Crate unit tests are already covered by cfg!(test); set this for
+# integration/e2e runs (the CI workflows set it automatically). Leave UNSET in
+# production so the real keychain fallback works.
+# IRONCLAW_DISABLE_OS_KEYCHAIN=1
+
 # Logging
 RUST_LOG=ironclaw=debug,tower_http=debug

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -19,6 +19,13 @@ concurrency:
   group: code-style-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Tests must never touch the real OS keychain (macOS Keychain auth dialog /
+  # Linux Secret Service). Guarded by src/secrets/keychain.rs::os_keychain_suppressed:
+  # cfg!(test) covers unit tests; this covers integration/e2e that link the
+  # non-cfg(test) library.
+  IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+
 jobs:
   changes:
     name: Detect code changes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # Tests must never touch the real OS keychain (macOS Keychain auth dialog /
+  # Linux Secret Service). Guarded by src/secrets/keychain.rs::os_keychain_suppressed:
+  # cfg!(test) covers unit tests; this covers integration/e2e that link the
+  # non-cfg(test) library.
+  IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+
 jobs:
   coverage:
     name: Coverage (${{ matrix.name }})

--- a/.github/workflows/reborn-integration.yml
+++ b/.github/workflows/reborn-integration.yml
@@ -26,6 +26,13 @@ concurrency:
   group: reborn-integration-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Tests must never touch the real OS keychain (macOS Keychain auth dialog /
+  # Linux Secret Service). Guarded by src/secrets/keychain.rs::os_keychain_suppressed:
+  # cfg!(test) covers unit tests; this covers integration/e2e that link the
+  # non-cfg(test) library.
+  IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+
 jobs:
   package-matrix:
     name: Discover Reborn binary crates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,13 @@ concurrency:
   group: test-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Tests must never touch the real OS keychain (macOS Keychain auth dialog /
+  # Linux Secret Service). Guarded by src/secrets/keychain.rs::os_keychain_suppressed:
+  # cfg!(test) covers unit tests; this covers integration/e2e that link the
+  # non-cfg(test) library.
+  IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
+
 jobs:
   changes:
     name: Detect code changes

--- a/src/secrets/keychain.rs
+++ b/src/secrets/keychain.rs
@@ -259,8 +259,61 @@ mod platform {
     }
 }
 
-// Re-export platform-specific functions
-pub use platform::{delete_master_key, get_master_key, has_master_key, store_master_key};
+/// Whether OS-keychain access should be suppressed.
+///
+/// Touching the real OS keychain during automated tests pops a macOS Keychain
+/// authorization dialog (and blocks on a locked Secret Service on Linux), which
+/// derails `cargo test`. We suppress it when compiled for tests (`cfg!(test)`,
+/// covering this crate's unit tests) or when `IRONCLAW_DISABLE_OS_KEYCHAIN` is
+/// set in the environment (covering integration/e2e tests and CI, which link
+/// the non-`cfg(test)` library). When suppressed, lookups behave as "no key
+/// present" and writes fail closed — so `resolve_master_key` falls through to
+/// `None`/the env var exactly as it would with an empty keychain, with no
+/// prompt. Production (no `cfg(test)`, env unset) is unaffected.
+fn os_keychain_suppressed() -> bool {
+    cfg!(test) || std::env::var_os("IRONCLAW_DISABLE_OS_KEYCHAIN").is_some()
+}
+
+/// Retrieve the master key from the OS keychain (suppressed in tests/headless).
+pub async fn get_master_key() -> Result<Vec<u8>, SecretError> {
+    if os_keychain_suppressed() {
+        return Err(SecretError::KeychainError(
+            "OS keychain access suppressed (cfg!(test) or IRONCLAW_DISABLE_OS_KEYCHAIN)"
+                .to_string(),
+        ));
+    }
+    platform::get_master_key().await
+}
+
+/// Whether a master key exists in the OS keychain (suppressed in tests/headless).
+pub async fn has_master_key() -> bool {
+    if os_keychain_suppressed() {
+        return false;
+    }
+    platform::has_master_key().await
+}
+
+/// Store the master key in the OS keychain (suppressed in tests/headless).
+pub async fn store_master_key(key: &[u8]) -> Result<(), SecretError> {
+    if os_keychain_suppressed() {
+        return Err(SecretError::KeychainError(
+            "OS keychain access suppressed (cfg!(test) or IRONCLAW_DISABLE_OS_KEYCHAIN)"
+                .to_string(),
+        ));
+    }
+    platform::store_master_key(key).await
+}
+
+/// Delete the master key from the OS keychain (suppressed in tests/headless).
+pub async fn delete_master_key() -> Result<(), SecretError> {
+    if os_keychain_suppressed() {
+        return Err(SecretError::KeychainError(
+            "OS keychain access suppressed (cfg!(test) or IRONCLAW_DISABLE_OS_KEYCHAIN)"
+                .to_string(),
+        ));
+    }
+    platform::delete_master_key().await
+}
 
 /// Parse a hex string to bytes.
 #[cfg(any(target_os = "macos", target_os = "linux", test))]

--- a/src/secrets/keychain.rs
+++ b/src/secrets/keychain.rs
@@ -368,4 +368,24 @@ mod tests {
         assert!(hex_to_bytes("abc").is_err()); // Odd length
         assert!(hex_to_bytes("gg").is_err()); // Invalid chars
     }
+
+    // Regression: under a test build the real OS keychain must never be
+    // consulted — touching it pops a macOS Keychain auth dialog / blocks on a
+    // locked Linux Secret Service and derails `cargo test`. `cfg!(test)` is
+    // unconditionally true here, so the guard short-circuits before any
+    // platform keychain call (no env manipulation needed — keeps this test
+    // race-free under parallel execution).
+    #[tokio::test]
+    async fn os_keychain_access_is_suppressed_under_test_build() {
+        assert!(
+            os_keychain_suppressed(),
+            "cfg!(test) must suppress OS keychain access"
+        );
+        // Reads behave as "no key present"; writes fail closed — without
+        // reaching the platform keychain (which would prompt).
+        assert!(get_master_key().await.is_err());
+        assert!(!has_master_key().await);
+        assert!(store_master_key(&[0u8; 32]).await.is_err());
+        assert!(delete_master_key().await.is_err());
+    }
 }


### PR DESCRIPTION
## Problem
`cargo test` on macOS pops a Keychain authorization dialog (and blocks on a locked Secret Service on Linux). Root cause: `secrets::resolve_master_key()` is env-first but then falls back to the **real OS keychain** (`get_generic_password` / Secret Service) when `SECRETS_MASTER_KEY` is unset, with no test guard. Any test that resolves the master key without the env var set (doctor/status/secrets unit tests, app-boot integration tests) triggers the prompt.

## Fix
Guard the keychain public API in `src/secrets/keychain.rs` with a single boundary check:

```rust
fn os_keychain_suppressed() -> bool {
    cfg!(test) || std::env::var_os("IRONCLAW_DISABLE_OS_KEYCHAIN").is_some()
}
```

`get_master_key` / `has_master_key` / `store_master_key` / `delete_master_key` short-circuit when suppressed (lookups → "not present", writes → fail closed) **before** touching the OS, then delegate to the platform impl otherwise.

- **`cfg!(test)`** covers this crate's unit tests — the common case (the agents and devs run `cargo test -p ironclaw` constantly).
- **`IRONCLAW_DISABLE_OS_KEYCHAIN`** covers integration/e2e tests and CI, which link the non-`cfg(test)` library and so don't get `cfg!(test)`. Set it in CI / integration harnesses to suppress prompts there too.

When suppressed, `resolve_master_key` falls through to `None`/the env var exactly as it would with an empty keychain — **no prompt, no behavior change observable to callers**. **Production (no `cfg(test)`, env unset) is unaffected** — the real keychain is still used.

Safe because the keychain module's own tests only exercise the `generate`/`hex` helpers — none round-trips the real keychain.

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p ironclaw --lib --all-features -- -D warnings` — exit 0
- `cargo test -p ironclaw --lib -- secrets cli::doctor cli::status` — 141 passed, 0 failed (incl. `keychain_wins_when_env_unset`, `resolve_persists_generated_key_when_nothing_available` — behavior parity), and they no longer touch the real keychain under `cfg!(test)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
