### PR TITLE
Enable save_to for Reborn builtin HTTP

### DIFF
--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -221,6 +221,22 @@ where
         self.root.write_file(&virtual_path, bytes).await
     }
 
+    /// Write bytes using an already-authorized mount view instead of the
+    /// filesystem's configured resolver.
+    ///
+    /// This is for host adapters that parse a scoped path against the exact
+    /// invocation-visible mounts and need the write to use that same authority.
+    pub async fn write_file_with_mount_view(
+        &self,
+        view: &MountView,
+        path: &ScopedPath,
+        bytes: &[u8],
+    ) -> Result<(), FilesystemError> {
+        let virtual_path =
+            resolve_with_permission_view(view, path, FilesystemOperation::WriteFile)?;
+        self.root.write_file(&virtual_path, bytes).await
+    }
+
     /// **DEPRECATED — no direct replacement on the unified surface.** Use
     /// `append`/`tail` for log-shaped mounts or `get`+`put` for
     /// read-modify-write.

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    CapabilityId, HostApiError, NetworkMethod, NetworkPolicy, ResourceScope, RuntimeKind,
-    ScopedPath, SecretHandle,
+    CapabilityId, HostApiError, MountView, NetworkMethod, NetworkPolicy, ResourceScope,
+    RuntimeKind, ScopedPath, SecretHandle,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,6 +51,14 @@ pub struct RuntimeHttpEgressRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeHttpSaveTarget {
     pub path: ScopedPath,
+    /// Host-derived mount authority used to parse and authorize `path`.
+    ///
+    /// This is skipped on the wire so guest/runtime-provided requests cannot
+    /// grant themselves filesystem authority by serializing a custom mount
+    /// view. Host translators that already hold an invocation mount view may
+    /// attach it before dispatching to the host egress service.
+    #[serde(skip)]
+    pub mount_view: Option<MountView>,
 }
 
 /// One host-approved credential injection.

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1005,6 +1005,7 @@ fn runtime_http_egress_request_defaults_optional_body_controls() {
         response_body_limit: Some(4096),
         save_body_to: Some(RuntimeHttpSaveTarget {
             path: ScopedPath::new("/workspace/body.json").unwrap(),
+            mount_view: None,
         }),
         timeout_ms: None,
     })

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -1,10 +1,10 @@
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use ironclaw_extensions::{CapabilityManifest, ExtensionError};
 use ironclaw_host_api::{
-    EffectKind, NetworkMethod, NetworkPolicy, PermissionMode, ResourceCeiling, ResourceEstimate,
-    ResourceProfile, ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgressError,
-    RuntimeHttpEgressReasonCode, RuntimeHttpEgressRequest, RuntimeKind, SandboxQuota,
-    valid_http_field_name,
+    EffectKind, MountView, NetworkMethod, NetworkPolicy, PermissionMode, ResourceCeiling,
+    ResourceEstimate, ResourceProfile, ResourceUsage, RuntimeDispatchErrorKind,
+    RuntimeHttpEgressError, RuntimeHttpEgressReasonCode, RuntimeHttpEgressRequest,
+    RuntimeHttpSaveTarget, RuntimeKind, SandboxQuota, ScopedPath, valid_http_field_name,
 };
 use serde_json::{Map, Value, json};
 
@@ -124,6 +124,14 @@ pub(super) async fn dispatch(
             error,
         )
     })?;
+    let save_body_to = save_body_to(&request.input, request.mounts.as_ref()).map_err(|error| {
+        log_raw_http_input_error_for_local_diagnostics(
+            unsafe_raw_diagnostics_allowed,
+            &request.input,
+            "save_to",
+            error,
+        )
+    })?;
     let http_request = RuntimeHttpEgressRequest {
         runtime: RuntimeKind::FirstParty,
         scope: request.scope.clone(),
@@ -137,7 +145,7 @@ pub(super) async fn dispatch(
         // Always send a bounded limit, even when caller omits the field, so the
         // host transport stays fail-closed instead of inheriting an unbounded cap.
         response_body_limit: Some(response_body_limit),
-        save_body_to: None,
+        save_body_to,
         timeout_ms: Some(timeout_ms),
     };
     let response = tokio::task::spawn_blocking(move || egress.execute(http_request))
@@ -152,17 +160,27 @@ pub(super) async fn dispatch(
     let mut output = Map::new();
     output.insert("status".to_string(), json!(response.status));
     output.insert("headers".to_string(), response_headers(response.headers));
-    // Response bodies must be valid UTF-8 to appear as body_text. Any invalid
-    // byte returns the full response as body_base64 to avoid lossy surprises.
-    match String::from_utf8(response.body) {
-        Ok(body_text) => {
-            output.insert("body_text".to_string(), Value::String(body_text));
-        }
-        Err(error) => {
-            output.insert(
-                "body_base64".to_string(),
-                Value::String(BASE64_STANDARD.encode(error.into_bytes())),
-            );
+    if let Some(saved_body) = response.saved_body {
+        output.insert(
+            "saved_body".to_string(),
+            json!({
+                "path": saved_body.path.as_str(),
+                "bytes_written": saved_body.bytes_written,
+            }),
+        );
+    } else {
+        // Response bodies must be valid UTF-8 to appear as body_text. Any invalid
+        // byte returns the full response as body_base64 to avoid lossy surprises.
+        match String::from_utf8(response.body) {
+            Ok(body_text) => {
+                output.insert("body_text".to_string(), Value::String(body_text));
+            }
+            Err(error) => {
+                output.insert(
+                    "body_base64".to_string(),
+                    Value::String(BASE64_STANDARD.encode(error.into_bytes())),
+                );
+            }
         }
     }
     output.insert("request_bytes".to_string(), json!(response.request_bytes));
@@ -308,6 +326,28 @@ fn timeout_ms(input: &Value) -> Result<u32, FirstPartyCapabilityError> {
     )?;
     let value = value.min(u64::from(MAX_HTTP_TIMEOUT_MS));
     u32::try_from(value).map_err(|_| input_error())
+}
+
+fn save_body_to(
+    input: &Value,
+    mounts: Option<&MountView>,
+) -> Result<Option<RuntimeHttpSaveTarget>, FirstPartyCapabilityError> {
+    let Some(value) = input.get("save_to") else {
+        return Ok(None);
+    };
+    let path = value.as_str().ok_or_else(input_error)?;
+    if path.trim().is_empty() {
+        return Ok(None);
+    }
+    let path = match mounts {
+        Some(mounts) => mounts.scoped_path(path.to_string()),
+        None => ScopedPath::new(path.to_string()),
+    }
+    .map_err(|_| input_error())?;
+    Ok(Some(RuntimeHttpSaveTarget {
+        path,
+        mount_view: mounts.cloned(),
+    }))
 }
 
 fn ranged_u64(

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -63,6 +63,10 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
                     "default": 10485760,
                     "description": "Maximum response body bytes. Defaults to 10 MiB; smaller values are raised to 10 MiB."
                 },
+                "save_to": {
+                    "type": "string",
+                    "description": "Scoped path to save the sanitized response body, e.g. /workspace/response.json"
+                },
                 "timeout_ms": {
                     "type": "integer",
                     "minimum": 1,

--- a/crates/ironclaw_host_runtime/src/http_body.rs
+++ b/crates/ironclaw_host_runtime/src/http_body.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use ironclaw_filesystem::{FilesystemError, FilesystemOperation, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     CapabilityId, ResourceScope, RuntimeHttpEgressError, RuntimeHttpSaveTarget,
     RuntimeHttpSavedBody,
@@ -28,6 +29,95 @@ pub trait RuntimeHttpBodyStore: fmt::Debug + Send + Sync {
 #[error("runtime HTTP body store error: {reason}")]
 pub struct RuntimeHttpBodyStoreError {
     pub reason: String,
+}
+
+impl<F> RuntimeHttpBodyStore for ScopedFilesystem<F>
+where
+    F: RootFilesystem + ?Sized,
+{
+    fn authorize_write(
+        &self,
+        scope: &ResourceScope,
+        _capability_id: &CapabilityId,
+        target: &RuntimeHttpSaveTarget,
+    ) -> Result<(), RuntimeHttpBodyStoreError> {
+        let resolved_view;
+        let view = match target.mount_view.as_ref() {
+            Some(view) => view,
+            None => {
+                resolved_view = self
+                    .mount_view(scope)
+                    .map_err(runtime_http_body_store_error)?;
+                &resolved_view
+            }
+        };
+        let (_path, grant) = view
+            .resolve_with_grant(&target.path)
+            .map_err(runtime_http_body_store_error)?;
+        if !grant.permissions.write {
+            return Err(RuntimeHttpBodyStoreError {
+                reason: format!(
+                    "write permission denied for {} on {}",
+                    FilesystemOperation::WriteFile,
+                    target.path
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    fn write_body(
+        &self,
+        scope: &ResourceScope,
+        _capability_id: &CapabilityId,
+        target: &RuntimeHttpSaveTarget,
+        body: &[u8],
+    ) -> Result<(), RuntimeHttpBodyStoreError> {
+        let write = async {
+            match target.mount_view.as_ref() {
+                Some(view) => {
+                    self.write_file_with_mount_view(view, &target.path, body)
+                        .await
+                }
+                None => self.write_file(scope, &target.path, body).await,
+            }
+        };
+        block_on_filesystem(write).map(|_| ())
+    }
+}
+
+fn block_on_filesystem<T>(
+    future: impl std::future::Future<Output = Result<T, FilesystemError>> + Send,
+) -> Result<T, RuntimeHttpBodyStoreError>
+where
+    T: Send,
+{
+    let joined = std::thread::scope(|scope| {
+        scope
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|_| RuntimeHttpBodyStoreError {
+                        reason: "filesystem runtime unavailable".to_string(),
+                    })?;
+                runtime
+                    .block_on(future)
+                    .map_err(runtime_http_body_store_error)
+            })
+            .join()
+    });
+    joined.unwrap_or_else(|_| {
+        Err(RuntimeHttpBodyStoreError {
+            reason: "filesystem worker panicked".to_string(),
+        })
+    })
+}
+
+fn runtime_http_body_store_error(error: impl std::fmt::Display) -> RuntimeHttpBodyStoreError {
+    RuntimeHttpBodyStoreError {
+        reason: error.to_string(),
+    }
 }
 
 pub(crate) fn apply_body_disposition(

--- a/crates/ironclaw_host_runtime/src/services/builder.rs
+++ b/crates/ironclaw_host_runtime/src/services/builder.rs
@@ -24,6 +24,7 @@ use super::{
     production_wiring_report, set_runtime_http_egress,
 };
 use crate::LocalHostProcessPort;
+use crate::RuntimeHttpBodyStore;
 use crate::wasm_credentials::SharedHostWasmRuntimeCredentials;
 
 impl<F, G, S, R> HostRuntimeServices<F, G, S, R>
@@ -740,6 +741,30 @@ where
     where
         N: NetworkHttpEgress + 'static,
     {
+        self.try_with_host_http_egress_internal(network, None)
+    }
+
+    pub fn try_with_host_http_egress_with_body_store<N, T>(
+        self,
+        network: N,
+        body_store: Arc<T>,
+    ) -> Result<Self, ProductionWiringReport>
+    where
+        N: NetworkHttpEgress + 'static,
+        T: RuntimeHttpBodyStore + 'static,
+    {
+        let body_store: Arc<dyn RuntimeHttpBodyStore> = body_store;
+        self.try_with_host_http_egress_internal(network, Some(body_store))
+    }
+
+    fn try_with_host_http_egress_internal<N>(
+        self,
+        network: N,
+        body_store: Option<Arc<dyn RuntimeHttpBodyStore>>,
+    ) -> Result<Self, ProductionWiringReport>
+    where
+        N: NetworkHttpEgress + 'static,
+    {
         let Some(secret_store) = self.secret_store.clone() else {
             return Err(production_wiring_report(
                 ProductionWiringComponent::SecretStore,
@@ -747,7 +772,7 @@ where
                 None,
             ));
         };
-        let runtime_http_egress = Arc::new(
+        let mut service =
             crate::HostHttpEgressService::new(network, SharedSecretStore(secret_store))
                 .with_network_policy_store(Arc::clone(&self.network_policy_store))
                 .with_secret_injection_store(Arc::clone(&self.secret_injection_store))
@@ -755,8 +780,11 @@ where
                     crate::runtime_policy_allows_unsafe_raw_http_diagnostics(
                         self.runtime_policy.as_ref(),
                     ),
-                ),
-        );
+                );
+        if let Some(store) = body_store {
+            service = service.with_body_store(store);
+        }
+        let runtime_http_egress = Arc::new(service);
         Ok(self.with_host_http_egress_service(runtime_http_egress))
     }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -657,8 +657,62 @@ async fn builtin_http_invokes_through_host_runtime_egress() {
     assert_eq!(request.url, "https://api.example.test/v1/items");
     assert_eq!(request.body, br#"{"ok":true}"#);
     assert_eq!(request.response_body_limit, Some(10 * 1024 * 1024));
+    assert_eq!(request.save_body_to, None);
     assert_eq!(request.timeout_ms, Some(2500));
     assert!(request.credential_injections.is_empty());
+}
+
+#[tokio::test]
+async fn builtin_http_passes_save_to_and_returns_saved_body_metadata() {
+    let egress = Arc::new(
+        RecordingRuntimeHttpEgress::with_body(br#"{"accepted":true}"#.to_vec())
+            .with_saved_body("/workspace/response.json", 17),
+    );
+    let runtime = runtime_with_http_egress(Arc::clone(&egress));
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/workspace").unwrap(),
+        MountPermissions::read_write(),
+    )])
+    .unwrap();
+
+    let output = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "save_to": "/workspace/response.json"
+        }),
+        execution_context_with_mounts_and_network([HTTP_CAPABILITY_ID], mounts, http_test_policy()),
+    )
+    .await
+    .unwrap_or_else(|error| {
+        panic!(
+            "expected saved-body HTTP success, got {error:?}; recorded requests: {:?}",
+            egress.requests()
+        )
+    });
+
+    assert_eq!(output["status"], json!(200));
+    assert_eq!(
+        output["saved_body"],
+        json!({
+            "path": "/workspace/response.json",
+            "bytes_written": 17
+        })
+    );
+    assert!(output.get("body_text").is_none());
+    assert!(output.get("body_base64").is_none());
+
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0]
+            .save_body_to
+            .as_ref()
+            .map(|target| target.path.as_str()),
+        Some("/workspace/response.json")
+    );
 }
 
 // arch-exempt: large-test-file, URL install tests share this first-party runtime harness; split plan #4062
@@ -3960,6 +4014,7 @@ struct RecordingRuntimeHttpEgress {
     requests: Arc<std::sync::Mutex<Vec<RuntimeHttpEgressRequest>>>,
     status: u16,
     body: Vec<u8>,
+    saved_body: Option<RuntimeHttpSavedBody>,
     error: Option<RuntimeHttpEgressError>,
     responses: Option<BTreeMap<String, (u16, Vec<u8>)>>,
 }
@@ -3970,6 +4025,7 @@ impl RecordingRuntimeHttpEgress {
             requests: Arc::new(std::sync::Mutex::new(Vec::new())),
             status: 200,
             body,
+            saved_body: None,
             error: None,
             responses: None,
         }
@@ -3980,6 +4036,7 @@ impl RecordingRuntimeHttpEgress {
             requests: Arc::new(std::sync::Mutex::new(Vec::new())),
             status,
             body,
+            saved_body: None,
             error: None,
             responses: None,
         }
@@ -3990,9 +4047,18 @@ impl RecordingRuntimeHttpEgress {
             requests: Arc::new(std::sync::Mutex::new(Vec::new())),
             status: 200,
             body: Vec::new(),
+            saved_body: None,
             error: Some(error),
             responses: None,
         }
+    }
+
+    fn with_saved_body(mut self, path: &str, bytes_written: u64) -> Self {
+        self.saved_body = Some(RuntimeHttpSavedBody {
+            path: ScopedPath::new(path).unwrap(),
+            bytes_written,
+        });
+        self
     }
 
     fn with_url_bodies(responses: BTreeMap<String, (u16, Vec<u8>)>) -> Self {
@@ -4000,6 +4066,7 @@ impl RecordingRuntimeHttpEgress {
             requests: Arc::new(std::sync::Mutex::new(Vec::new())),
             status: 200,
             body: Vec::new(),
+            saved_body: None,
             error: None,
             responses: Some(responses),
         }
@@ -4033,7 +4100,7 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
             status,
             headers: vec![("content-type".to_string(), "application/json".to_string())],
             body: body.clone(),
-            saved_body: None,
+            saved_body: self.saved_body.clone(),
             request_bytes: request.body.len() as u64,
             response_bytes: body.len() as u64,
             redaction_applied: false,

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -2,12 +2,14 @@ use ironclaw_capabilities::{
     CapabilityObligationHandler, CapabilityObligationPhase, CapabilityObligationRequest,
 };
 use ironclaw_events::InMemoryAuditSink;
+use ironclaw_filesystem::{InMemoryBackend, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
-    AgentId, CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, InvocationId, MountView,
-    NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern, Obligation,
-    ResourceEstimate, ResourceScope, RuntimeCredentialInjection, RuntimeCredentialSource,
-    RuntimeCredentialTarget, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
-    RuntimeHttpSaveTarget, RuntimeKind, ScopedPath, SecretHandle, TenantId, TrustClass, UserId,
+    AgentId, CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, InvocationId, MountAlias,
+    MountGrant, MountPermissions, MountView, NetworkMethod, NetworkPolicy, NetworkScheme,
+    NetworkTargetPattern, Obligation, ResourceEstimate, ResourceScope, RuntimeCredentialInjection,
+    RuntimeCredentialSource, RuntimeCredentialTarget, RuntimeHttpEgress, RuntimeHttpEgressError,
+    RuntimeHttpEgressRequest, RuntimeHttpSaveTarget, RuntimeKind, ScopedPath, SecretHandle,
+    TenantId, TrustClass, UserId, VirtualPath,
 };
 use ironclaw_host_runtime::{
     BuiltinObligationServices, HostHttpEgressService, RuntimeHttpBodyStore,
@@ -2048,6 +2050,126 @@ fn host_http_egress_saves_sanitized_response_body_to_store() {
 }
 
 #[test]
+fn host_http_egress_saves_response_body_to_scoped_filesystem_store() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![("content-type".to_string(), "text/plain".to_string())],
+        body: b"filesystem patch body".to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 21,
+            resolved_ip: None,
+        },
+    });
+    let root = Arc::new(InMemoryBackend::new());
+    let scoped_filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::clone(&root),
+        MountView::new(Vec::new()).unwrap(),
+    ));
+    let save_mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/workspace").unwrap(),
+        MountPermissions::read_write(),
+    )])
+    .unwrap();
+    let service = HostHttpEgressService::new_with_request_policy_for_tests(
+        network,
+        InMemorySecretStore::new(),
+    )
+    .with_body_store(scoped_filesystem.clone());
+
+    let mut target = save_target("/workspace/pr.diff");
+    target.mount_view = Some(save_mounts);
+    let response = service
+        .execute(RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::FirstParty,
+            scope: sample_scope(),
+            capability_id: sample_capability_id(),
+            method: NetworkMethod::Get,
+            url: "https://api.example.test/v1/run".to_string(),
+            headers: vec![],
+            body: b"hello".to_vec(),
+            network_policy: sample_policy(),
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            save_body_to: Some(target.clone()),
+            timeout_ms: None,
+        })
+        .expect("response body should be saved through the scoped filesystem");
+
+    assert_eq!(response.body, Vec::<u8>::new());
+    assert_eq!(
+        response
+            .saved_body
+            .as_ref()
+            .map(|saved| saved.bytes_written),
+        Some(21)
+    );
+    let saved =
+        block_on_test(root.read_file(&VirtualPath::new("/projects/workspace/pr.diff").unwrap()))
+            .unwrap();
+    assert_eq!(saved, b"filesystem patch body".to_vec());
+}
+
+#[test]
+fn host_http_egress_rejects_save_when_target_mount_view_is_read_only() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![("content-type".to_string(), "text/plain".to_string())],
+        body: b"filesystem patch body".to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 21,
+            resolved_ip: None,
+        },
+    });
+    let network_recorder = network.requests.clone();
+    let scoped_filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::new(InMemoryBackend::new()),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/workspace").unwrap(),
+            MountPermissions::read_write(),
+        )])
+        .unwrap(),
+    ));
+    let service = HostHttpEgressService::new_with_request_policy_for_tests(
+        network,
+        InMemorySecretStore::new(),
+    )
+    .with_body_store(scoped_filesystem.clone());
+
+    let mut target = save_target("/workspace/pr.diff");
+    target.mount_view = Some(
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/workspace").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap(),
+    );
+    let error = service
+        .execute(RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::FirstParty,
+            scope: sample_scope(),
+            capability_id: sample_capability_id(),
+            method: NetworkMethod::Get,
+            url: "https://api.example.test/v1/run".to_string(),
+            headers: vec![],
+            body: b"hello".to_vec(),
+            network_policy: sample_policy(),
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            save_body_to: Some(target.clone()),
+            timeout_ms: None,
+        })
+        .expect_err("read-only target mount should deny saving before network");
+
+    assert_eq!(error.stable_runtime_reason(), "request_denied");
+    assert!(network_recorder.lock().unwrap().is_empty());
+}
+
+#[test]
 fn host_http_egress_save_target_requires_configured_body_store_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
@@ -3080,6 +3202,7 @@ fn sample_capability_id() -> CapabilityId {
 fn save_target(path: &str) -> RuntimeHttpSaveTarget {
     RuntimeHttpSaveTarget {
         path: ScopedPath::new(path).unwrap(),
+        mount_view: None,
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -352,6 +352,10 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         build_local_dev_root_filesystem(&root, &workspace_root, host_home_root.as_ref()).await?;
     let (skill_filesystem, workspace_filesystem, runtime_workspace_mounts) =
         build_workspace_filesystems(Arc::clone(&filesystem), host_home_root.as_ref())?;
+    let http_body_filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
+        Arc::clone(&filesystem),
+        runtime_workspace_mounts.clone(),
+    ));
     let owner_user_id = UserId::new(owner_id).map_err(|error| RebornBuildError::InvalidConfig {
         reason: error.to_string(),
     })?;
@@ -376,9 +380,12 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     .with_first_party_capabilities(Arc::new(builtin_first_party_registry()?))
     .with_trust_policy(Arc::new(local_dev_first_party_trust_policy()?))
     .with_secret_store(Arc::new(ironclaw_secrets::InMemorySecretStore::new()))
-    .try_with_host_http_egress(ironclaw_network::PolicyNetworkHttpEgress::new(
-        ironclaw_network::ReqwestNetworkTransport::default(),
-    ))?
+    .try_with_host_http_egress_with_body_store(
+        ironclaw_network::PolicyNetworkHttpEgress::new(
+            ironclaw_network::ReqwestNetworkTransport::default(),
+        ),
+        http_body_filesystem,
+    )?
     .with_run_state(Arc::clone(&store_graph.run_state))
     .with_approval_requests(Arc::clone(&store_graph.approval_requests))
     .with_capability_leases(Arc::clone(&store_graph.capability_leases))
@@ -1177,9 +1184,12 @@ where
     .with_first_party_capabilities(Arc::new(builtin_first_party_registry()?))
     .with_capability_leases(stores.leases)
     .with_secret_store(stores.secret_store)
-    .try_with_host_http_egress(ironclaw_network::PolicyNetworkHttpEgress::new(
-        ironclaw_network::ReqwestNetworkTransport::default(),
-    ))?
+    .try_with_host_http_egress_with_body_store(
+        ironclaw_network::PolicyNetworkHttpEgress::new(
+            ironclaw_network::ReqwestNetworkTransport::default(),
+        ),
+        Arc::clone(&stores.scoped_filesystem),
+    )?
     .with_filesystem_resource_governor(Arc::clone(&stores.scoped_filesystem))
     .with_reborn_event_store_config(profile.to_event_store_profile(), stores.event_store)
     .await?

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -284,6 +284,7 @@ const PER_USER_ALIASES: &[&str] = &[
     "/resources",
     "/engine",
     "/skills",
+    "/workspace",
 ];
 
 /// Per-invocation [`MountView`] used as the production resolver.
@@ -488,9 +489,10 @@ where
     // `Missing(SecretStore)` wiring report if the host-runtime builder API
     // regresses; treat that as infallible here.
     let services = services
-        .try_with_host_http_egress(PolicyNetworkHttpEgress::new(
-            ReqwestNetworkTransport::default(),
-        ))
+        .try_with_host_http_egress_with_body_store(
+            PolicyNetworkHttpEgress::new(ReqwestNetworkTransport::default()),
+            Arc::clone(&scoped_filesystem),
+        )
         .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
 
     Ok(services)
@@ -557,9 +559,10 @@ where
     // `Missing(SecretStore)` wiring report if the host-runtime builder API
     // regresses; treat that as infallible here.
     let services = services
-        .try_with_host_http_egress(PolicyNetworkHttpEgress::new(
-            ReqwestNetworkTransport::default(),
-        ))
+        .try_with_host_http_egress_with_body_store(
+            PolicyNetworkHttpEgress::new(ReqwestNetworkTransport::default()),
+            Arc::clone(&scoped_filesystem),
+        )
         .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
 
     Ok(services)


### PR DESCRIPTION
## Summary
- expose `save_to` on `builtin.http` and return `saved_body` metadata instead of inline body bytes when used
- wire Reborn host HTTP egress to a scoped filesystem-backed body store
- add handler and egress contract coverage for saved HTTP response bodies

## Verification
- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_http_ -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract host_http_egress_ -- --nocapture`
- `cargo check -p ironclaw_reborn_composition --all-features`
- `cargo fmt --check`
- `cargo clippy -p ironclaw_host_runtime -p ironclaw_reborn_composition --all-features --tests -- -D warnings`
- `bash scripts/pre-commit-safety.sh`

Note: an extra libSQL facade test attempt (`cargo test -p ironclaw_reborn_composition --test facade_factory production_libsql_services_wire_first_party_runtime_http_egress --features libsql -- --nocapture`) was blocked by local disk exhaustion while compiling dependencies (`No space left on device`), after the all-features composition check and clippy had passed.