### PR TITLE
feat(reborn): add manual token secure submit

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -1115,6 +1115,30 @@ fn reborn_product_auth_contract_stays_reborn_native() {
             reason: "Reborn product auth must not retrieve raw secret material directly",
         },
         ForbiddenUse {
+            pattern: "auth-token",
+            reason: "Reborn manual-token setup must not fall back to v1 chat token route names",
+        },
+        ForbiddenUse {
+            pattern: "auth_token",
+            reason: "Reborn manual-token setup must not fall back to v1 chat token command paths",
+        },
+        ForbiddenUse {
+            pattern: "IncomingMessage",
+            reason: "Reborn product auth must not capture manual tokens through chat transcripts",
+        },
+        ForbiddenUse {
+            pattern: "ChatMessage",
+            reason: "Reborn product auth must not capture manual tokens through chat transcripts",
+        },
+        ForbiddenUse {
+            pattern: "secret_name",
+            reason: "Reborn product auth must use scoped credential accounts and opaque handles, not raw v1 secret names",
+        },
+        ForbiddenUse {
+            pattern: "SecretName",
+            reason: "Reborn product auth must use scoped credential accounts and opaque handles, not raw v1 secret names",
+        },
+        ForbiddenUse {
             pattern: "reqwest",
             reason: "Reborn product auth must not own outbound HTTP transport",
         },

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -749,13 +749,12 @@ fn validate_account_update_target(
             "credential account update target provider mismatch",
         ));
     }
-    if account.ownership != request.ownership
-        || account.owner_extension != request.owner_extension
-        || account.granted_extensions != request.granted_extensions
-    {
-        return Err(AuthProductError::CrossScopeDenied);
-    }
-    Ok(())
+    validate_update_authority_fields(
+        account,
+        request.ownership,
+        request.owner_extension.as_ref(),
+        &request.granted_extensions,
+    )
 }
 
 fn validate_flow_update_binding(
@@ -819,9 +818,23 @@ fn validate_bound_update_authority(
     account: &CredentialAccount,
     binding: &crate::CredentialAccountUpdateBinding,
 ) -> Result<(), AuthProductError> {
-    if account.ownership != binding.ownership
-        || account.owner_extension != binding.owner_extension
-        || account.granted_extensions != binding.granted_extensions
+    validate_update_authority_fields(
+        account,
+        binding.ownership,
+        binding.owner_extension.as_ref(),
+        &binding.granted_extensions,
+    )
+}
+
+fn validate_update_authority_fields(
+    account: &CredentialAccount,
+    ownership: CredentialOwnership,
+    owner_extension: Option<&ExtensionId>,
+    granted_extensions: &[ExtensionId],
+) -> Result<(), AuthProductError> {
+    if account.ownership != ownership
+        || account.owner_extension.as_ref() != owner_extension
+        || account.granted_extensions.as_slice() != granted_extensions
     {
         return Err(AuthProductError::CrossScopeDenied);
     }

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -3,7 +3,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use async_trait::async_trait;
 use chrono::Utc;
-use ironclaw_host_api::SecretHandle;
+use ironclaw_host_api::{ExtensionId, SecretHandle};
 
 use crate::{
     AuthChallenge, AuthContinuationEvent, AuthFlowId, AuthFlowManager, AuthFlowRecord,
@@ -676,9 +676,14 @@ fn create_or_update_manual_token_account(
     state: &mut AuthState,
     pending: PendingSecretInteraction,
 ) -> Result<CredentialAccount, AuthProductError> {
-    let account_request = manual_token_account_request(&pending)?;
-    match pending.update_binding {
+    match pending.update_binding.as_ref() {
         Some(binding) => {
+            let account_request = manual_token_account_request(
+                &pending,
+                binding.ownership,
+                binding.owner_extension.clone(),
+                binding.granted_extensions.clone(),
+            )?;
             let now = Utc::now();
             let account = state
                 .accounts
@@ -687,22 +692,24 @@ fn create_or_update_manual_token_account(
             validate_account_update_target(account, &account_request)?;
             update_account_from_request(account, account_request, now)
         }
-        None => create_account_in_state(state, account_request),
+        None => create_account_in_state(
+            state,
+            manual_token_account_request(
+                &pending,
+                CredentialOwnership::UserReusable,
+                None,
+                Vec::new(),
+            )?,
+        ),
     }
 }
 
 fn manual_token_account_request(
     pending: &PendingSecretInteraction,
+    ownership: CredentialOwnership,
+    owner_extension: Option<ExtensionId>,
+    granted_extensions: Vec<ExtensionId>,
 ) -> Result<NewCredentialAccount, AuthProductError> {
-    let (ownership, owner_extension, granted_extensions) = match &pending.update_binding {
-        Some(binding) => (
-            binding.ownership,
-            binding.owner_extension.clone(),
-            binding.granted_extensions.clone(),
-        ),
-        None => (CredentialOwnership::UserReusable, None, Vec::new()),
-    };
-
     Ok(NewCredentialAccount {
         scope: pending.scope.clone(),
         provider: pending.provider.clone(),
@@ -763,7 +770,7 @@ fn validate_flow_update_binding(
         &request.scope,
         &request.provider,
         binding,
-        "auth flow update target provider mismatch",
+        UpdateBindingValidationContext::AuthFlow,
     )
 }
 
@@ -777,8 +784,14 @@ fn validate_manual_token_update_binding(
         &request.scope,
         &request.provider,
         binding,
-        "manual token update target provider mismatch",
+        UpdateBindingValidationContext::ManualToken,
     )
+}
+
+#[derive(Debug, Clone, Copy)]
+enum UpdateBindingValidationContext {
+    AuthFlow,
+    ManualToken,
 }
 
 fn validate_scoped_update_binding(
@@ -786,13 +799,18 @@ fn validate_scoped_update_binding(
     scope: &crate::AuthProductScope,
     provider: &crate::AuthProviderId,
     binding: &CredentialAccountUpdateBinding,
-    provider_mismatch_reason: &'static str,
+    context: UpdateBindingValidationContext,
 ) -> Result<(), AuthProductError> {
     if !scope_matches(scope, &account.scope) {
         return Err(AuthProductError::CrossScopeDenied);
     }
     if &account.provider != provider {
-        return Err(AuthProductError::invalid_request(provider_mismatch_reason));
+        return Err(AuthProductError::invalid_request(match context {
+            UpdateBindingValidationContext::AuthFlow => "auth flow update target provider mismatch",
+            UpdateBindingValidationContext::ManualToken => {
+                "manual token update target provider mismatch"
+            }
+        }));
     }
     validate_bound_update_authority(account, binding)
 }

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -11,13 +11,14 @@ use crate::{
     AuthProviderClient, CredentialAccount, CredentialAccountId, CredentialAccountListPage,
     CredentialAccountListRequest, CredentialAccountMutation, CredentialAccountProjection,
     CredentialAccountSelectionRequest, CredentialAccountService, CredentialAccountStatus,
-    CredentialOwnership, CredentialSetupService, ManualTokenSetupRequest, NewAuthFlow,
-    NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
-    OAuthProviderCallbackRequest, OAuthProviderExchange, ProviderCallbackOutcome,
-    SecretCleanupAction, SecretCleanupReport, SecretCleanupRequest, SecretCleanupService,
-    SecretSubmitRequest, SecretSubmitResult, cleanup::SecretCleanupAction::Deactivate,
-    flow::credential_status_for_completed_flow, interaction::PendingSecretInteraction,
-    provider::validate_provider_callback_request, scope_matches,
+    CredentialAccountUpdateBinding, CredentialOwnership, CredentialSetupService,
+    ManualTokenSetupRequest, NewAuthFlow, NewCredentialAccount, OAuthCallbackClaimRequest,
+    OAuthCallbackFailureInput, OAuthCallbackInput, OAuthProviderCallbackRequest,
+    OAuthProviderExchange, ProviderCallbackOutcome, SecretCleanupAction, SecretCleanupReport,
+    SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
+    cleanup::SecretCleanupAction::Deactivate, flow::credential_status_for_completed_flow,
+    interaction::PendingSecretInteraction, provider::validate_provider_callback_request,
+    scope_matches,
 };
 
 #[derive(Default)]
@@ -394,13 +395,22 @@ impl AuthInteractionService for InMemoryAuthProductServices {
         request: ManualTokenSetupRequest,
     ) -> Result<AuthChallenge, AuthProductError> {
         let interaction_id = AuthInteractionId::new();
-        self.lock_state().interactions.insert(
+        let mut state = self.lock_state();
+        if let Some(binding) = &request.update_binding {
+            let account = state
+                .accounts
+                .get(&binding.account_id)
+                .ok_or(AuthProductError::CredentialMissing)?;
+            validate_manual_token_update_binding(account, &request, binding)?;
+        }
+        state.interactions.insert(
             interaction_id,
             PendingSecretInteraction {
                 scope: request.scope,
                 provider: request.provider.clone(),
                 label: request.label.clone(),
                 continuation: request.continuation,
+                update_binding: request.update_binding,
                 expires_at: request.expires_at,
             },
         );
@@ -435,25 +445,12 @@ impl AuthInteractionService for InMemoryAuthProductServices {
             .interactions
             .remove(&request.interaction_id)
             .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
-        let account = create_account_in_state(
-            &mut state,
-            NewCredentialAccount {
-                scope: pending.scope,
-                provider: pending.provider,
-                label: pending.label,
-                status: credential_status_for_completed_flow(),
-                ownership: CredentialOwnership::UserReusable,
-                owner_extension: None,
-                granted_extensions: Vec::new(),
-                access_secret: Some(generated_secret_handle("manual-access")?),
-                refresh_secret: None,
-                scopes: Vec::new(),
-            },
-        )?;
+        let continuation = pending.continuation.clone();
+        let account = create_or_update_manual_token_account(&mut state, pending)?;
         Ok(SecretSubmitResult {
             account_id: account.id,
             status: account.status,
-            continuation: pending.continuation,
+            continuation,
         })
     }
 }
@@ -675,6 +672,51 @@ fn update_account_from_request(
     Ok(account.clone())
 }
 
+fn create_or_update_manual_token_account(
+    state: &mut AuthState,
+    pending: PendingSecretInteraction,
+) -> Result<CredentialAccount, AuthProductError> {
+    let account_request = manual_token_account_request(&pending)?;
+    match pending.update_binding {
+        Some(binding) => {
+            let now = Utc::now();
+            let account = state
+                .accounts
+                .get_mut(&binding.account_id)
+                .ok_or(AuthProductError::CredentialMissing)?;
+            validate_account_update_target(account, &account_request)?;
+            update_account_from_request(account, account_request, now)
+        }
+        None => create_account_in_state(state, account_request),
+    }
+}
+
+fn manual_token_account_request(
+    pending: &PendingSecretInteraction,
+) -> Result<NewCredentialAccount, AuthProductError> {
+    let (ownership, owner_extension, granted_extensions) = match &pending.update_binding {
+        Some(binding) => (
+            binding.ownership,
+            binding.owner_extension.clone(),
+            binding.granted_extensions.clone(),
+        ),
+        None => (CredentialOwnership::UserReusable, None, Vec::new()),
+    };
+
+    Ok(NewCredentialAccount {
+        scope: pending.scope.clone(),
+        provider: pending.provider.clone(),
+        label: pending.label.clone(),
+        status: credential_status_for_completed_flow(),
+        ownership,
+        owner_extension,
+        granted_extensions,
+        access_secret: Some(generated_secret_handle("manual-access")?),
+        refresh_secret: None,
+        scopes: Vec::new(),
+    })
+}
+
 fn update_account_from_exchange(
     account: &mut CredentialAccount,
     exchange: &OAuthProviderExchange,
@@ -713,17 +755,45 @@ fn validate_flow_update_binding(
     account: &CredentialAccount,
     request: &NewAuthFlow,
 ) -> Result<(), AuthProductError> {
-    if !scope_matches(&request.scope, &account.scope) {
-        return Err(AuthProductError::CrossScopeDenied);
-    }
-    if account.provider != request.provider {
-        return Err(AuthProductError::invalid_request(
-            "auth flow update target provider mismatch",
-        ));
-    }
     let Some(binding) = request.update_binding.as_ref() else {
         return Ok(());
     };
+    validate_scoped_update_binding(
+        account,
+        &request.scope,
+        &request.provider,
+        binding,
+        "auth flow update target provider mismatch",
+    )
+}
+
+fn validate_manual_token_update_binding(
+    account: &CredentialAccount,
+    request: &ManualTokenSetupRequest,
+    binding: &CredentialAccountUpdateBinding,
+) -> Result<(), AuthProductError> {
+    validate_scoped_update_binding(
+        account,
+        &request.scope,
+        &request.provider,
+        binding,
+        "manual token update target provider mismatch",
+    )
+}
+
+fn validate_scoped_update_binding(
+    account: &CredentialAccount,
+    scope: &crate::AuthProductScope,
+    provider: &crate::AuthProviderId,
+    binding: &CredentialAccountUpdateBinding,
+    provider_mismatch_reason: &'static str,
+) -> Result<(), AuthProductError> {
+    if !scope_matches(scope, &account.scope) {
+        return Err(AuthProductError::CrossScopeDenied);
+    }
+    if &account.provider != provider {
+        return Err(AuthProductError::invalid_request(provider_mismatch_reason));
+    }
     validate_bound_update_authority(account, binding)
 }
 

--- a/crates/ironclaw_auth/src/interaction.rs
+++ b/crates/ironclaw_auth/src/interaction.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AuthContinuationRef, AuthProductError, CredentialAccountId, CredentialAccountLabel,
-    CredentialAccountStatus, Timestamp,
+    CredentialAccountStatus, CredentialAccountUpdateBinding, Timestamp,
     ids::{AuthInteractionId, AuthProviderId},
     scope::AuthProductScope,
 };
@@ -18,6 +18,7 @@ pub struct ManualTokenSetupRequest {
     pub provider: AuthProviderId,
     pub label: CredentialAccountLabel,
     pub continuation: AuthContinuationRef,
+    pub update_binding: Option<CredentialAccountUpdateBinding>,
     pub expires_at: Timestamp,
 }
 
@@ -82,5 +83,6 @@ pub(crate) struct PendingSecretInteraction {
     pub provider: AuthProviderId,
     pub label: CredentialAccountLabel,
     pub continuation: AuthContinuationRef,
+    pub update_binding: Option<CredentialAccountUpdateBinding>,
     pub expires_at: Timestamp,
 }

--- a/crates/ironclaw_auth/tests/auth_product_contract/manual_token_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/manual_token_contract.rs
@@ -10,6 +10,7 @@ async fn manual_token_submit_is_secure_scoped_and_rejects_invalid_inputs() {
             provider: provider(),
             label: label("manual github"),
             continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
             expires_at: Utc::now() + Duration::minutes(5),
         })
         .await
@@ -86,6 +87,7 @@ async fn manual_token_submit_consumes_interaction_once() {
             provider: provider(),
             label: label("manual github"),
             continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
             expires_at: Utc::now() + Duration::minutes(5),
         })
         .await
@@ -134,6 +136,7 @@ async fn manual_token_submit_rejects_control_characters_without_consuming_intera
             provider: provider(),
             label: label("manual github"),
             continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
             expires_at: Utc::now() + Duration::minutes(5),
         })
         .await
@@ -178,6 +181,7 @@ async fn expired_manual_token_interaction_fails_closed() {
             provider: provider(),
             label: label("manual github"),
             continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
             expires_at: Utc::now() - Duration::seconds(1),
         })
         .await
@@ -197,4 +201,99 @@ async fn expired_manual_token_interaction_fails_closed() {
         .await
         .expect_err("expired");
     assert_eq!(expired, AuthProductError::UnknownOrExpiredFlow);
+}
+
+#[tokio::test]
+async fn manual_token_submit_can_update_bound_account() {
+    let services = InMemoryAuthProductServices::new();
+    let owner = scope("alice");
+    let account = services
+        .create_account(account_request(
+            owner.clone(),
+            "old manual github",
+            CredentialAccountStatus::Expired,
+        ))
+        .await
+        .expect("existing account");
+    let challenge = services
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: owner.clone(),
+            provider: provider(),
+            label: label("updated manual github"),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: Some(update_binding(&account)),
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect("manual update challenge");
+    let interaction_id = match challenge {
+        AuthChallenge::ManualTokenRequired { interaction_id, .. } => interaction_id,
+        other => panic!("unexpected challenge {other:?}"),
+    };
+
+    let result = services
+        .submit_manual_token(
+            &owner,
+            SecretSubmitRequest {
+                interaction_id,
+                secret: secret("ghp_updated_token"),
+            },
+        )
+        .await
+        .expect("manual update submit");
+
+    assert_eq!(result.account_id, account.id);
+    assert_eq!(result.status, CredentialAccountStatus::Configured);
+    let updated = services
+        .get_account(&owner, account.id)
+        .await
+        .expect("account lookup")
+        .expect("updated account");
+    assert_eq!(updated.id, account.id);
+    assert_eq!(updated.label, label("updated manual github"));
+    assert_eq!(updated.status, CredentialAccountStatus::Configured);
+    assert!(updated.access_secret.is_some());
+    assert_eq!(updated.created_at, account.created_at);
+    assert!(updated.updated_at >= account.updated_at);
+
+    let accounts = services
+        .list_accounts(CredentialAccountListRequest::new(owner, provider()).with_limit(10))
+        .await
+        .expect("list accounts");
+    assert_eq!(accounts.accounts.len(), 1);
+    assert_eq!(accounts.accounts[0].id, account.id);
+}
+
+#[tokio::test]
+async fn manual_token_update_binding_is_scope_checked_before_challenge() {
+    let services = InMemoryAuthProductServices::new();
+    let owner = scope("alice");
+    let account = services
+        .create_account(account_request(
+            owner.clone(),
+            "manual github",
+            CredentialAccountStatus::Expired,
+        ))
+        .await
+        .expect("existing account");
+
+    let error = services
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: scope("bob"),
+            provider: provider(),
+            label: label("attacker manual github"),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: Some(update_binding(&account)),
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect_err("cross-scope update binding is rejected before challenge");
+
+    assert_eq!(error, AuthProductError::CrossScopeDenied);
+    let accounts = services
+        .list_accounts(CredentialAccountListRequest::new(owner, provider()).with_limit(10))
+        .await
+        .expect("list accounts");
+    assert_eq!(accounts.accounts.len(), 1);
+    assert_eq!(accounts.accounts[0].id, account.id);
 }

--- a/crates/ironclaw_auth/tests/auth_product_contract/manual_token_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/manual_token_contract.rs
@@ -297,3 +297,61 @@ async fn manual_token_update_binding_is_scope_checked_before_challenge() {
     assert_eq!(accounts.accounts.len(), 1);
     assert_eq!(accounts.accounts[0].id, account.id);
 }
+
+#[tokio::test]
+async fn manual_token_update_binding_rejects_missing_account_before_challenge() {
+    let services = InMemoryAuthProductServices::new();
+    let owner = scope("alice");
+
+    let error = services
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: owner.clone(),
+            provider: provider(),
+            label: label("manual github"),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: Some(CredentialAccountUpdateBinding {
+                account_id: ironclaw_auth::CredentialAccountId::new(),
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+            }),
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect_err("missing update target is rejected before challenge");
+
+    assert_eq!(error, AuthProductError::CredentialMissing);
+    let accounts = services
+        .list_accounts(CredentialAccountListRequest::new(owner, provider()).with_limit(10))
+        .await
+        .expect("list accounts");
+    assert!(accounts.accounts.is_empty());
+}
+
+#[tokio::test]
+async fn manual_token_update_binding_rejects_provider_mismatch_before_challenge() {
+    let services = InMemoryAuthProductServices::new();
+    let owner = scope("alice");
+    let account = services
+        .create_account(account_request(
+            owner.clone(),
+            "manual github",
+            CredentialAccountStatus::Expired,
+        ))
+        .await
+        .expect("existing account");
+
+    let error = services
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: owner,
+            provider: AuthProviderId::new("gitlab").expect("valid provider"),
+            label: label("manual gitlab"),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: Some(update_binding(&account)),
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect_err("provider mismatch is rejected before challenge");
+
+    assert_eq!(error.code(), AuthErrorCode::InvalidRequest);
+}

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -268,7 +268,7 @@ impl TurnSpawnTreePort for RecordingChildRuns {
         &self,
         request: SubmitChildRunRequest,
     ) -> Result<SubmitTurnResponse, TurnError> {
-        let run_id = request.requested_run_id.unwrap_or_else(TurnRunId::new);
+        let run_id = request.requested_run_id.unwrap_or_default();
         let turn_id = TurnId::new();
         let accepted_message_ref = request.accepted_message_ref.clone();
         let reply_target_binding_ref = request.reply_target_binding_ref.clone();

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -15,6 +15,15 @@
   the scoped flow/state/provider through `AuthFlowManager` before exchanging
   provider material through `AuthProviderClient`, then complete the flow and
   emit typed continuations.
+- Manual-token setup routes should call
+  `RebornProductAuthServices::request_manual_token_setup` for the typed
+  challenge and `RebornProductAuthServices::submit_manual_token` with a
+  one-shot `RebornManualTokenSubmitRequest` for the dedicated secret-submit
+  body. Build setup request scope from authenticated caller/session context,
+  not a browser body; attach `CredentialAccountUpdateBinding` only after
+  pre-authorizing the existing scoped account. Do not route raw token values
+  through chat commands, model-visible messages, serializable DTOs,
+  projections, or route-local pending maps.
 - Blocked run-state approval/auth gate rendering and resume belongs to #3094;
   keep this crate's #3811 auth seam reusable by that layer without implementing
   a second gate-resolution path.

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -85,14 +85,14 @@ pub struct RebornOAuthCallbackResponse {
     pub continuation: AuthContinuationRef,
 }
 
-/// Stable sanitized callback failure safe for route rendering.
+/// Stable sanitized auth failure safe for route rendering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RebornOAuthCallbackError {
+pub struct RebornAuthProductError {
     pub code: AuthErrorCode,
     pub retryable: bool,
 }
 
-impl From<AuthProductError> for RebornOAuthCallbackError {
+impl From<AuthProductError> for RebornAuthProductError {
     fn from(error: AuthProductError) -> Self {
         let code = error.code();
         Self {
@@ -101,6 +101,9 @@ impl From<AuthProductError> for RebornOAuthCallbackError {
         }
     }
 }
+
+/// Stable sanitized callback failure safe for route rendering.
+pub type RebornOAuthCallbackError = RebornAuthProductError;
 
 /// Request to open a Reborn manual-token setup interaction.
 ///
@@ -116,6 +119,30 @@ pub struct RebornManualTokenSetupRequest {
     pub continuation: AuthContinuationRef,
     pub update_binding: Option<CredentialAccountUpdateBinding>,
     pub expires_at: Timestamp,
+}
+
+impl RebornManualTokenSetupRequest {
+    pub fn new(
+        scope: AuthProductScope,
+        provider: AuthProviderId,
+        label: CredentialAccountLabel,
+        continuation: AuthContinuationRef,
+        expires_at: Timestamp,
+    ) -> Self {
+        Self {
+            scope,
+            provider,
+            label,
+            continuation,
+            update_binding: None,
+            expires_at,
+        }
+    }
+
+    pub fn with_update_binding(mut self, update_binding: CredentialAccountUpdateBinding) -> Self {
+        self.update_binding = Some(update_binding);
+        self
+    }
 }
 
 /// Manual-token challenge safe to render to Web/CLI/API surfaces.
@@ -173,21 +200,7 @@ pub struct RebornManualTokenSubmitResponse {
 }
 
 /// Stable sanitized manual-token setup/submit failure safe for route rendering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RebornManualTokenError {
-    pub code: AuthErrorCode,
-    pub retryable: bool,
-}
-
-impl From<AuthProductError> for RebornManualTokenError {
-    fn from(error: AuthProductError) -> Self {
-        let code = error.code();
-        Self {
-            code,
-            retryable: is_retryable_auth_error(code),
-        }
-    }
-}
+pub type RebornManualTokenError = RebornAuthProductError;
 
 fn is_retryable_auth_error(code: AuthErrorCode) -> bool {
     matches!(code, AuthErrorCode::BackendUnavailable)

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -4,13 +4,16 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_auth::{
     AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowManager,
-    AuthFlowStatus, AuthInteractionService, AuthProductError, AuthProductScope, AuthProviderClient,
-    CredentialAccountId, CredentialAccountService, CredentialSetupService,
-    InMemoryAuthProductServices, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
-    OAuthCallbackInput, OAuthProviderCallbackRequest, OpaqueStateHash, ProviderCallbackOutcome,
-    SecretCleanupService,
+    AuthFlowStatus, AuthInteractionId, AuthInteractionService, AuthProductError, AuthProductScope,
+    AuthProviderClient, AuthProviderId, CredentialAccountId, CredentialAccountLabel,
+    CredentialAccountService, CredentialAccountStatus, CredentialAccountUpdateBinding,
+    CredentialSetupService, InMemoryAuthProductServices, ManualTokenSetupRequest,
+    OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
+    OAuthProviderCallbackRequest, OpaqueStateHash, ProviderCallbackOutcome, SecretCleanupService,
+    SecretSubmitRequest, Timestamp,
 };
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 
 #[async_trait]
@@ -94,9 +97,100 @@ impl From<AuthProductError> for RebornOAuthCallbackError {
         let code = error.code();
         Self {
             code,
-            retryable: matches!(code, AuthErrorCode::BackendUnavailable),
+            retryable: is_retryable_auth_error(code),
         }
     }
+}
+
+/// Request to open a Reborn manual-token setup interaction.
+///
+/// This request is intentionally not serializable because the scope must be
+/// constructed from trusted caller/session context, not copied from a browser
+/// body. The raw token is submitted later through
+/// [`RebornManualTokenSubmitRequest`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebornManualTokenSetupRequest {
+    pub scope: AuthProductScope,
+    pub provider: AuthProviderId,
+    pub label: CredentialAccountLabel,
+    pub continuation: AuthContinuationRef,
+    pub update_binding: Option<CredentialAccountUpdateBinding>,
+    pub expires_at: Timestamp,
+}
+
+/// Manual-token challenge safe to render to Web/CLI/API surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RebornManualTokenChallenge {
+    pub interaction_id: AuthInteractionId,
+    pub provider: AuthProviderId,
+    pub label: CredentialAccountLabel,
+    pub expires_at: Timestamp,
+}
+
+/// Secure manual-token submit request.
+///
+/// This type intentionally does not implement serde serialization. Host-owned
+/// routes may construct it after reading a dedicated secret input body, but raw
+/// token material must not be written into product DTOs, projections, logs, or
+/// model-visible messages.
+pub struct RebornManualTokenSubmitRequest {
+    pub scope: AuthProductScope,
+    pub interaction_id: AuthInteractionId,
+    pub secret: SecretString,
+}
+
+impl RebornManualTokenSubmitRequest {
+    pub fn new(
+        scope: AuthProductScope,
+        interaction_id: AuthInteractionId,
+        secret: SecretString,
+    ) -> Self {
+        Self {
+            scope,
+            interaction_id,
+            secret,
+        }
+    }
+}
+
+impl std::fmt::Debug for RebornManualTokenSubmitRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RebornManualTokenSubmitRequest")
+            .field("scope", &self.scope)
+            .field("interaction_id", &self.interaction_id)
+            .field("secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Stable sanitized manual-token submit response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RebornManualTokenSubmitResponse {
+    pub account_id: CredentialAccountId,
+    pub status: CredentialAccountStatus,
+    pub continuation: AuthContinuationRef,
+}
+
+/// Stable sanitized manual-token setup/submit failure safe for route rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RebornManualTokenError {
+    pub code: AuthErrorCode,
+    pub retryable: bool,
+}
+
+impl From<AuthProductError> for RebornManualTokenError {
+    fn from(error: AuthProductError) -> Self {
+        let code = error.code();
+        Self {
+            code,
+            retryable: is_retryable_auth_error(code),
+        }
+    }
+}
+
+fn is_retryable_auth_error(code: AuthErrorCode) -> bool {
+    matches!(code, AuthErrorCode::BackendUnavailable)
 }
 
 /// Product-auth ports supplied to Reborn composition before the turn coordinator
@@ -454,6 +548,65 @@ impl RebornProductAuthServices {
             status: completed.status,
             credential_account_id: completed.credential_account_id,
             continuation: completed.continuation,
+        })
+    }
+
+    pub async fn request_manual_token_setup(
+        &self,
+        request: RebornManualTokenSetupRequest,
+    ) -> Result<RebornManualTokenChallenge, RebornManualTokenError> {
+        let challenge = self
+            .interaction_service
+            .request_secret_input(ManualTokenSetupRequest {
+                scope: request.scope,
+                provider: request.provider,
+                label: request.label,
+                continuation: request.continuation,
+                update_binding: request.update_binding,
+                expires_at: request.expires_at,
+            })
+            .await
+            .map_err(RebornManualTokenError::from)?;
+
+        match challenge {
+            ironclaw_auth::AuthChallenge::ManualTokenRequired {
+                interaction_id,
+                provider,
+                label,
+                expires_at,
+            } => Ok(RebornManualTokenChallenge {
+                interaction_id,
+                provider,
+                label,
+                expires_at,
+            }),
+            _ => Err(AuthProductError::InvalidRequest {
+                reason: "manual token setup returned an unexpected challenge".to_string(),
+            }
+            .into()),
+        }
+    }
+
+    pub async fn submit_manual_token(
+        &self,
+        request: RebornManualTokenSubmitRequest,
+    ) -> Result<RebornManualTokenSubmitResponse, RebornManualTokenError> {
+        let result = self
+            .interaction_service
+            .submit_manual_token(
+                &request.scope,
+                SecretSubmitRequest {
+                    interaction_id: request.interaction_id,
+                    secret: request.secret,
+                },
+            )
+            .await
+            .map_err(RebornManualTokenError::from)?;
+
+        Ok(RebornManualTokenSubmitResponse {
+            account_id: result.account_id,
+            status: result.status,
+            continuation: result.continuation,
         })
     }
 

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -48,9 +48,10 @@ mod webui_serve;
 mod webui_ws_origin;
 
 pub use auth::{
-    RebornAuthContinuationDispatcher, RebornOAuthCallbackError, RebornOAuthCallbackOutcome,
-    RebornOAuthCallbackRequest, RebornOAuthCallbackResponse, RebornProductAuthServicePorts,
-    RebornProductAuthServices,
+    RebornAuthContinuationDispatcher, RebornManualTokenChallenge, RebornManualTokenError,
+    RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest, RebornManualTokenSubmitResponse,
+    RebornOAuthCallbackError, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
+    RebornOAuthCallbackResponse, RebornProductAuthServicePorts, RebornProductAuthServices,
 };
 pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -48,10 +48,11 @@ mod webui_serve;
 mod webui_ws_origin;
 
 pub use auth::{
-    RebornAuthContinuationDispatcher, RebornManualTokenChallenge, RebornManualTokenError,
-    RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest, RebornManualTokenSubmitResponse,
-    RebornOAuthCallbackError, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
-    RebornOAuthCallbackResponse, RebornProductAuthServicePorts, RebornProductAuthServices,
+    RebornAuthContinuationDispatcher, RebornAuthProductError, RebornManualTokenChallenge,
+    RebornManualTokenError, RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest,
+    RebornManualTokenSubmitResponse, RebornOAuthCallbackError, RebornOAuthCallbackOutcome,
+    RebornOAuthCallbackRequest, RebornOAuthCallbackResponse, RebornProductAuthServicePorts,
+    RebornProductAuthServices,
 };
 pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -34,7 +34,10 @@ use ironclaw_reborn_composition::RebornCompositionProfile;
 use ironclaw_reborn_composition::RebornRuntimeProcessBinding;
 #[cfg(feature = "libsql")]
 use ironclaw_reborn_composition::{RebornBuildError, RebornCompositionProfile};
-use ironclaw_reborn_composition::{RebornBuildInput, RebornReadinessState, build_reborn_services};
+use ironclaw_reborn_composition::{
+    RebornBuildInput, RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest,
+    RebornReadinessState, build_reborn_services,
+};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_secrets::SecretMaterial;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -428,40 +431,28 @@ async fn local_dev_product_auth_entrypoint_redacts_manual_token_submit() {
     let label = ironclaw_auth::CredentialAccountLabel::new("work github").unwrap();
 
     let challenge = product_auth
-        .interaction_service()
-        .request_secret_input(ironclaw_auth::ManualTokenSetupRequest {
+        .request_manual_token_setup(RebornManualTokenSetupRequest {
             scope: scope.clone(),
             provider: provider.clone(),
             label: label.clone(),
             continuation: ironclaw_auth::AuthContinuationRef::SetupOnly,
+            update_binding: None,
             expires_at: chrono::Utc::now() + chrono::Duration::minutes(5),
         })
         .await
         .unwrap();
-    let ironclaw_auth::AuthChallenge::ManualTokenRequired {
-        interaction_id,
-        provider: challenge_provider,
-        label: challenge_label,
-        ..
-    } = challenge
-    else {
-        panic!("expected manual-token challenge");
-    };
-    assert_eq!(challenge_provider, provider);
-    assert_eq!(challenge_label, label);
+    assert_eq!(challenge.provider, provider);
+    assert_eq!(challenge.label, label);
 
-    let submit = ironclaw_auth::SecretSubmitRequest {
-        interaction_id,
-        secret: SecretString::from("super-secret-token".to_string()),
-    };
+    let submit = RebornManualTokenSubmitRequest::new(
+        scope.clone(),
+        challenge.interaction_id,
+        SecretString::from("super-secret-token".to_string()),
+    );
     let debug = format!("{submit:?}");
     assert!(!debug.contains("super-secret-token"));
 
-    let result = product_auth
-        .interaction_service()
-        .submit_manual_token(&scope, submit)
-        .await
-        .unwrap();
+    let result = product_auth.submit_manual_token(submit).await.unwrap();
     assert_eq!(
         result.status,
         ironclaw_auth::CredentialAccountStatus::Configured

--- a/crates/ironclaw_reborn_composition/tests/manual_tokens.rs
+++ b/crates/ironclaw_reborn_composition/tests/manual_tokens.rs
@@ -9,7 +9,7 @@ use ironclaw_auth::{
     CredentialAccountListRequest, CredentialAccountService, CredentialAccountStatus,
     CredentialAccountUpdateBinding, CredentialOwnership, CredentialSetupService,
     InMemoryAuthProductServices, ManualTokenSetupRequest, NewCredentialAccount,
-    SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
+    OAuthAuthorizationUrl, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
 };
 use ironclaw_host_api::{InvocationId, ResourceScope, SecretHandle, UserId};
 use ironclaw_reborn_composition::{
@@ -53,6 +53,31 @@ impl AuthInteractionService for FailingInteractionService {
         _request: SecretSubmitRequest,
     ) -> Result<SecretSubmitResult, AuthProductError> {
         Err(self.error.clone())
+    }
+}
+
+#[derive(Debug, Default)]
+struct UnexpectedChallengeInteractionService;
+
+#[async_trait]
+impl AuthInteractionService for UnexpectedChallengeInteractionService {
+    async fn request_secret_input(
+        &self,
+        _request: ManualTokenSetupRequest,
+    ) -> Result<AuthChallenge, AuthProductError> {
+        Ok(AuthChallenge::OAuthUrl {
+            authorization_url: OAuthAuthorizationUrl::new("https://provider.example/oauth")
+                .unwrap(),
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+    }
+
+    async fn submit_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        _request: SecretSubmitRequest,
+    ) -> Result<SecretSubmitResult, AuthProductError> {
+        unreachable!("unexpected-challenge test does not submit manual tokens")
     }
 }
 
@@ -105,14 +130,13 @@ fn secret(value: &str) -> SecretString {
 }
 
 fn setup_request(scope: AuthProductScope) -> RebornManualTokenSetupRequest {
-    RebornManualTokenSetupRequest {
+    RebornManualTokenSetupRequest::new(
         scope,
-        provider: provider(),
-        label: label(),
-        continuation: AuthContinuationRef::SetupOnly,
-        update_binding: None,
-        expires_at: Utc::now() + Duration::minutes(5),
-    }
+        provider(),
+        label(),
+        AuthContinuationRef::SetupOnly,
+        Utc::now() + Duration::minutes(5),
+    )
 }
 
 fn expired_setup_request(scope: AuthProductScope) -> RebornManualTokenSetupRequest {
@@ -178,12 +202,8 @@ async fn manual_token_facade_updates_bound_account_without_exposing_token() {
         .expect("existing account");
     let challenge = services
         .request_manual_token_setup(RebornManualTokenSetupRequest {
-            scope: owner.clone(),
-            provider: provider(),
             label: CredentialAccountLabel::new("updated work github").unwrap(),
-            continuation: AuthContinuationRef::SetupOnly,
-            update_binding: Some(update_binding(&existing)),
-            expires_at: Utc::now() + Duration::minutes(5),
+            ..setup_request(owner.clone()).with_update_binding(update_binding(&existing))
         })
         .await
         .expect("manual-token update challenge");
@@ -384,4 +404,18 @@ async fn manual_token_facade_returns_sanitized_backend_and_canceled_failures() {
     assert_eq!(canceled_error.code, AuthErrorCode::Canceled);
     assert!(!canceled_error.retryable);
     assert_error_safe(&canceled_error);
+}
+
+#[tokio::test]
+async fn request_manual_token_setup_returns_error_on_unexpected_challenge() {
+    let services = auth_services_with_interaction(Arc::new(UnexpectedChallengeInteractionService));
+
+    let error = services
+        .request_manual_token_setup(setup_request(scope("alice")))
+        .await
+        .expect_err("unexpected challenge is rejected");
+
+    assert_eq!(error.code, AuthErrorCode::InvalidRequest);
+    assert!(!error.retryable);
+    assert_error_safe(&error);
 }

--- a/crates/ironclaw_reborn_composition/tests/manual_tokens.rs
+++ b/crates/ironclaw_reborn_composition/tests/manual_tokens.rs
@@ -1,0 +1,387 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{Duration, Utc};
+use ironclaw_auth::{
+    AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowManager,
+    AuthInteractionId, AuthInteractionService, AuthProductError, AuthProductScope,
+    AuthProviderClient, AuthProviderId, AuthSessionId, AuthSurface, CredentialAccountLabel,
+    CredentialAccountListRequest, CredentialAccountService, CredentialAccountStatus,
+    CredentialAccountUpdateBinding, CredentialOwnership, CredentialSetupService,
+    InMemoryAuthProductServices, ManualTokenSetupRequest, NewCredentialAccount,
+    SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
+};
+use ironclaw_host_api::{InvocationId, ResourceScope, SecretHandle, UserId};
+use ironclaw_reborn_composition::{
+    RebornAuthContinuationDispatcher, RebornManualTokenError, RebornManualTokenSetupRequest,
+    RebornManualTokenSubmitRequest, RebornManualTokenSubmitResponse, RebornProductAuthServices,
+};
+use secrecy::SecretString;
+
+const RAW_TOKEN: &str = "super-secret-manual-token";
+
+#[derive(Debug, Default)]
+struct NoopContinuationDispatcher;
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for NoopContinuationDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        _event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FailingInteractionService {
+    error: AuthProductError,
+}
+
+#[async_trait]
+impl AuthInteractionService for FailingInteractionService {
+    async fn request_secret_input(
+        &self,
+        _request: ManualTokenSetupRequest,
+    ) -> Result<AuthChallenge, AuthProductError> {
+        Err(self.error.clone())
+    }
+
+    async fn submit_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        _request: SecretSubmitRequest,
+    ) -> Result<SecretSubmitResult, AuthProductError> {
+        Err(self.error.clone())
+    }
+}
+
+fn auth_services() -> RebornProductAuthServices {
+    RebornProductAuthServices::from_shared(
+        Arc::new(InMemoryAuthProductServices::new()),
+        Arc::new(NoopContinuationDispatcher),
+    )
+}
+
+fn auth_services_with_interaction(
+    interaction_service: Arc<dyn AuthInteractionService>,
+) -> RebornProductAuthServices {
+    let shared = Arc::new(InMemoryAuthProductServices::new());
+    let flow_manager: Arc<dyn AuthFlowManager> = shared.clone();
+    let credential_setup_service: Arc<dyn CredentialSetupService> = shared.clone();
+    let credential_account_service: Arc<dyn CredentialAccountService> = shared.clone();
+    let provider_client: Arc<dyn AuthProviderClient> = shared.clone();
+    let cleanup_service: Arc<dyn SecretCleanupService> = shared;
+
+    RebornProductAuthServices::new(
+        flow_manager,
+        interaction_service,
+        credential_setup_service,
+        credential_account_service,
+        provider_client,
+        cleanup_service,
+        Arc::new(NoopContinuationDispatcher),
+    )
+}
+
+fn scope(user: &str) -> AuthProductScope {
+    AuthProductScope::new(
+        ResourceScope::local_default(UserId::new(user).unwrap(), InvocationId::new()).unwrap(),
+        AuthSurface::Web,
+    )
+    .with_session_id(AuthSessionId::new(format!("web-session-{user}")).unwrap())
+}
+
+fn provider() -> AuthProviderId {
+    AuthProviderId::new("github").unwrap()
+}
+
+fn label() -> CredentialAccountLabel {
+    CredentialAccountLabel::new("work github").unwrap()
+}
+
+fn secret(value: &str) -> SecretString {
+    SecretString::from(value.to_string())
+}
+
+fn setup_request(scope: AuthProductScope) -> RebornManualTokenSetupRequest {
+    RebornManualTokenSetupRequest {
+        scope,
+        provider: provider(),
+        label: label(),
+        continuation: AuthContinuationRef::SetupOnly,
+        update_binding: None,
+        expires_at: Utc::now() + Duration::minutes(5),
+    }
+}
+
+fn expired_setup_request(scope: AuthProductScope) -> RebornManualTokenSetupRequest {
+    RebornManualTokenSetupRequest {
+        expires_at: Utc::now() - Duration::seconds(1),
+        ..setup_request(scope)
+    }
+}
+
+async fn request_challenge(
+    services: &RebornProductAuthServices,
+    owner: AuthProductScope,
+) -> AuthInteractionId {
+    services
+        .request_manual_token_setup(setup_request(owner))
+        .await
+        .expect("manual-token challenge")
+        .interaction_id
+}
+
+fn update_binding(account: &ironclaw_auth::CredentialAccount) -> CredentialAccountUpdateBinding {
+    CredentialAccountUpdateBinding {
+        account_id: account.id,
+        ownership: account.ownership,
+        owner_extension: account.owner_extension.clone(),
+        granted_extensions: account.granted_extensions.clone(),
+    }
+}
+
+fn account_request(owner: AuthProductScope) -> NewCredentialAccount {
+    NewCredentialAccount {
+        scope: owner,
+        provider: provider(),
+        label: CredentialAccountLabel::new("old work github").unwrap(),
+        status: CredentialAccountStatus::Expired,
+        ownership: CredentialOwnership::UserReusable,
+        owner_extension: None,
+        granted_extensions: Vec::new(),
+        access_secret: Some(SecretHandle::new("old-manual-access").unwrap()),
+        refresh_secret: None,
+        scopes: Vec::new(),
+    }
+}
+
+fn assert_error_safe(error: &RebornManualTokenError) {
+    let serialized = serde_json::to_string(error).unwrap();
+    assert_eq!(
+        serde_json::from_str::<RebornManualTokenError>(&serialized).unwrap(),
+        *error
+    );
+    assert!(!serialized.contains(RAW_TOKEN));
+    assert!(!format!("{error:?}").contains(RAW_TOKEN));
+}
+
+#[tokio::test]
+async fn manual_token_facade_updates_bound_account_without_exposing_token() {
+    let services = auth_services();
+    let owner = scope("alice");
+    let existing = services
+        .credential_account_service()
+        .create_account(account_request(owner.clone()))
+        .await
+        .expect("existing account");
+    let challenge = services
+        .request_manual_token_setup(RebornManualTokenSetupRequest {
+            scope: owner.clone(),
+            provider: provider(),
+            label: CredentialAccountLabel::new("updated work github").unwrap(),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: Some(update_binding(&existing)),
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect("manual-token update challenge");
+
+    let response = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner.clone(),
+            challenge.interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect("manual token update succeeds");
+
+    assert_eq!(response.account_id, existing.id);
+    assert_eq!(response.status, CredentialAccountStatus::Configured);
+    assert_response_safe(&response);
+
+    let accounts = services
+        .credential_account_service()
+        .list_accounts(CredentialAccountListRequest::new(owner, provider()))
+        .await
+        .expect("account list");
+    assert_eq!(accounts.accounts.len(), 1);
+    assert_eq!(accounts.accounts[0].id, existing.id);
+    assert_eq!(
+        accounts.accounts[0].label,
+        CredentialAccountLabel::new("updated work github").unwrap()
+    );
+    let serialized = serde_json::to_string(&accounts).unwrap();
+    assert!(!serialized.contains(RAW_TOKEN));
+    assert!(!serialized.contains("manual-access-"));
+}
+
+fn assert_response_safe(response: &RebornManualTokenSubmitResponse) {
+    let serialized = serde_json::to_string(response).unwrap();
+    assert_eq!(
+        serde_json::from_str::<RebornManualTokenSubmitResponse>(&serialized).unwrap(),
+        *response
+    );
+    assert!(!serialized.contains(RAW_TOKEN));
+    assert!(!serialized.contains("manual-access-"));
+}
+
+#[tokio::test]
+async fn manual_token_facade_submits_secret_without_exposing_token() {
+    let services = auth_services();
+    let owner = scope("alice");
+    let challenge = services
+        .request_manual_token_setup(setup_request(owner.clone()))
+        .await
+        .expect("manual-token challenge");
+    assert_eq!(challenge.provider, provider());
+    assert_eq!(challenge.label, label());
+
+    let request = RebornManualTokenSubmitRequest::new(
+        owner.clone(),
+        challenge.interaction_id,
+        secret(RAW_TOKEN),
+    );
+    let debug = format!("{request:?}");
+    assert!(!debug.contains(RAW_TOKEN));
+
+    let response = services
+        .submit_manual_token(request)
+        .await
+        .expect("manual token submit succeeds");
+
+    assert_eq!(response.status, CredentialAccountStatus::Configured);
+    assert_eq!(response.continuation, AuthContinuationRef::SetupOnly);
+    assert_response_safe(&response);
+
+    let accounts = services
+        .credential_account_service()
+        .list_accounts(CredentialAccountListRequest::new(owner, provider()))
+        .await
+        .expect("account list");
+    assert_eq!(accounts.accounts.len(), 1);
+    let accounts_json = serde_json::to_string(&accounts).unwrap();
+    assert!(!accounts_json.contains(RAW_TOKEN));
+    assert!(!accounts_json.contains("manual-access-"));
+}
+
+#[tokio::test]
+async fn manual_token_facade_denies_cross_scope_submit_without_consuming_interaction() {
+    let services = auth_services();
+    let owner = scope("alice");
+    let interaction_id = request_challenge(&services, owner.clone()).await;
+
+    let error = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            scope("bob"),
+            interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect_err("cross-scope submit is denied");
+    assert_eq!(error.code, AuthErrorCode::CrossScopeDenied);
+    assert!(!error.retryable);
+    assert_error_safe(&error);
+
+    let response = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner,
+            interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect("owner can still submit after denied foreign attempt");
+    assert_eq!(response.status, CredentialAccountStatus::Configured);
+}
+
+#[tokio::test]
+async fn manual_token_facade_fails_closed_for_stale_duplicate_and_malformed_submit() {
+    let services = auth_services();
+    let owner = scope("alice");
+
+    let expired = services
+        .request_manual_token_setup(expired_setup_request(owner.clone()))
+        .await
+        .expect("expired challenge is still typed");
+    let stale = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner.clone(),
+            expired.interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect_err("expired interaction fails closed");
+    assert_eq!(stale.code, AuthErrorCode::UnknownOrExpiredFlow);
+    assert_error_safe(&stale);
+
+    let malformed_interaction = request_challenge(&services, owner.clone()).await;
+    let malformed = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner.clone(),
+            malformed_interaction,
+            secret(""),
+        ))
+        .await
+        .expect_err("empty secret is rejected");
+    assert_eq!(malformed.code, AuthErrorCode::InvalidRequest);
+    assert!(!malformed.retryable);
+
+    services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner.clone(),
+            malformed_interaction,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect("malformed submit does not consume the interaction");
+
+    let one_shot_interaction = request_challenge(&services, owner.clone()).await;
+    services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner.clone(),
+            one_shot_interaction,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect("first submit succeeds");
+    let duplicate = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner,
+            one_shot_interaction,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect_err("duplicate submit is stale");
+    assert_eq!(duplicate.code, AuthErrorCode::UnknownOrExpiredFlow);
+    assert_error_safe(&duplicate);
+}
+
+#[tokio::test]
+async fn manual_token_facade_returns_sanitized_backend_and_canceled_failures() {
+    let backend = auth_services_with_interaction(Arc::new(FailingInteractionService {
+        error: AuthProductError::BackendUnavailable,
+    }));
+    let backend_error = backend
+        .request_manual_token_setup(setup_request(scope("alice")))
+        .await
+        .expect_err("backend failures are sanitized");
+    assert_eq!(backend_error.code, AuthErrorCode::BackendUnavailable);
+    assert!(backend_error.retryable);
+    assert_error_safe(&backend_error);
+
+    let canceled = auth_services_with_interaction(Arc::new(FailingInteractionService {
+        error: AuthProductError::Canceled,
+    }));
+    let canceled_error = canceled
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            scope("alice"),
+            AuthInteractionId::new(),
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect_err("canceled interactions are sanitized");
+    assert_eq!(canceled_error.code, AuthErrorCode::Canceled);
+    assert!(!canceled_error.retryable);
+    assert_error_safe(&canceled_error);
+}

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -1,7 +1,7 @@
 # Reborn Product Auth Contract
 
 - **Status:** contract and composition seam
-- **Issue:** #3289 / #3810 / #3811 / #3812
+- **Issue:** #3289 / #3810 / #3811 / #3812 / #3882
 - **Crate:** `crates/ironclaw_auth`
 - **Composition:** `ironclaw_reborn_composition::RebornProductAuthServices`
 
@@ -15,10 +15,11 @@ providers, extensions, MCP servers, WASM tools/channels, and future identity
 login flows.
 
 This slice is contract-first. It defines Reborn-native vocabulary and fake
-services, #3811 adds a Reborn composition seam, and #3812 adds callback
-completion handling for host-mounted Reborn OAuth callback routes. It does not
-migrate production extension setup routes, CLI/setup flows, durable secret
-storage, or runtime credential injection.
+services, #3811 adds a Reborn composition seam, #3812 adds callback completion
+handling for host-mounted Reborn OAuth callback routes, and #3882 adds the
+composition-facing manual-token secure-submit entrypoint. It does not migrate
+production extension setup routes, CLI/setup flows, durable secret storage, or
+runtime credential injection.
 
 Behavior may remain compatible with legacy UX. Code paths must not mingle V1
 components with Reborn components: V1 route handlers, pending maps, extension
@@ -176,10 +177,23 @@ request_secret_input -> AuthChallenge::manual_token_required
 submit_manual_token  -> SecretSubmitResult { account_id, status, continuation }
 ```
 
+Host-owned routes should call
+`RebornProductAuthServices::request_manual_token_setup` to mint the typed
+challenge and `RebornProductAuthServices::submit_manual_token` with a
+non-serializable `RebornManualTokenSubmitRequest` after reading the dedicated
+secret-submit body. Routes must not pass manual-token material through chat
+commands, model-visible messages, product projections, route DTOs, or logs.
+The setup request is also not a route DTO: host routes must construct its
+`AuthProductScope` from authenticated caller/session context, and may attach a
+pre-authorized `CredentialAccountUpdateBinding` when the secret submit is
+intended to update an existing scoped account.
+
 Rules:
 
 - Raw token values must not enter model transcript, tool arguments, durable
   chat history, projections, debug output, or errors.
+- Manual-token account updates must be bound to a pre-authorized account update
+  binding before the challenge is minted.
 - Cross-scope submit attempts must not consume another user's pending
   interaction.
 - Empty, expired, malformed, or cross-scope submissions fail closed with stable
@@ -238,7 +252,7 @@ strings.
 | Extension/provider OAuth start | `src/extensions/manager.rs`, `src/auth/mod.rs` | `AuthFlowManager`, `CredentialSetupService`, `AuthProviderClient` | Contracted; production migration deferred |
 | Hosted OAuth callback | `src/channels/web/features/oauth/mod.rs` | `RebornProductAuthServices::handle_oauth_callback`, `ProductAuthTurnGateResumeDispatcher` for turn-gate resume continuations | Reborn handler seam ready; HTTP route mounting deferred |
 | Local OAuth callback | `src/extensions/manager.rs`, `src/auth/oauth.rs` | `AuthFlowManager`, `AuthProviderClient` | Inventory only |
-| Manual token entry from chat | `src/agent/agent_loop.rs`, `src/agent/thread_ops.rs` | `AuthInteractionService` secure submit | Contracted; route migration deferred |
+| Manual token entry from chat | `src/agent/agent_loop.rs`, `src/agent/thread_ops.rs` | `AuthInteractionService` secure submit via `RebornProductAuthServices::{request_manual_token_setup,submit_manual_token}` | Reborn facade ready; route migration deferred |
 | Engine/gate auth credential submit | `src/bridge/router.rs` | `AuthInteractionService`, `CredentialSetupService`, typed continuation | Contracted; migration deferred |
 | Extension/channel setup token storage | `src/extensions/manager.rs` | `CredentialSetupService`, `CredentialAccountService` | Contracted; migration deferred |
 | MCP OAuth/DCR/discovery/refresh | `src/tools/mcp/auth.rs` | `AuthFlowManager`, `AuthProviderClient`, `CredentialAccountService` | Inventory only |
@@ -257,8 +271,12 @@ strings.
 
 - OAuth start, provider exchange, callback success, callback replay, stale,
   canceled, malformed, denied, and cross-scope callback behavior;
-- secure manual-token submit, cross-scope denial, empty input, expiry, and debug
-  redaction;
+- secure manual-token submit, bound account update, cross-scope denial, empty
+  input, expiry, and debug redaction;
+- composition-facade manual-token request/submit, stale/duplicate/malformed
+  failures, bound account update, sanitized backend/canceled errors, and no
+  raw-token exposure in debug output, serialized responses/errors, or account
+  projections;
 - missing, refresh-failed, single-account, and multi-account selection states;
 - extension-owned owner validation and deactivate/uninstall cleanup behavior;
 - serde validation for newtypes and snake_case wire enums;

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -870,7 +870,7 @@ impl RebornBinaryE2EHarness {
         milestone_sink: Arc<ironclaw_turns::run_profile::InMemoryLoopHostMilestoneSink>,
         composition: RebornRuntimeLoopComposition<
             FilesystemTurnStateStore<LocalFilesystem>,
-            FilesystemSessionThreadService<LocalFilesystem>,
+            dyn SessionThreadService,
             RebornTraceReplayModelGateway,
         >,
         turn_root: Arc<tempfile::TempDir>,


### PR DESCRIPTION
## Summary

- Added Reborn product-auth manual-token setup/submit facade types on `RebornProductAuthServices`.
- Kept raw token material on non-serializable `SecretString` submit requests while returning sanitized challenge/response/error DTOs.
- Added bound credential-account update support for manual-token submit, with scoped update-binding validation before challenge creation.
- Added contract/facade/architecture tests and docs for no raw-token exposure and no v1 chat-token fallback.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Closes #3882

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_auth`, `cargo test -p ironclaw_reborn_composition`, `cargo test -p ironclaw_architecture reborn_product_auth_contract_stays_reborn_native`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; contract/facade behavior covered by tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo clippy -p ironclaw_auth --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_architecture --test reborn_dependency_boundaries -- -D warnings`
- `git diff --check`

## Security Impact

Yes. This adds the Reborn manual-token secure-submit boundary. Raw token values are accepted only through non-serializable secret-submit request types, and tests assert token material does not appear in debug output, serialized responses/errors, or account projections. The setup request is intentionally non-serializable so host routes construct scope from authenticated caller/session context rather than browser body input.

## Database Impact

None. This extends in-memory contract/fake behavior and composition facade types only; no migrations or persistent schema changes.

## Blast Radius

Limited to `ironclaw_auth` manual-token contracts/fake service behavior, `ironclaw_reborn_composition` product-auth facade types, and Reborn auth docs/architecture guardrails.

## Rollback Plan

Revert this PR to remove the Reborn manual-token facade entrypoint and the manual-token update-binding extension from the auth contract fake.

## Review Follow-Through

Reviewer judgment requested on the manual-token facade shape and whether account-update binding should stay directly on `ManualTokenSetupRequest` or move behind a future recovery/account-selection helper.

---

**Review track**: C