### PR TITLE
chore: allow configuring log truncation size with `IRONCLAW_LOG_MAX_BYTES` env var

### DIFF
--- a/src/channels/web/log_layer.rs
+++ b/src/channels/web/log_layer.rs
@@ -219,7 +219,7 @@ pub fn init_tracing(
         Some(
             tracing_subscriber::fmt::layer()
                 .with_target(false)
-                .with_writer(crate::tracing_fmt::TruncatingStderr::default()),
+                .with_writer(crate::tracing_fmt::TruncatingStderr::from_env()),
         )
     };
 

--- a/src/tracing_fmt.rs
+++ b/src/tracing_fmt.rs
@@ -12,7 +12,7 @@
 //!        v
 //!   tracing_subscriber::registry()
 //!        |
-//!        +-- fmt::layer().with_writer(TruncatingStderr)  <-- caps at 500B
+//!        +-- fmt::layer().with_writer(TruncatingStderr)  <-- caps at 500B (IRONCLAW_LOG_MAX_BYTES to override)
 //!        |       \-- stderr (truncated)
 //!        |
 //!        \-- WebLogLayer (unchanged)
@@ -58,9 +58,20 @@ pub struct TruncatingStderr {
 
 impl Default for TruncatingStderr {
     fn default() -> Self {
-        Self {
-            max_bytes: TERMINAL_MAX_EVENT_BYTES,
-        }
+        let max_bytes = std::env::var("IRONCLAW_LOG_MAX_BYTES")
+            .ok()
+            .and_then(|v| match v.parse::<usize>() {
+                Ok(n) => Some(n),
+                Err(_) => {
+                    eprintln!(
+                        "warning: IRONCLAW_LOG_MAX_BYTES={v:?} is not a valid number, \
+                         using default ({TERMINAL_MAX_EVENT_BYTES})"
+                    );
+                    None
+                }
+            })
+            .unwrap_or(TERMINAL_MAX_EVENT_BYTES);
+        Self { max_bytes }
     }
 }
 

--- a/src/tracing_fmt.rs
+++ b/src/tracing_fmt.rs
@@ -58,6 +58,16 @@ pub struct TruncatingStderr {
 
 impl Default for TruncatingStderr {
     fn default() -> Self {
+        Self {
+            max_bytes: TERMINAL_MAX_EVENT_BYTES,
+        }
+    }
+}
+
+impl TruncatingStderr {
+    /// Construct from `IRONCLAW_LOG_MAX_BYTES`, falling back to the default if
+    /// the variable is unset or unparseable.
+    pub fn from_env() -> Self {
         let max_bytes = std::env::var("IRONCLAW_LOG_MAX_BYTES")
             .ok()
             .and_then(|v| match v.parse::<usize>() {
@@ -73,9 +83,7 @@ impl Default for TruncatingStderr {
             .unwrap_or(TERMINAL_MAX_EVENT_BYTES);
         Self { max_bytes }
     }
-}
 
-impl TruncatingStderr {
     #[cfg(test)]
     fn with_max_bytes(max_bytes: usize) -> Self {
         Self { max_bytes }

--- a/src/tracing_fmt.rs
+++ b/src/tracing_fmt.rs
@@ -189,6 +189,8 @@ mod tests {
 
     use crate::tracing_fmt::{EventBuffer, TruncatingStderr, utf8_floor};
 
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
     use std::io::Write;
 
     /// Helper: create an EventBuffer that captures output to a shared Vec
@@ -353,5 +355,31 @@ mod tests {
         // Should back up to byte 2 (just "AB"), since bytes 2..5 are all part of 𝄞
         assert!(s.starts_with("AB"), "expected 'AB', got: {}", s);
         assert!(s.contains("...["), "should be truncated, got: {}", s);
+    }
+
+    #[test]
+    fn test_from_env_valid_number() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("IRONCLAW_LOG_MAX_BYTES", "2000") };
+        let writer = TruncatingStderr::from_env();
+        unsafe { std::env::remove_var("IRONCLAW_LOG_MAX_BYTES") };
+        assert_eq!(writer.max_bytes, 2000);
+    }
+
+    #[test]
+    fn test_from_env_invalid_value_falls_back_to_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("IRONCLAW_LOG_MAX_BYTES", "not_a_number") };
+        let writer = TruncatingStderr::from_env();
+        unsafe { std::env::remove_var("IRONCLAW_LOG_MAX_BYTES") };
+        assert_eq!(writer.max_bytes, 500);
+    }
+
+    #[test]
+    fn test_from_env_unset_falls_back_to_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("IRONCLAW_LOG_MAX_BYTES") };
+        let writer = TruncatingStderr::from_env();
+        assert_eq!(writer.max_bytes, 500);
     }
 }


### PR DESCRIPTION


## Summary

- Adds `IRONCLAW_LOG_MAX_BYTES` environment variable to override the terminal log truncation limit (default: 500 bytes)
- Useful for debugging when you need to see full tool call inputs or LLM request bodies in stderr without recompiling
- Invalid values (non-numeric, zero-length, etc.) print a warning to stderr and fall back to the 500-byte default
- No config file changes, no Settings struct changes — set the var at runtime and unset when done

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: confirmed `TruncatingStderr::default()` reads the env var
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None.

## Database Impact

None.

## Blast Radius

Only `src/tracing_fmt.rs`.

## Rollback Plan

Revert the one-function change in the `src/tracing_fmt.rs`.

## Review Follow-Through

None.

---

**Review track**: A (chore)