### PR TITLE
Clarify capability activity output window

### DIFF
--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -1216,18 +1216,20 @@ impl ReplayEventProjectionService {
     /// consumers that use snapshots to rebase after a replay gap.
     ///
     /// The same bounded-memory contract applies: pages are folded
-    /// incrementally, allocation is `O(scoped runs + requested activity
-    /// window)` regardless of stream length, and scanning more than
-    /// [`STATE_REPLAY_MAX_EVENTS`] events surfaces
-    /// [`ProjectionError::RebaseRequired`] instead of silently returning a
-    /// partial run-state view.
+    /// incrementally, allocation is `O(scoped invocations)` regardless of
+    /// stream length, and scanning more than [`STATE_REPLAY_MAX_EVENTS`]
+    /// events surfaces [`ProjectionError::RebaseRequired`] instead of
+    /// silently returning a partial run-state view. The requested limit is
+    /// applied only to the emitted activity window after the fold, so late
+    /// terminal events cannot be lost while compacting the output.
     async fn fold_runtime_to_head(
         &self,
         scope: &ProjectionScope,
-        capability_activity_limit: usize,
+        capability_activity_output_limit: usize,
     ) -> Result<RuntimeProjectionState, ProjectionError> {
-        let mut state =
-            RuntimeProjectionState::with_capability_activity_limit(capability_activity_limit);
+        let mut state = RuntimeProjectionState::with_capability_activity_output_limit(
+            capability_activity_output_limit,
+        );
         let mut after: Option<EventCursor> = None;
         let mut scanned: usize = 0;
         loop {

--- a/crates/ironclaw_event_projections/src/runtime_projection.rs
+++ b/crates/ironclaw_event_projections/src/runtime_projection.rs
@@ -12,13 +12,13 @@ use crate::{
 pub(crate) struct RuntimeProjectionState {
     runs: HashMap<InvocationId, RunStatusProjection>,
     capability_activities: HashMap<InvocationId, CapabilityActivityProjection>,
-    capability_activity_limit: Option<usize>,
+    capability_activity_output_limit: Option<usize>,
 }
 
 impl RuntimeProjectionState {
-    pub(crate) fn with_capability_activity_limit(limit: usize) -> Self {
+    pub(crate) fn with_capability_activity_output_limit(limit: usize) -> Self {
         Self {
-            capability_activity_limit: Some(limit),
+            capability_activity_output_limit: Some(limit),
             ..Self::default()
         }
     }
@@ -32,15 +32,15 @@ impl RuntimeProjectionState {
         self,
     ) -> (Vec<RunStatusProjection>, Vec<CapabilityActivityProjection>) {
         let mut capability_activities = self.capability_activities.into_values().collect();
-        enforce_capability_activity_limit(
+        enforce_capability_activity_output_limit(
             &mut capability_activities,
-            self.capability_activity_limit,
+            self.capability_activity_output_limit,
         );
         (self.runs.into_values().collect(), capability_activities)
     }
 }
 
-fn enforce_capability_activity_limit(
+fn enforce_capability_activity_output_limit(
     activities: &mut Vec<CapabilityActivityProjection>,
     limit: Option<usize>,
 ) {


### PR DESCRIPTION
## Summary
- Rename the capability activity projection limit internals to make clear the limit applies to emitted output, not fold-time state retention.
- Update the snapshot folding comment so future maintainers do not mistake the activity window for a memory-bound invariant.

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p ironclaw_event_projections --locked`

Follow-up from #4004 after it merged while the thermo loop was running.