### PR TITLE
[codex] Use shared LLM config resolution for Reborn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4852,6 +4852,7 @@ dependencies = [
  "ironclaw_approvals",
  "ironclaw_auth",
  "ironclaw_authorization",
+ "ironclaw_common",
  "ironclaw_event_projections",
  "ironclaw_event_streams",
  "ironclaw_events",

--- a/crates/ironclaw_common/src/env_helpers.rs
+++ b/crates/ironclaw_common/src/env_helpers.rs
@@ -52,6 +52,14 @@ pub fn set_runtime_env(key: &str, value: &str) {
         .insert(key.to_string(), value.to_string());
 }
 
+/// Remove a runtime env override.
+pub fn remove_runtime_env(key: &str) {
+    runtime_overrides()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(key);
+}
+
 /// Read an env var, checking real env first, then runtime overrides, then any
 /// secondary fallback registered by the embedding application.
 ///
@@ -101,5 +109,13 @@ mod tests {
         let _guard = lock_env();
         set_runtime_env("IRONCLAW_TEST_EMPTY", "");
         assert_eq!(env_or_override("IRONCLAW_TEST_EMPTY"), None);
+    }
+
+    #[test]
+    fn runtime_override_can_be_removed() {
+        let _guard = lock_env();
+        set_runtime_env("IRONCLAW_TEST_REMOVE", "1");
+        remove_runtime_env("IRONCLAW_TEST_REMOVE");
+        assert_eq!(env_or_override("IRONCLAW_TEST_REMOVE"), None);
     }
 }

--- a/crates/ironclaw_llm/CLAUDE.md
+++ b/crates/ironclaw_llm/CLAUDE.md
@@ -34,6 +34,7 @@ Multi-provider LLM integration with circuit breaker, retry, failover, and respon
 | `host.rs` | Host-side trait surface: `SessionDb`, `SessionSecrets`, `SessionRenewer`, `SessionKeyPersistor` (binary supplies adapters in `src/llm_host.rs`) |
 | `runtime.rs` | `SwappableLlmProvider` + `LlmReloadHandle` for hot-reloading the provider chain on settings change |
 | `registry.rs` | Provider registry (`ProviderDefinition`, `ProviderProtocol`); resolves backend strings to clients |
+| `resolution.rs` | Full `LlmConfig` resolution for composition roots that select from `providers.json` and need dedicated providers plus the shared provider chain |
 | `tool_schema.rs` | Tool schema normalization policies (`FlattenOnly` for NearAI, strict OpenAI for `RigAdapter` / Codex) |
 | `transcription/{mod,openai,chat_completions}.rs` | Audio transcription pipeline (Whisper / chat-completions back-ends) |
 | `image_models.rs` | Image-generation model metadata table |

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -31,6 +31,8 @@ mod provider;
 mod reasoning;
 pub mod recording;
 pub mod registry;
+#[cfg(feature = "registry-provider-factory")]
+mod resolution;
 pub mod response_cache;
 pub mod retry;
 mod rig_adapter;
@@ -83,6 +85,10 @@ pub use reasoning::{
 pub use reasoning::{clean_response, recover_tool_calls_from_content};
 pub use recording::{MemorySnapshotEntry, RecordingLlm};
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
+#[cfg(feature = "registry-provider-factory")]
+pub use resolution::{
+    ResolvedProviderConfig, build_llm_config_from_resolved_provider, resolve_llm_config_from_env,
+};
 pub use response_cache::{CachedProvider, ResponseCacheConfig};
 pub use retry::{RetryConfig, RetryProvider};
 pub use rig_adapter::RigAdapter;

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -87,7 +87,10 @@ pub use recording::{MemorySnapshotEntry, RecordingLlm};
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 #[cfg(feature = "registry-provider-factory")]
 pub use resolution::{
-    ResolvedProviderConfig, build_llm_config_from_resolved_provider, resolve_llm_config_from_env,
+    ProviderSelection, ResolvedProviderConfig, build_llm_config_from_resolved_provider,
+    build_registry_provider_config_from_resolved_provider, resolve_llm_config_from_env,
+    resolve_llm_config_from_selection, resolve_provider_config_from_env,
+    resolve_provider_config_from_selection,
 };
 pub use response_cache::{CachedProvider, ResponseCacheConfig};
 pub use retry::{RetryConfig, RetryProvider};
@@ -103,8 +106,6 @@ use std::sync::Arc;
 
 use rig::client::CompletionClient;
 use secrecy::ExposeSecret;
-#[cfg(feature = "registry-provider-factory")]
-use secrecy::SecretString;
 
 // LlmConfig, NearAiConfig, RegistryProviderConfig, and LlmError are
 // re-exported via `pub use` above from config and error submodules.
@@ -213,191 +214,9 @@ pub fn create_registry_provider(
 pub fn resolve_registry_provider_from_env(
     user_providers_path: Option<&Path>,
 ) -> Result<Option<RegistryProviderConfig>, LlmError> {
-    if let Some(backend) = nonempty_env("LLM_BACKEND") {
-        if is_openai_codex_backend(&backend) {
-            return resolve_openai_codex_registry_provider_from_env().map(Some);
-        }
-        let registry = try_load_provider_registry(user_providers_path)?;
-        let provider = registry
-            .find(&backend)
-            .ok_or_else(|| LlmError::AuthFailed {
-                provider: backend.clone(),
-            })?;
-        return resolve_registry_provider_definition_from_env(provider).map(Some);
-    }
-
-    if codex_auth_enabled_from_env() {
-        return resolve_openai_codex_registry_provider_from_env().map(Some);
-    }
-
-    let registry = ProviderRegistry::load_from_path(user_providers_path);
-    let Some(provider) = registry
-        .all()
-        .iter()
-        .find(|provider| registry_provider_env_present(provider))
-    else {
-        return Ok(None);
-    };
-    resolve_registry_provider_definition_from_env(provider).map(Some)
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn try_load_provider_registry(
-    user_providers_path: Option<&Path>,
-) -> Result<ProviderRegistry, LlmError> {
-    ProviderRegistry::try_load_from_path(user_providers_path).map_err(|source| {
-        LlmError::RequestFailed {
-            provider: "provider_registry".to_string(),
-            reason: source.to_string(),
-        }
-    })
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn registry_provider_env_present(provider: &ProviderDefinition) -> bool {
-    provider
-        .api_key_env
-        .as_deref()
-        .and_then(nonempty_env)
-        .is_some()
-        || provider
-            .base_url_env
-            .as_deref()
-            .and_then(nonempty_env)
-            .is_some()
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn resolve_registry_provider_definition_from_env(
-    provider: &ProviderDefinition,
-) -> Result<RegistryProviderConfig, LlmError> {
-    let api_key = match provider.api_key_env.as_deref().and_then(nonempty_env) {
-        Some(value) => Some(SecretString::from(value)),
-        None if provider.api_key_required => {
-            return Err(LlmError::AuthFailed {
-                provider: provider.id.clone(),
-            });
-        }
-        None => None,
-    };
-    let base_url = provider
-        .base_url_env
-        .as_deref()
-        .and_then(nonempty_env)
-        .or_else(|| provider.default_base_url.clone())
-        .unwrap_or_default();
-    if provider.base_url_required && base_url.is_empty() {
-        return Err(LlmError::RequestFailed {
-            provider: provider.id.clone(),
-            reason: "base URL is required but no base URL environment variable is set".to_string(),
-        });
-    }
-    let model = nonempty_env(&provider.model_env)
-        .or_else(|| nonempty_env("LLM_MODEL"))
-        .unwrap_or_else(|| provider.default_model.clone());
-    let extra_headers = provider
-        .extra_headers_env
-        .as_deref()
-        .and_then(nonempty_env)
-        .map(|value| parse_registry_extra_headers(&provider.id, &value))
-        .transpose()?;
-
-    Ok(RegistryProviderConfig::generic(
-        provider.protocol,
-        provider.id.clone(),
-        api_key,
-        base_url,
-        model,
-    )
-    .with_extra_headers(extra_headers.unwrap_or_default())
-    .with_unsupported_params(provider.unsupported_params.clone()))
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn resolve_openai_codex_registry_provider_from_env() -> Result<RegistryProviderConfig, LlmError> {
-    let auth_path = std::env::var_os("CODEX_AUTH_PATH")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(codex_auth::default_codex_auth_path);
-    let credentials =
-        codex_auth::load_codex_credentials(&auth_path).ok_or_else(|| LlmError::AuthFailed {
-            provider: "openai_codex".to_string(),
-        })?;
-    let model = nonempty_env("OPENAI_CODEX_MODEL")
-        .or_else(|| nonempty_env("OPENAI_MODEL"))
-        .or_else(|| nonempty_env("LLM_MODEL"))
-        .unwrap_or_else(|| {
-            if credentials.is_chatgpt_mode {
-                "gpt-5.3-codex".to_string()
-            } else {
-                "gpt-4o-mini".to_string()
-            }
-        });
-    let base_url = credentials.base_url().to_string();
-
-    Ok(RegistryProviderConfig {
-        protocol: ProviderProtocol::OpenAiCompletions,
-        provider_id: if credentials.is_chatgpt_mode {
-            "codex_chatgpt".to_string()
-        } else {
-            "openai".to_string()
-        },
-        api_key: Some(credentials.token),
-        base_url,
-        model,
-        extra_headers: Vec::new(),
-        oauth_token: None,
-        is_codex_chatgpt: credentials.is_chatgpt_mode,
-        refresh_token: credentials.refresh_token,
-        auth_path: credentials.is_chatgpt_mode.then_some(auth_path),
-        cache_retention: CacheRetention::None,
-        unsupported_params: Vec::new(),
-    })
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn is_openai_codex_backend(backend: &str) -> bool {
-    matches!(backend, "openai_codex" | "openai-codex" | "codex")
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn codex_auth_enabled_from_env() -> bool {
-    std::env::var("LLM_USE_CODEX_AUTH")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(false)
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn nonempty_env(name: &str) -> Option<String> {
-    std::env::var(name).ok().filter(|value| !value.is_empty())
-}
-
-#[cfg(feature = "registry-provider-factory")]
-fn parse_registry_extra_headers(
-    provider: &str,
-    value: &str,
-) -> Result<Vec<(String, String)>, LlmError> {
-    let mut headers = Vec::new();
-    for part in value.split(',') {
-        let part = part.trim();
-        if part.is_empty() {
-            continue;
-        }
-        let Some((key, header_value)) = part.split_once(':') else {
-            return Err(LlmError::RequestFailed {
-                provider: provider.to_string(),
-                reason: "extra header must use `Name:Value` format".to_string(),
-            });
-        };
-        let key = key.trim();
-        if key.is_empty() {
-            return Err(LlmError::RequestFailed {
-                provider: provider.to_string(),
-                reason: "extra header name must not be empty".to_string(),
-            });
-        }
-        headers.push((key.to_string(), header_value.trim().to_string()));
-    }
-    Ok(headers)
+    resolution::resolve_provider_config_from_env(user_providers_path)?
+        .map(resolution::build_registry_provider_config_from_resolved_provider)
+        .transpose()
 }
 
 fn create_registry_provider_inner(
@@ -1039,6 +858,14 @@ pub(crate) async fn build_provider_chain_components(
     config: &LlmConfig,
     session: Arc<SessionManager>,
 ) -> Result<ProviderChainComponents, LlmError> {
+    build_provider_chain_components_with_options(config, session, true).await
+}
+
+async fn build_provider_chain_components_with_options(
+    config: &LlmConfig,
+    session: Arc<SessionManager>,
+    include_standalone_cheap: bool,
+) -> Result<ProviderChainComponents, LlmError> {
     let llm: Arc<dyn LlmProvider> = if config.backend == "openai_codex" {
         create_openai_codex_provider(config).await?
     } else {
@@ -1163,7 +990,11 @@ pub(crate) async fn build_provider_chain_components(
     };
 
     // Standalone cheap LLM for heartbeat/evaluation (not part of the chain)
-    let cheap_llm = create_cheap_llm_provider(config, session)?;
+    let cheap_llm = if include_standalone_cheap {
+        create_cheap_llm_provider(config, session)?
+    } else {
+        None
+    };
     if let Some(ref cheap) = cheap_llm {
         tracing::debug!("Cheap LLM provider initialized: {}", cheap.model_name());
     }
@@ -1171,6 +1002,22 @@ pub(crate) async fn build_provider_chain_components(
     Ok(ProviderChainComponents {
         primary: llm,
         cheap: cheap_llm,
+    })
+}
+
+/// Build a primary provider chain for composition roots that do not own
+/// hot-reload or standalone cheap-provider lifecycle handles.
+pub async fn build_static_provider_chain(
+    config: &LlmConfig,
+    session: Arc<SessionManager>,
+) -> Result<Arc<dyn LlmProvider>, LlmError> {
+    let components = build_provider_chain_components_with_options(config, session, false).await?;
+    let primary = components.primary;
+    let recording_handle = RecordingLlm::from_env(primary.clone());
+    Ok(if let Some(recorder) = recording_handle {
+        recorder as Arc<dyn LlmProvider>
+    } else {
+        primary
     })
 }
 

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -87,7 +87,8 @@ pub use recording::{MemorySnapshotEntry, RecordingLlm};
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 #[cfg(feature = "registry-provider-factory")]
 pub use resolution::{
-    ProviderSelection, ResolvedProviderConfig, build_llm_config_from_resolved_provider,
+    ProviderResolutionError, ProviderSelection, ResolvedDedicatedProviderConfig,
+    ResolvedProviderConfig, build_llm_config_from_resolved_provider,
     build_registry_provider_config_from_resolved_provider, resolve_llm_config_from_env,
     resolve_llm_config_from_selection, resolve_provider_config_from_env,
     resolve_provider_config_from_selection,

--- a/crates/ironclaw_llm/src/resolution.rs
+++ b/crates/ironclaw_llm/src/resolution.rs
@@ -115,7 +115,9 @@ pub fn resolve_provider_config_from_env(
             .ok_or_else(|| LlmError::AuthFailed {
                 provider: backend.clone(),
             })?;
-        if codex_auth_enabled_from_env() && provider.protocol == ProviderProtocol::OpenAiCodex {
+        if provider.protocol == ProviderProtocol::OpenAiCodex
+            && (codex_auth_enabled_from_env() || std::env::var_os("CODEX_AUTH_PATH").is_some())
+        {
             return resolve_codex_cli_auth_provider().map(Some);
         }
         return resolve_provider_definition_from_env(provider).map(Some);
@@ -746,7 +748,10 @@ mod tests {
     const CHAIN_ENV_VARS: &[&str] = &[
         "LLM_REQUEST_TIMEOUT_SECS",
         "LLM_CHEAP_MODEL",
+        "LLM_BACKEND",
         "SMART_ROUTING_CASCADE",
+        "CODEX_AUTH_PATH",
+        "LLM_USE_CODEX_AUTH",
         "LLM_MAX_RETRIES",
         "NEARAI_MAX_RETRIES",
         "LLM_CIRCUIT_BREAKER_THRESHOLD",
@@ -848,5 +853,21 @@ mod tests {
 
         assert!(!config.smart_routing_cascade);
         assert!(config.response_cache_enabled);
+    }
+
+    #[test]
+    fn openai_codex_backend_with_missing_codex_auth_path_fails_fast() {
+        let _env_lock = ironclaw_common::env_helpers::lock_env();
+        let env = EnvGuard::clear(CHAIN_ENV_VARS);
+        env.set("LLM_BACKEND", "openai_codex");
+        env.set("CODEX_AUTH_PATH", "/tmp/ironclaw-missing-codex-auth.json");
+
+        let error = resolve_provider_config_from_env(None)
+            .expect_err("missing explicit Codex auth path should fail before provider startup");
+
+        assert!(matches!(
+            error,
+            LlmError::AuthFailed { provider } if provider == "openai_codex"
+        ));
     }
 }

--- a/crates/ironclaw_llm/src/resolution.rs
+++ b/crates/ironclaw_llm/src/resolution.rs
@@ -1,0 +1,573 @@
+//! Full LLM config resolution for composition roots.
+//!
+//! This is the shared path for callers that select providers from
+//! `providers.json` but still want the normal `LlmConfig`/provider-chain
+//! behavior, including dedicated providers such as NEAR AI, OpenAI Codex,
+//! Gemini OAuth, and Bedrock.
+
+use std::path::{Path, PathBuf};
+
+use secrecy::SecretString;
+
+use crate::auth::{self, CredentialSource};
+use crate::config::{
+    BedrockConfig, CacheRetention, GeminiOauthConfig, LlmConfig, NearAiConfig, OAUTH_PLACEHOLDER,
+    OpenAiCodexConfig, RegistryProviderConfig,
+};
+use crate::error::{LlmConfigError, LlmError};
+use crate::registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
+use crate::session::SessionConfig;
+
+/// Already-resolved provider input from a catalog selection.
+#[derive(Debug, Clone)]
+pub struct ResolvedProviderConfig {
+    pub protocol: ProviderProtocol,
+    pub provider_id: String,
+    pub api_key: Option<SecretString>,
+    pub base_url: String,
+    pub model: String,
+    pub extra_headers: Vec<(String, String)>,
+    pub unsupported_params: Vec<String>,
+}
+
+/// Resolve a full [`LlmConfig`] from generic LLM environment variables.
+///
+/// This is the full-config counterpart to `resolve_registry_provider_from_env`.
+/// It returns dedicated `LlmConfig` variants for dedicated protocols instead
+/// of trying to squeeze them through `RegistryProviderConfig`.
+pub fn resolve_llm_config_from_env(
+    user_providers_path: Option<&Path>,
+) -> Result<Option<LlmConfig>, LlmError> {
+    if codex_auth_enabled_from_env() {
+        return resolve_codex_cli_auth_config().map(Some);
+    }
+
+    if let Some(backend) = nonempty_env("LLM_BACKEND") {
+        let registry = try_load_provider_registry(user_providers_path)?;
+        let provider = registry
+            .find(&backend)
+            .ok_or_else(|| LlmError::AuthFailed {
+                provider: backend.clone(),
+            })?;
+        return resolve_provider_definition_from_env(provider).map(Some);
+    }
+
+    let registry = ProviderRegistry::load_from_path(user_providers_path);
+    let Some(provider) = registry
+        .all()
+        .iter()
+        .find(|provider| provider_env_present(provider))
+    else {
+        return Ok(None);
+    };
+    resolve_provider_definition_from_env(provider).map(Some)
+}
+
+/// Build a full [`LlmConfig`] from a catalog entry whose basic fields
+/// have already been resolved and validated by the caller.
+pub fn build_llm_config_from_resolved_provider(
+    resolved: ResolvedProviderConfig,
+) -> Result<LlmConfig, LlmError> {
+    let chain = ChainSettings::from_env()?;
+    let session = nearai_session_config();
+    let nearai = nearai_config_from_resolved(&resolved, &chain)?;
+
+    let mut provider = None;
+    let mut bedrock = None;
+    let mut gemini_oauth = None;
+    let mut openai_codex = None;
+
+    match resolved.protocol {
+        ProviderProtocol::NearAi => {}
+        ProviderProtocol::Bedrock => {
+            bedrock = Some(
+                BedrockConfig::build(
+                    nonempty_env("BEDROCK_REGION"),
+                    Some(resolved.model.clone()),
+                    nonempty_env("BEDROCK_CROSS_REGION"),
+                    nonempty_env("AWS_PROFILE"),
+                )
+                .map_err(config_error_to_llm_error("bedrock"))?,
+            );
+        }
+        ProviderProtocol::GeminiOauth => {
+            gemini_oauth = Some(GeminiOauthConfig::build(
+                Some(resolved.model.clone()),
+                nonempty_env("GEMINI_CREDENTIALS_PATH").map(PathBuf::from),
+            ));
+        }
+        ProviderProtocol::OpenAiCodex => {
+            openai_codex = Some(OpenAiCodexConfig::build(
+                Some(resolved.model.clone()),
+                nonempty_env("OPENAI_CODEX_AUTH_URL"),
+                nonempty_env("OPENAI_CODEX_API_URL"),
+                nonempty_env("OPENAI_CODEX_CLIENT_ID"),
+                nonempty_env("OPENAI_CODEX_SESSION_PATH").map(PathBuf::from),
+                parse_optional_u64("OPENAI_CODEX_REFRESH_MARGIN_SECS", "openai_codex")?,
+            ));
+        }
+        ProviderProtocol::OpenAiCompletions
+        | ProviderProtocol::Anthropic
+        | ProviderProtocol::Ollama
+        | ProviderProtocol::GithubCopilot
+        | ProviderProtocol::DeepSeek
+        | ProviderProtocol::Gemini
+        | ProviderProtocol::OpenRouter => {
+            provider = Some(registry_config_from_resolved(resolved.clone())?);
+        }
+    }
+
+    Ok(LlmConfig {
+        backend: resolved.provider_id,
+        session,
+        nearai,
+        provider,
+        bedrock,
+        gemini_oauth,
+        openai_codex,
+        request_timeout_secs: chain.request_timeout_secs,
+        cheap_model: chain.cheap_model,
+        smart_routing_cascade: chain.smart_routing_cascade,
+        max_retries: chain.max_retries,
+        circuit_breaker_threshold: chain.circuit_breaker_threshold,
+        circuit_breaker_recovery_secs: chain.circuit_breaker_recovery_secs,
+        response_cache_enabled: chain.response_cache_enabled,
+        response_cache_ttl_secs: chain.response_cache_ttl_secs,
+        response_cache_max_entries: chain.response_cache_max_entries,
+    })
+}
+
+fn resolve_provider_definition_from_env(
+    provider: &ProviderDefinition,
+) -> Result<LlmConfig, LlmError> {
+    let api_key = match provider.api_key_env.as_deref().and_then(nonempty_env) {
+        Some(value) => Some(SecretString::from(value)),
+        None if provider.api_key_required => {
+            return Err(LlmError::AuthFailed {
+                provider: provider.id.clone(),
+            });
+        }
+        None => None,
+    };
+    let base_url = provider
+        .base_url_env
+        .as_deref()
+        .and_then(nonempty_env)
+        .or_else(|| provider.default_base_url.clone())
+        .unwrap_or_default();
+    if provider.base_url_required && base_url.is_empty() {
+        return Err(LlmError::RequestFailed {
+            provider: provider.id.clone(),
+            reason: "base URL is required but no base URL environment variable is set".to_string(),
+        });
+    }
+    let model = nonempty_env(&provider.model_env)
+        .or_else(|| nonempty_env("LLM_MODEL"))
+        .unwrap_or_else(|| provider.default_model.clone());
+    let extra_headers = provider
+        .extra_headers_env
+        .as_deref()
+        .and_then(nonempty_env)
+        .map(|value| parse_extra_headers(&provider.id, &value))
+        .transpose()?
+        .unwrap_or_default();
+    let extra_headers = if provider.protocol == ProviderProtocol::GithubCopilot {
+        merge_extra_headers(
+            auth::default_headers(auth::AuthBackend::GithubCopilot),
+            extra_headers,
+        )
+    } else {
+        extra_headers
+    };
+
+    build_llm_config_from_resolved_provider(ResolvedProviderConfig {
+        protocol: provider.protocol,
+        provider_id: provider.id.clone(),
+        api_key,
+        base_url,
+        model,
+        extra_headers,
+        unsupported_params: provider.unsupported_params.clone(),
+    })
+}
+
+fn resolve_codex_cli_auth_config() -> Result<LlmConfig, LlmError> {
+    let auth_path = std::env::var_os("CODEX_AUTH_PATH").map(PathBuf::from);
+    let credentials =
+        auth::load_persisted_credentials(CredentialSource::CodexCli, auth_path.as_deref())
+            .ok_or_else(|| LlmError::AuthFailed {
+                provider: "openai_codex".to_string(),
+            })?;
+    let model = nonempty_env("OPENAI_CODEX_MODEL")
+        .or_else(|| nonempty_env("OPENAI_MODEL"))
+        .or_else(|| nonempty_env("LLM_MODEL"))
+        .unwrap_or_else(|| {
+            if credentials.is_subscription {
+                "gpt-5.3-codex".to_string()
+            } else {
+                "gpt-4o-mini".to_string()
+            }
+        });
+    let provider_id = if credentials.is_subscription {
+        "codex_chatgpt"
+    } else {
+        "openai"
+    };
+
+    let mut registry_config = RegistryProviderConfig::generic(
+        ProviderProtocol::OpenAiCompletions,
+        provider_id,
+        Some(credentials.token),
+        credentials.base_url,
+        model,
+    );
+    registry_config.is_codex_chatgpt = credentials.is_subscription;
+    registry_config.refresh_token = credentials.refresh_token;
+    registry_config.auth_path = credentials.source_path;
+
+    let chain = ChainSettings::from_env()?;
+    Ok(config_from_registry_provider(registry_config, chain))
+}
+
+fn registry_config_from_resolved(
+    resolved: ResolvedProviderConfig,
+) -> Result<RegistryProviderConfig, LlmError> {
+    let mut config = RegistryProviderConfig::generic(
+        resolved.protocol,
+        resolved.provider_id.clone(),
+        resolved.api_key,
+        resolved.base_url,
+        resolved.model,
+    )
+    .with_extra_headers(resolved.extra_headers)
+    .with_unsupported_params(resolved.unsupported_params);
+
+    if resolved.protocol == ProviderProtocol::Anthropic {
+        config.cache_retention = nonempty_env("ANTHROPIC_CACHE_RETENTION")
+            .map(|value| {
+                value
+                    .parse::<CacheRetention>()
+                    .map_err(|reason| LlmError::RequestFailed {
+                        provider: resolved.provider_id.clone(),
+                        reason: format!("invalid ANTHROPIC_CACHE_RETENTION: {reason}"),
+                    })
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        if let Some(token) = nonempty_env("ANTHROPIC_OAUTH_TOKEN") {
+            config.oauth_token = Some(SecretString::from(token));
+            if config.api_key.is_none() {
+                config.api_key = Some(SecretString::from(OAUTH_PLACEHOLDER.to_string()));
+            }
+        }
+    }
+
+    Ok(config)
+}
+
+fn config_from_registry_provider(
+    registry_config: RegistryProviderConfig,
+    chain: ChainSettings,
+) -> LlmConfig {
+    let session = nearai_session_config();
+    LlmConfig {
+        backend: registry_config.provider_id.clone(),
+        session,
+        nearai: default_nearai_config(),
+        provider: Some(registry_config),
+        bedrock: None,
+        gemini_oauth: None,
+        openai_codex: None,
+        request_timeout_secs: chain.request_timeout_secs,
+        cheap_model: chain.cheap_model,
+        smart_routing_cascade: chain.smart_routing_cascade,
+        max_retries: chain.max_retries,
+        circuit_breaker_threshold: chain.circuit_breaker_threshold,
+        circuit_breaker_recovery_secs: chain.circuit_breaker_recovery_secs,
+        response_cache_enabled: chain.response_cache_enabled,
+        response_cache_ttl_secs: chain.response_cache_ttl_secs,
+        response_cache_max_entries: chain.response_cache_max_entries,
+    }
+}
+
+fn nearai_config_from_resolved(
+    resolved: &ResolvedProviderConfig,
+    chain: &ChainSettings,
+) -> Result<NearAiConfig, LlmError> {
+    let api_key = if resolved.protocol == ProviderProtocol::NearAi {
+        resolved.api_key.clone()
+    } else {
+        nonempty_env("NEARAI_API_KEY").map(SecretString::from)
+    };
+    let base_url = if resolved.protocol == ProviderProtocol::NearAi && !resolved.base_url.is_empty()
+    {
+        resolved.base_url.clone()
+    } else if let Some(base_url) = nonempty_env("NEARAI_BASE_URL") {
+        base_url
+    } else if api_key.is_some() {
+        "https://cloud-api.near.ai".to_string()
+    } else {
+        "https://private.near.ai".to_string()
+    };
+    let model = if resolved.protocol == ProviderProtocol::NearAi {
+        resolved.model.clone()
+    } else {
+        nonempty_env("NEARAI_MODEL").unwrap_or_else(|| crate::DEFAULT_MODEL.to_string())
+    };
+
+    let failover_cooldown_secs = if resolved.protocol == ProviderProtocol::NearAi {
+        parse_optional_u64("LLM_FAILOVER_COOLDOWN_SECS", "nearai")?.unwrap_or(300)
+    } else {
+        300
+    };
+    let failover_cooldown_threshold = if resolved.protocol == ProviderProtocol::NearAi {
+        parse_optional_u32("LLM_FAILOVER_THRESHOLD", "nearai")?.unwrap_or(3)
+    } else {
+        3
+    };
+
+    Ok(NearAiConfig {
+        model,
+        cheap_model: nonempty_env("NEARAI_CHEAP_MODEL"),
+        base_url,
+        api_key,
+        fallback_model: nonempty_env("NEARAI_FALLBACK_MODEL"),
+        max_retries: chain.max_retries,
+        circuit_breaker_threshold: chain.circuit_breaker_threshold,
+        circuit_breaker_recovery_secs: chain.circuit_breaker_recovery_secs,
+        response_cache_enabled: chain.response_cache_enabled,
+        response_cache_ttl_secs: chain.response_cache_ttl_secs,
+        response_cache_max_entries: chain.response_cache_max_entries,
+        failover_cooldown_secs,
+        failover_cooldown_threshold,
+        smart_routing_cascade: chain.smart_routing_cascade,
+    })
+}
+
+fn default_nearai_config() -> NearAiConfig {
+    let chain = ChainSettings::default();
+    nearai_config_from_resolved(
+        &ResolvedProviderConfig {
+            protocol: ProviderProtocol::OpenAiCompletions,
+            provider_id: "openai".to_string(),
+            api_key: None,
+            base_url: String::new(),
+            model: String::new(),
+            extra_headers: Vec::new(),
+            unsupported_params: Vec::new(),
+        },
+        &chain,
+    )
+    .expect("default non-NEAR AI fallback config does not parse fallible provider fields")
+}
+
+fn nearai_session_config() -> SessionConfig {
+    SessionConfig {
+        auth_base_url: nonempty_env("NEARAI_AUTH_URL")
+            .unwrap_or_else(|| "https://private.near.ai".to_string()),
+        session_path: nonempty_env("NEARAI_SESSION_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| ironclaw_common::paths::ironclaw_base_dir().join("session.json")),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChainSettings {
+    request_timeout_secs: u64,
+    cheap_model: Option<String>,
+    smart_routing_cascade: bool,
+    max_retries: u32,
+    circuit_breaker_threshold: Option<u32>,
+    circuit_breaker_recovery_secs: u64,
+    response_cache_enabled: bool,
+    response_cache_ttl_secs: u64,
+    response_cache_max_entries: usize,
+}
+
+impl Default for ChainSettings {
+    fn default() -> Self {
+        Self {
+            request_timeout_secs: 120,
+            cheap_model: None,
+            smart_routing_cascade: true,
+            max_retries: 3,
+            circuit_breaker_threshold: None,
+            circuit_breaker_recovery_secs: 30,
+            response_cache_enabled: false,
+            response_cache_ttl_secs: 3600,
+            response_cache_max_entries: 1000,
+        }
+    }
+}
+
+impl ChainSettings {
+    fn from_env() -> Result<Self, LlmError> {
+        let defaults = Self::default();
+        Ok(Self {
+            request_timeout_secs: parse_optional_u64("LLM_REQUEST_TIMEOUT_SECS", "llm_config")?
+                .unwrap_or(defaults.request_timeout_secs),
+            cheap_model: nonempty_env("LLM_CHEAP_MODEL"),
+            smart_routing_cascade: parse_optional_bool("SMART_ROUTING_CASCADE", "llm_config")?
+                .unwrap_or(defaults.smart_routing_cascade),
+            max_retries: parse_optional_u32("LLM_MAX_RETRIES", "llm_config")?
+                .unwrap_or(defaults.max_retries),
+            circuit_breaker_threshold: parse_optional_u32(
+                "LLM_CIRCUIT_BREAKER_THRESHOLD",
+                "llm_config",
+            )?,
+            circuit_breaker_recovery_secs: parse_optional_u64(
+                "LLM_CIRCUIT_BREAKER_RECOVERY_SECS",
+                "llm_config",
+            )?
+            .unwrap_or(defaults.circuit_breaker_recovery_secs),
+            response_cache_enabled: parse_optional_bool(
+                "LLM_RESPONSE_CACHE_ENABLED",
+                "llm_config",
+            )?
+            .unwrap_or(defaults.response_cache_enabled),
+            response_cache_ttl_secs: parse_optional_u64(
+                "LLM_RESPONSE_CACHE_TTL_SECS",
+                "llm_config",
+            )?
+            .unwrap_or(defaults.response_cache_ttl_secs),
+            response_cache_max_entries: parse_optional_usize(
+                "LLM_RESPONSE_CACHE_MAX_ENTRIES",
+                "llm_config",
+            )?
+            .unwrap_or(defaults.response_cache_max_entries),
+        })
+    }
+}
+
+fn try_load_provider_registry(
+    user_providers_path: Option<&Path>,
+) -> Result<ProviderRegistry, LlmError> {
+    ProviderRegistry::try_load_from_path(user_providers_path).map_err(|source| {
+        LlmError::RequestFailed {
+            provider: "provider_registry".to_string(),
+            reason: source.to_string(),
+        }
+    })
+}
+
+fn provider_env_present(provider: &ProviderDefinition) -> bool {
+    provider
+        .api_key_env
+        .as_deref()
+        .and_then(nonempty_env)
+        .is_some()
+        || provider
+            .base_url_env
+            .as_deref()
+            .and_then(nonempty_env)
+            .is_some()
+        || nonempty_env(&provider.model_env).is_some()
+}
+
+fn parse_extra_headers(provider: &str, value: &str) -> Result<Vec<(String, String)>, LlmError> {
+    let mut headers = Vec::new();
+    for part in value.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let Some((key, header_value)) = part.split_once(':') else {
+            return Err(LlmError::RequestFailed {
+                provider: provider.to_string(),
+                reason: "extra header must use `Name:Value` format".to_string(),
+            });
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            return Err(LlmError::RequestFailed {
+                provider: provider.to_string(),
+                reason: "extra header name must not be empty".to_string(),
+            });
+        }
+        headers.push((key.to_string(), header_value.trim().to_string()));
+    }
+    Ok(headers)
+}
+
+fn merge_extra_headers(
+    defaults: Vec<(String, String)>,
+    overrides: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    let mut merged = defaults;
+    for (key, value) in overrides {
+        if let Some((_, existing_value)) = merged
+            .iter_mut()
+            .find(|(existing_key, _)| existing_key.eq_ignore_ascii_case(&key))
+        {
+            *existing_value = value;
+        } else {
+            merged.push((key, value));
+        }
+    }
+    merged
+}
+
+fn codex_auth_enabled_from_env() -> bool {
+    std::env::var("LLM_USE_CODEX_AUTH")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+fn nonempty_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn parse_optional_bool(name: &str, provider: &str) -> Result<Option<bool>, LlmError> {
+    nonempty_env(name)
+        .map(|value| {
+            value
+                .parse::<bool>()
+                .map_err(|source| invalid_env(provider, name, source))
+        })
+        .transpose()
+}
+
+fn parse_optional_u32(name: &str, provider: &str) -> Result<Option<u32>, LlmError> {
+    nonempty_env(name)
+        .map(|value| {
+            value
+                .parse::<u32>()
+                .map_err(|source| invalid_env(provider, name, source))
+        })
+        .transpose()
+}
+
+fn parse_optional_u64(name: &str, provider: &str) -> Result<Option<u64>, LlmError> {
+    nonempty_env(name)
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .map_err(|source| invalid_env(provider, name, source))
+        })
+        .transpose()
+}
+
+fn parse_optional_usize(name: &str, provider: &str) -> Result<Option<usize>, LlmError> {
+    nonempty_env(name)
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .map_err(|source| invalid_env(provider, name, source))
+        })
+        .transpose()
+}
+
+fn invalid_env(provider: &str, name: &str, source: impl std::fmt::Display) -> LlmError {
+    LlmError::RequestFailed {
+        provider: provider.to_string(),
+        reason: format!("{name} is invalid: {source}"),
+    }
+}
+
+fn config_error_to_llm_error(provider: &'static str) -> impl FnOnce(LlmConfigError) -> LlmError {
+    move |source| LlmError::RequestFailed {
+        provider: provider.to_string(),
+        reason: source.to_string(),
+    }
+}

--- a/crates/ironclaw_llm/src/resolution.rs
+++ b/crates/ironclaw_llm/src/resolution.rs
@@ -18,21 +18,44 @@ use crate::error::{LlmConfigError, LlmError};
 use crate::registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 use crate::session::SessionConfig;
 
-/// Already-resolved provider input from a catalog selection.
+/// Already-resolved provider input from env or a catalog selection.
 #[derive(Debug, Clone)]
-pub struct ResolvedProviderConfig {
+pub enum ResolvedProviderConfig {
+    Registry(RegistryProviderConfig),
+    Dedicated(ResolvedDedicatedProviderConfig),
+}
+
+/// Resolved input for providers represented by dedicated `LlmConfig` slots.
+#[derive(Debug, Clone)]
+pub struct ResolvedDedicatedProviderConfig {
     pub protocol: ProviderProtocol,
     pub provider_id: String,
     pub api_key: Option<SecretString>,
     pub base_url: String,
     pub model: String,
-    pub extra_headers: Vec<(String, String)>,
-    pub oauth_token: Option<SecretString>,
-    pub is_codex_chatgpt: bool,
-    pub refresh_token: Option<SecretString>,
-    pub auth_path: Option<PathBuf>,
-    pub cache_retention: Option<CacheRetention>,
-    pub unsupported_params: Vec<String>,
+}
+
+impl ResolvedProviderConfig {
+    pub fn provider_id(&self) -> &str {
+        match self {
+            Self::Registry(config) => &config.provider_id,
+            Self::Dedicated(config) => &config.provider_id,
+        }
+    }
+
+    pub fn base_url(&self) -> &str {
+        match self {
+            Self::Registry(config) => &config.base_url,
+            Self::Dedicated(config) => &config.base_url,
+        }
+    }
+
+    pub fn model(&self) -> &str {
+        match self {
+            Self::Registry(config) => &config.model,
+            Self::Dedicated(config) => &config.model,
+        }
+    }
 }
 
 /// Provider selection overrides supplied by a composition root.
@@ -42,6 +65,34 @@ pub struct ProviderSelection {
     pub api_key_env: Option<String>,
     pub base_url: Option<String>,
     pub model: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderResolutionError {
+    #[error("provider `{provider}` is not in the provider registry")]
+    UnknownProvider { provider: String },
+    #[error("provider `{provider}` requires an API key")]
+    MissingApiKey { provider: String },
+    #[error("provider `{provider}` requires a base URL")]
+    MissingBaseUrl { provider: String },
+    #[error(transparent)]
+    Llm(#[from] LlmError),
+}
+
+impl ProviderResolutionError {
+    pub fn into_llm_error(self) -> LlmError {
+        match self {
+            Self::UnknownProvider { provider } | Self::MissingApiKey { provider } => {
+                LlmError::AuthFailed { provider }
+            }
+            Self::MissingBaseUrl { provider } => LlmError::RequestFailed {
+                provider,
+                reason: "base URL is required but no base URL environment variable is set"
+                    .to_string(),
+            },
+            Self::Llm(source) => source,
+        }
+    }
 }
 
 /// Resolve a full [`LlmConfig`] from generic LLM environment variables.
@@ -89,12 +140,12 @@ pub fn resolve_provider_config_from_env(
 pub fn resolve_provider_config_from_selection(
     selection: ProviderSelection,
     registry: &ProviderRegistry,
-) -> Result<ResolvedProviderConfig, LlmError> {
-    let provider = registry
-        .find(&selection.provider_id)
-        .ok_or_else(|| LlmError::AuthFailed {
+) -> Result<ResolvedProviderConfig, ProviderResolutionError> {
+    let provider = registry.find(&selection.provider_id).ok_or_else(|| {
+        ProviderResolutionError::UnknownProvider {
             provider: selection.provider_id.clone(),
-        })?;
+        }
+    })?;
     resolve_provider_definition(
         provider,
         selection.api_key_env.as_deref(),
@@ -109,7 +160,8 @@ pub fn resolve_llm_config_from_selection(
     selection: ProviderSelection,
     registry: &ProviderRegistry,
 ) -> Result<LlmConfig, LlmError> {
-    let resolved = resolve_provider_config_from_selection(selection, registry)?;
+    let resolved = resolve_provider_config_from_selection(selection, registry)
+        .map_err(ProviderResolutionError::into_llm_error)?;
     build_llm_config_from_resolved_provider(resolved)
 }
 
@@ -120,57 +172,66 @@ pub fn build_llm_config_from_resolved_provider(
 ) -> Result<LlmConfig, LlmError> {
     let chain = ChainSettings::from_env()?;
     let session = nearai_session_config();
-    let nearai = nearai_config_from_resolved(&resolved, &chain)?;
 
+    let backend = resolved.provider_id().to_string();
+    let mut nearai = nearai_config_from_env(&chain)?;
     let mut provider = None;
     let mut bedrock = None;
     let mut gemini_oauth = None;
     let mut openai_codex = None;
 
-    match resolved.protocol {
-        ProviderProtocol::NearAi => {}
-        ProviderProtocol::Bedrock => {
-            bedrock = Some(
-                BedrockConfig::build(
-                    nonempty_env("BEDROCK_REGION"),
-                    Some(resolved.model.clone()),
-                    nonempty_env("BEDROCK_CROSS_REGION"),
-                    nonempty_env("AWS_PROFILE"),
-                )
-                .map_err(config_error_to_llm_error("bedrock"))?,
-            );
+    match resolved {
+        ResolvedProviderConfig::Registry(registry_config) => {
+            provider = Some(registry_config);
         }
-        ProviderProtocol::GeminiOauth => {
-            gemini_oauth = Some(GeminiOauthConfig::build(
-                Some(resolved.model.clone()),
-                nonempty_env("GEMINI_CREDENTIALS_PATH").map(PathBuf::from),
-            ));
-        }
-        ProviderProtocol::OpenAiCodex => {
-            openai_codex = Some(OpenAiCodexConfig::build(
-                Some(resolved.model.clone()),
-                nonempty_env("OPENAI_CODEX_AUTH_URL"),
-                nonempty_env("OPENAI_CODEX_API_URL"),
-                nonempty_env("OPENAI_CODEX_CLIENT_ID"),
-                nonempty_env("OPENAI_CODEX_SESSION_PATH").map(PathBuf::from),
-                parse_optional_u64("OPENAI_CODEX_REFRESH_MARGIN_SECS", "openai_codex")?,
-            ));
-        }
-        ProviderProtocol::OpenAiCompletions
-        | ProviderProtocol::Anthropic
-        | ProviderProtocol::Ollama
-        | ProviderProtocol::GithubCopilot
-        | ProviderProtocol::DeepSeek
-        | ProviderProtocol::Gemini
-        | ProviderProtocol::OpenRouter => {
-            provider = Some(build_registry_provider_config_from_resolved_provider(
-                resolved.clone(),
-            )?);
-        }
+        ResolvedProviderConfig::Dedicated(dedicated) => match dedicated.protocol {
+            ProviderProtocol::NearAi => {
+                nearai = nearai_config_from_dedicated(&dedicated, &chain)?;
+            }
+            ProviderProtocol::Bedrock => {
+                bedrock = Some(
+                    BedrockConfig::build(
+                        nonempty_env("BEDROCK_REGION"),
+                        Some(dedicated.model.clone()),
+                        nonempty_env("BEDROCK_CROSS_REGION"),
+                        nonempty_env("AWS_PROFILE"),
+                    )
+                    .map_err(config_error_to_llm_error("bedrock"))?,
+                );
+            }
+            ProviderProtocol::GeminiOauth => {
+                gemini_oauth = Some(GeminiOauthConfig::build(
+                    Some(dedicated.model.clone()),
+                    nonempty_env("GEMINI_CREDENTIALS_PATH").map(PathBuf::from),
+                ));
+            }
+            ProviderProtocol::OpenAiCodex => {
+                openai_codex = Some(OpenAiCodexConfig::build(
+                    Some(dedicated.model.clone()),
+                    nonempty_env("OPENAI_CODEX_AUTH_URL"),
+                    nonempty_env("OPENAI_CODEX_API_URL"),
+                    nonempty_env("OPENAI_CODEX_CLIENT_ID"),
+                    nonempty_env("OPENAI_CODEX_SESSION_PATH").map(PathBuf::from),
+                    parse_optional_u64("OPENAI_CODEX_REFRESH_MARGIN_SECS", "openai_codex")?,
+                ));
+            }
+            ProviderProtocol::OpenAiCompletions
+            | ProviderProtocol::Anthropic
+            | ProviderProtocol::Ollama
+            | ProviderProtocol::GithubCopilot
+            | ProviderProtocol::DeepSeek
+            | ProviderProtocol::Gemini
+            | ProviderProtocol::OpenRouter => {
+                return Err(LlmError::RequestFailed {
+                    provider: dedicated.provider_id,
+                    reason: "registry provider protocol resolved as dedicated config".to_string(),
+                });
+            }
+        },
     }
 
     Ok(LlmConfig {
-        backend: resolved.provider_id,
+        backend,
         session,
         nearai,
         provider,
@@ -193,26 +254,20 @@ pub fn build_llm_config_from_resolved_provider(
 pub fn build_registry_provider_config_from_resolved_provider(
     resolved: ResolvedProviderConfig,
 ) -> Result<RegistryProviderConfig, LlmError> {
-    if matches!(
-        resolved.protocol,
-        ProviderProtocol::NearAi
-            | ProviderProtocol::Bedrock
-            | ProviderProtocol::GeminiOauth
-            | ProviderProtocol::OpenAiCodex
-    ) {
-        return Err(LlmError::RequestFailed {
-            provider: resolved.provider_id,
+    match resolved {
+        ResolvedProviderConfig::Registry(config) => Ok(config),
+        ResolvedProviderConfig::Dedicated(config) => Err(LlmError::RequestFailed {
+            provider: config.provider_id,
             reason: "dedicated provider protocols require full LlmConfig resolution".to_string(),
-        });
+        }),
     }
-
-    registry_config_from_resolved(resolved)
 }
 
 fn resolve_provider_definition_from_env(
     provider: &ProviderDefinition,
 ) -> Result<ResolvedProviderConfig, LlmError> {
     resolve_provider_definition(provider, None, None, None, true)
+        .map_err(ProviderResolutionError::into_llm_error)
 }
 
 fn resolve_provider_definition(
@@ -221,12 +276,12 @@ fn resolve_provider_definition(
     base_url_override: Option<String>,
     model_override: Option<String>,
     allow_llm_model_fallback: bool,
-) -> Result<ResolvedProviderConfig, LlmError> {
+) -> Result<ResolvedProviderConfig, ProviderResolutionError> {
     let api_key_env = api_key_env_override.or(provider.api_key_env.as_deref());
     let api_key = match api_key_env.and_then(nonempty_env) {
         Some(value) => Some(SecretString::from(value)),
         None if provider.api_key_required => {
-            return Err(LlmError::AuthFailed {
+            return Err(ProviderResolutionError::MissingApiKey {
                 provider: provider.id.clone(),
             });
         }
@@ -240,9 +295,8 @@ fn resolve_provider_definition(
         .or_else(|| provider.default_base_url.clone())
         .unwrap_or_default();
     if provider.base_url_required && base_url.is_empty() {
-        return Err(LlmError::RequestFailed {
+        return Err(ProviderResolutionError::MissingBaseUrl {
             provider: provider.id.clone(),
-            reason: "base URL is required but no base URL environment variable is set".to_string(),
         });
     }
     let model = nonempty_env(&provider.model_env)
@@ -258,7 +312,8 @@ fn resolve_provider_definition(
         .as_deref()
         .and_then(nonempty_env)
         .map(|value| parse_extra_headers(&provider.id, &value))
-        .transpose()?
+        .transpose()
+        .map_err(ProviderResolutionError::Llm)?
         .unwrap_or_default();
     let extra_headers = if provider.protocol == ProviderProtocol::GithubCopilot {
         merge_extra_headers(
@@ -269,20 +324,29 @@ fn resolve_provider_definition(
         extra_headers
     };
 
-    Ok(ResolvedProviderConfig {
+    let resolved = ResolvedDedicatedProviderConfig {
         protocol: provider.protocol,
         provider_id: provider.id.clone(),
         api_key,
         base_url,
         model,
-        extra_headers,
-        oauth_token: None,
-        is_codex_chatgpt: false,
-        refresh_token: None,
-        auth_path: None,
-        cache_retention: None,
-        unsupported_params: provider.unsupported_params.clone(),
-    })
+    };
+
+    if is_registry_protocol(provider.protocol) {
+        let mut config = RegistryProviderConfig::generic(
+            resolved.protocol,
+            resolved.provider_id,
+            resolved.api_key,
+            resolved.base_url,
+            resolved.model,
+        )
+        .with_extra_headers(extra_headers)
+        .with_unsupported_params(provider.unsupported_params.clone());
+        apply_registry_provider_env(&mut config).map_err(ProviderResolutionError::Llm)?;
+        Ok(ResolvedProviderConfig::Registry(config))
+    } else {
+        Ok(ResolvedProviderConfig::Dedicated(resolved))
+    }
 }
 
 fn resolve_codex_cli_auth_provider() -> Result<ResolvedProviderConfig, LlmError> {
@@ -319,83 +383,54 @@ fn resolve_codex_cli_auth_provider() -> Result<ResolvedProviderConfig, LlmError>
     registry_config.refresh_token = credentials.refresh_token;
     registry_config.auth_path = credentials.source_path;
 
-    Ok(ResolvedProviderConfig {
-        protocol: registry_config.protocol,
-        provider_id: registry_config.provider_id,
-        api_key: registry_config.api_key,
-        base_url: registry_config.base_url,
-        model: registry_config.model,
-        extra_headers: registry_config.extra_headers,
-        oauth_token: registry_config.oauth_token,
-        is_codex_chatgpt: registry_config.is_codex_chatgpt,
-        refresh_token: registry_config.refresh_token,
-        auth_path: registry_config.auth_path,
-        cache_retention: Some(registry_config.cache_retention),
-        unsupported_params: registry_config.unsupported_params,
-    })
+    Ok(ResolvedProviderConfig::Registry(registry_config))
 }
 
-fn registry_config_from_resolved(
-    resolved: ResolvedProviderConfig,
-) -> Result<RegistryProviderConfig, LlmError> {
-    let mut config = RegistryProviderConfig::generic(
-        resolved.protocol,
-        resolved.provider_id.clone(),
-        resolved.api_key,
-        resolved.base_url,
-        resolved.model,
-    )
-    .with_extra_headers(resolved.extra_headers)
-    .with_unsupported_params(resolved.unsupported_params);
-    config.oauth_token = resolved.oauth_token;
-    config.is_codex_chatgpt = resolved.is_codex_chatgpt;
-    config.refresh_token = resolved.refresh_token;
-    config.auth_path = resolved.auth_path;
+fn apply_registry_provider_env(config: &mut RegistryProviderConfig) -> Result<(), LlmError> {
+    if config.protocol == ProviderProtocol::Anthropic {
+        config.cache_retention = nonempty_env("ANTHROPIC_CACHE_RETENTION")
+            .map(|value| {
+                value
+                    .parse::<CacheRetention>()
+                    .map_err(|reason| LlmError::RequestFailed {
+                        provider: config.provider_id.clone(),
+                        reason: format!("invalid ANTHROPIC_CACHE_RETENTION: {reason}"),
+                    })
+            })
+            .transpose()?
+            .unwrap_or_default();
 
-    if resolved.protocol == ProviderProtocol::Anthropic {
-        config.cache_retention = match resolved.cache_retention {
-            Some(cache_retention) => cache_retention,
-            None => nonempty_env("ANTHROPIC_CACHE_RETENTION")
-                .map(|value| {
-                    value
-                        .parse::<CacheRetention>()
-                        .map_err(|reason| LlmError::RequestFailed {
-                            provider: resolved.provider_id.clone(),
-                            reason: format!("invalid ANTHROPIC_CACHE_RETENTION: {reason}"),
-                        })
-                })
-                .transpose()?
-                .unwrap_or_default(),
-        };
-
-        if config.oauth_token.is_none() {
-            if let Some(token) = nonempty_env("ANTHROPIC_OAUTH_TOKEN") {
-                config.oauth_token = Some(SecretString::from(token));
-                if config.api_key.is_none() {
-                    config.api_key = Some(SecretString::from(OAUTH_PLACEHOLDER.to_string()));
-                }
+        if let Some(token) = nonempty_env("ANTHROPIC_OAUTH_TOKEN") {
+            config.oauth_token = Some(SecretString::from(token));
+            if config.api_key.is_none() {
+                config.api_key = Some(SecretString::from(OAUTH_PLACEHOLDER.to_string()));
             }
-        } else if config.api_key.is_none() {
-            config.api_key = Some(SecretString::from(OAUTH_PLACEHOLDER.to_string()));
         }
-    } else if let Some(cache_retention) = resolved.cache_retention {
-        config.cache_retention = cache_retention;
     }
-
-    Ok(config)
+    Ok(())
 }
 
-fn nearai_config_from_resolved(
-    resolved: &ResolvedProviderConfig,
+fn nearai_config_from_env(chain: &ChainSettings) -> Result<NearAiConfig, LlmError> {
+    let api_key = nonempty_env("NEARAI_API_KEY").map(SecretString::from);
+    let base_url = default_nearai_base_url(api_key.is_some(), nonempty_env("NEARAI_BASE_URL"));
+    Ok(build_nearai_config(
+        NearAiRuntimeFields {
+            model: nonempty_env("NEARAI_MODEL").unwrap_or_else(|| crate::DEFAULT_MODEL.to_string()),
+            api_key,
+            base_url,
+            failover_cooldown_secs: 300,
+            failover_cooldown_threshold: 3,
+        },
+        chain,
+    ))
+}
+
+fn nearai_config_from_dedicated(
+    resolved: &ResolvedDedicatedProviderConfig,
     chain: &ChainSettings,
 ) -> Result<NearAiConfig, LlmError> {
-    let api_key = if resolved.protocol == ProviderProtocol::NearAi {
-        resolved.api_key.clone()
-    } else {
-        nonempty_env("NEARAI_API_KEY").map(SecretString::from)
-    };
-    let base_url = if resolved.protocol == ProviderProtocol::NearAi && !resolved.base_url.is_empty()
-    {
+    let api_key = resolved.api_key.clone();
+    let base_url = if !resolved.base_url.is_empty() {
         resolved.base_url.clone()
     } else if let Some(base_url) = nonempty_env("NEARAI_BASE_URL") {
         base_url
@@ -404,28 +439,35 @@ fn nearai_config_from_resolved(
     } else {
         "https://private.near.ai".to_string()
     };
-    let model = if resolved.protocol == ProviderProtocol::NearAi {
-        resolved.model.clone()
-    } else {
-        nonempty_env("NEARAI_MODEL").unwrap_or_else(|| crate::DEFAULT_MODEL.to_string())
-    };
 
-    let failover_cooldown_secs = if resolved.protocol == ProviderProtocol::NearAi {
-        parse_optional_u64("LLM_FAILOVER_COOLDOWN_SECS", "nearai")?.unwrap_or(300)
-    } else {
-        300
-    };
-    let failover_cooldown_threshold = if resolved.protocol == ProviderProtocol::NearAi {
-        parse_optional_u32("LLM_FAILOVER_THRESHOLD", "nearai")?.unwrap_or(3)
-    } else {
-        3
-    };
+    Ok(build_nearai_config(
+        NearAiRuntimeFields {
+            model: resolved.model.clone(),
+            api_key,
+            base_url,
+            failover_cooldown_secs: parse_optional_u64("LLM_FAILOVER_COOLDOWN_SECS", "nearai")?
+                .unwrap_or(300),
+            failover_cooldown_threshold: parse_optional_u32("LLM_FAILOVER_THRESHOLD", "nearai")?
+                .unwrap_or(3),
+        },
+        chain,
+    ))
+}
 
-    Ok(NearAiConfig {
-        model,
+struct NearAiRuntimeFields {
+    model: String,
+    api_key: Option<SecretString>,
+    base_url: String,
+    failover_cooldown_secs: u64,
+    failover_cooldown_threshold: u32,
+}
+
+fn build_nearai_config(fields: NearAiRuntimeFields, chain: &ChainSettings) -> NearAiConfig {
+    NearAiConfig {
+        model: fields.model,
         cheap_model: nonempty_env("NEARAI_CHEAP_MODEL"),
-        base_url,
-        api_key,
+        base_url: fields.base_url,
+        api_key: fields.api_key,
         fallback_model: nonempty_env("NEARAI_FALLBACK_MODEL"),
         max_retries: chain.max_retries,
         circuit_breaker_threshold: chain.circuit_breaker_threshold,
@@ -433,10 +475,33 @@ fn nearai_config_from_resolved(
         response_cache_enabled: chain.response_cache_enabled,
         response_cache_ttl_secs: chain.response_cache_ttl_secs,
         response_cache_max_entries: chain.response_cache_max_entries,
-        failover_cooldown_secs,
-        failover_cooldown_threshold,
+        failover_cooldown_secs: fields.failover_cooldown_secs,
+        failover_cooldown_threshold: fields.failover_cooldown_threshold,
         smart_routing_cascade: chain.smart_routing_cascade,
-    })
+    }
+}
+
+fn default_nearai_base_url(api_key_present: bool, configured_base_url: Option<String>) -> String {
+    if let Some(base_url) = configured_base_url {
+        base_url
+    } else if api_key_present {
+        "https://cloud-api.near.ai".to_string()
+    } else {
+        "https://private.near.ai".to_string()
+    }
+}
+
+fn is_registry_protocol(protocol: ProviderProtocol) -> bool {
+    matches!(
+        protocol,
+        ProviderProtocol::OpenAiCompletions
+            | ProviderProtocol::Anthropic
+            | ProviderProtocol::Ollama
+            | ProviderProtocol::GithubCopilot
+            | ProviderProtocol::DeepSeek
+            | ProviderProtocol::Gemini
+            | ProviderProtocol::OpenRouter
+    )
 }
 
 fn nearai_session_config() -> SessionConfig {
@@ -482,34 +547,46 @@ impl ChainSettings {
     fn from_env() -> Result<Self, LlmError> {
         let defaults = Self::default();
         Ok(Self {
-            request_timeout_secs: parse_optional_u64("LLM_REQUEST_TIMEOUT_SECS", "llm_config")?
-                .unwrap_or(defaults.request_timeout_secs),
+            request_timeout_secs: parse_option_env::<u64>(
+                "LLM_REQUEST_TIMEOUT_SECS",
+                "llm_config",
+            )?
+            .unwrap_or(defaults.request_timeout_secs),
             cheap_model: nonempty_env("LLM_CHEAP_MODEL"),
-            smart_routing_cascade: parse_optional_bool("SMART_ROUTING_CASCADE", "llm_config")?
+            smart_routing_cascade: parse_option_env::<bool>("SMART_ROUTING_CASCADE", "llm_config")?
                 .unwrap_or(defaults.smart_routing_cascade),
-            max_retries: parse_optional_u32("LLM_MAX_RETRIES", "llm_config")?
-                .unwrap_or(defaults.max_retries),
-            circuit_breaker_threshold: parse_optional_u32(
+            max_retries: parse_option_env_with_fallback::<u32>(
+                "LLM_MAX_RETRIES",
+                "NEARAI_MAX_RETRIES",
+                "llm_config",
+            )?
+            .unwrap_or(defaults.max_retries),
+            circuit_breaker_threshold: parse_option_env_with_fallback::<u32>(
                 "LLM_CIRCUIT_BREAKER_THRESHOLD",
+                "CIRCUIT_BREAKER_THRESHOLD",
                 "llm_config",
             )?,
-            circuit_breaker_recovery_secs: parse_optional_u64(
+            circuit_breaker_recovery_secs: parse_option_env_with_fallback::<u64>(
                 "LLM_CIRCUIT_BREAKER_RECOVERY_SECS",
+                "CIRCUIT_BREAKER_RECOVERY_SECS",
                 "llm_config",
             )?
             .unwrap_or(defaults.circuit_breaker_recovery_secs),
-            response_cache_enabled: parse_optional_bool(
+            response_cache_enabled: parse_option_env_with_fallback::<bool>(
                 "LLM_RESPONSE_CACHE_ENABLED",
+                "RESPONSE_CACHE_ENABLED",
                 "llm_config",
             )?
             .unwrap_or(defaults.response_cache_enabled),
-            response_cache_ttl_secs: parse_optional_u64(
+            response_cache_ttl_secs: parse_option_env_with_fallback::<u64>(
                 "LLM_RESPONSE_CACHE_TTL_SECS",
+                "RESPONSE_CACHE_TTL_SECS",
                 "llm_config",
             )?
             .unwrap_or(defaults.response_cache_ttl_secs),
-            response_cache_max_entries: parse_optional_usize(
+            response_cache_max_entries: parse_option_env_with_fallback::<usize>(
                 "LLM_RESPONSE_CACHE_MAX_ENTRIES",
+                "RESPONSE_CACHE_MAX_ENTRIES",
                 "llm_config",
             )?
             .unwrap_or(defaults.response_cache_max_entries),
@@ -595,44 +672,57 @@ fn nonempty_env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|value| !value.is_empty())
 }
 
-fn parse_optional_bool(name: &str, provider: &str) -> Result<Option<bool>, LlmError> {
-    nonempty_env(name)
-        .map(|value| {
-            value
-                .parse::<bool>()
-                .map_err(|source| invalid_env(provider, name, source))
-        })
-        .transpose()
-}
-
 fn parse_optional_u32(name: &str, provider: &str) -> Result<Option<u32>, LlmError> {
-    nonempty_env(name)
-        .map(|value| {
-            value
-                .parse::<u32>()
-                .map_err(|source| invalid_env(provider, name, source))
-        })
-        .transpose()
+    parse_option_env(name, provider)
 }
 
 fn parse_optional_u64(name: &str, provider: &str) -> Result<Option<u64>, LlmError> {
+    parse_option_env(name, provider)
+}
+
+trait EnvParse: Sized {
+    fn parse_env(value: &str) -> Result<Self, String>;
+}
+
+macro_rules! impl_env_parse_from_str {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl EnvParse for $ty {
+                fn parse_env(value: &str) -> Result<Self, String> {
+                    value.parse::<Self>().map_err(|source| source.to_string())
+                }
+            }
+        )*
+    };
+}
+
+impl_env_parse_from_str!(u32, u64, usize);
+
+impl EnvParse for bool {
+    fn parse_env(value: &str) -> Result<Self, String> {
+        match value.to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Ok(true),
+            "0" | "false" | "no" | "off" => Ok(false),
+            _ => Err("expected a boolean value".to_string()),
+        }
+    }
+}
+
+fn parse_option_env<T: EnvParse>(name: &str, provider: &str) -> Result<Option<T>, LlmError> {
     nonempty_env(name)
-        .map(|value| {
-            value
-                .parse::<u64>()
-                .map_err(|source| invalid_env(provider, name, source))
-        })
+        .map(|value| T::parse_env(&value).map_err(|source| invalid_env(provider, name, source)))
         .transpose()
 }
 
-fn parse_optional_usize(name: &str, provider: &str) -> Result<Option<usize>, LlmError> {
-    nonempty_env(name)
-        .map(|value| {
-            value
-                .parse::<usize>()
-                .map_err(|source| invalid_env(provider, name, source))
-        })
-        .transpose()
+fn parse_option_env_with_fallback<T: EnvParse>(
+    primary: &str,
+    fallback: &str,
+    provider: &str,
+) -> Result<Option<T>, LlmError> {
+    match parse_option_env(primary, provider)? {
+        Some(value) => Ok(Some(value)),
+        None => parse_option_env(fallback, provider),
+    }
 }
 
 fn invalid_env(provider: &str, name: &str, source: impl std::fmt::Display) -> LlmError {
@@ -646,5 +736,117 @@ fn config_error_to_llm_error(provider: &'static str) -> impl FnOnce(LlmConfigErr
     move |source| LlmError::RequestFailed {
         provider: provider.to_string(),
         reason: source.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHAIN_ENV_VARS: &[&str] = &[
+        "LLM_REQUEST_TIMEOUT_SECS",
+        "LLM_CHEAP_MODEL",
+        "SMART_ROUTING_CASCADE",
+        "LLM_MAX_RETRIES",
+        "NEARAI_MAX_RETRIES",
+        "LLM_CIRCUIT_BREAKER_THRESHOLD",
+        "CIRCUIT_BREAKER_THRESHOLD",
+        "LLM_CIRCUIT_BREAKER_RECOVERY_SECS",
+        "CIRCUIT_BREAKER_RECOVERY_SECS",
+        "LLM_RESPONSE_CACHE_ENABLED",
+        "RESPONSE_CACHE_ENABLED",
+        "LLM_RESPONSE_CACHE_TTL_SECS",
+        "RESPONSE_CACHE_TTL_SECS",
+        "LLM_RESPONSE_CACHE_MAX_ENTRIES",
+        "RESPONSE_CACHE_MAX_ENTRIES",
+        "NEARAI_API_KEY",
+        "NEARAI_BASE_URL",
+        "NEARAI_MODEL",
+        "NEARAI_CHEAP_MODEL",
+        "NEARAI_FALLBACK_MODEL",
+    ];
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn clear(names: &[&'static str]) -> Self {
+            let saved = names
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect();
+            for name in names {
+                unsafe {
+                    std::env::remove_var(name);
+                }
+            }
+            Self { saved }
+        }
+
+        fn set(&self, name: &str, value: &str) {
+            unsafe {
+                std::env::set_var(name, value);
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.saved.drain(..) {
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+        }
+    }
+
+    fn registry_resolved_provider() -> ResolvedProviderConfig {
+        ResolvedProviderConfig::Registry(RegistryProviderConfig::generic(
+            ProviderProtocol::OpenAiCompletions,
+            "openai",
+            None,
+            "https://api.openai.com/v1",
+            "gpt-test",
+        ))
+    }
+
+    #[test]
+    fn full_config_resolution_uses_legacy_chain_env_fallbacks() {
+        let _env_lock = ironclaw_common::env_helpers::lock_env();
+        let env = EnvGuard::clear(CHAIN_ENV_VARS);
+        env.set("NEARAI_MAX_RETRIES", "7");
+        env.set("CIRCUIT_BREAKER_THRESHOLD", "11");
+        env.set("CIRCUIT_BREAKER_RECOVERY_SECS", "19");
+        env.set("RESPONSE_CACHE_ENABLED", "true");
+        env.set("RESPONSE_CACHE_TTL_SECS", "23");
+        env.set("RESPONSE_CACHE_MAX_ENTRIES", "29");
+
+        let config = build_llm_config_from_resolved_provider(registry_resolved_provider())
+            .expect("legacy chain environment fallbacks should resolve");
+
+        assert_eq!(config.max_retries, 7);
+        assert_eq!(config.circuit_breaker_threshold, Some(11));
+        assert_eq!(config.circuit_breaker_recovery_secs, 19);
+        assert!(config.response_cache_enabled);
+        assert_eq!(config.response_cache_ttl_secs, 23);
+        assert_eq!(config.response_cache_max_entries, 29);
+    }
+
+    #[test]
+    fn full_config_resolution_accepts_common_boolean_env_values() {
+        let _env_lock = ironclaw_common::env_helpers::lock_env();
+        let env = EnvGuard::clear(CHAIN_ENV_VARS);
+        env.set("SMART_ROUTING_CASCADE", "off");
+        env.set("LLM_RESPONSE_CACHE_ENABLED", "yes");
+
+        let config = build_llm_config_from_resolved_provider(registry_resolved_provider())
+            .expect("common boolean environment values should resolve");
+
+        assert!(!config.smart_routing_cascade);
+        assert!(config.response_cache_enabled);
     }
 }

--- a/crates/ironclaw_llm/src/resolution.rs
+++ b/crates/ironclaw_llm/src/resolution.rs
@@ -27,21 +27,36 @@ pub struct ResolvedProviderConfig {
     pub base_url: String,
     pub model: String,
     pub extra_headers: Vec<(String, String)>,
+    pub oauth_token: Option<SecretString>,
+    pub is_codex_chatgpt: bool,
+    pub refresh_token: Option<SecretString>,
+    pub auth_path: Option<PathBuf>,
+    pub cache_retention: Option<CacheRetention>,
     pub unsupported_params: Vec<String>,
 }
 
+/// Provider selection overrides supplied by a composition root.
+#[derive(Debug, Clone)]
+pub struct ProviderSelection {
+    pub provider_id: String,
+    pub api_key_env: Option<String>,
+    pub base_url: Option<String>,
+    pub model: Option<String>,
+}
+
 /// Resolve a full [`LlmConfig`] from generic LLM environment variables.
-///
-/// This is the full-config counterpart to `resolve_registry_provider_from_env`.
-/// It returns dedicated `LlmConfig` variants for dedicated protocols instead
-/// of trying to squeeze them through `RegistryProviderConfig`.
 pub fn resolve_llm_config_from_env(
     user_providers_path: Option<&Path>,
 ) -> Result<Option<LlmConfig>, LlmError> {
-    if codex_auth_enabled_from_env() {
-        return resolve_codex_cli_auth_config().map(Some);
-    }
+    resolve_provider_config_from_env(user_providers_path)?
+        .map(build_llm_config_from_resolved_provider)
+        .transpose()
+}
 
+/// Resolve a provider selection from generic LLM environment variables.
+pub fn resolve_provider_config_from_env(
+    user_providers_path: Option<&Path>,
+) -> Result<Option<ResolvedProviderConfig>, LlmError> {
     if let Some(backend) = nonempty_env("LLM_BACKEND") {
         let registry = try_load_provider_registry(user_providers_path)?;
         let provider = registry
@@ -49,7 +64,14 @@ pub fn resolve_llm_config_from_env(
             .ok_or_else(|| LlmError::AuthFailed {
                 provider: backend.clone(),
             })?;
+        if codex_auth_enabled_from_env() && provider.protocol == ProviderProtocol::OpenAiCodex {
+            return resolve_codex_cli_auth_provider().map(Some);
+        }
         return resolve_provider_definition_from_env(provider).map(Some);
+    }
+
+    if codex_auth_enabled_from_env() {
+        return resolve_codex_cli_auth_provider().map(Some);
     }
 
     let registry = ProviderRegistry::load_from_path(user_providers_path);
@@ -61,6 +83,34 @@ pub fn resolve_llm_config_from_env(
         return Ok(None);
     };
     resolve_provider_definition_from_env(provider).map(Some)
+}
+
+/// Resolve a catalog selection against an already-loaded provider registry.
+pub fn resolve_provider_config_from_selection(
+    selection: ProviderSelection,
+    registry: &ProviderRegistry,
+) -> Result<ResolvedProviderConfig, LlmError> {
+    let provider = registry
+        .find(&selection.provider_id)
+        .ok_or_else(|| LlmError::AuthFailed {
+            provider: selection.provider_id.clone(),
+        })?;
+    resolve_provider_definition(
+        provider,
+        selection.api_key_env.as_deref(),
+        selection.base_url,
+        selection.model,
+        false,
+    )
+}
+
+/// Resolve a full [`LlmConfig`] from a catalog selection.
+pub fn resolve_llm_config_from_selection(
+    selection: ProviderSelection,
+    registry: &ProviderRegistry,
+) -> Result<LlmConfig, LlmError> {
+    let resolved = resolve_provider_config_from_selection(selection, registry)?;
+    build_llm_config_from_resolved_provider(resolved)
 }
 
 /// Build a full [`LlmConfig`] from a catalog entry whose basic fields
@@ -113,7 +163,9 @@ pub fn build_llm_config_from_resolved_provider(
         | ProviderProtocol::DeepSeek
         | ProviderProtocol::Gemini
         | ProviderProtocol::OpenRouter => {
-            provider = Some(registry_config_from_resolved(resolved.clone())?);
+            provider = Some(build_registry_provider_config_from_resolved_provider(
+                resolved.clone(),
+            )?);
         }
     }
 
@@ -137,10 +189,41 @@ pub fn build_llm_config_from_resolved_provider(
     })
 }
 
+/// Build a registry provider config from an already-resolved provider.
+pub fn build_registry_provider_config_from_resolved_provider(
+    resolved: ResolvedProviderConfig,
+) -> Result<RegistryProviderConfig, LlmError> {
+    if matches!(
+        resolved.protocol,
+        ProviderProtocol::NearAi
+            | ProviderProtocol::Bedrock
+            | ProviderProtocol::GeminiOauth
+            | ProviderProtocol::OpenAiCodex
+    ) {
+        return Err(LlmError::RequestFailed {
+            provider: resolved.provider_id,
+            reason: "dedicated provider protocols require full LlmConfig resolution".to_string(),
+        });
+    }
+
+    registry_config_from_resolved(resolved)
+}
+
 fn resolve_provider_definition_from_env(
     provider: &ProviderDefinition,
-) -> Result<LlmConfig, LlmError> {
-    let api_key = match provider.api_key_env.as_deref().and_then(nonempty_env) {
+) -> Result<ResolvedProviderConfig, LlmError> {
+    resolve_provider_definition(provider, None, None, None, true)
+}
+
+fn resolve_provider_definition(
+    provider: &ProviderDefinition,
+    api_key_env_override: Option<&str>,
+    base_url_override: Option<String>,
+    model_override: Option<String>,
+    allow_llm_model_fallback: bool,
+) -> Result<ResolvedProviderConfig, LlmError> {
+    let api_key_env = api_key_env_override.or(provider.api_key_env.as_deref());
+    let api_key = match api_key_env.and_then(nonempty_env) {
         Some(value) => Some(SecretString::from(value)),
         None if provider.api_key_required => {
             return Err(LlmError::AuthFailed {
@@ -153,6 +236,7 @@ fn resolve_provider_definition_from_env(
         .base_url_env
         .as_deref()
         .and_then(nonempty_env)
+        .or(base_url_override)
         .or_else(|| provider.default_base_url.clone())
         .unwrap_or_default();
     if provider.base_url_required && base_url.is_empty() {
@@ -162,7 +246,12 @@ fn resolve_provider_definition_from_env(
         });
     }
     let model = nonempty_env(&provider.model_env)
-        .or_else(|| nonempty_env("LLM_MODEL"))
+        .or(model_override)
+        .or_else(|| {
+            allow_llm_model_fallback
+                .then(|| nonempty_env("LLM_MODEL"))
+                .flatten()
+        })
         .unwrap_or_else(|| provider.default_model.clone());
     let extra_headers = provider
         .extra_headers_env
@@ -180,18 +269,23 @@ fn resolve_provider_definition_from_env(
         extra_headers
     };
 
-    build_llm_config_from_resolved_provider(ResolvedProviderConfig {
+    Ok(ResolvedProviderConfig {
         protocol: provider.protocol,
         provider_id: provider.id.clone(),
         api_key,
         base_url,
         model,
         extra_headers,
+        oauth_token: None,
+        is_codex_chatgpt: false,
+        refresh_token: None,
+        auth_path: None,
+        cache_retention: None,
         unsupported_params: provider.unsupported_params.clone(),
     })
 }
 
-fn resolve_codex_cli_auth_config() -> Result<LlmConfig, LlmError> {
+fn resolve_codex_cli_auth_provider() -> Result<ResolvedProviderConfig, LlmError> {
     let auth_path = std::env::var_os("CODEX_AUTH_PATH").map(PathBuf::from);
     let credentials =
         auth::load_persisted_credentials(CredentialSource::CodexCli, auth_path.as_deref())
@@ -225,8 +319,20 @@ fn resolve_codex_cli_auth_config() -> Result<LlmConfig, LlmError> {
     registry_config.refresh_token = credentials.refresh_token;
     registry_config.auth_path = credentials.source_path;
 
-    let chain = ChainSettings::from_env()?;
-    Ok(config_from_registry_provider(registry_config, chain))
+    Ok(ResolvedProviderConfig {
+        protocol: registry_config.protocol,
+        provider_id: registry_config.provider_id,
+        api_key: registry_config.api_key,
+        base_url: registry_config.base_url,
+        model: registry_config.model,
+        extra_headers: registry_config.extra_headers,
+        oauth_token: registry_config.oauth_token,
+        is_codex_chatgpt: registry_config.is_codex_chatgpt,
+        refresh_token: registry_config.refresh_token,
+        auth_path: registry_config.auth_path,
+        cache_retention: Some(registry_config.cache_retention),
+        unsupported_params: registry_config.unsupported_params,
+    })
 }
 
 fn registry_config_from_resolved(
@@ -241,54 +347,42 @@ fn registry_config_from_resolved(
     )
     .with_extra_headers(resolved.extra_headers)
     .with_unsupported_params(resolved.unsupported_params);
+    config.oauth_token = resolved.oauth_token;
+    config.is_codex_chatgpt = resolved.is_codex_chatgpt;
+    config.refresh_token = resolved.refresh_token;
+    config.auth_path = resolved.auth_path;
 
     if resolved.protocol == ProviderProtocol::Anthropic {
-        config.cache_retention = nonempty_env("ANTHROPIC_CACHE_RETENTION")
-            .map(|value| {
-                value
-                    .parse::<CacheRetention>()
-                    .map_err(|reason| LlmError::RequestFailed {
-                        provider: resolved.provider_id.clone(),
-                        reason: format!("invalid ANTHROPIC_CACHE_RETENTION: {reason}"),
-                    })
-            })
-            .transpose()?
-            .unwrap_or_default();
+        config.cache_retention = match resolved.cache_retention {
+            Some(cache_retention) => cache_retention,
+            None => nonempty_env("ANTHROPIC_CACHE_RETENTION")
+                .map(|value| {
+                    value
+                        .parse::<CacheRetention>()
+                        .map_err(|reason| LlmError::RequestFailed {
+                            provider: resolved.provider_id.clone(),
+                            reason: format!("invalid ANTHROPIC_CACHE_RETENTION: {reason}"),
+                        })
+                })
+                .transpose()?
+                .unwrap_or_default(),
+        };
 
-        if let Some(token) = nonempty_env("ANTHROPIC_OAUTH_TOKEN") {
-            config.oauth_token = Some(SecretString::from(token));
-            if config.api_key.is_none() {
-                config.api_key = Some(SecretString::from(OAUTH_PLACEHOLDER.to_string()));
+        if config.oauth_token.is_none() {
+            if let Some(token) = nonempty_env("ANTHROPIC_OAUTH_TOKEN") {
+                config.oauth_token = Some(SecretString::from(token));
+                if config.api_key.is_none() {
+                    config.api_key = Some(SecretString::from(OAUTH_PLACEHOLDER.to_string()));
+                }
             }
+        } else if config.api_key.is_none() {
+            config.api_key = Some(SecretString::from(OAUTH_PLACEHOLDER.to_string()));
         }
+    } else if let Some(cache_retention) = resolved.cache_retention {
+        config.cache_retention = cache_retention;
     }
 
     Ok(config)
-}
-
-fn config_from_registry_provider(
-    registry_config: RegistryProviderConfig,
-    chain: ChainSettings,
-) -> LlmConfig {
-    let session = nearai_session_config();
-    LlmConfig {
-        backend: registry_config.provider_id.clone(),
-        session,
-        nearai: default_nearai_config(),
-        provider: Some(registry_config),
-        bedrock: None,
-        gemini_oauth: None,
-        openai_codex: None,
-        request_timeout_secs: chain.request_timeout_secs,
-        cheap_model: chain.cheap_model,
-        smart_routing_cascade: chain.smart_routing_cascade,
-        max_retries: chain.max_retries,
-        circuit_breaker_threshold: chain.circuit_breaker_threshold,
-        circuit_breaker_recovery_secs: chain.circuit_breaker_recovery_secs,
-        response_cache_enabled: chain.response_cache_enabled,
-        response_cache_ttl_secs: chain.response_cache_ttl_secs,
-        response_cache_max_entries: chain.response_cache_max_entries,
-    }
 }
 
 fn nearai_config_from_resolved(
@@ -343,23 +437,6 @@ fn nearai_config_from_resolved(
         failover_cooldown_threshold,
         smart_routing_cascade: chain.smart_routing_cascade,
     })
-}
-
-fn default_nearai_config() -> NearAiConfig {
-    let chain = ChainSettings::default();
-    nearai_config_from_resolved(
-        &ResolvedProviderConfig {
-            protocol: ProviderProtocol::OpenAiCompletions,
-            provider_id: "openai".to_string(),
-            api_key: None,
-            base_url: String::new(),
-            model: String::new(),
-            extra_headers: Vec::new(),
-            unsupported_params: Vec::new(),
-        },
-        &chain,
-    )
-    .expect("default non-NEAR AI fallback config does not parse fallible provider fields")
 }
 
 fn nearai_session_config() -> SessionConfig {

--- a/crates/ironclaw_llm/src/session.rs
+++ b/crates/ironclaw_llm/src/session.rs
@@ -522,9 +522,7 @@ pub async fn create_session_manager(config: SessionConfig) -> Arc<SessionManager
     // NEARAI_SESSION_TOKEN env var always takes precedence over file-based
     // tokens. Hosting providers set this env var and expect it to be used
     // directly — no file persistence needed.
-    if let Ok(token) = std::env::var("NEARAI_SESSION_TOKEN")
-        && !token.is_empty()
-    {
+    if let Some(token) = ironclaw_common::env_helpers::env_or_override("NEARAI_SESSION_TOKEN") {
         tracing::info!("Using session token from NEARAI_SESSION_TOKEN env var");
         manager.set_token(SecretString::from(token)).await;
     }

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -113,6 +113,7 @@ uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
 http = "1"
 http-body-util = "0.1"
+ironclaw_common = { path = "../ironclaw_common" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime", features = ["test-support"] }
 ironclaw_threads = { path = "../ironclaw_threads" }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -82,12 +82,12 @@ pub use runtime::{
     RebornSkillActivationMode, RebornSkillAsset, RebornSkillBundle, RebornSkillExecutionPlan,
     RebornSkillExecutionResult, RebornSkillSourceKind, build_reborn_runtime,
 };
+#[cfg(feature = "root-llm-provider")]
+pub use runtime_input::ResolvedRebornLlm;
 pub use runtime_input::{
     DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL, DEFAULT_TURN_RUNNER_POLL_INTERVAL, PollSettings,
     RebornRuntimeIdentity, RebornRuntimeInput, TurnRunnerSettings,
 };
-#[cfg(feature = "root-llm-provider")]
-pub use runtime_input::{RebornLlmConfig, ResolvedRebornLlm};
 pub use webui::{RebornWebuiBundle, build_webui_services};
 #[cfg(feature = "webui-v2-beta")]
 pub use webui_rate_limit::RateLimitConfigError;

--- a/crates/ironclaw_reborn_composition/src/llm_catalog.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_catalog.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use ironclaw_llm::{ProviderRegistry, ResolvedProviderConfig, registry::ProviderDefinition};
+use ironclaw_llm::{ProviderRegistry, ProviderSelection, registry::ProviderDefinition};
 use ironclaw_reborn_config::{
     LlmSlotSelection, RebornBootConfig, RebornConfigFile, reject_inline_secret,
 };
@@ -99,13 +99,6 @@ pub enum RebornLlmCatalogError {
         #[source]
         source: ironclaw_llm::registry::ProviderRegistryLoadError,
     },
-    /// Provider extra headers env var is malformed.
-    #[error("llm provider `{provider}` extra headers env var `{env}` is invalid: {reason}")]
-    ExtraHeadersInvalid {
-        provider: String,
-        env: String,
-        reason: String,
-    },
     /// Environment fallback could not be resolved by the LLM provider layer.
     #[error("could not resolve LLM environment fallback: {source}")]
     EnvResolution {
@@ -149,11 +142,8 @@ fn resolve_llm_from_env(
 /// Steps:
 /// 1. Build the catalog (`ProviderRegistry::load_from_path(user)`).
 /// 2. Look up the requested `provider_id`.
-/// 3. Determine api_key_env (selection override > catalog default).
-/// 4. Read the API key value from that env var (fail-closed if absent).
-/// 5. Determine base_url (selection override > catalog default).
-/// 6. Determine model (selection override > catalog default).
-/// 7. Build and return a full `ironclaw_llm::LlmConfig`.
+/// 3. Validate Reborn-specific secret/env-var policy on catalog and selection.
+/// 4. Let `ironclaw_llm` resolve provider fields and build the full config.
 pub fn resolve_llm_selection_against_catalog(
     selection: &LlmSlotSelection,
     user_providers_path: Option<&Path>,
@@ -196,29 +186,88 @@ pub fn resolve_against_registry(
         .position(|candidate| std::ptr::eq(candidate, provider))
         .unwrap_or(0);
 
-    // API key resolution.
-    let api_key = read_api_key(selection, provider)?;
+    validate_selection(selection, provider, catalog_index)?;
 
-    // Base URL resolution (provider env override > selection > catalog default).
-    // An empty base URL is intentional for providers such as OpenAI: the
-    // `ironclaw_llm` client constructors use it to select protocol defaults.
-    let base_url = resolve_base_url(selection, provider, catalog_index)?;
+    let resolved = ironclaw_llm::resolve_provider_config_from_selection(
+        ProviderSelection {
+            provider_id: provider.id.clone(),
+            api_key_env: selection.api_key_env.clone(),
+            base_url: selection.base_url.clone(),
+            model: selection.model.clone(),
+        },
+        registry,
+    )
+    .map_err(|source| map_selection_resolution_error(source, selection, provider))?;
 
-    // Model resolution (provider env override > selection > catalog default).
-    let model = resolve_model(selection, provider, catalog_index)?;
+    validate_catalog_text(
+        provider,
+        catalog_index,
+        "resolved_base_url",
+        &resolved.base_url,
+    )?;
+    validate_catalog_text(provider, catalog_index, "resolved_model", &resolved.model)?;
 
-    let extra_headers = resolve_extra_headers(provider)?;
+    ironclaw_llm::build_llm_config_from_resolved_provider(resolved)
+        .map_err(|source| RebornLlmCatalogError::EnvResolution { source })
+}
 
-    ironclaw_llm::build_llm_config_from_resolved_provider(ResolvedProviderConfig {
-        protocol: provider.protocol,
-        provider_id: provider.id.clone(),
-        api_key,
-        base_url,
-        model,
-        extra_headers,
-        unsupported_params: provider.unsupported_params.clone(),
-    })
-    .map_err(|source| RebornLlmCatalogError::EnvResolution { source })
+fn validate_selection(
+    selection: &LlmSlotSelection,
+    provider: &ProviderDefinition,
+    catalog_index: usize,
+) -> Result<(), RebornLlmCatalogError> {
+    if let Some(env) = selection.api_key_env.as_deref() {
+        if reject_inline_secret("llm.<slot>.api_key_env", env).is_err() || !is_env_var_name(env) {
+            return Err(RebornLlmCatalogError::ApiKeyEnvInvalid {
+                provider: provider.id.clone(),
+            });
+        }
+    }
+    if let Some(base_url) = selection.base_url.as_deref() {
+        validate_catalog_text(provider, catalog_index, "selection_base_url", base_url)?;
+    }
+    if let Some(model) = selection.model.as_deref() {
+        validate_catalog_text(provider, catalog_index, "selection_model", model)?;
+    }
+    Ok(())
+}
+
+fn map_selection_resolution_error(
+    source: ironclaw_llm::LlmError,
+    selection: &LlmSlotSelection,
+    provider: &ProviderDefinition,
+) -> RebornLlmCatalogError {
+    match source {
+        ironclaw_llm::LlmError::AuthFailed {
+            provider: error_provider,
+        } if error_provider == provider.id && provider.api_key_required => {
+            match selection
+                .api_key_env
+                .clone()
+                .or_else(|| provider.api_key_env.clone())
+            {
+                Some(env) => RebornLlmCatalogError::ApiKeyEnvUnset {
+                    provider: provider.id.clone(),
+                    env,
+                },
+                None => RebornLlmCatalogError::ApiKeyEnvUnconfigured {
+                    provider: provider.id.clone(),
+                },
+            }
+        }
+        ironclaw_llm::LlmError::RequestFailed {
+            provider: error_provider,
+            reason,
+        } if error_provider == provider.id
+            && provider.base_url_required
+            && reason.contains("base URL is required") =>
+        {
+            RebornLlmCatalogError::BaseUrlUnconfigured {
+                provider: provider.id.clone(),
+            }
+        }
+        source => RebornLlmCatalogError::EnvResolution { source },
+    }
 }
 
 fn validate_catalog(registry: &ProviderRegistry) -> Result<(), RebornLlmCatalogError> {
@@ -302,45 +351,6 @@ fn safe_catalog_display_value(label: &'static str, value: &str) -> String {
     }
 }
 
-fn read_api_key(
-    selection: &LlmSlotSelection,
-    provider: &ProviderDefinition,
-) -> Result<Option<secrecy::SecretString>, RebornLlmCatalogError> {
-    let env_var = selection
-        .api_key_env
-        .clone()
-        .or_else(|| provider.api_key_env.clone());
-
-    match (env_var, provider.api_key_required) {
-        (Some(env), required) => {
-            if reject_inline_secret("llm.<slot>.api_key_env", &env).is_err()
-                || !is_env_var_name(&env)
-            {
-                return Err(RebornLlmCatalogError::ApiKeyEnvInvalid {
-                    provider: provider.id.clone(),
-                });
-            }
-            match std::env::var(&env) {
-                Ok(value) if !value.is_empty() => Ok(Some(secrecy::SecretString::from(value))),
-                Ok(_) if required => Err(RebornLlmCatalogError::ApiKeyEnvUnset {
-                    provider: provider.id.clone(),
-                    env,
-                }),
-                Ok(_) => Ok(None),
-                Err(_) if required => Err(RebornLlmCatalogError::ApiKeyEnvUnset {
-                    provider: provider.id.clone(),
-                    env,
-                }),
-                Err(_) => Ok(None),
-            }
-        }
-        (None, true) => Err(RebornLlmCatalogError::ApiKeyEnvUnconfigured {
-            provider: provider.id.clone(),
-        }),
-        (None, false) => Ok(None),
-    }
-}
-
 fn is_env_var_name(value: &str) -> bool {
     let mut chars = value.chars();
     let Some(first) = chars.next() else {
@@ -348,128 +358,6 @@ fn is_env_var_name(value: &str) -> bool {
     };
     (first.is_ascii_alphabetic() || first == '_')
         && chars.all(|character| character.is_ascii_alphanumeric() || character == '_')
-}
-
-fn resolve_base_url(
-    selection: &LlmSlotSelection,
-    provider: &ProviderDefinition,
-    catalog_index: usize,
-) -> Result<String, RebornLlmCatalogError> {
-    let base_url = provider
-        .base_url_env
-        .as_deref()
-        .and_then(nonempty_env)
-        .or_else(|| selection.base_url.clone())
-        .or_else(|| provider.default_base_url.clone())
-        .unwrap_or_default();
-
-    validate_catalog_text(provider, catalog_index, "resolved_base_url", &base_url)?;
-
-    if provider.base_url_required && base_url.is_empty() {
-        return Err(RebornLlmCatalogError::BaseUrlUnconfigured {
-            provider: provider.id.clone(),
-        });
-    }
-
-    Ok(base_url)
-}
-
-fn resolve_model(
-    selection: &LlmSlotSelection,
-    provider: &ProviderDefinition,
-    catalog_index: usize,
-) -> Result<String, RebornLlmCatalogError> {
-    let model = nonempty_env(&provider.model_env)
-        .or_else(|| selection.model.clone())
-        .unwrap_or_else(|| provider.default_model.clone());
-    validate_catalog_text(provider, catalog_index, "resolved_model", &model)?;
-    Ok(model)
-}
-
-fn resolve_extra_headers(
-    provider: &ProviderDefinition,
-) -> Result<Vec<(String, String)>, RebornLlmCatalogError> {
-    let env_headers = match provider.extra_headers_env.as_deref() {
-        Some(env) => {
-            // Header values intentionally come from env without inline-secret rejection:
-            // env vars are the approved secret-carrying channel. The catalog-supplied
-            // env var name is validated by `validate_catalog_env_var` before this runs,
-            // and `parse_extra_headers` never echoes header values in errors.
-            nonempty_env(env)
-                .map(|value| parse_extra_headers(&provider.id, env, &value))
-                .transpose()?
-                .unwrap_or_default()
-        }
-        None => Vec::new(),
-    };
-
-    if matches!(
-        provider.protocol,
-        ironclaw_llm::ProviderProtocol::GithubCopilot
-    ) {
-        Ok(merge_extra_headers(
-            ironclaw_llm::auth::default_headers(ironclaw_llm::auth::AuthBackend::GithubCopilot),
-            env_headers,
-        ))
-    } else {
-        Ok(env_headers)
-    }
-}
-
-fn nonempty_env(name: &str) -> Option<String> {
-    std::env::var(name).ok().filter(|value| !value.is_empty())
-}
-
-fn parse_extra_headers(
-    provider: &str,
-    env: &str,
-    value: &str,
-) -> Result<Vec<(String, String)>, RebornLlmCatalogError> {
-    let mut headers = Vec::new();
-    for part in value.split(',') {
-        let part = part.trim();
-        if part.is_empty() {
-            continue;
-        }
-        let Some((key, header_value)) = part.split_once(':') else {
-            return Err(RebornLlmCatalogError::ExtraHeadersInvalid {
-                provider: provider.to_string(),
-                env: env.to_string(),
-                reason: "header must use `Name:Value` format".to_string(),
-            });
-        };
-        let key = key.trim();
-        if key.is_empty() {
-            return Err(RebornLlmCatalogError::ExtraHeadersInvalid {
-                provider: provider.to_string(),
-                env: env.to_string(),
-                reason: "header name must not be empty".to_string(),
-            });
-        }
-        // Empty values are allowed: some APIs use presence-only headers,
-        // and the env var is operator-controlled. Servers that reject an
-        // empty value will return a provider-specific HTTP error later.
-        headers.push((key.to_string(), header_value.trim().to_string()));
-    }
-    Ok(headers)
-}
-
-fn merge_extra_headers(
-    defaults: Vec<(String, String)>,
-    overrides: Vec<(String, String)>,
-) -> Vec<(String, String)> {
-    let mut merged = defaults;
-    for (key, value) in overrides {
-        if let Some((_, existing_value)) = merged
-            .iter_mut()
-            .find(|(existing_key, _)| existing_key.eq_ignore_ascii_case(&key))
-        {
-            *existing_value = value;
-        } else {
-            merged.push((key, value));
-        }
-    }
-    merged
 }
 
 #[cfg(test)]
@@ -914,39 +802,6 @@ mod tests {
             "gemini-test"
         );
         assert!(config.provider.is_none());
-    }
-
-    #[test]
-    fn parses_extra_headers_with_colons_in_values() {
-        let headers = parse_extra_headers(
-            "alpha",
-            "ALPHA_HEADERS",
-            "HTTP-Referer:https://example.test,X-Token:Bearer abc:def",
-        )
-        .expect("headers parse");
-
-        assert_eq!(
-            headers,
-            vec![
-                (
-                    "HTTP-Referer".to_string(),
-                    "https://example.test".to_string()
-                ),
-                ("X-Token".to_string(), "Bearer abc:def".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn malformed_extra_header_error_does_not_echo_value() {
-        let pasted_secret = format!("Authorization Bearer {}{}", "s", "k-proj-1234567890abcdef");
-        let err = parse_extra_headers("alpha", "ALPHA_HEADERS", &pasted_secret)
-            .expect_err("malformed header must error");
-        let rendered = err.to_string();
-        assert!(
-            !rendered.contains(&pasted_secret),
-            "error must not echo header value: {rendered}"
-        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/llm_catalog.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_catalog.rs
@@ -218,12 +218,12 @@ fn validate_selection(
     provider: &ProviderDefinition,
     catalog_index: usize,
 ) -> Result<(), RebornLlmCatalogError> {
-    if let Some(env) = selection.api_key_env.as_deref() {
-        if reject_inline_secret("llm.<slot>.api_key_env", env).is_err() || !is_env_var_name(env) {
-            return Err(RebornLlmCatalogError::ApiKeyEnvInvalid {
-                provider: provider.id.clone(),
-            });
-        }
+    if let Some(env) = selection.api_key_env.as_deref()
+        && (reject_inline_secret("llm.<slot>.api_key_env", env).is_err() || !is_env_var_name(env))
+    {
+        return Err(RebornLlmCatalogError::ApiKeyEnvInvalid {
+            provider: provider.id.clone(),
+        });
     }
     if let Some(base_url) = selection.base_url.as_deref() {
         validate_catalog_text(provider, catalog_index, "selection_base_url", base_url)?;

--- a/crates/ironclaw_reborn_composition/src/llm_catalog.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_catalog.rs
@@ -30,7 +30,9 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use ironclaw_llm::{ProviderRegistry, ProviderSelection, registry::ProviderDefinition};
+use ironclaw_llm::{
+    ProviderRegistry, ProviderResolutionError, ProviderSelection, registry::ProviderDefinition,
+};
 use ironclaw_reborn_config::{
     LlmSlotSelection, RebornBootConfig, RebornConfigFile, reject_inline_secret,
 };
@@ -203,9 +205,9 @@ pub fn resolve_against_registry(
         provider,
         catalog_index,
         "resolved_base_url",
-        &resolved.base_url,
+        resolved.base_url(),
     )?;
-    validate_catalog_text(provider, catalog_index, "resolved_model", &resolved.model)?;
+    validate_catalog_text(provider, catalog_index, "resolved_model", resolved.model())?;
 
     ironclaw_llm::build_llm_config_from_resolved_provider(resolved)
         .map_err(|source| RebornLlmCatalogError::EnvResolution { source })
@@ -233,14 +235,14 @@ fn validate_selection(
 }
 
 fn map_selection_resolution_error(
-    source: ironclaw_llm::LlmError,
+    source: ProviderResolutionError,
     selection: &LlmSlotSelection,
     provider: &ProviderDefinition,
 ) -> RebornLlmCatalogError {
     match source {
-        ironclaw_llm::LlmError::AuthFailed {
+        ProviderResolutionError::MissingApiKey {
             provider: error_provider,
-        } if error_provider == provider.id && provider.api_key_required => {
+        } if error_provider == provider.id => {
             match selection
                 .api_key_env
                 .clone()
@@ -255,18 +257,14 @@ fn map_selection_resolution_error(
                 },
             }
         }
-        ironclaw_llm::LlmError::RequestFailed {
+        ProviderResolutionError::MissingBaseUrl {
             provider: error_provider,
-            reason,
-        } if error_provider == provider.id
-            && provider.base_url_required
-            && reason.contains("base URL is required") =>
-        {
-            RebornLlmCatalogError::BaseUrlUnconfigured {
-                provider: provider.id.clone(),
-            }
-        }
-        source => RebornLlmCatalogError::EnvResolution { source },
+        } if error_provider == provider.id => RebornLlmCatalogError::BaseUrlUnconfigured {
+            provider: provider.id.clone(),
+        },
+        source => RebornLlmCatalogError::EnvResolution {
+            source: source.into_llm_error(),
+        },
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/llm_catalog.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_catalog.rs
@@ -10,9 +10,9 @@
 //!    `ironclaw_reborn_config::LlmSlotSelection`. "Use provider X
 //!    for the `default` slot, with model Y."
 //! 3. **Runtime config** — derived here. The resolved `ProviderDefinition`
-//!    plus the selection's overrides becomes a `RebornLlmConfig` that
-//!    `build_reborn_runtime` knows how to wire into a host-managed
-//!    model gateway.
+//!    plus the selection's overrides becomes an `ironclaw_llm::LlmConfig`
+//!    that `build_reborn_runtime` wires through the shared LLM provider
+//!    chain.
 //!
 //! This module is the home of step 3. Lives behind the
 //! `root-llm-provider` feature so the substrate-only composition stays
@@ -30,12 +30,12 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use ironclaw_llm::{ProviderRegistry, registry::ProviderDefinition};
+use ironclaw_llm::{ProviderRegistry, ResolvedProviderConfig, registry::ProviderDefinition};
 use ironclaw_reborn_config::{
     LlmSlotSelection, RebornBootConfig, RebornConfigFile, reject_inline_secret,
 };
 
-use crate::runtime_input::{DEFAULT_LLM_REQUEST_TIMEOUT_SECS, RebornLlmConfig, ResolvedRebornLlm};
+use crate::runtime_input::ResolvedRebornLlm;
 
 /// Errors surfaced when resolving an `LlmSlotSelection` against the
 /// merged provider catalog.
@@ -129,7 +129,7 @@ pub fn resolve_reborn_runtime_llm(
             selection,
             Some(boot.home().providers_file_path().as_path()),
         )
-        .map(ResolvedRebornLlm::from_catalog)
+        .map(ResolvedRebornLlm::from_llm_config)
         .map(Some);
     }
 
@@ -139,15 +139,9 @@ pub fn resolve_reborn_runtime_llm(
 fn resolve_llm_from_env(
     boot: &RebornBootConfig,
 ) -> Result<Option<ResolvedRebornLlm>, RebornLlmCatalogError> {
-    ironclaw_llm::resolve_registry_provider_from_env(Some(
-        boot.home().providers_file_path().as_path(),
-    ))
-    .map(|maybe_config| {
-        maybe_config.map(|config| {
-            ResolvedRebornLlm::from_registry_provider(config, DEFAULT_LLM_REQUEST_TIMEOUT_SECS)
-        })
-    })
-    .map_err(|source| RebornLlmCatalogError::EnvResolution { source })
+    ironclaw_llm::resolve_llm_config_from_env(Some(boot.home().providers_file_path().as_path()))
+        .map(|maybe_config| maybe_config.map(ResolvedRebornLlm::from_llm_config))
+        .map_err(|source| RebornLlmCatalogError::EnvResolution { source })
 }
 
 /// Resolve an `LlmSlotSelection` against the merged provider catalog.
@@ -159,11 +153,11 @@ fn resolve_llm_from_env(
 /// 4. Read the API key value from that env var (fail-closed if absent).
 /// 5. Determine base_url (selection override > catalog default).
 /// 6. Determine model (selection override > catalog default).
-/// 7. Build and return a `RebornLlmConfig`.
+/// 7. Build and return a full `ironclaw_llm::LlmConfig`.
 pub fn resolve_llm_selection_against_catalog(
     selection: &LlmSlotSelection,
     user_providers_path: Option<&Path>,
-) -> Result<RebornLlmConfig, RebornLlmCatalogError> {
+) -> Result<ironclaw_llm::LlmConfig, RebornLlmCatalogError> {
     let registry = ProviderRegistry::try_load_from_path(user_providers_path)
         .map_err(|source| RebornLlmCatalogError::CatalogLoad { source })?;
     resolve_against_registry(selection, &registry)
@@ -175,7 +169,7 @@ pub fn resolve_llm_selection_against_catalog(
 pub fn resolve_against_registry(
     selection: &LlmSlotSelection,
     registry: &ProviderRegistry,
-) -> Result<RebornLlmConfig, RebornLlmCatalogError> {
+) -> Result<ironclaw_llm::LlmConfig, RebornLlmCatalogError> {
     validate_catalog(registry)?;
 
     let provider_id = selection
@@ -215,15 +209,16 @@ pub fn resolve_against_registry(
 
     let extra_headers = resolve_extra_headers(provider)?;
 
-    Ok(RebornLlmConfig {
+    ironclaw_llm::build_llm_config_from_resolved_provider(ResolvedProviderConfig {
+        protocol: provider.protocol,
         provider_id: provider.id.clone(),
-        model,
-        base_url,
         api_key,
-        protocol: serialize_protocol(provider.protocol),
-        request_timeout_secs: DEFAULT_LLM_REQUEST_TIMEOUT_SECS,
+        base_url,
+        model,
         extra_headers,
+        unsupported_params: provider.unsupported_params.clone(),
     })
+    .map_err(|source| RebornLlmCatalogError::EnvResolution { source })
 }
 
 fn validate_catalog(registry: &ProviderRegistry) -> Result<(), RebornLlmCatalogError> {
@@ -477,26 +472,6 @@ fn merge_extra_headers(
     merged
 }
 
-/// Map `ironclaw_llm::ProviderProtocol` to the wire string
-/// `RebornLlmConfig.protocol` accepts.
-fn serialize_protocol(protocol: ironclaw_llm::ProviderProtocol) -> String {
-    use ironclaw_llm::ProviderProtocol;
-    match protocol {
-        ProviderProtocol::OpenAiCompletions => "open_ai_completions",
-        ProviderProtocol::Anthropic => "anthropic",
-        ProviderProtocol::Ollama => "ollama",
-        ProviderProtocol::GithubCopilot => "github_copilot",
-        ProviderProtocol::DeepSeek => "deep_seek",
-        ProviderProtocol::Gemini => "gemini",
-        ProviderProtocol::OpenRouter => "open_router",
-        ProviderProtocol::Bedrock => "bedrock",
-        ProviderProtocol::OpenAiCodex => "openai_codex",
-        ProviderProtocol::GeminiOauth => "gemini_oauth",
-        ProviderProtocol::NearAi => "nearai",
-    }
-    .to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -579,6 +554,25 @@ mod tests {
             model_env: "REBORN_TEST_GITHUB_COPILOT_MODEL_UNSET_DO_NOT_SET_9c13".to_string(),
             default_model: "gpt-4o".to_string(),
             description: "test github copilot".to_string(),
+            extra_headers_env: None,
+            unsupported_params: Vec::new(),
+            setup: None,
+        }
+    }
+
+    fn provider_with_protocol(id: &str, protocol: ProviderProtocol) -> ProviderDefinition {
+        ProviderDefinition {
+            id: id.to_string(),
+            aliases: Vec::new(),
+            protocol,
+            default_base_url: None,
+            base_url_env: None,
+            base_url_required: false,
+            api_key_env: None,
+            api_key_required: false,
+            model_env: "REBORN_TEST_DEDICATED_MODEL_UNSET_DO_NOT_SET_9c13".to_string(),
+            default_model: "dedicated-default-model".to_string(),
+            description: "test dedicated provider".to_string(),
             extra_headers_env: None,
             unsupported_params: Vec::new(),
             setup: None,
@@ -768,38 +762,12 @@ mod tests {
         };
 
         let config = resolve_against_registry(&selection, &registry).expect("must resolve");
-        assert_eq!(config.provider_id, "alpha");
-        assert_eq!(config.model, "llama3"); // catalog default
-        assert_eq!(config.base_url, "http://localhost:11434"); // catalog default
-        assert_eq!(config.protocol, "ollama");
-        assert!(config.api_key.is_none());
-    }
-
-    #[test]
-    fn serializes_protocols_with_serde_snake_case_names() {
-        assert_eq!(
-            serialize_protocol(ProviderProtocol::OpenAiCompletions),
-            "open_ai_completions"
-        );
-        assert_eq!(serialize_protocol(ProviderProtocol::DeepSeek), "deep_seek");
-        assert_eq!(
-            serialize_protocol(ProviderProtocol::OpenRouter),
-            "open_router"
-        );
-        assert_eq!(
-            serialize_protocol(ProviderProtocol::GithubCopilot),
-            "github_copilot"
-        );
-        assert_eq!(serialize_protocol(ProviderProtocol::Bedrock), "bedrock");
-        assert_eq!(
-            serialize_protocol(ProviderProtocol::OpenAiCodex),
-            "openai_codex"
-        );
-        assert_eq!(
-            serialize_protocol(ProviderProtocol::GeminiOauth),
-            "gemini_oauth"
-        );
-        assert_eq!(serialize_protocol(ProviderProtocol::NearAi), "nearai");
+        let provider = config.provider.as_ref().expect("registry provider");
+        assert_eq!(provider.provider_id, "alpha");
+        assert_eq!(provider.model, "llama3"); // catalog default
+        assert_eq!(provider.base_url, "http://localhost:11434"); // catalog default
+        assert_eq!(provider.protocol, ProviderProtocol::Ollama);
+        assert!(provider.api_key.is_none());
     }
 
     #[test]
@@ -811,8 +779,9 @@ mod tests {
         };
 
         let config = resolve_against_registry(&selection, &registry).expect("must resolve");
-        assert_eq!(config.base_url, "");
-        assert_eq!(config.model, "default-model");
+        let provider = config.provider.as_ref().expect("registry provider");
+        assert_eq!(provider.base_url, "");
+        assert_eq!(provider.model, "default-model");
     }
 
     #[test]
@@ -841,8 +810,9 @@ mod tests {
         };
 
         let config = resolve_against_registry(&selection, &registry).expect("must resolve");
-        assert_eq!(config.model, "custom-model");
-        assert_eq!(config.base_url, "https://override.test/v1");
+        let provider = config.provider.as_ref().expect("registry provider");
+        assert_eq!(provider.model, "custom-model");
+        assert_eq!(provider.base_url, "https://override.test/v1");
     }
 
     #[test]
@@ -858,20 +828,92 @@ mod tests {
         let config = resolve_against_registry(&selection, &registry).expect("must resolve");
         assert!(
             config
+                .provider
+                .as_ref()
+                .expect("registry provider")
                 .extra_headers
                 .iter()
                 .any(|(key, _)| key == "Editor-Version"),
             "headers: {:?}",
-            config.extra_headers
+            config.provider.as_ref().unwrap().extra_headers
         );
         assert!(
             config
+                .provider
+                .as_ref()
+                .expect("registry provider")
                 .extra_headers
                 .iter()
                 .any(|(key, _)| key == "Copilot-Integration-Id"),
             "headers: {:?}",
-            config.extra_headers
+            config.provider.as_ref().unwrap().extra_headers
         );
+    }
+
+    #[test]
+    fn nearai_catalog_selection_resolves_to_full_dedicated_llm_config() {
+        let registry = ProviderRegistry::new(vec![provider_with_protocol(
+            "nearai",
+            ProviderProtocol::NearAi,
+        )]);
+        let selection = LlmSlotSelection {
+            provider_id: Some("nearai".to_string()),
+            model: Some("nearai/test-model".to_string()),
+            base_url: Some("https://private.near.ai".to_string()),
+            api_key_env: None,
+        };
+
+        let config = resolve_against_registry(&selection, &registry).expect("must resolve");
+        assert_eq!(config.backend, "nearai");
+        assert_eq!(config.nearai.model, "nearai/test-model");
+        assert_eq!(config.nearai.base_url, "https://private.near.ai");
+        assert!(config.provider.is_none());
+    }
+
+    #[test]
+    fn openai_codex_catalog_selection_resolves_to_full_dedicated_llm_config() {
+        let registry = ProviderRegistry::new(vec![provider_with_protocol(
+            "openai_codex",
+            ProviderProtocol::OpenAiCodex,
+        )]);
+        let selection = LlmSlotSelection {
+            provider_id: Some("openai_codex".to_string()),
+            model: Some("gpt-test-codex".to_string()),
+            ..Default::default()
+        };
+
+        let config = resolve_against_registry(&selection, &registry).expect("must resolve");
+        assert_eq!(config.backend, "openai_codex");
+        assert_eq!(
+            config.openai_codex.as_ref().expect("codex config").model,
+            "gpt-test-codex"
+        );
+        assert!(config.provider.is_none());
+    }
+
+    #[test]
+    fn gemini_oauth_catalog_selection_resolves_to_full_dedicated_llm_config() {
+        let registry = ProviderRegistry::new(vec![provider_with_protocol(
+            "gemini_oauth",
+            ProviderProtocol::GeminiOauth,
+        )]);
+        let selection = LlmSlotSelection {
+            provider_id: Some("gemini_oauth".to_string()),
+            model: Some("gemini-test".to_string()),
+            ..Default::default()
+        };
+
+        let config = resolve_against_registry(&selection, &registry).expect("must resolve");
+        assert_eq!(config.backend, "gemini_oauth");
+        assert_eq!(
+            config
+                .gemini_oauth
+                .as_ref()
+                .expect("gemini oauth config")
+                .model,
+            "gemini-test"
+        );
+        assert!(config.provider.is_none());
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -98,7 +98,7 @@ pub use skills::{
 use skills::skill_asset_error;
 
 #[cfg(feature = "root-llm-provider")]
-use crate::runtime_input::{ResolvedRebornLlm, ResolvedRebornLlmSource};
+use crate::runtime_input::ResolvedRebornLlm;
 
 /// Stable identifier for a Reborn CLI conversation. Wraps a `ThreadId`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -407,7 +407,7 @@ impl RebornRuntime {
     /// from the session thread service.
     ///
     /// Without an LLM gateway wired in (i.e. when this crate is built
-    /// without the `root-llm-provider` feature or `RebornLlmConfig` is not
+    /// without the `root-llm-provider` feature or an LLM config is not
     /// provided), the run will fail and the returned reply will surface
     /// that failure via `status = Failed` and `text = None`.
     pub async fn send_user_message(
@@ -921,14 +921,14 @@ pub async fn build_reborn_runtime(
             gateway
         } else {
             match llm {
-                Some(cfg) => build_llm_gateway(cfg)?,
+                Some(cfg) => build_llm_gateway(cfg).await?,
                 None => build_stub_gateway(),
             }
         }
         #[cfg(not(test))]
         {
             match llm {
-                Some(cfg) => build_llm_gateway(cfg)?,
+                Some(cfg) => build_llm_gateway(cfg).await?,
                 None => build_stub_gateway(),
             }
         }
@@ -1254,33 +1254,20 @@ impl HostIdentityContextSource for EmptyIdentityContextSource {
 }
 
 #[cfg(feature = "root-llm-provider")]
-fn build_llm_gateway(
+async fn build_llm_gateway(
     llm: ResolvedRebornLlm,
 ) -> Result<Arc<dyn ironclaw_loop_support::HostManagedModelGateway>, RebornRuntimeError> {
-    use ironclaw_llm::RegistryProviderConfig;
     use ironclaw_reborn::model_gateway::{LlmModelProfilePolicy, LlmProviderModelGateway};
     use ironclaw_turns::run_profile::ModelProfileId;
 
     let model = llm.model().to_string();
-    let provider = match llm.source {
-        ResolvedRebornLlmSource::Catalog(cfg) => {
-            let protocol = parse_provider_protocol(&cfg.protocol)?;
-            let registry_config = RegistryProviderConfig::generic(
-                protocol,
-                cfg.provider_id.clone(),
-                cfg.api_key.clone(),
-                cfg.base_url.clone(),
-                cfg.model.clone(),
-            )
-            .with_extra_headers(cfg.extra_headers.clone());
-            ironclaw_llm::create_registry_provider(&registry_config, cfg.request_timeout_secs)
-        }
-        ResolvedRebornLlmSource::RegistryProvider {
-            config,
-            request_timeout_secs,
-        } => ironclaw_llm::create_registry_provider(&config, request_timeout_secs),
-    }
-    .map_err(|error| RebornRuntimeError::LlmProvider(error.to_string()))?;
+    let session = Arc::new(ironclaw_llm::SessionManager::new(
+        llm.config.session.clone(),
+    ));
+    let (provider, _cheap_provider, _recording_handle, _reload_handle) =
+        ironclaw_llm::build_provider_chain(&llm.config, session)
+            .await
+            .map_err(|error| RebornRuntimeError::LlmProvider(error.to_string()))?;
 
     let model_profile_id = ModelProfileId::new("interactive_model").map_err(|reason| {
         RebornRuntimeError::LlmProvider(format!("invalid interactive model profile id: {reason}"))
@@ -1288,32 +1275,6 @@ fn build_llm_gateway(
     let policy = LlmModelProfilePolicy::new().allow_model_profile(model_profile_id, Some(model));
     let gateway = LlmProviderModelGateway::new(provider, policy);
     Ok(Arc::new(gateway))
-}
-
-#[cfg(feature = "root-llm-provider")]
-fn parse_provider_protocol(
-    protocol: &str,
-) -> Result<ironclaw_llm::ProviderProtocol, RebornRuntimeError> {
-    use ironclaw_llm::ProviderProtocol;
-
-    match protocol {
-        "open_ai_completions" | "openai_completions" | "openai" => {
-            Ok(ProviderProtocol::OpenAiCompletions)
-        }
-        "anthropic" => Ok(ProviderProtocol::Anthropic),
-        "ollama" => Ok(ProviderProtocol::Ollama),
-        "github_copilot" => Ok(ProviderProtocol::GithubCopilot),
-        "deep_seek" | "deepseek" => Ok(ProviderProtocol::DeepSeek),
-        "gemini" => Ok(ProviderProtocol::Gemini),
-        "open_router" | "openrouter" => Ok(ProviderProtocol::OpenRouter),
-        "bedrock" => Ok(ProviderProtocol::Bedrock),
-        "openai_codex" | "open_ai_codex" => Ok(ProviderProtocol::OpenAiCodex),
-        "gemini_oauth" => Ok(ProviderProtocol::GeminiOauth),
-        "nearai" | "near_ai" => Ok(ProviderProtocol::NearAi),
-        _ => Err(RebornRuntimeError::LlmProvider(format!(
-            "unsupported llm protocol: {protocol}"
-        ))),
-    }
 }
 
 fn build_stub_gateway() -> Arc<dyn ironclaw_loop_support::HostManagedModelGateway> {
@@ -3222,65 +3183,5 @@ mod tests {
         assert!(combined_skill_context.contains("WEBUI_HELPER_PROMPT_SENTINEL"));
 
         runtime.shutdown().await.expect("runtime shutdown");
-    }
-}
-
-#[cfg(all(test, feature = "root-llm-provider"))]
-mod llm_provider_tests {
-    use ironclaw_llm::ProviderProtocol;
-
-    use super::parse_provider_protocol;
-
-    #[test]
-    fn parses_supported_provider_protocols_without_wildcard_mapping() {
-        assert_eq!(
-            parse_provider_protocol("open_ai_completions").unwrap(),
-            ProviderProtocol::OpenAiCompletions
-        );
-        assert_eq!(
-            parse_provider_protocol("openai_completions").unwrap(),
-            ProviderProtocol::OpenAiCompletions
-        );
-        assert_eq!(
-            parse_provider_protocol("openai").unwrap(),
-            ProviderProtocol::OpenAiCompletions
-        );
-        assert_eq!(
-            parse_provider_protocol("anthropic").unwrap(),
-            ProviderProtocol::Anthropic
-        );
-        assert_eq!(
-            parse_provider_protocol("ollama").unwrap(),
-            ProviderProtocol::Ollama
-        );
-        assert_eq!(
-            parse_provider_protocol("deep_seek").unwrap(),
-            ProviderProtocol::DeepSeek
-        );
-        assert_eq!(
-            parse_provider_protocol("deepseek").unwrap(),
-            ProviderProtocol::DeepSeek
-        );
-        assert_eq!(
-            parse_provider_protocol("gemini").unwrap(),
-            ProviderProtocol::Gemini
-        );
-        assert_eq!(
-            parse_provider_protocol("open_router").unwrap(),
-            ProviderProtocol::OpenRouter
-        );
-        assert_eq!(
-            parse_provider_protocol("openrouter").unwrap(),
-            ProviderProtocol::OpenRouter
-        );
-        assert_eq!(
-            parse_provider_protocol("github_copilot").unwrap(),
-            ProviderProtocol::GithubCopilot
-        );
-    }
-
-    #[test]
-    fn rejects_unsupported_provider_protocol() {
-        assert!(parse_provider_protocol("made_up_protocol").is_err());
     }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1264,10 +1264,9 @@ async fn build_llm_gateway(
     let session = Arc::new(ironclaw_llm::SessionManager::new(
         llm.config.session.clone(),
     ));
-    let (provider, _cheap_provider, _recording_handle, _reload_handle) =
-        ironclaw_llm::build_provider_chain(&llm.config, session)
-            .await
-            .map_err(|error| RebornRuntimeError::LlmProvider(error.to_string()))?;
+    let provider = ironclaw_llm::build_static_provider_chain(&llm.config, session)
+        .await
+        .map_err(|error| RebornRuntimeError::LlmProvider(error.to_string()))?;
 
     let model_profile_id = ModelProfileId::new("interactive_model").map_err(|reason| {
         RebornRuntimeError::LlmProvider(format!("invalid interactive model profile id: {reason}"))

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1261,9 +1261,7 @@ async fn build_llm_gateway(
     use ironclaw_turns::run_profile::ModelProfileId;
 
     let model = llm.model().to_string();
-    let session = Arc::new(ironclaw_llm::SessionManager::new(
-        llm.config.session.clone(),
-    ));
+    let session = ironclaw_llm::create_session_manager(llm.config.session.clone()).await;
     let provider = ironclaw_llm::build_static_provider_chain(&llm.config, session)
         .await
         .map_err(|error| RebornRuntimeError::LlmProvider(error.to_string()))?;
@@ -1620,6 +1618,120 @@ mod tests {
         HostManagedModelError::safe(HostManagedModelErrorKind::Unavailable, safe_summary)
     }
 
+    #[cfg(feature = "root-llm-provider")]
+    struct RuntimeEnvGuard {
+        name: &'static str,
+        previous: Option<String>,
+    }
+
+    #[cfg(feature = "root-llm-provider")]
+    impl RuntimeEnvGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let previous = ironclaw_common::env_helpers::env_or_override(name);
+            ironclaw_common::env_helpers::set_runtime_env(name, value);
+            Self { name, previous }
+        }
+    }
+
+    #[cfg(feature = "root-llm-provider")]
+    impl Drop for RuntimeEnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => ironclaw_common::env_helpers::set_runtime_env(self.name, value),
+                None => ironclaw_common::env_helpers::remove_runtime_env(self.name),
+            }
+        }
+    }
+
+    #[cfg(feature = "root-llm-provider")]
+    async fn start_nearai_auth_capture_server() -> (String, tokio::sync::oneshot::Receiver<String>)
+    {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpSocket;
+
+        let socket = TcpSocket::new_v4().expect("test server socket");
+        socket
+            .bind("127.0.0.1:0".parse().expect("test server address"))
+            .expect("test server binds");
+        let listener = socket.listen(1024).expect("test server listens");
+        let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (auth_tx, auth_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let mut auth_tx = Some(auth_tx);
+            loop {
+                let (mut stream, _) = listener.accept().await.expect("accept test request");
+                let mut buffer = Vec::new();
+                loop {
+                    let mut chunk = [0_u8; 1024];
+                    let read = stream.read(&mut chunk).await.expect("read test request");
+                    if read == 0 {
+                        break;
+                    }
+                    buffer.extend_from_slice(&chunk[..read]);
+                    if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+
+                let request = String::from_utf8_lossy(&buffer);
+                let request_line = request.lines().next().unwrap_or_default();
+                let auth_header = request
+                    .lines()
+                    .filter_map(|line| line.split_once(':'))
+                    .find(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+                    .map(|(_, value)| value.trim())
+                    .unwrap_or_default()
+                    .to_string();
+                let is_chat_completion = request_line.contains("/v1/chat/completions");
+                let body = if is_chat_completion {
+                    r#"{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#
+                } else {
+                    r#"{"data":[]}"#
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write test response");
+
+                if is_chat_completion {
+                    if let Some(auth_tx) = auth_tx.take() {
+                        let _ = auth_tx.send(auth_header);
+                    }
+                    break;
+                }
+            }
+        });
+
+        (base_url, auth_rx)
+    }
+
+    #[cfg(feature = "root-llm-provider")]
+    fn nearai_gateway_test_request() -> HostManagedModelRequest {
+        HostManagedModelRequest {
+            model_profile_id: ironclaw_turns::run_profile::ModelProfileId::new("interactive_model")
+                .expect("model profile id"),
+            messages: vec![ironclaw_loop_support::HostManagedModelMessage {
+                role: HostManagedModelMessageRole::User,
+                content: "hello model".to_string(),
+                content_ref: ironclaw_turns::LoopMessageRef::new(
+                    "msg:22222222-2222-2222-2222-222222222222",
+                )
+                .expect("message ref"),
+                tool_result_provider_call: None,
+            }],
+            surface_version: None,
+            resolved_model_route: None,
+            run_id: TurnRunId::new(),
+            turn_id: TurnId::new(),
+        }
+    }
+
     fn skill_md(name: &str, description: &str, prompt: &str) -> String {
         format!(
             "---\nname: {name}\ndescription: {description}\nactivation:\n  keywords: [\"{name}\"]\n---\n\n{prompt}"
@@ -1642,6 +1754,65 @@ mod tests {
             .lock()
             .expect("recording gateway requests lock poisoned")
             .len()
+    }
+
+    #[cfg(feature = "root-llm-provider")]
+    #[tokio::test]
+    async fn root_llm_gateway_bootstraps_nearai_session_token_from_env() {
+        let _token_guard = RuntimeEnvGuard::set("NEARAI_SESSION_TOKEN", "sess_reborn_env_token");
+        let session_dir = tempfile::tempdir().expect("session tempdir");
+        let (base_url, auth_rx) = start_nearai_auth_capture_server().await;
+
+        let config = ironclaw_llm::LlmConfig {
+            backend: "nearai".to_string(),
+            session: ironclaw_llm::SessionConfig {
+                auth_base_url: base_url.clone(),
+                session_path: session_dir.path().join("session.json"),
+            },
+            nearai: ironclaw_llm::NearAiConfig {
+                model: "test-model".to_string(),
+                cheap_model: None,
+                base_url,
+                api_key: None,
+                fallback_model: None,
+                max_retries: 0,
+                circuit_breaker_threshold: None,
+                circuit_breaker_recovery_secs: 30,
+                response_cache_enabled: false,
+                response_cache_ttl_secs: 3600,
+                response_cache_max_entries: 1000,
+                failover_cooldown_secs: 300,
+                failover_cooldown_threshold: 3,
+                smart_routing_cascade: false,
+            },
+            provider: None,
+            bedrock: None,
+            gemini_oauth: None,
+            openai_codex: None,
+            request_timeout_secs: 5,
+            cheap_model: None,
+            smart_routing_cascade: false,
+            max_retries: 0,
+            circuit_breaker_threshold: None,
+            circuit_breaker_recovery_secs: 30,
+            response_cache_enabled: false,
+            response_cache_ttl_secs: 3600,
+            response_cache_max_entries: 1000,
+        };
+        let llm = crate::runtime_input::ResolvedRebornLlm::from_llm_config(config);
+
+        let gateway = super::build_llm_gateway(llm).await.expect("gateway builds");
+        let response = gateway
+            .stream_model(nearai_gateway_test_request())
+            .await
+            .expect("gateway calls NEAR AI provider");
+
+        assert_eq!(response.safe_text_deltas, vec!["ok".to_string()]);
+        let auth_header = tokio::time::timeout(Duration::from_secs(2), auth_rx)
+            .await
+            .expect("chat request should be captured")
+            .expect("auth header should be sent by capture server");
+        assert_eq!(auth_header, "Bearer sess_reborn_env_token");
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -59,81 +59,15 @@ impl Default for RebornRuntimeIdentity {
     }
 }
 
-/// Configuration for the host-managed LLM model gateway wired into the
-/// composed Reborn runtime.
-///
-/// Only available when this crate is built with the `root-llm-provider`
-/// feature. Mirrors `ironclaw_llm::RegistryProviderConfig` but stays in
-/// composition-owned types so callers (the CLI) never name `ironclaw_llm`
-/// directly.
-#[cfg(feature = "root-llm-provider")]
-pub(crate) const DEFAULT_LLM_REQUEST_TIMEOUT_SECS: u64 = 120;
-
 pub const DEFAULT_TURN_RUNNER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 pub const DEFAULT_TURN_RUNNER_POLL_INTERVAL: Duration = Duration::from_millis(200);
-
-#[cfg(feature = "root-llm-provider")]
-#[derive(Debug, Clone)]
-pub struct RebornLlmConfig {
-    /// Provider id (e.g. `"openai"`, `"anthropic"`, `"ollama"`).
-    pub provider_id: String,
-    /// Model id passed to the provider (e.g. `"gpt-4o-mini"`).
-    pub model: String,
-    /// Provider API base URL.
-    pub base_url: String,
-    /// API key, if the provider requires one. `None` for keyless providers
-    /// like Ollama.
-    pub api_key: Option<secrecy::SecretString>,
-    /// API protocol identifier — maps onto
-    /// `ironclaw_llm::ProviderProtocol`. Canonical accepted values:
-    /// `"open_ai_completions"`, `"anthropic"`, `"ollama"`, `"deep_seek"`,
-    /// `"gemini"`, `"open_router"`, `"github_copilot"`.
-    /// Legacy aliases `"openai"`, `"openai_completions"`, `"deepseek"`,
-    /// and `"openrouter"` are also accepted.
-    pub protocol: String,
-    /// Request timeout in seconds passed to the underlying HTTP client.
-    pub request_timeout_secs: u64,
-    /// Extra HTTP headers injected on every request.
-    pub extra_headers: Vec<(String, String)>,
-}
-
-#[cfg(feature = "root-llm-provider")]
-impl RebornLlmConfig {
-    /// Convenience constructor for the common OpenAI Chat Completions case.
-    pub fn openai_compat(
-        provider_id: impl Into<String>,
-        base_url: impl Into<String>,
-        model: impl Into<String>,
-        api_key: secrecy::SecretString,
-    ) -> Self {
-        Self {
-            provider_id: provider_id.into(),
-            model: model.into(),
-            base_url: base_url.into(),
-            api_key: Some(api_key),
-            protocol: "open_ai_completions".to_string(),
-            request_timeout_secs: DEFAULT_LLM_REQUEST_TIMEOUT_SECS,
-            extra_headers: Vec::new(),
-        }
-    }
-}
 
 #[cfg(feature = "root-llm-provider")]
 #[derive(Debug, Clone)]
 pub struct ResolvedRebornLlm {
     provider_id: String,
     model: String,
-    pub(crate) source: ResolvedRebornLlmSource,
-}
-
-#[cfg(feature = "root-llm-provider")]
-#[derive(Debug, Clone)]
-pub(crate) enum ResolvedRebornLlmSource {
-    Catalog(RebornLlmConfig),
-    RegistryProvider {
-        config: ironclaw_llm::RegistryProviderConfig,
-        request_timeout_secs: u64,
-    },
+    pub(crate) config: ironclaw_llm::LlmConfig,
 }
 
 #[cfg(feature = "root-llm-provider")]
@@ -146,25 +80,11 @@ impl ResolvedRebornLlm {
         &self.model
     }
 
-    pub fn from_catalog(config: RebornLlmConfig) -> Self {
+    pub fn from_llm_config(config: ironclaw_llm::LlmConfig) -> Self {
         Self {
-            provider_id: config.provider_id.clone(),
-            model: config.model.clone(),
-            source: ResolvedRebornLlmSource::Catalog(config),
-        }
-    }
-
-    pub(crate) fn from_registry_provider(
-        config: ironclaw_llm::RegistryProviderConfig,
-        request_timeout_secs: u64,
-    ) -> Self {
-        Self {
-            provider_id: config.provider_id.clone(),
-            model: config.model.clone(),
-            source: ResolvedRebornLlmSource::RegistryProvider {
-                config,
-                request_timeout_secs,
-            },
+            provider_id: config.active_provider_id(),
+            model: config.active_model_name(),
+            config,
         }
     }
 }
@@ -233,12 +153,6 @@ impl RebornRuntimeInput {
             #[cfg(test)]
             model_gateway_override: None,
         }
-    }
-
-    #[cfg(feature = "root-llm-provider")]
-    pub fn with_llm(mut self, llm: RebornLlmConfig) -> Self {
-        self.llm = Some(ResolvedRebornLlm::from_catalog(llm));
-        self
     }
 
     #[cfg(feature = "root-llm-provider")]


### PR DESCRIPTION
## Summary
- Add shared full LlmConfig resolution in ironclaw_llm for Reborn/provider-catalog callers.
- Wire Reborn runtime through ironclaw_llm::build_provider_chain instead of handrolled RegistryProviderConfig/protocol parsing.
- Add regression coverage for dedicated provider catalog selections: nearai, openai_codex, and gemini_oauth.

## Validation
- cargo fmt --check
- git diff --check
- cargo check -p ironclaw_llm -p ironclaw_reborn_composition --features ironclaw_reborn_composition/root-llm-provider
- cargo test -p ironclaw_reborn_composition --features root-llm-provider llm_catalog
- cargo test -p ironclaw_reborn_composition --features root-llm-provider local_dev_runtime_webui_streams_model_reasoning_as_thinking_projection
- cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway reasoning
- cargo test -p ironclaw_reborn_cli repl_resolves_codex_auth_env_without_openai_api_key