### PR TITLE
[codex] Add Reborn first-party tool e2e coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,16 +3454,6 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
-dependencies = [
- "log",
- "markup5ever 0.38.0",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
@@ -4031,6 +4021,7 @@ dependencies = [
  "ironclaw_resources",
  "ironclaw_runtime_policy",
  "ironclaw_safety",
+ "ironclaw_secrets",
  "ironclaw_skills",
  "ironclaw_threads",
  "ironclaw_trust",
@@ -5448,17 +5439,17 @@ dependencies = [
 
 [[package]]
 name = "kuchikikiki"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73885c6a3cefdf7a1db0327cefbe4b9b72cac94cae4b19ede4fa492d8af02a0"
+checksum = "14683223e533503d404478bfd32826a4cba1b4906034ff74135404372390e87b"
 dependencies = [
  "bitflags 2.11.1",
  "crc",
  "cssparser",
- "html5ever 0.38.0",
+ "html5ever 0.36.1",
  "indexmap 2.14.0",
  "precomputed-hash",
- "selectors 0.35.0",
+ "selectors",
 ]
 
 [[package]]
@@ -5836,17 +5827,6 @@ checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
 dependencies = [
  "log",
  "tendril 0.4.3",
- "web_atoms",
-]
-
-[[package]]
-name = "markup5ever"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
-dependencies = [
- "log",
- "tendril 0.5.0",
  "web_atoms",
 ]
 
@@ -8094,7 +8074,7 @@ dependencies = [
  "getopts",
  "html5ever 0.36.1",
  "precomputed-hash",
- "selectors 0.33.0",
+ "selectors",
  "tendril 0.4.3",
 ]
 
@@ -8184,25 +8164,6 @@ name = "selectors"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
-dependencies = [
- "bitflags 2.11.1",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash 2.1.2",
- "servo_arc",
- "smallvec",
-]
-
-[[package]]
-name = "selectors"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,7 @@ ironclaw_host_runtime = { path = "crates/ironclaw_host_runtime", version = "0.1.
 ironclaw_network = { path = "crates/ironclaw_network", version = "0.1.0" }
 ironclaw_processes = { path = "crates/ironclaw_processes", version = "0.1.0" }
 ironclaw_resources = { path = "crates/ironclaw_resources", version = "0.1.0" }
+ironclaw_secrets = { path = "crates/ironclaw_secrets", version = "0.1.0" }
 ironclaw_product_adapters = { path = "crates/ironclaw_product_adapters", version = "0.1.0", features = ["test-support"] }
 ironclaw_product_workflow = { path = "crates/ironclaw_product_workflow", version = "0.1.0", features = ["test-support"] }
 ironclaw_reborn = { path = "crates/ironclaw_reborn", version = "0.1.0" }

--- a/tests/reborn_trace_core_builtin_tools_parity.rs
+++ b/tests/reborn_trace_core_builtin_tools_parity.rs
@@ -3,7 +3,17 @@
 mod reborn_support;
 mod support;
 
+use std::sync::{Arc, Mutex};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{HeaderMap, StatusCode, header},
+    response::IntoResponse,
+    routing::get,
+};
 use ironclaw_host_api::CapabilityId;
+use ironclaw_host_api::{NetworkPolicy, NetworkScheme, NetworkTargetPattern};
 use ironclaw_host_runtime::{
     APPLY_PATCH_CAPABILITY_ID, HTTP_CAPABILITY_ID, JSON_CAPABILITY_ID, READ_FILE_CAPABILITY_ID,
     TIME_CAPABILITY_ID,
@@ -26,6 +36,7 @@ async fn reborn_trace_core_builtin_tools_parity() {
     let http = CapabilityId::new(HTTP_CAPABILITY_ID).expect("valid capability id");
     let read_file = CapabilityId::new(READ_FILE_CAPABILITY_ID).expect("valid capability id");
     let apply_patch = CapabilityId::new(APPLY_PATCH_CAPABILITY_ID).expect("valid capability id");
+    let live_http = LiveHttpServer::start().await;
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
             calls: vec![
@@ -51,7 +62,7 @@ async fn reborn_trace_core_builtin_tools_parity() {
                     http.clone(),
                     "call_http_get",
                     serde_json::json!({
-                        "url": "https://api.example.test/v1/items",
+                        "url": live_http.url("/v1/items"),
                         "headers": {"x-request-id": "reborn-core-builtins"},
                         "timeout_ms": 2500,
                     }),
@@ -84,12 +95,14 @@ async fn reborn_trace_core_builtin_tools_parity() {
             expected_tool_results: Vec::new(),
         },
     ]);
-    let mut harness = RebornBinaryE2EHarness::with_host_runtime_core_builtin_capabilities(
-        "room-trace-core-builtins",
-        model_gateway,
-    )
-    .await
-    .expect("harness");
+    let mut harness =
+        RebornBinaryE2EHarness::with_host_runtime_core_builtin_capabilities_live_http_egress(
+            "room-trace-core-builtins",
+            model_gateway,
+            live_http_network_policy(live_http.port),
+        )
+        .await
+        .expect("harness");
     seed_workspace(&harness);
     harness.start();
 
@@ -121,6 +134,22 @@ async fn reborn_trace_core_builtin_tools_parity() {
     assert_eq!(invocations[2].capability_id, http);
     assert_eq!(invocations[3].capability_id, read_file);
     assert_eq!(invocations[4].capability_id, apply_patch);
+
+    let seen_requests = live_http.requests();
+    assert_eq!(seen_requests.len(), 1);
+    assert_eq!(seen_requests[0].path, "/v1/items");
+    assert_eq!(
+        seen_requests[0].request_id.as_deref(),
+        Some("reborn-core-builtins")
+    );
+
+    let results = harness.capability_results();
+    assert_eq!(results[2].capability_id, http);
+    assert_eq!(results[2].output["status"], serde_json::json!(200));
+    assert_eq!(
+        results[2].output["body_text"],
+        serde_json::json!(r#"{"accepted":true,"source":"live-loopback"}"#)
+    );
 
     let requests = harness.model_requests();
     assert_eq!(requests.len(), 4);
@@ -160,4 +189,96 @@ fn tool_result_count(request: &ironclaw_loop_support::HostManagedModelRequest) -
         .iter()
         .filter(|message| message.role == HostManagedModelMessageRole::ToolResult)
         .count()
+}
+
+struct LiveHttpServer {
+    port: u16,
+    requests: Arc<Mutex<Vec<LiveHttpRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LiveHttpRequest {
+    path: String,
+    request_id: Option<String>,
+}
+
+impl LiveHttpServer {
+    async fn start() -> Self {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind live HTTP test server");
+        let port = listener.local_addr().expect("local addr").port();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let state = LiveHttpState {
+            requests: Arc::clone(&requests),
+        };
+        let app = Router::new()
+            .route("/v1/items", get(live_items))
+            .with_state(state);
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        Self {
+            port,
+            requests,
+            task,
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{path}", self.port)
+    }
+
+    fn requests(&self) -> Vec<LiveHttpRequest> {
+        self.requests
+            .lock()
+            .expect("live HTTP request log lock poisoned")
+            .clone()
+    }
+}
+
+impl Drop for LiveHttpServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Clone)]
+struct LiveHttpState {
+    requests: Arc<Mutex<Vec<LiveHttpRequest>>>,
+}
+
+async fn live_items(State(state): State<LiveHttpState>, headers: HeaderMap) -> impl IntoResponse {
+    state
+        .requests
+        .lock()
+        .expect("live HTTP request log lock poisoned")
+        .push(LiveHttpRequest {
+            path: "/v1/items".to_string(),
+            request_id: headers
+                .get("x-request-id")
+                .and_then(|value| value.to_str().ok())
+                .map(ToString::to_string),
+        });
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        Json(serde_json::json!({"accepted": true, "source": "live-loopback"})),
+    )
+        .into_response()
+}
+
+fn live_http_network_policy(port: u16) -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Http),
+            host_pattern: "127.0.0.1".to_string(),
+            port: Some(port),
+        }],
+        deny_private_ip_ranges: false,
+        max_egress_bytes: Some(10_000),
+    }
 }

--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -1,0 +1,277 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use std::collections::BTreeSet;
+
+use ironclaw_host_api::CapabilityId;
+use ironclaw_host_runtime::{
+    APPLY_PATCH_CAPABILITY_ID, ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID,
+    HTTP_CAPABILITY_ID, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID,
+    SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID,
+    SKILL_REMOVE_CAPABILITY_ID, TIME_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
+    builtin_first_party_package,
+};
+use ironclaw_loop_support::{HostManagedModelMessageRole, HostManagedModelResponse};
+use ironclaw_turns::{TurnStatus, run_profile::LoopHostMilestoneKind};
+use reborn_support::{
+    harness::{RebornBinaryE2EHarness, assert_milestone_order},
+    model_replay::{
+        RebornModelReplayStep, RebornScriptedProviderToolCall, RebornTraceReplayModelGateway,
+    },
+};
+
+const REBORN_FIRST_PARTY_E2E_COVERED_CAPABILITIES: &[&str] = &[
+    ECHO_CAPABILITY_ID,
+    TIME_CAPABILITY_ID,
+    JSON_CAPABILITY_ID,
+    HTTP_CAPABILITY_ID,
+    SHELL_CAPABILITY_ID,
+    READ_FILE_CAPABILITY_ID,
+    WRITE_FILE_CAPABILITY_ID,
+    LIST_DIR_CAPABILITY_ID,
+    GLOB_CAPABILITY_ID,
+    GREP_CAPABILITY_ID,
+    APPLY_PATCH_CAPABILITY_ID,
+    SKILL_LIST_CAPABILITY_ID,
+    SKILL_INSTALL_CAPABILITY_ID,
+    SKILL_REMOVE_CAPABILITY_ID,
+];
+
+const SKILL_NAME: &str = "reborn-skill-e2e";
+
+#[test]
+fn reborn_builtin_first_party_capability_e2e_coverage_is_complete() {
+    let declared = builtin_first_party_package()
+        .expect("built-in first-party package builds")
+        .capabilities
+        .into_iter()
+        .map(|capability| capability.id.as_str().to_string())
+        .collect::<BTreeSet<_>>();
+    let covered = REBORN_FIRST_PARTY_E2E_COVERED_CAPABILITIES
+        .iter()
+        .map(|capability| (*capability).to_string())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        declared, covered,
+        "each built-in first-party capability must have Reborn e2e coverage"
+    );
+}
+
+#[tokio::test]
+async fn reborn_trace_process_first_party_tools_parity() {
+    let echo = CapabilityId::new(ECHO_CAPABILITY_ID).expect("valid capability id");
+    let shell = CapabilityId::new(SHELL_CAPABILITY_ID).expect("valid capability id");
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![RebornScriptedProviderToolCall::new(
+                echo.clone(),
+                "call_echo_first_party",
+                serde_json::json!({"message": "reborn echo e2e"}),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("process tools trace complete"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = RebornBinaryE2EHarness::with_host_runtime_process_capabilities(
+        "room-trace-process-first-party-tools",
+        model_gateway,
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-trace-process-first-party-tools",
+            "exercise process first-party tools",
+        )
+        .await
+        .expect("submit text");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("completed run");
+    harness
+        .assert_final_reply("process tools trace complete")
+        .await
+        .expect("final reply");
+
+    let invocations = harness.capability_invocations();
+    assert_eq!(invocations.len(), 1);
+    assert_eq!(invocations[0].capability_id, echo);
+
+    let results = harness.capability_results();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].capability_id, echo);
+    assert_eq!(results[0].output, serde_json::json!("reborn echo e2e"));
+
+    let requests = harness.model_requests();
+    assert_eq!(requests.len(), 2);
+    // The loop approval-gates shell execution; the product-live adapter e2e
+    // covers direct shell execution while this test guards model-surface parity.
+    assert!(
+        requests[0]
+            .messages
+            .iter()
+            .any(|message| message.content.contains(shell.as_str())),
+        "shell must be advertised on the Reborn model-facing first-party surface"
+    );
+    assert_eq!(tool_result_count(&requests[1]), 1);
+    assert_milestone_order(
+        &harness.milestones(),
+        |kind| matches!(kind, LoopHostMilestoneKind::CapabilityBatchCompleted { .. }),
+        |kind| matches!(kind, LoopHostMilestoneKind::AssistantReplyFinalized { .. }),
+    );
+    harness.assert_model_exhausted();
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn reborn_trace_skill_management_first_party_tools_parity() {
+    let skill_install =
+        CapabilityId::new(SKILL_INSTALL_CAPABILITY_ID).expect("valid capability id");
+    let skill_list = CapabilityId::new(SKILL_LIST_CAPABILITY_ID).expect("valid capability id");
+    let skill_remove = CapabilityId::new(SKILL_REMOVE_CAPABILITY_ID).expect("valid capability id");
+    let skill_content = skill_md(SKILL_NAME, "Reborn skill management e2e");
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![RebornScriptedProviderToolCall::new(
+                skill_install.clone(),
+                "call_skill_install_first_party",
+                serde_json::json!({
+                    "name": SKILL_NAME,
+                    "content": skill_content,
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![RebornScriptedProviderToolCall::new(
+                skill_list.clone(),
+                "call_skill_list_after_install",
+                serde_json::json!({}),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![RebornScriptedProviderToolCall::new(
+                skill_remove.clone(),
+                "call_skill_remove_first_party",
+                serde_json::json!({"name": SKILL_NAME}),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![RebornScriptedProviderToolCall::new(
+                skill_list.clone(),
+                "call_skill_list_after_remove",
+                serde_json::json!({}),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply(
+                "skill management tools trace complete",
+            ),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = RebornBinaryE2EHarness::with_host_runtime_skill_management_capabilities(
+        "room-trace-skill-management-first-party-tools",
+        model_gateway,
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-trace-skill-management-first-party-tools",
+            "exercise skill management first-party tools",
+        )
+        .await
+        .expect("submit text");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("completed run");
+    harness
+        .assert_final_reply("skill management tools trace complete")
+        .await
+        .expect("final reply");
+
+    let invocations = harness.capability_invocations();
+    assert_eq!(invocations.len(), 4);
+    assert_eq!(invocations[0].capability_id, skill_install);
+    assert_eq!(invocations[1].capability_id, skill_list);
+    assert_eq!(invocations[2].capability_id, skill_remove);
+    assert_eq!(invocations[3].capability_id, skill_list);
+
+    let results = harness.capability_results();
+    assert_eq!(results.len(), 4);
+    assert_eq!(results[0].capability_id, skill_install);
+    assert_eq!(results[0].output["installed"], serde_json::json!(true));
+    assert_eq!(results[0].output["name"], serde_json::json!(SKILL_NAME));
+    assert_skill_list_contains(&results[1].output, SKILL_NAME);
+    assert_eq!(results[2].capability_id, skill_remove);
+    assert_eq!(results[2].output["removed"], serde_json::json!(true));
+    assert_eq!(results[2].output["name"], serde_json::json!(SKILL_NAME));
+    assert_skill_list_excludes(&results[3].output, SKILL_NAME);
+
+    let requests = harness.model_requests();
+    assert_eq!(requests.len(), 5);
+    assert_eq!(tool_result_count(&requests[1]), 1);
+    assert_eq!(tool_result_count(&requests[2]), 2);
+    assert_eq!(tool_result_count(&requests[3]), 3);
+    assert_eq!(tool_result_count(&requests[4]), 4);
+    assert_milestone_order(
+        &harness.milestones(),
+        |kind| matches!(kind, LoopHostMilestoneKind::CapabilityBatchCompleted { .. }),
+        |kind| matches!(kind, LoopHostMilestoneKind::AssistantReplyFinalized { .. }),
+    );
+    harness.assert_model_exhausted();
+
+    harness.shutdown().await;
+}
+
+fn skill_md(name: &str, description: &str) -> String {
+    format!("---\nname: {name}\ndescription: {description}\n---\nSkill body for {name}.\n")
+}
+
+fn tool_result_count(request: &ironclaw_loop_support::HostManagedModelRequest) -> usize {
+    request
+        .messages
+        .iter()
+        .filter(|message| message.role == HostManagedModelMessageRole::ToolResult)
+        .count()
+}
+
+fn assert_skill_list_contains(output: &serde_json::Value, expected: &str) {
+    assert!(
+        skill_names(output).contains(&expected),
+        "expected skill list to include {expected:?}, got {output:?}"
+    );
+}
+
+fn assert_skill_list_excludes(output: &serde_json::Value, unexpected: &str) {
+    assert!(
+        skill_names(output).iter().all(|name| *name != unexpected),
+        "expected skill list to exclude {unexpected:?}, got {output:?}"
+    );
+}
+
+fn skill_names(output: &serde_json::Value) -> Vec<&str> {
+    output["skills"]
+        .as_array()
+        .expect("skill list output should contain skills array")
+        .iter()
+        .filter_map(|skill| skill["name"].as_str())
+        .collect()
+}

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -10,8 +10,7 @@
 //! Documented test-support substitutions:
 //! - the model gateway is scripted trace replay;
 //! - the capability port is a local recording echo/approval port;
-//! - external network, delivery, OAuth, and sandbox process execution are not
-//!   exercised by this harness.
+//! - external internet, delivery, and OAuth are not exercised by this harness.
 
 #![allow(dead_code)] // Shared by staged Reborn binary-E2E validation ports.
 
@@ -38,16 +37,19 @@ use ironclaw_host_api::{
 };
 use ironclaw_host_runtime::{
     APPLY_PATCH_CAPABILITY_ID, BUILTIN_FIRST_PARTY_PROVIDER, CapabilitySurfacePolicy,
-    CapabilitySurfaceVersion as HostRuntimeCapabilitySurfaceVersion, GLOB_CAPABILITY_ID,
-    GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HostRuntime, HostRuntimeServices, JSON_CAPABILITY_ID,
-    LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, SurfaceKind, TIME_CAPABILITY_ID,
-    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
+    CapabilitySurfaceVersion as HostRuntimeCapabilitySurfaceVersion, ECHO_CAPABILITY_ID,
+    GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HostRuntime, HostRuntimeServices,
+    JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, SHELL_CAPABILITY_ID,
+    SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SurfaceKind,
+    TIME_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
+    builtin_first_party_package,
 };
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
     HostManagedModelRequest, HostRuntimeLoopCapabilityPortFactory, LoopCapabilityResultWriter,
 };
+use ironclaw_network::{PolicyNetworkHttpEgress, ReqwestNetworkTransport};
 use ironclaw_product_adapters::{
     ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload, ProductTriggerReason,
     ProductWorkflow,
@@ -74,6 +76,7 @@ use ironclaw_reborn_composition::{
     build_reborn_services, visible_capability_request_for_run,
 };
 use ironclaw_resources::InMemoryResourceGovernor;
+use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_threads::{
     FilesystemSessionThreadService, SessionThreadService, ThreadHistoryRequest,
     ThreadMessageRecord, ThreadScope,
@@ -449,6 +452,34 @@ impl RebornBinaryE2EHarness {
         .await
     }
 
+    pub async fn with_host_runtime_process_capabilities(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+    ) -> HarnessResult<Self> {
+        let host_runtime = Arc::new(HostRuntimeCapabilityHarness::process_tools().await?);
+        Self::with_model_gateway_capability_mode(
+            conversation_id,
+            model_gateway,
+            HarnessCapabilityMode::HostRuntime(host_runtime),
+            false,
+        )
+        .await
+    }
+
+    pub async fn with_host_runtime_skill_management_capabilities(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+    ) -> HarnessResult<Self> {
+        let host_runtime = Arc::new(HostRuntimeCapabilityHarness::skill_management_tools().await?);
+        Self::with_model_gateway_capability_mode(
+            conversation_id,
+            model_gateway,
+            HarnessCapabilityMode::HostRuntime(host_runtime),
+            false,
+        )
+        .await
+    }
+
     pub async fn with_host_runtime_core_builtin_capabilities_network_policy(
         conversation_id: &str,
         model_gateway: RebornTraceReplayModelGateway,
@@ -456,6 +487,24 @@ impl RebornBinaryE2EHarness {
     ) -> HarnessResult<Self> {
         let host_runtime = Arc::new(
             HostRuntimeCapabilityHarness::core_builtin_tools_with_network_policy(network_policy)
+                .await?,
+        );
+        Self::with_model_gateway_capability_mode(
+            conversation_id,
+            model_gateway,
+            HarnessCapabilityMode::HostRuntime(host_runtime),
+            false,
+        )
+        .await
+    }
+
+    pub async fn with_host_runtime_core_builtin_capabilities_live_http_egress(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        network_policy: NetworkPolicy,
+    ) -> HarnessResult<Self> {
+        let host_runtime = Arc::new(
+            HostRuntimeCapabilityHarness::core_builtin_tools_with_live_http_egress(network_policy)
                 .await?,
         );
         Self::with_model_gateway_capability_mode(
@@ -1323,6 +1372,46 @@ impl HostRuntimeCapabilityHarness {
         .await
     }
 
+    async fn process_tools() -> HarnessResult<Self> {
+        Self::new_with_mounts(
+            "reborn-e2e-process-tools",
+            vec![
+                CapabilityId::new(ECHO_CAPABILITY_ID)?,
+                CapabilityId::new(SHELL_CAPABILITY_ID)?,
+            ],
+            vec![
+                EffectKind::DispatchCapability,
+                EffectKind::ReadFilesystem,
+                EffectKind::WriteFilesystem,
+                EffectKind::Network,
+                EffectKind::SpawnProcess,
+                EffectKind::ExecuteCode,
+            ],
+            Vec::new(),
+            ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER)?,
+            UserId::new("reborn-e2e-process-user")?,
+            MountView::default(),
+        )
+        .await
+    }
+
+    async fn skill_management_tools() -> HarnessResult<Self> {
+        Self::new_with_mounts(
+            "reborn-e2e-skill-management-tools",
+            vec![
+                CapabilityId::new(SKILL_LIST_CAPABILITY_ID)?,
+                CapabilityId::new(SKILL_INSTALL_CAPABILITY_ID)?,
+                CapabilityId::new(SKILL_REMOVE_CAPABILITY_ID)?,
+            ],
+            vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
+            Vec::new(),
+            ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER)?,
+            UserId::new("reborn-e2e-skill-management-user")?,
+            skill_mounts()?,
+        )
+        .await
+    }
+
     async fn new(
         service_label: &'static str,
         capability_ids: Vec<CapabilityId>,
@@ -1330,6 +1419,27 @@ impl HostRuntimeCapabilityHarness {
         secrets: Vec<SecretHandle>,
         provider_id: ExtensionId,
         user_id: UserId,
+    ) -> HarnessResult<Self> {
+        Self::new_with_mounts(
+            service_label,
+            capability_ids,
+            effect_kinds,
+            secrets,
+            provider_id,
+            user_id,
+            workspace_mounts(MountPermissions::read_write_list_delete())?,
+        )
+        .await
+    }
+
+    async fn new_with_mounts(
+        service_label: &'static str,
+        capability_ids: Vec<CapabilityId>,
+        effect_kinds: Vec<EffectKind>,
+        secrets: Vec<SecretHandle>,
+        provider_id: ExtensionId,
+        user_id: UserId,
+        mounts: MountView,
     ) -> HarnessResult<Self> {
         let root = Arc::new(tempfile::tempdir()?);
         let storage_root = root.path().join("local-dev");
@@ -1340,7 +1450,6 @@ impl HostRuntimeCapabilityHarness {
         let runtime = services
             .host_runtime
             .ok_or("local-dev Reborn services missing host runtime")?;
-        let mounts = workspace_mounts(MountPermissions::read_write_list_delete())?;
         Ok(Self {
             runtime,
             io: Arc::new(ProductLiveCapabilityIo::default()),
@@ -1365,16 +1474,43 @@ impl HostRuntimeCapabilityHarness {
     async fn core_builtin_tools_with_network_policy(
         network_policy: NetworkPolicy,
     ) -> HarnessResult<Self> {
-        let root = Arc::new(tempfile::tempdir()?);
-        let storage_root = root.path().join("local-dev");
-        let workspace_root = storage_root.join("workspace");
-        std::fs::create_dir_all(&workspace_root)?;
+        let (root, storage_root, workspace_root) = host_runtime_storage_roots()?;
         let runtime = local_dev_host_runtime_with_http_egress(
             storage_root.clone(),
             Arc::new(RecordingRuntimeHttpEgress::with_body(
                 br#"{"accepted":true}"#.to_vec(),
             )),
         )?;
+        Self::core_builtin_tools_from_runtime(
+            root,
+            workspace_root,
+            runtime,
+            network_policy,
+            UserId::new("reborn-e2e-core-builtins-user")?,
+        )
+    }
+
+    async fn core_builtin_tools_with_live_http_egress(
+        network_policy: NetworkPolicy,
+    ) -> HarnessResult<Self> {
+        let (root, storage_root, workspace_root) = host_runtime_storage_roots()?;
+        let runtime = local_dev_host_runtime_with_live_http_egress(storage_root.clone())?;
+        Self::core_builtin_tools_from_runtime(
+            root,
+            workspace_root,
+            runtime,
+            network_policy,
+            UserId::new("reborn-e2e-core-builtins-live-http-user")?,
+        )
+    }
+
+    fn core_builtin_tools_from_runtime(
+        root: Arc<tempfile::TempDir>,
+        workspace_root: PathBuf,
+        runtime: Arc<dyn HostRuntime>,
+        network_policy: NetworkPolicy,
+        user_id: UserId,
+    ) -> HarnessResult<Self> {
         let mounts = workspace_mounts(MountPermissions::read_write_list_delete())?;
         Ok(Self {
             runtime,
@@ -1398,7 +1534,7 @@ impl HostRuntimeCapabilityHarness {
             network_policy,
             secrets: Vec::new(),
             provider_id: ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER)?,
-            user_id: UserId::new("reborn-e2e-core-builtins-user")?,
+            user_id,
             invocations: Arc::new(Mutex::new(Vec::new())),
             results: Arc::new(Mutex::new(Vec::new())),
         })
@@ -1574,6 +1710,14 @@ fn local_dev_host_runtime_with_http_egress(
     local_dev_host_runtime_with_registry_and_http_egress(storage_root, registry, egress)
 }
 
+fn host_runtime_storage_roots() -> HarnessResult<(Arc<tempfile::TempDir>, PathBuf, PathBuf)> {
+    let root = Arc::new(tempfile::tempdir()?);
+    let storage_root = root.path().join("local-dev");
+    let workspace_root = storage_root.join("workspace");
+    std::fs::create_dir_all(&workspace_root)?;
+    Ok((root, storage_root, workspace_root))
+}
+
 fn local_dev_host_runtime_with_registry_and_http_egress(
     storage_root: PathBuf,
     registry: ExtensionRegistry,
@@ -1595,6 +1739,41 @@ fn local_dev_host_runtime_with_registry_and_http_egress(
     )
     .with_first_party_capabilities(Arc::new(builtin_first_party_handlers()?))
     .with_runtime_http_egress(egress)
+    .with_trust_policy(Arc::new(first_party_trust_policy()?));
+
+    Ok(Arc::new(services.host_runtime_for_local_testing()))
+}
+
+fn local_dev_host_runtime_with_live_http_egress(
+    storage_root: PathBuf,
+) -> HarnessResult<Arc<dyn HostRuntime>> {
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(builtin_first_party_package()?)?;
+
+    let mut filesystem = LocalFilesystem::new();
+    filesystem.mount_local(
+        VirtualPath::new("/projects")?,
+        HostPath::from_path_buf(storage_root),
+    )?;
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry),
+        Arc::new(filesystem),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        HostRuntimeCapabilitySurfaceVersion::new("reborn-app-v1")?,
+    )
+    .with_secret_store(Arc::new(InMemorySecretStore::new()))
+    .with_first_party_capabilities(Arc::new(builtin_first_party_handlers()?))
+    .try_with_host_http_egress(PolicyNetworkHttpEgress::new(ReqwestNetworkTransport::new(
+        Duration::from_secs(2),
+    )))
+    .map_err(|report| {
+        std::io::Error::other(format!(
+            "live HTTP egress production wiring failed: {report:?}"
+        ))
+    })?
     .with_trust_policy(Arc::new(first_party_trust_policy()?));
 
     Ok(Arc::new(services.host_runtime_for_local_testing()))
@@ -1688,6 +1867,21 @@ fn workspace_mounts(permissions: MountPermissions) -> HarnessResult<MountView> {
         VirtualPath::new("/projects/workspace")?,
         permissions,
     )])?)
+}
+
+fn skill_mounts() -> HarnessResult<MountView> {
+    Ok(MountView::new(vec![
+        MountGrant::new(
+            MountAlias::new("/skills")?,
+            VirtualPath::new("/projects/skills")?,
+            MountPermissions::read_write_list_delete(),
+        ),
+        MountGrant::new(
+            MountAlias::new("/system/skills")?,
+            VirtualPath::new("/projects/system/skills")?,
+            MountPermissions::read_only(),
+        ),
+    ])?)
 }
 
 fn capability_grants(


### PR DESCRIPTION
## Summary

- Add a declared-capability coverage guard for built-in first-party Reborn tools.
- Add Reborn trace e2e coverage for echo and skill install/list/remove.
- Upgrade the core builtins HTTP trace from mocked egress to a real loopback HTTP request through production-shaped host egress, network policy, and reqwest transport.
- Extend the Reborn test harness with process, skill-management, and live HTTP egress profiles.

## Notes

`builtin.shell` remains Reborn model-surface covered here and execution-covered by the existing product-live adapter e2e, because shell execution is approval-gated in the completed Reborn loop.

## Validation

- `cargo test --test reborn_trace_core_builtin_tools_parity`
- `cargo test --test reborn_trace_file_tools_parity --test reborn_trace_coding_read_tools_parity --test reborn_trace_core_builtin_tools_parity --test reborn_trace_first_party_tool_coverage`
- `cargo fmt --check`
- `cargo test --test reborn_http_network_scope_isolation_parity`