### PR TITLE
[codex] Skip unchanged turn state snapshots

### DIFF
--- a/crates/ironclaw_turns/src/filesystem_store.rs
+++ b/crates/ironclaw_turns/src/filesystem_store.rs
@@ -175,9 +175,13 @@ where
         let _guard = record_lock.lock().await;
         for _ in 0..FILESYSTEM_CAS_RETRIES {
             let (snapshot, version) = self.read_snapshot_unlocked().await?;
+            let old_snapshot = snapshot.clone();
             let store = self.build_in_memory_store(snapshot)?;
             let (outcome, store) = apply(store).await;
             let new_snapshot = store.persistence_snapshot();
+            if new_snapshot == old_snapshot {
+                return outcome;
+            }
             let entry = snapshot_entry(&new_snapshot)?;
             let cas = match version {
                 Some(v) => CasExpectation::Version(v),

--- a/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
+++ b/crates/ironclaw_turns/tests/filesystem_turn_state_contract.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
-use ironclaw_filesystem::{LocalFilesystem, RootFilesystem, ScopedFilesystem};
+use ironclaw_filesystem::{FilesystemError, LocalFilesystem, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     AgentId, HostPath, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, TenantId,
     ThreadId, UserId, VirtualPath,
@@ -14,7 +14,9 @@ use ironclaw_turns::{
     AcceptedMessageRef, AllowAllTurnAdmissionPolicy, FilesystemTurnStateStore, GetRunStateRequest,
     IdempotencyKey, InMemoryRunProfileResolver, ReplyTargetBindingRef, RunProfileRequest,
     SourceBindingRef, SubmitChildRunRequest, SubmitTurnRequest, SubmitTurnResponse, TurnActor,
-    TurnError, TurnRunId, TurnScope, TurnSpawnTreeStateStore, TurnStateStore, TurnStatus,
+    TurnError, TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope, TurnSpawnTreeStateStore,
+    TurnStateStore, TurnStatus,
+    runner::{ClaimRunRequest, RecoverExpiredLeasesRequest, TurnRunTransitionPort},
 };
 
 /// Build a [`LocalFilesystem`] with `/engine` mounted to a tempdir; the
@@ -55,6 +57,10 @@ where
     scoped_turns_fs_at(backend, "test-tenant", "test-user")
 }
 
+fn snapshot_virtual_path() -> VirtualPath {
+    VirtualPath::new("/engine/tenants/test-tenant/users/test-user/turns/state.json").unwrap()
+}
+
 fn turn_scope(thread: &str) -> TurnScope {
     TurnScope::new(
         TenantId::new("tenant1").unwrap(),
@@ -89,6 +95,41 @@ fn submit_request_for(scope: TurnScope, idempotency_key: &str) -> SubmitTurnRequ
 fn accepted_run_id(response: &SubmitTurnResponse) -> TurnRunId {
     let SubmitTurnResponse::Accepted { run_id, .. } = response;
     *run_id
+}
+
+#[tokio::test]
+async fn filesystem_turn_state_store_does_not_write_unchanged_idle_runner_snapshot() {
+    let backend = Arc::new(engine_filesystem());
+    let scoped = scoped_turns_fs(Arc::clone(&backend));
+    let store = FilesystemTurnStateStore::new(scoped);
+
+    let claimed = store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: TurnRunnerId::new(),
+            lease_token: TurnLeaseToken::new(),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+    assert!(claimed.is_none());
+
+    let recovered = store
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: Utc.with_ymd_and_hms(2026, 5, 27, 0, 12, 0).unwrap(),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+    assert!(recovered.recovered.is_empty());
+
+    let err = backend
+        .read_file(&snapshot_virtual_path())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, FilesystemError::NotFound { .. }),
+        "idle no-op runner polling must not create or rewrite the snapshot: {err:?}"
+    );
 }
 
 fn child_run_request(


### PR DESCRIPTION
## Summary

Skip filesystem snapshot writes when a turn-state operation leaves the durable snapshot unchanged.

## Observed bug

During idle Reborn turn-runner polling, the runner repeatedly called state-store operations such as `claim_next_run` and expired-lease recovery even when there was no work to claim and no lease to recover. The filesystem-backed turn store implemented those operations by loading the persisted snapshot into the in-memory store and then always writing the resulting snapshot back through the configured filesystem.

That meant logically read-only idle polling still performed writes to `/turns/state.json`. In the observed local-dev failure, those no-op writes went through the filesystem backend backed by SQLite/libSQL and failed with `SQLite failure: unable to open database file`. Because the runner kept polling, the same persistence failure repeated as `turn state persistence temporarily unavailable`, even though there was no turn-state change that actually needed to be persisted.

## Fix

`FilesystemTurnStateStore::apply` now compares the post-operation persistence snapshot with the snapshot it loaded. If the operation made no logical change, it returns the operation outcome without serializing or writing `state.json`.

This keeps the fix at the persistence boundary instead of special-casing individual runner operations.

## Tests

- `cargo fmt --check`
- `cargo test -p ironclaw_turns filesystem_turn_state_store_does_not_write_unchanged_idle_runner_snapshot`
- `cargo test -p ironclaw_turns --test filesystem_turn_state_contract`
