### PR TITLE
fix(signing): fail-closed wire encoding for attestation canonical bytes (#3961 follow-up)

### DIFF
--- a/crates/ironclaw_attestation/src/approved_tx_hash.rs
+++ b/crates/ironclaw_attestation/src/approved_tx_hash.rs
@@ -29,6 +29,7 @@ use sha2::{Digest, Sha256};
 
 use crate::canonical::canonical_signing_bytes;
 use crate::decoded_tx::{DecodedTransaction, RenderingSchemaVersion};
+use crate::error::AttestationError;
 use crate::rendered::{RenderedTx, render};
 
 /// Domain separator for the approved-tx hash pre-image. Distinct from the
@@ -79,17 +80,17 @@ pub fn approved_tx_hash_for(
     tx: &DecodedTransaction,
     signer_account: &str,
     schema_version: RenderingSchemaVersion,
-) -> ApprovedTxHash {
-    let rendered = render(tx, schema_version);
-    let canonical = canonical_signing_bytes(tx, schema_version);
-    compute_approved_tx_hash_inner(
+) -> Result<ApprovedTxHash, AttestationError> {
+    let rendered = render(tx, schema_version)?;
+    let canonical = canonical_signing_bytes(tx, schema_version)?;
+    Ok(compute_approved_tx_hash_inner(
         &rendered,
         &canonical,
         signer_account,
         &tx.chain_network(),
         &tx.tx_type_label(),
         schema_version,
-    )
+    ))
 }
 
 /// Compute the binding [`ApprovedTxHash`] from already-derived components.

--- a/crates/ironclaw_attestation/src/canonical.rs
+++ b/crates/ironclaw_attestation/src/canonical.rs
@@ -26,6 +26,7 @@
 //! collide, so a hidden / reordered / extra field always changes the bytes.
 
 use crate::decoded_tx::{DecodedTransaction, RenderingSchemaVersion};
+use crate::error::AttestationError;
 use crate::fields::project;
 
 /// Domain separator for the canonical signing-bytes encoding. Distinct from the
@@ -48,8 +49,8 @@ fn push_lp(out: &mut Vec<u8>, bytes: &[u8]) {
 pub fn canonical_signing_bytes(
     tx: &DecodedTransaction,
     schema_version: RenderingSchemaVersion,
-) -> Vec<u8> {
-    let fields = project(tx);
+) -> Result<Vec<u8>, AttestationError> {
+    let fields = project(tx)?;
     let mut out = Vec::new();
     out.extend_from_slice(CANONICAL_DOMAIN);
     push_lp(&mut out, tx.chain_tag().as_bytes());
@@ -61,5 +62,5 @@ pub fn canonical_signing_bytes(
         push_lp(&mut out, field.tag.as_bytes());
         push_lp(&mut out, &field.canonical_bytes);
     }
-    out
+    Ok(out)
 }

--- a/crates/ironclaw_attestation/src/decoded_tx.rs
+++ b/crates/ironclaw_attestation/src/decoded_tx.rs
@@ -283,13 +283,19 @@ pub enum NearAction {
         /// Beneficiary account id.
         beneficiary_id: String,
     },
-    /// Meta-transaction delegate action (NEP-366). Carries the inner action's
-    /// fields needed for the signed commitment.
+    /// Meta-transaction delegate action (NEP-366). Carries the full inner
+    /// `DelegateAction`, including its inner actions, so the signed commitment
+    /// is injective over them.
     Delegate {
         /// The account whose key signs the delegate action.
         sender_id: String,
         /// The receiver of the delegated actions.
         receiver_id: String,
+        /// The inner actions the delegate authorizes. NEP-366 types these as
+        /// `NonDelegateAction`: a delegate may not nest another delegate. A
+        /// nested `Delegate` here is unrepresentable on-chain and is rejected
+        /// (fail closed) at canonicalization time rather than serialized.
+        actions: Vec<NearAction>,
         /// Nonce for the delegate action.
         nonce: u64,
         /// Block height past which the delegate action is invalid.

--- a/crates/ironclaw_attestation/src/error.rs
+++ b/crates/ironclaw_attestation/src/error.rs
@@ -1,0 +1,61 @@
+//! Error type for the attestation core.
+//!
+//! Canonicalization is **fail-closed**: any decoded transaction that cannot be
+//! reproduced byte-for-byte as the exact wallet/HSM-signed payload is rejected
+//! rather than silently truncated. Silent truncation of a wire length prefix
+//! would desynchronize the length from the payload and let an attacker smuggle
+//! extra instructions/accounts/value past the what-you-see-is-what-you-sign
+//! (WYSIWYS) binding (approve-A / sign-B). Returning an error instead of
+//! truncating keeps the canonical bytes and the bound [`crate::ApprovedTxHash`]
+//! an exact, injective commitment to the signed wire form.
+
+use thiserror::Error;
+
+/// An error produced while projecting / canonicalizing a decoded transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AttestationError {
+    /// A Solana compact-u16 ("shortvec") length would exceed `u16::MAX`. The
+    /// Solana wire format cannot represent it, so faithfully reproducing the
+    /// signed bytes is impossible — reject rather than truncate.
+    #[error(
+        "solana {what} length {len} exceeds the compact-u16 maximum {max}; \
+         cannot reproduce the signed wire bytes"
+    )]
+    SolanaShortVecOverflow {
+        /// Which vector overflowed (e.g. `account_indices`, `instructions`).
+        what: &'static str,
+        /// The offending length.
+        len: usize,
+        /// The compact-u16 maximum (`u16::MAX`).
+        max: usize,
+    },
+
+    /// A NEAR borsh `u32` length prefix would exceed `u32::MAX`. Borsh encodes
+    /// `String`/`Vec` lengths as `u32`; a longer slice cannot be faithfully
+    /// serialized, so reject rather than truncate.
+    #[error(
+        "near borsh {what} length {len} exceeds the u32 maximum {max}; \
+         cannot reproduce the signed wire bytes"
+    )]
+    NearBorshLengthOverflow {
+        /// Which field overflowed (e.g. `string`, `bytes`, `actions`).
+        what: &'static str,
+        /// The offending length.
+        len: usize,
+        /// The borsh `u32` maximum (`u32::MAX`).
+        max: usize,
+    },
+
+    /// A NEAR yoctoNEAR amount (`deposit` / `stake` / `allowance`) carried more
+    /// than 16 big-endian bytes and so does not fit a borsh `u128`. The
+    /// human-rendered value would not match the signed (wrapped/truncated)
+    /// value — an approve-vs-sign divergence — so reject rather than wrap.
+    #[error(
+        "near u128 amount has {len} big-endian bytes, exceeding the 16-byte \
+         u128 maximum; the rendered value would diverge from the signed value"
+    )]
+    NearU128Overflow {
+        /// The number of big-endian bytes supplied.
+        len: usize,
+    },
+}

--- a/crates/ironclaw_attestation/src/error.rs
+++ b/crates/ironclaw_attestation/src/error.rs
@@ -51,11 +51,25 @@ pub enum AttestationError {
     /// human-rendered value would not match the signed (wrapped/truncated)
     /// value — an approve-vs-sign divergence — so reject rather than wrap.
     #[error(
-        "near u128 amount has {len} big-endian bytes, exceeding the 16-byte \
-         u128 maximum; the rendered value would diverge from the signed value"
+        "near {what} u128 amount has {len} big-endian bytes, exceeding the \
+         16-byte u128 maximum; the rendered value would diverge from the \
+         signed value"
     )]
     NearU128Overflow {
+        /// Which amount overflowed (e.g. `deposit`, `stake`, `allowance`).
+        what: &'static str,
         /// The number of big-endian bytes supplied.
         len: usize,
     },
+
+    /// A NEAR NEP-366 `DelegateAction` carried an inner `Delegate` action.
+    /// Inner actions are typed `NonDelegateAction` on-chain — a delegate may
+    /// not nest a delegate — so the nested delegate cannot be reproduced
+    /// faithfully as the signed bytes. Reject rather than emit ambiguous bytes.
+    #[error(
+        "near delegate action nests another delegate action, which NEP-366 \
+         forbids (inner actions are NonDelegateAction); cannot reproduce the \
+         signed wire bytes"
+    )]
+    NearNestedDelegate,
 }

--- a/crates/ironclaw_attestation/src/error.rs
+++ b/crates/ironclaw_attestation/src/error.rs
@@ -1,0 +1,75 @@
+//! Error type for the attestation core.
+//!
+//! Canonicalization is **fail-closed**: any decoded transaction that cannot be
+//! reproduced byte-for-byte as the exact wallet/HSM-signed payload is rejected
+//! rather than silently truncated. Silent truncation of a wire length prefix
+//! would desynchronize the length from the payload and let an attacker smuggle
+//! extra instructions/accounts/value past the what-you-see-is-what-you-sign
+//! (WYSIWYS) binding (approve-A / sign-B). Returning an error instead of
+//! truncating keeps the canonical bytes and the bound [`crate::ApprovedTxHash`]
+//! an exact, injective commitment to the signed wire form.
+
+use thiserror::Error;
+
+/// An error produced while projecting / canonicalizing a decoded transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AttestationError {
+    /// A Solana compact-u16 ("shortvec") length would exceed `u16::MAX`. The
+    /// Solana wire format cannot represent it, so faithfully reproducing the
+    /// signed bytes is impossible — reject rather than truncate.
+    #[error(
+        "solana {what} length {len} exceeds the compact-u16 maximum {max}; \
+         cannot reproduce the signed wire bytes"
+    )]
+    SolanaShortVecOverflow {
+        /// Which vector overflowed (e.g. `account_indices`, `instructions`).
+        what: &'static str,
+        /// The offending length.
+        len: usize,
+        /// The compact-u16 maximum (`u16::MAX`).
+        max: usize,
+    },
+
+    /// A NEAR borsh `u32` length prefix would exceed `u32::MAX`. Borsh encodes
+    /// `String`/`Vec` lengths as `u32`; a longer slice cannot be faithfully
+    /// serialized, so reject rather than truncate.
+    #[error(
+        "near borsh {what} length {len} exceeds the u32 maximum {max}; \
+         cannot reproduce the signed wire bytes"
+    )]
+    NearBorshLengthOverflow {
+        /// Which field overflowed (e.g. `string`, `bytes`, `actions`).
+        what: &'static str,
+        /// The offending length.
+        len: usize,
+        /// The borsh `u32` maximum (`u32::MAX`).
+        max: usize,
+    },
+
+    /// A NEAR yoctoNEAR amount (`deposit` / `stake` / `allowance`) carried more
+    /// than 16 big-endian bytes and so does not fit a borsh `u128`. The
+    /// human-rendered value would not match the signed (wrapped/truncated)
+    /// value — an approve-vs-sign divergence — so reject rather than wrap.
+    #[error(
+        "near {what} u128 amount has {len} big-endian bytes, exceeding the \
+         16-byte u128 maximum; the rendered value would diverge from the \
+         signed value"
+    )]
+    NearU128Overflow {
+        /// Which amount overflowed (e.g. `deposit`, `stake`, `allowance`).
+        what: &'static str,
+        /// The number of big-endian bytes supplied.
+        len: usize,
+    },
+
+    /// A NEAR NEP-366 `DelegateAction` carried an inner `Delegate` action.
+    /// Inner actions are typed `NonDelegateAction` on-chain — a delegate may
+    /// not nest a delegate — so the nested delegate cannot be reproduced
+    /// faithfully as the signed bytes. Reject rather than emit ambiguous bytes.
+    #[error(
+        "near delegate action nests another delegate action, which NEP-366 \
+         forbids (inner actions are NonDelegateAction); cannot reproduce the \
+         signed wire bytes"
+    )]
+    NearNestedDelegate,
+}

--- a/crates/ironclaw_attestation/src/fields.rs
+++ b/crates/ironclaw_attestation/src/fields.rs
@@ -26,6 +26,7 @@ use crate::decoded_tx::{
     DecodedTransaction, NearAccessKeyPermission, NearAction, NearPublicKey, SolanaMessageVersion,
     hex_lower,
 };
+use crate::error::AttestationError;
 use crate::wire::{near_transaction_bytes, solana_message_bytes};
 
 /// One signing-relevant field, projected into a stable wire form.
@@ -78,7 +79,7 @@ impl Field {
 
 /// Project a decoded transaction into the ordered, signing-relevant field list
 /// shared by the renderer and the canonical encoder.
-pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
+pub(crate) fn project(tx: &DecodedTransaction) -> Result<Vec<Field>, AttestationError> {
     match tx {
         DecodedTransaction::Evm(evm) => {
             let mut fields = vec![
@@ -140,7 +141,7 @@ pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
                     &hash.0,
                 ));
             }
-            fields
+            Ok(fields)
         }
         DecodedTransaction::Solana(sol) => {
             let version_label = match sol.version {
@@ -228,14 +229,16 @@ pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
                 ));
             }
             // Bind the EXACT signed message bytes so two distinct messages can
-            // never collapse to the same projection.
+            // never collapse to the same projection. Serialize ONCE and reuse
+            // for both the human value and the canonical commitment.
+            let message_bytes = solana_message_bytes(sol)?;
             fields.push(Field {
                 tag: "solana.message_bytes",
                 label: "Signed Message Bytes",
-                value: format!("0x{}", hex_lower(&solana_message_bytes(sol))),
-                canonical_bytes: solana_message_bytes(sol),
+                value: format!("0x{}", hex_lower(&message_bytes)),
+                canonical_bytes: message_bytes,
             });
-            fields
+            Ok(fields)
         }
         DecodedTransaction::Near(near) => {
             let mut fields = vec![
@@ -255,14 +258,16 @@ pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
                 ));
                 project_near_action(&mut fields, action);
             }
-            // Bind the EXACT borsh-signed transaction bytes.
+            // Bind the EXACT borsh-signed transaction bytes. Serialize ONCE and
+            // reuse for both the human value and the canonical commitment.
+            let transaction_bytes = near_transaction_bytes(near)?;
             fields.push(Field {
                 tag: "near.transaction_bytes",
                 label: "Signed Transaction Bytes",
-                value: format!("0x{}", hex_lower(&near_transaction_bytes(near))),
-                canonical_bytes: near_transaction_bytes(near),
+                value: format!("0x{}", hex_lower(&transaction_bytes)),
+                canonical_bytes: transaction_bytes,
             });
-            fields
+            Ok(fields)
         }
     }
 }

--- a/crates/ironclaw_attestation/src/fields.rs
+++ b/crates/ironclaw_attestation/src/fields.rs
@@ -403,6 +403,7 @@ fn project_near_action(fields: &mut Vec<Field>, action: &NearAction) {
         NearAction::Delegate {
             sender_id,
             receiver_id,
+            actions,
             nonce,
             max_block_height,
             public_key,
@@ -432,6 +433,29 @@ fn project_near_action(fields: &mut Vec<Field>, action: &NearAction) {
                 "Delegate Public Key",
                 public_key,
             ));
+            // Project the inner actions so the human render shows what the
+            // delegate authorizes. The binding/injectivity over inner actions
+            // is enforced by the `near.transaction_bytes` wire field (which
+            // also fails closed on a nested delegate); here we mirror the inner
+            // actions into the human view so render and canonical stay in step.
+            fields.push(Field::num(
+                "action.delegate.inner_count",
+                "Delegate Inner Action Count",
+                actions.len() as u64,
+            ));
+            for (i, inner) in actions.iter().enumerate() {
+                fields.push(Field::num(
+                    "action.delegate.inner.index",
+                    "Delegate Inner Action Index",
+                    i as u64,
+                ));
+                fields.push(Field::text(
+                    "action.delegate.inner.kind",
+                    "Delegate Inner Action Kind",
+                    inner.kind_label(),
+                ));
+                project_near_action(fields, inner);
+            }
         }
     }
 }

--- a/crates/ironclaw_attestation/src/fields.rs
+++ b/crates/ironclaw_attestation/src/fields.rs
@@ -26,6 +26,7 @@ use crate::decoded_tx::{
     DecodedTransaction, NearAccessKeyPermission, NearAction, NearPublicKey, SolanaMessageVersion,
     hex_lower,
 };
+use crate::error::AttestationError;
 use crate::wire::{near_transaction_bytes, solana_message_bytes};
 
 /// One signing-relevant field, projected into a stable wire form.
@@ -78,7 +79,7 @@ impl Field {
 
 /// Project a decoded transaction into the ordered, signing-relevant field list
 /// shared by the renderer and the canonical encoder.
-pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
+pub(crate) fn project(tx: &DecodedTransaction) -> Result<Vec<Field>, AttestationError> {
     match tx {
         DecodedTransaction::Evm(evm) => {
             let mut fields = vec![
@@ -140,7 +141,7 @@ pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
                     &hash.0,
                 ));
             }
-            fields
+            Ok(fields)
         }
         DecodedTransaction::Solana(sol) => {
             let version_label = match sol.version {
@@ -228,14 +229,16 @@ pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
                 ));
             }
             // Bind the EXACT signed message bytes so two distinct messages can
-            // never collapse to the same projection.
+            // never collapse to the same projection. Serialize ONCE and reuse
+            // for both the human value and the canonical commitment.
+            let message_bytes = solana_message_bytes(sol)?;
             fields.push(Field {
                 tag: "solana.message_bytes",
                 label: "Signed Message Bytes",
-                value: format!("0x{}", hex_lower(&solana_message_bytes(sol))),
-                canonical_bytes: solana_message_bytes(sol),
+                value: format!("0x{}", hex_lower(&message_bytes)),
+                canonical_bytes: message_bytes,
             });
-            fields
+            Ok(fields)
         }
         DecodedTransaction::Near(near) => {
             let mut fields = vec![
@@ -255,14 +258,16 @@ pub(crate) fn project(tx: &DecodedTransaction) -> Vec<Field> {
                 ));
                 project_near_action(&mut fields, action);
             }
-            // Bind the EXACT borsh-signed transaction bytes.
+            // Bind the EXACT borsh-signed transaction bytes. Serialize ONCE and
+            // reuse for both the human value and the canonical commitment.
+            let transaction_bytes = near_transaction_bytes(near)?;
             fields.push(Field {
                 tag: "near.transaction_bytes",
                 label: "Signed Transaction Bytes",
-                value: format!("0x{}", hex_lower(&near_transaction_bytes(near))),
-                canonical_bytes: near_transaction_bytes(near),
+                value: format!("0x{}", hex_lower(&transaction_bytes)),
+                canonical_bytes: transaction_bytes,
             });
-            fields
+            Ok(fields)
         }
     }
 }
@@ -398,6 +403,7 @@ fn project_near_action(fields: &mut Vec<Field>, action: &NearAction) {
         NearAction::Delegate {
             sender_id,
             receiver_id,
+            actions,
             nonce,
             max_block_height,
             public_key,
@@ -427,6 +433,29 @@ fn project_near_action(fields: &mut Vec<Field>, action: &NearAction) {
                 "Delegate Public Key",
                 public_key,
             ));
+            // Project the inner actions so the human render shows what the
+            // delegate authorizes. The binding/injectivity over inner actions
+            // is enforced by the `near.transaction_bytes` wire field (which
+            // also fails closed on a nested delegate); here we mirror the inner
+            // actions into the human view so render and canonical stay in step.
+            fields.push(Field::num(
+                "action.delegate.inner_count",
+                "Delegate Inner Action Count",
+                actions.len() as u64,
+            ));
+            for (i, inner) in actions.iter().enumerate() {
+                fields.push(Field::num(
+                    "action.delegate.inner.index",
+                    "Delegate Inner Action Index",
+                    i as u64,
+                ));
+                fields.push(Field::text(
+                    "action.delegate.inner.kind",
+                    "Delegate Inner Action Kind",
+                    inner.kind_label(),
+                ));
+                project_near_action(fields, inner);
+            }
         }
     }
 }

--- a/crates/ironclaw_attestation/src/lib.rs
+++ b/crates/ironclaw_attestation/src/lib.rs
@@ -34,6 +34,7 @@
 mod approved_tx_hash;
 mod canonical;
 mod decoded_tx;
+mod error;
 mod fields;
 mod rendered;
 
@@ -47,6 +48,7 @@ pub use decoded_tx::{
     SolanaAddressTableLookup, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
     SolanaTransaction,
 };
+pub use error::AttestationError;
 pub use rendered::{RenderedField, RenderedTx, render};
 
 /// Test-only re-export of the low-level component hasher.

--- a/crates/ironclaw_attestation/src/rendered.rs
+++ b/crates/ironclaw_attestation/src/rendered.rs
@@ -7,6 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::decoded_tx::{DecodedTransaction, RenderingSchemaVersion};
+use crate::error::AttestationError;
 use crate::fields::project;
 
 /// One displayed label/value pair.
@@ -54,19 +55,22 @@ impl RenderedTx {
 /// The renderer surfaces EVERY signing-relevant field that
 /// [`crate::canonical::canonical_signing_bytes`] consumes — there are no silent
 /// fields, because both walk [`crate::fields::project`].
-pub fn render(tx: &DecodedTransaction, schema_version: RenderingSchemaVersion) -> RenderedTx {
-    let fields = project(tx)
+pub fn render(
+    tx: &DecodedTransaction,
+    schema_version: RenderingSchemaVersion,
+) -> Result<RenderedTx, AttestationError> {
+    let fields = project(tx)?
         .into_iter()
         .map(|f| RenderedField {
             label: f.label.to_string(),
             value: f.value,
         })
         .collect();
-    RenderedTx {
+    Ok(RenderedTx {
         schema_version,
         chain: tx.chain_tag().to_string(),
         chain_network: tx.chain_network(),
         tx_type: tx.tx_type_label(),
         fields,
-    }
+    })
 }

--- a/crates/ironclaw_attestation/src/wire.rs
+++ b/crates/ironclaw_attestation/src/wire.rs
@@ -18,13 +18,37 @@
 //! the signature; NEAR: the borsh-serialized `Transaction` that is then
 //! sha256'd and signed). They are folded into the canonical signing bytes so
 //! the human-approved hash commits to the precise wire form.
+//!
+//! ## Fail-closed length handling
+//!
+//! Every length prefix here is derived from a `usize` slice length. A length
+//! that does not fit the on-wire prefix width (compact-u16 for Solana, `u32`
+//! for borsh) cannot be serialized faithfully. We therefore **reject** such
+//! inputs (returning [`AttestationError`]) rather than casting with silent
+//! truncation: a truncated prefix would desync the length from the payload,
+//! letting trailing bytes be reinterpreted as extra instructions/accounts and
+//! breaking the what-you-see-is-what-you-sign binding.
 
 use crate::decoded_tx::{
     NearAccessKeyPermission, NearAction, NearPublicKey, NearTransaction, SolanaMessageVersion,
     SolanaTransaction,
 };
+use crate::error::AttestationError;
 
 // ---- Solana compact-u16 (shortvec) -------------------------------------
+
+/// Convert a `usize` length into a Solana compact-u16, rejecting any value that
+/// exceeds `u16::MAX`. The Solana wire format encodes every vector length as a
+/// compact-u16; a longer vector simply cannot be represented, so we fail closed
+/// rather than truncate (which would desync the length from the payload and
+/// allow instruction/account smuggling past the WYSIWYS binding).
+fn checked_short_vec_len(len: usize, what: &'static str) -> Result<u16, AttestationError> {
+    u16::try_from(len).map_err(|_| AttestationError::SolanaShortVecOverflow {
+        what,
+        len,
+        max: u16::MAX as usize,
+    })
+}
 
 /// Append a Solana compact-u16 ("shortvec") length prefix. Matches
 /// `solana_short_vec`: 7 bits per byte, little-endian, high bit = continuation.
@@ -42,11 +66,16 @@ fn push_compact_u16(out: &mut Vec<u8>, mut value: u16) {
     }
 }
 
-/// Append a compact-u16-prefixed byte slice.
-fn push_compact_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
-    debug_assert!(bytes.len() <= u16::MAX as usize);
-    push_compact_u16(out, bytes.len() as u16);
+/// Append a compact-u16-prefixed byte slice, rejecting slices longer than
+/// `u16::MAX` instead of silently truncating the length prefix.
+fn push_compact_bytes(
+    out: &mut Vec<u8>,
+    bytes: &[u8],
+    what: &'static str,
+) -> Result<(), AttestationError> {
+    push_compact_u16(out, checked_short_vec_len(bytes.len(), what)?);
     out.extend_from_slice(bytes);
+    Ok(())
 }
 
 /// Serialize a Solana message to its exact signed bytes (legacy or v0).
@@ -57,7 +86,7 @@ fn push_compact_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
 /// Each instruction: `program_id_index(u8) ∥ shortvec(account_indices) ∥
 /// shortvec(data)`. Each lookup: `account_key(32) ∥ shortvec(writable) ∥
 /// shortvec(readonly)`.
-pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Vec<u8> {
+pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Result<Vec<u8>, AttestationError> {
     let mut out = Vec::new();
 
     if matches!(tx.version, SolanaMessageVersion::V0) {
@@ -71,7 +100,10 @@ pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Vec<u8> {
     out.push(tx.header.num_readonly_unsigned_accounts);
 
     // Static account keys.
-    push_compact_u16(&mut out, tx.static_account_keys.len() as u16);
+    push_compact_u16(
+        &mut out,
+        checked_short_vec_len(tx.static_account_keys.len(), "static_account_keys")?,
+    );
     for key in &tx.static_account_keys {
         out.extend_from_slice(&key.0);
     }
@@ -80,59 +112,97 @@ pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Vec<u8> {
     out.extend_from_slice(&tx.recent_blockhash.0);
 
     // Compiled instructions.
-    push_compact_u16(&mut out, tx.instructions.len() as u16);
+    push_compact_u16(
+        &mut out,
+        checked_short_vec_len(tx.instructions.len(), "instructions")?,
+    );
     for ix in &tx.instructions {
         out.push(ix.program_id_index);
-        push_compact_bytes(&mut out, &ix.account_indices);
-        push_compact_bytes(&mut out, &ix.data);
+        push_compact_bytes(&mut out, &ix.account_indices, "instruction.account_indices")?;
+        push_compact_bytes(&mut out, &ix.data, "instruction.data")?;
     }
 
     // Address-table lookups (v0 only).
     if matches!(tx.version, SolanaMessageVersion::V0) {
-        push_compact_u16(&mut out, tx.address_table_lookups.len() as u16);
+        push_compact_u16(
+            &mut out,
+            checked_short_vec_len(tx.address_table_lookups.len(), "address_table_lookups")?,
+        );
         for lookup in &tx.address_table_lookups {
             out.extend_from_slice(&lookup.account_key.0);
-            push_compact_bytes(&mut out, &lookup.writable_indexes);
-            push_compact_bytes(&mut out, &lookup.readonly_indexes);
+            push_compact_bytes(
+                &mut out,
+                &lookup.writable_indexes,
+                "lookup.writable_indexes",
+            )?;
+            push_compact_bytes(
+                &mut out,
+                &lookup.readonly_indexes,
+                "lookup.readonly_indexes",
+            )?;
         }
     }
 
-    out
+    Ok(out)
 }
 
 // ---- NEAR borsh --------------------------------------------------------
 
+/// Borsh `u32` length prefix for a slice, rejecting lengths beyond `u32::MAX`.
+/// Borsh encodes `String`/`Vec` lengths as `u32` little-endian; a longer slice
+/// cannot be represented, so we fail closed rather than truncate the prefix.
+fn borsh_len_le(len: usize, what: &'static str) -> Result<[u8; 4], AttestationError> {
+    u32::try_from(len).map(u32::to_le_bytes).map_err(|_| {
+        AttestationError::NearBorshLengthOverflow {
+            what,
+            len,
+            max: u32::MAX as usize,
+        }
+    })
+}
+
 /// Append a borsh `u32` length-prefixed byte slice (used for `String`/`Vec<u8>`
 /// and as the length for other vectors).
-fn push_borsh_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
-    out.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+fn push_borsh_bytes(
+    out: &mut Vec<u8>,
+    bytes: &[u8],
+    what: &'static str,
+) -> Result<(), AttestationError> {
+    out.extend_from_slice(&borsh_len_le(bytes.len(), what)?);
     out.extend_from_slice(bytes);
+    Ok(())
 }
 
 /// Append a borsh `String`.
-fn push_borsh_string(out: &mut Vec<u8>, s: &str) {
-    push_borsh_bytes(out, s.as_bytes());
+fn push_borsh_string(out: &mut Vec<u8>, s: &str) -> Result<(), AttestationError> {
+    push_borsh_bytes(out, s.as_bytes(), "string")
 }
 
 /// Append a yoctoNEAR `u128` carried as big-endian minimal bytes, re-encoded as
-/// borsh `u128` (little-endian, 16 bytes).
-fn push_borsh_u128_be(out: &mut Vec<u8>, be_minimal: &[u8]) {
-    let value = u128_from_be_minimal(be_minimal);
+/// borsh `u128` (little-endian, 16 bytes). Rejects inputs longer than 16 bytes:
+/// such a value does not fit a `u128`, so the human-rendered amount would
+/// diverge from the (wrapped) signed amount — an approve-vs-sign mismatch.
+fn push_borsh_u128_be(out: &mut Vec<u8>, be_minimal: &[u8]) -> Result<(), AttestationError> {
+    let value = u128_from_be_minimal(be_minimal)?;
     out.extend_from_slice(&value.to_le_bytes());
+    Ok(())
 }
 
-/// Parse a big-endian minimal byte string into a `u128`. Bytes beyond 16 (only
-/// possible from malformed input) are folded in by treating the value as
-/// big-endian; the high bytes simply shift, which is acceptable because the
-/// canonical bytes still commit to the raw `deposit` slice separately in the
-/// field projection. This conversion exists only to reproduce the NEAR wire
-/// `u128`.
-fn u128_from_be_minimal(be_minimal: &[u8]) -> u128 {
+/// Parse a big-endian minimal byte string into a `u128`, rejecting inputs that
+/// exceed 16 bytes (which cannot fit a `u128`). Leading-zero padding within 16
+/// bytes is tolerated; only a genuine length overflow is rejected, so the
+/// canonical wire `u128` always equals the value the human approved.
+fn u128_from_be_minimal(be_minimal: &[u8]) -> Result<u128, AttestationError> {
+    if be_minimal.len() > 16 {
+        return Err(AttestationError::NearU128Overflow {
+            len: be_minimal.len(),
+        });
+    }
     let mut value: u128 = 0;
     for &b in be_minimal {
-        value = value.wrapping_shl(8) | u128::from(b);
+        value = (value << 8) | u128::from(b);
     }
-    value
+    Ok(value)
 }
 
 /// Append a borsh-serialized NEAR `PublicKey`: `key_type(u8) ∥ data`.
@@ -144,12 +214,12 @@ fn push_near_public_key(out: &mut Vec<u8>, pk: &NearPublicKey) {
 }
 
 /// Append a borsh-serialized NEAR `Action`.
-fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
+fn push_near_action(out: &mut Vec<u8>, action: &NearAction) -> Result<(), AttestationError> {
     match action {
         NearAction::CreateAccount => out.push(0),
         NearAction::DeployContract { code } => {
             out.push(1);
-            push_borsh_bytes(out, code);
+            push_borsh_bytes(out, code, "deploy_contract.code")?;
         }
         NearAction::FunctionCall {
             method_name,
@@ -158,18 +228,18 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
             deposit,
         } => {
             out.push(2);
-            push_borsh_string(out, method_name);
-            push_borsh_bytes(out, args);
+            push_borsh_string(out, method_name)?;
+            push_borsh_bytes(out, args, "function_call.args")?;
             out.extend_from_slice(&gas.to_le_bytes());
-            push_borsh_u128_be(out, deposit);
+            push_borsh_u128_be(out, deposit)?;
         }
         NearAction::Transfer { deposit } => {
             out.push(3);
-            push_borsh_u128_be(out, deposit);
+            push_borsh_u128_be(out, deposit)?;
         }
         NearAction::Stake { stake, public_key } => {
             out.push(4);
-            push_borsh_u128_be(out, stake);
+            push_borsh_u128_be(out, stake)?;
             push_near_public_key(out, public_key);
         }
         NearAction::AddKey {
@@ -192,15 +262,15 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
                     match allowance {
                         Some(a) => {
                             out.push(1);
-                            push_borsh_u128_be(out, a);
+                            push_borsh_u128_be(out, a)?;
                         }
                         None => out.push(0),
                     }
-                    push_borsh_string(out, receiver_id);
+                    push_borsh_string(out, receiver_id)?;
                     // Vec<String>: u32 len ∥ each borsh String.
-                    out.extend_from_slice(&(method_names.len() as u32).to_le_bytes());
+                    out.extend_from_slice(&borsh_len_le(method_names.len(), "method_names")?);
                     for name in method_names {
-                        push_borsh_string(out, name);
+                        push_borsh_string(out, name)?;
                     }
                 }
                 NearAccessKeyPermission::FullAccess => {
@@ -215,7 +285,7 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
         }
         NearAction::DeleteAccount { beneficiary_id } => {
             out.push(7);
-            push_borsh_string(out, beneficiary_id);
+            push_borsh_string(out, beneficiary_id)?;
         }
         NearAction::Delegate {
             sender_id,
@@ -225,30 +295,39 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
             public_key,
         } => {
             out.push(8);
-            push_borsh_string(out, sender_id);
-            push_borsh_string(out, receiver_id);
+            // NEP-366 DelegateAction borsh layout:
+            // `sender_id ∥ receiver_id ∥ Vec<Action> ∥ nonce(u64 le) ∥
+            //  max_block_height(u64 le) ∥ public_key`. The decoded model does
+            // not carry the inner delegated actions, so we serialize an
+            // explicit empty `Vec<Action>` (borsh `0u32`) in the correct
+            // position — omitting it entirely (as before) made deserializers
+            // read `nonce` as the actions-vector length, corrupting the parse.
+            push_borsh_string(out, sender_id)?;
+            push_borsh_string(out, receiver_id)?;
+            out.extend_from_slice(&0u32.to_le_bytes());
             out.extend_from_slice(&nonce.to_le_bytes());
             out.extend_from_slice(&max_block_height.to_le_bytes());
             push_near_public_key(out, public_key);
         }
     }
+    Ok(())
 }
 
 /// Serialize a NEAR transaction to its exact borsh-signed bytes:
 /// `signer_id ∥ public_key ∥ nonce(u64 le) ∥ receiver_id ∥ block_hash(32) ∥
 /// Vec<Action>`.
-pub(crate) fn near_transaction_bytes(tx: &NearTransaction) -> Vec<u8> {
+pub(crate) fn near_transaction_bytes(tx: &NearTransaction) -> Result<Vec<u8>, AttestationError> {
     let mut out = Vec::new();
-    push_borsh_string(&mut out, &tx.signer_id);
+    push_borsh_string(&mut out, &tx.signer_id)?;
     push_near_public_key(&mut out, &tx.public_key);
     out.extend_from_slice(&tx.nonce.to_le_bytes());
-    push_borsh_string(&mut out, &tx.receiver_id);
+    push_borsh_string(&mut out, &tx.receiver_id)?;
     out.extend_from_slice(&tx.block_hash.0);
-    out.extend_from_slice(&(tx.actions.len() as u32).to_le_bytes());
+    out.extend_from_slice(&borsh_len_le(tx.actions.len(), "actions")?);
     for action in &tx.actions {
-        push_near_action(&mut out, action);
+        push_near_action(&mut out, action)?;
     }
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -274,12 +353,65 @@ mod tests {
 
     #[test]
     fn u128_be_minimal_round_trips() {
-        assert_eq!(u128_from_be_minimal(&[]), 0);
-        assert_eq!(u128_from_be_minimal(&[0x01]), 1);
-        assert_eq!(u128_from_be_minimal(&[0x01, 0x00]), 256);
+        assert_eq!(u128_from_be_minimal(&[]), Ok(0));
+        assert_eq!(u128_from_be_minimal(&[0x01]), Ok(1));
+        assert_eq!(u128_from_be_minimal(&[0x01, 0x00]), Ok(256));
         assert_eq!(
             u128_from_be_minimal(&[0x0d, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00]),
-            1_000_000_000_000_000_000
+            Ok(1_000_000_000_000_000_000)
+        );
+        // Exactly 16 bytes (u128::MAX) is the boundary and must be accepted.
+        assert_eq!(u128_from_be_minimal(&[0xff; 16]), Ok(u128::MAX));
+    }
+
+    #[test]
+    fn u128_be_minimal_oversized_bytes() {
+        // 17 bytes cannot fit a u128. Rather than silently wrapping/discarding
+        // the high bytes (which would make the signed value diverge from the
+        // human-approved one), the parse must fail closed.
+        let err = u128_from_be_minimal(&[0x01; 17]).expect_err("17 bytes must be rejected");
+        assert_eq!(err, AttestationError::NearU128Overflow { len: 17 });
+        // A leading-zero-padded value within 16 bytes is still fine.
+        assert_eq!(u128_from_be_minimal(&[0x00, 0x00, 0x01]), Ok(1));
+    }
+
+    #[test]
+    fn compact_bytes_rejects_overlong_slice() {
+        // A byte slice longer than u16::MAX cannot be length-prefixed by a
+        // compact-u16. Truncating the prefix would let the trailing bytes be
+        // reinterpreted as separate instructions/accounts (field smuggling), so
+        // the encoder must fail closed.
+        let oversized = vec![0u8; u16::MAX as usize + 1];
+        let mut out = Vec::new();
+        let err = push_compact_bytes(&mut out, &oversized, "instruction.data")
+            .expect_err("oversized compact slice must be rejected");
+        assert_eq!(
+            err,
+            AttestationError::SolanaShortVecOverflow {
+                what: "instruction.data",
+                len: u16::MAX as usize + 1,
+                max: u16::MAX as usize,
+            }
+        );
+        // Exactly u16::MAX is the boundary and must encode.
+        let mut ok = Vec::new();
+        assert!(push_compact_bytes(&mut ok, &vec![0u8; u16::MAX as usize], "d").is_ok());
+    }
+
+    #[test]
+    fn borsh_bytes_rejects_overlong_length() {
+        // borsh_len_le is the choke point for every borsh u32 length prefix.
+        // usize values beyond u32::MAX must be rejected, not truncated.
+        assert!(borsh_len_le(u32::MAX as usize, "bytes").is_ok());
+        let err = borsh_len_le(u32::MAX as usize + 1, "bytes")
+            .expect_err("u32 overflow must be rejected");
+        assert_eq!(
+            err,
+            AttestationError::NearBorshLengthOverflow {
+                what: "bytes",
+                len: u32::MAX as usize + 1,
+                max: u32::MAX as usize,
+            }
         );
     }
 }

--- a/crates/ironclaw_attestation/src/wire.rs
+++ b/crates/ironclaw_attestation/src/wire.rs
@@ -151,6 +151,12 @@ pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Result<Vec<u8>, At
 /// Borsh `u32` length prefix for a slice, rejecting lengths beyond `u32::MAX`.
 /// Borsh encodes `String`/`Vec` lengths as `u32` little-endian; a longer slice
 /// cannot be represented, so we fail closed rather than truncate the prefix.
+///
+/// Target-width note: the overflow branch (`NearBorshLengthOverflow`) is
+/// reachable only on targets where `usize > u32` — i.e. 64-bit. On 32-bit
+/// targets `usize == u32`, so `u32::try_from` is infallible and the branch (and
+/// the `borsh_bytes_rejects_overlong_length` test exercising it) cannot fire;
+/// that is expected, not dead code.
 fn borsh_len_le(len: usize, what: &'static str) -> Result<[u8; 4], AttestationError> {
     u32::try_from(len).map(u32::to_le_bytes).map_err(|_| {
         AttestationError::NearBorshLengthOverflow {
@@ -182,8 +188,14 @@ fn push_borsh_string(out: &mut Vec<u8>, s: &str) -> Result<(), AttestationError>
 /// borsh `u128` (little-endian, 16 bytes). Rejects inputs longer than 16 bytes:
 /// such a value does not fit a `u128`, so the human-rendered amount would
 /// diverge from the (wrapped) signed amount — an approve-vs-sign mismatch.
-fn push_borsh_u128_be(out: &mut Vec<u8>, be_minimal: &[u8]) -> Result<(), AttestationError> {
-    let value = u128_from_be_minimal(be_minimal)?;
+/// `what` names the offending amount (`deposit` / `stake` / `allowance`) so a
+/// rejection can identify which field overflowed.
+fn push_borsh_u128_be(
+    out: &mut Vec<u8>,
+    be_minimal: &[u8],
+    what: &'static str,
+) -> Result<(), AttestationError> {
+    let value = u128_from_be_minimal(be_minimal, what)?;
     out.extend_from_slice(&value.to_le_bytes());
     Ok(())
 }
@@ -192,9 +204,10 @@ fn push_borsh_u128_be(out: &mut Vec<u8>, be_minimal: &[u8]) -> Result<(), Attest
 /// exceed 16 bytes (which cannot fit a `u128`). Leading-zero padding within 16
 /// bytes is tolerated; only a genuine length overflow is rejected, so the
 /// canonical wire `u128` always equals the value the human approved.
-fn u128_from_be_minimal(be_minimal: &[u8]) -> Result<u128, AttestationError> {
+fn u128_from_be_minimal(be_minimal: &[u8], what: &'static str) -> Result<u128, AttestationError> {
     if be_minimal.len() > 16 {
         return Err(AttestationError::NearU128Overflow {
+            what,
             len: be_minimal.len(),
         });
     }
@@ -231,15 +244,15 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) -> Result<(), Attest
             push_borsh_string(out, method_name)?;
             push_borsh_bytes(out, args, "function_call.args")?;
             out.extend_from_slice(&gas.to_le_bytes());
-            push_borsh_u128_be(out, deposit)?;
+            push_borsh_u128_be(out, deposit, "function_call.deposit")?;
         }
         NearAction::Transfer { deposit } => {
             out.push(3);
-            push_borsh_u128_be(out, deposit)?;
+            push_borsh_u128_be(out, deposit, "transfer.deposit")?;
         }
         NearAction::Stake { stake, public_key } => {
             out.push(4);
-            push_borsh_u128_be(out, stake)?;
+            push_borsh_u128_be(out, stake, "stake.stake")?;
             push_near_public_key(out, public_key);
         }
         NearAction::AddKey {
@@ -262,7 +275,7 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) -> Result<(), Attest
                     match allowance {
                         Some(a) => {
                             out.push(1);
-                            push_borsh_u128_be(out, a)?;
+                            push_borsh_u128_be(out, a, "add_key.allowance")?;
                         }
                         None => out.push(0),
                     }
@@ -290,21 +303,28 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) -> Result<(), Attest
         NearAction::Delegate {
             sender_id,
             receiver_id,
+            actions,
             nonce,
             max_block_height,
             public_key,
         } => {
             out.push(8);
             // NEP-366 DelegateAction borsh layout:
-            // `sender_id ∥ receiver_id ∥ Vec<Action> ∥ nonce(u64 le) ∥
-            //  max_block_height(u64 le) ∥ public_key`. The decoded model does
-            // not carry the inner delegated actions, so we serialize an
-            // explicit empty `Vec<Action>` (borsh `0u32`) in the correct
-            // position — omitting it entirely (as before) made deserializers
-            // read `nonce` as the actions-vector length, corrupting the parse.
+            // `sender_id ∥ receiver_id ∥ Vec<NonDelegateAction> ∥ nonce(u64 le)
+            //  ∥ max_block_height(u64 le) ∥ public_key`. The inner actions are
+            // carried at full fidelity so two delegates differing only in their
+            // inner actions produce distinct bytes (injectivity). Inner actions
+            // are `NonDelegateAction`: a nested `Delegate` is unrepresentable
+            // on-chain, so it is rejected (fail closed) rather than serialized.
             push_borsh_string(out, sender_id)?;
             push_borsh_string(out, receiver_id)?;
-            out.extend_from_slice(&0u32.to_le_bytes());
+            out.extend_from_slice(&borsh_len_le(actions.len(), "delegate.actions")?);
+            for inner in actions {
+                if matches!(inner, NearAction::Delegate { .. }) {
+                    return Err(AttestationError::NearNestedDelegate);
+                }
+                push_near_action(out, inner)?;
+            }
             out.extend_from_slice(&nonce.to_le_bytes());
             out.extend_from_slice(&max_block_height.to_le_bytes());
             push_near_public_key(out, public_key);
@@ -353,15 +373,15 @@ mod tests {
 
     #[test]
     fn u128_be_minimal_round_trips() {
-        assert_eq!(u128_from_be_minimal(&[]), Ok(0));
-        assert_eq!(u128_from_be_minimal(&[0x01]), Ok(1));
-        assert_eq!(u128_from_be_minimal(&[0x01, 0x00]), Ok(256));
+        assert_eq!(u128_from_be_minimal(&[], "deposit"), Ok(0));
+        assert_eq!(u128_from_be_minimal(&[0x01], "deposit"), Ok(1));
+        assert_eq!(u128_from_be_minimal(&[0x01, 0x00], "deposit"), Ok(256));
         assert_eq!(
-            u128_from_be_minimal(&[0x0d, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00]),
+            u128_from_be_minimal(&[0x0d, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00], "deposit"),
             Ok(1_000_000_000_000_000_000)
         );
         // Exactly 16 bytes (u128::MAX) is the boundary and must be accepted.
-        assert_eq!(u128_from_be_minimal(&[0xff; 16]), Ok(u128::MAX));
+        assert_eq!(u128_from_be_minimal(&[0xff; 16], "deposit"), Ok(u128::MAX));
     }
 
     #[test]
@@ -369,10 +389,17 @@ mod tests {
         // 17 bytes cannot fit a u128. Rather than silently wrapping/discarding
         // the high bytes (which would make the signed value diverge from the
         // human-approved one), the parse must fail closed.
-        let err = u128_from_be_minimal(&[0x01; 17]).expect_err("17 bytes must be rejected");
-        assert_eq!(err, AttestationError::NearU128Overflow { len: 17 });
+        let err =
+            u128_from_be_minimal(&[0x01; 17], "stake").expect_err("17 bytes must be rejected");
+        assert_eq!(
+            err,
+            AttestationError::NearU128Overflow {
+                what: "stake",
+                len: 17
+            }
+        );
         // A leading-zero-padded value within 16 bytes is still fine.
-        assert_eq!(u128_from_be_minimal(&[0x00, 0x00, 0x01]), Ok(1));
+        assert_eq!(u128_from_be_minimal(&[0x00, 0x00, 0x01], "stake"), Ok(1));
     }
 
     #[test]

--- a/crates/ironclaw_attestation/src/wire.rs
+++ b/crates/ironclaw_attestation/src/wire.rs
@@ -18,13 +18,37 @@
 //! the signature; NEAR: the borsh-serialized `Transaction` that is then
 //! sha256'd and signed). They are folded into the canonical signing bytes so
 //! the human-approved hash commits to the precise wire form.
+//!
+//! ## Fail-closed length handling
+//!
+//! Every length prefix here is derived from a `usize` slice length. A length
+//! that does not fit the on-wire prefix width (compact-u16 for Solana, `u32`
+//! for borsh) cannot be serialized faithfully. We therefore **reject** such
+//! inputs (returning [`AttestationError`]) rather than casting with silent
+//! truncation: a truncated prefix would desync the length from the payload,
+//! letting trailing bytes be reinterpreted as extra instructions/accounts and
+//! breaking the what-you-see-is-what-you-sign binding.
 
 use crate::decoded_tx::{
     NearAccessKeyPermission, NearAction, NearPublicKey, NearTransaction, SolanaMessageVersion,
     SolanaTransaction,
 };
+use crate::error::AttestationError;
 
 // ---- Solana compact-u16 (shortvec) -------------------------------------
+
+/// Convert a `usize` length into a Solana compact-u16, rejecting any value that
+/// exceeds `u16::MAX`. The Solana wire format encodes every vector length as a
+/// compact-u16; a longer vector simply cannot be represented, so we fail closed
+/// rather than truncate (which would desync the length from the payload and
+/// allow instruction/account smuggling past the WYSIWYS binding).
+fn checked_short_vec_len(len: usize, what: &'static str) -> Result<u16, AttestationError> {
+    u16::try_from(len).map_err(|_| AttestationError::SolanaShortVecOverflow {
+        what,
+        len,
+        max: u16::MAX as usize,
+    })
+}
 
 /// Append a Solana compact-u16 ("shortvec") length prefix. Matches
 /// `solana_short_vec`: 7 bits per byte, little-endian, high bit = continuation.
@@ -42,11 +66,16 @@ fn push_compact_u16(out: &mut Vec<u8>, mut value: u16) {
     }
 }
 
-/// Append a compact-u16-prefixed byte slice.
-fn push_compact_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
-    debug_assert!(bytes.len() <= u16::MAX as usize);
-    push_compact_u16(out, bytes.len() as u16);
+/// Append a compact-u16-prefixed byte slice, rejecting slices longer than
+/// `u16::MAX` instead of silently truncating the length prefix.
+fn push_compact_bytes(
+    out: &mut Vec<u8>,
+    bytes: &[u8],
+    what: &'static str,
+) -> Result<(), AttestationError> {
+    push_compact_u16(out, checked_short_vec_len(bytes.len(), what)?);
     out.extend_from_slice(bytes);
+    Ok(())
 }
 
 /// Serialize a Solana message to its exact signed bytes (legacy or v0).
@@ -57,7 +86,7 @@ fn push_compact_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
 /// Each instruction: `program_id_index(u8) ∥ shortvec(account_indices) ∥
 /// shortvec(data)`. Each lookup: `account_key(32) ∥ shortvec(writable) ∥
 /// shortvec(readonly)`.
-pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Vec<u8> {
+pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Result<Vec<u8>, AttestationError> {
     let mut out = Vec::new();
 
     if matches!(tx.version, SolanaMessageVersion::V0) {
@@ -71,7 +100,10 @@ pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Vec<u8> {
     out.push(tx.header.num_readonly_unsigned_accounts);
 
     // Static account keys.
-    push_compact_u16(&mut out, tx.static_account_keys.len() as u16);
+    push_compact_u16(
+        &mut out,
+        checked_short_vec_len(tx.static_account_keys.len(), "static_account_keys")?,
+    );
     for key in &tx.static_account_keys {
         out.extend_from_slice(&key.0);
     }
@@ -80,59 +112,110 @@ pub(crate) fn solana_message_bytes(tx: &SolanaTransaction) -> Vec<u8> {
     out.extend_from_slice(&tx.recent_blockhash.0);
 
     // Compiled instructions.
-    push_compact_u16(&mut out, tx.instructions.len() as u16);
+    push_compact_u16(
+        &mut out,
+        checked_short_vec_len(tx.instructions.len(), "instructions")?,
+    );
     for ix in &tx.instructions {
         out.push(ix.program_id_index);
-        push_compact_bytes(&mut out, &ix.account_indices);
-        push_compact_bytes(&mut out, &ix.data);
+        push_compact_bytes(&mut out, &ix.account_indices, "instruction.account_indices")?;
+        push_compact_bytes(&mut out, &ix.data, "instruction.data")?;
     }
 
     // Address-table lookups (v0 only).
     if matches!(tx.version, SolanaMessageVersion::V0) {
-        push_compact_u16(&mut out, tx.address_table_lookups.len() as u16);
+        push_compact_u16(
+            &mut out,
+            checked_short_vec_len(tx.address_table_lookups.len(), "address_table_lookups")?,
+        );
         for lookup in &tx.address_table_lookups {
             out.extend_from_slice(&lookup.account_key.0);
-            push_compact_bytes(&mut out, &lookup.writable_indexes);
-            push_compact_bytes(&mut out, &lookup.readonly_indexes);
+            push_compact_bytes(
+                &mut out,
+                &lookup.writable_indexes,
+                "lookup.writable_indexes",
+            )?;
+            push_compact_bytes(
+                &mut out,
+                &lookup.readonly_indexes,
+                "lookup.readonly_indexes",
+            )?;
         }
     }
 
-    out
+    Ok(out)
 }
 
 // ---- NEAR borsh --------------------------------------------------------
 
+/// Borsh `u32` length prefix for a slice, rejecting lengths beyond `u32::MAX`.
+/// Borsh encodes `String`/`Vec` lengths as `u32` little-endian; a longer slice
+/// cannot be represented, so we fail closed rather than truncate the prefix.
+///
+/// Target-width note: the overflow branch (`NearBorshLengthOverflow`) is
+/// reachable only on targets where `usize > u32` — i.e. 64-bit. On 32-bit
+/// targets `usize == u32`, so `u32::try_from` is infallible and the branch (and
+/// the `borsh_bytes_rejects_overlong_length` test exercising it) cannot fire;
+/// that is expected, not dead code.
+fn borsh_len_le(len: usize, what: &'static str) -> Result<[u8; 4], AttestationError> {
+    u32::try_from(len).map(u32::to_le_bytes).map_err(|_| {
+        AttestationError::NearBorshLengthOverflow {
+            what,
+            len,
+            max: u32::MAX as usize,
+        }
+    })
+}
+
 /// Append a borsh `u32` length-prefixed byte slice (used for `String`/`Vec<u8>`
 /// and as the length for other vectors).
-fn push_borsh_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
-    out.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+fn push_borsh_bytes(
+    out: &mut Vec<u8>,
+    bytes: &[u8],
+    what: &'static str,
+) -> Result<(), AttestationError> {
+    out.extend_from_slice(&borsh_len_le(bytes.len(), what)?);
     out.extend_from_slice(bytes);
+    Ok(())
 }
 
 /// Append a borsh `String`.
-fn push_borsh_string(out: &mut Vec<u8>, s: &str) {
-    push_borsh_bytes(out, s.as_bytes());
+fn push_borsh_string(out: &mut Vec<u8>, s: &str) -> Result<(), AttestationError> {
+    push_borsh_bytes(out, s.as_bytes(), "string")
 }
 
 /// Append a yoctoNEAR `u128` carried as big-endian minimal bytes, re-encoded as
-/// borsh `u128` (little-endian, 16 bytes).
-fn push_borsh_u128_be(out: &mut Vec<u8>, be_minimal: &[u8]) {
-    let value = u128_from_be_minimal(be_minimal);
+/// borsh `u128` (little-endian, 16 bytes). Rejects inputs longer than 16 bytes:
+/// such a value does not fit a `u128`, so the human-rendered amount would
+/// diverge from the (wrapped) signed amount — an approve-vs-sign mismatch.
+/// `what` names the offending amount (`deposit` / `stake` / `allowance`) so a
+/// rejection can identify which field overflowed.
+fn push_borsh_u128_be(
+    out: &mut Vec<u8>,
+    be_minimal: &[u8],
+    what: &'static str,
+) -> Result<(), AttestationError> {
+    let value = u128_from_be_minimal(be_minimal, what)?;
     out.extend_from_slice(&value.to_le_bytes());
+    Ok(())
 }
 
-/// Parse a big-endian minimal byte string into a `u128`. Bytes beyond 16 (only
-/// possible from malformed input) are folded in by treating the value as
-/// big-endian; the high bytes simply shift, which is acceptable because the
-/// canonical bytes still commit to the raw `deposit` slice separately in the
-/// field projection. This conversion exists only to reproduce the NEAR wire
-/// `u128`.
-fn u128_from_be_minimal(be_minimal: &[u8]) -> u128 {
+/// Parse a big-endian minimal byte string into a `u128`, rejecting inputs that
+/// exceed 16 bytes (which cannot fit a `u128`). Leading-zero padding within 16
+/// bytes is tolerated; only a genuine length overflow is rejected, so the
+/// canonical wire `u128` always equals the value the human approved.
+fn u128_from_be_minimal(be_minimal: &[u8], what: &'static str) -> Result<u128, AttestationError> {
+    if be_minimal.len() > 16 {
+        return Err(AttestationError::NearU128Overflow {
+            what,
+            len: be_minimal.len(),
+        });
+    }
     let mut value: u128 = 0;
     for &b in be_minimal {
-        value = value.wrapping_shl(8) | u128::from(b);
+        value = (value << 8) | u128::from(b);
     }
-    value
+    Ok(value)
 }
 
 /// Append a borsh-serialized NEAR `PublicKey`: `key_type(u8) ∥ data`.
@@ -144,12 +227,12 @@ fn push_near_public_key(out: &mut Vec<u8>, pk: &NearPublicKey) {
 }
 
 /// Append a borsh-serialized NEAR `Action`.
-fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
+fn push_near_action(out: &mut Vec<u8>, action: &NearAction) -> Result<(), AttestationError> {
     match action {
         NearAction::CreateAccount => out.push(0),
         NearAction::DeployContract { code } => {
             out.push(1);
-            push_borsh_bytes(out, code);
+            push_borsh_bytes(out, code, "deploy_contract.code")?;
         }
         NearAction::FunctionCall {
             method_name,
@@ -158,18 +241,18 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
             deposit,
         } => {
             out.push(2);
-            push_borsh_string(out, method_name);
-            push_borsh_bytes(out, args);
+            push_borsh_string(out, method_name)?;
+            push_borsh_bytes(out, args, "function_call.args")?;
             out.extend_from_slice(&gas.to_le_bytes());
-            push_borsh_u128_be(out, deposit);
+            push_borsh_u128_be(out, deposit, "function_call.deposit")?;
         }
         NearAction::Transfer { deposit } => {
             out.push(3);
-            push_borsh_u128_be(out, deposit);
+            push_borsh_u128_be(out, deposit, "transfer.deposit")?;
         }
         NearAction::Stake { stake, public_key } => {
             out.push(4);
-            push_borsh_u128_be(out, stake);
+            push_borsh_u128_be(out, stake, "stake.stake")?;
             push_near_public_key(out, public_key);
         }
         NearAction::AddKey {
@@ -192,15 +275,15 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
                     match allowance {
                         Some(a) => {
                             out.push(1);
-                            push_borsh_u128_be(out, a);
+                            push_borsh_u128_be(out, a, "add_key.allowance")?;
                         }
                         None => out.push(0),
                     }
-                    push_borsh_string(out, receiver_id);
+                    push_borsh_string(out, receiver_id)?;
                     // Vec<String>: u32 len ∥ each borsh String.
-                    out.extend_from_slice(&(method_names.len() as u32).to_le_bytes());
+                    out.extend_from_slice(&borsh_len_le(method_names.len(), "method_names")?);
                     for name in method_names {
-                        push_borsh_string(out, name);
+                        push_borsh_string(out, name)?;
                     }
                 }
                 NearAccessKeyPermission::FullAccess => {
@@ -215,40 +298,56 @@ fn push_near_action(out: &mut Vec<u8>, action: &NearAction) {
         }
         NearAction::DeleteAccount { beneficiary_id } => {
             out.push(7);
-            push_borsh_string(out, beneficiary_id);
+            push_borsh_string(out, beneficiary_id)?;
         }
         NearAction::Delegate {
             sender_id,
             receiver_id,
+            actions,
             nonce,
             max_block_height,
             public_key,
         } => {
             out.push(8);
-            push_borsh_string(out, sender_id);
-            push_borsh_string(out, receiver_id);
+            // NEP-366 DelegateAction borsh layout:
+            // `sender_id ∥ receiver_id ∥ Vec<NonDelegateAction> ∥ nonce(u64 le)
+            //  ∥ max_block_height(u64 le) ∥ public_key`. The inner actions are
+            // carried at full fidelity so two delegates differing only in their
+            // inner actions produce distinct bytes (injectivity). Inner actions
+            // are `NonDelegateAction`: a nested `Delegate` is unrepresentable
+            // on-chain, so it is rejected (fail closed) rather than serialized.
+            push_borsh_string(out, sender_id)?;
+            push_borsh_string(out, receiver_id)?;
+            out.extend_from_slice(&borsh_len_le(actions.len(), "delegate.actions")?);
+            for inner in actions {
+                if matches!(inner, NearAction::Delegate { .. }) {
+                    return Err(AttestationError::NearNestedDelegate);
+                }
+                push_near_action(out, inner)?;
+            }
             out.extend_from_slice(&nonce.to_le_bytes());
             out.extend_from_slice(&max_block_height.to_le_bytes());
             push_near_public_key(out, public_key);
         }
     }
+    Ok(())
 }
 
 /// Serialize a NEAR transaction to its exact borsh-signed bytes:
 /// `signer_id ∥ public_key ∥ nonce(u64 le) ∥ receiver_id ∥ block_hash(32) ∥
 /// Vec<Action>`.
-pub(crate) fn near_transaction_bytes(tx: &NearTransaction) -> Vec<u8> {
+pub(crate) fn near_transaction_bytes(tx: &NearTransaction) -> Result<Vec<u8>, AttestationError> {
     let mut out = Vec::new();
-    push_borsh_string(&mut out, &tx.signer_id);
+    push_borsh_string(&mut out, &tx.signer_id)?;
     push_near_public_key(&mut out, &tx.public_key);
     out.extend_from_slice(&tx.nonce.to_le_bytes());
-    push_borsh_string(&mut out, &tx.receiver_id);
+    push_borsh_string(&mut out, &tx.receiver_id)?;
     out.extend_from_slice(&tx.block_hash.0);
-    out.extend_from_slice(&(tx.actions.len() as u32).to_le_bytes());
+    out.extend_from_slice(&borsh_len_le(tx.actions.len(), "actions")?);
     for action in &tx.actions {
-        push_near_action(&mut out, action);
+        push_near_action(&mut out, action)?;
     }
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -274,12 +373,72 @@ mod tests {
 
     #[test]
     fn u128_be_minimal_round_trips() {
-        assert_eq!(u128_from_be_minimal(&[]), 0);
-        assert_eq!(u128_from_be_minimal(&[0x01]), 1);
-        assert_eq!(u128_from_be_minimal(&[0x01, 0x00]), 256);
+        assert_eq!(u128_from_be_minimal(&[], "deposit"), Ok(0));
+        assert_eq!(u128_from_be_minimal(&[0x01], "deposit"), Ok(1));
+        assert_eq!(u128_from_be_minimal(&[0x01, 0x00], "deposit"), Ok(256));
         assert_eq!(
-            u128_from_be_minimal(&[0x0d, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00]),
-            1_000_000_000_000_000_000
+            u128_from_be_minimal(&[0x0d, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00], "deposit"),
+            Ok(1_000_000_000_000_000_000)
+        );
+        // Exactly 16 bytes (u128::MAX) is the boundary and must be accepted.
+        assert_eq!(u128_from_be_minimal(&[0xff; 16], "deposit"), Ok(u128::MAX));
+    }
+
+    #[test]
+    fn u128_be_minimal_oversized_bytes() {
+        // 17 bytes cannot fit a u128. Rather than silently wrapping/discarding
+        // the high bytes (which would make the signed value diverge from the
+        // human-approved one), the parse must fail closed.
+        let err =
+            u128_from_be_minimal(&[0x01; 17], "stake").expect_err("17 bytes must be rejected");
+        assert_eq!(
+            err,
+            AttestationError::NearU128Overflow {
+                what: "stake",
+                len: 17
+            }
+        );
+        // A leading-zero-padded value within 16 bytes is still fine.
+        assert_eq!(u128_from_be_minimal(&[0x00, 0x00, 0x01], "stake"), Ok(1));
+    }
+
+    #[test]
+    fn compact_bytes_rejects_overlong_slice() {
+        // A byte slice longer than u16::MAX cannot be length-prefixed by a
+        // compact-u16. Truncating the prefix would let the trailing bytes be
+        // reinterpreted as separate instructions/accounts (field smuggling), so
+        // the encoder must fail closed.
+        let oversized = vec![0u8; u16::MAX as usize + 1];
+        let mut out = Vec::new();
+        let err = push_compact_bytes(&mut out, &oversized, "instruction.data")
+            .expect_err("oversized compact slice must be rejected");
+        assert_eq!(
+            err,
+            AttestationError::SolanaShortVecOverflow {
+                what: "instruction.data",
+                len: u16::MAX as usize + 1,
+                max: u16::MAX as usize,
+            }
+        );
+        // Exactly u16::MAX is the boundary and must encode.
+        let mut ok = Vec::new();
+        assert!(push_compact_bytes(&mut ok, &vec![0u8; u16::MAX as usize], "d").is_ok());
+    }
+
+    #[test]
+    fn borsh_bytes_rejects_overlong_length() {
+        // borsh_len_le is the choke point for every borsh u32 length prefix.
+        // usize values beyond u32::MAX must be rejected, not truncated.
+        assert!(borsh_len_le(u32::MAX as usize, "bytes").is_ok());
+        let err = borsh_len_le(u32::MAX as usize + 1, "bytes")
+            .expect_err("u32 overflow must be rejected");
+        assert_eq!(
+            err,
+            AttestationError::NearBorshLengthOverflow {
+                what: "bytes",
+                len: u32::MAX as usize + 1,
+                max: u32::MAX as usize,
+            }
         );
     }
 }

--- a/crates/ironclaw_attestation/tests/binding.rs
+++ b/crates/ironclaw_attestation/tests/binding.rs
@@ -9,11 +9,11 @@
 //! separation prevents cross-chain collisions.
 
 use ironclaw_attestation::{
-    Bytes32, DecodedTransaction, EvmAccessListEntry, EvmAddress, EvmTransaction, NearAccessKey,
-    NearAccessKeyPermission, NearAction, NearPublicKey, NearTransaction, RenderingSchemaVersion,
-    SolanaAddressTableLookup, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
-    SolanaTransaction, approved_tx_hash_for, canonical_signing_bytes, compute_approved_tx_hash,
-    render,
+    AttestationError, Bytes32, DecodedTransaction, EvmAccessListEntry, EvmAddress, EvmTransaction,
+    NearAccessKey, NearAccessKeyPermission, NearAction, NearPublicKey, NearTransaction,
+    RenderingSchemaVersion, SolanaAddressTableLookup, SolanaCompiledInstruction,
+    SolanaMessageHeader, SolanaMessageVersion, SolanaTransaction, approved_tx_hash_for,
+    canonical_signing_bytes, compute_approved_tx_hash, render,
 };
 
 const SV: RenderingSchemaVersion = RenderingSchemaVersion::CURRENT;
@@ -22,7 +22,23 @@ const SIGNER: &str = "0x1111111111111111111111111111111111111111";
 /// Full hash via the SAFE public API (derives render + canonical from the same
 /// tx and binds the explicit signer).
 fn hash_of(tx: &DecodedTransaction, schema: RenderingSchemaVersion) -> [u8; 32] {
-    *approved_tx_hash_for(tx, SIGNER, schema).as_bytes()
+    *approved_tx_hash_for(tx, SIGNER, schema)
+        .expect("hash")
+        .as_bytes()
+}
+
+/// Canonical signing bytes for a well-formed sample (panics on overflow, which
+/// the dedicated fail-closed tests cover explicitly).
+fn canon(tx: &DecodedTransaction, schema: RenderingSchemaVersion) -> Vec<u8> {
+    canonical_signing_bytes(tx, schema).expect("canonical bytes")
+}
+
+/// Render a well-formed sample (panics on overflow).
+fn render_ok(
+    tx: &DecodedTransaction,
+    schema: RenderingSchemaVersion,
+) -> ironclaw_attestation::RenderedTx {
+    render(tx, schema).expect("render")
 }
 
 fn sample_evm() -> EvmTransaction {
@@ -96,10 +112,7 @@ fn sample_near() -> NearTransaction {
 #[test]
 fn canonical_bytes_are_deterministic_across_calls() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    assert_eq!(
-        canonical_signing_bytes(&tx, SV),
-        canonical_signing_bytes(&tx, SV)
-    );
+    assert_eq!(canon(&tx, SV), canon(&tx, SV));
     assert_eq!(hash_of(&tx, SV), hash_of(&tx, SV));
 }
 
@@ -113,10 +126,7 @@ fn canonical_bytes_survive_serde_round_trip() {
         let json = serde_json::to_string(&tx).expect("serialize");
         let back: DecodedTransaction = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, tx);
-        assert_eq!(
-            canonical_signing_bytes(&tx, SV),
-            canonical_signing_bytes(&back, SV)
-        );
+        assert_eq!(canon(&tx, SV), canon(&back, SV));
         assert_eq!(hash_of(&tx, SV), hash_of(&back, SV));
     }
 }
@@ -129,10 +139,12 @@ fn changing_signer_account_changes_hash_with_fixed_to() {
     // The hash MUST change — the approval commits to *who signs*, not to a
     // heuristic recovered from the tx body.
     let tx = DecodedTransaction::Evm(sample_evm());
-    let h_a =
-        *approved_tx_hash_for(&tx, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SV).as_bytes();
-    let h_b =
-        *approved_tx_hash_for(&tx, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", SV).as_bytes();
+    let h_a = *approved_tx_hash_for(&tx, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SV)
+        .expect("hash a")
+        .as_bytes();
+    let h_b = *approved_tx_hash_for(&tx, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", SV)
+        .expect("hash b")
+        .as_bytes();
     assert_ne!(h_a, h_b, "changing the bound signer must change the hash");
 
     // Sanity: `to` is identical across both hashes (same tx), proving the
@@ -145,8 +157,8 @@ fn changing_signer_account_changes_hash_with_fixed_to() {
 #[test]
 fn safe_api_matches_manual_component_assembly() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    let rendered = render(&tx, SV);
-    let canonical = canonical_signing_bytes(&tx, SV);
+    let rendered = render_ok(&tx, SV);
+    let canonical = canon(&tx, SV);
     let manual = compute_approved_tx_hash(
         &rendered,
         &canonical,
@@ -155,7 +167,7 @@ fn safe_api_matches_manual_component_assembly() {
         &tx.tx_type_label(),
         SV,
     );
-    assert_eq!(approved_tx_hash_for(&tx, SIGNER, SV), manual);
+    assert_eq!(approved_tx_hash_for(&tx, SIGNER, SV).expect("hash"), manual);
 }
 
 // ---- Anti-field-smuggling: every component changes the hash -------------
@@ -170,7 +182,7 @@ fn changing_schema_version_changes_hash() {
 fn changing_any_evm_field_changes_canonical_bytes_and_hash() {
     let base = sample_evm();
     let baseline = DecodedTransaction::Evm(base.clone());
-    let baseline_bytes = canonical_signing_bytes(&baseline, SV);
+    let baseline_bytes = canon(&baseline, SV);
     let baseline_hash = hash_of(&baseline, SV);
 
     type Mutator = Box<dyn Fn(&mut EvmTransaction)>;
@@ -210,7 +222,7 @@ fn changing_any_evm_field_changes_canonical_bytes_and_hash() {
         f(&mut m);
         let tx = DecodedTransaction::Evm(m);
         assert_ne!(
-            canonical_signing_bytes(&tx, SV),
+            canon(&tx, SV),
             baseline_bytes,
             "mutating `{name}` must change canonical bytes"
         );
@@ -225,8 +237,8 @@ fn changing_any_evm_field_changes_canonical_bytes_and_hash() {
 #[test]
 fn changing_chain_network_or_tx_type_component_changes_hash() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    let rendered = render(&tx, SV);
-    let canonical = canonical_signing_bytes(&tx, SV);
+    let rendered = render_ok(&tx, SV);
+    let canonical = canon(&tx, SV);
     let base = compute_approved_tx_hash(
         &rendered,
         &canonical,
@@ -261,8 +273,8 @@ fn same_render_different_canonical_bytes_changes_hash() {
     // If an attacker could keep the displayed render fixed while swapping the
     // signed bytes (approve-A / sign-B), the hash MUST still change.
     let tx = DecodedTransaction::Evm(sample_evm());
-    let rendered = render(&tx, SV);
-    let canonical_a = canonical_signing_bytes(&tx, SV);
+    let rendered = render_ok(&tx, SV);
+    let canonical_a = canon(&tx, SV);
     let mut canonical_b = canonical_a.clone();
     *canonical_b.last_mut().expect("non-empty") ^= 0xff;
     assert_ne!(canonical_a, canonical_b);
@@ -292,8 +304,8 @@ fn same_render_different_canonical_bytes_changes_hash() {
 #[test]
 fn changing_render_component_changes_hash() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    let canonical = canonical_signing_bytes(&tx, SV);
-    let r1 = render(&tx, SV);
+    let canonical = canon(&tx, SV);
+    let r1 = render_ok(&tx, SV);
     let mut r2 = r1.clone();
     r2.fields[0].value = "tampered".to_string();
     let h1 = compute_approved_tx_hash(
@@ -398,7 +410,7 @@ fn near_nested_structs_reject_unknown_fields() {
 fn solana_distinct_messages_hash_differently() {
     let base = DecodedTransaction::Solana(sample_solana());
     let baseline = hash_of(&base, SV);
-    let baseline_bytes = canonical_signing_bytes(&base, SV);
+    let baseline_bytes = canon(&base, SV);
 
     type Mutator = Box<dyn Fn(&mut SolanaTransaction)>;
     let mutate: Vec<(&str, Mutator)> = vec![
@@ -457,7 +469,7 @@ fn solana_distinct_messages_hash_differently() {
         f(&mut m);
         let tx = DecodedTransaction::Solana(m);
         assert_ne!(
-            canonical_signing_bytes(&tx, SV),
+            canon(&tx, SV),
             baseline_bytes,
             "mutating Solana `{name}` must change canonical bytes"
         );
@@ -480,8 +492,8 @@ fn solana_legacy_and_v0_with_same_contents_differ() {
     v0.version = SolanaMessageVersion::V0;
 
     assert_ne!(
-        canonical_signing_bytes(&DecodedTransaction::Solana(legacy.clone()), SV),
-        canonical_signing_bytes(&DecodedTransaction::Solana(v0.clone()), SV)
+        canon(&DecodedTransaction::Solana(legacy.clone()), SV),
+        canon(&DecodedTransaction::Solana(v0.clone()), SV)
     );
     assert_ne!(
         hash_of(&DecodedTransaction::Solana(legacy), SV),
@@ -510,7 +522,7 @@ fn solana_message_bytes_match_known_layout() {
         }],
         address_table_lookups: vec![],
     };
-    let bytes = canonical_signing_bytes(&DecodedTransaction::Solana(tx), SV);
+    let bytes = canon(&DecodedTransaction::Solana(tx), SV);
     // The canonical bytes embed the message; assert the message slice appears.
     // Expected message = header(1,0,1) ∥ shortvec(2) ∥ key0 ∥ key1 ∥ blockhash
     //                    ∥ shortvec(1) ∥ [1, shortvec(1), 0, shortvec(2), de ad]
@@ -581,7 +593,7 @@ fn near_distinct_actions_hash_differently() {
     for action in variants {
         let tx = near_with_action(action);
         assert!(
-            byte_sets.insert(canonical_signing_bytes(&tx, SV)),
+            byte_sets.insert(canon(&tx, SV)),
             "each NEAR action variant must produce unique canonical bytes"
         );
         assert!(
@@ -666,7 +678,7 @@ fn near_public_key_binds() {
 // ---- Render coverage: render touches every consumed field ---------------
 
 fn assert_render_covers(tx: &DecodedTransaction, expected_labels: &[&str]) {
-    let rendered = render(tx, SV);
+    let rendered = render_ok(tx, SV);
     for label in expected_labels {
         assert!(
             rendered.has_label(label),
@@ -675,7 +687,7 @@ fn assert_render_covers(tx: &DecodedTransaction, expected_labels: &[&str]) {
             rendered.fields.iter().map(|f| &f.label).collect::<Vec<_>>()
         );
     }
-    assert!(!canonical_signing_bytes(tx, SV).is_empty());
+    assert!(!canon(tx, SV).is_empty());
     assert!(rendered.fields.len() >= expected_labels.len());
 }
 
@@ -750,8 +762,8 @@ fn render_field_count_matches_canonical_field_count() {
         DecodedTransaction::Solana(sample_solana()),
         DecodedTransaction::Near(sample_near()),
     ] {
-        let rendered = render(&tx, SV);
-        let bytes = canonical_signing_bytes(&tx, SV);
+        let rendered = render_ok(&tx, SV);
+        let bytes = canon(&tx, SV);
         let count = parse_canonical_field_count(&bytes);
         assert_eq!(
             count,
@@ -813,10 +825,7 @@ fn evm_and_solana_with_similar_bytes_hash_differently() {
         instructions: vec![],
         address_table_lookups: vec![],
     });
-    assert_ne!(
-        canonical_signing_bytes(&evm, SV),
-        canonical_signing_bytes(&sol, SV)
-    );
+    assert_ne!(canon(&evm, SV), canon(&sol, SV));
     assert_ne!(hash_of(&evm, SV), hash_of(&sol, SV));
 }
 
@@ -829,5 +838,123 @@ fn same_tx_on_different_evm_networks_hash_differently() {
     assert_ne!(
         hash_of(&DecodedTransaction::Evm(a), SV),
         hash_of(&DecodedTransaction::Evm(b), SV)
+    );
+}
+
+// ---- Fail-closed wire encoding (henrypark133 Critical/High findings) -----
+//
+// These drive the SAFE public API (`approved_tx_hash_for` /
+// `canonical_signing_bytes`) — not the private wire helpers — so they regress
+// the actual call site a signing flow uses. An input that cannot be reproduced
+// byte-for-byte as the signed payload must be REJECTED, never truncated: a
+// truncated length prefix would let trailing bytes be reinterpreted as extra
+// instructions/accounts (Solana) or desync the borsh stream (NEAR), smuggling
+// fields past the what-you-see-is-what-you-sign binding.
+
+#[test]
+fn solana_oversized_instruction_data_is_rejected() {
+    // Instruction data longer than the compact-u16 maximum cannot be
+    // length-prefixed faithfully. The canonical/hash path must fail closed
+    // rather than truncate the shortvec prefix.
+    let mut sol = sample_solana();
+    sol.instructions[0].data = vec![0u8; u16::MAX as usize + 1];
+    let tx = DecodedTransaction::Solana(sol);
+    assert_eq!(
+        canonical_signing_bytes(&tx, SV),
+        Err(AttestationError::SolanaShortVecOverflow {
+            what: "instruction.data",
+            len: u16::MAX as usize + 1,
+            max: u16::MAX as usize,
+        })
+    );
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_err());
+    assert!(render(&tx, SV).is_err());
+}
+
+#[test]
+fn solana_max_instruction_data_still_encodes() {
+    // Exactly u16::MAX is representable and must succeed (boundary).
+    let mut sol = sample_solana();
+    sol.instructions[0].data = vec![0u8; u16::MAX as usize];
+    let tx = DecodedTransaction::Solana(sol);
+    assert!(canonical_signing_bytes(&tx, SV).is_ok());
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_ok());
+}
+
+#[test]
+fn near_oversized_deposit_is_rejected() {
+    // A deposit carrying more than 16 big-endian bytes does not fit a borsh
+    // u128. Wrapping it (as the old `wrapping_shl` did) would make the SIGNED
+    // amount differ from the human-RENDERED amount — an approve-vs-sign
+    // divergence — so canonicalization must fail closed.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Transfer {
+        deposit: vec![0x01; 17],
+    }];
+    let tx = DecodedTransaction::Near(near);
+    assert_eq!(
+        canonical_signing_bytes(&tx, SV),
+        Err(AttestationError::NearU128Overflow { len: 17 })
+    );
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_err());
+}
+
+#[test]
+fn near_max_width_deposit_still_encodes() {
+    // A full 16-byte (u128::MAX) deposit is representable and must succeed.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Transfer {
+        deposit: vec![0xff; 16],
+    }];
+    let tx = DecodedTransaction::Near(near);
+    assert!(canonical_signing_bytes(&tx, SV).is_ok());
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_ok());
+}
+
+#[test]
+fn near_delegate_action_serializes_empty_inner_actions_vector() {
+    // NEP-366 DelegateAction places a `Vec<Action>` between `receiver_id` and
+    // `nonce`. Omitting it (the previous bug) makes a borsh deserializer read
+    // the 8-byte `nonce` as the actions-vector length, corrupting the parse.
+    // We serialize an explicit empty actions vector (borsh `0u32`) in the
+    // correct position; assert that exact slice appears in the canonical bytes.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Delegate {
+        sender_id: "s.near".to_string(),
+        receiver_id: "r.near".to_string(),
+        nonce: 0x0102_0304_0506_0708,
+        max_block_height: 100,
+        public_key: ed25519_pk(0x44),
+    }];
+    let tx = DecodedTransaction::Near(near);
+    let bytes = canon(&tx, SV);
+
+    // Expected wire fragment for the Delegate action body:
+    //   discriminant(8) ∥ borsh("s.near") ∥ borsh("r.near") ∥
+    //   actions_len(0u32 le) ∥ nonce(u64 le) ∥ ...
+    let mut expected = vec![8u8]; // Delegate discriminant
+    expected.extend_from_slice(&6u32.to_le_bytes());
+    expected.extend_from_slice(b"s.near");
+    expected.extend_from_slice(&6u32.to_le_bytes());
+    expected.extend_from_slice(b"r.near");
+    expected.extend_from_slice(&0u32.to_le_bytes()); // empty inner actions vec
+    expected.extend_from_slice(&0x0102_0304_0506_0708u64.to_le_bytes()); // nonce
+    assert!(
+        bytes.windows(expected.len()).any(|w| w == expected),
+        "Delegate action must serialize an explicit empty actions vector before the nonce"
+    );
+
+    // Distinct delegate transactions must still hash distinctly.
+    let mut other = sample_near();
+    other.actions = vec![NearAction::Delegate {
+        sender_id: "s.near".to_string(),
+        receiver_id: "r.near".to_string(),
+        nonce: 0x0102_0304_0506_0709, // differs by one
+        max_block_height: 100,
+        public_key: ed25519_pk(0x44),
+    }];
+    assert_ne!(
+        hash_of(&tx, SV),
+        hash_of(&DecodedTransaction::Near(other), SV)
     );
 }

--- a/crates/ironclaw_attestation/tests/binding.rs
+++ b/crates/ironclaw_attestation/tests/binding.rs
@@ -583,6 +583,7 @@ fn near_distinct_actions_hash_differently() {
         NearAction::Delegate {
             sender_id: "s.near".to_string(),
             receiver_id: "r.near".to_string(),
+            actions: vec![],
             nonce: 2,
             max_block_height: 100,
             public_key: ed25519_pk(0x44),
@@ -894,7 +895,10 @@ fn near_oversized_deposit_is_rejected() {
     let tx = DecodedTransaction::Near(near);
     assert_eq!(
         canonical_signing_bytes(&tx, SV),
-        Err(AttestationError::NearU128Overflow { len: 17 })
+        Err(AttestationError::NearU128Overflow {
+            what: "transfer.deposit",
+            len: 17
+        })
     );
     assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_err());
 }
@@ -914,14 +918,14 @@ fn near_max_width_deposit_still_encodes() {
 #[test]
 fn near_delegate_action_serializes_empty_inner_actions_vector() {
     // NEP-366 DelegateAction places a `Vec<Action>` between `receiver_id` and
-    // `nonce`. Omitting it (the previous bug) makes a borsh deserializer read
-    // the 8-byte `nonce` as the actions-vector length, corrupting the parse.
-    // We serialize an explicit empty actions vector (borsh `0u32`) in the
-    // correct position; assert that exact slice appears in the canonical bytes.
+    // `nonce`. A delegate with no inner actions serializes an explicit empty
+    // actions vector (borsh `0u32`) in the correct position; assert that exact
+    // slice appears in the canonical bytes.
     let mut near = sample_near();
     near.actions = vec![NearAction::Delegate {
         sender_id: "s.near".to_string(),
         receiver_id: "r.near".to_string(),
+        actions: vec![],
         nonce: 0x0102_0304_0506_0708,
         max_block_height: 100,
         public_key: ed25519_pk(0x44),
@@ -949,6 +953,7 @@ fn near_delegate_action_serializes_empty_inner_actions_vector() {
     other.actions = vec![NearAction::Delegate {
         sender_id: "s.near".to_string(),
         receiver_id: "r.near".to_string(),
+        actions: vec![],
         nonce: 0x0102_0304_0506_0709, // differs by one
         max_block_height: 100,
         public_key: ed25519_pk(0x44),
@@ -957,4 +962,96 @@ fn near_delegate_action_serializes_empty_inner_actions_vector() {
         hash_of(&tx, SV),
         hash_of(&DecodedTransaction::Near(other), SV)
     );
+}
+
+#[test]
+fn near_delegate_inner_actions_are_injective() {
+    // NEP-366 DelegateAction carries an inner `Vec<Action>`. Two delegates that
+    // differ ONLY in their inner actions must NOT collapse to the same canonical
+    // bytes / hash, or an attestation signed for delegate-with-actions-A would
+    // also validate for delegate-with-actions-B (approve-A / sign-B confusion).
+    let delegate = |inner: Vec<NearAction>| {
+        let mut near = sample_near();
+        near.actions = vec![NearAction::Delegate {
+            sender_id: "s.near".to_string(),
+            receiver_id: "r.near".to_string(),
+            actions: inner,
+            nonce: 7,
+            max_block_height: 100,
+            public_key: ed25519_pk(0x44),
+        }];
+        DecodedTransaction::Near(near)
+    };
+
+    let a = delegate(vec![NearAction::Transfer {
+        deposit: vec![0x01],
+    }]);
+    let b = delegate(vec![NearAction::Transfer {
+        deposit: vec![0x02], // same shape, different amount
+    }]);
+    let c = delegate(vec![]); // no inner actions at all
+    let d = delegate(vec![
+        NearAction::Transfer {
+            deposit: vec![0x01],
+        },
+        NearAction::Transfer {
+            deposit: vec![0x01],
+        },
+    ]); // same first action, but a second one appended
+
+    // All four must be pairwise distinct in both canonical bytes and hash.
+    let txs = [&a, &b, &c, &d];
+    let mut byte_sets = std::collections::HashSet::new();
+    let mut hashes = std::collections::HashSet::new();
+    for tx in txs {
+        assert!(
+            byte_sets.insert(canon(tx, SV)),
+            "delegates differing only in inner actions must have distinct canonical bytes"
+        );
+        assert!(
+            hashes.insert(hash_of(tx, SV)),
+            "delegates differing only in inner actions must have distinct hashes"
+        );
+    }
+
+    // The inner action's serialized body must actually appear in the canonical
+    // bytes (proving it is carried, not dropped): a Transfer of 0x02.
+    let bytes = canon(&b, SV);
+    let inner_fragment = vec![3u8, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    assert!(
+        bytes
+            .windows(inner_fragment.len())
+            .any(|w| w == inner_fragment),
+        "inner Transfer action body must be serialized into the delegate wire bytes"
+    );
+}
+
+#[test]
+fn near_delegate_nested_delegate_is_rejected() {
+    // NEP-366 inner actions are `NonDelegateAction`: a delegate may not nest a
+    // delegate. An inner Delegate cannot be represented faithfully on-chain, so
+    // canonicalization must fail closed rather than emit ambiguous bytes.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Delegate {
+        sender_id: "s.near".to_string(),
+        receiver_id: "r.near".to_string(),
+        actions: vec![NearAction::Delegate {
+            sender_id: "inner.near".to_string(),
+            receiver_id: "innerr.near".to_string(),
+            actions: vec![],
+            nonce: 1,
+            max_block_height: 1,
+            public_key: ed25519_pk(0x55),
+        }],
+        nonce: 7,
+        max_block_height: 100,
+        public_key: ed25519_pk(0x44),
+    }];
+    let tx = DecodedTransaction::Near(near);
+    assert_eq!(
+        canonical_signing_bytes(&tx, SV),
+        Err(AttestationError::NearNestedDelegate)
+    );
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_err());
+    assert!(render(&tx, SV).is_err());
 }

--- a/crates/ironclaw_attestation/tests/binding.rs
+++ b/crates/ironclaw_attestation/tests/binding.rs
@@ -9,11 +9,11 @@
 //! separation prevents cross-chain collisions.
 
 use ironclaw_attestation::{
-    Bytes32, DecodedTransaction, EvmAccessListEntry, EvmAddress, EvmTransaction, NearAccessKey,
-    NearAccessKeyPermission, NearAction, NearPublicKey, NearTransaction, RenderingSchemaVersion,
-    SolanaAddressTableLookup, SolanaCompiledInstruction, SolanaMessageHeader, SolanaMessageVersion,
-    SolanaTransaction, approved_tx_hash_for, canonical_signing_bytes, compute_approved_tx_hash,
-    render,
+    AttestationError, Bytes32, DecodedTransaction, EvmAccessListEntry, EvmAddress, EvmTransaction,
+    NearAccessKey, NearAccessKeyPermission, NearAction, NearPublicKey, NearTransaction,
+    RenderingSchemaVersion, SolanaAddressTableLookup, SolanaCompiledInstruction,
+    SolanaMessageHeader, SolanaMessageVersion, SolanaTransaction, approved_tx_hash_for,
+    canonical_signing_bytes, compute_approved_tx_hash, render,
 };
 
 const SV: RenderingSchemaVersion = RenderingSchemaVersion::CURRENT;
@@ -22,7 +22,23 @@ const SIGNER: &str = "0x1111111111111111111111111111111111111111";
 /// Full hash via the SAFE public API (derives render + canonical from the same
 /// tx and binds the explicit signer).
 fn hash_of(tx: &DecodedTransaction, schema: RenderingSchemaVersion) -> [u8; 32] {
-    *approved_tx_hash_for(tx, SIGNER, schema).as_bytes()
+    *approved_tx_hash_for(tx, SIGNER, schema)
+        .expect("hash")
+        .as_bytes()
+}
+
+/// Canonical signing bytes for a well-formed sample (panics on overflow, which
+/// the dedicated fail-closed tests cover explicitly).
+fn canon(tx: &DecodedTransaction, schema: RenderingSchemaVersion) -> Vec<u8> {
+    canonical_signing_bytes(tx, schema).expect("canonical bytes")
+}
+
+/// Render a well-formed sample (panics on overflow).
+fn render_ok(
+    tx: &DecodedTransaction,
+    schema: RenderingSchemaVersion,
+) -> ironclaw_attestation::RenderedTx {
+    render(tx, schema).expect("render")
 }
 
 fn sample_evm() -> EvmTransaction {
@@ -96,10 +112,7 @@ fn sample_near() -> NearTransaction {
 #[test]
 fn canonical_bytes_are_deterministic_across_calls() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    assert_eq!(
-        canonical_signing_bytes(&tx, SV),
-        canonical_signing_bytes(&tx, SV)
-    );
+    assert_eq!(canon(&tx, SV), canon(&tx, SV));
     assert_eq!(hash_of(&tx, SV), hash_of(&tx, SV));
 }
 
@@ -113,10 +126,7 @@ fn canonical_bytes_survive_serde_round_trip() {
         let json = serde_json::to_string(&tx).expect("serialize");
         let back: DecodedTransaction = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, tx);
-        assert_eq!(
-            canonical_signing_bytes(&tx, SV),
-            canonical_signing_bytes(&back, SV)
-        );
+        assert_eq!(canon(&tx, SV), canon(&back, SV));
         assert_eq!(hash_of(&tx, SV), hash_of(&back, SV));
     }
 }
@@ -129,10 +139,12 @@ fn changing_signer_account_changes_hash_with_fixed_to() {
     // The hash MUST change — the approval commits to *who signs*, not to a
     // heuristic recovered from the tx body.
     let tx = DecodedTransaction::Evm(sample_evm());
-    let h_a =
-        *approved_tx_hash_for(&tx, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SV).as_bytes();
-    let h_b =
-        *approved_tx_hash_for(&tx, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", SV).as_bytes();
+    let h_a = *approved_tx_hash_for(&tx, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SV)
+        .expect("hash a")
+        .as_bytes();
+    let h_b = *approved_tx_hash_for(&tx, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", SV)
+        .expect("hash b")
+        .as_bytes();
     assert_ne!(h_a, h_b, "changing the bound signer must change the hash");
 
     // Sanity: `to` is identical across both hashes (same tx), proving the
@@ -145,8 +157,8 @@ fn changing_signer_account_changes_hash_with_fixed_to() {
 #[test]
 fn safe_api_matches_manual_component_assembly() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    let rendered = render(&tx, SV);
-    let canonical = canonical_signing_bytes(&tx, SV);
+    let rendered = render_ok(&tx, SV);
+    let canonical = canon(&tx, SV);
     let manual = compute_approved_tx_hash(
         &rendered,
         &canonical,
@@ -155,7 +167,7 @@ fn safe_api_matches_manual_component_assembly() {
         &tx.tx_type_label(),
         SV,
     );
-    assert_eq!(approved_tx_hash_for(&tx, SIGNER, SV), manual);
+    assert_eq!(approved_tx_hash_for(&tx, SIGNER, SV).expect("hash"), manual);
 }
 
 // ---- Anti-field-smuggling: every component changes the hash -------------
@@ -170,7 +182,7 @@ fn changing_schema_version_changes_hash() {
 fn changing_any_evm_field_changes_canonical_bytes_and_hash() {
     let base = sample_evm();
     let baseline = DecodedTransaction::Evm(base.clone());
-    let baseline_bytes = canonical_signing_bytes(&baseline, SV);
+    let baseline_bytes = canon(&baseline, SV);
     let baseline_hash = hash_of(&baseline, SV);
 
     type Mutator = Box<dyn Fn(&mut EvmTransaction)>;
@@ -210,7 +222,7 @@ fn changing_any_evm_field_changes_canonical_bytes_and_hash() {
         f(&mut m);
         let tx = DecodedTransaction::Evm(m);
         assert_ne!(
-            canonical_signing_bytes(&tx, SV),
+            canon(&tx, SV),
             baseline_bytes,
             "mutating `{name}` must change canonical bytes"
         );
@@ -225,8 +237,8 @@ fn changing_any_evm_field_changes_canonical_bytes_and_hash() {
 #[test]
 fn changing_chain_network_or_tx_type_component_changes_hash() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    let rendered = render(&tx, SV);
-    let canonical = canonical_signing_bytes(&tx, SV);
+    let rendered = render_ok(&tx, SV);
+    let canonical = canon(&tx, SV);
     let base = compute_approved_tx_hash(
         &rendered,
         &canonical,
@@ -261,8 +273,8 @@ fn same_render_different_canonical_bytes_changes_hash() {
     // If an attacker could keep the displayed render fixed while swapping the
     // signed bytes (approve-A / sign-B), the hash MUST still change.
     let tx = DecodedTransaction::Evm(sample_evm());
-    let rendered = render(&tx, SV);
-    let canonical_a = canonical_signing_bytes(&tx, SV);
+    let rendered = render_ok(&tx, SV);
+    let canonical_a = canon(&tx, SV);
     let mut canonical_b = canonical_a.clone();
     *canonical_b.last_mut().expect("non-empty") ^= 0xff;
     assert_ne!(canonical_a, canonical_b);
@@ -292,8 +304,8 @@ fn same_render_different_canonical_bytes_changes_hash() {
 #[test]
 fn changing_render_component_changes_hash() {
     let tx = DecodedTransaction::Evm(sample_evm());
-    let canonical = canonical_signing_bytes(&tx, SV);
-    let r1 = render(&tx, SV);
+    let canonical = canon(&tx, SV);
+    let r1 = render_ok(&tx, SV);
     let mut r2 = r1.clone();
     r2.fields[0].value = "tampered".to_string();
     let h1 = compute_approved_tx_hash(
@@ -398,7 +410,7 @@ fn near_nested_structs_reject_unknown_fields() {
 fn solana_distinct_messages_hash_differently() {
     let base = DecodedTransaction::Solana(sample_solana());
     let baseline = hash_of(&base, SV);
-    let baseline_bytes = canonical_signing_bytes(&base, SV);
+    let baseline_bytes = canon(&base, SV);
 
     type Mutator = Box<dyn Fn(&mut SolanaTransaction)>;
     let mutate: Vec<(&str, Mutator)> = vec![
@@ -457,7 +469,7 @@ fn solana_distinct_messages_hash_differently() {
         f(&mut m);
         let tx = DecodedTransaction::Solana(m);
         assert_ne!(
-            canonical_signing_bytes(&tx, SV),
+            canon(&tx, SV),
             baseline_bytes,
             "mutating Solana `{name}` must change canonical bytes"
         );
@@ -480,8 +492,8 @@ fn solana_legacy_and_v0_with_same_contents_differ() {
     v0.version = SolanaMessageVersion::V0;
 
     assert_ne!(
-        canonical_signing_bytes(&DecodedTransaction::Solana(legacy.clone()), SV),
-        canonical_signing_bytes(&DecodedTransaction::Solana(v0.clone()), SV)
+        canon(&DecodedTransaction::Solana(legacy.clone()), SV),
+        canon(&DecodedTransaction::Solana(v0.clone()), SV)
     );
     assert_ne!(
         hash_of(&DecodedTransaction::Solana(legacy), SV),
@@ -510,7 +522,7 @@ fn solana_message_bytes_match_known_layout() {
         }],
         address_table_lookups: vec![],
     };
-    let bytes = canonical_signing_bytes(&DecodedTransaction::Solana(tx), SV);
+    let bytes = canon(&DecodedTransaction::Solana(tx), SV);
     // The canonical bytes embed the message; assert the message slice appears.
     // Expected message = header(1,0,1) ∥ shortvec(2) ∥ key0 ∥ key1 ∥ blockhash
     //                    ∥ shortvec(1) ∥ [1, shortvec(1), 0, shortvec(2), de ad]
@@ -571,6 +583,7 @@ fn near_distinct_actions_hash_differently() {
         NearAction::Delegate {
             sender_id: "s.near".to_string(),
             receiver_id: "r.near".to_string(),
+            actions: vec![],
             nonce: 2,
             max_block_height: 100,
             public_key: ed25519_pk(0x44),
@@ -581,7 +594,7 @@ fn near_distinct_actions_hash_differently() {
     for action in variants {
         let tx = near_with_action(action);
         assert!(
-            byte_sets.insert(canonical_signing_bytes(&tx, SV)),
+            byte_sets.insert(canon(&tx, SV)),
             "each NEAR action variant must produce unique canonical bytes"
         );
         assert!(
@@ -666,7 +679,7 @@ fn near_public_key_binds() {
 // ---- Render coverage: render touches every consumed field ---------------
 
 fn assert_render_covers(tx: &DecodedTransaction, expected_labels: &[&str]) {
-    let rendered = render(tx, SV);
+    let rendered = render_ok(tx, SV);
     for label in expected_labels {
         assert!(
             rendered.has_label(label),
@@ -675,7 +688,7 @@ fn assert_render_covers(tx: &DecodedTransaction, expected_labels: &[&str]) {
             rendered.fields.iter().map(|f| &f.label).collect::<Vec<_>>()
         );
     }
-    assert!(!canonical_signing_bytes(tx, SV).is_empty());
+    assert!(!canon(tx, SV).is_empty());
     assert!(rendered.fields.len() >= expected_labels.len());
 }
 
@@ -750,8 +763,8 @@ fn render_field_count_matches_canonical_field_count() {
         DecodedTransaction::Solana(sample_solana()),
         DecodedTransaction::Near(sample_near()),
     ] {
-        let rendered = render(&tx, SV);
-        let bytes = canonical_signing_bytes(&tx, SV);
+        let rendered = render_ok(&tx, SV);
+        let bytes = canon(&tx, SV);
         let count = parse_canonical_field_count(&bytes);
         assert_eq!(
             count,
@@ -813,10 +826,7 @@ fn evm_and_solana_with_similar_bytes_hash_differently() {
         instructions: vec![],
         address_table_lookups: vec![],
     });
-    assert_ne!(
-        canonical_signing_bytes(&evm, SV),
-        canonical_signing_bytes(&sol, SV)
-    );
+    assert_ne!(canon(&evm, SV), canon(&sol, SV));
     assert_ne!(hash_of(&evm, SV), hash_of(&sol, SV));
 }
 
@@ -830,4 +840,218 @@ fn same_tx_on_different_evm_networks_hash_differently() {
         hash_of(&DecodedTransaction::Evm(a), SV),
         hash_of(&DecodedTransaction::Evm(b), SV)
     );
+}
+
+// ---- Fail-closed wire encoding (henrypark133 Critical/High findings) -----
+//
+// These drive the SAFE public API (`approved_tx_hash_for` /
+// `canonical_signing_bytes`) — not the private wire helpers — so they regress
+// the actual call site a signing flow uses. An input that cannot be reproduced
+// byte-for-byte as the signed payload must be REJECTED, never truncated: a
+// truncated length prefix would let trailing bytes be reinterpreted as extra
+// instructions/accounts (Solana) or desync the borsh stream (NEAR), smuggling
+// fields past the what-you-see-is-what-you-sign binding.
+
+#[test]
+fn solana_oversized_instruction_data_is_rejected() {
+    // Instruction data longer than the compact-u16 maximum cannot be
+    // length-prefixed faithfully. The canonical/hash path must fail closed
+    // rather than truncate the shortvec prefix.
+    let mut sol = sample_solana();
+    sol.instructions[0].data = vec![0u8; u16::MAX as usize + 1];
+    let tx = DecodedTransaction::Solana(sol);
+    assert_eq!(
+        canonical_signing_bytes(&tx, SV),
+        Err(AttestationError::SolanaShortVecOverflow {
+            what: "instruction.data",
+            len: u16::MAX as usize + 1,
+            max: u16::MAX as usize,
+        })
+    );
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_err());
+    assert!(render(&tx, SV).is_err());
+}
+
+#[test]
+fn solana_max_instruction_data_still_encodes() {
+    // Exactly u16::MAX is representable and must succeed (boundary).
+    let mut sol = sample_solana();
+    sol.instructions[0].data = vec![0u8; u16::MAX as usize];
+    let tx = DecodedTransaction::Solana(sol);
+    assert!(canonical_signing_bytes(&tx, SV).is_ok());
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_ok());
+}
+
+#[test]
+fn near_oversized_deposit_is_rejected() {
+    // A deposit carrying more than 16 big-endian bytes does not fit a borsh
+    // u128. Wrapping it (as the old `wrapping_shl` did) would make the SIGNED
+    // amount differ from the human-RENDERED amount — an approve-vs-sign
+    // divergence — so canonicalization must fail closed.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Transfer {
+        deposit: vec![0x01; 17],
+    }];
+    let tx = DecodedTransaction::Near(near);
+    assert_eq!(
+        canonical_signing_bytes(&tx, SV),
+        Err(AttestationError::NearU128Overflow {
+            what: "transfer.deposit",
+            len: 17
+        })
+    );
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_err());
+}
+
+#[test]
+fn near_max_width_deposit_still_encodes() {
+    // A full 16-byte (u128::MAX) deposit is representable and must succeed.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Transfer {
+        deposit: vec![0xff; 16],
+    }];
+    let tx = DecodedTransaction::Near(near);
+    assert!(canonical_signing_bytes(&tx, SV).is_ok());
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_ok());
+}
+
+#[test]
+fn near_delegate_action_serializes_empty_inner_actions_vector() {
+    // NEP-366 DelegateAction places a `Vec<Action>` between `receiver_id` and
+    // `nonce`. A delegate with no inner actions serializes an explicit empty
+    // actions vector (borsh `0u32`) in the correct position; assert that exact
+    // slice appears in the canonical bytes.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Delegate {
+        sender_id: "s.near".to_string(),
+        receiver_id: "r.near".to_string(),
+        actions: vec![],
+        nonce: 0x0102_0304_0506_0708,
+        max_block_height: 100,
+        public_key: ed25519_pk(0x44),
+    }];
+    let tx = DecodedTransaction::Near(near);
+    let bytes = canon(&tx, SV);
+
+    // Expected wire fragment for the Delegate action body:
+    //   discriminant(8) ∥ borsh("s.near") ∥ borsh("r.near") ∥
+    //   actions_len(0u32 le) ∥ nonce(u64 le) ∥ ...
+    let mut expected = vec![8u8]; // Delegate discriminant
+    expected.extend_from_slice(&6u32.to_le_bytes());
+    expected.extend_from_slice(b"s.near");
+    expected.extend_from_slice(&6u32.to_le_bytes());
+    expected.extend_from_slice(b"r.near");
+    expected.extend_from_slice(&0u32.to_le_bytes()); // empty inner actions vec
+    expected.extend_from_slice(&0x0102_0304_0506_0708u64.to_le_bytes()); // nonce
+    assert!(
+        bytes.windows(expected.len()).any(|w| w == expected),
+        "Delegate action must serialize an explicit empty actions vector before the nonce"
+    );
+
+    // Distinct delegate transactions must still hash distinctly.
+    let mut other = sample_near();
+    other.actions = vec![NearAction::Delegate {
+        sender_id: "s.near".to_string(),
+        receiver_id: "r.near".to_string(),
+        actions: vec![],
+        nonce: 0x0102_0304_0506_0709, // differs by one
+        max_block_height: 100,
+        public_key: ed25519_pk(0x44),
+    }];
+    assert_ne!(
+        hash_of(&tx, SV),
+        hash_of(&DecodedTransaction::Near(other), SV)
+    );
+}
+
+#[test]
+fn near_delegate_inner_actions_are_injective() {
+    // NEP-366 DelegateAction carries an inner `Vec<Action>`. Two delegates that
+    // differ ONLY in their inner actions must NOT collapse to the same canonical
+    // bytes / hash, or an attestation signed for delegate-with-actions-A would
+    // also validate for delegate-with-actions-B (approve-A / sign-B confusion).
+    let delegate = |inner: Vec<NearAction>| {
+        let mut near = sample_near();
+        near.actions = vec![NearAction::Delegate {
+            sender_id: "s.near".to_string(),
+            receiver_id: "r.near".to_string(),
+            actions: inner,
+            nonce: 7,
+            max_block_height: 100,
+            public_key: ed25519_pk(0x44),
+        }];
+        DecodedTransaction::Near(near)
+    };
+
+    let a = delegate(vec![NearAction::Transfer {
+        deposit: vec![0x01],
+    }]);
+    let b = delegate(vec![NearAction::Transfer {
+        deposit: vec![0x02], // same shape, different amount
+    }]);
+    let c = delegate(vec![]); // no inner actions at all
+    let d = delegate(vec![
+        NearAction::Transfer {
+            deposit: vec![0x01],
+        },
+        NearAction::Transfer {
+            deposit: vec![0x01],
+        },
+    ]); // same first action, but a second one appended
+
+    // All four must be pairwise distinct in both canonical bytes and hash.
+    let txs = [&a, &b, &c, &d];
+    let mut byte_sets = std::collections::HashSet::new();
+    let mut hashes = std::collections::HashSet::new();
+    for tx in txs {
+        assert!(
+            byte_sets.insert(canon(tx, SV)),
+            "delegates differing only in inner actions must have distinct canonical bytes"
+        );
+        assert!(
+            hashes.insert(hash_of(tx, SV)),
+            "delegates differing only in inner actions must have distinct hashes"
+        );
+    }
+
+    // The inner action's serialized body must actually appear in the canonical
+    // bytes (proving it is carried, not dropped): a Transfer of 0x02.
+    let bytes = canon(&b, SV);
+    let inner_fragment = vec![3u8, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    assert!(
+        bytes
+            .windows(inner_fragment.len())
+            .any(|w| w == inner_fragment),
+        "inner Transfer action body must be serialized into the delegate wire bytes"
+    );
+}
+
+#[test]
+fn near_delegate_nested_delegate_is_rejected() {
+    // NEP-366 inner actions are `NonDelegateAction`: a delegate may not nest a
+    // delegate. An inner Delegate cannot be represented faithfully on-chain, so
+    // canonicalization must fail closed rather than emit ambiguous bytes.
+    let mut near = sample_near();
+    near.actions = vec![NearAction::Delegate {
+        sender_id: "s.near".to_string(),
+        receiver_id: "r.near".to_string(),
+        actions: vec![NearAction::Delegate {
+            sender_id: "inner.near".to_string(),
+            receiver_id: "innerr.near".to_string(),
+            actions: vec![],
+            nonce: 1,
+            max_block_height: 1,
+            public_key: ed25519_pk(0x55),
+        }],
+        nonce: 7,
+        max_block_height: 100,
+        public_key: ed25519_pk(0x44),
+    }];
+    let tx = DecodedTransaction::Near(near);
+    assert_eq!(
+        canonical_signing_bytes(&tx, SV),
+        Err(AttestationError::NearNestedDelegate)
+    );
+    assert!(approved_tx_hash_for(&tx, SIGNER, SV).is_err());
+    assert!(render(&tx, SV).is_err());
 }


### PR DESCRIPTION
> **Rebased onto current `main` (attested-signing cascade, 2026-07-23).** The stack was 1184 commits behind (merge base 2026-05-24). Tracking issue: #6532 — it carries the full plan, the measured hop difficulty, and the baseline.
>
> Inline review threads may have re-anchored or orphaned from the force-push. Reviewers: the per-PR "Cascade changes" section below states exactly what the rebase altered beyond the original work.

## What this PR is
Fail-closed wire encoding for the attestation canonical bytes (#3961 follow-up): fallible `approved_tx_hash_for` / `render` / `canonical_signing_bytes`, signer sourced from the gate-bound `SigningContext.key_or_account_id` (never the tx body), and the Solana/NEAR wire-model reshape.

## Cascade changes
Clean rebase onto the ported parent — **no conflicts**, no semantic changes.

## Verification
Workspace resolves; 5 + 32 + 15 + 1 crate tests pass; boundary test green; clippy clean.
