### PR TITLE
chore: add WeCom release artifact

### DIFF
--- a/registry/channels/wecom.json
+++ b/registry/channels/wecom.json
@@ -16,7 +16,12 @@
     "capabilities": "wecom.capabilities.json",
     "crate_name": "wecom-channel"
   },
-  "artifacts": {},
+  "artifacts": {
+    "wasm32-wasip2": {
+      "url": "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.29.0/channel-wecom-0.1.0-wasm32-wasip2.tar.gz",
+      "sha256": "25d674b3d68c7689ab269be9b40b944c1d5a0f9b20378b81688c25c8b7859bda"
+    }
+  },
   "auth_summary": {
     "method": "manual",
     "provider": "WeCom",


### PR DESCRIPTION
## Summary
- Add the published WeCom WASM artifact URL to the channel registry manifest
- Pin the artifact SHA256 from the ironclaw-v0.29.0 release checksums

## Validation
- jq empty registry/channels/wecom.json
- git diff --check
- Verified release asset digest and checksums.txt both match 25d674b3d68c7689ab269be9b40b944c1d5a0f9b20378b81688c25c8b7859bda