### PR TITLE
Revert unreviewed process sandbox spawn approval wiring

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -730,7 +730,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 | SSRF IPv6 transition bypass block | ✅ | ❌ | Block IPv4-mapped IPv6 bypasses |
 | Cron webhook SSRF guard | ✅ | ❌ | SSRF checks on webhook delivery |
 | Loopback-first | ✅ | 🚧 | HTTP binds 0.0.0.0 |
-| Docker sandbox | ✅ | ✅ | Orchestrator/worker containers; opt-in `sandbox.docker.gpus` passthrough; Reborn process sandbox MVP adds typed `SandboxProcessPlan`, backend-neutral `ProcessSandboxBackend`, hardened Docker command construction, fail-closed unenforced network hosts, explicit timeout/cancel cleanup, and a host-runtime approval/lease spawn path for `system.process_sandbox.run`; production MITM broker/product wiring still partial |
+| Docker sandbox | ✅ | ✅ | Orchestrator/worker containers; opt-in `sandbox.docker.gpus` passthrough; Reborn process sandbox MVP adds typed `SandboxProcessPlan`, backend-neutral `ProcessSandboxBackend`, hardened Docker command construction, fail-closed unenforced network hosts, and explicit timeout/cancel cleanup, with production MITM broker/product wiring still partial |
 | Podman support | ✅ | ❌ | `--container` accepts both Docker + Podman |
 | WASM sandbox | ❌ | ✅ | IronClaw innovation |
 | Sandbox env sanitization | ✅ | 🚧 | Shell tool scrubs env vars (secret detection); Reborn process sandbox rejects sensitive raw env values in plans and uses placeholders for brokered credentials, but production secure-capture and MITM transport wiring remain partial |

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -875,36 +875,10 @@ pub trait HostRuntime: Send + Sync {
         request: RuntimeCapabilityRequest,
     ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError>;
 
-    async fn spawn_capability(
-        &self,
-        request: RuntimeCapabilityRequest,
-    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
-        Ok(RuntimeCapabilityOutcome::Failed(
-            RuntimeCapabilityFailure::new(
-                request.capability_id,
-                RuntimeFailureKind::Unavailable,
-                Some("capability spawn is unsupported by this host runtime".to_string()),
-            ),
-        ))
-    }
-
     async fn resume_capability(
         &self,
         request: RuntimeCapabilityResumeRequest,
     ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError>;
-
-    async fn resume_spawn_capability(
-        &self,
-        request: RuntimeCapabilityResumeRequest,
-    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
-        Ok(RuntimeCapabilityOutcome::Failed(
-            RuntimeCapabilityFailure::new(
-                request.capability_id,
-                RuntimeFailureKind::Unavailable,
-                Some("capability spawn resume is unsupported by this host runtime".to_string()),
-            ),
-        ))
-    }
 
     async fn visible_capabilities(
         &self,

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -20,7 +20,6 @@ use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchA
 use ironclaw_capabilities::{
     CapabilityHost, CapabilityInvocationError, CapabilityInvocationRequest,
     CapabilityInvocationResult, CapabilityObligationHandler, CapabilityResumeRequest,
-    CapabilitySpawnRequest, CapabilitySpawnResult,
 };
 use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry};
 use ironclaw_host_api::{
@@ -345,77 +344,6 @@ impl HostRuntime for DefaultHostRuntime {
         }
     }
 
-    async fn spawn_capability(
-        &self,
-        request: RuntimeCapabilityRequest,
-    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
-        let RuntimeCapabilityRequest {
-            mut context,
-            capability_id,
-            estimate,
-            input,
-            idempotency_key,
-            trust_decision: _caller_trust_decision,
-        } = request;
-        let scope = context.resource_scope.clone();
-        let invocation_id = context.invocation_id;
-        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
-        if let Some(key) = idempotency_key.as_deref() {
-            tracing::debug!(
-                capability_id = %capability_id,
-                idempotency_key = %key,
-                "capability spawn accepted advisory idempotency key (not yet enforced)"
-            );
-        }
-
-        if let Err(error) = self.enforce_runtime_policy(&capability_id) {
-            tracing::debug!(
-                capability_id = %capability_id,
-                runtime_policy_error_kind = error.kind(),
-                "capability runtime policy rejected spawn before process start"
-            );
-            return Ok(runtime_policy_failure(capability_id, error));
-        }
-
-        let trust_decision = match self.evaluate_invocation_trust(&capability_id) {
-            Ok(host_decision) => host_decision,
-            Err(error) => {
-                tracing::debug!(
-                    capability_id = %capability_id,
-                    trust_error_kind = error.kind(),
-                    "capability trust evaluation failed before spawn"
-                );
-                return Ok(trust_evaluation_failure(capability_id, error));
-            }
-        };
-        context.trust = trust_decision.effective_trust.class();
-
-        let host = self.capability_host();
-        let spawn = CapabilitySpawnRequest {
-            context,
-            capability_id: capability_id.clone(),
-            estimate,
-            input,
-            trust_decision,
-        };
-
-        match host.spawn_json(spawn).await {
-            Ok(result) => Ok(RuntimeCapabilityOutcome::SpawnedProcess(
-                spawned_process_outcome_from(result, capability_id),
-            )),
-            Err(error) => {
-                tracing::debug!(
-                    capability_id = %capability_id,
-                    error_kind = failure_kind_from(&error).as_str(),
-                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
-                    "capability spawn failed"
-                );
-                self.translate_invocation_error(error, capability_id, scope, invocation_id)
-                    .await
-            }
-        }
-    }
-
     async fn resume_capability(
         &self,
         request: RuntimeCapabilityResumeRequest,
@@ -498,94 +426,6 @@ impl HostRuntime for DefaultHostRuntime {
                     error_kind = failure_kind_from(&error).as_str(),
                     idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability resume failed"
-                );
-                Ok(RuntimeCapabilityOutcome::Failed(failure_from(
-                    error,
-                    capability_id,
-                )))
-            }
-        }
-    }
-
-    async fn resume_spawn_capability(
-        &self,
-        request: RuntimeCapabilityResumeRequest,
-    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
-        let RuntimeCapabilityResumeRequest {
-            mut context,
-            approval_request_id,
-            capability_id,
-            estimate,
-            input,
-            idempotency_key,
-            trust_decision: _caller_trust_decision,
-        } = request;
-        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
-        if let Some(key) = idempotency_key.as_deref() {
-            tracing::debug!(
-                capability_id = %capability_id,
-                approval_request_id = %approval_request_id,
-                idempotency_key = %key,
-                "capability spawn resume accepted advisory idempotency key (not yet enforced)"
-            );
-        }
-
-        if let Err(error) = self.enforce_runtime_policy(&capability_id) {
-            tracing::debug!(
-                capability_id = %capability_id,
-                runtime_policy_error_kind = error.kind(),
-                "capability runtime policy rejected spawn resume before process start"
-            );
-            self.fail_matching_blocked_resume_on_preflight_error(
-                &context,
-                &capability_id,
-                approval_request_id,
-                error.kind(),
-            )
-            .await;
-            return Ok(runtime_policy_failure(capability_id, error));
-        }
-
-        let trust_decision = match self.evaluate_invocation_trust(&capability_id) {
-            Ok(host_decision) => host_decision,
-            Err(error) => {
-                tracing::debug!(
-                    capability_id = %capability_id,
-                    trust_error_kind = error.kind(),
-                    "capability trust evaluation failed before spawn resume"
-                );
-                self.fail_matching_blocked_resume_on_preflight_error(
-                    &context,
-                    &capability_id,
-                    approval_request_id,
-                    error.kind(),
-                )
-                .await;
-                return Ok(trust_evaluation_failure(capability_id, error));
-            }
-        };
-        context.trust = trust_decision.effective_trust.class();
-
-        let host = self.capability_host();
-        let resume = CapabilityResumeRequest {
-            context,
-            approval_request_id,
-            capability_id: capability_id.clone(),
-            estimate,
-            input,
-            trust_decision,
-        };
-
-        match host.resume_spawn_json(resume).await {
-            Ok(result) => Ok(RuntimeCapabilityOutcome::SpawnedProcess(
-                spawned_process_outcome_from(result, capability_id),
-            )),
-            Err(error) => {
-                tracing::debug!(
-                    capability_id = %capability_id,
-                    error_kind = failure_kind_from(&error).as_str(),
-                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
-                    "capability spawn resume failed"
                 );
                 Ok(RuntimeCapabilityOutcome::Failed(failure_from(
                     error,
@@ -1211,16 +1051,6 @@ fn completed_outcome_from(
         capability_id,
         output: result.dispatch.output,
         usage: result.dispatch.usage,
-    }
-}
-
-fn spawned_process_outcome_from(
-    result: CapabilitySpawnResult,
-    capability_id: CapabilityId,
-) -> crate::RuntimeProcessHandle {
-    crate::RuntimeProcessHandle {
-        process_id: result.process.process_id,
-        capability_id,
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -2974,121 +2974,6 @@ async fn host_runtime_routes_system_process_sandbox_to_configured_executor() {
 }
 
 #[tokio::test]
-async fn host_runtime_spawn_process_sandbox_routes_approved_request_to_configured_executor() {
-    let process_services = ProcessServices::in_memory();
-    let result_store = process_services.result_store();
-    let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
-    let runtime = HostRuntimeServices::new(
-        Arc::new(registry_with_host_bundled_manifest(
-            PROCESS_SANDBOX_MANIFEST,
-        )),
-        Arc::new(LocalFilesystem::new()),
-        Arc::new(InMemoryResourceGovernor::new()),
-        Arc::new(GrantAuthorizer::new()),
-        process_services,
-        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
-    )
-    .with_trust_policy(Arc::new(local_manifest_trust_policy(
-        "system.process_sandbox",
-        process_sandbox_authority_effects(),
-    )))
-    .with_process_sandbox_executor(Arc::clone(&sandbox_executor))
-    .host_runtime_for_local_testing();
-    let scope = sample_scope(InvocationId::new());
-
-    let outcome = runtime
-        .spawn_capability(process_sandbox_runtime_request_for_scope(scope.clone()))
-        .await
-        .unwrap();
-
-    let process_id = match outcome {
-        RuntimeCapabilityOutcome::SpawnedProcess(handle) => {
-            assert_eq!(handle.capability_id, process_sandbox_capability_id());
-            handle.process_id
-        }
-        other => panic!("expected spawned process, got {other:?}"),
-    };
-    wait_for_sandbox_process_result(&sandbox_executor, &scope, process_id, result_store.as_ref())
-        .await;
-}
-
-#[tokio::test]
-async fn host_runtime_spawn_process_sandbox_blocks_for_approval_before_executor() {
-    let run_state = Arc::new(InMemoryRunStateStore::new());
-    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
-    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
-    let process_services = ProcessServices::in_memory();
-    let result_store = process_services.result_store();
-    let sandbox_executor = Arc::new(RecordingSandboxProcessExecutor::default());
-    let services = HostRuntimeServices::new(
-        Arc::new(registry_with_host_bundled_manifest(
-            PROCESS_SANDBOX_MANIFEST,
-        )),
-        Arc::new(LocalFilesystem::new()),
-        Arc::new(InMemoryResourceGovernor::new()),
-        Arc::new(ApprovalThenGrantAuthorizer),
-        process_services,
-        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
-    )
-    .with_trust_policy(Arc::new(local_manifest_trust_policy(
-        "system.process_sandbox",
-        process_sandbox_authority_effects(),
-    )))
-    .with_run_state(Arc::clone(&run_state))
-    .with_approval_requests(Arc::clone(&approval_requests))
-    .with_capability_leases(Arc::clone(&capability_leases))
-    .with_process_sandbox_executor(Arc::clone(&sandbox_executor));
-    let runtime = services.host_runtime_for_local_testing();
-    let scope = sample_scope(InvocationId::new());
-    let context = execution_context_without_grants_for_scope(scope.clone());
-    let input = process_sandbox_input();
-    let estimate = process_sandbox_estimate();
-
-    let blocked = runtime
-        .spawn_capability(RuntimeCapabilityRequest::new(
-            context.clone(),
-            process_sandbox_capability_id(),
-            estimate.clone(),
-            input.clone(),
-            process_sandbox_trust_decision(),
-        ))
-        .await
-        .unwrap();
-
-    let approval_request_id = match blocked {
-        RuntimeCapabilityOutcome::ApprovalRequired(gate) => {
-            assert_eq!(gate.capability_id, process_sandbox_capability_id());
-            gate.approval_request_id
-        }
-        other => panic!("expected approval gate, got {other:?}"),
-    };
-    assert!(
-        sandbox_executor.requests().is_empty(),
-        "process sandbox executor must not run before approval"
-    );
-
-    approve_spawn_for_services(&services, &scope, approval_request_id, None).await;
-    let resumed = runtime
-        .resume_spawn_capability(RuntimeCapabilityResumeRequest::new(
-            context,
-            approval_request_id,
-            process_sandbox_capability_id(),
-            estimate,
-            input,
-            process_sandbox_trust_decision(),
-        ))
-        .await
-        .unwrap();
-
-    let process_id = match resumed {
-        RuntimeCapabilityOutcome::SpawnedProcess(handle) => handle.process_id,
-        other => panic!("expected spawned process after approval, got {other:?}"),
-    };
-    wait_for_sandbox_process_result(&sandbox_executor, &scope, process_id, result_store.as_ref())
-        .await;
-}
-
-#[tokio::test]
 async fn host_runtime_services_installs_builtin_obligation_handler_with_audit_sink() {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
     let filesystem = Arc::new(LocalFilesystem::new());
@@ -5283,33 +5168,6 @@ async fn approve_dispatch_for_services(
         .unwrap()
 }
 
-async fn approve_spawn_for_services(
-    services: &InMemoryHostRuntimeServices,
-    scope: &ResourceScope,
-    approval_request_id: ApprovalRequestId,
-    expires_at: Option<Timestamp>,
-) -> ironclaw_authorization::CapabilityLease {
-    services
-        .approval_resolver()
-        .expect("approval resolver should be configured")
-        .approve_spawn(
-            scope,
-            approval_request_id,
-            LeaseApproval {
-                issued_by: Principal::HostRuntime,
-                allowed_effects: process_sandbox_authority_effects(),
-                mounts: MountView::default(),
-                network: NetworkPolicy::default(),
-                secrets: Vec::new(),
-                resource_ceiling: None,
-                expires_at,
-                max_invocations: Some(1),
-            },
-        )
-        .await
-        .unwrap()
-}
-
 struct SentinelApprovalAuthorizer;
 
 #[async_trait]
@@ -5374,35 +5232,6 @@ impl TrustAwareCapabilityDispatchAuthorizer for ApprovalThenGrantAuthorizer {
         } else {
             GrantAuthorizer::new()
                 .authorize_dispatch_with_trust(context, descriptor, estimate, trust_decision)
-                .await
-        }
-    }
-
-    async fn authorize_spawn_with_trust(
-        &self,
-        context: &ExecutionContext,
-        descriptor: &CapabilityDescriptor,
-        estimate: &ResourceEstimate,
-        trust_decision: &TrustDecision,
-    ) -> Decision {
-        if context.grants.grants.is_empty() {
-            Decision::RequireApproval {
-                request: ApprovalRequest {
-                    id: ApprovalRequestId::new(),
-                    correlation_id: context.correlation_id,
-                    requested_by: Principal::Extension(context.extension_id.clone()),
-                    action: Box::new(Action::SpawnCapability {
-                        capability: descriptor.id.clone(),
-                        estimated_resources: estimate.clone(),
-                    }),
-                    invocation_fingerprint: None,
-                    reason: "spawn approval required".to_string(),
-                    reusable_scope: None,
-                },
-            }
-        } else {
-            GrantAuthorizer::new()
-                .authorize_spawn_with_trust(context, descriptor, estimate, trust_decision)
                 .await
         }
     }
@@ -6327,15 +6156,6 @@ fn registry_with_manifest(manifest: &str) -> ExtensionRegistry {
     registry_with_manifests(&[manifest])
 }
 
-fn registry_with_host_bundled_manifest(manifest: &str) -> ExtensionRegistry {
-    let mut registry = ExtensionRegistry::new();
-    let manifest = parse_manifest_from_source(manifest, ManifestSource::HostBundled);
-    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
-    let package = ExtensionPackage::from_manifest(manifest, root).unwrap();
-    registry.insert(package).unwrap();
-    registry
-}
-
 fn registry_with_builtin_first_party_package() -> ExtensionRegistry {
     let mut registry = ExtensionRegistry::new();
     registry
@@ -6357,12 +6177,13 @@ fn registry_with_manifests(manifests: &[&str]) -> ExtensionRegistry {
 }
 
 fn parse_manifest(manifest: &str) -> ExtensionManifest {
-    parse_manifest_from_source(manifest, ManifestSource::InstalledLocal)
-}
-
-fn parse_manifest_from_source(manifest: &str, source: ManifestSource) -> ExtensionManifest {
     let manifest = legacy_capability_fixture_to_v2(manifest);
-    ExtensionManifest::parse(&manifest, source, &HostPortCatalog::empty()).unwrap()
+    ExtensionManifest::parse(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap()
 }
 
 fn execution_context_without_grants() -> ExecutionContext {
@@ -6417,18 +6238,6 @@ fn execution_context_with_dispatch_grant_for_scope(
     capability: CapabilityId,
     scope: ResourceScope,
 ) -> ExecutionContext {
-    execution_context_with_effect_grants_for_scope(
-        capability,
-        scope,
-        vec![EffectKind::DispatchCapability, EffectKind::Network],
-    )
-}
-
-fn execution_context_with_effect_grants_for_scope(
-    capability: CapabilityId,
-    scope: ResourceScope,
-    allowed_effects: Vec<EffectKind>,
-) -> ExecutionContext {
     let context = ExecutionContext {
         invocation_id: scope.invocation_id,
         correlation_id: CorrelationId::new(),
@@ -6443,7 +6252,7 @@ fn execution_context_with_effect_grants_for_scope(
         extension_id: ExtensionId::new("caller").unwrap(),
         runtime: RuntimeKind::Wasm,
         trust: TrustClass::UserTrusted,
-        grants: capability_grants_with_effects(capability, allowed_effects),
+        grants: capability_grants(capability),
         mounts: MountView::default(),
         resource_scope: scope,
     };
@@ -6452,16 +6261,6 @@ fn execution_context_with_effect_grants_for_scope(
 }
 
 fn capability_grants(capability: CapabilityId) -> CapabilitySet {
-    capability_grants_with_effects(
-        capability,
-        vec![EffectKind::DispatchCapability, EffectKind::Network],
-    )
-}
-
-fn capability_grants_with_effects(
-    capability: CapabilityId,
-    allowed_effects: Vec<EffectKind>,
-) -> CapabilitySet {
     let mut grants = CapabilitySet::default();
     grants.grants.push(CapabilityGrant {
         id: CapabilityGrantId::new(),
@@ -6469,7 +6268,7 @@ fn capability_grants_with_effects(
         grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
         issued_by: Principal::HostRuntime,
         constraints: GrantConstraints {
-            allowed_effects,
+            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
             mounts: MountView::default(),
             network: NetworkPolicy::default(),
             secrets: Vec::new(),
@@ -6508,14 +6307,10 @@ fn local_manifest_trust_policy(
 }
 
 fn trust_decision_with_dispatch_authority() -> TrustDecision {
-    trust_decision_with_authority(vec![EffectKind::DispatchCapability, EffectKind::Network])
-}
-
-fn trust_decision_with_authority(allowed_effects: Vec<EffectKind>) -> TrustDecision {
     TrustDecision {
         effective_trust: EffectiveTrustClass::user_trusted(),
         authority_ceiling: AuthorityCeiling {
-            allowed_effects,
+            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
             max_resource_ceiling: None,
         },
         provenance: TrustProvenance::Default,
@@ -6661,42 +6456,8 @@ fn process_sandbox_start(process_id: ProcessId, scope: ResourceScope) -> Process
         mounts: MountView::default(),
         estimated_resources: ResourceEstimate::default(),
         resource_reservation_id: None,
-        input: process_sandbox_input(),
+        input: json!({"run": {"command": "echo", "args": ["ok"]}}),
     }
-}
-
-fn process_sandbox_runtime_request_for_scope(scope: ResourceScope) -> RuntimeCapabilityRequest {
-    RuntimeCapabilityRequest::new(
-        execution_context_with_effect_grants_for_scope(
-            process_sandbox_capability_id(),
-            scope,
-            process_sandbox_authority_effects(),
-        ),
-        process_sandbox_capability_id(),
-        process_sandbox_estimate(),
-        process_sandbox_input(),
-        process_sandbox_trust_decision(),
-    )
-}
-
-fn process_sandbox_estimate() -> ResourceEstimate {
-    ResourceEstimate {
-        process_count: Some(1),
-        concurrency_slots: Some(1),
-        ..ResourceEstimate::default()
-    }
-}
-
-fn process_sandbox_input() -> serde_json::Value {
-    json!({"run": {"command": "echo", "args": ["ok"]}})
-}
-
-fn process_sandbox_authority_effects() -> Vec<EffectKind> {
-    vec![EffectKind::ExecuteCode, EffectKind::SpawnProcess]
-}
-
-fn process_sandbox_trust_decision() -> TrustDecision {
-    trust_decision_with_authority(process_sandbox_authority_effects())
 }
 
 fn script_extension_id() -> ExtensionId {
@@ -6980,25 +6741,6 @@ id = "script.echo"
 description = "Echo through Script"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
-"#;
-
-const PROCESS_SANDBOX_MANIFEST: &str = r#"
-id = "system.process_sandbox"
-name = "Process Sandbox"
-version = "0.1.0"
-description = "System process sandbox runtime"
-trust = "system_requested"
-
-[runtime]
-kind = "system"
-service = "process_sandbox"
-
-[[capabilities]]
-id = "system.process_sandbox.run"
-description = "Run a process inside the system sandbox backend"
-effects = ["execute_code", "spawn_process"]
-default_permission = "ask"
 parameters_schema = { type = "object" }
 "#;
 


### PR DESCRIPTION
## Summary

Reverts the unreviewed `wire process sandbox spawn approvals` change that was included in the squash merge of #4072.

This removes the host-runtime `spawn_capability` / `resume_spawn_capability` additions, the process-sandbox approval-path tests, and the parity note that described that wiring. The change should be reviewed separately in a follow-up PR.

## Validation

- `git diff --check HEAD~1..HEAD`
