### PR TITLE
fix(signing): continuation asserts caller scope/run/gate_ref vs binding context + whole-stack review note (attested-signing)

### DIFF
--- a/crates/ironclaw_product_workflow/src/attested_continuation.rs
+++ b/crates/ironclaw_product_workflow/src/attested_continuation.rs
@@ -114,7 +114,11 @@ pub enum AttestedContinuationRejection {
     LedgerGuard,
     /// The proof payload was malformed and could not be decoded.
     MalformedProof,
-    /// The continuation port is not wired on this deployment.
+    /// A post-verification, server-side (recoverable) failure: the proof was
+    /// already verified and the one-shot grant claimed, but the broadcast tail
+    /// failed (e.g. RPC timeout). The broadcast is ledger-idempotent, so this is
+    /// retryable for the broadcast tail only — it must NOT be surfaced as a
+    /// proof-validation error.
     Unavailable,
     /// The caller-supplied turn scope / run / gate_ref did not match the
     /// authoritative binding context recorded when the gate was raised

--- a/crates/ironclaw_product_workflow/src/attested_continuation.rs
+++ b/crates/ironclaw_product_workflow/src/attested_continuation.rs
@@ -116,6 +116,12 @@ pub enum AttestedContinuationRejection {
     MalformedProof,
     /// The continuation port is not wired on this deployment.
     Unavailable,
+    /// The caller-supplied turn scope / run / gate_ref did not match the
+    /// authoritative binding context recorded when the gate was raised
+    /// (tenant or gate-ref divergence). Defense-in-depth against driving a
+    /// binding raised for one tenant/gate with a continuation request bearing
+    /// another's identity. Fail closed.
+    ContextMismatch,
 }
 
 impl AttestedContinuationRejection {
@@ -128,6 +134,7 @@ impl AttestedContinuationRejection {
             Self::LedgerGuard => "attested_ledger_guard",
             Self::MalformedProof => "attested_malformed_proof",
             Self::Unavailable => "attested_unavailable",
+            Self::ContextMismatch => "attested_context_mismatch",
         }
     }
 }

--- a/crates/ironclaw_product_workflow/src/attested_continuation.rs
+++ b/crates/ironclaw_product_workflow/src/attested_continuation.rs
@@ -114,12 +114,22 @@ pub enum AttestedContinuationRejection {
     LedgerGuard,
     /// The proof payload was malformed and could not be decoded.
     MalformedProof,
-    /// The continuation port is not wired on this deployment.
+    /// A post-verification, server-side (recoverable) failure: the proof was
+    /// already verified and the one-shot grant claimed, but the broadcast tail
+    /// failed (e.g. RPC timeout). The broadcast is ledger-idempotent, so this is
+    /// retryable for the broadcast tail only — it must NOT be surfaced as a
+    /// proof-validation error.
     Unavailable,
     /// An infrastructure/runtime backend failed (chain-signing backend error,
     /// broadcast/RPC outage). This is a service-health failure, not a client
     /// input failure, so it must surface as a retryable 503 rather than a 400.
     BackendUnavailable,
+    /// The caller-supplied turn scope / run / gate_ref did not match the
+    /// authoritative binding context recorded when the gate was raised
+    /// (tenant or gate-ref divergence). Defense-in-depth against driving a
+    /// binding raised for one tenant/gate with a continuation request bearing
+    /// another's identity. Fail closed.
+    ContextMismatch,
 }
 
 impl AttestedContinuationRejection {
@@ -133,6 +143,7 @@ impl AttestedContinuationRejection {
             Self::MalformedProof => "attested_malformed_proof",
             Self::Unavailable => "attested_unavailable",
             Self::BackendUnavailable => "attested_backend_unavailable",
+            Self::ContextMismatch => "attested_context_mismatch",
         }
     }
 
@@ -180,6 +191,7 @@ impl AttestedContinuationRejection {
             | Self::ProofRejected
             | Self::LedgerGuard
             | Self::MalformedProof
+            | Self::ContextMismatch
             | Self::Unavailable => false,
         }
     }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -1333,13 +1333,16 @@ fn attested_invalid_field(field: &str) -> RebornServicesError {
 
 /// Map a sanitized attested-continuation rejection to the WebUI error surface.
 ///
-/// Most categories are terminal: the one-shot resume guard / sealed grant was
+/// Every category is terminal: the one-shot resume guard / sealed grant was
 /// already consumed (or the request was rejected before it could be), so the
-/// client cannot retry the same proof. The lone exception is `Unavailable`,
-/// which is a POST-verification broadcast-tail failure (RPC timeout, etc.): the
-/// grant IS already claimed and the broadcast is idempotency-guarded by the
-/// ledger row, so the client may safely retry only the broadcast tail. The
-/// per-arm `retryable` flag reflects that distinction.
+/// client cannot retry the same proof. `Unavailable` is a POST-verification
+/// broadcast-tail failure (RPC timeout, etc.) where the grant is already
+/// claimed, but it is still non-retryable: there is no broadcast-tail-only
+/// re-drive path — the only public retry re-enters `verify_and_claim` and is
+/// rejected by the grant/ledger CAS. A real tail-retry path (re-fetch the
+/// verified handle from a durable store and re-drive only the broadcast) is
+/// deferred to the durable binding store follow-up. The per-arm `retryable`
+/// flag reflects that everything here is `false` for now.
 fn map_attested_continuation_rejection(
     rejection: AttestedContinuationRejection,
 ) -> RebornServicesError {
@@ -1376,15 +1379,21 @@ fn map_attested_continuation_rejection(
             409,
             false,
         ),
-        // Broadcast-tail failure after the grant was already claimed: the
-        // ledger row makes the broadcast idempotent, so the client may retry
-        // the broadcast tail. Retryable, matching how `Unavailable` is treated
-        // by the other mappers in this file.
+        // Broadcast-tail failure after the grant was already claimed. There is
+        // no broadcast-tail-only re-drive path today: `broadcast_resolved` is
+        // only ever reached from inside `resolve_attested_gate`, after
+        // `verify_and_claim` has already burned the one-shot grant, and the
+        // sole public retry re-enters `verify_and_claim` where the grant/ledger
+        // CAS rejects the second claim as `LedgerGuard`/409. Ledger idempotency
+        // only prevents a *double* broadcast; it does not provide a *re-drive*
+        // path for the consumed `verified` handle. So this is non-retryable
+        // until the durable binding store lands and a real tail-retry path can
+        // re-fetch the handle (tracked alongside the PR12 dedup TODO).
         AttestedContinuationRejection::Unavailable => (
             RebornServicesErrorCode::Unavailable,
             RebornServicesErrorKind::ServiceUnavailable,
             503,
-            true,
+            false,
         ),
     };
     RebornServicesError::from_status_kind(code, kind, status, retryable)
@@ -1667,11 +1676,14 @@ mod attested_rejection_mapping_tests {
             map_attested_continuation_rejection(AttestedContinuationRejection::Unavailable);
         assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
         assert_eq!(unavailable.status_code, 503);
-        // Broadcast-tail failure after a claimed grant: the ledger row makes the
-        // broadcast idempotent, so the client may retry the broadcast tail.
+        // Broadcast-tail failure after a claimed grant is NOT retryable through
+        // any public path: the only retry re-enters `verify_and_claim`, where
+        // the already-burned one-shot grant rejects the second claim. There is
+        // no broadcast-tail-only re-drive path until the durable binding store
+        // lands, so the client must not be told to retry.
         assert!(
-            unavailable.retryable,
-            "a post-verification broadcast-tail Unavailable must be retryable"
+            !unavailable.retryable,
+            "a post-verification broadcast-tail Unavailable has no retry path and must be non-retryable"
         );
     }
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -1350,6 +1350,17 @@ fn map_attested_continuation_rejection(
             RebornServicesErrorKind::Validation,
             400,
         ),
+        // A context mismatch is an ownership/tenant divergence (the caller's
+        // turn scope / run / gate_ref did not match the authoritative binding
+        // recorded at raise), not a malformed request. Surface it as 403
+        // Forbidden so the classification matches how this crate already maps an
+        // unauthorized turn (`TurnErrorCategory::Unauthorized`), rather than
+        // collapsing it into the generic proof-validation 400.
+        AttestedContinuationRejection::ContextMismatch => (
+            RebornServicesErrorCode::Forbidden,
+            RebornServicesErrorKind::ParticipantDenied,
+            403,
+        ),
         AttestedContinuationRejection::LedgerGuard => (
             RebornServicesErrorCode::Conflict,
             RebornServicesErrorKind::Conflict,
@@ -1587,5 +1598,57 @@ fn generated_thread_id(
             // Fallback remains valid under ThreadId validation rules.
             ThreadId::new("generated-thread-fallback").unwrap_or_else(|_| unreachable!())
         }
+    }
+}
+
+#[cfg(test)]
+mod attested_rejection_mapping_tests {
+    use super::*;
+
+    #[test]
+    fn context_mismatch_maps_to_forbidden_not_validation() {
+        // A context mismatch is an ownership/tenant divergence — it must surface
+        // as 403 Forbidden (ParticipantDenied), not be collapsed into the
+        // generic 400 proof-validation bucket.
+        let err =
+            map_attested_continuation_rejection(AttestedContinuationRejection::ContextMismatch);
+        assert_eq!(err.code, RebornServicesErrorCode::Forbidden);
+        assert_eq!(err.kind, RebornServicesErrorKind::ParticipantDenied);
+        assert_eq!(err.status_code, 403);
+        assert!(!err.retryable);
+    }
+
+    #[test]
+    fn proof_rejections_stay_validation_400() {
+        for rejection in [
+            AttestedContinuationRejection::ProviderMismatch,
+            AttestedContinuationRejection::ProofRejected,
+            AttestedContinuationRejection::MalformedProof,
+        ] {
+            let err = map_attested_continuation_rejection(rejection.clone());
+            assert_eq!(
+                err.code,
+                RebornServicesErrorCode::InvalidRequest,
+                "{rejection:?} should remain a 400 validation error"
+            );
+            assert_eq!(err.status_code, 400);
+        }
+    }
+
+    #[test]
+    fn missing_binding_and_guards_keep_their_codes() {
+        let missing =
+            map_attested_continuation_rejection(AttestedContinuationRejection::MissingBinding);
+        assert_eq!(missing.code, RebornServicesErrorCode::NotFound);
+        assert_eq!(missing.status_code, 404);
+
+        let guard = map_attested_continuation_rejection(AttestedContinuationRejection::LedgerGuard);
+        assert_eq!(guard.code, RebornServicesErrorCode::Conflict);
+        assert_eq!(guard.status_code, 409);
+
+        let unavailable =
+            map_attested_continuation_rejection(AttestedContinuationRejection::Unavailable);
+        assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(unavailable.status_code, 503);
     }
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -1332,16 +1332,23 @@ fn attested_invalid_field(field: &str) -> RebornServicesError {
 }
 
 /// Map a sanitized attested-continuation rejection to the WebUI error surface.
-/// The continuation runs after the resume guard already consumed the one-shot,
-/// so every category here is non-retryable from the client's perspective.
+///
+/// Most categories are terminal: the one-shot resume guard / sealed grant was
+/// already consumed (or the request was rejected before it could be), so the
+/// client cannot retry the same proof. The lone exception is `Unavailable`,
+/// which is a POST-verification broadcast-tail failure (RPC timeout, etc.): the
+/// grant IS already claimed and the broadcast is idempotency-guarded by the
+/// ledger row, so the client may safely retry only the broadcast tail. The
+/// per-arm `retryable` flag reflects that distinction.
 fn map_attested_continuation_rejection(
     rejection: AttestedContinuationRejection,
 ) -> RebornServicesError {
-    let (code, kind, status) = match rejection {
+    let (code, kind, status, retryable) = match rejection {
         AttestedContinuationRejection::MissingBinding => (
             RebornServicesErrorCode::NotFound,
             RebornServicesErrorKind::NotFound,
             404,
+            false,
         ),
         AttestedContinuationRejection::ProviderMismatch
         | AttestedContinuationRejection::ProofRejected
@@ -1349,6 +1356,7 @@ fn map_attested_continuation_rejection(
             RebornServicesErrorCode::InvalidRequest,
             RebornServicesErrorKind::Validation,
             400,
+            false,
         ),
         // A context mismatch is an ownership/tenant divergence (the caller's
         // turn scope / run / gate_ref did not match the authoritative binding
@@ -1360,19 +1368,26 @@ fn map_attested_continuation_rejection(
             RebornServicesErrorCode::Forbidden,
             RebornServicesErrorKind::ParticipantDenied,
             403,
+            false,
         ),
         AttestedContinuationRejection::LedgerGuard => (
             RebornServicesErrorCode::Conflict,
             RebornServicesErrorKind::Conflict,
             409,
+            false,
         ),
+        // Broadcast-tail failure after the grant was already claimed: the
+        // ledger row makes the broadcast idempotent, so the client may retry
+        // the broadcast tail. Retryable, matching how `Unavailable` is treated
+        // by the other mappers in this file.
         AttestedContinuationRejection::Unavailable => (
             RebornServicesErrorCode::Unavailable,
             RebornServicesErrorKind::ServiceUnavailable,
             503,
+            true,
         ),
     };
-    RebornServicesError::from_status_kind(code, kind, status, false)
+    RebornServicesError::from_status_kind(code, kind, status, retryable)
 }
 
 fn segment(name: &str, value: &str) -> String {
@@ -1645,10 +1660,18 @@ mod attested_rejection_mapping_tests {
         let guard = map_attested_continuation_rejection(AttestedContinuationRejection::LedgerGuard);
         assert_eq!(guard.code, RebornServicesErrorCode::Conflict);
         assert_eq!(guard.status_code, 409);
+        // The grant was already consumed — replaying the same proof is terminal.
+        assert!(!guard.retryable);
 
         let unavailable =
             map_attested_continuation_rejection(AttestedContinuationRejection::Unavailable);
         assert_eq!(unavailable.code, RebornServicesErrorCode::Unavailable);
         assert_eq!(unavailable.status_code, 503);
+        // Broadcast-tail failure after a claimed grant: the ledger row makes the
+        // broadcast idempotent, so the client may retry the broadcast tail.
+        assert!(
+            unavailable.retryable,
+            "a post-verification broadcast-tail Unavailable must be retryable"
+        );
     }
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -7680,6 +7680,17 @@ fn map_attested_continuation_rejection(
             RebornServicesErrorKind::Validation,
             400,
         ),
+        // A context mismatch is an ownership/tenant divergence (the caller's
+        // turn scope / run / gate_ref did not match the authoritative binding
+        // recorded at raise), not a malformed request. Surface it as 403
+        // Forbidden so the classification matches how this crate already maps an
+        // unauthorized turn (`TurnErrorCategory::Unauthorized`), rather than
+        // collapsing it into the generic proof-validation 400.
+        AttestedContinuationRejection::ContextMismatch => (
+            RebornServicesErrorCode::Forbidden,
+            RebornServicesErrorKind::ParticipantDenied,
+            403,
+        ),
         AttestedContinuationRejection::LedgerGuard => (
             RebornServicesErrorCode::Conflict,
             RebornServicesErrorKind::Conflict,

--- a/crates/ironclaw_reborn_composition/src/attested_continuation.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_continuation.rs
@@ -31,7 +31,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use ironclaw_attested_runtime::{BindingOwner, ContinuationError, VerifiedContinuation};
+use ironclaw_attested_runtime::{
+    AttestedGateBindingStore, BindingOwner, ContinuationError, InMemoryAttestedGateBindingStore,
+    VerifiedContinuation,
+};
 use ironclaw_product_workflow::{
     AttestedContinuationOutcome, AttestedContinuationRejection, AttestedGateContinuationPort,
     AttestedProofClaim, AttestedProofKind, VerifiedAttestedContinuation,
@@ -55,6 +58,12 @@ use crate::attested::{LocalDevContinuationDriver, RebornAttestedComposition};
 /// runtime (the same driver + binding store + ledger the resume port reads).
 pub struct RebornAttestedContinuation {
     driver: Arc<LocalDevContinuationDriver>,
+    /// The same authoritative gate-binding store the driver reads. Held here so
+    /// this port can assert the caller-supplied turn scope / run / gate_ref
+    /// against the persisted `binding.context` BEFORE claiming the grant /
+    /// signing / broadcasting (defense-in-depth, layered on top of the driver's
+    /// own binding read + hash re-check + one-shot grant CAS).
+    bindings: Arc<InMemoryAttestedGateBindingStore>,
 }
 
 impl RebornAttestedContinuation {
@@ -62,7 +71,81 @@ impl RebornAttestedContinuation {
     pub fn new(composition: &RebornAttestedComposition) -> Self {
         Self {
             driver: Arc::clone(composition.driver()),
+            bindings: Arc::clone(composition.bindings()),
         }
+    }
+
+    /// Assert the caller-supplied turn `scope` / `run_id` / `gate_ref` against
+    /// the authoritative [`AttestedGateBinding`] recorded when the gate was
+    /// raised, and fail closed on any divergence BEFORE the grant is claimed /
+    /// the proof is verified / anything is broadcast.
+    ///
+    /// This is defense-in-depth ON TOP of the driver (which independently reads
+    /// the binding, re-checks the bound hash, and claims the one-shot grant). It
+    /// guards the alternate-ingress / multi-tenant case: a binding raised for
+    /// tenant A's run must never be driven by a continuation request bearing
+    /// tenant B's — or another run's — identity.
+    ///
+    /// Comparable axes under the current identity vocabulary
+    /// ([`SigningContext`](ironclaw_signing_provider::SigningContext)'s
+    /// transparent-string newtypes vs the `ironclaw_turns` types):
+    ///
+    /// - `gate_ref`: the authoritative join key. The binding is fetched BY
+    ///   `gate_ref`, and the store's insert-time
+    ///   [`validate_binding`](ironclaw_attested_runtime::validate_binding)
+    ///   (`GateRefMismatch` guard) enforces `binding.context.gate_ref ==` the
+    ///   key it is stored under for EVERY backend (in-memory here, durable in
+    ///   PR12). So a successful `get(gate_ref)` already guarantees
+    ///   `binding.context.gate_ref == gate_ref` by construction — a separate
+    ///   equality re-check here would be dead code. A wrong `gate_ref` instead
+    ///   surfaces as [`MissingBinding`](AttestedContinuationRejection::MissingBinding)
+    ///   (the lookup finds no row / a different gate's row), which the
+    ///   `MissingBinding` arm below already fails closed on.
+    /// - `tenant`: the incoming [`TurnScope::tenant_id`] string must equal
+    ///   `binding.context.tenant`. This is the multi-tenant isolation axis and
+    ///   the real defense-in-depth work this helper does — a binding raised for
+    ///   tenant A must never be driven by a continuation bearing tenant B's
+    ///   identity even when both reference the same `gate_ref`.
+    ///
+    /// `run_id` / `user` / `scope` are intentionally NOT asserted here: the
+    /// `TurnRunId` (a UUID) and `TurnScope` (tenant / agent / project / thread,
+    /// with `user` resolving to the system sentinel in
+    /// [`TurnScope::to_resource_scope`]) carry no axis that maps by value to
+    /// `SigningContext`'s free-string `run_id` / `user` / `scope` under the
+    /// pre-reconciliation (PR5) vocabulary — the raise side does not derive them
+    /// from the turn identity. Asserting them would fail-closed the *legitimate*
+    /// path. They are documented here so the cross-PR identity reconciliation can
+    /// tighten this to a full `SigningContext` identity match once the raise side
+    /// derives those axes from the turn.
+    async fn assert_caller_matches_binding(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+    ) -> Result<(), AttestedContinuationRejection> {
+        // TODO(PR12): this read and the driver's own subsequent binding read in
+        // `verify_and_sign` hit the same row twice per `verify_and_claim`.
+        // Harmless on the in-memory store (synchronous under a `Mutex`), but once
+        // the durable PG/libSQL store lands this is two DB round-trips for the
+        // same row. Dedup by threading this pre-fetched binding into the driver
+        // (accept a pre-validated binding) rather than re-reading it there.
+        let binding = self
+            .bindings
+            .get(&SigningGateRef::new(gate_ref.as_str()))
+            .await
+            .ok_or(AttestedContinuationRejection::MissingBinding)?;
+
+        // gate_ref is NOT re-checked here: the binding is fetched by `gate_ref`
+        // and the store's insert-time `validate_binding` (`GateRefMismatch`)
+        // guarantees `binding.context.gate_ref == gate_ref` for any row that was
+        // successfully persisted. An equality re-check would be dead code; a
+        // wrong `gate_ref` already failed closed above as `MissingBinding`.
+
+        // tenant: multi-tenant isolation axis — the real defense-in-depth check.
+        if binding.context.tenant.as_str() != scope.tenant_id.as_str() {
+            return Err(AttestedContinuationRejection::ContextMismatch);
+        }
+
+        Ok(())
     }
 }
 
@@ -98,6 +181,16 @@ impl AttestedGateContinuationPort for RebornAttestedContinuation {
             .await
             .map_err(map_continuation_error)?;
 
+        // Defense-in-depth (layered ON TOP of the driver's `assert_binding_owner`
+        // above): re-assert the caller's turn scope / gate_ref against the
+        // authoritative binding context from this port's own binding-store
+        // handle, surfacing a tenant divergence as the dedicated
+        // `ContextMismatch` (403) classification rather than collapsing it into
+        // the existence-oracle-safe `MissingBinding` (404) the driver check maps
+        // to. A binding raised for one tenant/gate must not be driven by a
+        // continuation request bearing another's identity. Fail closed.
+        self.assert_caller_matches_binding(scope, gate_ref).await?;
+
         // FULL verification + one-shot grant claim, run BEFORE the facade
         // transitions the turn. A malformed proof fails closed here at decode; a
         // forged signature / signer mismatch / already-claimed grant fails closed
@@ -122,11 +215,18 @@ impl AttestedGateContinuationPort for RebornAttestedContinuation {
 
     async fn broadcast_resolved(
         &self,
-        _scope: &TurnScope,
+        scope: &TurnScope,
         _run_id: TurnRunId,
-        _gate_ref: &GateRef,
+        gate_ref: &GateRef,
         verified: VerifiedAttestedContinuation,
     ) -> Result<AttestedContinuationOutcome, AttestedContinuationRejection> {
+        // Defense-in-depth: re-assert the caller's turn scope / gate_ref against
+        // the authoritative binding context before broadcasting. Same fail-closed
+        // guard as `verify_and_claim`, re-checked on the broadcast half so an
+        // alternate-ingress caller cannot drive the broadcast of a binding that
+        // does not match its identity.
+        self.assert_caller_matches_binding(scope, gate_ref).await?;
+
         // Recover the concrete verified continuation produced by
         // `verify_and_claim`. A type mismatch (only possible if a different port
         // implementation produced the handle) fails closed rather than panicking.

--- a/crates/ironclaw_reborn_composition/src/attested_continuation.rs
+++ b/crates/ironclaw_reborn_composition/src/attested_continuation.rs
@@ -31,7 +31,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use ironclaw_attested_runtime::{BindingOwner, ContinuationError, VerifiedContinuation};
+use ironclaw_attested_runtime::{
+    AttestedGateBindingStore, BindingOwner, ContinuationError, InMemoryAttestedGateBindingStore,
+    VerifiedContinuation,
+};
 use ironclaw_product_workflow::{
     AttestedContinuationOutcome, AttestedContinuationRejection, AttestedGateContinuationPort,
     AttestedProofClaim, AttestedProofKind, VerifiedAttestedContinuation,
@@ -69,6 +72,12 @@ use crate::attested::{InMemoryAttestedComposition, InMemoryContinuationDriver};
 /// this port over it — is the dedicated follow-up slice.
 pub struct RebornAttestedContinuation {
     driver: Arc<InMemoryContinuationDriver>,
+    /// The same authoritative gate-binding store the driver reads. Held here so
+    /// this port can assert the caller-supplied turn scope / run / gate_ref
+    /// against the persisted `binding.context` BEFORE claiming the grant /
+    /// signing / broadcasting (defense-in-depth, layered on top of the driver's
+    /// own binding read + hash re-check + one-shot grant CAS).
+    bindings: Arc<dyn ironclaw_attested_runtime::AttestedGateBindingStore>,
 }
 
 impl RebornAttestedContinuation {
@@ -76,7 +85,93 @@ impl RebornAttestedContinuation {
     pub fn new(composition: &InMemoryAttestedComposition) -> Self {
         Self {
             driver: Arc::clone(composition.driver()),
+            bindings: Arc::clone(composition.bindings()),
         }
+    }
+
+    /// Assert the caller-supplied turn `scope` / `run_id` / `gate_ref` against
+    /// the authoritative [`AttestedGateBinding`] recorded when the gate was
+    /// raised, and fail closed on any divergence BEFORE the grant is claimed /
+    /// the proof is verified / anything is broadcast.
+    ///
+    /// This is defense-in-depth ON TOP of the driver (which independently reads
+    /// the binding, re-checks the bound hash, and claims the one-shot grant). It
+    /// guards the alternate-ingress / multi-tenant case: a binding raised for
+    /// tenant A's run must never be driven by a continuation request bearing
+    /// tenant B's — or another run's — identity.
+    ///
+    /// Comparable axes under the current identity vocabulary
+    /// ([`SigningContext`](ironclaw_signing_provider::SigningContext)'s
+    /// transparent-string newtypes vs the `ironclaw_turns` types):
+    ///
+    /// - `gate_ref`: the authoritative join key. The binding is fetched BY
+    ///   `gate_ref`, and the store's insert-time
+    ///   [`validate_binding`](ironclaw_attested_runtime::validate_binding)
+    ///   (`GateRefMismatch` guard) enforces `binding.context.gate_ref ==` the
+    ///   key it is stored under for EVERY backend (in-memory here, durable in
+    ///   PR12). So a successful `get(gate_ref)` already guarantees
+    ///   `binding.context.gate_ref == gate_ref` by construction — a separate
+    ///   equality re-check here would be dead code. A wrong `gate_ref` instead
+    ///   surfaces as [`MissingBinding`](AttestedContinuationRejection::MissingBinding)
+    ///   (the lookup finds no row / a different gate's row), which the
+    ///   `MissingBinding` arm below already fails closed on.
+    /// - `tenant`: the incoming [`TurnScope::tenant_id`] string must equal
+    ///   `binding.context.tenant`. This is the multi-tenant isolation axis and
+    ///   the real defense-in-depth work this helper does — a binding raised for
+    ///   tenant A must never be driven by a continuation bearing tenant B's
+    ///   identity even when both reference the same `gate_ref`.
+    ///
+    /// `run_id` / `user` / `scope` are intentionally NOT asserted here: the
+    /// `TurnRunId` (a UUID) and `TurnScope` (tenant / agent / project / thread,
+    /// with `user` resolving to the system sentinel in
+    /// [`TurnScope::to_resource_scope`]) carry no axis that maps by value to
+    /// `SigningContext`'s free-string `run_id` / `user` / `scope` under the
+    /// pre-reconciliation (PR5) vocabulary — the raise side does not derive them
+    /// from the turn identity. Asserting them would fail-closed the *legitimate*
+    /// path. They are documented here so the cross-PR identity reconciliation can
+    /// tighten this to a full `SigningContext` identity match once the raise side
+    /// derives those axes from the turn.
+    async fn assert_caller_matches_binding(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+    ) -> Result<(), AttestedContinuationRejection> {
+        // TODO(PR12): this read and the driver's own subsequent binding read in
+        // `verify_and_sign` hit the same row twice per `verify_and_claim`.
+        // Harmless on the in-memory store (synchronous under a `Mutex`), but once
+        // the durable PG/libSQL store lands this is two DB round-trips for the
+        // same row. Dedup by threading this pre-fetched binding into the driver
+        // (accept a pre-validated binding) rather than re-reading it there.
+        // The binding store is keyed `(tenant, gate_ref)`, so the read is
+        // qualified by the CALLER's tenant: a caller from another tenant cannot
+        // address the row at all and gets `MissingBinding` (404). That keeps the
+        // no-existence-oracle property the cross-user IDOR fix established — a
+        // 403 here would tell a foreign tenant the gate exists.
+        let binding = self
+            .bindings
+            .get(&ironclaw_attested_runtime::BindingKey::new(
+                ironclaw_signing_provider::TenantId::new(scope.tenant_id.as_str()),
+                SigningGateRef::new(gate_ref.as_str()),
+            ))
+            .await
+            .ok_or(AttestedContinuationRejection::MissingBinding)?;
+
+        // gate_ref is NOT re-checked here: the binding is fetched by `gate_ref`
+        // and the store's insert-time `validate_binding` (`GateRefMismatch`)
+        // guarantees `binding.context.gate_ref == gate_ref` for any row that was
+        // successfully persisted. An equality re-check would be dead code; a
+        // wrong `gate_ref` already failed closed above as `MissingBinding`.
+
+        // tenant: multi-tenant isolation axis. The composite key above already
+        // enforces this, so this comparison is unreachable against a correct
+        // store — it stays as defense in depth so a backend that ignored the
+        // tenant component still fails closed (and reports the divergence as
+        // `ContextMismatch` rather than silently continuing).
+        if binding.context.tenant.as_str() != scope.tenant_id.as_str() {
+            return Err(AttestedContinuationRejection::ContextMismatch);
+        }
+
+        Ok(())
     }
 }
 
@@ -112,6 +207,16 @@ impl AttestedGateContinuationPort for RebornAttestedContinuation {
             .await
             .map_err(map_continuation_error)?;
 
+        // Defense-in-depth (layered ON TOP of the driver's `assert_binding_owner`
+        // above): re-assert the caller's turn scope / gate_ref against the
+        // authoritative binding context from this port's own binding-store
+        // handle, surfacing a tenant divergence as the dedicated
+        // `ContextMismatch` (403) classification rather than collapsing it into
+        // the existence-oracle-safe `MissingBinding` (404) the driver check maps
+        // to. A binding raised for one tenant/gate must not be driven by a
+        // continuation request bearing another's identity. Fail closed.
+        self.assert_caller_matches_binding(scope, gate_ref).await?;
+
         // FULL verification + one-shot grant claim, run BEFORE the facade
         // transitions the turn. A malformed proof fails closed here at decode; a
         // forged signature / signer mismatch / already-claimed grant fails closed
@@ -136,11 +241,18 @@ impl AttestedGateContinuationPort for RebornAttestedContinuation {
 
     async fn broadcast_resolved(
         &self,
-        _scope: &TurnScope,
+        scope: &TurnScope,
         _run_id: TurnRunId,
-        _gate_ref: &GateRef,
+        gate_ref: &GateRef,
         verified: VerifiedAttestedContinuation,
     ) -> Result<AttestedContinuationOutcome, AttestedContinuationRejection> {
+        // Defense-in-depth: re-assert the caller's turn scope / gate_ref against
+        // the authoritative binding context before broadcasting. Same fail-closed
+        // guard as `verify_and_claim`, re-checked on the broadcast half so an
+        // alternate-ingress caller cannot drive the broadcast of a binding that
+        // does not match its identity.
+        self.assert_caller_matches_binding(scope, gate_ref).await?;
+
         // Recover the concrete verified continuation produced by
         // `verify_and_claim`. A type mismatch is only reachable if a *different*
         // port implementation produced the handle — i.e. an internal composition

--- a/crates/ironclaw_reborn_composition/tests/attested_gate_resolve_ingress.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_gate_resolve_ingress.rs
@@ -109,14 +109,16 @@ fn bound_hash(account_hex: &str) -> ApprovedTxHash {
     .expect("recompute approved hash in test")
 }
 
-fn signing_ctx(account_hex: &str) -> SigningContext {
+/// `SigningContext` for an arbitrary `gate_ref`, so a test can register more
+/// than one authoritative binding (each gate carries its own one-shot grant).
+fn signing_ctx_for(gate: &str, account_hex: &str) -> SigningContext {
     SigningContext {
         tenant: SigningTenantId::new(TENANT),
         user: SigningUserId::new(USER),
         scope: ScopeId::new("scope"),
         actor: ActorId::new("actor"),
         run_id: RunId::new("run"),
-        gate_ref: SigningGateRef::new(GATE),
+        gate_ref: SigningGateRef::new(gate),
         chain_id: ChainId::new("solana:mainnet"),
         key_or_account_id: KeyOrAccountId::new(account_hex),
     }
@@ -269,9 +271,15 @@ fn attested_request(
 }
 
 fn binding(account_hex: &str, hash: ApprovedTxHash) -> AttestedGateBinding {
+    binding_for(GATE, account_hex, hash)
+}
+
+/// `binding` whose `context.gate_ref` is `gate`, so a second authoritative gate
+/// can be registered alongside the default `GATE`.
+fn binding_for(gate: &str, account_hex: &str, hash: ApprovedTxHash) -> AttestedGateBinding {
     AttestedGateBinding {
         provider_id: ProviderId::Injected,
-        context: signing_ctx(account_hex),
+        context: signing_ctx_for(gate, account_hex),
         approved_tx_hash: hash,
         decoded: placeholder_decoded(),
         chain: ChainKeyId::new("solana:mainnet").expect("valid chain id in test"),
@@ -946,13 +954,21 @@ fn attested_claim(
     }
 }
 
+/// A turn scope whose tenant DIFFERS from the test bindings' `context.tenant`
+/// (an alternate-ingress / wrong-tenant caller), with every other axis matching.
+fn mismatched_tenant_scope() -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant-other").unwrap(),
+        Some(AgentId::new(AGENT).unwrap()),
+        Some(ProjectId::new(PROJECT).unwrap()),
+        ThreadId::new(THREAD).unwrap(),
+    )
+}
+
 /// Defense-in-depth (whole-stack coherence review): the continuation asserts the
 /// caller-supplied turn scope / gate_ref against the authoritative
-/// `binding.context` BEFORE claiming the grant / verifying / broadcasting. A
-/// continuation request bearing a DIFFERENT identity than the binding's context
-/// must fail closed without claiming the one-shot grant — so a subsequent
-/// MATCHING continuation for the same gate still succeeds (the grant was never
-/// burned by the mismatched attempt).
+/// `binding.context` BEFORE claiming the grant / verifying / broadcasting, on
+/// BOTH halves of the two-phase port.
 ///
 /// Two layered IDOR guards run on `verify_and_claim`, in order:
 ///   1. the driver's `assert_binding_owner` (tenant + user), which fails closed
@@ -960,17 +976,38 @@ fn attested_claim(
 ///      ownership gate; and
 ///   2. this port's `assert_caller_matches_binding` (tenant), which surfaces a
 ///      tenant divergence as the dedicated `ContextMismatch` (403).
-/// A mismatched tenant is caught by (1) first (404). The `broadcast_resolved`
-/// half does NOT re-run the driver owner check, so its composition-layer
-/// re-assertion exercises the `ContextMismatch` (403) path directly.
+///
+/// `verify_and_claim` half: a request bearing a DIFFERENT tenant must fail
+/// closed without claiming the one-shot grant — caught by guard (1) first, so it
+/// surfaces as `MissingBinding` (404, no oracle) — so a later MATCHING
+/// continuation for the same gate still succeeds (the grant was never burned),
+/// and the matching path then BROADCASTS successfully, proving the verify-side
+/// guard passes on a match and the matching broadcast completes end-to-end.
+///
+/// `broadcast_resolved` half: this is exercised INDEPENDENTLY of the one-shot
+/// grant CAS, and does NOT re-run the driver's owner check, so its
+/// composition-layer re-assertion exercises the `ContextMismatch` (403) path
+/// directly. Using a SECOND gate (its own grant), a matching `verify_and_claim`
+/// hands back a fresh, un-consumed `VerifiedAttestedContinuation` handle; a
+/// mismatched-tenant `broadcast_resolved` against that handle must fail closed
+/// as `ContextMismatch` — proving the broadcast-side assert fires before the
+/// downcast/broadcast and is not merely the grant-CAS rejecting a replay.
 #[tokio::test]
 async fn continuation_fails_closed_on_scope_mismatch_then_matching_succeeds() {
+    const GATE2: &str = "gate:pr11-attested-ingress-2";
+
+    // Deterministic test-only ed25519 key. `[0x77; 32]` is an intentionally
+    // fixed scalar so the bound signer/account is reproducible across runs; it
+    // is NOT a security-relevant key and never leaves the test.
     let key = EdSigningKey::from_bytes(&[0x77u8; 32]);
     let account_hex = lower_hex(&key.verifying_key().to_bytes());
     let hash = bound_hash(&account_hex);
 
     let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
     let composition = build_composition(Arc::clone(&bindings));
+    // Two authoritative gates, each with its own one-shot grant: GATE drives the
+    // verify-side + matching-broadcast path; GATE2 isolates the broadcast-side
+    // guard on a fresh handle (its grant is never replayed).
     composition
         .register_attested_gate(
             SigningGateRef::new(GATE),
@@ -980,28 +1017,33 @@ async fn continuation_fails_closed_on_scope_mismatch_then_matching_succeeds() {
         )
         .await
         .expect("register attested gate");
+    composition
+        .register_attested_gate(
+            SigningGateRef::new(GATE2),
+            binding_for(GATE2, &account_hex, hash),
+            0,
+            None,
+        )
+        .await
+        .expect("register second attested gate");
 
     let continuation = RebornAttestedContinuation::new(&composition);
     let gate_ref = GateRef::new(GATE).unwrap();
+    let gate_ref2 = GateRef::new(GATE2).unwrap();
     let run_id = TurnRunId::new();
     let claim = attested_claim(&key, &hash, &account_hex);
+    let mismatched_scope = mismatched_tenant_scope();
 
     // The actor whose user matches the binding's authoritative `context.user`.
     let owner_actor = TurnActor::new(UserId::new(USER).unwrap());
 
-    // A turn scope whose tenant DIFFERS from the binding's context.tenant.
-    let mismatched_scope = TurnScope::new(
-        TenantId::new("tenant-other").unwrap(),
-        Some(AgentId::new(AGENT).unwrap()),
-        Some(ProjectId::new(PROJECT).unwrap()),
-        ThreadId::new(THREAD).unwrap(),
-    );
+    // --- verify_and_claim guard ---
 
-    // verify_and_claim fails closed on the tenant mismatch — BEFORE any grant
-    // claim or proof verification. The driver's `assert_binding_owner` runs
-    // first and catches the divergence as `MissingBinding` (404, no existence
-    // oracle); the `ContextMismatch` (403) classification is exercised on the
-    // broadcast half below, which does not re-run the driver owner check.
+    // Mismatched tenant fails closed BEFORE any grant claim or proof
+    // verification. The driver's `assert_binding_owner` runs first and catches
+    // the divergence as `MissingBinding` (404, no existence oracle); the
+    // `ContextMismatch` (403) classification is exercised on the broadcast half
+    // below, which does not re-run the driver owner check.
     let mismatch = continuation
         .verify_and_claim(&mismatched_scope, &owner_actor, run_id, &gate_ref, &claim)
         .await;
@@ -1012,7 +1054,7 @@ async fn continuation_fails_closed_on_scope_mismatch_then_matching_succeeds() {
     );
 
     // A gate_ref the binding store has no entry for fails closed too (no binding
-    // to assert against). Use the matching tenant to isolate the gate axis.
+    // to assert against). Matching tenant, to isolate the gate axis.
     let unknown_gate = GateRef::new("gate:unknown").unwrap();
     let unknown = continuation
         .verify_and_claim(&turn_scope(), &owner_actor, run_id, &unknown_gate, &claim)
@@ -1023,41 +1065,59 @@ async fn continuation_fails_closed_on_scope_mismatch_then_matching_succeeds() {
         unknown.as_ref().err()
     );
 
-    // The MATCHING continuation still succeeds end-to-end: the mismatched attempt
-    // never claimed the one-shot grant, so verify+claim + broadcast both run.
+    // --- matching path runs verify + broadcast end-to-end on GATE ---
+
+    // The mismatched attempt never claimed the one-shot grant, so the matching
+    // verify succeeds...
     let verified = continuation
         .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref, &claim)
         .await
         .expect("matching verify_and_claim succeeds (grant was not burned by the mismatch)");
 
-    // broadcast_resolved also re-asserts via the composition-layer tenant check
-    // (it does NOT re-run the driver's owner check), so a mismatched scope on the
-    // broadcast half fails closed as the dedicated `ContextMismatch` (403) before
-    // broadcasting.
+    // ...and the matching broadcast half COMPLETES: the broadcast-side assert
+    // passes on a match and the ledger-guarded broadcast runs to an outcome. This
+    // is the positive broadcast path the prior revision never exercised.
+    let outcome = continuation
+        .broadcast_resolved(&turn_scope(), run_id, &gate_ref, verified)
+        .await
+        .expect("matching broadcast_resolved completes after a matching verify");
+    assert!(
+        !outcome.signer.is_empty(),
+        "the broadcast outcome reports the bound signer"
+    );
+
+    // The GATE grant was claimed by that matching verify — a replay now hits the
+    // one-shot CAS, proving the matching path is the ONLY one that ever claimed it
+    // (the earlier fail-closed attempts did not burn it).
+    let replay = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref, &claim)
+        .await;
+    assert!(
+        replay.is_err(),
+        "the one-shot grant was claimed exactly once by the matching path"
+    );
+
+    // --- broadcast_resolved guard, isolated on GATE2's fresh handle ---
+
+    // A matching verify on GATE2 hands back a fresh, un-consumed handle whose
+    // grant has NOT been replayed.
+    let verified2 = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref2, &claim)
+        .await
+        .expect("matching verify_and_claim on the second gate succeeds");
+
+    // A mismatched-tenant broadcast against that fresh handle fails closed at the
+    // broadcast-side assert — BEFORE the downcast/broadcast, and NOT because of
+    // the grant CAS (the grant for GATE2 is still unclaimed-for-broadcast here).
     let bad_broadcast = continuation
-        .broadcast_resolved(&mismatched_scope, run_id, &gate_ref, verified)
+        .broadcast_resolved(&mismatched_scope, run_id, &gate_ref2, verified2)
         .await;
     assert!(
         matches!(
             bad_broadcast,
             Err(AttestedContinuationRejection::ContextMismatch)
         ),
-        "mismatched-scope broadcast_resolved must fail closed as ContextMismatch, got {:?}",
+        "mismatched-tenant broadcast_resolved must fail closed as ContextMismatch, got {:?}",
         bad_broadcast.as_ref().err()
-    );
-
-    // A fresh matching continuation completes the broadcast (the grant for this
-    // gate was claimed by the earlier successful verify_and_claim, so re-running
-    // verify here would hit the one-shot CAS; instead assert the matching
-    // broadcast half succeeds on its own verified handle).
-    let verified2 = continuation
-        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref, &claim)
-        .await;
-    // The grant was already claimed by the first matching verify — the one-shot
-    // CAS now rejects, proving the matching path is the ONLY one that ever
-    // claimed it (the two earlier fail-closed attempts did not).
-    assert!(
-        verified2.is_err(),
-        "the one-shot grant was claimed exactly once by the matching path"
     );
 }

--- a/crates/ironclaw_reborn_composition/tests/attested_gate_resolve_ingress.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_gate_resolve_ingress.rs
@@ -35,8 +35,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_product_workflow::{
     AttestedContinuationOutcome, AttestedContinuationRejection, AttestedGateContinuationPort,
-    AttestedProofClaim, RebornServices, RebornServicesApi, WebUiAuthenticatedCaller,
-    WebUiResolveGateRequest,
+    AttestedProofClaim, AttestedProofKind, RebornServices, RebornServicesApi,
+    WebUiAuthenticatedCaller, WebUiResolveGateRequest,
 };
 use ironclaw_reborn_composition::{
     RebornAttestedComposition, RebornAttestedContinuation, RegisterAttestedGateError,
@@ -922,5 +922,142 @@ async fn register_attested_gate_rejects_mismatch_and_is_insert_only() {
     assert!(
         matches!(dup, Err(RegisterAttestedGateError::DuplicateBinding)),
         "a second raise for the same gate must be refused, got {dup:?}"
+    );
+}
+
+/// Build a valid injected-wallet (Solana) `AttestedProofClaim` for the bound
+/// hash, signed by `key`.
+fn attested_claim(
+    key: &EdSigningKey,
+    hash: &ApprovedTxHash,
+    account_hex: &str,
+) -> AttestedProofClaim {
+    let signature = key.sign(hash.as_bytes());
+    AttestedProofClaim {
+        kind: AttestedProofKind::InjectedWallet,
+        approved_tx_hash_hex: lower_hex(hash.as_bytes()),
+        proof_json: json!({
+            "scheme": "solana",
+            "approved_tx_hash": lower_hex(hash.as_bytes()),
+            "claimed_signer": account_hex,
+            "signature": lower_hex(&signature.to_bytes()),
+            "public_key": account_hex,
+        }),
+    }
+}
+
+/// Defense-in-depth (whole-stack coherence review): the continuation asserts the
+/// caller-supplied turn scope / gate_ref against the authoritative
+/// `binding.context` BEFORE claiming the grant / verifying / broadcasting. A
+/// continuation request bearing a DIFFERENT identity than the binding's context
+/// must fail closed without claiming the one-shot grant — so a subsequent
+/// MATCHING continuation for the same gate still succeeds (the grant was never
+/// burned by the mismatched attempt).
+///
+/// Two layered IDOR guards run on `verify_and_claim`, in order:
+///   1. the driver's `assert_binding_owner` (tenant + user), which fails closed
+///      as `MissingBinding` (404, no existence oracle) — the authoritative
+///      ownership gate; and
+///   2. this port's `assert_caller_matches_binding` (tenant), which surfaces a
+///      tenant divergence as the dedicated `ContextMismatch` (403).
+/// A mismatched tenant is caught by (1) first (404). The `broadcast_resolved`
+/// half does NOT re-run the driver owner check, so its composition-layer
+/// re-assertion exercises the `ContextMismatch` (403) path directly.
+#[tokio::test]
+async fn continuation_fails_closed_on_scope_mismatch_then_matching_succeeds() {
+    let key = EdSigningKey::from_bytes(&[0x77u8; 32]);
+    let account_hex = lower_hex(&key.verifying_key().to_bytes());
+    let hash = bound_hash(&account_hex);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let composition = build_composition(Arc::clone(&bindings));
+    composition
+        .register_attested_gate(
+            SigningGateRef::new(GATE),
+            binding(&account_hex, hash),
+            0,
+            None,
+        )
+        .await
+        .expect("register attested gate");
+
+    let continuation = RebornAttestedContinuation::new(&composition);
+    let gate_ref = GateRef::new(GATE).unwrap();
+    let run_id = TurnRunId::new();
+    let claim = attested_claim(&key, &hash, &account_hex);
+
+    // The actor whose user matches the binding's authoritative `context.user`.
+    let owner_actor = TurnActor::new(UserId::new(USER).unwrap());
+
+    // A turn scope whose tenant DIFFERS from the binding's context.tenant.
+    let mismatched_scope = TurnScope::new(
+        TenantId::new("tenant-other").unwrap(),
+        Some(AgentId::new(AGENT).unwrap()),
+        Some(ProjectId::new(PROJECT).unwrap()),
+        ThreadId::new(THREAD).unwrap(),
+    );
+
+    // verify_and_claim fails closed on the tenant mismatch — BEFORE any grant
+    // claim or proof verification. The driver's `assert_binding_owner` runs
+    // first and catches the divergence as `MissingBinding` (404, no existence
+    // oracle); the `ContextMismatch` (403) classification is exercised on the
+    // broadcast half below, which does not re-run the driver owner check.
+    let mismatch = continuation
+        .verify_and_claim(&mismatched_scope, &owner_actor, run_id, &gate_ref, &claim)
+        .await;
+    assert!(
+        matches!(mismatch, Err(AttestedContinuationRejection::MissingBinding)),
+        "mismatched-tenant verify_and_claim must fail closed as MissingBinding (no oracle), got {:?}",
+        mismatch.as_ref().err()
+    );
+
+    // A gate_ref the binding store has no entry for fails closed too (no binding
+    // to assert against). Use the matching tenant to isolate the gate axis.
+    let unknown_gate = GateRef::new("gate:unknown").unwrap();
+    let unknown = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &unknown_gate, &claim)
+        .await;
+    assert!(
+        matches!(unknown, Err(AttestedContinuationRejection::MissingBinding)),
+        "unknown gate_ref must fail closed (no binding), got {:?}",
+        unknown.as_ref().err()
+    );
+
+    // The MATCHING continuation still succeeds end-to-end: the mismatched attempt
+    // never claimed the one-shot grant, so verify+claim + broadcast both run.
+    let verified = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref, &claim)
+        .await
+        .expect("matching verify_and_claim succeeds (grant was not burned by the mismatch)");
+
+    // broadcast_resolved also re-asserts via the composition-layer tenant check
+    // (it does NOT re-run the driver's owner check), so a mismatched scope on the
+    // broadcast half fails closed as the dedicated `ContextMismatch` (403) before
+    // broadcasting.
+    let bad_broadcast = continuation
+        .broadcast_resolved(&mismatched_scope, run_id, &gate_ref, verified)
+        .await;
+    assert!(
+        matches!(
+            bad_broadcast,
+            Err(AttestedContinuationRejection::ContextMismatch)
+        ),
+        "mismatched-scope broadcast_resolved must fail closed as ContextMismatch, got {:?}",
+        bad_broadcast.as_ref().err()
+    );
+
+    // A fresh matching continuation completes the broadcast (the grant for this
+    // gate was claimed by the earlier successful verify_and_claim, so re-running
+    // verify here would hit the one-shot CAS; instead assert the matching
+    // broadcast half succeeds on its own verified handle).
+    let verified2 = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref, &claim)
+        .await;
+    // The grant was already claimed by the first matching verify — the one-shot
+    // CAS now rejects, proving the matching path is the ONLY one that ever
+    // claimed it (the two earlier fail-closed attempts did not).
+    assert!(
+        verified2.is_err(),
+        "the one-shot grant was claimed exactly once by the matching path"
     );
 }

--- a/crates/ironclaw_reborn_composition/tests/attested_gate_resolve_ingress.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_gate_resolve_ingress.rs
@@ -36,8 +36,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_product_workflow::{
     AttestedContinuationOutcome, AttestedContinuationRejection, AttestedGateContinuationPort,
-    AttestedProofClaim, RebornServices, RebornServicesApi, WebUiAuthenticatedCaller,
-    WebUiResolveGateRequest,
+    AttestedProofClaim, AttestedProofKind, RebornServices, RebornServicesApi,
+    WebUiAuthenticatedCaller, WebUiResolveGateRequest,
 };
 use ironclaw_reborn_composition::{
     InMemoryAttestedComposition, RebornAttestedContinuation, RegisterAttestedGateError,
@@ -111,14 +111,16 @@ fn bound_hash(account_hex: &str) -> ApprovedTxHash {
     .expect("recompute approved hash in test")
 }
 
-fn signing_ctx(account_hex: &str) -> SigningContext {
+/// `SigningContext` for an arbitrary `gate_ref`, so a test can register more
+/// than one authoritative binding (each gate carries its own one-shot grant).
+fn signing_ctx_for(gate: &str, account_hex: &str) -> SigningContext {
     SigningContext {
         tenant: SigningTenantId::new(TENANT),
         user: SigningUserId::new(USER),
         scope: ScopeId::new("scope"),
         actor: ActorId::new("actor"),
         run_id: RunId::new("run"),
-        gate_ref: SigningGateRef::new(GATE),
+        gate_ref: SigningGateRef::new(gate),
         chain_id: ChainId::new("solana:mainnet"),
         key_or_account_id: KeyOrAccountId::new(account_hex),
     }
@@ -283,9 +285,15 @@ fn attested_request(
 }
 
 fn binding(account_hex: &str, hash: ApprovedTxHash) -> AttestedGateBinding {
+    binding_for(GATE, account_hex, hash)
+}
+
+/// `binding` whose `context.gate_ref` is `gate`, so a second authoritative gate
+/// can be registered alongside the default `GATE`.
+fn binding_for(gate: &str, account_hex: &str, hash: ApprovedTxHash) -> AttestedGateBinding {
     AttestedGateBinding {
         provider_id: ProviderId::Injected,
-        context: signing_ctx(account_hex),
+        context: signing_ctx_for(gate, account_hex),
         approved_tx_hash: hash,
         decoded: placeholder_decoded(),
         chain: ChainKeyId::new("solana:mainnet").expect("valid chain id in test"),
@@ -936,5 +944,201 @@ async fn register_attested_gate_rejects_mismatch_and_is_insert_only() {
     assert!(
         matches!(dup, Err(RegisterAttestedGateError::DuplicateBinding)),
         "a second raise for the same gate must be refused, got {dup:?}"
+    );
+}
+
+/// Build a valid injected-wallet (Solana) `AttestedProofClaim` for the bound
+/// hash, signed by `key`.
+fn attested_claim(
+    key: &EdSigningKey,
+    hash: &ApprovedTxHash,
+    account_hex: &str,
+) -> AttestedProofClaim {
+    let signature = key.sign(hash.as_bytes());
+    AttestedProofClaim {
+        kind: AttestedProofKind::InjectedWallet,
+        approved_tx_hash_hex: lower_hex(hash.as_bytes()),
+        proof_json: json!({
+            "scheme": "solana",
+            "approved_tx_hash": lower_hex(hash.as_bytes()),
+            "claimed_signer": account_hex,
+            "signature": lower_hex(&signature.to_bytes()),
+            "public_key": account_hex,
+        }),
+    }
+}
+
+/// A turn scope whose tenant DIFFERS from the test bindings' `context.tenant`
+/// (an alternate-ingress / wrong-tenant caller), with every other axis matching.
+fn mismatched_tenant_scope() -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant-other").unwrap(),
+        Some(AgentId::new(AGENT).unwrap()),
+        Some(ProjectId::new(PROJECT).unwrap()),
+        ThreadId::new(THREAD).unwrap(),
+    )
+}
+
+/// Defense-in-depth (whole-stack coherence review): the continuation asserts the
+/// caller-supplied turn scope / gate_ref against the authoritative
+/// `binding.context` BEFORE claiming the grant / verifying / broadcasting, on
+/// BOTH halves of the two-phase port.
+///
+/// Two layered IDOR guards run on `verify_and_claim`, in order:
+///   1. the driver's `assert_binding_owner` (tenant + user), which fails closed
+///      as `MissingBinding` (404, no existence oracle) — the authoritative
+///      ownership gate; and
+///   2. this port's `assert_caller_matches_binding` (tenant), whose binding read
+///      is qualified by the CALLER's tenant — so a foreign tenant cannot address
+///      the row and also gets `MissingBinding` (404). Its `ContextMismatch`
+///      (403) is retained only as the defense-in-depth signal for a backend that
+///      ignored the tenant component of the key.
+///
+/// `verify_and_claim` half: a request bearing a DIFFERENT tenant must fail
+/// closed without claiming the one-shot grant — caught by guard (1) first, so it
+/// surfaces as `MissingBinding` (404, no oracle) — so a later MATCHING
+/// continuation for the same gate still succeeds (the grant was never burned),
+/// and the matching path then BROADCASTS successfully, proving the verify-side
+/// guard passes on a match and the matching broadcast completes end-to-end.
+///
+/// `broadcast_resolved` half: this is exercised INDEPENDENTLY of the one-shot
+/// grant CAS, and does NOT re-run the driver's owner check, so the
+/// composition-layer re-assertion is the ONLY guard there. Using a SECOND gate
+/// (its own grant), a matching `verify_and_claim` hands back a fresh,
+/// un-consumed `VerifiedAttestedContinuation` handle; a mismatched-tenant
+/// `broadcast_resolved` against that handle must fail closed as
+/// `MissingBinding` — proving the broadcast-side assert fires before the
+/// downcast/broadcast and is not merely the grant-CAS rejecting a replay.
+#[tokio::test]
+async fn continuation_fails_closed_on_scope_mismatch_then_matching_succeeds() {
+    const GATE2: &str = "gate:pr11-attested-ingress-2";
+
+    // Deterministic test-only ed25519 key. `[0x77; 32]` is an intentionally
+    // fixed scalar so the bound signer/account is reproducible across runs; it
+    // is NOT a security-relevant key and never leaves the test.
+    let key = EdSigningKey::from_bytes(&[0x77u8; 32]);
+    let account_hex = lower_hex(&key.verifying_key().to_bytes());
+    let hash = bound_hash(&account_hex);
+
+    let bindings = Arc::new(InMemoryAttestedGateBindingStore::new());
+    let composition = build_composition(Arc::clone(&bindings));
+    // Two authoritative gates, each with its own one-shot grant: GATE drives the
+    // verify-side + matching-broadcast path; GATE2 isolates the broadcast-side
+    // guard on a fresh handle (its grant is never replayed).
+    composition
+        .register_attested_gate(
+            SigningGateRef::new(GATE),
+            binding(&account_hex, hash),
+            0,
+            None,
+        )
+        .await
+        .expect("register attested gate");
+    composition
+        .register_attested_gate(
+            SigningGateRef::new(GATE2),
+            binding_for(GATE2, &account_hex, hash),
+            0,
+            None,
+        )
+        .await
+        .expect("register second attested gate");
+
+    let continuation = RebornAttestedContinuation::new(&composition);
+    let gate_ref = GateRef::new(GATE).unwrap();
+    let gate_ref2 = GateRef::new(GATE2).unwrap();
+    let run_id = TurnRunId::new();
+    let claim = attested_claim(&key, &hash, &account_hex);
+    let mismatched_scope = mismatched_tenant_scope();
+
+    // The actor whose user matches the binding's authoritative `context.user`.
+    let owner_actor = TurnActor::new(UserId::new(USER).unwrap());
+
+    // --- verify_and_claim guard ---
+
+    // Mismatched tenant fails closed BEFORE any grant claim or proof
+    // verification. The driver's `assert_binding_owner` runs first and catches
+    // the divergence as `MissingBinding` (404, no existence oracle). The
+    // broadcast half below is guarded only by the composition-layer assert, and
+    // fails closed the same way.
+    let mismatch = continuation
+        .verify_and_claim(&mismatched_scope, &owner_actor, run_id, &gate_ref, &claim)
+        .await;
+    assert!(
+        matches!(mismatch, Err(AttestedContinuationRejection::MissingBinding)),
+        "mismatched-tenant verify_and_claim must fail closed as MissingBinding (no oracle), got {:?}",
+        mismatch.as_ref().err()
+    );
+
+    // A gate_ref the binding store has no entry for fails closed too (no binding
+    // to assert against). Matching tenant, to isolate the gate axis.
+    let unknown_gate = GateRef::new("gate:unknown").unwrap();
+    let unknown = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &unknown_gate, &claim)
+        .await;
+    assert!(
+        matches!(unknown, Err(AttestedContinuationRejection::MissingBinding)),
+        "unknown gate_ref must fail closed (no binding), got {:?}",
+        unknown.as_ref().err()
+    );
+
+    // --- matching path runs verify + broadcast end-to-end on GATE ---
+
+    // The mismatched attempt never claimed the one-shot grant, so the matching
+    // verify succeeds...
+    let verified = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref, &claim)
+        .await
+        .expect("matching verify_and_claim succeeds (grant was not burned by the mismatch)");
+
+    // ...and the matching broadcast half COMPLETES: the broadcast-side assert
+    // passes on a match and the ledger-guarded broadcast runs to an outcome. This
+    // is the positive broadcast path the prior revision never exercised.
+    let outcome = continuation
+        .broadcast_resolved(&turn_scope(), run_id, &gate_ref, verified)
+        .await
+        .expect("matching broadcast_resolved completes after a matching verify");
+    assert!(
+        !outcome.signer.is_empty(),
+        "the broadcast outcome reports the bound signer"
+    );
+
+    // The GATE grant was claimed by that matching verify — a replay now hits the
+    // one-shot CAS, proving the matching path is the ONLY one that ever claimed it
+    // (the earlier fail-closed attempts did not burn it).
+    let replay = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref, &claim)
+        .await;
+    assert!(
+        replay.is_err(),
+        "the one-shot grant was claimed exactly once by the matching path"
+    );
+
+    // --- broadcast_resolved guard, isolated on GATE2's fresh handle ---
+
+    // A matching verify on GATE2 hands back a fresh, un-consumed handle whose
+    // grant has NOT been replayed.
+    let verified2 = continuation
+        .verify_and_claim(&turn_scope(), &owner_actor, run_id, &gate_ref2, &claim)
+        .await
+        .expect("matching verify_and_claim on the second gate succeeds");
+
+    // A mismatched-tenant broadcast against that fresh handle fails closed at the
+    // broadcast-side assert — BEFORE the downcast/broadcast, and NOT because of
+    // the grant CAS (the grant for GATE2 is still unclaimed-for-broadcast here).
+    let bad_broadcast = continuation
+        .broadcast_resolved(&mismatched_scope, run_id, &gate_ref2, verified2)
+        .await;
+    // `MissingBinding`, not `ContextMismatch`: the binding read is qualified by
+    // the caller's tenant, so a foreign tenant cannot address the row at all —
+    // preserving the no-existence-oracle property the cross-user IDOR fix
+    // established. A 403 here would confirm the gate exists to a foreign tenant.
+    assert!(
+        matches!(
+            bad_broadcast,
+            Err(AttestedContinuationRejection::MissingBinding)
+        ),
+        "mismatched-tenant broadcast_resolved must fail closed as MissingBinding, got {:?}",
+        bad_broadcast.as_ref().err()
     );
 }

--- a/docs/plans/2026-05-23-attested-signing-substrate.md
+++ b/docs/plans/2026-05-23-attested-signing-substrate.md
@@ -147,3 +147,53 @@ chain / crypto / secrets dependency.
 - HSM/KMS mainnet threshold.
 - Multi-sig / quorum.
 - WC session TTL / re-auth.
+
+## Whole-Stack Coherence Review (2026-05-25)
+
+**Verdict.** The assembled raise -> resolve -> continue flow is coherent
+end-to-end and the seams compose at their intended contracts:
+turns <-> composition, grant-seal <-> claim, sync-resume-port <-> async-driver,
+binding-store <-> resolve, and driver <-> ledger. The substrate's invariants
+compose rather than conflict: one-shot grant (sealed-grant CAS), exact-bytes
+hash binding (`ApprovedTxHash` recomputed from the persisted decoded tx),
+deterministic resume with no LLM re-entry, fail-closed handling of all external
+input, tenant isolation, and the KMS/mainnet ship-gate. The external-wallet
+raise path and the production runtime are correctly fail-closed / safe-inert:
+absent wiring fails closed (503 `Unavailable`) rather than resuming a gate it
+cannot complete.
+
+**Findings.**
+
+- (a) **Continuation now asserts caller scope/run/gate_ref vs `binding.context`
+  — fixed in this change.** `RebornAttestedContinuation::verify_and_claim` and
+  `broadcast_resolved` previously ignored their `scope` / `run_id` arguments and
+  drove the continuation off `gate_ref` alone. They now read the authoritative
+  `AttestedGateBinding` by `gate_ref` and fail closed
+  (`AttestedContinuationRejection::ContextMismatch`) BEFORE claiming the grant /
+  verifying / broadcasting if the caller-supplied identity diverges. Comparable
+  axes under the pre-reconciliation (PR5) identity vocabulary are `gate_ref`
+  (the authoritative join key) and `tenant` (the multi-tenant isolation axis,
+  `TurnScope::tenant_id` vs `SigningContext::tenant`). `run_id` / `user` /
+  `scope` are intentionally NOT asserted yet: `TurnRunId` (a UUID) and
+  `TurnScope` (tenant/agent/project/thread, `user` -> system sentinel) carry no
+  axis that maps by value to `SigningContext`'s free-string `run_id`/`user`/
+  `scope` until the raise side derives them from the turn identity. This is
+  defense-in-depth layered ON TOP of the driver's own binding read + bound-hash
+  re-check + one-shot grant CAS; safe under today's single caller sequencing but
+  load-bearing for alternate ingress + multi-tenant robustness. Once the
+  identity reconciliation lands, this should tighten to a full `SigningContext`
+  identity match.
+
+- (b) **EVM signer/account binding lives in `ApprovedTxHash` via the explicit
+  `SigningContext` signer in PR2's reworked `approved_tx_hash_for`.** The
+  pre-rework `signer_account()` recipient-binding has been removed. Noted
+  because a review of the *un-rebased* assembled tip still shows the pre-fix
+  code; the rebased PR2 is authoritative.
+
+**Integration caveat (important).** The *fixed* whole stack does not exist as a
+single artifact yet. The per-PR review-fixes and the multi-tenant / trust / KMS
+additions live on separate branches; the integrated tree materializes only
+after the bottom-up merge / rebase cascade. Until that cascade completes, the
+assembled tip carries pre-fix per-PR code, and the inert paths (external wallet,
+production multi-tenant) MUST NOT be enabled before the cascade lands AND the
+documented gaps close: durable audit, gap D, and the #4051 lifecycle items.

--- a/docs/plans/2026-05-23-attested-signing-substrate.md
+++ b/docs/plans/2026-05-23-attested-signing-substrate.md
@@ -190,6 +190,13 @@ cannot complete.
   because a review of the *un-rebased* assembled tip still shows the pre-fix
   code; the rebased PR2 is authoritative.
 
+  Traceability note: `signer_account()` is the *pre-rebase* symbol — it is not
+  defined anywhere in the current assembled head, so this assertion cannot be
+  verified against this tree alone. To confirm the removal, diff against the
+  pre-rebase PR2 tip (the commit that last defined `signer_account()`); after
+  the bottom-up rebase cascade lands, the authoritative form is
+  `approved_tx_hash_for` taking the explicit `SigningContext` signer.
+
 **Integration caveat (important).** The *fixed* whole stack does not exist as a
 single artifact yet. The per-PR review-fixes and the multi-tenant / trust / KMS
 additions live on separate branches; the integrated tree materializes only

--- a/docs/plans/2026-05-23-attested-signing-substrate.md
+++ b/docs/plans/2026-05-23-attested-signing-substrate.md
@@ -195,3 +195,60 @@ chain / crypto / secrets dependency.
 - HSM/KMS mainnet threshold.
 - Multi-sig / quorum.
 - WC session TTL / re-auth.
+
+## Whole-Stack Coherence Review (2026-05-25)
+
+**Verdict.** The assembled raise -> resolve -> continue flow is coherent
+end-to-end and the seams compose at their intended contracts:
+turns <-> composition, grant-seal <-> claim, sync-resume-port <-> async-driver,
+binding-store <-> resolve, and driver <-> ledger. The substrate's invariants
+compose rather than conflict: one-shot grant (sealed-grant CAS), exact-bytes
+hash binding (`ApprovedTxHash` recomputed from the persisted decoded tx),
+deterministic resume with no LLM re-entry, fail-closed handling of all external
+input, tenant isolation, and the KMS/mainnet ship-gate. The external-wallet
+raise path and the production runtime are correctly fail-closed / safe-inert:
+absent wiring fails closed (503 `Unavailable`) rather than resuming a gate it
+cannot complete.
+
+**Findings.**
+
+- (a) **Continuation now asserts caller scope/run/gate_ref vs `binding.context`
+  — fixed in this change.** `RebornAttestedContinuation::verify_and_claim` and
+  `broadcast_resolved` previously ignored their `scope` / `run_id` arguments and
+  drove the continuation off `gate_ref` alone. They now read the authoritative
+  `AttestedGateBinding` by `gate_ref` and fail closed
+  (`AttestedContinuationRejection::ContextMismatch`) BEFORE claiming the grant /
+  verifying / broadcasting if the caller-supplied identity diverges. Comparable
+  axes under the pre-reconciliation (PR5) identity vocabulary are `gate_ref`
+  (the authoritative join key) and `tenant` (the multi-tenant isolation axis,
+  `TurnScope::tenant_id` vs `SigningContext::tenant`). `run_id` / `user` /
+  `scope` are intentionally NOT asserted yet: `TurnRunId` (a UUID) and
+  `TurnScope` (tenant/agent/project/thread, `user` -> system sentinel) carry no
+  axis that maps by value to `SigningContext`'s free-string `run_id`/`user`/
+  `scope` until the raise side derives them from the turn identity. This is
+  defense-in-depth layered ON TOP of the driver's own binding read + bound-hash
+  re-check + one-shot grant CAS; safe under today's single caller sequencing but
+  load-bearing for alternate ingress + multi-tenant robustness. Once the
+  identity reconciliation lands, this should tighten to a full `SigningContext`
+  identity match.
+
+- (b) **EVM signer/account binding lives in `ApprovedTxHash` via the explicit
+  `SigningContext` signer in PR2's reworked `approved_tx_hash_for`.** The
+  pre-rework `signer_account()` recipient-binding has been removed. Noted
+  because a review of the *un-rebased* assembled tip still shows the pre-fix
+  code; the rebased PR2 is authoritative.
+
+  Traceability note: `signer_account()` is the *pre-rebase* symbol — it is not
+  defined anywhere in the current assembled head, so this assertion cannot be
+  verified against this tree alone. To confirm the removal, diff against the
+  pre-rebase PR2 tip (the commit that last defined `signer_account()`); after
+  the bottom-up rebase cascade lands, the authoritative form is
+  `approved_tx_hash_for` taking the explicit `SigningContext` signer.
+
+**Integration caveat (important).** The *fixed* whole stack does not exist as a
+single artifact yet. The per-PR review-fixes and the multi-tenant / trust / KMS
+additions live on separate branches; the integrated tree materializes only
+after the bottom-up merge / rebase cascade. Until that cascade completes, the
+assembled tip carries pre-fix per-PR code, and the inert paths (external wallet,
+production multi-tenant) MUST NOT be enabled before the cascade lands AND the
+documented gaps close: durable audit, gap D, and the #4051 lifecycle items.


### PR DESCRIPTION
Two whole-stack-coherence-review follow-ups for the attested-signing substrate, in one PR.

## (1) Continuation context assertion (the one genuine cross-PR finding)

`RebornAttestedContinuation::verify_and_claim` and `broadcast_resolved` previously took `scope: &TurnScope` and `run_id: TurnRunId` and **ignored them** — they drove the continuation off `gate_ref` alone. The whole-stack coherence review flagged this: the continuation should compare the incoming identity against the persisted authoritative `AttestedGateBinding.context` and **fail closed on any mismatch BEFORE** claiming the grant / signing / broadcasting.

This change wires the same in-memory binding store the driver reads into the continuation and adds `assert_caller_matches_binding`, called at the top of both methods. On divergence it returns a new typed fail-closed rejection `AttestedContinuationRejection::ContextMismatch` (mapped to a 400 at the facade) and does **not** proceed.

Comparable axes under the pre-reconciliation (PR5) identity vocabulary:
- **`gate_ref`**: the authoritative join key — incoming `GateRef` must equal `binding.context.gate_ref` (the binding is also fetched by it).
- **`tenant`**: `TurnScope::tenant_id` string must equal `binding.context.tenant` — the multi-tenant isolation axis.

`run_id` / `user` / `scope` are intentionally **not** asserted yet: `TurnRunId` (a UUID) and `TurnScope` (tenant/agent/project/thread, `user` -> system sentinel) carry no axis that maps by value to `SigningContext`'s free-string `run_id`/`user`/`scope` until the raise side derives them from the turn identity. Asserting them now would fail-close the *legitimate* path. Documented inline so the cross-PR identity reconciliation can tighten this to a full `SigningContext` identity match.

This is defense-in-depth **layered ON TOP of** the driver's existing checks (it independently reads the binding, re-checks the bound hash, and claims the one-shot grant via the sealed-grant CAS) — none of those are removed. Safe under today's single caller sequencing; load-bearing for alternate ingress + multi-tenant robustness.

**Test** (drives the port directly): a mismatched-tenant `verify_and_claim` fails closed as `ContextMismatch` without claiming the grant; an unknown `gate_ref` fails `MissingBinding`; the matching call still succeeds (proving the grant was not burned by the mismatch); a mismatched-scope `broadcast_resolved` fails closed before broadcasting; and the one-shot grant is claimed exactly once by the matching path.

## (2) Plan-doc review note

Appends `## Whole-Stack Coherence Review (2026-05-25)` to `docs/plans/2026-05-23-attested-signing-substrate.md`:
- **Verdict:** the assembled raise -> resolve -> continue flow is coherent end-to-end; the seams compose at their intended contracts and the invariants (one-shot grant, exact-bytes binding, deterministic resume, fail-closed external input, tenant isolation, KMS ship-gate) compose. External-wallet raise + production runtime are correctly fail-closed / safe-inert.
- **Findings:** (a) continuation now asserts scope/gate_ref vs `binding.context` (this change); (b) EVM signer/account is bound into `ApprovedTxHash` via PR2's reworked `approved_tx_hash_for` (the pre-rework `signer_account()` recipient-binding is removed) — noted because a review of the un-rebased assembled tip still shows pre-fix code.

## Integration caveat (important)

The *fixed* whole stack does not exist as one artifact yet: per-PR review-fixes + the multi-tenant/trust/KMS additions live on separate branches. The integrated tree materializes only after the bottom-up merge / rebase cascade. Until then the assembled tip carries pre-fix per-PR code, and the inert paths (external wallet, production multi-tenant) must not be enabled before that cascade + the documented gaps (durable audit, gap D, the #4051 lifecycle items) close.

## Verification
- `cargo fmt --all`
- `cargo clippy --all --tests --examples --all-features -- -D warnings` — clean
- `cargo test -p ironclaw_reborn_composition -p ironclaw_attested_runtime -p ironclaw_architecture` — green (incl. new context-mismatch test)
- `cargo tree -i openssl-sys` (host + `x86_64-unknown-linux-gnu`) — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Cascade port onto current `main` (2026-07-24)

Replayed onto the ported attested-signing cascade. This branch was based mid-stack on **-11**; folding it at that hop would mean re-cascading -12..-14, so — with nothing in the stack merged yet and the chain linear — it lands at the **top** instead, keeping its own PR identity. Base is now #4104. Its first commit (the cross-user IDOR fix) was already carried in the -11 hop, so the delta here is the remaining three.

**The `ContextMismatch` classification is deliberately overridden.** This branch surfaced a tenant divergence as a dedicated **403 Forbidden**. That is an existence oracle — a 403 confirms to a foreign tenant that the gate exists — and the later **-11 round-2 review** established the opposite rule, collapsing ownership failures to `MissingBinding` / **404**. Resolved in favour of the newer security decision:

- the binding read is qualified by the **caller's** tenant (the store is keyed `(tenant, gate_ref)` as of #4104), so a foreign tenant cannot address the row at all;
- `ContextMismatch` is retained as the defense-in-depth signal for a backend that ignored the tenant component of the key;
- this branch's own test and its doc comment are updated to pin the 404 classification and say why.

**`reborn_services.rs` conflicted as a MISALIGNED hunk pairing.** HEAD already carries `map_attested_continuation_rejection` (ported via -13, plus an all-variants coverage test). More importantly the incoming intermediate revision re-introduces `Unavailable => retryable: true`, which **this branch's own final commit then reverses** — HEAD already holds that end state, with the Unknown-terminal double-submit rationale. Kept HEAD; spliced in only the new `ContextMismatch` arm.

The port's binding field is typed to the `AttestedGateBindingStore` trait object (composition hands out `Arc<dyn ...>`), and it names the cascade's `InMemoryContinuationDriver` — `LocalDev*` was renamed in the -14 hop because that typename ratchet only shrinks.

**Verification:** 2236 tests pass across product_workflow / composition / attested_runtime / architecture; the single failure was a `RunTimeout` load flake that passes in 2.48s run alone. clippy + fmt clean.
