### PR TITLE
feat(signing): KMS curve-capability fail-closed on the custodial-mainnet ship-gate (#4053)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -589,7 +589,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3220,7 +3220,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3496,7 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4536,7 +4536,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6171,7 +6171,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7035,7 +7035,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7823,9 +7823,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -7841,9 +7841,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -8169,7 +8169,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8206,7 +8206,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8975,7 +8975,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9795,7 +9795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10110,7 +10110,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10406,9 +10406,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -10982,7 +10982,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11968,7 +11968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/ironclaw_chain_signing/src/chain.rs
+++ b/crates/ironclaw_chain_signing/src/chain.rs
@@ -4,6 +4,8 @@
 use ironclaw_attestation::DecodedTransaction;
 use serde::{Deserialize, Serialize};
 
+use crate::kms::SignatureAlg;
+
 /// A chain / network identity string, e.g. `eip155:1`, `solana:mainnet-beta`,
 /// `near:mainnet`.
 ///
@@ -115,6 +117,22 @@ impl ChainFamily {
             DecodedTransaction::Evm(_) => ChainFamily::Evm,
             DecodedTransaction::Solana(_) => ChainFamily::Solana,
             DecodedTransaction::Near(_) => ChainFamily::Near,
+        }
+    }
+
+    /// The native signature algorithm/curve for this family. `Evm` is secp256k1;
+    /// `Solana`/`Near` are ed25519. `Unknown` has no native curve and so cannot
+    /// resolve one (it never reaches signing — the exact-binding check fails
+    /// closed first).
+    ///
+    /// This is the single source of truth for the family↔curve binding, used by
+    /// the custodial signer to run the KMS curve-capability check up front (before
+    /// claiming the one-shot grant) and to select the alg inside each `sign_*`.
+    pub fn signing_alg(self) -> Option<SignatureAlg> {
+        match self {
+            ChainFamily::Evm => Some(SignatureAlg::Secp256k1),
+            ChainFamily::Solana | ChainFamily::Near => Some(SignatureAlg::Ed25519),
+            ChainFamily::Unknown => None,
         }
     }
 }

--- a/crates/ironclaw_chain_signing/src/custodial.rs
+++ b/crates/ironclaw_chain_signing/src/custodial.rs
@@ -278,7 +278,7 @@ where
             SigningPath::Kms => {
                 let key_ref = self.require_kms_ref(&authorized)?;
                 let raw = self
-                    .require_kms()?
+                    .require_kms_supporting(req.chain.as_str(), SignatureAlg::Secp256k1)?
                     .sign_digest(key_ref, &digest.0, SignatureAlg::Secp256k1)
                     .await?;
                 crate::evm::sign::bind_kms_signature(digest, &raw, bound)?
@@ -336,7 +336,7 @@ where
             SigningPath::Kms => {
                 let key_ref = self.require_kms_ref(&authorized)?;
                 let raw = self
-                    .require_kms()?
+                    .require_kms_supporting(req.chain.as_str(), SignatureAlg::Ed25519)?
                     .sign_digest(key_ref, &digest, SignatureAlg::Ed25519)
                     .await?;
                 crate::solana::sign::bind_kms_signature(&digest, &raw, fee_payer)?
@@ -384,7 +384,7 @@ where
             SigningPath::Kms => {
                 let key_ref = self.require_kms_ref(&authorized)?;
                 let raw = self
-                    .require_kms()?
+                    .require_kms_supporting(req.chain.as_str(), SignatureAlg::Ed25519)?
                     .sign_digest(key_ref, &digest, SignatureAlg::Ed25519)
                     .await?;
                 crate::near::sign::bind_kms_signature(&digest, &raw, expected_pubkey)?
@@ -408,6 +408,35 @@ where
             .ok_or_else(|| ChainSigningError::ShipGateRefused {
                 reason: "mainnet KMS path required but no KMS backend wired".to_string(),
             })
+    }
+
+    /// Borrow the wired KMS backend AND assert it can sign the chain's native
+    /// curve, failing closed otherwise. This runs on the mainnet/KMS path BEFORE
+    /// any digest crosses the boundary: a curve-limited cloud backend (e.g. AWS
+    /// KMS, which signs secp256k1 but not ed25519) is refused for the ed25519
+    /// mainnet chains here rather than via a downstream runtime sign error — and
+    /// never via a hot-key fallback. `LocalKmsSigner` supports both curves, so it
+    /// passes for every chain.
+    ///
+    // follow-up: when the stack integrates `ironclaw_attested_runtime`'s
+    // `CustodialMainnetShipGate` (PR10), this curve-capability check composes
+    // with — and is independent of — the `CUSTODIAL_MAINNET_ENABLED` env flag and
+    // the "require BOTH flag AND wired KMS" composition that live at that layer.
+    fn require_kms_supporting(
+        &self,
+        chain: &str,
+        alg: SignatureAlg,
+    ) -> Result<&Arc<dyn KmsSigner>, ChainSigningError> {
+        let kms = self.require_kms()?;
+        if !kms.supports_alg(alg) {
+            return Err(ChainSigningError::ShipGateRefused {
+                reason: format!(
+                    "mainnet {chain} requires a KMS backend that can sign {alg:?}; configured \
+                     backend cannot"
+                ),
+            });
+        }
+        Ok(kms)
     }
 
     /// Borrow the binding's KMS key reference or fail closed.

--- a/crates/ironclaw_chain_signing/src/custodial.rs
+++ b/crates/ironclaw_chain_signing/src/custodial.rs
@@ -190,6 +190,21 @@ where
             });
         }
 
+        // --- KMS curve-capability gate (mainnet path only), hoisted ahead of the
+        //     grant claim / ledger advance. This is a pure-configuration check
+        //     (it depends only on the wired backend and the family's native
+        //     curve), so a refusal here must be side-effect-free: it must NOT burn
+        //     the one-shot grant nor wedge the ledger at `Signing`, leaving a
+        //     clean retryable state so the request can succeed after an
+        //     ed25519-capable KMS is wired (Codex P2). The alg is the family's
+        //     native curve — the same one each `sign_*` arm passes to the
+        //     backend, kept in sync via `ChainFamily::signing_alg`. ---
+        if path == SigningPath::Kms
+            && let Some(alg) = requested_family.signing_alg()
+        {
+            self.require_kms_supporting(bound_chain, alg)?;
+        }
+
         // --- Enforcement point #1: claim the sealed one-shot grant. ---
         // Refuse to sign without a successfully-claimed grant. A second claim
         // of the same grant fails (one-shot), so a replayed approval cannot

--- a/crates/ironclaw_chain_signing/src/custodial.rs
+++ b/crates/ironclaw_chain_signing/src/custodial.rs
@@ -198,6 +198,25 @@ where
             });
         }
 
+        // --- KMS curve-capability gate (mainnet path only), ahead of the grant
+        //     claim / ledger advance. This is a pure-configuration check (it
+        //     depends only on the wired backend and the family's native curve),
+        //     so a refusal here must be side-effect-free: it must NOT burn the
+        //     one-shot grant nor wedge the ledger at `Signing`, leaving a clean
+        //     retryable state so the request can succeed after an
+        //     ed25519-capable KMS is wired (Codex P2). The alg is the family's
+        //     native curve — the same one each `sign_*` arm passes to the
+        //     backend, kept in sync via `ChainFamily::signing_alg`.
+        //
+        //     In this cascade the grant claim lives in `claim_grant()` (driven
+        //     after authorize + chain pre-flight), so this check is already
+        //     ahead of it by construction. ---
+        if path == SigningPath::Kms
+            && let Some(alg) = requested_family.signing_alg()
+        {
+            self.require_kms_supporting(bound_chain, alg)?;
+        }
+
         // --- Enforcement point #1: sign-time approved-tx-hash re-check. ---
         // Recompute the binding hash FROM THE PERSISTED decoded tx and compare
         // to the approved hash. Any post-approval mutation of `decoded` diverges
@@ -295,7 +314,7 @@ where
                             reason: "internal: missing resolved KMS key_ref".to_string(),
                         })?;
                 let raw = self
-                    .require_kms()?
+                    .require_kms_supporting(req.chain.as_str(), SignatureAlg::Secp256k1)?
                     .sign_digest(key_ref, &digest.0, SignatureAlg::Secp256k1)
                     .await?;
                 crate::evm::sign::bind_kms_signature(digest, &raw, bound)?
@@ -371,7 +390,7 @@ where
                             reason: "internal: missing resolved KMS key_ref".to_string(),
                         })?;
                 let raw = self
-                    .require_kms()?
+                    .require_kms_supporting(req.chain.as_str(), SignatureAlg::Ed25519)?
                     .sign_digest(key_ref, &digest, SignatureAlg::Ed25519)
                     .await?;
                 crate::solana::sign::bind_kms_signature(&digest, &raw, fee_payer)?
@@ -437,7 +456,7 @@ where
                             reason: "internal: missing resolved KMS key_ref".to_string(),
                         })?;
                 let raw = self
-                    .require_kms()?
+                    .require_kms_supporting(req.chain.as_str(), SignatureAlg::Ed25519)?
                     .sign_digest(key_ref, &digest, SignatureAlg::Ed25519)
                     .await?;
                 crate::near::sign::bind_kms_signature(&digest, &raw, expected_pubkey)?
@@ -484,6 +503,35 @@ where
             .ok_or_else(|| ChainSigningError::ShipGateRefused {
                 reason: "mainnet KMS path required but no KMS backend wired".to_string(),
             })
+    }
+
+    /// Borrow the wired KMS backend AND assert it can sign the chain's native
+    /// curve, failing closed otherwise. This runs on the mainnet/KMS path BEFORE
+    /// any digest crosses the boundary: a curve-limited cloud backend (e.g. AWS
+    /// KMS, which signs secp256k1 but not ed25519) is refused for the ed25519
+    /// mainnet chains here rather than via a downstream runtime sign error — and
+    /// never via a hot-key fallback. `LocalKmsSigner` supports both curves, so it
+    /// passes for every chain.
+    ///
+    // follow-up: when the stack integrates `ironclaw_attested_runtime`'s
+    // `CustodialMainnetShipGate` (PR10), this curve-capability check composes
+    // with — and is independent of — the `CUSTODIAL_MAINNET_ENABLED` env flag and
+    // the "require BOTH flag AND wired KMS" composition that live at that layer.
+    fn require_kms_supporting(
+        &self,
+        chain: &str,
+        alg: SignatureAlg,
+    ) -> Result<&Arc<dyn KmsSigner>, ChainSigningError> {
+        let kms = self.require_kms()?;
+        if !kms.supports_alg(alg) {
+            return Err(ChainSigningError::ShipGateRefused {
+                reason: format!(
+                    "mainnet {chain} requires a KMS backend that can sign {alg:?}; configured \
+                     backend cannot"
+                ),
+            });
+        }
+        Ok(kms)
     }
 
     /// Borrow the binding's KMS key reference or fail closed.

--- a/crates/ironclaw_chain_signing/src/kms.rs
+++ b/crates/ironclaw_chain_signing/src/kms.rs
@@ -530,6 +530,7 @@ mod tests {
     #[test]
     fn curve_limited_backend_reports_unsupported_alg() {
         struct Secp256k1Only;
+        #[async_trait]
         impl KmsSigner for Secp256k1Only {
             fn backend_id(&self) -> &str {
                 "secp256k1-only"
@@ -543,7 +544,7 @@ mod tests {
                     SignatureAlg::Ed25519 => false,
                 }
             }
-            fn sign_digest(
+            async fn sign_digest(
                 &self,
                 _key_ref: &str,
                 _digest: &[u8; 32],

--- a/crates/ironclaw_chain_signing/src/kms.rs
+++ b/crates/ironclaw_chain_signing/src/kms.rs
@@ -84,6 +84,29 @@ pub trait KmsSigner: Send + Sync {
     /// host memory (`false`). The ship-gate consults this to allow mainnet.
     fn is_secure_custody(&self) -> bool;
 
+    /// Whether this backend can sign with the given signature algorithm/curve.
+    ///
+    /// The custodial signer consults this on the mainnet/KMS path BEFORE handing
+    /// over a digest, failing closed if the configured backend cannot service the
+    /// chain's native curve — rather than discovering it via a runtime sign error
+    /// (and never via a hot-key fallback). This matters because a real cloud
+    /// backend may be curve-limited: e.g. AWS KMS supports secp256k1 (EVM) but
+    /// NOT ed25519 (Solana/NEAR), so it must fail closed for the ed25519 mainnet
+    /// chains instead of silently routing to a key it cannot sign.
+    ///
+    /// Defaults to `true` (supports everything); curve-limited backends override
+    /// it to report exactly the curves they can sign. [`LocalKmsSigner`] supports
+    /// both secp256k1 and ed25519, so it keeps the default.
+    ///
+    /// The exhaustive match (rather than a `_` wildcard) is deliberate: adding a
+    /// new [`SignatureAlg`] variant must break compilation here so the default's
+    /// "supports everything" assumption is re-reviewed for each new curve.
+    fn supports_alg(&self, alg: SignatureAlg) -> bool {
+        match alg {
+            SignatureAlg::Secp256k1 | SignatureAlg::Ed25519 => true,
+        }
+    }
+
     /// Sign a 32-byte `digest` with the key referenced by `key_ref` under
     /// `alg`, returning the raw signature bytes. `key_ref` is an opaque backend
     /// handle — NOT key material.
@@ -495,6 +518,43 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ChainSigningError::Sign { .. }));
+    }
+
+    #[test]
+    fn local_kms_supports_both_curves_by_default() {
+        let kms = secure();
+        assert!(kms.supports_alg(SignatureAlg::Secp256k1));
+        assert!(kms.supports_alg(SignatureAlg::Ed25519));
+    }
+
+    #[test]
+    fn curve_limited_backend_reports_unsupported_alg() {
+        struct Secp256k1Only;
+        impl KmsSigner for Secp256k1Only {
+            fn backend_id(&self) -> &str {
+                "secp256k1-only"
+            }
+            fn is_secure_custody(&self) -> bool {
+                true
+            }
+            fn supports_alg(&self, alg: SignatureAlg) -> bool {
+                match alg {
+                    SignatureAlg::Secp256k1 => true,
+                    SignatureAlg::Ed25519 => false,
+                }
+            }
+            fn sign_digest(
+                &self,
+                _key_ref: &str,
+                _digest: &[u8; 32],
+                _alg: SignatureAlg,
+            ) -> Result<Vec<u8>, ChainSigningError> {
+                Ok(vec![0u8; 64])
+            }
+        }
+        let b = Secp256k1Only;
+        assert!(b.supports_alg(SignatureAlg::Secp256k1));
+        assert!(!b.supports_alg(SignatureAlg::Ed25519));
     }
 
     #[test]

--- a/crates/ironclaw_chain_signing/src/kms.rs
+++ b/crates/ironclaw_chain_signing/src/kms.rs
@@ -88,6 +88,29 @@ pub trait KmsSigner: Send + Sync {
     /// host memory (`false`). The ship-gate consults this to allow mainnet.
     fn is_secure_custody(&self) -> bool;
 
+    /// Whether this backend can sign with the given signature algorithm/curve.
+    ///
+    /// The custodial signer consults this on the mainnet/KMS path BEFORE handing
+    /// over a digest, failing closed if the configured backend cannot service the
+    /// chain's native curve — rather than discovering it via a runtime sign error
+    /// (and never via a hot-key fallback). This matters because a real cloud
+    /// backend may be curve-limited: e.g. AWS KMS supports secp256k1 (EVM) but
+    /// NOT ed25519 (Solana/NEAR), so it must fail closed for the ed25519 mainnet
+    /// chains instead of silently routing to a key it cannot sign.
+    ///
+    /// Defaults to `true` (supports everything); curve-limited backends override
+    /// it to report exactly the curves they can sign. [`LocalKmsSigner`] supports
+    /// both secp256k1 and ed25519, so it keeps the default.
+    ///
+    /// The exhaustive match (rather than a `_` wildcard) is deliberate: adding a
+    /// new [`SignatureAlg`] variant must break compilation here so the default's
+    /// "supports everything" assumption is re-reviewed for each new curve.
+    fn supports_alg(&self, alg: SignatureAlg) -> bool {
+        match alg {
+            SignatureAlg::Secp256k1 | SignatureAlg::Ed25519 => true,
+        }
+    }
+
     /// Sign a 32-byte `digest` with the key referenced by `key_ref` under
     /// `alg`, returning the raw signature bytes. `key_ref` is an opaque backend
     /// handle — NOT key material.
@@ -545,6 +568,44 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ChainSigningError::Sign { .. }));
+    }
+
+    #[test]
+    fn local_kms_supports_both_curves_by_default() {
+        let kms = secure();
+        assert!(kms.supports_alg(SignatureAlg::Secp256k1));
+        assert!(kms.supports_alg(SignatureAlg::Ed25519));
+    }
+
+    #[test]
+    fn curve_limited_backend_reports_unsupported_alg() {
+        struct Secp256k1Only;
+        #[async_trait]
+        impl KmsSigner for Secp256k1Only {
+            fn backend_id(&self) -> &str {
+                "secp256k1-only"
+            }
+            fn is_secure_custody(&self) -> bool {
+                true
+            }
+            fn supports_alg(&self, alg: SignatureAlg) -> bool {
+                match alg {
+                    SignatureAlg::Secp256k1 => true,
+                    SignatureAlg::Ed25519 => false,
+                }
+            }
+            async fn sign_digest(
+                &self,
+                _key_ref: &str,
+                _digest: &[u8; 32],
+                _alg: SignatureAlg,
+            ) -> Result<Vec<u8>, ChainSigningError> {
+                Ok(vec![0u8; 64])
+            }
+        }
+        let b = Secp256k1Only;
+        assert!(b.supports_alg(SignatureAlg::Secp256k1));
+        assert!(!b.supports_alg(SignatureAlg::Ed25519));
     }
 
     #[test]

--- a/crates/ironclaw_chain_signing/tests/custodial_signing.rs
+++ b/crates/ironclaw_chain_signing/tests/custodial_signing.rs
@@ -820,6 +820,7 @@ async fn near_signs_over_canonical_bytes() {
 /// false`, so the curve-capability gate must refuse Solana/NEAR mainnet signing
 /// before any digest crosses the boundary — never falling back to a hot key.
 struct Secp256k1OnlyKms;
+#[async_trait::async_trait]
 impl ironclaw_chain_signing::KmsSigner for Secp256k1OnlyKms {
     fn backend_id(&self) -> &str {
         "secp256k1-only-kms"
@@ -833,7 +834,7 @@ impl ironclaw_chain_signing::KmsSigner for Secp256k1OnlyKms {
             SignatureAlg::Ed25519 => false,
         }
     }
-    fn sign_digest(
+    async fn sign_digest(
         &self,
         _key_ref: &str,
         _digest: &[u8; 32],
@@ -851,7 +852,10 @@ impl ironclaw_chain_signing::KmsSigner for Secp256k1OnlyKms {
 #[tokio::test]
 async fn solana_mainnet_refused_when_kms_lacks_ed25519() {
     use ed25519_dalek::SigningKey as EdKey;
-    use ironclaw_attestation::{Bytes32, SolanaInstruction, SolanaTransaction};
+    use ironclaw_attestation::{
+        Bytes32, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
+        SolanaTransaction,
+    };
 
     let chain = "solana:mainnet"; // not a known testnet => Mainnet
     let ed = EdKey::from_bytes(&[0x42u8; 32]);
@@ -859,18 +863,23 @@ async fn solana_mainnet_refused_when_kms_lacks_ed25519() {
 
     let sol = SolanaTransaction {
         cluster: "mainnet".into(),
-        account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
+        version: SolanaMessageVersion::Legacy,
+        header: SolanaMessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        },
+        static_account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
         recent_blockhash: Bytes32([2u8; 32]),
-        instructions: vec![SolanaInstruction {
-            program_id: Bytes32([9u8; 32]),
-            accounts: vec![Bytes32(pubkey)],
+        instructions: vec![SolanaCompiledInstruction {
+            program_id_index: 1,
+            account_indices: vec![0],
             data: vec![1, 2, 3],
         }],
-        compute_unit_limit: Some(200_000),
-        compute_unit_price: Some(5),
+        address_table_lookups: vec![],
     };
     let decoded = DecodedTransaction::Solana(sol);
-    let approved = recompute_approved_hash(&decoded, SCHEMA);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
 
     let keystore = Arc::new(SecretsKeyStore::new(crypto()));
     keystore
@@ -908,7 +917,7 @@ async fn solana_mainnet_refused_when_kms_lacks_ed25519() {
     let req = CustodialSignRequest {
         context,
         scope: host_scope(),
-        chain: ChainKeyId::new(chain),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
         decoded,
         approved_tx_hash: approved,
         schema_version: SCHEMA,
@@ -925,7 +934,7 @@ async fn solana_mainnet_refused_when_kms_lacks_ed25519() {
 #[tokio::test]
 async fn near_mainnet_refused_when_kms_lacks_ed25519() {
     use ed25519_dalek::SigningKey as EdKey;
-    use ironclaw_attestation::{Bytes32, NearAction, NearTransaction};
+    use ironclaw_attestation::{Bytes32, NearAction, NearPublicKey, NearTransaction};
 
     let chain = "near:mainnet"; // not a known testnet => Mainnet
     let ed = EdKey::from_bytes(&[0x55u8; 32]);
@@ -934,19 +943,19 @@ async fn near_mainnet_refused_when_kms_lacks_ed25519() {
     let near = NearTransaction {
         network: "mainnet".into(),
         signer_id: "alice.near".into(),
+        public_key: NearPublicKey {
+            key_type: 0,
+            data: pubkey.to_vec(),
+        },
         receiver_id: "bob.near".into(),
         nonce: 11,
         block_hash: Bytes32([3u8; 32]),
-        actions: vec![NearAction {
-            kind: "Transfer".into(),
-            method_name: String::new(),
-            args: vec![],
+        actions: vec![NearAction::Transfer {
             deposit: vec![1, 2],
-            gas: 0,
         }],
     };
     let decoded = DecodedTransaction::Near(near);
-    let approved = recompute_approved_hash(&decoded, SCHEMA);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
 
     let keystore = Arc::new(SecretsKeyStore::new(crypto()));
     keystore
@@ -982,7 +991,7 @@ async fn near_mainnet_refused_when_kms_lacks_ed25519() {
     let req = CustodialSignRequest {
         context,
         scope: host_scope(),
-        chain: ChainKeyId::new(chain),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
         decoded,
         approved_tx_hash: approved,
         schema_version: SCHEMA,
@@ -1023,7 +1032,7 @@ async fn evm_mainnet_signs_when_kms_supports_secp256k1() {
         .await
         .unwrap();
     let decoded = evm::decode_eip1559(&tx);
-    let approved = recompute_approved_hash(&decoded, SCHEMA);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
     let grants = Arc::new(InMemorySealedGrantStore::new());
     let ledger = Arc::new(InMemorySigningLedger::new());
     let context = ctx(chain);
@@ -1048,7 +1057,7 @@ async fn evm_mainnet_signs_when_kms_supports_secp256k1() {
     let req = CustodialSignRequest {
         context,
         scope: host_scope(),
-        chain: ChainKeyId::new(chain),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
         decoded,
         approved_tx_hash: approved,
         schema_version: SCHEMA,

--- a/crates/ironclaw_chain_signing/tests/custodial_signing.rs
+++ b/crates/ironclaw_chain_signing/tests/custodial_signing.rs
@@ -814,6 +814,249 @@ async fn near_signs_over_canonical_bytes() {
         .expect("signature must verify over sha256(canonical_signing_bytes)");
 }
 
+/// A secure-custody KMS backend that can sign secp256k1 but NOT ed25519 —
+/// modeling AWS KMS (secp256k1-only). It reports `is_secure_custody() == true`
+/// (so the ship-gate accepts it for mainnet) but `supports_alg(Ed25519) ==
+/// false`, so the curve-capability gate must refuse Solana/NEAR mainnet signing
+/// before any digest crosses the boundary — never falling back to a hot key.
+struct Secp256k1OnlyKms;
+impl ironclaw_chain_signing::KmsSigner for Secp256k1OnlyKms {
+    fn backend_id(&self) -> &str {
+        "secp256k1-only-kms"
+    }
+    fn is_secure_custody(&self) -> bool {
+        true
+    }
+    fn supports_alg(&self, alg: SignatureAlg) -> bool {
+        match alg {
+            SignatureAlg::Secp256k1 => true,
+            SignatureAlg::Ed25519 => false,
+        }
+    }
+    fn sign_digest(
+        &self,
+        _key_ref: &str,
+        _digest: &[u8; 32],
+        _alg: SignatureAlg,
+    ) -> Result<Vec<u8>, ChainSigningError> {
+        // Must never be reached on the ed25519 mainnet path: the curve-capability
+        // gate fails closed before any sign attempt.
+        panic!("sign_digest must not be called when the curve is unsupported");
+    }
+}
+
+/// Curve-capability fail-closed: a secp256k1-only secure KMS refuses Solana
+/// mainnet (ed25519) signing at the ship-gate's curve check — not via a runtime
+/// sign error, and never via a hot-key fallback.
+#[tokio::test]
+async fn solana_mainnet_refused_when_kms_lacks_ed25519() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{Bytes32, SolanaInstruction, SolanaTransaction};
+
+    let chain = "solana:mainnet"; // not a known testnet => Mainnet
+    let ed = EdKey::from_bytes(&[0x42u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let sol = SolanaTransaction {
+        cluster: "mainnet".into(),
+        account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
+        recent_blockhash: Bytes32([2u8; 32]),
+        instructions: vec![SolanaInstruction {
+            program_id: Bytes32([9u8; 32]),
+            accounts: vec![Bytes32(pubkey)],
+            data: vec![1, 2, 3],
+        }],
+        compute_unit_limit: Some(200_000),
+        compute_unit_price: Some(5),
+    };
+    let decoded = DecodedTransaction::Solana(sol);
+    let approved = recompute_approved_hash(&decoded, SCHEMA);
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            // Bind a KMS key_ref so the missing-key_ref guard passes and we reach
+            // the curve-capability check.
+            binding(chain, hex::encode(pubkey), Some("kms-sol".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger.create(&context.gate_ref).await.unwrap();
+    grants
+        .seal(AttestedSigningGrant::seal(
+            GrantKey::from_context(&context, approved),
+            0,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+    let err = signer.sign_solana(&req).await.unwrap_err();
+    assert!(
+        matches!(err, ChainSigningError::ShipGateRefused { .. }),
+        "Solana mainnet must fail closed when KMS cannot sign ed25519, got {err:?}"
+    );
+}
+
+/// Curve-capability fail-closed for NEAR mainnet (ed25519) with a secp256k1-only
+/// secure KMS.
+#[tokio::test]
+async fn near_mainnet_refused_when_kms_lacks_ed25519() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{Bytes32, NearAction, NearTransaction};
+
+    let chain = "near:mainnet"; // not a known testnet => Mainnet
+    let ed = EdKey::from_bytes(&[0x55u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let near = NearTransaction {
+        network: "mainnet".into(),
+        signer_id: "alice.near".into(),
+        receiver_id: "bob.near".into(),
+        nonce: 11,
+        block_hash: Bytes32([3u8; 32]),
+        actions: vec![NearAction {
+            kind: "Transfer".into(),
+            method_name: String::new(),
+            args: vec![],
+            deposit: vec![1, 2],
+            gas: 0,
+        }],
+    };
+    let decoded = DecodedTransaction::Near(near);
+    let approved = recompute_approved_hash(&decoded, SCHEMA);
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(chain, hex::encode(pubkey), Some("kms-near".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger.create(&context.gate_ref).await.unwrap();
+    grants
+        .seal(AttestedSigningGrant::seal(
+            GrantKey::from_context(&context, approved),
+            0,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+    let err = signer.sign_near(&req).await.unwrap_err();
+    assert!(
+        matches!(err, ChainSigningError::ShipGateRefused { .. }),
+        "NEAR mainnet must fail closed when KMS cannot sign ed25519, got {err:?}"
+    );
+}
+
+/// Positive: a secp256k1-capable secure KMS still signs EVM mainnet (secp256k1)
+/// — the curve-capability gate passes for the supported curve.
+#[tokio::test]
+async fn evm_mainnet_signs_when_kms_supports_secp256k1() {
+    let chain = MAINNET_CHAIN;
+    let tx = sample_tx(1);
+    let key = signing_key();
+    let bound = evm::address_of(&key);
+
+    let kms_backend = LocalKmsSigner::new("secure-kms");
+    kms_backend
+        .import_key("kms-evm", SignatureAlg::Secp256k1, key.to_bytes().to_vec())
+        .unwrap();
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(kms_backend);
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(
+                chain,
+                hex::encode(bound.as_slice()),
+                Some("kms-evm".to_string()),
+            ),
+            vec![0u8; 32],
+        )
+        .await
+        .unwrap();
+    let decoded = evm::decode_eip1559(&tx);
+    let approved = recompute_approved_hash(&decoded, SCHEMA);
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger.create(&context.gate_ref).await.unwrap();
+    grants
+        .seal(AttestedSigningGrant::seal(
+            GrantKey::from_context(&context, approved),
+            0,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+    let out = signer.sign_evm(&req).await.expect("evm kms sign");
+    assert_eq!(out.signer, format!("0x{}", hex::encode(bound.as_slice())));
+}
+
 #[test]
 fn untrusted_metadata_rejected_by_policy() {
     let tx = sample_tx(11155111);

--- a/crates/ironclaw_chain_signing/tests/custodial_signing.rs
+++ b/crates/ironclaw_chain_signing/tests/custodial_signing.rs
@@ -929,6 +929,193 @@ async fn solana_mainnet_refused_when_kms_lacks_ed25519() {
     );
 }
 
+/// Curve refusal is a pure-config error and MUST be side-effect-free: it must
+/// occur before the one-shot grant is claimed and before the ledger advances out
+/// of `Approved`, so that retrying after wiring an ed25519-capable KMS is not
+/// blocked by a consumed grant or a wedged ledger row (Medium / Codex P2).
+#[tokio::test]
+async fn curve_refusal_leaves_grant_unconsumed_and_ledger_retryable() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{
+        Bytes32, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
+        SolanaTransaction,
+    };
+
+    let chain = "solana:mainnet";
+    let ed = EdKey::from_bytes(&[0x42u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let sol = SolanaTransaction {
+        cluster: "mainnet".into(),
+        version: SolanaMessageVersion::Legacy,
+        header: SolanaMessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        },
+        static_account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
+        recent_blockhash: Bytes32([2u8; 32]),
+        instructions: vec![SolanaCompiledInstruction {
+            program_id_index: 1,
+            account_indices: vec![0],
+            data: vec![1, 2, 3],
+        }],
+        address_table_lookups: vec![],
+    };
+    let decoded = DecodedTransaction::Solana(sol);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(chain, hex::encode(pubkey), Some("kms-sol".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger.create(&context.gate_ref).await.unwrap();
+    grants
+        .seal(AttestedSigningGrant::seal(
+            GrantKey::from_context(&context, approved),
+            0,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+
+    let err = signer.sign_solana(&req).await.unwrap_err();
+    assert!(
+        matches!(err, ChainSigningError::ShipGateRefused { .. }),
+        "got {err:?}"
+    );
+
+    // The ledger must still be at Approved: a pure-config refusal must not wedge
+    // it at Signing.
+    assert_eq!(
+        ledger.state(&req.context.gate_ref).await.unwrap(),
+        SigningLedgerState::Approved,
+        "curve refusal must not advance the ledger out of Approved"
+    );
+
+    // The one-shot grant must be unconsumed: a subsequent claim succeeds (it
+    // would be AlreadyClaimed if the refusal had burned it).
+    grants
+        .claim(&GrantKey::from_context(&req.context, req.approved_tx_hash))
+        .await
+        .expect("grant must be unconsumed after a pure-config curve refusal");
+}
+
+/// The curve refusal reason must name BOTH the chain and the algorithm so an
+/// operator can tell which mainnet chain and which curve the configured KMS
+/// cannot service.
+#[tokio::test]
+async fn curve_refusal_reason_names_chain_and_alg() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{
+        Bytes32, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
+        SolanaTransaction,
+    };
+
+    let chain = "solana:mainnet";
+    let ed = EdKey::from_bytes(&[0x42u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let sol = SolanaTransaction {
+        cluster: "mainnet".into(),
+        version: SolanaMessageVersion::Legacy,
+        header: SolanaMessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        },
+        static_account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
+        recent_blockhash: Bytes32([2u8; 32]),
+        instructions: vec![SolanaCompiledInstruction {
+            program_id_index: 1,
+            account_indices: vec![0],
+            data: vec![1, 2, 3],
+        }],
+        address_table_lookups: vec![],
+    };
+    let decoded = DecodedTransaction::Solana(sol);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(chain, hex::encode(pubkey), Some("kms-sol".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger.create(&context.gate_ref).await.unwrap();
+    grants
+        .seal(AttestedSigningGrant::seal(
+            GrantKey::from_context(&context, approved),
+            0,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+
+    let err = signer.sign_solana(&req).await.unwrap_err();
+    let ChainSigningError::ShipGateRefused { reason } = err else {
+        panic!("expected ShipGateRefused, got {err:?}");
+    };
+    assert!(
+        reason.contains(chain),
+        "refusal reason must name the chain ({chain}), got: {reason}"
+    );
+    assert!(
+        reason.contains("Ed25519"),
+        "refusal reason must name the algorithm (Ed25519), got: {reason}"
+    );
+}
+
 /// Curve-capability fail-closed for NEAR mainnet (ed25519) with a secp256k1-only
 /// secure KMS.
 #[tokio::test]

--- a/crates/ironclaw_chain_signing/tests/custodial_signing.rs
+++ b/crates/ironclaw_chain_signing/tests/custodial_signing.rs
@@ -972,6 +972,484 @@ async fn near_signs_over_canonical_bytes() {
         .expect("signature must verify over sha256(canonical_signing_bytes)");
 }
 
+/// A secure-custody KMS backend that can sign secp256k1 but NOT ed25519 —
+/// modeling AWS KMS (secp256k1-only). It reports `is_secure_custody() == true`
+/// (so the ship-gate accepts it for mainnet) but `supports_alg(Ed25519) ==
+/// false`, so the curve-capability gate must refuse Solana/NEAR mainnet signing
+/// before any digest crosses the boundary — never falling back to a hot key.
+struct Secp256k1OnlyKms;
+#[async_trait::async_trait]
+impl ironclaw_chain_signing::KmsSigner for Secp256k1OnlyKms {
+    fn backend_id(&self) -> &str {
+        "secp256k1-only-kms"
+    }
+    fn is_secure_custody(&self) -> bool {
+        true
+    }
+    fn supports_alg(&self, alg: SignatureAlg) -> bool {
+        match alg {
+            SignatureAlg::Secp256k1 => true,
+            SignatureAlg::Ed25519 => false,
+        }
+    }
+    async fn sign_digest(
+        &self,
+        _key_ref: &str,
+        _digest: &[u8; 32],
+        _alg: SignatureAlg,
+    ) -> Result<Vec<u8>, ChainSigningError> {
+        // Must never be reached on the ed25519 mainnet path: the curve-capability
+        // gate fails closed before any sign attempt.
+        panic!("sign_digest must not be called when the curve is unsupported");
+    }
+}
+
+/// Curve-capability fail-closed: a secp256k1-only secure KMS refuses Solana
+/// mainnet (ed25519) signing at the ship-gate's curve check — not via a runtime
+/// sign error, and never via a hot-key fallback.
+#[tokio::test]
+async fn solana_mainnet_refused_when_kms_lacks_ed25519() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{
+        Bytes32, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
+        SolanaTransaction,
+    };
+
+    let chain = "solana:mainnet"; // not a known testnet => Mainnet
+    let ed = EdKey::from_bytes(&[0x42u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let sol = SolanaTransaction {
+        cluster: "mainnet".into(),
+        version: SolanaMessageVersion::Legacy,
+        header: SolanaMessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        },
+        static_account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
+        recent_blockhash: Bytes32([2u8; 32]),
+        instructions: vec![SolanaCompiledInstruction {
+            program_id_index: 1,
+            account_indices: vec![0],
+            data: vec![1, 2, 3],
+        }],
+        address_table_lookups: vec![],
+    };
+    let decoded = DecodedTransaction::Solana(sol);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            // Bind a KMS key_ref so the missing-key_ref guard passes and we reach
+            // the curve-capability check.
+            binding(chain, hex::encode(pubkey), Some("kms-sol".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger
+        .create(&LedgerKey::new(
+            context.tenant.clone(),
+            context.gate_ref.clone(),
+        ))
+        .await
+        .unwrap();
+    grants
+        .seal(
+            AttestedSigningGrant::new(GrantKey::from_context(&context, approved), 0, None)
+                .expect("valid grant"),
+        )
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+    let err = signer.sign_solana(&req).await.unwrap_err();
+    assert!(
+        matches!(err, ChainSigningError::ShipGateRefused { .. }),
+        "Solana mainnet must fail closed when KMS cannot sign ed25519, got {err:?}"
+    );
+}
+
+/// Curve refusal is a pure-config error and MUST be side-effect-free: it must
+/// occur before the one-shot grant is claimed and before the ledger advances out
+/// of `Approved`, so that retrying after wiring an ed25519-capable KMS is not
+/// blocked by a consumed grant or a wedged ledger row (Medium / Codex P2).
+#[tokio::test]
+async fn curve_refusal_leaves_grant_unconsumed_and_ledger_retryable() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{
+        Bytes32, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
+        SolanaTransaction,
+    };
+
+    let chain = "solana:mainnet";
+    let ed = EdKey::from_bytes(&[0x42u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let sol = SolanaTransaction {
+        cluster: "mainnet".into(),
+        version: SolanaMessageVersion::Legacy,
+        header: SolanaMessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        },
+        static_account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
+        recent_blockhash: Bytes32([2u8; 32]),
+        instructions: vec![SolanaCompiledInstruction {
+            program_id_index: 1,
+            account_indices: vec![0],
+            data: vec![1, 2, 3],
+        }],
+        address_table_lookups: vec![],
+    };
+    let decoded = DecodedTransaction::Solana(sol);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(chain, hex::encode(pubkey), Some("kms-sol".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger
+        .create(&LedgerKey::new(
+            context.tenant.clone(),
+            context.gate_ref.clone(),
+        ))
+        .await
+        .unwrap();
+    grants
+        .seal(
+            AttestedSigningGrant::new(GrantKey::from_context(&context, approved), 0, None)
+                .expect("valid grant"),
+        )
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        Arc::clone(&keystore),
+        Arc::clone(&grants),
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+
+    let err = signer.sign_solana(&req).await.unwrap_err();
+    assert!(
+        matches!(err, ChainSigningError::ShipGateRefused { .. }),
+        "got {err:?}"
+    );
+
+    // The ledger must still be at Approved: a pure-config refusal must not wedge
+    // it at Signing.
+    assert_eq!(
+        ledger
+            .state(&LedgerKey::new(
+                req.context.tenant.clone(),
+                req.context.gate_ref.clone(),
+            ))
+            .await
+            .unwrap(),
+        SigningLedgerState::Approved,
+        "curve refusal must not advance the ledger out of Approved"
+    );
+
+    // The one-shot grant must be unconsumed: a subsequent claim succeeds (it
+    // would be AlreadyClaimed if the refusal had burned it).
+    grants
+        .claim(
+            &GrantKey::from_context(&req.context, req.approved_tx_hash),
+            ironclaw_attestation::now_unix_millis(),
+        )
+        .await
+        .expect("grant must be unconsumed after a pure-config curve refusal");
+}
+
+/// The curve refusal reason must name BOTH the chain and the algorithm so an
+/// operator can tell which mainnet chain and which curve the configured KMS
+/// cannot service.
+#[tokio::test]
+async fn curve_refusal_reason_names_chain_and_alg() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{
+        Bytes32, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
+        SolanaTransaction,
+    };
+
+    let chain = "solana:mainnet";
+    let ed = EdKey::from_bytes(&[0x42u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let sol = SolanaTransaction {
+        cluster: "mainnet".into(),
+        version: SolanaMessageVersion::Legacy,
+        header: SolanaMessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        },
+        static_account_keys: vec![Bytes32(pubkey), Bytes32([9u8; 32])],
+        recent_blockhash: Bytes32([2u8; 32]),
+        instructions: vec![SolanaCompiledInstruction {
+            program_id_index: 1,
+            account_indices: vec![0],
+            data: vec![1, 2, 3],
+        }],
+        address_table_lookups: vec![],
+    };
+    let decoded = DecodedTransaction::Solana(sol);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(chain, hex::encode(pubkey), Some("kms-sol".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger
+        .create(&LedgerKey::new(
+            context.tenant.clone(),
+            context.gate_ref.clone(),
+        ))
+        .await
+        .unwrap();
+    grants
+        .seal(
+            AttestedSigningGrant::new(GrantKey::from_context(&context, approved), 0, None)
+                .expect("valid grant"),
+        )
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+
+    let err = signer.sign_solana(&req).await.unwrap_err();
+    let ChainSigningError::ShipGateRefused { reason } = err else {
+        panic!("expected ShipGateRefused, got {err:?}");
+    };
+    assert!(
+        reason.contains(chain),
+        "refusal reason must name the chain ({chain}), got: {reason}"
+    );
+    assert!(
+        reason.contains("Ed25519"),
+        "refusal reason must name the algorithm (Ed25519), got: {reason}"
+    );
+}
+
+/// Curve-capability fail-closed for NEAR mainnet (ed25519) with a secp256k1-only
+/// secure KMS.
+#[tokio::test]
+async fn near_mainnet_refused_when_kms_lacks_ed25519() {
+    use ed25519_dalek::SigningKey as EdKey;
+    use ironclaw_attestation::{Bytes32, NearAction, NearPublicKey, NearTransaction};
+
+    let chain = "near:mainnet"; // not a known testnet => Mainnet
+    let ed = EdKey::from_bytes(&[0x55u8; 32]);
+    let pubkey = ed.verifying_key().to_bytes();
+
+    let near = NearTransaction {
+        network: "mainnet".into(),
+        signer_id: "alice.near".into(),
+        public_key: NearPublicKey {
+            key_type: 0,
+            data: pubkey.to_vec(),
+        },
+        receiver_id: "bob.near".into(),
+        nonce: 11,
+        block_hash: Bytes32([3u8; 32]),
+        actions: vec![NearAction::Transfer {
+            deposit: vec![1, 2],
+        }],
+    };
+    let decoded = DecodedTransaction::Near(near);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(chain, hex::encode(pubkey), Some("kms-near".to_string())),
+            ed.to_bytes().to_vec(),
+        )
+        .await
+        .unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger
+        .create(&LedgerKey::new(
+            context.tenant.clone(),
+            context.gate_ref.clone(),
+        ))
+        .await
+        .unwrap();
+    grants
+        .seal(
+            AttestedSigningGrant::new(GrantKey::from_context(&context, approved), 0, None)
+                .expect("valid grant"),
+        )
+        .await
+        .unwrap();
+
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(Secp256k1OnlyKms);
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+    let err = signer.sign_near(&req).await.unwrap_err();
+    assert!(
+        matches!(err, ChainSigningError::ShipGateRefused { .. }),
+        "NEAR mainnet must fail closed when KMS cannot sign ed25519, got {err:?}"
+    );
+}
+
+/// Positive: a secp256k1-capable secure KMS still signs EVM mainnet (secp256k1)
+/// — the curve-capability gate passes for the supported curve.
+#[tokio::test]
+async fn evm_mainnet_signs_when_kms_supports_secp256k1() {
+    let chain = MAINNET_CHAIN;
+    let tx = sample_tx(1);
+    let key = signing_key();
+    let bound = evm::address_of(&key);
+
+    // The mainnet ship-gate additionally requires SECURE custody (threat #18):
+    // `LocalKmsSigner::new` reports `is_secure_custody() == false` because its
+    // keys live in process heap memory, so a mainnet path must use the explicit,
+    // test-only opt-in — otherwise this positive case fails as
+    // `ShipGateRefused` before the curve gate under test is ever reached.
+    let kms_backend = LocalKmsSigner::new_modeling_secure_custody("secure-kms");
+    kms_backend
+        .import_key("kms-evm", SignatureAlg::Secp256k1, key.to_bytes().to_vec())
+        .unwrap();
+    let kms: Arc<dyn ironclaw_chain_signing::KmsSigner> = Arc::new(kms_backend);
+
+    let keystore = Arc::new(SecretsKeyStore::new(crypto()));
+    keystore
+        .bind(
+            &host_scope(),
+            binding(
+                chain,
+                hex::encode(bound.as_slice()),
+                Some("kms-evm".to_string()),
+            ),
+            vec![0u8; 32],
+        )
+        .await
+        .unwrap();
+    let decoded = evm::decode_eip1559(&tx);
+    let approved = recompute_approved_hash(&decoded, "custodial", SCHEMA).unwrap();
+    let grants = Arc::new(InMemorySealedGrantStore::new());
+    let ledger = Arc::new(InMemorySigningLedger::new());
+    let context = ctx(chain);
+    ledger
+        .create(&LedgerKey::new(
+            context.tenant.clone(),
+            context.gate_ref.clone(),
+        ))
+        .await
+        .unwrap();
+    grants
+        .seal(
+            AttestedSigningGrant::new(GrantKey::from_context(&context, approved), 0, None)
+                .expect("valid grant"),
+        )
+        .await
+        .unwrap();
+
+    let signer = CustodialSigner::with_kms(
+        keystore,
+        grants,
+        Arc::clone(&ledger),
+        ShipGate::new(true, Some(kms.as_ref())),
+        kms,
+        Arc::new(DenyFirstCustodyPolicy),
+    );
+    let req = CustodialSignRequest {
+        context,
+        scope: host_scope(),
+        chain: ChainKeyId::new(chain).expect("valid chain id in test"),
+        decoded,
+        approved_tx_hash: approved,
+        schema_version: SCHEMA,
+    };
+    let out = signer.sign_evm(&req).await.expect("evm kms sign");
+    assert_eq!(out.signer, format!("0x{}", hex::encode(bound.as_slice())));
+}
+
 #[test]
 fn untrusted_metadata_rejected_by_policy() {
     let tx = sample_tx(11155111);

--- a/crates/ironclaw_reborn_composition/src/attested_continuation.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_continuation.rs
@@ -32,8 +32,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use ironclaw_attested_runtime::{
-    AttestedGateBindingStore, BindingOwner, ContinuationError, InMemoryAttestedGateBindingStore,
-    VerifiedContinuation,
+    AttestedGateBindingStore, BindingKey, BindingOwner, ContinuationError, VerifiedContinuation,
 };
 use ironclaw_product_workflow::{
     AttestedContinuationOutcome, AttestedContinuationRejection, AttestedGateContinuationPort,
@@ -77,7 +76,7 @@ pub struct RebornAttestedContinuation {
     /// against the persisted `binding.context` BEFORE claiming the grant /
     /// signing / broadcasting (defense-in-depth, layered on top of the driver's
     /// own binding read + hash re-check + one-shot grant CAS).
-    bindings: Arc<dyn ironclaw_attested_runtime::AttestedGateBindingStore>,
+    bindings: Arc<dyn AttestedGateBindingStore>,
 }
 
 impl RebornAttestedContinuation {
@@ -149,7 +148,7 @@ impl RebornAttestedContinuation {
         // 403 here would tell a foreign tenant the gate exists.
         let binding = self
             .bindings
-            .get(&ironclaw_attested_runtime::BindingKey::new(
+            .get(&BindingKey::new(
                 ironclaw_signing_provider::TenantId::new(scope.tenant_id.as_str()),
                 SigningGateRef::new(gate_ref.as_str()),
             ))


### PR DESCRIPTION
Implements #4053 — the narrow remaining hardening of the custodial-mainnet KMS fail-closed guard, on top of PR6's review fix.

## What PR6-fix already provided (not redone here)
- `ValueClass::classify` mainnet⇒KMS / testnet⇒hot-key (fail-closed default to mainnet for unknown chain ids).
- `ShipGate::authorize`/`authorize_chain` requiring BOTH the `CUSTODIAL_MAINNET_ENABLED`-style opt-in AND `is_secure_custody()` for mainnet (flag alone cannot enable hot-key mainnet).
- `CustodialSigner` routing mainnet through `KmsSigner::sign_digest` for EVM/Solana/NEAR.
- Fail-closed for no KMS backend wired (`require_kms`) and missing `kms_key_ref` binding (`require_kms_ref`).
- `is_secure_custody()` capability consulted by the ship-gate.
- Tests `secure_kms_configured_but_mainnet_hot_key_is_refused`, `mainnet_signs_via_kms_key_ref_path`, no-KMS-refused, no-opt-in-refused, testnet hot-key — all still pass.

## New: curve-capability fail-closed (the only new work)
Previously, if the configured KMS backend could not sign a chain's native curve (e.g. AWS KMS supports secp256k1 but NOT ed25519), it would only fail when the backend errored at sign time. Now:
- `KmsSigner` gains `fn supports_alg(&self, alg: SignatureAlg) -> bool` (default `true`; curve-limited backends override).
- `CustodialSigner::require_kms_supporting(chain, alg)` checks it on the mainnet/KMS path BEFORE any digest crosses the boundary, failing closed with `ShipGateRefused { reason: "mainnet <chain> requires a KMS backend that can sign <alg>; configured backend cannot" }` — never a hot-key fallback.
- `LocalKmsSigner` keeps the default and supports both secp256k1 + ed25519, so it stays working for every chain.

## Tests
- `solana_mainnet_refused_when_kms_lacks_ed25519` / `near_mainnet_refused_when_kms_lacks_ed25519`: a secure-custody secp256k1-only mock KMS refuses ed25519 mainnet signing (the mock's `sign_digest` panics if ever reached — proving the gate fails closed first, no hot-key fallback).
- `evm_mainnet_signs_when_kms_supports_secp256k1`: positive path still signs.
- Unit tests in `kms.rs` for the trait default and a curve-limited override.

## Follow-ups (out of scope, noted in code)
- The `CUSTODIAL_MAINNET_ENABLED` env flag + "require BOTH flag AND wired KMS" composition live in `ironclaw_attested_runtime`'s `CustodialMainnetShipGate` (PR10, not on this branch); the curve-capability check composes with that flag at the attested_runtime layer when the stack integrates (`// follow-up:` note added).
- A concrete cloud KMS backend (AWS/GCP), per-tenant key_ref provisioning, and quorum/multi-sig (#4051 / gap D) — no cloud SDK dependency added.

References #4053 and #4051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Cascade port onto current `main` (2026-07-24)

Replayed onto the ported attested-signing cascade. This branch was based mid-stack on **-06**; folding it there would mean re-cascading -07..-14, so — with nothing in the stack merged yet and the chain linear — it lands at the **top** instead, keeping its own PR identity. Base is now #4060.

Two of the five commits needed judgement:

**`5711af0e5` ("PR6 review") is already carried.** Its content landed with the -06 hop — verified against the tree (e.g. the EIP-155 y-parity normalization note in `evm/sign.rs`). Only the parts touching the curve-capability code this branch introduces were re-applied; the rest resolved to HEAD.

**`16e4ccc22` (the hoist) conflicted as a MISALIGNED hunk pairing — the one worth review attention.** Its point is to run the curve check BEFORE the grant claim so a refusal is side-effect-free. But the incoming block also inlines `self.grants.claim(..)` into `authorize()`, while in this cascade the claim lives in `claim_grant()` — driven as the last step before the `Signing` ledger transition, precisely so a pre-flight failure leaves the gate retryable. Taking it verbatim would have produced a **second claim of a one-shot grant**, breaking every custodial signature compile-clean. Took only the hoist; the property it wants already holds by construction here, since `authorize()` runs before `claim_grant()`. `curve_refusal_leaves_grant_unconsumed_and_ledger_retryable` passes, which is the assertion that matters.

The `759fdad75` postgres RUSTSEC dependency bump is dropped — `main` carries its own dependency state.

**Test drift** fixed against the cascade's evolved APIs: the ledger is keyed `(tenant, gate_ref)` since -12, `AttestedSigningGrant::new` is fallible, and `claim` takes the runtime clock since #4104. The positive mainnet case (`evm_mainnet_signs_when_kms_supports_secp256k1`) now builds its KMS via `LocalKmsSigner::new_modeling_secure_custody` — the plain constructor reports `is_secure_custody() == false` under the threat-#18 hardening, so the test was failing as `ShipGateRefused` before ever reaching the curve gate it exercises.

**Verification:** 2660 tests pass across chain_signing / composition / product_workflow / architecture, 0 failures. clippy `--tests --all-features`, fmt, and `check_no_panics.py` clean.
