### PR TITLE
feat(signing): grant expiry + binding tenant-key + retryable consistency (#4102)

### DIFF
--- a/crates/ironclaw_attestation/src/grant.rs
+++ b/crates/ironclaw_attestation/src/grant.rs
@@ -96,9 +96,12 @@ pub struct AttestedSigningGrant {
     /// Creation timestamp (unix millis), set by the sealer. Opaque clock at
     /// this layer; the durable backends carry the same value.
     pub created_at_ms: i64,
-    /// Optional expiry (unix millis). `None` means no expiry. Enforcement of
-    /// expiry on claim is a durable-backend concern noted for later PRs; the
-    /// field is carried now so the wire shape is stable.
+    /// Optional expiry (unix millis). `None` means no expiry. Enforced uniformly
+    /// on [`SealedGrantStore::claim`] across the in-memory reference and both
+    /// durable backends: a grant whose `expiry_ms` is `Some(exp)` with
+    /// `now_ms >= exp` is rejected with [`GrantError::Expired`] and is NEVER
+    /// consumed (it stays `Sealed`, not deleted). Defense-in-depth over the
+    /// one-shot CAS: a sealed-but-never-claimed grant cannot be claimed forever.
     pub expiry_ms: Option<i64>,
 }
 
@@ -142,6 +145,18 @@ pub enum GrantError {
     #[error("grant already claimed (one-shot)")]
     AlreadyClaimed,
 
+    /// `claim` was attempted at or after the sealed grant's `expiry_ms`. The
+    /// grant is NOT consumed (it stays `Sealed`) and is NOT deleted — expiry
+    /// fails closed, leaving the row in place for audit. Distinct from
+    /// [`GrantError::NotFound`]: the grant exists, it is simply past its window.
+    #[error("grant expired (expiry {expiry_ms}, now {now_ms})")]
+    Expired {
+        /// The grant's sealed expiry (unix millis).
+        expiry_ms: i64,
+        /// The runtime clock value the claim was evaluated against (unix millis).
+        now_ms: i64,
+    },
+
     /// A backend-internal failure with an opaque description.
     #[error("grant store error: {reason}")]
     Backend {
@@ -165,10 +180,18 @@ pub trait SealedGrantStore: Send + Sync {
 
     /// Atomically claim a sealed grant exactly once.
     ///
-    /// * First claim of a sealed key -> `Ok(ClaimedGrant)`, key now `Claimed`.
+    /// * First claim of a sealed, unexpired key -> `Ok(ClaimedGrant)`, key now
+    ///   `Claimed`.
     /// * Any later claim of that key -> `Err(GrantError::AlreadyClaimed)`.
     /// * Claim of a never-sealed (or mismatched) key -> `Err(GrantError::NotFound)`.
-    async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError>;
+    /// * Claim of a sealed key whose `expiry_ms` is `Some(exp)` with
+    ///   `now_ms >= exp` -> `Err(GrantError::Expired { .. })`, WITHOUT consuming
+    ///   or deleting the grant (it stays `Sealed`).
+    ///
+    /// `now_ms` is the runtime clock supplied by the caller (the same source the
+    /// driver uses). The store NEVER reads the clock itself — passing it in keeps
+    /// resume deterministic and the expiry check unit-testable.
+    async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError>;
 }
 
 /// In-memory [`SealedGrantStore`].
@@ -201,7 +224,7 @@ impl SealedGrantStore for InMemorySealedGrantStore {
         Ok(())
     }
 
-    async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError> {
+    async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError> {
         let mut grants = self.grants.lock().map_err(|e| GrantError::Backend {
             reason: e.to_string(),
         })?;
@@ -212,6 +235,14 @@ impl SealedGrantStore for InMemorySealedGrantStore {
         match grant.status {
             GrantStatus::Claimed => Err(GrantError::AlreadyClaimed),
             GrantStatus::Sealed => {
+                // Expiry check BEFORE the CAS: an expired grant fails closed and
+                // is NOT consumed (status stays `Sealed`, row is not deleted —
+                // "LLM data is never deleted"; expiry only marks, never burns).
+                if let Some(expiry_ms) = grant.expiry_ms
+                    && now_ms >= expiry_ms
+                {
+                    return Err(GrantError::Expired { expiry_ms, now_ms });
+                }
                 grant.status = GrantStatus::Claimed;
                 Ok(ClaimedGrant {
                     key: grant.key.clone(),
@@ -253,13 +284,20 @@ pub mod contract {
         }
     }
 
+    /// A fixed "now" used by the cases that do not exercise expiry. Far below any
+    /// expiry the tests seal, so an unexpired grant always claims.
+    const NOW: i64 = 1_000;
+
     pub async fn seal_then_claim_succeeds<S: SealedGrantStore>(store: S) {
         let k = key(1);
         store
             .seal(AttestedSigningGrant::seal(k.clone(), 1_000, None))
             .await
             .expect("seal must succeed");
-        let claimed = store.claim(&k).await.expect("first claim must succeed");
+        let claimed = store
+            .claim(&k, NOW)
+            .await
+            .expect("first claim must succeed");
         assert_eq!(claimed.key, k);
         assert_eq!(claimed.created_at_ms, 1_000);
     }
@@ -270,12 +308,48 @@ pub mod contract {
             .seal(AttestedSigningGrant::seal(k.clone(), 0, None))
             .await
             .expect("seal");
-        store.claim(&k).await.expect("first claim");
-        assert_eq!(store.claim(&k).await, Err(GrantError::AlreadyClaimed));
+        store.claim(&k, NOW).await.expect("first claim");
+        assert_eq!(store.claim(&k, NOW).await, Err(GrantError::AlreadyClaimed));
     }
 
     pub async fn claim_unsealed_is_not_found<S: SealedGrantStore>(store: S) {
-        assert_eq!(store.claim(&key(3)).await, Err(GrantError::NotFound));
+        assert_eq!(store.claim(&key(3), NOW).await, Err(GrantError::NotFound));
+    }
+
+    /// A sealed grant whose `expiry_ms` is in the past is rejected with
+    /// [`GrantError::Expired`] and is NEVER consumed: the grant stays `Sealed`,
+    /// so a subsequent claim with a clock BEFORE the expiry still succeeds (the
+    /// expired claim did not burn the one-shot). Runs against every backend.
+    pub async fn claim_expired_grant_is_rejected<S: SealedGrantStore>(store: S) {
+        let k = key(8);
+        let expiry = 5_000;
+        store
+            .seal(AttestedSigningGrant::seal(k.clone(), 0, Some(expiry)))
+            .await
+            .expect("seal");
+        // now == expiry is already expired (inclusive lower bound).
+        assert_eq!(
+            store.claim(&k, expiry).await,
+            Err(GrantError::Expired {
+                expiry_ms: expiry,
+                now_ms: expiry,
+            })
+        );
+        // And a clock strictly past expiry is also rejected.
+        assert_eq!(
+            store.claim(&k, expiry + 1).await,
+            Err(GrantError::Expired {
+                expiry_ms: expiry,
+                now_ms: expiry + 1,
+            })
+        );
+        // The expired claim did NOT consume the grant: a claim with a clock
+        // before expiry still wins the one-shot CAS.
+        let claimed = store
+            .claim(&k, expiry - 1)
+            .await
+            .expect("an unexpired claim of the still-sealed grant must succeed");
+        assert_eq!(claimed.key, k);
     }
 
     pub async fn claim_mismatched_component_is_not_found<S: SealedGrantStore>(store: S) {
@@ -286,11 +360,17 @@ pub mod contract {
             .expect("seal");
         let mut mismatched = sealed.clone();
         mismatched.user = UserId::new("someone-else");
-        assert_eq!(store.claim(&mismatched).await, Err(GrantError::NotFound));
+        assert_eq!(
+            store.claim(&mismatched, NOW).await,
+            Err(GrantError::NotFound)
+        );
         // Differing only by the approved hash is also a different grant.
         let mut hash_mismatch = sealed;
         hash_mismatch.approved_tx_hash = ApprovedTxHash::from_bytes([99; 32]);
-        assert_eq!(store.claim(&hash_mismatch).await, Err(GrantError::NotFound));
+        assert_eq!(
+            store.claim(&hash_mismatch, NOW).await,
+            Err(GrantError::NotFound)
+        );
     }
 
     /// Seal one grant, then attempt a claim that differs by EACH individual
@@ -358,7 +438,7 @@ pub mod contract {
                 "probe for `{component}` must actually change the key"
             );
             assert_eq!(
-                store.claim(&probe).await,
+                store.claim(&probe, NOW).await,
                 Err(GrantError::NotFound),
                 "claim differing only by `{component}` must be a distinct (unsealed) grant"
             );
@@ -366,7 +446,7 @@ pub mod contract {
 
         // The original grant is still untouched and claimable exactly once.
         store
-            .claim(&sealed)
+            .claim(&sealed, NOW)
             .await
             .expect("the sealed grant itself must still be claimable");
     }
@@ -398,7 +478,7 @@ pub mod contract {
         for _ in 0..32 {
             let store = Arc::clone(&store);
             let k = k.clone();
-            handles.push(tokio::spawn(async move { store.claim(&k).await }));
+            handles.push(tokio::spawn(async move { store.claim(&k, NOW).await }));
         }
 
         let mut ok = 0usize;
@@ -430,6 +510,10 @@ pub mod contract {
                 #[tokio::test]
                 async fn claim_unsealed_is_not_found() {
                     $crate::grant::contract::claim_unsealed_is_not_found($factory()).await;
+                }
+                #[tokio::test]
+                async fn claim_expired_grant_is_rejected() {
+                    $crate::grant::contract::claim_expired_grant_is_rejected($factory()).await;
                 }
                 #[tokio::test]
                 async fn claim_mismatched_component_is_not_found() {
@@ -508,7 +592,7 @@ mod tests {
 
         let key = super::contract::key(1);
         assert!(matches!(
-            store.claim(&key).await,
+            store.claim(&key, 0).await,
             Err(GrantError::Backend { .. })
         ));
         let grant = AttestedSigningGrant::seal(key, 1, None);

--- a/crates/ironclaw_attestation/src/grant.rs
+++ b/crates/ironclaw_attestation/src/grant.rs
@@ -96,9 +96,12 @@ pub struct AttestedSigningGrant {
     /// Creation timestamp (unix millis), set by the sealer. Opaque clock at
     /// this layer; the durable backends carry the same value.
     pub created_at_ms: i64,
-    /// Optional expiry (unix millis). `None` means no expiry. Enforcement of
-    /// expiry on claim is a durable-backend concern noted for later PRs; the
-    /// field is carried now so the wire shape is stable.
+    /// Optional expiry (unix millis). `None` means no expiry. Enforced uniformly
+    /// on [`SealedGrantStore::claim`] across the in-memory reference and both
+    /// durable backends: a grant whose `expiry_ms` is `Some(exp)` with
+    /// `now_ms >= exp` is rejected with [`GrantError::Expired`] and is NEVER
+    /// consumed (it stays `Sealed`, not deleted). Defense-in-depth over the
+    /// one-shot CAS: a sealed-but-never-claimed grant cannot be claimed forever.
     pub expiry_ms: Option<i64>,
 }
 
@@ -188,6 +191,18 @@ pub enum GrantError {
         expiry_ms: i64,
     },
 
+    /// `claim` was attempted at or after the sealed grant's `expiry_ms`. The
+    /// grant is NOT consumed (it stays `Sealed`) and is NOT deleted — expiry
+    /// fails closed, leaving the row in place for audit. Distinct from
+    /// [`GrantError::NotFound`]: the grant exists, it is simply past its window.
+    #[error("grant expired (expiry {expiry_ms}, now {now_ms})")]
+    Expired {
+        /// The grant's sealed expiry (unix millis).
+        expiry_ms: i64,
+        /// The runtime clock value the claim was evaluated against (unix millis).
+        now_ms: i64,
+    },
+
     /// A backend-internal failure with an opaque description.
     #[error("grant store error: {reason}")]
     Backend {
@@ -219,10 +234,18 @@ pub trait SealedGrantStore: Send + Sync {
 
     /// Atomically claim a sealed grant exactly once.
     ///
-    /// * First claim of a sealed key -> `Ok(ClaimedGrant)`, key now `Claimed`.
+    /// * First claim of a sealed, unexpired key -> `Ok(ClaimedGrant)`, key now
+    ///   `Claimed`.
     /// * Any later claim of that key -> `Err(GrantError::AlreadyClaimed)`.
     /// * Claim of a never-sealed (or mismatched) key -> `Err(GrantError::NotFound)`.
-    async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError>;
+    /// * Claim of a sealed key whose `expiry_ms` is `Some(exp)` with
+    ///   `now_ms >= exp` -> `Err(GrantError::Expired { .. })`, WITHOUT consuming
+    ///   or deleting the grant (it stays `Sealed`).
+    ///
+    /// `now_ms` is the runtime clock supplied by the caller (the same source the
+    /// driver uses). The store NEVER reads the clock itself — passing it in keeps
+    /// resume deterministic and the expiry check unit-testable.
+    async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError>;
 }
 
 /// In-memory [`SealedGrantStore`].
@@ -255,7 +278,7 @@ impl SealedGrantStore for InMemorySealedGrantStore {
         Ok(())
     }
 
-    async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError> {
+    async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError> {
         let mut grants = self.grants.lock().map_err(|e| GrantError::Backend {
             reason: e.to_string(),
         })?;
@@ -266,6 +289,14 @@ impl SealedGrantStore for InMemorySealedGrantStore {
         match grant.status {
             GrantStatus::Claimed => Err(GrantError::AlreadyClaimed),
             GrantStatus::Sealed => {
+                // Expiry check BEFORE the CAS: an expired grant fails closed and
+                // is NOT consumed (status stays `Sealed`, row is not deleted —
+                // "LLM data is never deleted"; expiry only marks, never burns).
+                if let Some(expiry_ms) = grant.expiry_ms
+                    && now_ms >= expiry_ms
+                {
+                    return Err(GrantError::Expired { expiry_ms, now_ms });
+                }
                 grant.status = GrantStatus::Claimed;
                 Ok(ClaimedGrant {
                     key: grant.key.clone(),
@@ -323,13 +354,20 @@ pub mod contract {
         AttestedSigningGrant::new(key, created_at_ms, expiry_ms).expect("valid grant")
     }
 
+    /// A fixed "now" used by the cases that do not exercise expiry. Far below any
+    /// expiry the tests seal, so an unexpired grant always claims.
+    const NOW: i64 = 1_000;
+
     pub async fn seal_then_claim_succeeds<S: SealedGrantStore>(store: S) {
         let k = key(1);
         store
             .seal(grant_for(k.clone(), 1_000, None))
             .await
             .expect("seal must succeed");
-        let claimed = store.claim(&k).await.expect("first claim must succeed");
+        let claimed = store
+            .claim(&k, NOW)
+            .await
+            .expect("first claim must succeed");
         assert_eq!(claimed.key, k);
         assert_eq!(claimed.created_at_ms, 1_000);
     }
@@ -340,12 +378,48 @@ pub mod contract {
             .seal(grant_for(k.clone(), 0, None))
             .await
             .expect("seal");
-        store.claim(&k).await.expect("first claim");
-        assert_eq!(store.claim(&k).await, Err(GrantError::AlreadyClaimed));
+        store.claim(&k, NOW).await.expect("first claim");
+        assert_eq!(store.claim(&k, NOW).await, Err(GrantError::AlreadyClaimed));
     }
 
     pub async fn claim_unsealed_is_not_found<S: SealedGrantStore>(store: S) {
-        assert_eq!(store.claim(&key(3)).await, Err(GrantError::NotFound));
+        assert_eq!(store.claim(&key(3), NOW).await, Err(GrantError::NotFound));
+    }
+
+    /// A sealed grant whose `expiry_ms` is in the past is rejected with
+    /// [`GrantError::Expired`] and is NEVER consumed: the grant stays `Sealed`,
+    /// so a subsequent claim with a clock BEFORE the expiry still succeeds (the
+    /// expired claim did not burn the one-shot). Runs against every backend.
+    pub async fn claim_expired_grant_is_rejected<S: SealedGrantStore>(store: S) {
+        let k = key(8);
+        let expiry = 5_000;
+        store
+            .seal(grant_for(k.clone(), 0, Some(expiry)))
+            .await
+            .expect("seal");
+        // now == expiry is already expired (inclusive lower bound).
+        assert_eq!(
+            store.claim(&k, expiry).await,
+            Err(GrantError::Expired {
+                expiry_ms: expiry,
+                now_ms: expiry,
+            })
+        );
+        // And a clock strictly past expiry is also rejected.
+        assert_eq!(
+            store.claim(&k, expiry + 1).await,
+            Err(GrantError::Expired {
+                expiry_ms: expiry,
+                now_ms: expiry + 1,
+            })
+        );
+        // The expired claim did NOT consume the grant: a claim with a clock
+        // before expiry still wins the one-shot CAS.
+        let claimed = store
+            .claim(&k, expiry - 1)
+            .await
+            .expect("an unexpired claim of the still-sealed grant must succeed");
+        assert_eq!(claimed.key, k);
     }
 
     pub async fn claim_mismatched_component_is_not_found<S: SealedGrantStore>(store: S) {
@@ -356,11 +430,17 @@ pub mod contract {
             .expect("seal");
         let mut mismatched = sealed.clone();
         mismatched.user = UserId::new("someone-else");
-        assert_eq!(store.claim(&mismatched).await, Err(GrantError::NotFound));
+        assert_eq!(
+            store.claim(&mismatched, NOW).await,
+            Err(GrantError::NotFound)
+        );
         // Differing only by the approved hash is also a different grant.
         let mut hash_mismatch = sealed;
         hash_mismatch.approved_tx_hash = ApprovedTxHash::from_bytes([99; 32]);
-        assert_eq!(store.claim(&hash_mismatch).await, Err(GrantError::NotFound));
+        assert_eq!(
+            store.claim(&hash_mismatch, NOW).await,
+            Err(GrantError::NotFound)
+        );
     }
 
     /// Seal one grant, then attempt a claim that differs by EACH individual
@@ -428,7 +508,7 @@ pub mod contract {
                 "probe for `{component}` must actually change the key"
             );
             assert_eq!(
-                store.claim(&probe).await,
+                store.claim(&probe, NOW).await,
                 Err(GrantError::NotFound),
                 "claim differing only by `{component}` must be a distinct (unsealed) grant"
             );
@@ -436,7 +516,7 @@ pub mod contract {
 
         // The original grant is still untouched and claimable exactly once.
         store
-            .claim(&sealed)
+            .claim(&sealed, NOW)
             .await
             .expect("the sealed grant itself must still be claimable");
     }
@@ -462,50 +542,17 @@ pub mod contract {
         tenant_b.tenant = TenantId::new("tenant-b");
         assert_ne!(tenant_b.tenant, tenant_a.tenant);
         assert_eq!(
-            store.claim(&tenant_b).await,
+            store.claim(&tenant_b, NOW).await,
             Err(GrantError::NotFound),
             "a claim carrying a different tenant must not match tenant-a's grant"
         );
 
         // Tenant A's grant is untouched and still wins its one-shot claim.
         let claimed = store
-            .claim(&tenant_a)
+            .claim(&tenant_a, NOW)
             .await
             .expect("original tenant-a grant must still be claimable");
         assert_eq!(claimed.key.tenant, tenant_a.tenant);
-    }
-
-    /// Expiry enforcement on claim — currently UNENFORCED across all backends.
-    ///
-    /// `AttestedSigningGrant.expiry_ms` is carried in the in-memory and durable
-    /// stores but no `claim` path consults it: a grant whose `expiry_ms` is in
-    /// the past can still be claimed. This case pins the *intended* contract —
-    /// claiming an expired grant must fail closed — so that every backend the
-    /// macro runs for is forced to demonstrate enforcement once it lands. It is
-    /// `#[ignore]`d (wired into the macro below with `#[ignore]`) until expiry
-    /// enforcement is implemented; see the H2 follow-up tracked in
-    /// `docs/plans/2026-05-23-attested-signing-substrate.md`. When enforcement
-    /// arrives, drop the `#[ignore]` and add the rejection-error variant.
-    ///
-    /// Seals a grant whose `expiry_ms` is strictly before its `created_at_ms`
-    /// (i.e. already expired at seal time) and asserts the claim is rejected
-    /// rather than succeeding. The assertion intentionally fails today (the
-    /// claim succeeds), which is exactly why the case is ignored: it is a
-    /// red-flag stub, not a passing test.
-    pub async fn claim_expired_grant_is_rejected<S: SealedGrantStore>(store: S) {
-        let k = key(9);
-        // created_at = 10_000, expiry = 1 (long past): unambiguously expired.
-        store
-            .seal(grant_for(k.clone(), 10_000, Some(1)))
-            .await
-            .expect("seal expired grant");
-        // INTENT: an expired grant must NOT be claimable. Today no backend
-        // enforces this, so the claim erroneously succeeds — keep this case
-        // `#[ignore]`d until enforcement lands, then this assertion will hold.
-        assert!(
-            store.claim(&k).await.is_err(),
-            "an expired grant must fail closed on claim (enforcement pending — H2)"
-        );
     }
 
     pub async fn double_seal_is_already_sealed<S: SealedGrantStore>(store: S) {
@@ -533,7 +580,7 @@ pub mod contract {
             .seal(grant_for(k.clone(), 0, None))
             .await
             .expect("seal");
-        store.claim(&k).await.expect("claim");
+        store.claim(&k, NOW).await.expect("claim");
         assert_eq!(
             store.seal(grant_for(k, 0, None)).await,
             Err(GrantError::AlreadySealed),
@@ -551,7 +598,7 @@ pub mod contract {
             .seal(grant_for(k.clone(), 1_000, Some(9_999)))
             .await
             .expect("seal");
-        let claimed = store.claim(&k).await.expect("claim");
+        let claimed = store.claim(&k, NOW).await.expect("claim");
         assert_eq!(claimed.created_at_ms, 1_000);
         assert_eq!(
             claimed.expiry_ms,
@@ -575,7 +622,7 @@ pub mod contract {
         for _ in 0..32 {
             let store = Arc::clone(&store);
             let k = k.clone();
-            handles.push(tokio::spawn(async move { store.claim(&k).await }));
+            handles.push(tokio::spawn(async move { store.claim(&k, NOW).await }));
         }
 
         let mut ok = 0usize;
@@ -609,6 +656,10 @@ pub mod contract {
                     $crate::grant::contract::claim_unsealed_is_not_found($factory()).await;
                 }
                 #[tokio::test]
+                async fn claim_expired_grant_is_rejected() {
+                    $crate::grant::contract::claim_expired_grant_is_rejected($factory()).await;
+                }
+                #[tokio::test]
                 async fn claim_mismatched_component_is_not_found() {
                     $crate::grant::contract::claim_mismatched_component_is_not_found($factory())
                         .await;
@@ -623,15 +674,6 @@ pub mod contract {
                 #[tokio::test]
                 async fn cross_tenant_claim_is_not_found() {
                     $crate::grant::contract::cross_tenant_claim_is_not_found($factory()).await;
-                }
-                // Expiry enforcement is not yet implemented in any backend, so
-                // this contract case is `#[ignore]`d: it pins the intended
-                // fail-closed-on-expiry behaviour and forces every future
-                // backend to satisfy it once enforcement lands (H2 follow-up).
-                #[tokio::test]
-                #[ignore = "expiry enforcement not yet implemented (H2 follow-up)"]
-                async fn claim_expired_grant_is_rejected() {
-                    $crate::grant::contract::claim_expired_grant_is_rejected($factory()).await;
                 }
                 #[tokio::test]
                 async fn double_seal_is_already_sealed() {
@@ -734,7 +776,7 @@ mod tests {
 
         let key = super::contract::key(1);
         assert!(matches!(
-            store.claim(&key).await,
+            store.claim(&key, 0).await,
             Err(GrantError::Backend { .. })
         ));
         let grant = AttestedSigningGrant::new(key, 1, None).expect("valid grant");

--- a/crates/ironclaw_attestation/src/lib.rs
+++ b/crates/ironclaw_attestation/src/lib.rs
@@ -86,3 +86,18 @@ pub use approved_tx_hash::compute_approved_tx_hash;
 // Re-export the binding hash type so downstream PRs import it from the
 // attestation crate alongside the functions that produce it.
 pub use ironclaw_signing_provider::{APPROVED_TX_HASH_LEN, ApprovedTxHash};
+
+/// The runtime wall clock as unix milliseconds.
+///
+/// The single source production callers pass into
+/// [`SealedGrantStore::claim`] so the store never reads the clock itself
+/// (deterministic resume + testable expiry). Tests pass an explicit `now_ms`
+/// instead of calling this. Returns `0` for a clock before the unix epoch
+/// (which would otherwise be undefined), so an expiry check degrades to
+/// "never expired" rather than panicking.
+pub fn now_unix_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/crates/ironclaw_attestation/src/lib.rs
+++ b/crates/ironclaw_attestation/src/lib.rs
@@ -88,3 +88,18 @@ pub use approved_tx_hash::compute_approved_tx_hash;
 // Re-export the binding hash type so downstream PRs import it from the
 // attestation crate alongside the functions that produce it.
 pub use ironclaw_signing_provider::{APPROVED_TX_HASH_LEN, ApprovedTxHash};
+
+/// The runtime wall clock as unix milliseconds.
+///
+/// The single source production callers pass into
+/// [`SealedGrantStore::claim`] so the store never reads the clock itself
+/// (deterministic resume + testable expiry). Tests pass an explicit `now_ms`
+/// instead of calling this. Returns `0` for a clock before the unix epoch
+/// (which would otherwise be undefined), so an expiry check degrades to
+/// "never expired" rather than panicking.
+pub fn now_unix_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/crates/ironclaw_attested_runtime/src/binding.rs
+++ b/crates/ironclaw_attested_runtime/src/binding.rs
@@ -20,7 +20,46 @@ use serde::{Deserialize, Serialize};
 
 use ironclaw_attestation::{DecodedTransaction, RenderingSchemaVersion};
 use ironclaw_chain_signing::{ChainKeyId, recompute_approved_hash};
-use ironclaw_signing_provider::{ApprovedTxHash, GateRef, ProviderId, SigningContext};
+use ironclaw_signing_provider::{ApprovedTxHash, GateRef, ProviderId, SigningContext, TenantId};
+
+/// The tenant-qualified identity of a gate binding.
+///
+/// Mirrors `LedgerKey { tenant, gate_ref }` and `GrantKey`'s tenant-first
+/// keying: a binding is owned by exactly one `(tenant, gate_ref)`. Adding the
+/// tenant axis at the store layer is defense-in-depth on top of
+/// [`validate_binding`] (which pins the key to the binding's OWN
+/// `context.gate_ref`) and the resolve-layer `assert_binding_owner` user check —
+/// two tenants can never collide on, or read each other's, binding even if a
+/// `gate_ref` were ever reused across tenants.
+///
+/// The synchronous resume read ([`SyncBindingRead::get_sync`]) stays keyed by
+/// `gate_ref` alone: the crypto-free `ironclaw_turns` resume contract carries no
+/// tenant, and the binding's persisted `context.tenant` plus the ownership
+/// checks already bind it. The tenant axis is enforced on the async
+/// driver/ingress paths, which always have a [`SigningContext`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BindingKey {
+    /// Tenant boundary that owns the binding.
+    pub tenant: TenantId,
+    /// The gate the binding is for.
+    pub gate_ref: GateRef,
+}
+
+impl BindingKey {
+    /// Construct a binding key from its tenant and gate.
+    pub fn new(tenant: TenantId, gate_ref: GateRef) -> Self {
+        Self { tenant, gate_ref }
+    }
+
+    /// Derive the binding key from a [`SigningContext`]: the binding is owned by
+    /// the context's tenant and keyed by its gate.
+    pub fn from_context(context: &SigningContext) -> Self {
+        Self {
+            tenant: context.tenant.clone(),
+            gate_ref: context.gate_ref.clone(),
+        }
+    }
+}
 
 /// Errors a binding write can fail closed with. A binding is authoritative —
 /// the resume port and driver trust it — so creation is INSERT-ONLY (CAS) and
@@ -35,6 +74,10 @@ pub enum BindingError {
     /// The store key does not equal `binding.context.gate_ref` — the binding
     /// would be retrievable under a gate_ref it does not describe.
     GateRefMismatch,
+    /// The store key's `tenant` does not equal `binding.context.tenant` — the
+    /// binding would be filed under a tenant it does not describe (cross-tenant
+    /// mis-binding). Fail closed.
+    TenantMismatch,
     /// The bound `approved_tx_hash` does not equal the hash recomputed from the
     /// binding's own decoded tx + schema (the binding contradicts itself).
     ApprovedHashMismatch,
@@ -55,6 +98,7 @@ impl std::fmt::Display for BindingError {
         match self {
             Self::AlreadyExists => write!(f, "a binding already exists for this gate_ref"),
             Self::GateRefMismatch => write!(f, "store key does not match binding context gate_ref"),
+            Self::TenantMismatch => write!(f, "store key does not match binding context tenant"),
             Self::ApprovedHashMismatch => {
                 write!(f, "approved hash does not match the decoded transaction")
             }
@@ -151,6 +195,23 @@ pub fn validate_binding(key: &GateRef, binding: &AttestedGateBinding) -> Result<
     Ok(())
 }
 
+/// Validate a binding write against its full tenant-qualified [`BindingKey`].
+///
+/// Runs [`validate_binding`] (gate_ref + self-consistency) AND additionally
+/// requires `key.tenant` to equal the binding's own `context.tenant`, so a
+/// binding can never be filed under, or read back through, a tenant it does not
+/// describe. Every [`AttestedGateBindingStore`] uses this so the tenant axis is
+/// enforced uniformly across the in-memory and durable backends.
+pub fn validate_binding_key(
+    key: &BindingKey,
+    binding: &AttestedGateBinding,
+) -> Result<(), BindingError> {
+    if key.tenant.as_str() != binding.context.tenant.as_str() {
+        return Err(BindingError::TenantMismatch);
+    }
+    validate_binding(&key.gate_ref, binding)
+}
+
 /// Store of authoritative attested-gate bindings, keyed by `gate_ref`.
 ///
 /// One binding per `gate_ref`, created when the gate is raised and then
@@ -159,25 +220,30 @@ pub fn validate_binding(key: &GateRef, binding: &AttestedGateBinding) -> Result<
 /// backends (PR12) carry identical semantics.
 #[async_trait]
 pub trait AttestedGateBindingStore: SyncBindingRead {
-    /// Persist the authoritative binding for a freshly-raised attested gate.
+    /// Persist the authoritative binding for a freshly-raised attested gate,
+    /// keyed by `(tenant, gate_ref)`.
     ///
     /// INSERT-ONLY: errors [`BindingError::AlreadyExists`] if a binding already
-    /// exists for `gate_ref` (no overwrite, ever). Validates the binding
-    /// ([`validate_binding`]) before persisting.
-    async fn put(
-        &self,
-        gate_ref: GateRef,
-        binding: AttestedGateBinding,
-    ) -> Result<(), BindingError>;
+    /// exists for `key` (no overwrite, ever). Validates the binding
+    /// ([`validate_binding`]) before persisting, and requires `key.tenant` to
+    /// equal the binding's own `context.tenant` (defense-in-depth: a binding can
+    /// never be filed under a tenant it does not describe).
+    async fn put(&self, key: BindingKey, binding: AttestedGateBinding) -> Result<(), BindingError>;
 
-    /// Read the authoritative binding for `gate_ref`, if one exists.
-    async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding>;
+    /// Read the authoritative binding for `(tenant, gate_ref)`, if one exists.
+    async fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding>;
 }
 
 /// In-memory [`AttestedGateBindingStore`].
+///
+/// Keyed by the tenant-qualified [`BindingKey`] for the async driver/ingress
+/// paths. A secondary `gate_ref -> BindingKey` index serves the synchronous
+/// resume read ([`SyncBindingRead::get_sync`]), which has no tenant in the
+/// crypto-free `ironclaw_turns` resume contract.
 #[derive(Default)]
 pub struct InMemoryAttestedGateBindingStore {
-    bindings: Mutex<HashMap<GateRef, AttestedGateBinding>>,
+    bindings: Mutex<HashMap<BindingKey, AttestedGateBinding>>,
+    by_gate_ref: Mutex<HashMap<GateRef, BindingKey>>,
 }
 
 impl InMemoryAttestedGateBindingStore {
@@ -189,38 +255,47 @@ impl InMemoryAttestedGateBindingStore {
 
 impl SyncBindingRead for InMemoryAttestedGateBindingStore {
     /// Synchronous read used by the resume port, which runs inside the turn
-    /// store's sync critical section and therefore cannot `.await`. The async
-    /// trait method is for the driver / ingress paths.
+    /// store's sync critical section and therefore cannot `.await`. Resolves the
+    /// gate_ref to its owning [`BindingKey`] via the index, then reads the
+    /// binding. The async trait method ([`AttestedGateBindingStore::get`]) is the
+    /// tenant-qualified read for the driver / ingress paths.
     fn get_sync(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
+        let key = self.by_gate_ref.lock().ok()?.get(gate_ref).cloned()?;
         self.bindings
             .lock()
             .ok()
-            .and_then(|map| map.get(gate_ref).cloned())
+            .and_then(|map| map.get(&key).cloned())
     }
 }
 
 #[async_trait]
 impl AttestedGateBindingStore for InMemoryAttestedGateBindingStore {
-    async fn put(
-        &self,
-        gate_ref: GateRef,
-        binding: AttestedGateBinding,
-    ) -> Result<(), BindingError> {
-        // Validate before taking the lock so a malformed binding never even
-        // races for the slot.
-        validate_binding(&gate_ref, &binding)?;
+    async fn put(&self, key: BindingKey, binding: AttestedGateBinding) -> Result<(), BindingError> {
+        // Validate (gate_ref + tenant + self-consistency) before taking the lock
+        // so a malformed/mis-tenanted binding never even races for the slot.
+        validate_binding_key(&key, &binding)?;
         let mut map = self.bindings.lock().map_err(|_| BindingError::Poisoned)?;
+        let mut index = self
+            .by_gate_ref
+            .lock()
+            .map_err(|_| BindingError::Poisoned)?;
         // INSERT-ONLY CAS: a binding is authoritative and immutable. The first
-        // write for a gate_ref wins; any later write fails closed so it can
-        // never mutate the binding the port + driver already trust.
-        if map.contains_key(&gate_ref) {
+        // write for a (tenant, gate_ref) wins; any later write fails closed so it
+        // can never mutate the binding the port + driver already trust. A second
+        // tenant cannot reuse the same gate_ref either — the gate_ref index is
+        // also insert-only.
+        if map.contains_key(&key) || index.contains_key(&key.gate_ref) {
             return Err(BindingError::AlreadyExists);
         }
-        map.insert(gate_ref, binding);
+        index.insert(key.gate_ref.clone(), key.clone());
+        map.insert(key, binding);
         Ok(())
     }
 
-    async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-        self.get_sync(gate_ref)
+    async fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding> {
+        self.bindings
+            .lock()
+            .ok()
+            .and_then(|map| map.get(key).cloned())
     }
 }

--- a/crates/ironclaw_attested_runtime/src/driver.rs
+++ b/crates/ironclaw_attested_runtime/src/driver.rs
@@ -378,10 +378,16 @@ where
     where
         S: CustodialSignerLike,
     {
+        // The continuation is identified by `gate_ref` alone (the resolved-gate
+        // ref carried through the turn); the tenant is not on this path. Read via
+        // the gate_ref-keyed sync index — the same authoritative binding the
+        // resume port verified. The tenant axis on the binding store guards the
+        // WRITE (a binding can never be filed under a foreign tenant) and the
+        // async tenant-qualified reads on the ingress paths; here we trust the
+        // binding's own persisted `context.tenant`, exactly as before.
         let binding = self
             .bindings
-            .get(gate_ref)
-            .await
+            .get_sync(gate_ref)
             .ok_or(ContinuationError::MissingBinding)?;
 
         match binding.provider_id {

--- a/crates/ironclaw_attested_runtime/src/driver.rs
+++ b/crates/ironclaw_attested_runtime/src/driver.rs
@@ -416,10 +416,16 @@ where
     where
         S: CustodialSignerLike,
     {
+        // The continuation is identified by `gate_ref` alone (the resolved-gate
+        // ref carried through the turn); the tenant is not on this path. Read via
+        // the gate_ref-keyed sync index — the same authoritative binding the
+        // resume port verified. The tenant axis on the binding store guards the
+        // WRITE (a binding can never be filed under a foreign tenant) and the
+        // async tenant-qualified reads on the ingress paths; here we trust the
+        // binding's own persisted `context.tenant`, exactly as before.
         let binding = self
             .bindings
-            .get(gate_ref)
-            .await
+            .get_sync(gate_ref)
             .ok_or(ContinuationError::MissingBinding)?;
 
         match binding.provider_id {
@@ -452,11 +458,22 @@ where
         gate_ref: &GateRef,
         caller: BindingOwner<'_>,
     ) -> Result<(), ContinuationError> {
+        // Read through the CALLER's tenant: the binding store is keyed
+        // `(tenant, gate_ref)`, so a caller from another tenant cannot even
+        // address this row — the lookup misses and yields `MissingBinding`
+        // (no existence oracle) rather than reaching the identity comparison.
+        let key = crate::BindingKey::new(
+            ironclaw_signing_provider::TenantId::new(caller.tenant_id),
+            gate_ref.clone(),
+        );
         let binding = self
             .bindings
-            .get(gate_ref)
+            .get(&key)
             .await
             .ok_or(ContinuationError::MissingBinding)?;
+        // Defence in depth: the tenant axis is already enforced by the key, but
+        // re-assert both axes so a store that ignored the tenant still cannot
+        // let a foreign caller drive someone else's continuation.
         if binding.context.tenant.as_str() != caller.tenant_id
             || binding.context.user.as_str() != caller.user_id
         {

--- a/crates/ironclaw_attested_runtime/src/lib.rs
+++ b/crates/ironclaw_attested_runtime/src/lib.rs
@@ -54,8 +54,8 @@ mod port;
 mod ship_gate;
 
 pub use binding::{
-    AttestedGateBinding, AttestedGateBindingStore, BindingError, InMemoryAttestedGateBindingStore,
-    SyncBindingRead, validate_binding,
+    AttestedGateBinding, AttestedGateBindingStore, BindingError, BindingKey,
+    InMemoryAttestedGateBindingStore, SyncBindingRead, validate_binding, validate_binding_key,
 };
 pub use driver::{
     AttestedSignerContinuationDriver, BroadcastDisposition, BroadcastOutcome, Broadcaster,

--- a/crates/ironclaw_attested_runtime/src/lib.rs
+++ b/crates/ironclaw_attested_runtime/src/lib.rs
@@ -57,14 +57,15 @@ mod trust;
 #[cfg(any(test, feature = "unsafe-always-trust-near"))]
 pub use trust::AlwaysTrustNearAccessKeyVerifier;
 pub use trust::{
-    BindingKey, BindingStatus, CsprngNonceSource, EnrollmentState, InMemoryTrustStore,
-    NearAccessKeyVerifier, NonceSource, SignedChallenge, TrustChallenge, TrustEnrollment,
-    TrustError, TrustKind, TrustRegistrar, TrustStore, TrustedSignerBinding, VerifiedControl,
+    BindingKey as TrustBindingKey, BindingStatus, CsprngNonceSource, EnrollmentState,
+    InMemoryTrustStore, NearAccessKeyVerifier, NonceSource, SignedChallenge, TrustChallenge,
+    TrustEnrollment, TrustError, TrustKind, TrustRegistrar, TrustStore, TrustedSignerBinding,
+    VerifiedControl,
 };
 
 pub use binding::{
-    AttestedGateBinding, AttestedGateBindingStore, BindingError, InMemoryAttestedGateBindingStore,
-    SyncBindingRead, validate_binding,
+    AttestedGateBinding, AttestedGateBindingStore, BindingError, BindingKey,
+    InMemoryAttestedGateBindingStore, SyncBindingRead, validate_binding, validate_binding_key,
 };
 pub use driver::{
     AttestedSignerContinuationDriver, BindingOwner, BroadcastDisposition, BroadcastOutcome,

--- a/crates/ironclaw_attested_runtime/tests/resume_through_store.rs
+++ b/crates/ironclaw_attested_runtime/tests/resume_through_store.rs
@@ -16,7 +16,7 @@ use alloy_primitives::{Address, Bytes, TxKind, U256};
 use chrono::{TimeZone, Utc};
 use ironclaw_attestation::{DecodedTransaction, RenderingSchemaVersion};
 use ironclaw_attested_runtime::{
-    AttestedGateBinding, AttestedGateBindingStore, InMemoryAttestedGateBindingStore,
+    AttestedGateBinding, AttestedGateBindingStore, BindingKey, InMemoryAttestedGateBindingStore,
     InMemoryResumeGuard, ResumeGuard, RuntimeAttestedResumePort, SyncBindingRead,
     approved_tx_hash_ref_hex,
 };
@@ -165,7 +165,7 @@ async fn real_port_resolves_attested_gate_and_never_requeues_loop() {
     // PR11 ingress would persist the authoritative binding when raising the gate.
     bindings
         .put(
-            SigningGateRef::new(GATE),
+            BindingKey::new(signing_ctx().tenant, SigningGateRef::new(GATE)),
             AttestedGateBinding {
                 provider_id: ProviderId::Injected,
                 context: signing_ctx(),

--- a/crates/ironclaw_attested_runtime/tests/threat_matrix.rs
+++ b/crates/ironclaw_attested_runtime/tests/threat_matrix.rs
@@ -31,7 +31,7 @@ use ironclaw_attestation::{
     SigningLedgerState,
 };
 use ironclaw_attested_runtime::{
-    AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver,
+    AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver, BindingKey,
     ContinuationError, CustodialMainnetShipGate, InMemoryAttestedGateBindingStore,
     InMemoryResumeGuard, ProviderRegistry, ResumeGuard, RuntimeAttestedResumePort, SyncBindingRead,
     approved_tx_hash_ref_hex,
@@ -384,7 +384,7 @@ async fn put_binding_res(
 ) -> Result<(), ironclaw_attested_runtime::BindingError> {
     bindings
         .put(
-            SigningGateRef::new(GATE),
+            BindingKey::new(ctx.tenant.clone(), SigningGateRef::new(GATE)),
             AttestedGateBinding {
                 provider_id: ProviderId::Custodial,
                 context: ctx.clone(),
@@ -483,8 +483,14 @@ async fn threat_1_sealed_grant_one_shot_claim() {
     let grants = InMemorySealedGrantStore::new();
     seal_grant(&grants, &ctx, hash).await;
     let key = GrantKey::from_context(&ctx, hash);
-    grants.claim(&key).await.expect("first claim wins");
-    let err = grants.claim(&key).await.expect_err("second claim fails");
+    grants
+        .claim(&key, ironclaw_attestation::now_unix_millis())
+        .await
+        .expect("first claim wins");
+    let err = grants
+        .claim(&key, ironclaw_attestation::now_unix_millis())
+        .await
+        .expect_err("second claim fails");
     assert_eq!(err, ironclaw_attestation::GrantError::AlreadyClaimed);
     let _ = keystore; // keep the bound key alive for parity with other cases
 }
@@ -539,12 +545,15 @@ async fn driver_rechecks_inconsistent_binding() {
     impl AttestedGateBindingStore for InconsistentStore {
         async fn put(
             &self,
-            _gate_ref: SigningGateRef,
+            _key: ironclaw_attested_runtime::BindingKey,
             _binding: AttestedGateBinding,
         ) -> Result<(), ironclaw_attested_runtime::BindingError> {
             Ok(())
         }
-        async fn get(&self, _gate_ref: &SigningGateRef) -> Option<AttestedGateBinding> {
+        async fn get(
+            &self,
+            _key: &ironclaw_attested_runtime::BindingKey,
+        ) -> Option<AttestedGateBinding> {
             Some(self.0.clone())
         }
     }
@@ -995,6 +1004,7 @@ async fn binding_write_rejects_chain_mismatch() {
 
     // The decoded tx is on eip155:11155111 (testnet); bind a MAINNET chain. The
     // store must reject this so a testnet/mainnet smuggle never persists.
+    let tenant = ctx.tenant.clone();
     let binding = AttestedGateBinding {
         provider_id: ProviderId::Custodial,
         context: ctx,
@@ -1006,7 +1016,7 @@ async fn binding_write_rejects_chain_mismatch() {
     };
     let bindings = InMemoryAttestedGateBindingStore::new();
     let err = bindings
-        .put(SigningGateRef::new(GATE), binding)
+        .put(BindingKey::new(tenant, SigningGateRef::new(GATE)), binding)
         .await
         .expect_err("chain mismatch must be rejected");
     assert_eq!(err, ironclaw_attested_runtime::BindingError::ChainMismatch);
@@ -1130,7 +1140,7 @@ async fn put_external_binding(
 ) {
     bindings
         .put(
-            SigningGateRef::new(GATE),
+            BindingKey::new(ctx.tenant.clone(), SigningGateRef::new(GATE)),
             AttestedGateBinding {
                 provider_id,
                 context: ctx.clone(),
@@ -1260,12 +1270,15 @@ async fn driver_rejects_binding_chain_mismatch() {
     impl AttestedGateBindingStore for ChainMismatchStore {
         async fn put(
             &self,
-            _gate_ref: SigningGateRef,
+            _key: ironclaw_attested_runtime::BindingKey,
             _binding: AttestedGateBinding,
         ) -> Result<(), ironclaw_attested_runtime::BindingError> {
             Ok(())
         }
-        async fn get(&self, _gate_ref: &SigningGateRef) -> Option<AttestedGateBinding> {
+        async fn get(
+            &self,
+            _key: &ironclaw_attested_runtime::BindingKey,
+        ) -> Option<AttestedGateBinding> {
             Some(self.0.clone())
         }
     }

--- a/crates/ironclaw_attested_runtime/tests/threat_matrix.rs
+++ b/crates/ironclaw_attested_runtime/tests/threat_matrix.rs
@@ -31,7 +31,7 @@ use ironclaw_attestation::{
     SigningLedgerState,
 };
 use ironclaw_attested_runtime::{
-    AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver,
+    AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver, BindingKey,
     ContinuationError, CustodialMainnetShipGate, InMemoryAttestedGateBindingStore,
     InMemoryResumeGuard, ProviderRegistry, ResumeGuard, RuntimeAttestedResumePort, SyncBindingRead,
     approved_tx_hash_ref_hex,
@@ -434,7 +434,7 @@ async fn put_binding_with_scope_res(
 ) -> Result<(), ironclaw_attested_runtime::BindingError> {
     bindings
         .put(
-            SigningGateRef::new(GATE),
+            BindingKey::new(ctx.tenant.clone(), SigningGateRef::new(GATE)),
             AttestedGateBinding {
                 provider_id: ProviderId::Custodial,
                 context: ctx.clone(),
@@ -538,8 +538,14 @@ async fn threat_1_sealed_grant_one_shot_claim() {
     let grants = InMemorySealedGrantStore::new();
     seal_grant(&grants, &ctx, hash).await;
     let key = GrantKey::from_context(&ctx, hash);
-    grants.claim(&key).await.expect("first claim wins");
-    let err = grants.claim(&key).await.expect_err("second claim fails");
+    grants
+        .claim(&key, ironclaw_attestation::now_unix_millis())
+        .await
+        .expect("first claim wins");
+    let err = grants
+        .claim(&key, ironclaw_attestation::now_unix_millis())
+        .await
+        .expect_err("second claim fails");
     assert_eq!(err, ironclaw_attestation::GrantError::AlreadyClaimed);
     let _ = keystore; // keep the bound key alive for parity with other cases
 }
@@ -594,12 +600,15 @@ async fn driver_rechecks_inconsistent_binding() {
     impl AttestedGateBindingStore for InconsistentStore {
         async fn put(
             &self,
-            _gate_ref: SigningGateRef,
+            _key: ironclaw_attested_runtime::BindingKey,
             _binding: AttestedGateBinding,
         ) -> Result<(), ironclaw_attested_runtime::BindingError> {
             Ok(())
         }
-        async fn get(&self, _gate_ref: &SigningGateRef) -> Option<AttestedGateBinding> {
+        async fn get(
+            &self,
+            _key: &ironclaw_attested_runtime::BindingKey,
+        ) -> Option<AttestedGateBinding> {
             Some(self.0.clone())
         }
     }
@@ -954,7 +963,7 @@ async fn gate_resolve_is_tenant_isolated_cross_tenant_grant_fails_closed() {
     // Tenant B's grant was never claimed — it is still sealed and claimable.
     let b_key = GrantKey::from_context(&ctx_b, hash);
     grants
-        .claim(&b_key)
+        .claim(&b_key, ironclaw_attestation::now_unix_millis())
         .await
         .expect("tenant-B grant must remain unclaimed by the failed cross-tenant resolve");
 
@@ -1020,7 +1029,7 @@ async fn gate_resolve_cross_tenant_keystore_scope_fails_closed() {
     // the one-shot grant is untouched and still claimable.
     let a_key = GrantKey::from_context(&ctx_a, hash);
     grants
-        .claim(&a_key)
+        .claim(&a_key, ironclaw_attestation::now_unix_millis())
         .await
         .expect("grant must remain unclaimed when the keystore-scope lookup fails first");
 
@@ -1061,7 +1070,7 @@ async fn binding_store_is_tenant_isolated_by_gate_ref() {
     ctx_a.gate_ref = gate_a.clone();
     bindings
         .put(
-            gate_a.clone(),
+            BindingKey::new(ctx_a.tenant.clone(), gate_a.clone()),
             AttestedGateBinding {
                 provider_id: ProviderId::Custodial,
                 context: ctx_a.clone(),
@@ -1078,7 +1087,13 @@ async fn binding_store_is_tenant_isolated_by_gate_ref() {
     // Tenant B's gate_ref has NO binding just because tenant A's does.
     let gate_b = SigningGateRef::new("gate:tenant-b:resolve");
     assert!(
-        bindings.get(&gate_b).await.is_none(),
+        bindings
+            .get(&BindingKey::new(
+                SigningTenantId::new("tenant-b"),
+                gate_b.clone()
+            ))
+            .await
+            .is_none(),
         "tenant-B gate_ref must not resolve tenant-A's binding"
     );
     assert!(
@@ -1092,7 +1107,7 @@ async fn binding_store_is_tenant_isolated_by_gate_ref() {
     ctx_b.gate_ref = gate_b.clone();
     bindings
         .put(
-            gate_b.clone(),
+            BindingKey::new(ctx_b.tenant.clone(), gate_b.clone()),
             AttestedGateBinding {
                 provider_id: ProviderId::Custodial,
                 context: ctx_b.clone(),
@@ -1108,12 +1123,18 @@ async fn binding_store_is_tenant_isolated_by_gate_ref() {
 
     // Each gate_ref resolves to its OWN tenant's binding, never the other's.
     let got_a = bindings
-        .get(&gate_a)
+        .get(&BindingKey::new(
+            SigningTenantId::new("tenant-a"),
+            gate_a.clone(),
+        ))
         .await
         .expect("tenant-a binding present");
     assert_eq!(got_a.context.tenant.as_str(), "tenant-a");
     let got_b = bindings
-        .get(&gate_b)
+        .get(&BindingKey::new(
+            SigningTenantId::new("tenant-b"),
+            gate_b.clone(),
+        ))
         .await
         .expect("tenant-b binding present");
     assert_eq!(got_b.context.tenant.as_str(), "tenant-b");
@@ -1122,7 +1143,10 @@ async fn binding_store_is_tenant_isolated_by_gate_ref() {
     // the store key must equal the binding's own `context.gate_ref`.
     let err = bindings
         .put(
-            SigningGateRef::new("gate:tenant-a:resolve"),
+            BindingKey::new(
+                SigningTenantId::new("tenant-a"),
+                SigningGateRef::new("gate:tenant-a:resolve"),
+            ),
             AttestedGateBinding {
                 provider_id: ProviderId::Custodial,
                 context: ctx_b, // gate_ref is tenant-b's, keyed under tenant-a's
@@ -1134,11 +1158,11 @@ async fn binding_store_is_tenant_isolated_by_gate_ref() {
             },
         )
         .await
-        .expect_err("binding whose context.gate_ref != store key must be rejected");
-    assert_eq!(
-        err,
-        ironclaw_attested_runtime::BindingError::GateRefMismatch
-    );
+        .expect_err("binding filed under another tenant's key must be rejected");
+    // The composite key checks the tenant axis BEFORE the gate_ref, so a
+    // cross-tenant smuggle is refused as a tenant mismatch (it is also a
+    // gate_ref mismatch; the tenant is the stronger, first-checked axis).
+    assert_eq!(err, ironclaw_attested_runtime::BindingError::TenantMismatch);
 }
 
 // ── Threats #1/#16 via the resume PORT (drives the turns resume boundary) ──
@@ -1283,6 +1307,7 @@ async fn binding_write_rejects_chain_mismatch() {
 
     // The decoded tx is on eip155:11155111 (testnet); bind a MAINNET chain. The
     // store must reject this so a testnet/mainnet smuggle never persists.
+    let tenant = ctx.tenant.clone();
     let binding = AttestedGateBinding {
         provider_id: ProviderId::Custodial,
         context: ctx,
@@ -1294,7 +1319,7 @@ async fn binding_write_rejects_chain_mismatch() {
     };
     let bindings = InMemoryAttestedGateBindingStore::new();
     let err = bindings
-        .put(SigningGateRef::new(GATE), binding)
+        .put(BindingKey::new(tenant, SigningGateRef::new(GATE)), binding)
         .await
         .expect_err("chain mismatch must be rejected");
     assert_eq!(err, ironclaw_attested_runtime::BindingError::ChainMismatch);
@@ -1418,7 +1443,7 @@ async fn put_external_binding(
 ) {
     bindings
         .put(
-            SigningGateRef::new(GATE),
+            BindingKey::new(ctx.tenant.clone(), SigningGateRef::new(GATE)),
             AttestedGateBinding {
                 provider_id,
                 context: ctx.clone(),
@@ -1548,12 +1573,15 @@ async fn driver_rejects_binding_chain_mismatch() {
     impl AttestedGateBindingStore for ChainMismatchStore {
         async fn put(
             &self,
-            _gate_ref: SigningGateRef,
+            _key: ironclaw_attested_runtime::BindingKey,
             _binding: AttestedGateBinding,
         ) -> Result<(), ironclaw_attested_runtime::BindingError> {
             Ok(())
         }
-        async fn get(&self, _gate_ref: &SigningGateRef) -> Option<AttestedGateBinding> {
+        async fn get(
+            &self,
+            _key: &ironclaw_attested_runtime::BindingKey,
+        ) -> Option<AttestedGateBinding> {
             Some(self.0.clone())
         }
     }

--- a/crates/ironclaw_attested_store/src/binding.rs
+++ b/crates/ironclaw_attested_store/src/binding.rs
@@ -27,44 +27,72 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 use ironclaw_attested_runtime::{
-    AttestedGateBinding, AttestedGateBindingStore, BindingError, SyncBindingRead, validate_binding,
+    AttestedGateBinding, AttestedGateBindingStore, BindingError, BindingKey, SyncBindingRead,
+    validate_binding_key,
 };
 #[cfg(any(feature = "postgres", feature = "libsql"))]
-use ironclaw_signing_provider::GateRef;
+use ironclaw_signing_provider::{GateRef, TenantId};
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 use crate::error::StoreError;
 
+// The primary key is the tenant-qualified `(tenant, gate_ref)` pair, mirroring
+// the grant + ledger tenant-first keying. A binding can never collide across
+// tenants, and the insert-only CAS is per `(tenant, gate_ref)`.
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS attested_gate_bindings (
-    gate_ref     TEXT PRIMARY KEY,
-    binding_json TEXT NOT NULL
+    tenant       TEXT NOT NULL,
+    gate_ref     TEXT NOT NULL,
+    binding_json TEXT NOT NULL,
+    PRIMARY KEY (tenant, gate_ref)
 );";
 
 /// The write-through cache shared by both backends.
+///
+/// The primary map is keyed by the tenant-qualified [`BindingKey`] for the async
+/// `get`/`put`; a secondary `gate_ref -> BindingKey` index serves the sync resume
+/// read, which carries no tenant.
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 #[derive(Default)]
 struct BindingCache {
-    inner: Mutex<HashMap<GateRef, AttestedGateBinding>>,
+    inner: Mutex<HashMap<BindingKey, AttestedGateBinding>>,
+    by_gate_ref: Mutex<HashMap<GateRef, BindingKey>>,
 }
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 impl BindingCache {
-    fn insert(&self, gate_ref: GateRef, binding: AttestedGateBinding) {
+    fn insert(&self, key: BindingKey, binding: AttestedGateBinding) {
+        if let Ok(mut index) = self.by_gate_ref.lock() {
+            index.insert(key.gate_ref.clone(), key.clone());
+        }
         if let Ok(mut map) = self.inner.lock() {
-            map.insert(gate_ref, binding);
+            map.insert(key, binding);
         }
     }
 
-    fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
+    /// Tenant-qualified read for the async path.
+    fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding> {
         match self.inner.lock() {
-            Ok(map) => map.get(gate_ref).cloned(),
+            Ok(map) => map.get(key).cloned(),
             Err(_) => {
                 tracing::error!("binding cache lock poisoned");
                 None
             }
         }
+    }
+
+    /// gate_ref-only read for the sync resume path: resolve the gate_ref to its
+    /// owning [`BindingKey`] via the index, then read.
+    fn get_by_gate_ref(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
+        let key = match self.by_gate_ref.lock() {
+            Ok(index) => index.get(gate_ref).cloned()?,
+            Err(_) => {
+                tracing::error!("binding cache gate_ref index lock poisoned");
+                return None;
+            }
+        };
+        self.get(&key)
     }
 }
 
@@ -107,17 +135,21 @@ mod postgres {
             let client = self.client().await?;
             let rows = client
                 .query(
-                    "SELECT gate_ref, binding_json FROM attested_gate_bindings",
+                    "SELECT tenant, gate_ref, binding_json FROM attested_gate_bindings",
                     &[],
                 )
                 .await
                 .map_err(StoreError::backend)?;
             for row in rows {
-                let gate_ref: String = row.get(0);
-                let json: String = row.get(1);
+                let tenant: String = row.get(0);
+                let gate_ref: String = row.get(1);
+                let json: String = row.get(2);
                 let binding: AttestedGateBinding =
                     serde_json::from_str(&json).map_err(StoreError::backend)?;
-                self.cache.insert(GateRef::new(gate_ref), binding);
+                self.cache.insert(
+                    BindingKey::new(TenantId::new(tenant), GateRef::new(gate_ref)),
+                    binding,
+                );
             }
             Ok(())
         }
@@ -129,7 +161,7 @@ mod postgres {
 
     impl SyncBindingRead for PostgresAttestedGateBindingStore {
         fn get_sync(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            self.cache.get(gate_ref)
+            self.cache.get_by_gate_ref(gate_ref)
         }
     }
 
@@ -137,12 +169,12 @@ mod postgres {
     impl AttestedGateBindingStore for PostgresAttestedGateBindingStore {
         async fn put(
             &self,
-            gate_ref: GateRef,
+            key: BindingKey,
             binding: AttestedGateBinding,
         ) -> Result<(), BindingError> {
-            // Validate before any I/O so a malformed/self-contradictory binding
-            // never reaches the table or the resume cache.
-            validate_binding(&gate_ref, &binding)?;
+            // Validate (gate_ref + tenant + self-consistency) before any I/O so a
+            // malformed/mis-tenanted binding never reaches the table or cache.
+            validate_binding_key(&key, &binding)?;
             let json = serde_json::to_string(&binding).map_err(|error| {
                 tracing::error!(%error, "failed to serialize attested gate binding");
                 BindingError::Poisoned
@@ -151,17 +183,17 @@ mod postgres {
                 tracing::error!(%error, "failed to acquire connection for binding put");
                 BindingError::Poisoned
             })?;
-            // Insert-only per gate_ref: a binding is immutable once written. A
-            // conflicting write (a re-put after approval) is REJECTED, not
-            // silently applied — the approved binding must never change under
+            // Insert-only per (tenant, gate_ref): a binding is immutable once
+            // written. A conflicting write (a re-put after approval) is REJECTED,
+            // not silently applied — the approved binding must never change under
             // the resume path. `DO NOTHING` + the affected-row count is the
             // DB-level guard (no SELECT-then-INSERT race).
             let inserted = client
                 .execute(
-                    "INSERT INTO attested_gate_bindings (gate_ref, binding_json) \
-                     VALUES ($1, $2) \
-                     ON CONFLICT (gate_ref) DO NOTHING",
-                    &[&gate_ref.as_str(), &json],
+                    "INSERT INTO attested_gate_bindings (tenant, gate_ref, binding_json) \
+                     VALUES ($1, $2, $3) \
+                     ON CONFLICT (tenant, gate_ref) DO NOTHING",
+                    &[&key.tenant.as_str(), &key.gate_ref.as_str(), &json],
                 )
                 .await
                 .map_err(|error| {
@@ -170,18 +202,19 @@ mod postgres {
                 })?;
             if inserted == 0 {
                 tracing::error!(
-                    gate_ref = %gate_ref.as_str(),
+                    tenant = %key.tenant.as_str(),
+                    gate_ref = %key.gate_ref.as_str(),
                     "rejected attempt to overwrite an existing immutable gate binding"
                 );
                 return Err(BindingError::AlreadyExists);
             }
             // Write-through only after the durable insert succeeds.
-            self.cache.insert(gate_ref, binding);
+            self.cache.insert(key, binding);
             Ok(())
         }
 
-        async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            self.cache.get(gate_ref)
+        async fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding> {
+            self.cache.get(key)
         }
     }
 }
@@ -228,17 +261,21 @@ mod libsql_backend {
             let conn = self.connect_db().await?;
             let mut rows = conn
                 .query(
-                    "SELECT gate_ref, binding_json FROM attested_gate_bindings",
+                    "SELECT tenant, gate_ref, binding_json FROM attested_gate_bindings",
                     (),
                 )
                 .await
                 .map_err(StoreError::backend)?;
             while let Some(row) = rows.next().await.map_err(StoreError::backend)? {
-                let gate_ref: String = row.get(0).map_err(StoreError::backend)?;
-                let json: String = row.get(1).map_err(StoreError::backend)?;
+                let tenant: String = row.get(0).map_err(StoreError::backend)?;
+                let gate_ref: String = row.get(1).map_err(StoreError::backend)?;
+                let json: String = row.get(2).map_err(StoreError::backend)?;
                 let binding: AttestedGateBinding =
                     serde_json::from_str(&json).map_err(StoreError::backend)?;
-                self.cache.insert(GateRef::new(gate_ref), binding);
+                self.cache.insert(
+                    BindingKey::new(TenantId::new(tenant), GateRef::new(gate_ref)),
+                    binding,
+                );
             }
             Ok(())
         }
@@ -254,7 +291,7 @@ mod libsql_backend {
 
     impl SyncBindingRead for LibSqlAttestedGateBindingStore {
         fn get_sync(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            self.cache.get(gate_ref)
+            self.cache.get_by_gate_ref(gate_ref)
         }
     }
 
@@ -262,12 +299,12 @@ mod libsql_backend {
     impl AttestedGateBindingStore for LibSqlAttestedGateBindingStore {
         async fn put(
             &self,
-            gate_ref: GateRef,
+            key: BindingKey,
             binding: AttestedGateBinding,
         ) -> Result<(), BindingError> {
-            // Validate before any I/O so a malformed/self-contradictory binding
-            // never reaches the table or the resume cache.
-            validate_binding(&gate_ref, &binding)?;
+            // Validate (gate_ref + tenant + self-consistency) before any I/O so a
+            // malformed/mis-tenanted binding never reaches the table or cache.
+            validate_binding_key(&key, &binding)?;
             let json = serde_json::to_string(&binding).map_err(|error| {
                 tracing::error!(%error, "failed to serialize attested gate binding");
                 BindingError::Poisoned
@@ -276,16 +313,16 @@ mod libsql_backend {
                 tracing::error!(%error, "failed to open libsql connection for binding put");
                 BindingError::Poisoned
             })?;
-            // Insert-only per gate_ref: a binding is immutable once written. A
-            // conflicting re-put is REJECTED at the DB level (`DO NOTHING` +
-            // affected-row count), never silently overwriting the approved
-            // binding under the resume path.
+            // Insert-only per (tenant, gate_ref): a binding is immutable once
+            // written. A conflicting re-put is REJECTED at the DB level
+            // (`DO NOTHING` + affected-row count), never silently overwriting the
+            // approved binding under the resume path.
             let inserted = conn
                 .execute(
-                    "INSERT INTO attested_gate_bindings (gate_ref, binding_json) \
-                     VALUES (?1, ?2) \
-                     ON CONFLICT (gate_ref) DO NOTHING",
-                    libsql::params![gate_ref.as_str(), json],
+                    "INSERT INTO attested_gate_bindings (tenant, gate_ref, binding_json) \
+                     VALUES (?1, ?2, ?3) \
+                     ON CONFLICT (tenant, gate_ref) DO NOTHING",
+                    libsql::params![key.tenant.as_str(), key.gate_ref.as_str(), json],
                 )
                 .await
                 .map_err(|error| {
@@ -294,17 +331,18 @@ mod libsql_backend {
                 })?;
             if inserted == 0 {
                 tracing::error!(
-                    gate_ref = %gate_ref.as_str(),
+                    tenant = %key.tenant.as_str(),
+                    gate_ref = %key.gate_ref.as_str(),
                     "rejected attempt to overwrite an existing immutable gate binding"
                 );
                 return Err(BindingError::AlreadyExists);
             }
-            self.cache.insert(gate_ref, binding);
+            self.cache.insert(key, binding);
             Ok(())
         }
 
-        async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            self.cache.get(gate_ref)
+        async fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding> {
+            self.cache.get(key)
         }
     }
 }

--- a/crates/ironclaw_attested_store/src/binding.rs
+++ b/crates/ironclaw_attested_store/src/binding.rs
@@ -50,44 +50,72 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 use ironclaw_attested_runtime::{
-    AttestedGateBinding, AttestedGateBindingStore, BindingError, SyncBindingRead, validate_binding,
+    AttestedGateBinding, AttestedGateBindingStore, BindingError, BindingKey, SyncBindingRead,
+    validate_binding_key,
 };
 #[cfg(any(feature = "postgres", feature = "libsql"))]
-use ironclaw_signing_provider::GateRef;
+use ironclaw_signing_provider::{GateRef, TenantId};
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 use crate::error::StoreError;
 
+// The primary key is the tenant-qualified `(tenant, gate_ref)` pair, mirroring
+// the grant + ledger tenant-first keying. A binding can never collide across
+// tenants, and the insert-only CAS is per `(tenant, gate_ref)`.
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS attested_gate_bindings (
-    gate_ref     TEXT PRIMARY KEY,
-    binding_json TEXT NOT NULL
+    tenant       TEXT NOT NULL,
+    gate_ref     TEXT NOT NULL,
+    binding_json TEXT NOT NULL,
+    PRIMARY KEY (tenant, gate_ref)
 );";
 
 /// The write-through cache shared by both backends.
+///
+/// The primary map is keyed by the tenant-qualified [`BindingKey`] for the async
+/// `get`/`put`; a secondary `gate_ref -> BindingKey` index serves the sync resume
+/// read, which carries no tenant.
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 #[derive(Default)]
 struct BindingCache {
-    inner: Mutex<HashMap<GateRef, AttestedGateBinding>>,
+    inner: Mutex<HashMap<BindingKey, AttestedGateBinding>>,
+    by_gate_ref: Mutex<HashMap<GateRef, BindingKey>>,
 }
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 impl BindingCache {
-    fn insert(&self, gate_ref: GateRef, binding: AttestedGateBinding) {
+    fn insert(&self, key: BindingKey, binding: AttestedGateBinding) {
+        if let Ok(mut index) = self.by_gate_ref.lock() {
+            index.insert(key.gate_ref.clone(), key.clone());
+        }
         if let Ok(mut map) = self.inner.lock() {
-            map.insert(gate_ref, binding);
+            map.insert(key, binding);
         }
     }
 
-    fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
+    /// Tenant-qualified read for the async path.
+    fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding> {
         match self.inner.lock() {
-            Ok(map) => map.get(gate_ref).cloned(),
+            Ok(map) => map.get(key).cloned(),
             Err(_) => {
                 tracing::error!("binding cache lock poisoned");
                 None
             }
         }
+    }
+
+    /// gate_ref-only read for the sync resume path: resolve the gate_ref to its
+    /// owning [`BindingKey`] via the index, then read.
+    fn get_by_gate_ref(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
+        let key = match self.by_gate_ref.lock() {
+            Ok(index) => index.get(gate_ref).cloned()?,
+            Err(_) => {
+                tracing::error!("binding cache gate_ref index lock poisoned");
+                return None;
+            }
+        };
+        self.get(&key)
     }
 }
 
@@ -130,17 +158,21 @@ mod postgres {
             let client = self.client().await?;
             let rows = client
                 .query(
-                    "SELECT gate_ref, binding_json FROM attested_gate_bindings",
+                    "SELECT tenant, gate_ref, binding_json FROM attested_gate_bindings",
                     &[],
                 )
                 .await
                 .map_err(StoreError::backend)?;
             for row in rows {
-                let gate_ref: String = row.get(0);
-                let json: String = row.get(1);
+                let tenant: String = row.get(0);
+                let gate_ref: String = row.get(1);
+                let json: String = row.get(2);
                 let binding: AttestedGateBinding =
                     serde_json::from_str(&json).map_err(StoreError::backend)?;
-                self.cache.insert(GateRef::new(gate_ref), binding);
+                self.cache.insert(
+                    BindingKey::new(TenantId::new(tenant), GateRef::new(gate_ref)),
+                    binding,
+                );
             }
             Ok(())
         }
@@ -149,17 +181,20 @@ mod postgres {
             self.pool.get().await.map_err(StoreError::backend)
         }
 
-        /// Read a single binding from the table by `gate_ref`. Used as the
-        /// read-through fallback when the async `get` misses the cache.
+        /// Read a single binding from the table by its tenant-qualified key.
+        /// Used as the read-through fallback when the async `get` misses the
+        /// cache. Keyed on the full `(tenant, gate_ref)` primary key so the
+        /// fallback can never cross the tenant boundary.
         async fn load_one(
             &self,
-            gate_ref: &GateRef,
+            key: &BindingKey,
         ) -> Result<Option<AttestedGateBinding>, StoreError> {
             let client = self.client().await?;
             let row = client
                 .query_opt(
-                    "SELECT binding_json FROM attested_gate_bindings WHERE gate_ref = $1",
-                    &[&gate_ref.as_str()],
+                    "SELECT binding_json FROM attested_gate_bindings \
+                     WHERE tenant = $1 AND gate_ref = $2",
+                    &[&key.tenant.as_str(), &key.gate_ref.as_str()],
                 )
                 .await
                 .map_err(StoreError::backend)?;
@@ -177,7 +212,7 @@ mod postgres {
 
     impl SyncBindingRead for PostgresAttestedGateBindingStore {
         fn get_sync(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            self.cache.get(gate_ref)
+            self.cache.get_by_gate_ref(gate_ref)
         }
     }
 
@@ -185,12 +220,12 @@ mod postgres {
     impl AttestedGateBindingStore for PostgresAttestedGateBindingStore {
         async fn put(
             &self,
-            gate_ref: GateRef,
+            key: BindingKey,
             binding: AttestedGateBinding,
         ) -> Result<(), BindingError> {
-            // Validate before any I/O so a malformed/self-contradictory binding
-            // never reaches the table or the resume cache.
-            validate_binding(&gate_ref, &binding)?;
+            // Validate (gate_ref + tenant + self-consistency) before any I/O so a
+            // malformed/mis-tenanted binding never reaches the table or cache.
+            validate_binding_key(&key, &binding)?;
             let json = serde_json::to_string(&binding).map_err(|error| {
                 tracing::error!(%error, "failed to serialize attested gate binding");
                 BindingError::Poisoned
@@ -199,17 +234,17 @@ mod postgres {
                 tracing::error!(%error, "failed to acquire connection for binding put");
                 BindingError::Poisoned
             })?;
-            // Insert-only per gate_ref: a binding is immutable once written. A
-            // conflicting write (a re-put after approval) is REJECTED, not
-            // silently applied — the approved binding must never change under
+            // Insert-only per (tenant, gate_ref): a binding is immutable once
+            // written. A conflicting write (a re-put after approval) is REJECTED,
+            // not silently applied — the approved binding must never change under
             // the resume path. `DO NOTHING` + the affected-row count is the
             // DB-level guard (no SELECT-then-INSERT race).
             let inserted = client
                 .execute(
-                    "INSERT INTO attested_gate_bindings (gate_ref, binding_json) \
-                     VALUES ($1, $2) \
-                     ON CONFLICT (gate_ref) DO NOTHING",
-                    &[&gate_ref.as_str(), &json],
+                    "INSERT INTO attested_gate_bindings (tenant, gate_ref, binding_json) \
+                     VALUES ($1, $2, $3) \
+                     ON CONFLICT (tenant, gate_ref) DO NOTHING",
+                    &[&key.tenant.as_str(), &key.gate_ref.as_str(), &json],
                 )
                 .await
                 .map_err(|error| {
@@ -218,34 +253,38 @@ mod postgres {
                 })?;
             if inserted == 0 {
                 tracing::error!(
-                    gate_ref = %gate_ref.as_str(),
+                    tenant = %key.tenant.as_str(),
+                    gate_ref = %key.gate_ref.as_str(),
                     "rejected attempt to overwrite an existing immutable gate binding"
                 );
                 return Err(BindingError::AlreadyExists);
             }
             // Write-through only after the durable insert succeeds.
-            self.cache.insert(gate_ref, binding);
+            self.cache.insert(key, binding);
             Ok(())
         }
 
-        async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            if let Some(binding) = self.cache.get(gate_ref) {
+        async fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding> {
+            if let Some(binding) = self.cache.get(key) {
                 return Some(binding);
             }
             // Cache miss: the DB row is the source of truth. Fall back to a
             // table read (a binding written by another process/replica, or
             // after this instance's `load()`, is otherwise invisible) and warm
-            // the cache on a hit.
-            match self.load_one(gate_ref).await {
+            // the cache on a hit. The read is tenant-qualified — the table's
+            // primary key is `(tenant, gate_ref)`, so a gate_ref-only lookup
+            // could surface another tenant's row.
+            match self.load_one(key).await {
                 Ok(Some(binding)) => {
-                    self.cache.insert(gate_ref.clone(), binding.clone());
+                    self.cache.insert(key.clone(), binding.clone());
                     Some(binding)
                 }
                 Ok(None) => None,
                 Err(error) => {
                     tracing::error!(
                         %error,
-                        gate_ref = %gate_ref.as_str(),
+                        tenant = %key.tenant.as_str(),
+                        gate_ref = %key.gate_ref.as_str(),
                         "failed to read attested gate binding from db on cache miss"
                     );
                     None
@@ -297,17 +336,21 @@ mod libsql_backend {
             let conn = self.connect_db().await?;
             let mut rows = conn
                 .query(
-                    "SELECT gate_ref, binding_json FROM attested_gate_bindings",
+                    "SELECT tenant, gate_ref, binding_json FROM attested_gate_bindings",
                     (),
                 )
                 .await
                 .map_err(StoreError::backend)?;
             while let Some(row) = rows.next().await.map_err(StoreError::backend)? {
-                let gate_ref: String = row.get(0).map_err(StoreError::backend)?;
-                let json: String = row.get(1).map_err(StoreError::backend)?;
+                let tenant: String = row.get(0).map_err(StoreError::backend)?;
+                let gate_ref: String = row.get(1).map_err(StoreError::backend)?;
+                let json: String = row.get(2).map_err(StoreError::backend)?;
                 let binding: AttestedGateBinding =
                     serde_json::from_str(&json).map_err(StoreError::backend)?;
-                self.cache.insert(GateRef::new(gate_ref), binding);
+                self.cache.insert(
+                    BindingKey::new(TenantId::new(tenant), GateRef::new(gate_ref)),
+                    binding,
+                );
             }
             Ok(())
         }
@@ -320,17 +363,20 @@ mod libsql_backend {
             Ok(conn)
         }
 
-        /// Read a single binding from the table by `gate_ref`. Used as the
-        /// read-through fallback when the async `get` misses the cache.
+        /// Read a single binding from the table by its tenant-qualified key.
+        /// Used as the read-through fallback when the async `get` misses the
+        /// cache. Keyed on the full `(tenant, gate_ref)` primary key so the
+        /// fallback can never cross the tenant boundary.
         async fn load_one(
             &self,
-            gate_ref: &GateRef,
+            key: &BindingKey,
         ) -> Result<Option<AttestedGateBinding>, StoreError> {
             let conn = self.connect_db().await?;
             let mut rows = conn
                 .query(
-                    "SELECT binding_json FROM attested_gate_bindings WHERE gate_ref = ?1",
-                    libsql::params![gate_ref.as_str()],
+                    "SELECT binding_json FROM attested_gate_bindings \
+                     WHERE tenant = ?1 AND gate_ref = ?2",
+                    libsql::params![key.tenant.as_str(), key.gate_ref.as_str()],
                 )
                 .await
                 .map_err(StoreError::backend)?;
@@ -348,7 +394,7 @@ mod libsql_backend {
 
     impl SyncBindingRead for LibSqlAttestedGateBindingStore {
         fn get_sync(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            self.cache.get(gate_ref)
+            self.cache.get_by_gate_ref(gate_ref)
         }
     }
 
@@ -356,12 +402,12 @@ mod libsql_backend {
     impl AttestedGateBindingStore for LibSqlAttestedGateBindingStore {
         async fn put(
             &self,
-            gate_ref: GateRef,
+            key: BindingKey,
             binding: AttestedGateBinding,
         ) -> Result<(), BindingError> {
-            // Validate before any I/O so a malformed/self-contradictory binding
-            // never reaches the table or the resume cache.
-            validate_binding(&gate_ref, &binding)?;
+            // Validate (gate_ref + tenant + self-consistency) before any I/O so a
+            // malformed/mis-tenanted binding never reaches the table or cache.
+            validate_binding_key(&key, &binding)?;
             let json = serde_json::to_string(&binding).map_err(|error| {
                 tracing::error!(%error, "failed to serialize attested gate binding");
                 BindingError::Poisoned
@@ -370,16 +416,16 @@ mod libsql_backend {
                 tracing::error!(%error, "failed to open libsql connection for binding put");
                 BindingError::Poisoned
             })?;
-            // Insert-only per gate_ref: a binding is immutable once written. A
-            // conflicting re-put is REJECTED at the DB level (`DO NOTHING` +
-            // affected-row count), never silently overwriting the approved
-            // binding under the resume path.
+            // Insert-only per (tenant, gate_ref): a binding is immutable once
+            // written. A conflicting re-put is REJECTED at the DB level
+            // (`DO NOTHING` + affected-row count), never silently overwriting the
+            // approved binding under the resume path.
             let inserted = conn
                 .execute(
-                    "INSERT INTO attested_gate_bindings (gate_ref, binding_json) \
-                     VALUES (?1, ?2) \
-                     ON CONFLICT (gate_ref) DO NOTHING",
-                    libsql::params![gate_ref.as_str(), json],
+                    "INSERT INTO attested_gate_bindings (tenant, gate_ref, binding_json) \
+                     VALUES (?1, ?2, ?3) \
+                     ON CONFLICT (tenant, gate_ref) DO NOTHING",
+                    libsql::params![key.tenant.as_str(), key.gate_ref.as_str(), json],
                 )
                 .await
                 .map_err(|error| {
@@ -388,31 +434,37 @@ mod libsql_backend {
                 })?;
             if inserted == 0 {
                 tracing::error!(
-                    gate_ref = %gate_ref.as_str(),
+                    tenant = %key.tenant.as_str(),
+                    gate_ref = %key.gate_ref.as_str(),
                     "rejected attempt to overwrite an existing immutable gate binding"
                 );
                 return Err(BindingError::AlreadyExists);
             }
-            self.cache.insert(gate_ref, binding);
+            self.cache.insert(key, binding);
             Ok(())
         }
 
-        async fn get(&self, gate_ref: &GateRef) -> Option<AttestedGateBinding> {
-            if let Some(binding) = self.cache.get(gate_ref) {
+        async fn get(&self, key: &BindingKey) -> Option<AttestedGateBinding> {
+            if let Some(binding) = self.cache.get(key) {
                 return Some(binding);
             }
             // Cache miss: the DB row is the source of truth. Fall back to a
-            // table read and warm the cache on a hit.
-            match self.load_one(gate_ref).await {
+            // table read (a binding written by another process/replica, or
+            // after this instance's `load()`, is otherwise invisible) and warm
+            // the cache on a hit. The read is tenant-qualified — the table's
+            // primary key is `(tenant, gate_ref)`, so a gate_ref-only lookup
+            // could surface another tenant's row.
+            match self.load_one(key).await {
                 Ok(Some(binding)) => {
-                    self.cache.insert(gate_ref.clone(), binding.clone());
+                    self.cache.insert(key.clone(), binding.clone());
                     Some(binding)
                 }
                 Ok(None) => None,
                 Err(error) => {
                     tracing::error!(
                         %error,
-                        gate_ref = %gate_ref.as_str(),
+                        tenant = %key.tenant.as_str(),
+                        gate_ref = %key.gate_ref.as_str(),
                         "failed to read attested gate binding from db on cache miss"
                     );
                     None

--- a/crates/ironclaw_attested_store/src/grant.rs
+++ b/crates/ironclaw_attested_store/src/grant.rs
@@ -6,12 +6,21 @@
 //! UPDATE attested_sealed_grants
 //!    SET status = 'claimed', claimed_at_ms = $now
 //!  WHERE key_hash = $key AND status = 'sealed'
+//!    AND (expiry_ms IS NULL OR expiry_ms > $now)
 //! ```
 //!
 //! Exactly one concurrent claimer can match `status = 'sealed'` and flip the
 //! row; the row count is the verdict. We never read-then-write, so a
 //! `Stuck -> InProgress` job recovery that double-claims still resolves to one
 //! winner. Rows are never deleted — a claim stamps `claimed_at_ms` in place.
+//!
+//! Expiry is enforced in the same CAS: a still-`sealed` row whose `expiry_ms`
+//! has passed (`expiry_ms <= $now`) is NOT flipped, leaving it `sealed` (never
+//! consumed, never deleted). When the CAS matches nothing the backend
+//! disambiguates `NotFound` (no row), `AlreadyClaimed` (row is `claimed`), and
+//! `Expired` (row is still `sealed` but past `expiry_ms`). `$now` is the runtime
+//! clock supplied by the caller — the store never reads the wall clock, so
+//! resume stays deterministic and expiry is testable.
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 use async_trait::async_trait;
@@ -42,14 +51,6 @@ CREATE TABLE IF NOT EXISTS attested_sealed_grants (
     expiry_ms         BIGINT,
     claimed_at_ms     BIGINT
 );";
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
-fn now_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as i64)
-        .unwrap_or(0)
-}
 
 // ---------------------------------------------------------------------------
 // PostgreSQL
@@ -127,18 +128,20 @@ mod postgres {
             Ok(())
         }
 
-        async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError> {
+        async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError> {
             let client = self.client().await?;
             let key_hash = grant_key_hash(key);
-            // Atomic one-shot CAS + read-back of created_at in a single
-            // statement. RETURNING avoids a read-then-write race entirely.
+            // Atomic one-shot CAS + expiry guard + read-back of created_at in a
+            // single statement. RETURNING avoids a read-then-write race entirely.
+            // An expired (or claimed) row matches nothing and is left untouched.
             let claimed = client
                 .query_opt(
                     "UPDATE attested_sealed_grants \
                      SET status = 'claimed', claimed_at_ms = $2 \
                      WHERE key_hash = $1 AND status = 'sealed' \
+                       AND (expiry_ms IS NULL OR expiry_ms > $2) \
                      RETURNING created_at_ms",
-                    &[&key_hash, &now_ms()],
+                    &[&key_hash, &now_ms],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
@@ -151,18 +154,30 @@ mod postgres {
                 });
             }
 
-            // The CAS matched nothing: either the row never existed (NotFound)
-            // or it was already claimed (AlreadyClaimed). Disambiguate.
+            // The CAS matched nothing: the row never existed (NotFound), was
+            // already claimed (AlreadyClaimed), or is still sealed but past its
+            // expiry (Expired — distinct, and never consumed). Disambiguate from
+            // the persisted status + expiry.
             let existing = client
                 .query_opt(
-                    "SELECT status FROM attested_sealed_grants WHERE key_hash = $1",
+                    "SELECT status, expiry_ms FROM attested_sealed_grants WHERE key_hash = $1",
                     &[&key_hash],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
             match existing {
                 None => Err(GrantError::NotFound),
-                Some(_) => Err(GrantError::AlreadyClaimed),
+                Some(row) => {
+                    let status: String = row.get(0);
+                    let expiry_ms: Option<i64> = row.get(1);
+                    if status == "sealed"
+                        && let Some(expiry_ms) = expiry_ms
+                        && now_ms >= expiry_ms
+                    {
+                        return Err(GrantError::Expired { expiry_ms, now_ms });
+                    }
+                    Err(GrantError::AlreadyClaimed)
+                }
             }
         }
     }
@@ -249,16 +264,19 @@ mod libsql_backend {
             Ok(())
         }
 
-        async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError> {
+        async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError> {
             let conn = self.connect().await?;
             let key_hash = grant_key_hash(key);
-            // Atomic one-shot CAS: only a row still 'sealed' is flipped.
+            // Atomic one-shot CAS + expiry guard: only a row still 'sealed' AND
+            // not past its expiry is flipped. An expired row matches nothing and
+            // is left 'sealed' (never consumed, never deleted).
             let updated = conn
                 .execute(
                     "UPDATE attested_sealed_grants \
                      SET status = 'claimed', claimed_at_ms = ?2 \
-                     WHERE key_hash = ?1 AND status = 'sealed'",
-                    libsql::params![key_hash.clone(), now_ms()],
+                     WHERE key_hash = ?1 AND status = 'sealed' \
+                       AND (expiry_ms IS NULL OR expiry_ms > ?2)",
+                    libsql::params![key_hash.clone(), now_ms],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
@@ -282,17 +300,28 @@ mod libsql_backend {
                 });
             }
 
-            // CAS matched nothing: disambiguate NotFound vs AlreadyClaimed.
+            // CAS matched nothing: disambiguate NotFound, AlreadyClaimed, and
+            // Expired (still 'sealed' but past expiry — never consumed).
             let mut rows = conn
                 .query(
-                    "SELECT status FROM attested_sealed_grants WHERE key_hash = ?1",
+                    "SELECT status, expiry_ms FROM attested_sealed_grants WHERE key_hash = ?1",
                     libsql::params![key_hash],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
             match rows.next().await.map_err(|error| backend(&error))? {
                 None => Err(GrantError::NotFound),
-                Some(_) => Err(GrantError::AlreadyClaimed),
+                Some(row) => {
+                    let status = row.get::<String>(0).map_err(|error| backend(&error))?;
+                    let expiry_ms = row.get::<Option<i64>>(1).map_err(|error| backend(&error))?;
+                    if status == "sealed"
+                        && let Some(expiry_ms) = expiry_ms
+                        && now_ms >= expiry_ms
+                    {
+                        return Err(GrantError::Expired { expiry_ms, now_ms });
+                    }
+                    Err(GrantError::AlreadyClaimed)
+                }
             }
         }
     }

--- a/crates/ironclaw_attested_store/src/grant.rs
+++ b/crates/ironclaw_attested_store/src/grant.rs
@@ -6,12 +6,21 @@
 //! UPDATE attested_sealed_grants
 //!    SET status = 'claimed', claimed_at_ms = $now
 //!  WHERE key_hash = $key AND status = 'sealed'
+//!    AND (expiry_ms IS NULL OR expiry_ms > $now)
 //! ```
 //!
 //! Exactly one concurrent claimer can match `status = 'sealed'` and flip the
 //! row; the row count is the verdict. We never read-then-write, so a
 //! `Stuck -> InProgress` job recovery that double-claims still resolves to one
 //! winner. Rows are never deleted — a claim stamps `claimed_at_ms` in place.
+//!
+//! Expiry is enforced in the same CAS: a still-`sealed` row whose `expiry_ms`
+//! has passed (`expiry_ms <= $now`) is NOT flipped, leaving it `sealed` (never
+//! consumed, never deleted). When the CAS matches nothing the backend
+//! disambiguates `NotFound` (no row), `AlreadyClaimed` (row is `claimed`), and
+//! `Expired` (row is still `sealed` but past `expiry_ms`). `$now` is the runtime
+//! clock supplied by the caller — the store never reads the wall clock, so
+//! resume stays deterministic and expiry is testable.
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 use async_trait::async_trait;
@@ -42,14 +51,6 @@ CREATE TABLE IF NOT EXISTS attested_sealed_grants (
     expiry_ms         BIGINT,
     claimed_at_ms     BIGINT
 );";
-
-#[cfg(any(feature = "postgres", feature = "libsql"))]
-fn now_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as i64)
-        .unwrap_or(0)
-}
 
 // ---------------------------------------------------------------------------
 // PostgreSQL
@@ -127,18 +128,20 @@ mod postgres {
             Ok(())
         }
 
-        async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError> {
+        async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError> {
             let client = self.client().await?;
             let key_hash = grant_key_hash(key);
-            // Atomic one-shot CAS + read-back of created_at in a single
-            // statement. RETURNING avoids a read-then-write race entirely.
+            // Atomic one-shot CAS + expiry guard + read-back of created_at in a
+            // single statement. RETURNING avoids a read-then-write race entirely.
+            // An expired (or claimed) row matches nothing and is left untouched.
             let claimed = client
                 .query_opt(
                     "UPDATE attested_sealed_grants \
                      SET status = 'claimed', claimed_at_ms = $2 \
                      WHERE key_hash = $1 AND status = 'sealed' \
+                       AND (expiry_ms IS NULL OR expiry_ms > $2) \
                      RETURNING created_at_ms, expiry_ms",
-                    &[&key_hash, &now_ms()],
+                    &[&key_hash, &now_ms],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
@@ -153,18 +156,30 @@ mod postgres {
                 });
             }
 
-            // The CAS matched nothing: either the row never existed (NotFound)
-            // or it was already claimed (AlreadyClaimed). Disambiguate.
+            // The CAS matched nothing: the row never existed (NotFound), was
+            // already claimed (AlreadyClaimed), or is still sealed but past its
+            // expiry (Expired — distinct, and never consumed). Disambiguate from
+            // the persisted status + expiry.
             let existing = client
                 .query_opt(
-                    "SELECT status FROM attested_sealed_grants WHERE key_hash = $1",
+                    "SELECT status, expiry_ms FROM attested_sealed_grants WHERE key_hash = $1",
                     &[&key_hash],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
             match existing {
                 None => Err(GrantError::NotFound),
-                Some(_) => Err(GrantError::AlreadyClaimed),
+                Some(row) => {
+                    let status: String = row.get(0);
+                    let expiry_ms: Option<i64> = row.get(1);
+                    if status == "sealed"
+                        && let Some(expiry_ms) = expiry_ms
+                        && now_ms >= expiry_ms
+                    {
+                        return Err(GrantError::Expired { expiry_ms, now_ms });
+                    }
+                    Err(GrantError::AlreadyClaimed)
+                }
             }
         }
     }
@@ -251,16 +266,19 @@ mod libsql_backend {
             Ok(())
         }
 
-        async fn claim(&self, key: &GrantKey) -> Result<ClaimedGrant, GrantError> {
+        async fn claim(&self, key: &GrantKey, now_ms: i64) -> Result<ClaimedGrant, GrantError> {
             let conn = self.connect().await?;
             let key_hash = grant_key_hash(key);
-            // Atomic one-shot CAS: only a row still 'sealed' is flipped.
+            // Atomic one-shot CAS + expiry guard: only a row still 'sealed' AND
+            // not past its expiry is flipped. An expired row matches nothing and
+            // is left 'sealed' (never consumed, never deleted).
             let updated = conn
                 .execute(
                     "UPDATE attested_sealed_grants \
                      SET status = 'claimed', claimed_at_ms = ?2 \
-                     WHERE key_hash = ?1 AND status = 'sealed'",
-                    libsql::params![key_hash.clone(), now_ms()],
+                     WHERE key_hash = ?1 AND status = 'sealed' \
+                       AND (expiry_ms IS NULL OR expiry_ms > ?2)",
+                    libsql::params![key_hash.clone(), now_ms],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
@@ -290,17 +308,28 @@ mod libsql_backend {
                 });
             }
 
-            // CAS matched nothing: disambiguate NotFound vs AlreadyClaimed.
+            // CAS matched nothing: disambiguate NotFound, AlreadyClaimed, and
+            // Expired (still 'sealed' but past expiry — never consumed).
             let mut rows = conn
                 .query(
-                    "SELECT status FROM attested_sealed_grants WHERE key_hash = ?1",
+                    "SELECT status, expiry_ms FROM attested_sealed_grants WHERE key_hash = ?1",
                     libsql::params![key_hash],
                 )
                 .await
                 .map_err(|error| backend(&error))?;
             match rows.next().await.map_err(|error| backend(&error))? {
                 None => Err(GrantError::NotFound),
-                Some(_) => Err(GrantError::AlreadyClaimed),
+                Some(row) => {
+                    let status = row.get::<String>(0).map_err(|error| backend(&error))?;
+                    let expiry_ms = row.get::<Option<i64>>(1).map_err(|error| backend(&error))?;
+                    if status == "sealed"
+                        && let Some(expiry_ms) = expiry_ms
+                        && now_ms >= expiry_ms
+                    {
+                        return Err(GrantError::Expired { expiry_ms, now_ms });
+                    }
+                    Err(GrantError::AlreadyClaimed)
+                }
             }
         }
     }

--- a/crates/ironclaw_attested_store/tests/binding_contract.rs
+++ b/crates/ironclaw_attested_store/tests/binding_contract.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use alloy_consensus::TxEip1559;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use ironclaw_attestation::{DecodedTransaction, RenderingSchemaVersion};
-use ironclaw_attested_runtime::{AttestedGateBinding, AttestedGateBindingStore, SyncBindingRead};
+use ironclaw_attested_runtime::{
+    AttestedGateBinding, AttestedGateBindingStore, BindingKey, SyncBindingRead,
+};
 use ironclaw_attested_store::LibSqlAttestedGateBindingStore;
 use ironclaw_chain_signing::{ChainKeyId, evm};
 use ironclaw_host_api::{ResourceScope, TenantId, UserId};
@@ -71,6 +73,22 @@ fn sample_binding() -> AttestedGateBinding {
     }
 }
 
+/// The tenant-qualified key for the sample binding (tenant1 + the fixed gate).
+fn sample_key() -> BindingKey {
+    BindingKey::new(SigningTenantId::new("tenant1"), GateRef::new(GATE))
+}
+
+/// A binding for a specific tenant sharing the SAME `gate_ref`. Both the
+/// `context.tenant` and the custodial `scope.tenant_id` carry `tenant` so the
+/// binding is self-consistent (validate_binding_key requires the key tenant to
+/// equal the binding's own context tenant).
+fn sample_binding_for_tenant(tenant: &str) -> AttestedGateBinding {
+    let mut binding = sample_binding();
+    binding.context.tenant = SigningTenantId::new(tenant);
+    binding.scope.tenant_id = TenantId::new(tenant).unwrap();
+    binding
+}
+
 async fn build(path: &std::path::Path) -> LibSqlAttestedGateBindingStore {
     let db = Arc::new(
         libsql::Builder::new_local(path)
@@ -89,17 +107,18 @@ async fn put_then_async_and_sync_read_agree() {
     let path = dir.path().join("bindings.db");
     let store = build(&path).await;
     let gate = GateRef::new(GATE);
+    let key = sample_key();
 
-    assert!(store.get(&gate).await.is_none());
+    assert!(store.get(&key).await.is_none());
     assert!(store.get_sync(&gate).is_none());
 
     let binding = sample_binding();
     store
-        .put(gate.clone(), binding.clone())
+        .put(key.clone(), binding.clone())
         .await
         .expect("first put succeeds");
 
-    let via_async = store.get(&gate).await.expect("async read");
+    let via_async = store.get(&key).await.expect("async read");
     let via_sync = store.get_sync(&gate).expect("sync read");
     assert_eq!(via_async.approved_tx_hash, binding.approved_tx_hash);
     assert_eq!(via_sync.approved_tx_hash, binding.approved_tx_hash);
@@ -115,10 +134,11 @@ async fn binding_is_immutable_after_first_put() {
     let path = dir.path().join("bindings.db");
     let store = build(&path).await;
     let gate = GateRef::new(GATE);
+    let key = sample_key();
 
     let original = sample_binding();
     store
-        .put(gate.clone(), original.clone())
+        .put(key.clone(), original.clone())
         .await
         .expect("first put succeeds");
     let original_hash = original.approved_tx_hash;
@@ -150,15 +170,15 @@ async fn binding_is_immutable_after_first_put() {
         "test setup: tampered binding must differ"
     );
 
-    let rejected = store.put(gate.clone(), tampered).await;
+    let rejected = store.put(key.clone(), tampered).await;
     assert_eq!(
         rejected,
         Err(ironclaw_attested_runtime::BindingError::AlreadyExists),
-        "a second put for the same gate_ref must be rejected (immutable binding)"
+        "a second put for the same (tenant, gate_ref) must be rejected (immutable binding)"
     );
 
     // The overwrite was rejected: original binding still stands on both paths.
-    let via_async = store.get(&gate).await.expect("async read");
+    let via_async = store.get(&key).await.expect("async read");
     let via_sync = store.get_sync(&gate).expect("sync read");
     assert_eq!(via_async.approved_tx_hash, original_hash);
     assert_eq!(via_sync.approved_tx_hash, original_hash);
@@ -185,7 +205,7 @@ async fn binding_survives_store_reopen() {
     {
         let store = build(&path).await;
         store
-            .put(gate.clone(), binding.clone())
+            .put(sample_key(), binding.clone())
             .await
             .expect("first put succeeds");
     }
@@ -198,5 +218,46 @@ async fn binding_survives_store_reopen() {
     assert_eq!(
         rehydrated.context.gate_ref.as_str(),
         binding.context.gate_ref.as_str()
+    );
+}
+
+#[tokio::test]
+async fn two_tenants_same_gate_ref_are_isolated() {
+    // Mirrors the ledger's `two_gates_are_isolated`/tenant-isolation pinning: two
+    // tenants that happen to share a `gate_ref` get fully independent bindings.
+    // A backend that keyed by `gate_ref` alone would collide them — the first
+    // put would win and the second tenant would either be rejected as a
+    // duplicate or, worse, read back the first tenant's binding.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("bindings.db");
+    let store = build(&path).await;
+    let gate = GateRef::new(GATE);
+
+    let key_a = BindingKey::new(SigningTenantId::new("tenant-a"), gate.clone());
+    let key_b = BindingKey::new(SigningTenantId::new("tenant-b"), gate.clone());
+    let binding_a = sample_binding_for_tenant("tenant-a");
+    let binding_b = sample_binding_for_tenant("tenant-b");
+
+    // Both tenants can persist a binding under the same gate_ref.
+    store
+        .put(key_a.clone(), binding_a.clone())
+        .await
+        .expect("tenant-a put succeeds");
+    store
+        .put(key_b.clone(), binding_b.clone())
+        .await
+        .expect("tenant-b put under the same gate_ref must NOT collide");
+
+    // Each tenant reads back ITS OWN binding via the tenant-qualified async read.
+    let read_a = store.get(&key_a).await.expect("tenant-a async read");
+    let read_b = store.get(&key_b).await.expect("tenant-b async read");
+    assert_eq!(read_a.context.tenant.as_str(), "tenant-a");
+    assert_eq!(read_b.context.tenant.as_str(), "tenant-b");
+
+    // A tenant-qualified read for a tenant that never wrote returns nothing.
+    let key_c = BindingKey::new(SigningTenantId::new("tenant-c"), gate);
+    assert!(
+        store.get(&key_c).await.is_none(),
+        "a tenant with no binding must not read another tenant's"
     );
 }

--- a/crates/ironclaw_attested_store/tests/binding_contract.rs
+++ b/crates/ironclaw_attested_store/tests/binding_contract.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use alloy_consensus::TxEip1559;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use ironclaw_attestation::{DecodedTransaction, RenderingSchemaVersion};
-use ironclaw_attested_runtime::{AttestedGateBinding, AttestedGateBindingStore, SyncBindingRead};
+use ironclaw_attested_runtime::{
+    AttestedGateBinding, AttestedGateBindingStore, BindingKey, SyncBindingRead,
+};
 use ironclaw_attested_store::LibSqlAttestedGateBindingStore;
 use ironclaw_chain_signing::{ChainKeyId, evm};
 use ironclaw_host_api::{ResourceScope, TenantId, UserId};
@@ -71,6 +73,22 @@ fn sample_binding() -> AttestedGateBinding {
     }
 }
 
+/// The tenant-qualified key for the sample binding (tenant1 + the fixed gate).
+fn sample_key() -> BindingKey {
+    BindingKey::new(SigningTenantId::new("tenant1"), GateRef::new(GATE))
+}
+
+/// A binding for a specific tenant sharing the SAME `gate_ref`. Both the
+/// `context.tenant` and the custodial `scope.tenant_id` carry `tenant` so the
+/// binding is self-consistent (validate_binding_key requires the key tenant to
+/// equal the binding's own context tenant).
+fn sample_binding_for_tenant(tenant: &str) -> AttestedGateBinding {
+    let mut binding = sample_binding();
+    binding.context.tenant = SigningTenantId::new(tenant);
+    binding.scope.tenant_id = TenantId::new(tenant).unwrap();
+    binding
+}
+
 async fn build(path: &std::path::Path) -> LibSqlAttestedGateBindingStore {
     let db = Arc::new(
         libsql::Builder::new_local(path)
@@ -89,17 +107,18 @@ async fn put_then_async_and_sync_read_agree() {
     let path = dir.path().join("bindings.db");
     let store = build(&path).await;
     let gate = GateRef::new(GATE);
+    let key = sample_key();
 
-    assert!(store.get(&gate).await.is_none());
+    assert!(store.get(&key).await.is_none());
     assert!(store.get_sync(&gate).is_none());
 
     let binding = sample_binding();
     store
-        .put(gate.clone(), binding.clone())
+        .put(key.clone(), binding.clone())
         .await
         .expect("first put succeeds");
 
-    let via_async = store.get(&gate).await.expect("async read");
+    let via_async = store.get(&key).await.expect("async read");
     let via_sync = store.get_sync(&gate).expect("sync read");
     assert_eq!(via_async.approved_tx_hash, binding.approved_tx_hash);
     assert_eq!(via_sync.approved_tx_hash, binding.approved_tx_hash);
@@ -115,10 +134,11 @@ async fn binding_is_immutable_after_first_put() {
     let path = dir.path().join("bindings.db");
     let store = build(&path).await;
     let gate = GateRef::new(GATE);
+    let key = sample_key();
 
     let original = sample_binding();
     store
-        .put(gate.clone(), original.clone())
+        .put(key.clone(), original.clone())
         .await
         .expect("first put succeeds");
     let original_hash = original.approved_tx_hash;
@@ -150,15 +170,15 @@ async fn binding_is_immutable_after_first_put() {
         "test setup: tampered binding must differ"
     );
 
-    let rejected = store.put(gate.clone(), tampered).await;
+    let rejected = store.put(key.clone(), tampered).await;
     assert_eq!(
         rejected,
         Err(ironclaw_attested_runtime::BindingError::AlreadyExists),
-        "a second put for the same gate_ref must be rejected (immutable binding)"
+        "a second put for the same (tenant, gate_ref) must be rejected (immutable binding)"
     );
 
     // The overwrite was rejected: original binding still stands on both paths.
-    let via_async = store.get(&gate).await.expect("async read");
+    let via_async = store.get(&key).await.expect("async read");
     let via_sync = store.get_sync(&gate).expect("sync read");
     assert_eq!(via_async.approved_tx_hash, original_hash);
     assert_eq!(via_sync.approved_tx_hash, original_hash);
@@ -205,8 +225,9 @@ async fn async_get_falls_back_to_db_on_cache_miss() {
         let conn = db.connect().expect("connect for out-of-band write");
         let json = serde_json::to_string(&binding).expect("serialize binding");
         conn.execute(
-            "INSERT INTO attested_gate_bindings (gate_ref, binding_json) VALUES (?1, ?2)",
-            libsql::params![gate.as_str(), json],
+            "INSERT INTO attested_gate_bindings (tenant, gate_ref, binding_json) \
+             VALUES (?1, ?2, ?3)",
+            libsql::params![binding.context.tenant.as_str(), gate.as_str(), json],
         )
         .await
         .expect("out-of-band insert");
@@ -221,7 +242,10 @@ async fn async_get_falls_back_to_db_on_cache_miss() {
 
     // Async read-through: finds the row in the table and returns it.
     let via_async = store
-        .get(&gate)
+        .get(&BindingKey::new(
+            binding.context.tenant.clone(),
+            gate.clone(),
+        ))
         .await
         .expect("async get must fall back to the db on cache miss");
     assert_eq!(via_async.approved_tx_hash, binding.approved_tx_hash);
@@ -243,7 +267,7 @@ async fn binding_survives_store_reopen() {
     {
         let store = build(&path).await;
         store
-            .put(gate.clone(), binding.clone())
+            .put(sample_key(), binding.clone())
             .await
             .expect("first put succeeds");
     }
@@ -256,5 +280,46 @@ async fn binding_survives_store_reopen() {
     assert_eq!(
         rehydrated.context.gate_ref.as_str(),
         binding.context.gate_ref.as_str()
+    );
+}
+
+#[tokio::test]
+async fn two_tenants_same_gate_ref_are_isolated() {
+    // Mirrors the ledger's `two_gates_are_isolated`/tenant-isolation pinning: two
+    // tenants that happen to share a `gate_ref` get fully independent bindings.
+    // A backend that keyed by `gate_ref` alone would collide them — the first
+    // put would win and the second tenant would either be rejected as a
+    // duplicate or, worse, read back the first tenant's binding.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("bindings.db");
+    let store = build(&path).await;
+    let gate = GateRef::new(GATE);
+
+    let key_a = BindingKey::new(SigningTenantId::new("tenant-a"), gate.clone());
+    let key_b = BindingKey::new(SigningTenantId::new("tenant-b"), gate.clone());
+    let binding_a = sample_binding_for_tenant("tenant-a");
+    let binding_b = sample_binding_for_tenant("tenant-b");
+
+    // Both tenants can persist a binding under the same gate_ref.
+    store
+        .put(key_a.clone(), binding_a.clone())
+        .await
+        .expect("tenant-a put succeeds");
+    store
+        .put(key_b.clone(), binding_b.clone())
+        .await
+        .expect("tenant-b put under the same gate_ref must NOT collide");
+
+    // Each tenant reads back ITS OWN binding via the tenant-qualified async read.
+    let read_a = store.get(&key_a).await.expect("tenant-a async read");
+    let read_b = store.get(&key_b).await.expect("tenant-b async read");
+    assert_eq!(read_a.context.tenant.as_str(), "tenant-a");
+    assert_eq!(read_b.context.tenant.as_str(), "tenant-b");
+
+    // A tenant-qualified read for a tenant that never wrote returns nothing.
+    let key_c = BindingKey::new(SigningTenantId::new("tenant-c"), gate);
+    assert!(
+        store.get(&key_c).await.is_none(),
+        "a tenant with no binding must not read another tenant's"
     );
 }

--- a/crates/ironclaw_attested_store/tests/grant_contract.rs
+++ b/crates/ironclaw_attested_store/tests/grant_contract.rs
@@ -55,6 +55,10 @@ mod libsql_backend {
         contract::claim_unsealed_is_not_found(fresh().await).await;
     }
     #[tokio::test]
+    async fn claim_expired_grant_is_rejected() {
+        contract::claim_expired_grant_is_rejected(fresh().await).await;
+    }
+    #[tokio::test]
     async fn claim_mismatched_component_is_not_found() {
         contract::claim_mismatched_component_is_not_found(fresh().await).await;
     }
@@ -133,6 +137,7 @@ mod postgres_backend {
     pg_case!(seal_then_claim_succeeds);
     pg_case!(second_claim_is_already_claimed);
     pg_case!(claim_unsealed_is_not_found);
+    pg_case!(claim_expired_grant_is_rejected);
     pg_case!(claim_mismatched_component_is_not_found);
     pg_case!(double_seal_is_already_sealed);
     pg_case!(

--- a/crates/ironclaw_attested_store/tests/grant_contract.rs
+++ b/crates/ironclaw_attested_store/tests/grant_contract.rs
@@ -60,13 +60,19 @@ mod libsql_backend {
         contract::claim_unsealed_is_not_found(store).await;
     }
     #[tokio::test]
+    async fn claim_expired_grant_is_rejected() {
+        let (store, _dir) = fresh().await;
+        contract::claim_expired_grant_is_rejected(store).await;
+    }
+    #[tokio::test]
     async fn claim_mismatched_component_is_not_found() {
         let (store, _dir) = fresh().await;
         contract::claim_mismatched_component_is_not_found(store).await;
     }
     #[tokio::test]
     async fn cross_tenant_claim_is_not_found() {
-        contract::cross_tenant_claim_is_not_found(fresh().await).await;
+        let (store, _dir) = fresh().await;
+        contract::cross_tenant_claim_is_not_found(store).await;
     }
     #[tokio::test]
     async fn double_seal_is_already_sealed() {
@@ -145,6 +151,7 @@ mod postgres_backend {
     pg_case!(seal_then_claim_succeeds);
     pg_case!(second_claim_is_already_claimed);
     pg_case!(claim_unsealed_is_not_found);
+    pg_case!(claim_expired_grant_is_rejected);
     pg_case!(claim_mismatched_component_is_not_found);
     pg_case!(cross_tenant_claim_is_not_found);
     pg_case!(double_seal_is_already_sealed);

--- a/crates/ironclaw_attested_store/tests/ledger_contract.rs
+++ b/crates/ironclaw_attested_store/tests/ledger_contract.rs
@@ -149,7 +149,8 @@ mod libsql_backend {
     }
     #[tokio::test]
     async fn distinct_gates_advance_independently() {
-        contract::distinct_gates_advance_independently(fresh().await).await;
+        let (store, _dir) = fresh().await;
+        contract::distinct_gates_advance_independently(store).await;
     }
     #[tokio::test]
     async fn terminal_states_never_advance() {

--- a/crates/ironclaw_chain_signing/src/custodial.rs
+++ b/crates/ironclaw_chain_signing/src/custodial.rs
@@ -195,7 +195,12 @@ where
         // of the same grant fails (one-shot), so a replayed approval cannot
         // produce a second signature.
         let grant_key = GrantKey::from_context(&req.context, req.approved_tx_hash);
-        self.grants.claim(&grant_key).await?; // GrantError -> ChainSigningError
+        // Expiry is enforced inside the store against the runtime clock the
+        // caller passes in (the store never reads the wall clock itself). An
+        // expired grant fails closed here without burning the one-shot.
+        self.grants
+            .claim(&grant_key, ironclaw_attestation::now_unix_millis())
+            .await?; // GrantError -> ChainSigningError
 
         // --- Enforcement point #2: sign-time approved-tx-hash re-check. ---
         // Recompute the binding hash FROM THE PERSISTED decoded tx and compare

--- a/crates/ironclaw_chain_signing/src/custodial.rs
+++ b/crates/ironclaw_chain_signing/src/custodial.rs
@@ -468,7 +468,12 @@ where
     /// as possible).
     async fn claim_grant(&self, req: &CustodialSignRequest) -> Result<(), ChainSigningError> {
         let grant_key = GrantKey::from_context(&req.context, req.approved_tx_hash);
-        self.grants.claim(&grant_key).await?; // GrantError -> ChainSigningError
+        // Expiry is enforced inside the store against the runtime clock the
+        // caller passes in (the store never reads the wall clock itself). An
+        // expired grant fails closed here without burning the one-shot.
+        self.grants
+            .claim(&grant_key, ironclaw_attestation::now_unix_millis())
+            .await?; // GrantError -> ChainSigningError
         Ok(())
     }
 

--- a/crates/ironclaw_chain_signing/tests/custodial_signing.rs
+++ b/crates/ironclaw_chain_signing/tests/custodial_signing.rs
@@ -202,10 +202,10 @@ async fn second_signing_of_same_grant_is_refused_one_shot() {
     f.signer.sign_evm(&f.req).await.expect("first sign");
     let err = f
         .grants
-        .claim(&GrantKey::from_context(
-            &f.req.context,
-            f.req.approved_tx_hash,
-        ))
+        .claim(
+            &GrantKey::from_context(&f.req.context, f.req.approved_tx_hash),
+            ironclaw_attestation::now_unix_millis(),
+        )
         .await
         .unwrap_err();
     assert_eq!(err, ironclaw_attestation::GrantError::AlreadyClaimed);

--- a/crates/ironclaw_chain_signing/tests/custodial_signing.rs
+++ b/crates/ironclaw_chain_signing/tests/custodial_signing.rs
@@ -220,10 +220,10 @@ async fn second_signing_of_same_grant_is_refused_one_shot() {
     f.signer.sign_evm(&f.req).await.expect("first sign");
     let err = f
         .grants
-        .claim(&GrantKey::from_context(
-            &f.req.context,
-            f.req.approved_tx_hash,
-        ))
+        .claim(
+            &GrantKey::from_context(&f.req.context, f.req.approved_tx_hash),
+            ironclaw_attestation::now_unix_millis(),
+        )
         .await
         .unwrap_err();
     assert_eq!(err, ironclaw_attestation::GrantError::AlreadyClaimed);
@@ -453,7 +453,7 @@ async fn preflight_failure_after_authorize_does_not_consume_grant() {
     // Crucially, the grant must NOT have been consumed: claiming it now must
     // SUCCEED (proving the gate_ref is still retryable, not stranded).
     grants
-        .claim(&gk)
+        .claim(&gk, ironclaw_attestation::now_unix_millis())
         .await
         .expect("grant must remain claimable after a post-authorize pre-flight failure");
 }

--- a/crates/ironclaw_product_workflow/src/attested_continuation.rs
+++ b/crates/ironclaw_product_workflow/src/attested_continuation.rs
@@ -135,6 +135,54 @@ impl AttestedContinuationRejection {
             Self::BackendUnavailable => "attested_backend_unavailable",
         }
     }
+
+    /// Whether this rejection is safe to auto-retry.
+    ///
+    /// # The rule (codified to prevent drift between #4060 and #3997)
+    ///
+    /// The continuation has two phases that fail very differently:
+    ///
+    /// * **Broadcast-tail failure where the grant is already claimed and the
+    ///   ledger advance is idempotent** (e.g. a transient RPC error reaching a
+    ///   broadcaster that has NOT yet driven the ledger past
+    ///   `BroadcastSubmitted`): the one-shot grant CAS and the ledger guard make
+    ///   a re-drive safe — a retry cannot double-submit, it re-enters the same
+    ///   idempotent advance. This surfaces as [`Self::BackendUnavailable`] and is
+    ///   **retryable**.
+    /// * **A broadcast failure that drove the ledger to the `Unknown` /
+    ///   terminal state** (the submit may or may not have landed): an automatic
+    ///   retry with a fresh nonce/blockhash risks a DOUBLE-SUBMISSION. Those
+    ///   outcomes are surfaced as terminal rejections ([`Self::LedgerGuard`],
+    ///   [`Self::ProofRejected`]) and are **NOT retryable** — they require
+    ///   out-of-band resolution, never an auto-retry.
+    ///
+    /// Everything that fails BEFORE any broadcast (missing/mis-tenanted binding,
+    /// provider mismatch, malformed proof) is a client/input or wiring failure
+    /// and is non-retryable as-is. [`Self::Unavailable`] (port not wired) is a
+    /// deployment failure, also non-retryable from the continuation's view.
+    ///
+    /// NOTE: this is the *idempotency-safety* disposition of the rejection. The
+    /// WebUI HTTP mapping (`map_attested_continuation_rejection` in
+    /// `reborn_services`) may still present a category as non-retryable to the
+    /// *client* when the resume guard has already consumed the one-shot — a
+    /// client-visible retry would be rejected at the resume CAS. The two are
+    /// deliberately distinct: this method states whether re-driving the
+    /// continuation is double-submit-safe, not whether the client should retry.
+    pub fn retryable(&self) -> bool {
+        match self {
+            // Broadcast-tail / infra failure, grant claimed + ledger-idempotent:
+            // a re-drive cannot double-submit, so it is safe to retry.
+            Self::BackendUnavailable => true,
+            // Pre-broadcast input/wiring failures and terminal/double-submit-risk
+            // outcomes: never auto-retry.
+            Self::MissingBinding
+            | Self::ProviderMismatch
+            | Self::ProofRejected
+            | Self::LedgerGuard
+            | Self::MalformedProof
+            | Self::Unavailable => false,
+        }
+    }
 }
 
 /// Opaque, crypto-free handle proving that [`AttestedGateContinuationPort::verify_and_claim`]
@@ -215,4 +263,45 @@ pub trait AttestedGateContinuationPort: Send + Sync {
         gate_ref: &GateRef,
         verified: VerifiedAttestedContinuation,
     ) -> Result<AttestedContinuationOutcome, AttestedContinuationRejection>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_pins_both_arms_of_the_broadcast_rule() {
+        // Broadcast-tail / infra failure with the grant already claimed and the
+        // ledger advance idempotent: a re-drive cannot double-submit, so it is
+        // retryable (#4060).
+        assert!(
+            AttestedContinuationRejection::BackendUnavailable.retryable(),
+            "an idempotent broadcast-tail failure must be retryable"
+        );
+
+        // A broadcast failure that drove the ledger to a terminal / Unknown
+        // state is surfaced as a terminal rejection and must NOT auto-retry, or
+        // a fresh-nonce retry risks a double-submission (#3997).
+        assert!(
+            !AttestedContinuationRejection::LedgerGuard.retryable(),
+            "a terminal ledger-guard outcome must not auto-retry (double-submit risk)"
+        );
+        assert!(
+            !AttestedContinuationRejection::ProofRejected.retryable(),
+            "a proof rejection is terminal and must not auto-retry"
+        );
+
+        // Pre-broadcast input/wiring failures are never retryable as-is.
+        for non_retryable in [
+            AttestedContinuationRejection::MissingBinding,
+            AttestedContinuationRejection::ProviderMismatch,
+            AttestedContinuationRejection::MalformedProof,
+            AttestedContinuationRejection::Unavailable,
+        ] {
+            assert!(
+                !non_retryable.retryable(),
+                "{non_retryable:?} must not be retryable"
+            );
+        }
+    }
 }

--- a/crates/ironclaw_product_workflow/src/attested_continuation.rs
+++ b/crates/ironclaw_product_workflow/src/attested_continuation.rs
@@ -135,6 +135,54 @@ impl AttestedContinuationRejection {
             Self::BackendUnavailable => "attested_backend_unavailable",
         }
     }
+
+    /// Whether this rejection is safe to auto-retry.
+    ///
+    /// # The rule (codified to prevent drift between #4060 and #3997)
+    ///
+    /// The continuation has two phases that fail very differently:
+    ///
+    /// * **Broadcast-tail failure where the grant is already claimed and the
+    ///   ledger advance is idempotent** (e.g. a transient RPC error reaching a
+    ///   broadcaster that has NOT yet driven the ledger past
+    ///   `BroadcastSubmitted`): the one-shot grant CAS and the ledger guard make
+    ///   a re-drive safe — a retry cannot double-submit, it re-enters the same
+    ///   idempotent advance. This surfaces as [`Self::BackendUnavailable`] and is
+    ///   **retryable**.
+    /// * **A broadcast failure that drove the ledger to the `Unknown` /
+    ///   terminal state** (the submit may or may not have landed): an automatic
+    ///   retry with a fresh nonce/blockhash risks a DOUBLE-SUBMISSION. Those
+    ///   outcomes are surfaced as terminal rejections ([`Self::LedgerGuard`],
+    ///   [`Self::ProofRejected`]) and are **NOT retryable** — they require
+    ///   out-of-band resolution, never an auto-retry.
+    ///
+    /// Everything that fails BEFORE any broadcast (missing/mis-tenanted binding,
+    /// provider mismatch, malformed proof) is a client/input or wiring failure
+    /// and is non-retryable as-is. [`Self::Unavailable`] (port not wired) is a
+    /// deployment failure, also non-retryable from the continuation's view.
+    ///
+    /// NOTE: this is the *idempotency-safety* disposition of the rejection. The
+    /// WebUI HTTP mapping (`map_attested_continuation_rejection` in
+    /// `reborn_services`) may still present a category as non-retryable to the
+    /// *client* when the resume guard has already consumed the one-shot — a
+    /// client-visible retry would be rejected at the resume CAS. The two are
+    /// deliberately distinct: this method states whether re-driving the
+    /// continuation is double-submit-safe, not whether the client should retry.
+    pub fn retryable(&self) -> bool {
+        match self {
+            // Broadcast-tail / infra failure, grant claimed + ledger-idempotent:
+            // a re-drive cannot double-submit, so it is safe to retry.
+            Self::BackendUnavailable => true,
+            // Pre-broadcast input/wiring failures and terminal/double-submit-risk
+            // outcomes: never auto-retry.
+            Self::MissingBinding
+            | Self::ProviderMismatch
+            | Self::ProofRejected
+            | Self::LedgerGuard
+            | Self::MalformedProof
+            | Self::Unavailable => false,
+        }
+    }
 }
 
 /// Opaque, crypto-free handle proving that [`AttestedGateContinuationPort::verify_and_claim`]
@@ -222,4 +270,45 @@ pub trait AttestedGateContinuationPort: Send + Sync {
         gate_ref: &GateRef,
         verified: VerifiedAttestedContinuation,
     ) -> Result<AttestedContinuationOutcome, AttestedContinuationRejection>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_pins_both_arms_of_the_broadcast_rule() {
+        // Broadcast-tail / infra failure with the grant already claimed and the
+        // ledger advance idempotent: a re-drive cannot double-submit, so it is
+        // retryable (#4060).
+        assert!(
+            AttestedContinuationRejection::BackendUnavailable.retryable(),
+            "an idempotent broadcast-tail failure must be retryable"
+        );
+
+        // A broadcast failure that drove the ledger to a terminal / Unknown
+        // state is surfaced as a terminal rejection and must NOT auto-retry, or
+        // a fresh-nonce retry risks a double-submission (#3997).
+        assert!(
+            !AttestedContinuationRejection::LedgerGuard.retryable(),
+            "a terminal ledger-guard outcome must not auto-retry (double-submit risk)"
+        );
+        assert!(
+            !AttestedContinuationRejection::ProofRejected.retryable(),
+            "a proof rejection is terminal and must not auto-retry"
+        );
+
+        // Pre-broadcast input/wiring failures are never retryable as-is.
+        for non_retryable in [
+            AttestedContinuationRejection::MissingBinding,
+            AttestedContinuationRejection::ProviderMismatch,
+            AttestedContinuationRejection::MalformedProof,
+            AttestedContinuationRejection::Unavailable,
+        ] {
+            assert!(
+                !non_retryable.retryable(),
+                "{non_retryable:?} must not be retryable"
+            );
+        }
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/attested.rs
+++ b/crates/ironclaw_reborn_composition/src/attested.rs
@@ -32,7 +32,7 @@ use ironclaw_attestation::{
 };
 use ironclaw_attested_runtime::{
     AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver, BindingError,
-    BroadcastOutcome, Broadcaster, ContinuationError, InMemoryAttestedGateBindingStore,
+    BindingKey, BroadcastOutcome, Broadcaster, ContinuationError, InMemoryAttestedGateBindingStore,
     ProviderRegistry,
 };
 use ironclaw_chain_signing::{CustodialSigner, DenyFirstCustodyPolicy, SecretsKeyStore, ShipGate};
@@ -244,7 +244,12 @@ where
         // persisting. An existing binding for this gate fails closed with
         // `AlreadyExists` — treat it as a duplicate, consistent with the grant
         // CAS above; any other validation/backend error fails closed too.
-        match self.bindings.put(gate_ref, binding).await {
+        // Key the binding by its tenant-qualified identity. The tenant comes from
+        // the authoritative binding context (validated by the store's
+        // `validate_binding_key` to equal the binding's own `context.tenant`),
+        // never from a caller-supplied value.
+        let binding_key = BindingKey::new(binding.context.tenant.clone(), gate_ref);
+        match self.bindings.put(binding_key, binding).await {
             Ok(()) => Ok(()),
             Err(BindingError::AlreadyExists) => Err(RegisterAttestedGateError::DuplicateBinding),
             Err(other) => Err(RegisterAttestedGateError::BindingStore(other)),
@@ -429,7 +434,7 @@ mod tests {
         composition
             .bindings()
             .put(
-                GateRef::new(GATE),
+                BindingKey::new(ctx.tenant.clone(), GateRef::new(GATE)),
                 AttestedGateBinding {
                     provider_id: ProviderId::Custodial,
                     context: ctx.clone(),

--- a/crates/ironclaw_reborn_composition/src/attested.rs
+++ b/crates/ironclaw_reborn_composition/src/attested.rs
@@ -32,7 +32,7 @@ use ironclaw_attestation::{
 };
 use ironclaw_attested_runtime::{
     AttestedGateBinding, AttestedGateBindingStore, AttestedSignerContinuationDriver, BindingError,
-    BroadcastOutcome, Broadcaster, ContinuationError, InMemoryAttestedGateBindingStore,
+    BindingKey, BroadcastOutcome, Broadcaster, ContinuationError, InMemoryAttestedGateBindingStore,
     ProviderRegistry,
 };
 use ironclaw_chain_signing::{CustodialSigner, DenyFirstCustodyPolicy, SecretsKeyStore, ShipGate};
@@ -259,7 +259,12 @@ where
         // persisting. An existing binding for this gate fails closed with
         // `AlreadyExists` — treat it as a duplicate, consistent with the grant
         // CAS above; any other validation/backend error fails closed too.
-        match self.bindings.put(gate_ref, binding).await {
+        // Key the binding by its tenant-qualified identity. The tenant comes from
+        // the authoritative binding context (validated by the store's
+        // `validate_binding_key` to equal the binding's own `context.tenant`),
+        // never from a caller-supplied value.
+        let binding_key = BindingKey::new(binding.context.tenant.clone(), gate_ref);
+        match self.bindings.put(binding_key, binding).await {
             Ok(()) => Ok(()),
             Err(BindingError::AlreadyExists) => Err(RegisterAttestedGateError::DuplicateBinding),
             Err(other) => Err(RegisterAttestedGateError::BindingStore(other)),
@@ -449,7 +454,7 @@ mod tests {
         composition
             .bindings()
             .put(
-                GateRef::new(GATE),
+                BindingKey::new(ctx.tenant.clone(), GateRef::new(GATE)),
                 AttestedGateBinding {
                     provider_id: ProviderId::Custodial,
                     context: ctx.clone(),

--- a/crates/ironclaw_reborn_composition/tests/attested_durable_assembly.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_durable_assembly.rs
@@ -24,7 +24,7 @@ use alloy_consensus::TxEip1559;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 
 use ironclaw_attestation::RenderingSchemaVersion;
-use ironclaw_attested_runtime::{AttestedGateBinding, ContinuationError};
+use ironclaw_attested_runtime::{AttestedGateBinding, BindingKey, ContinuationError};
 use ironclaw_attested_store::ChainRpcEndpoints;
 use ironclaw_chain_signing::{ChainKeyId, SecretsKeyStore};
 use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
@@ -298,7 +298,13 @@ async fn durable_libsql_binding_survives_reassembly() {
     )
     .await
     .expect("second assembly");
-    let recovered = composition.bindings().get(&gate_ref).await;
+    let recovered = composition
+        .bindings()
+        .get(&BindingKey::new(
+            SigningTenantId::new(TENANT),
+            gate_ref.clone(),
+        ))
+        .await;
     assert!(
         recovered.is_some(),
         "durable binding must survive a process restart / re-assembly"
@@ -429,5 +435,14 @@ async fn durable_postgres_assembles_and_runs_migrations() {
         .register_attested_gate(gate_ref.clone(), binding, 0, None)
         .await
         .expect("binding write round-trips (migrations present)");
-    assert!(composition.bindings().get(&gate_ref).await.is_some());
+    assert!(
+        composition
+            .bindings()
+            .get(&BindingKey::new(
+                SigningTenantId::new(TENANT),
+                gate_ref.clone()
+            ))
+            .await
+            .is_some()
+    );
 }

--- a/crates/ironclaw_reborn_composition/tests/attested_durable_assembly.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_durable_assembly.rs
@@ -24,7 +24,7 @@ use alloy_consensus::TxEip1559;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 
 use ironclaw_attestation::RenderingSchemaVersion;
-use ironclaw_attested_runtime::{AttestedGateBinding, ContinuationError};
+use ironclaw_attested_runtime::{AttestedGateBinding, BindingKey, ContinuationError};
 use ironclaw_attested_store::ChainRpcEndpoints;
 use ironclaw_chain_signing::{ChainKeyId, SecretsKeyStore};
 use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
@@ -298,7 +298,13 @@ async fn durable_libsql_binding_survives_reassembly() {
     )
     .await
     .expect("second assembly");
-    let recovered = composition.bindings().get(&gate_ref).await;
+    let recovered = composition
+        .bindings()
+        .get(&BindingKey::new(
+            SigningTenantId::new(TENANT),
+            gate_ref.clone(),
+        ))
+        .await;
     assert!(
         recovered.is_some(),
         "durable binding must survive a process restart / re-assembly"
@@ -431,5 +437,14 @@ async fn durable_postgres_assembles_and_runs_migrations() {
         .register_attested_gate(gate_ref.clone(), binding, 0, None)
         .await
         .expect("binding write round-trips (migrations present)");
-    assert!(composition.bindings().get(&gate_ref).await.is_some());
+    assert!(
+        composition
+            .bindings()
+            .get(&BindingKey::new(
+                SigningTenantId::new(TENANT),
+                gate_ref.clone()
+            ))
+            .await
+            .is_some()
+    );
 }

--- a/crates/ironclaw_reborn_composition/tests/attested_provider_registration.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_provider_registration.rs
@@ -21,7 +21,7 @@ use alloy_consensus::TxEip1559;
 
 use ironclaw_attestation::{DecodedTransaction, RenderingSchemaVersion};
 use ironclaw_attested_runtime::{
-    AttestedGateBinding, ContinuationError, CustodialMainnetShipGate,
+    AttestedGateBinding, BindingKey, ContinuationError, CustodialMainnetShipGate,
     InMemoryAttestedGateBindingStore,
 };
 use ironclaw_chain_signing::{ChainKeyId, SecretsKeyStore};
@@ -340,7 +340,14 @@ async fn register_attested_gate_seals_grant_and_persists_binding() {
 
     // Binding half: the authoritative binding is readable back.
     assert!(
-        composition.bindings().get(&gate_ref).await.is_some(),
+        composition
+            .bindings()
+            .get(&BindingKey::new(
+                SigningTenantId::new(TENANT),
+                gate_ref.clone()
+            ))
+            .await
+            .is_some(),
         "binding must be persisted on raise"
     );
 

--- a/crates/ironclaw_reborn_composition/tests/attested_request_signature_raise.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_request_signature_raise.rs
@@ -188,8 +188,7 @@ async fn custodial_request_signature_raises_gate_and_existing_resolve_path_conti
     let signing_gate_ref = SigningGateRef::new(gate_ref_str);
     let binding = composition
         .bindings()
-        .get(&signing_gate_ref)
-        .await
+        .get_sync(&signing_gate_ref)
         .expect("authoritative binding persisted on raise");
     // The persisted decoded tx is exactly what resolve recomputes the hash from.
     assert_eq!(binding.decoded, decoded);
@@ -345,8 +344,7 @@ async fn signing_context_uses_user_id_when_no_project_or_agent() {
     let signing_gate_ref = SigningGateRef::new(format!("gate:attested-{}", gate.gate_id.as_str()));
     let binding = composition
         .bindings()
-        .get(&signing_gate_ref)
-        .await
+        .get_sync(&signing_gate_ref)
         .expect("binding persisted on raise");
     // Both fall back to the user id when project/agent are absent.
     assert_eq!(binding.context.scope.as_str(), user_id);
@@ -543,8 +541,7 @@ async fn concurrent_register_of_same_gate_serializes_to_one_winner() {
     let gate_ref = SigningGateRef::new(format!("gate:attested-{}", gate.gate_id.as_str()));
     let binding = seed
         .bindings()
-        .get(&gate_ref)
-        .await
+        .get_sync(&gate_ref)
         .expect("seed binding persisted");
 
     // Fresh composition that has never seen this gate. Two concurrent

--- a/crates/ironclaw_reborn_composition/tests/attested_request_signature_raise.rs
+++ b/crates/ironclaw_reborn_composition/tests/attested_request_signature_raise.rs
@@ -189,8 +189,7 @@ async fn custodial_request_signature_raises_gate_and_existing_resolve_path_conti
     let signing_gate_ref = SigningGateRef::new(gate_ref_str);
     let binding = composition
         .bindings()
-        .get(&signing_gate_ref)
-        .await
+        .get_sync(&signing_gate_ref)
         .expect("authoritative binding persisted on raise");
     // The persisted decoded tx is exactly what resolve recomputes the hash from.
     assert_eq!(binding.decoded, decoded);
@@ -233,6 +232,120 @@ async fn custodial_request_signature_raises_gate_and_existing_resolve_path_conti
         replay.is_err(),
         "replayed continuation must fail closed (grant/ledger guard)"
     );
+}
+
+#[tokio::test]
+async fn malformed_request_signature_params_fail_closed() {
+    // The raise path must fail closed (Failed/InvalidInput) — never panic or
+    // raise a half-formed gate — when the agent-supplied params cannot be
+    // deserialized into RequestSignatureParams. Covers missing fields, wrong
+    // types, and a non-object body.
+    let priv_bytes = [0x33u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let (_tx, decoded) = sample_evm();
+
+    let composition = composition_with_keystore(Arc::clone(&keystore));
+    let hook = RebornAttestedRaiseHook::new(Arc::clone(&composition));
+    let capability_id = CapabilityId::new("builtin.request_signature").unwrap();
+
+    let malformed_inputs = vec![
+        // Missing `decoded` field.
+        json!({ "provider_hint": "custodial", "signer_account": account }),
+        // Missing `signer_account` field.
+        json!({ "provider_hint": "custodial", "decoded": decoded }),
+        // Unknown provider_hint value (not a valid enum tag).
+        json!({ "provider_hint": "bogus", "signer_account": account, "decoded": decoded }),
+        // Wrong type for signer_account (number instead of string).
+        json!({ "provider_hint": "custodial", "signer_account": 42, "decoded": decoded }),
+        // Body is not a JSON object at all.
+        json!("not an object"),
+        json!(null),
+    ];
+
+    for input in malformed_inputs {
+        let outcome = hook
+            .raise(AttestedRaiseRequest::new(
+                capability_id.clone(),
+                execution_context(owner_scope()),
+                input.clone(),
+            ))
+            .await;
+
+        match outcome {
+            RuntimeCapabilityOutcome::Failed(failure) => {
+                assert_eq!(failure.capability_id, capability_id);
+                assert_eq!(
+                    failure.kind,
+                    RuntimeFailureKind::InvalidInput,
+                    "malformed input {input} should map to InvalidInput"
+                );
+            }
+            other => panic!("expected Failed for malformed input {input}, got {other:?}"),
+        }
+    }
+
+    // No binding was persisted for any malformed raise: a fabricated gate ref
+    // has no binding, so resolve fails closed with MissingBinding.
+    let signing_gate_ref = SigningGateRef::new("gate:attested-malformed-none");
+    let proof = SigningProof::WebAuthnAssertionProof(vec![]);
+    let err = composition
+        .driver()
+        .continue_after_resolved(&signing_gate_ref, &proof)
+        .await
+        .expect_err("no binding persisted for any malformed raise");
+    assert!(matches!(
+        err,
+        ironclaw_attested_runtime::ContinuationError::MissingBinding
+    ));
+}
+
+#[tokio::test]
+async fn signing_context_uses_user_id_when_no_project_or_agent() {
+    // When the execution context has no project_id and no agent_id, the signing
+    // context's scope label and actor label both fall back to the user_id. The
+    // raise still succeeds end-to-end (custodial) and persists a binding whose
+    // signing context reflects the fallback.
+    let priv_bytes = [0x44u8; 32];
+    let (keystore, account) = keystore_with_evm_key(&priv_bytes).await;
+    let (_tx, decoded) = sample_evm();
+
+    let composition = composition_with_keystore(Arc::clone(&keystore));
+    let hook = RebornAttestedRaiseHook::new(Arc::clone(&composition));
+    let capability_id = CapabilityId::new("builtin.request_signature").unwrap();
+
+    // Owner scope (so the keystore key is found) but with no project + no agent.
+    let mut scope = owner_scope();
+    scope.project_id = None;
+    scope.agent_id = None;
+    let user_id = scope.user_id.as_str().to_string();
+
+    let input = json!({
+        "provider_hint": "custodial",
+        "signer_account": account,
+        "decoded": decoded,
+    });
+    let outcome = hook
+        .raise(AttestedRaiseRequest::new(
+            capability_id.clone(),
+            execution_context(scope),
+            input,
+        ))
+        .await;
+
+    let gate = match outcome {
+        RuntimeCapabilityOutcome::AttestedSigningRequired(gate) => gate,
+        other => panic!("expected AttestedSigningRequired, got {other:?}"),
+    };
+
+    let signing_gate_ref = SigningGateRef::new(format!("gate:attested-{}", gate.gate_id.as_str()));
+    let binding = composition
+        .bindings()
+        .get_sync(&signing_gate_ref)
+        .expect("binding persisted on raise");
+    // Both fall back to the user id when project/agent are absent.
+    assert_eq!(binding.context.scope.as_str(), user_id);
+    assert_eq!(binding.context.actor.as_str(), user_id);
+    assert_eq!(binding.context.user.as_str(), user_id);
 }
 
 #[tokio::test]
@@ -424,8 +537,7 @@ async fn concurrent_register_of_same_gate_serializes_to_one_winner() {
     let gate_ref = SigningGateRef::new(format!("gate:attested-{}", gate.gate_id.as_str()));
     let binding = seed
         .bindings()
-        .get(&gate_ref)
-        .await
+        .get_sync(&gate_ref)
         .expect("seed binding persisted");
 
     // Fresh composition that has never seen this gate. Two concurrent

--- a/crates/ironclaw_wallet_external/src/injected/mod.rs
+++ b/crates/ironclaw_wallet_external/src/injected/mod.rs
@@ -178,7 +178,10 @@ impl SigningProvider for InjectedSigningProvider {
         // 3. One-shot grant (threat #1): claim the sealed grant atomically. A
         //    replay of an already-claimed grant fails closed here.
         let key = GrantKey::from_context(context, *approved_tx_hash);
-        self.grants.claim(&key).await.map_err(map_grant_error)?;
+        self.grants
+            .claim(&key, ironclaw_attestation::now_unix_millis())
+            .await
+            .map_err(map_grant_error)?;
 
         Ok(VerifiedProof::new(
             ProviderId::Injected,
@@ -191,11 +194,13 @@ impl SigningProvider for InjectedSigningProvider {
 /// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
 fn map_grant_error(err: GrantError) -> SigningProviderError {
     match err {
-        // Replay / missing / lost-CAS all collapse to a single fail-closed
-        // grant-claim failure; the distinction is not safe to leak to a caller.
-        GrantError::AlreadyClaimed | GrantError::NotFound | GrantError::AlreadySealed => {
-            SigningProviderError::GrantClaimFailed
-        }
+        // Replay / missing / lost-CAS / expired all collapse to a single
+        // fail-closed grant-claim failure; the distinction is not safe to leak
+        // to a caller.
+        GrantError::AlreadyClaimed
+        | GrantError::NotFound
+        | GrantError::AlreadySealed
+        | GrantError::Expired { .. } => SigningProviderError::GrantClaimFailed,
         GrantError::Backend { reason } => SigningProviderError::Provider { reason },
     }
 }

--- a/crates/ironclaw_wallet_external/src/injected/mod.rs
+++ b/crates/ironclaw_wallet_external/src/injected/mod.rs
@@ -189,7 +189,10 @@ impl SigningProvider for InjectedSigningProvider {
         // 3. One-shot grant (threat #1): claim the sealed grant atomically. A
         //    replay of an already-claimed grant fails closed here.
         let key = GrantKey::from_context(context, *approved_tx_hash);
-        self.grants.claim(&key).await.map_err(map_grant_error)?;
+        self.grants
+            .claim(&key, ironclaw_attestation::now_unix_millis())
+            .await
+            .map_err(map_grant_error)?;
 
         Ok(VerifiedProof::new(
             ProviderId::Injected,
@@ -202,14 +205,15 @@ impl SigningProvider for InjectedSigningProvider {
 /// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
 fn map_grant_error(err: GrantError) -> SigningProviderError {
     match err {
-        // Replay / missing / lost-CAS all collapse to a single fail-closed
-        // grant-claim failure; the distinction is not safe to leak to a caller.
-        // Fail-closed timestamp/expiry validation (added with the sealed-grant
-        // hardening) is a construction-time reject; collapse to the same
-        // grant-claim failure rather than leaking the distinction.
+        // Replay / missing / lost-CAS / expired all collapse to a single
+        // fail-closed grant-claim failure; the distinction is not safe to leak
+        // to a caller. The construction-time timestamp/expiry rejects (from the
+        // sealed-grant hardening) collapse to the same failure for the same
+        // reason.
         GrantError::AlreadyClaimed
         | GrantError::NotFound
         | GrantError::AlreadySealed
+        | GrantError::Expired { .. }
         | GrantError::InvalidTimestamp { .. }
         | GrantError::InvalidExpiry { .. } => SigningProviderError::GrantClaimFailed,
         GrantError::Backend { reason } => SigningProviderError::Provider { reason },

--- a/crates/ironclaw_wallet_external/src/near_redirect/mod.rs
+++ b/crates/ironclaw_wallet_external/src/near_redirect/mod.rs
@@ -303,7 +303,10 @@ impl SigningProvider for NearRedirectSigningProvider {
         // 6. One-shot grant (threat #1): claim the sealed grant atomically. A
         //    replay of an already-claimed grant fails closed here.
         let key = GrantKey::from_context(context, *approved_tx_hash);
-        self.grants.claim(&key).await.map_err(map_grant_error)?;
+        self.grants
+            .claim(&key, ironclaw_attestation::now_unix_millis())
+            .await
+            .map_err(map_grant_error)?;
 
         Ok(VerifiedProof::new(
             ProviderId::NearRedirect,
@@ -447,11 +450,13 @@ fn validate_access_key_scope(
 /// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
 fn map_grant_error(err: GrantError) -> SigningProviderError {
     match err {
-        // Replay / missing / lost-CAS all collapse to a single fail-closed
-        // grant-claim failure; the distinction is not safe to leak to a caller.
-        GrantError::AlreadyClaimed | GrantError::NotFound | GrantError::AlreadySealed => {
-            SigningProviderError::GrantClaimFailed
-        }
+        // Replay / missing / lost-CAS / expired all collapse to a single
+        // fail-closed grant-claim failure; the distinction is not safe to leak
+        // to a caller.
+        GrantError::AlreadyClaimed
+        | GrantError::NotFound
+        | GrantError::AlreadySealed
+        | GrantError::Expired { .. } => SigningProviderError::GrantClaimFailed,
         GrantError::Backend { reason } => SigningProviderError::Provider { reason },
     }
 }

--- a/crates/ironclaw_wallet_external/src/near_redirect/mod.rs
+++ b/crates/ironclaw_wallet_external/src/near_redirect/mod.rs
@@ -303,7 +303,10 @@ impl SigningProvider for NearRedirectSigningProvider {
         // 6. One-shot grant (threat #1): claim the sealed grant atomically. A
         //    replay of an already-claimed grant fails closed here.
         let key = GrantKey::from_context(context, *approved_tx_hash);
-        self.grants.claim(&key).await.map_err(map_grant_error)?;
+        self.grants
+            .claim(&key, ironclaw_attestation::now_unix_millis())
+            .await
+            .map_err(map_grant_error)?;
 
         Ok(VerifiedProof::new(
             ProviderId::NearRedirect,
@@ -447,11 +450,15 @@ fn validate_access_key_scope(
 /// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
 fn map_grant_error(err: GrantError) -> SigningProviderError {
     match err {
-        // Replay / missing / lost-CAS all collapse to a single fail-closed
-        // grant-claim failure; the distinction is not safe to leak to a caller.
+        // Replay / missing / lost-CAS / expired all collapse to a single
+        // fail-closed grant-claim failure; the distinction is not safe to leak
+        // to a caller. The construction-time timestamp/expiry rejects (from the
+        // sealed-grant hardening) collapse to the same failure for the same
+        // reason.
         GrantError::AlreadyClaimed
         | GrantError::NotFound
         | GrantError::AlreadySealed
+        | GrantError::Expired { .. }
         | GrantError::InvalidTimestamp { .. }
         | GrantError::InvalidExpiry { .. } => SigningProviderError::GrantClaimFailed,
         GrantError::Backend { reason } => SigningProviderError::Provider { reason },

--- a/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
@@ -273,7 +273,10 @@ impl SigningProvider for WalletConnectSigningProvider {
         // 5. One-shot grant (T20): claim the sealed grant atomically. A replay of
         //    an already-claimed grant fails closed here.
         let key = GrantKey::from_context(context, *approved_tx_hash);
-        self.grants.claim(&key).await.map_err(map_grant_error)?;
+        self.grants
+            .claim(&key, ironclaw_attestation::now_unix_millis())
+            .await
+            .map_err(map_grant_error)?;
 
         // Consume the binding only now that every check (incl. the durable grant
         // CAS) has passed — a malformed earlier response never burned it.
@@ -293,9 +296,10 @@ impl SigningProvider for WalletConnectSigningProvider {
 /// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
 fn map_grant_error(err: GrantError) -> SigningProviderError {
     match err {
-        GrantError::AlreadyClaimed | GrantError::NotFound | GrantError::AlreadySealed => {
-            SigningProviderError::GrantClaimFailed
-        }
+        GrantError::AlreadyClaimed
+        | GrantError::NotFound
+        | GrantError::AlreadySealed
+        | GrantError::Expired { .. } => SigningProviderError::GrantClaimFailed,
         GrantError::Backend { reason } => SigningProviderError::Provider { reason },
     }
 }

--- a/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
+++ b/crates/ironclaw_wallet_external/src/walletconnect/mod.rs
@@ -273,7 +273,10 @@ impl SigningProvider for WalletConnectSigningProvider {
         // 5. One-shot grant (T20): claim the sealed grant atomically. A replay of
         //    an already-claimed grant fails closed here.
         let key = GrantKey::from_context(context, *approved_tx_hash);
-        self.grants.claim(&key).await.map_err(map_grant_error)?;
+        self.grants
+            .claim(&key, ironclaw_attestation::now_unix_millis())
+            .await
+            .map_err(map_grant_error)?;
 
         // Consume the binding only now that every check (incl. the durable grant
         // CAS) has passed — a malformed earlier response never burned it.
@@ -293,9 +296,15 @@ impl SigningProvider for WalletConnectSigningProvider {
 /// Map a [`GrantError`] onto the provider error taxonomy, fail-closed.
 fn map_grant_error(err: GrantError) -> SigningProviderError {
     match err {
+        // Replay / missing / lost-CAS / expired all collapse to a single
+        // fail-closed grant-claim failure; the distinction is not safe to leak
+        // to a caller. The construction-time timestamp/expiry rejects (from the
+        // sealed-grant hardening) collapse to the same failure for the same
+        // reason.
         GrantError::AlreadyClaimed
         | GrantError::NotFound
         | GrantError::AlreadySealed
+        | GrantError::Expired { .. }
         | GrantError::InvalidTimestamp { .. }
         | GrantError::InvalidExpiry { .. } => SigningProviderError::GrantClaimFailed,
         GrantError::Backend { reason } => SigningProviderError::Provider { reason },

--- a/crates/ironclaw_wallet_external/tests/verify_resume.rs
+++ b/crates/ironclaw_wallet_external/tests/verify_resume.rs
@@ -103,7 +103,7 @@ impl SealedGrantStore for BackendErrorGrantStore {
         Ok(())
     }
 
-    async fn claim(&self, _key: &GrantKey) -> Result<ClaimedGrant, GrantError> {
+    async fn claim(&self, _key: &GrantKey, _now_ms: i64) -> Result<ClaimedGrant, GrantError> {
         Err(GrantError::Backend {
             reason: "simulated backend failure".to_string(),
         })


### PR DESCRIPTION
## Summary

Trait-level durable-store follow-ups from henrypark133's second-round review of the attested-signing PRs (deferred because a durable-backend-only fix would break contract-equivalence — the in-memory reference is the source of truth and every backend runs through one shared contract macro). Three items:

### 1. Grant `expiry_ms` enforcement
- `SealedGrantStore::claim` now takes `now_ms: i64` — the **caller** supplies the runtime clock (`ironclaw_attestation::now_unix_millis()`); the store never calls `SystemTime::now()`, keeping resume deterministic and expiry unit-testable.
- New `GrantError::Expired { expiry_ms, now_ms }`.
- A sealed grant claimed at/after its `expiry_ms` fails closed **without being consumed or deleted** (stays `Sealed`; "LLM data is never deleted" — mark/timestamp only).
- Enforced in the in-memory reference **and** both durable backends. The CAS becomes `... AND status = 'sealed' AND (expiry_ms IS NULL OR expiry_ms > $now)`; the no-match path disambiguates `NotFound` / `AlreadyClaimed` / `Expired`.
- New contract case `claim_expired_grant_is_rejected` runs against all backends via `sealed_grant_store_contract_cases!` (in-memory + libSQL durable; PG env-gated).
- Call sites updated: custodial signer (`ChainSigningError::Grant` via `#[from]`) and the three external-wallet providers (`map_grant_error` collapses `Expired` into the fail-closed `GrantClaimFailed`, not leaked).

### 2. Binding-store tenant-scoping
- New `BindingKey { tenant, gate_ref }` mirroring `LedgerKey`. Async `get`/`put` and the PG/libSQL primary key are now keyed by `(tenant, gate_ref)`.
- `validate_binding_key` adds a `BindingError::TenantMismatch` check (key tenant must equal the binding's own `context.tenant`) on top of the existing `validate_binding` (GateRefMismatch) and the resolve-layer owner check — defense-in-depth, neither replaced.
- `get_sync` (the crypto-free `ironclaw_turns` resume path, which has **no tenant**) stays gate_ref-keyed via a `gate_ref -> BindingKey` index; the driver continuation read is unchanged.
- New contract case `two_tenants_same_gate_ref_are_isolated`.

### 3. `retryable` mapping consistency
- `AttestedContinuationRejection::retryable()` codifies + documents the rule (no trait change): an idempotent broadcast-tail failure (grant claimed, ledger advance idempotent) → `BackendUnavailable` is **retryable** (#4060); a broadcast failure that drove the ledger to `Unknown`/terminal → `LedgerGuard`/`ProofRejected` is **not** retryable (double-submission risk, #3997). Unit test pins both arms.

## Invariants preserved
Sealed one-shot atomic CAS, WYSIWYS, broadcast-idempotency, deterministic resume, KMS ship-gate, TenantId isolation, never-delete, openssl-free.

## Verification
`cargo fmt --check` clean; `cargo clippy --all-features --tests` zero warnings on all touched crates; `cargo test --all-features` green for `ironclaw_attestation`, `ironclaw_attested_store`, `ironclaw_attested_runtime`, `ironclaw_chain_signing`, `ironclaw_wallet_external`, `ironclaw_product_workflow`, `ironclaw_reborn_composition` (PG-gated cases skip without a live DB). The 2 pre-existing `facade_factory` failures (`RuntimeProcessPort Missing`, #4085) are **confirmed identical on the base** and are not from this change. Full-workspace `--all-features` build succeeds.

## ⚠️ Staging note — must rebase before merge
This is a **staged draft** based on the stack tip `attested-signing-14-loop-raise` (`005760a91`), which transitively contains all four surfaces (grant, binding/driver, durable stores, continuation). The stack is **not yet merged to `reborn-integration`**.

After the bottom-up merge, this PR **must be rebased onto `reborn-integration`** and **reconciled with the latest per-branch second-round fixes**, in particular:
- **#3963** — the ledger `LedgerKey { tenant, gate_ref }`. **Reconciliation risk:** the ledger on this base branch still keys on `GateRef` alone (#3963 is not in the cascade here). `BindingKey` was modeled to mirror the *intended* `LedgerKey`; after rebase, confirm `BindingKey` and `LedgerKey` are shaped consistently.
- **#3995** — `assert_binding_owner` (keep the resolve-layer user-level check on top of the new store-layer tenant axis).
- **#3996** — the durable stores (this PR edits them; expect textual conflicts with any second-round store fixes).
- Note the `#[ignore]`d `claim_expired_grant_is_rejected` / `binding_store_is_tenant_isolated_by_gate_ref` stubs from **#4054** referenced in the issue are **not present** in this base; the equivalent contract cases were written fresh here. After rebase, dedupe against #4054's stubs if they land.

Closes #4102

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Cascade port onto current `main` (2026-07-24)

Replayed onto the ported attested-signing cascade. Base is now **#4055 (`attested-signing-trust-registration`)**: the three -14-based side branches were folded in their original authoring order (multitenant → trust-registration → these trait follow-ups, which were always designed to land on top), and they genuinely collide, so the honest topology is a stack.

Unlike its two siblings this one **conflicted**, because it re-does work this cascade had already done differently in the -12/-13 hops. Four reconciles are worth review attention:

**1. `custodial.rs` was a MISALIGNED conflict — the dangerous one.** Git paired unrelated hunks such that taking the incoming side would have inserted a **second** grant claim inside `authorize()` while `claim_grant()` still claims later. The grant is one-shot, so that second claim always fails — **every custodial signature would break**, compile-clean, with no test naming the cause. This PR's real change to that file is only the `claim()` arity (the store no longer reads the wall clock). Resolution: keep the single claim site — deliberately invoked as the LAST step before the `Signing` ledger transition so a pre-flight failure leaves the gate retryable — and apply only the arity change.

**2. The durable read-through was preserved.** This branch replaced the -12 cache-miss DB fallback with a bare `self.cache.get(key)`, which would make a binding written by another process/replica invisible to the async path. Kept the read-through **and** made it tenant-qualified: `load_one` now selects on the full `(tenant, gate_ref)` primary key, so the fallback can never surface another tenant's row (a `gate_ref`-only lookup could, under the new composite PK this PR introduces).

**3. The claim CAS keeps `RETURNING created_at_ms, expiry_ms`** — the -12 fix that carries `expiry_ms` through to `ClaimedGrant` for downstream time-window checks — layered on top of this PR's new expiry predicate.

**4. `assert_binding_owner` reads through the CALLER's tenant.** The -11 cross-user IDOR fix looked the binding up by bare `gate_ref`. With `(tenant, gate_ref)` keying it now keys on the caller's tenant, so a foreign-tenant caller cannot address the row at all and gets `MissingBinding` — preserving the no-existence-oracle property — before reaching the identity comparison. Both axes are still asserted as defence in depth.

**Two collisions with the sibling branches** (they never saw each other):
- `trust::BindingKey` (trusted-signer slot, from #4055) vs this PR's gate `BindingKey`. The gate one keeps the plain name — it is what `AttestedGateBinding` / `AttestedGateBindingStore` / attested_store / composition all use — and the trust one is re-exported as `TrustBindingKey`.
- #4054's `#[ignore]`d `claim_expired_grant_is_rejected` stub is **superseded** by the enforced version here and dropped. Expiry now runs for real against every backend, closing the H2 follow-up that stub tracked.

The set-aside `resume_through_store.rs` (parked in the -10 hop pending an -05-style row-store retarget) stays out of the tree; this PR's edit to it is preserved alongside the parked copy so the eventual fold does not lose it.

**Verification:** 2885 tests pass across the attested crates + composition + architecture + product_workflow, 0 failures. clippy `--tests --all-features` clean — that flag matters here, it is what compiles the libsql/postgres durable backends whose contract harnesses this PR's trait changes touch. fmt + `check_no_panics.py` clean.
