### PR TITLE
feat(reborn): add auth interaction service

### DIFF
--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -13,14 +13,14 @@ use crate::{
     CredentialAccountMutation, CredentialAccountProjection, CredentialAccountSelectionRequest,
     CredentialAccountService, CredentialAccountStatus, CredentialAccountUpdateBinding,
     CredentialOwnership, CredentialRecoveryKind, CredentialRecoveryProjection,
-    CredentialRecoveryReason, CredentialRecoveryRequest, CredentialSetupService,
-    ManualTokenSetupRequest, NewAuthFlow, NewCredentialAccount, OAuthCallbackClaimRequest,
-    OAuthCallbackFailureInput, OAuthCallbackInput, OAuthProviderCallbackRequest,
-    OAuthProviderExchange, ProviderCallbackOutcome, SecretCleanupAction, SecretCleanupReport,
-    SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
-    cleanup::SecretCleanupAction::Deactivate, flow::credential_status_for_completed_flow,
-    interaction::PendingSecretInteraction, provider::validate_provider_callback_request,
-    scope_matches,
+    CredentialRecoveryReason, CredentialRecoveryRequest, CredentialSelectionInput,
+    CredentialSetupService, ManualTokenSetupRequest, NewAuthFlow, NewCredentialAccount,
+    OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
+    OAuthProviderCallbackRequest, OAuthProviderExchange, ProviderCallbackOutcome,
+    SecretCleanupAction, SecretCleanupReport, SecretCleanupRequest, SecretCleanupService,
+    SecretSubmitRequest, SecretSubmitResult, cleanup::SecretCleanupAction::Deactivate,
+    flow::credential_status_for_completed_flow, interaction::PendingSecretInteraction,
+    provider::validate_provider_callback_request, scope_matches,
 };
 
 #[derive(Default)]
@@ -215,6 +215,92 @@ impl AuthFlowManager for InMemoryAuthProductServices {
         record.authorization_code_hash = Some(exchange.authorization_code_hash);
         record.pkce_verifier_hash = Some(exchange.pkce_verifier_hash);
         record.credential_account_id = Some(account_id);
+        record.updated_at = now;
+        let completed = record.clone();
+        state.continuations.push(AuthContinuationEvent {
+            flow_id: completed.id,
+            scope: completed.scope.clone(),
+            continuation: completed.continuation.clone(),
+            credential_account_id: completed.credential_account_id,
+            emitted_at: now,
+        });
+        Ok(completed)
+    }
+
+    async fn complete_credential_selection(
+        &self,
+        scope: &crate::AuthProductScope,
+        input: CredentialSelectionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        let now = Utc::now();
+        let mut state = self.lock_state();
+        let (flow_scope, flow_provider) = {
+            let record = state
+                .flows
+                .get_mut(&input.flow_id)
+                .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
+            if !scope_matches(scope, &record.scope) {
+                return Err(AuthProductError::CrossScopeDenied);
+            }
+            if crate::is_terminal_status(record.status) {
+                return match (record.status, record.credential_account_id) {
+                    (AuthFlowStatus::Completed, Some(account_id))
+                        if account_id == input.credential_account_id =>
+                    {
+                        Ok(record.clone())
+                    }
+                    (AuthFlowStatus::Canceled, _) => Err(AuthProductError::Canceled),
+                    _ => Err(AuthProductError::FlowAlreadyTerminal),
+                };
+            }
+            if now > record.expires_at {
+                record.status = AuthFlowStatus::Expired;
+                record.error = Some(crate::AuthErrorCode::UnknownOrExpiredFlow);
+                record.updated_at = now;
+                return Err(AuthProductError::UnknownOrExpiredFlow);
+            }
+            if record.status != AuthFlowStatus::AwaitingUser {
+                return Err(AuthProductError::FlowAlreadyTerminal);
+            }
+            let Some(AuthChallenge::AccountSelectionRequired { provider, accounts }) =
+                &record.challenge
+            else {
+                return Err(AuthProductError::invalid_request(
+                    "auth flow is not awaiting credential selection",
+                ));
+            };
+            if provider != &record.provider {
+                return Err(AuthProductError::invalid_request(
+                    "auth flow credential selection provider mismatch",
+                ));
+            }
+            let selected = accounts.iter().any(|account| {
+                account.id == input.credential_account_id
+                    && account.provider == record.provider
+                    && account.status == CredentialAccountStatus::Configured
+            });
+            if !selected {
+                return Err(AuthProductError::CredentialMissing);
+            }
+            (record.scope.clone(), record.provider.clone())
+        };
+        let account = state
+            .accounts
+            .get(&input.credential_account_id)
+            .ok_or(AuthProductError::CredentialMissing)?;
+        if !scope_matches(&flow_scope, &account.scope) || account.provider != flow_provider {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if account.status != CredentialAccountStatus::Configured {
+            return Err(AuthProductError::CredentialMissing);
+        }
+        let record = state
+            .flows
+            .get_mut(&input.flow_id)
+            .ok_or(AuthProductError::BackendUnavailable)?;
+        record.status = AuthFlowStatus::Completed;
+        record.error = None;
+        record.credential_account_id = Some(input.credential_account_id);
         record.updated_at = now;
         let completed = record.clone();
         state.continuations.push(AuthContinuationEvent {

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -50,6 +50,17 @@ impl InMemoryAuthProductServices {
         self.lock_state().continuations.clone()
     }
 
+    pub fn flow_records_snapshot(&self) -> Vec<AuthFlowRecord> {
+        let mut flows = self
+            .lock_state()
+            .flows
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        flows.sort_by_key(|flow| flow.id.as_uuid());
+        flows
+    }
+
     fn lock_state(&self) -> MutexGuard<'_, AuthState> {
         self.state
             .lock()

--- a/crates/ironclaw_auth/src/flow.rs
+++ b/crates/ironclaw_auth/src/flow.rs
@@ -174,6 +174,14 @@ pub struct OAuthCallbackFailureInput {
     pub error: AuthErrorCode,
 }
 
+/// User-selected configured credential that completes an account-selection
+/// auth flow without exposing credential internals to product surfaces.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialSelectionInput {
+    pub flow_id: AuthFlowId,
+    pub credential_account_id: CredentialAccountId,
+}
+
 /// Pre-egress claim for an authorized OAuth callback. This validates and marks
 /// the scoped flow before one-shot provider exchange can consume a raw code.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -204,6 +212,12 @@ pub trait AuthFlowManager: Send + Sync {
         &self,
         scope: &AuthProductScope,
         input: OAuthCallbackInput,
+    ) -> Result<AuthFlowRecord, AuthProductError>;
+
+    async fn complete_credential_selection(
+        &self,
+        scope: &AuthProductScope,
+        input: CredentialSelectionInput,
     ) -> Result<AuthFlowRecord, AuthProductError>;
 
     async fn fail_oauth_callback(

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -35,8 +35,8 @@ pub use error::{AuthErrorCode, AuthProductError};
 pub use fakes::InMemoryAuthProductServices;
 pub use flow::{
     AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthFlowKind, AuthFlowManager,
-    AuthFlowRecord, AuthFlowStatus, CredentialAccountUpdateBinding, NewAuthFlow,
-    OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
+    AuthFlowRecord, AuthFlowStatus, CredentialAccountUpdateBinding, CredentialSelectionInput,
+    NewAuthFlow, OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
     ProviderCallbackOutcome,
 };
 pub use ids::{

--- a/crates/ironclaw_auth/tests/auth_product_contract/common.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/common.rs
@@ -8,13 +8,13 @@ pub use ironclaw_auth::{
     CredentialAccountProjection, CredentialAccountSelectionRequest, CredentialAccountService,
     CredentialAccountStatus, CredentialAccountUpdate, CredentialAccountUpdateBinding,
     CredentialOwnership, CredentialRecoveryKind, CredentialRecoveryProjection,
-    CredentialRecoveryReason, CredentialRecoveryRequest, CredentialSetupService,
-    InMemoryAuthProductServices, LifecyclePackageRef, ManualTokenSetupRequest, NewAuthFlow,
-    NewCredentialAccount, OAuthAuthorizationCode, OAuthAuthorizationUrl, OAuthCallbackInput,
-    OAuthProviderCallbackRequest, OAuthProviderExchange, OpaqueStateHash, PkceVerifierHash,
-    PkceVerifierSecret, ProviderCallbackOutcome, ProviderScope, SecretCleanupAction,
-    SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
-    TurnRunRef,
+    CredentialRecoveryReason, CredentialRecoveryRequest, CredentialSelectionInput,
+    CredentialSetupService, InMemoryAuthProductServices, LifecyclePackageRef,
+    ManualTokenSetupRequest, NewAuthFlow, NewCredentialAccount, OAuthAuthorizationCode,
+    OAuthAuthorizationUrl, OAuthCallbackInput, OAuthProviderCallbackRequest, OAuthProviderExchange,
+    OpaqueStateHash, PkceVerifierHash, PkceVerifierSecret, ProviderCallbackOutcome, ProviderScope,
+    SecretCleanupAction, SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest,
+    SecretSubmitResult, TurnRunRef,
 };
 pub use ironclaw_host_api::{ExtensionId, InvocationId, ResourceScope, SecretHandle, UserId};
 pub use secrecy::SecretString;

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
@@ -57,6 +57,139 @@ async fn oauth_callback_exchanges_provider_code_then_completes_once() {
 }
 
 #[tokio::test]
+async fn credential_selection_completes_account_selection_flow_once() {
+    let services = InMemoryAuthProductServices::new();
+    let owner = scope("alice");
+    let account = services
+        .create_account(NewCredentialAccount {
+            scope: owner.clone(),
+            provider: provider(),
+            label: label("work github"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(SecretHandle::new("github-work-secret").unwrap()),
+            refresh_secret: None,
+            scopes: provider_scopes(&["repo"]),
+        })
+        .await
+        .expect("account");
+    let flow = services
+        .create_flow(NewAuthFlow {
+            scope: owner.clone(),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: provider(),
+            challenge: AuthChallenge::AccountSelectionRequired {
+                provider: provider(),
+                accounts: vec![account.projection()],
+            },
+            continuation: AuthContinuationRef::LifecycleActivation {
+                package_ref: LifecyclePackageRef::new("github-extension").expect("valid package"),
+            },
+            update_binding: None,
+            opaque_state_hash: None,
+            pkce_verifier_hash: None,
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect("flow");
+
+    let completed = services
+        .complete_credential_selection(
+            &owner,
+            CredentialSelectionInput {
+                flow_id: flow.id,
+                credential_account_id: account.id,
+            },
+        )
+        .await
+        .expect("credential selection completes");
+
+    assert_eq!(completed.status, AuthFlowStatus::Completed);
+    assert_eq!(completed.credential_account_id, Some(account.id));
+    assert_eq!(services.continuations().len(), 1);
+
+    let replay = services
+        .complete_credential_selection(
+            &owner,
+            CredentialSelectionInput {
+                flow_id: flow.id,
+                credential_account_id: account.id,
+            },
+        )
+        .await
+        .expect("matching completed selection is idempotent");
+    assert_eq!(replay.credential_account_id, Some(account.id));
+    assert_eq!(services.continuations().len(), 1);
+}
+
+#[tokio::test]
+async fn credential_selection_rejects_unlisted_or_cross_scope_account() {
+    let services = InMemoryAuthProductServices::new();
+    let owner = scope("alice");
+    let account = services
+        .create_account(NewCredentialAccount {
+            scope: owner.clone(),
+            provider: provider(),
+            label: label("work github"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(SecretHandle::new("github-work-secret").unwrap()),
+            refresh_secret: None,
+            scopes: provider_scopes(&["repo"]),
+        })
+        .await
+        .expect("account");
+    let flow = services
+        .create_flow(NewAuthFlow {
+            scope: owner.clone(),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: provider(),
+            challenge: AuthChallenge::AccountSelectionRequired {
+                provider: provider(),
+                accounts: vec![account.projection()],
+            },
+            continuation: AuthContinuationRef::LifecycleActivation {
+                package_ref: LifecyclePackageRef::new("github-extension").expect("valid package"),
+            },
+            update_binding: None,
+            opaque_state_hash: None,
+            pkce_verifier_hash: None,
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .expect("flow");
+
+    let unlisted = services
+        .complete_credential_selection(
+            &owner,
+            CredentialSelectionInput {
+                flow_id: flow.id,
+                credential_account_id: CredentialAccountId::new(),
+            },
+        )
+        .await
+        .expect_err("unlisted account rejected");
+    assert_eq!(unlisted, AuthProductError::CredentialMissing);
+
+    let cross_scope = services
+        .complete_credential_selection(
+            &scope("bob"),
+            CredentialSelectionInput {
+                flow_id: flow.id,
+                credential_account_id: account.id,
+            },
+        )
+        .await
+        .expect_err("cross-scope selection rejected");
+    assert_eq!(cross_scope, AuthProductError::CrossScopeDenied);
+    assert!(services.continuations().is_empty());
+}
+
+#[tokio::test]
 async fn oauth_callback_updates_existing_account_from_provider_exchange() {
     let services = InMemoryAuthProductServices::new();
     let owner = scope("alice");

--- a/crates/ironclaw_product_workflow/CLAUDE.md
+++ b/crates/ironclaw_product_workflow/CLAUDE.md
@@ -25,6 +25,7 @@ handling, gate routing, mission routing, and redacted acknowledgements.
 | `ProductCommandService` | Reborn-native product command execution port for already-admitted typed commands |
 | `ApprovalInteractionService` / `DefaultApprovalInteractionService` | Approval-only product/WebUI boundary for listing redacted pending approval gates and resolving click approve/deny through canonical approval resolver + turn coordinator ports |
 | `RunStateApprovalInteractionReadModel` | Canonical read model that returns status-bearing approval gates from scoped approval-request records plus the parked turn-run locator; `ApprovalInteractionService::list_pending` filters those records to pending UI DTOs |
+| `AuthInteractionService` / `DefaultAuthInteractionService` | Auth-required product/WebUI boundary for listing redacted pending auth gates and resolving credential/callback/cancel decisions through typed auth-flow manager + turn coordinator ports |
 | `RebornServicesApi` / `RebornServices` | Native WebChat v2 facade — stable surface beta WebUI route handlers consume in place of reaching into turn coordination, thread stores, runtime lanes, dispatchers, or capability hosts. Enforces caller ownership of the thread before any turn mutation; rejects stale or attacker-supplied `gate_ref` on denied/cancelled gate resolutions; refuses persistent (`always: true`) approvals until an approval-policy port lands |
 
 ## Dependencies
@@ -65,6 +66,16 @@ directly execute tools, mutate approval stores ad hoc, or implement
 `AlwaysAllow` before a durable approval-policy port exists. High-value signing
 and attested approvals require a separate service shape with canonical payload
 attestation and must not be folded into this redacted click-approval DTO.
+
+Auth interactions are auth-required gates only. Pending auth DTOs must be
+redacted, scoped, and derived from typed auth-flow state plus the parked
+turn-run locator. Credential/callback completion refs are opaque host-issued
+references; raw tokens, OAuth codes, verifier material, provider errors, host
+paths, or backend diagnostics must not enter product payloads or projection
+DTOs. Resume/cancel decisions must go through `AuthFlowManager` and
+`TurnCoordinator`; product/WebUI code must not handle raw credentials, mutate
+auth-flow records directly, or resume blocked auth gates without the
+`BlockedAuthGate` precondition.
 
 WebUI-facing facade methods must bind browser thread ids through
 `SessionThreadService` using a `ThreadScope` derived from the authenticated

--- a/crates/ironclaw_product_workflow/src/auth_interaction/gate_ref.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/gate_ref.rs
@@ -1,0 +1,58 @@
+use ironclaw_turns::{GateRef, ReplyTargetBindingRef, SourceBindingRef};
+
+use super::{AuthInteractionRejectionKind, auth_rejected};
+use crate::binding_ref::{
+    DEFAULT_BINDING_REF_RAW_MAX_BYTES, bounded_reply_target_binding_ref, bounded_source_binding_ref,
+};
+use crate::error::ProductWorkflowError;
+
+const AUTH_GATE_REF: &str = "gate:auth";
+const AUTH_GATE_PREFIX: &str = "gate:auth-";
+const HOOK_AUTH_GATE_PREFIX: &str = "gate:hook-auth-";
+
+pub fn is_auth_gate_ref(gate_ref: &GateRef) -> bool {
+    let value = gate_ref.as_str();
+    value == AUTH_GATE_REF
+        || value.starts_with(AUTH_GATE_PREFIX)
+        || value.starts_with(HOOK_AUTH_GATE_PREFIX)
+}
+
+pub(crate) fn auth_source_binding_ref(
+    binding_id: &str,
+) -> Result<SourceBindingRef, ProductWorkflowError> {
+    bounded_source_binding_ref(
+        "auth-interaction-src",
+        binding_id,
+        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
+    )
+    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
+}
+
+pub(crate) fn auth_reply_binding_ref(
+    binding_id: &str,
+) -> Result<ReplyTargetBindingRef, ProductWorkflowError> {
+    bounded_reply_target_binding_ref(
+        "auth-interaction-reply",
+        binding_id,
+        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
+    )
+    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_auth_gate_ref_matches_only_auth_gate_shapes() {
+        assert!(is_auth_gate_ref(&GateRef::new("gate:auth").unwrap()));
+        assert!(is_auth_gate_ref(&GateRef::new("gate:auth-oauth").unwrap()));
+        assert!(is_auth_gate_ref(
+            &GateRef::new("gate:hook-auth-oauth").unwrap()
+        ));
+        assert!(!is_auth_gate_ref(
+            &GateRef::new("gate:approval-123").unwrap()
+        ));
+        assert!(!is_auth_gate_ref(&GateRef::new("gate:other-auth").unwrap()));
+    }
+}

--- a/crates/ironclaw_product_workflow/src/auth_interaction/mod.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/mod.rs
@@ -4,18 +4,21 @@
 //! validates caller scope, exposes redacted auth challenge DTOs, and routes
 //! resume/cancel decisions through typed auth-flow and turn-coordinator ports.
 
+mod gate_ref;
 mod service;
 mod types;
 
+pub use gate_ref::is_auth_gate_ref;
+pub(super) use gate_ref::{auth_reply_binding_ref, auth_source_binding_ref};
 pub(crate) use service::RejectingAuthInteractionService;
 pub use service::{
     AuthInteractionReadModel, AuthInteractionService, DefaultAuthInteractionService,
 };
 pub use types::{
-    AuthGateRecord, AuthInteractionChallengeView, AuthInteractionDecision,
-    AuthInteractionRejectionKind, AuthInteractionScope, ListPendingAuthInteractionsRequest,
-    ListPendingAuthInteractionsResponse, PendingAuthInteractionView, ResolveAuthInteractionRequest,
-    ResolveAuthInteractionResponse, is_auth_gate_ref,
+    AuthCredentialAccountChoiceView, AuthGateRecord, AuthInteractionChallengeView,
+    AuthInteractionDecision, AuthInteractionRejectionKind, AuthInteractionScope,
+    AuthInteractionStatus, ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse,
+    PendingAuthInteractionView, ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
 };
 
 use crate::error::ProductWorkflowError;

--- a/crates/ironclaw_product_workflow/src/auth_interaction/mod.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/mod.rs
@@ -1,0 +1,25 @@
+//! Product-facing auth interaction boundary.
+//!
+//! This module owns adapter/UI-safe auth-required interaction handling. It
+//! validates caller scope, exposes redacted auth challenge DTOs, and routes
+//! resume/cancel decisions through typed auth-flow and turn-coordinator ports.
+
+mod service;
+mod types;
+
+pub(crate) use service::RejectingAuthInteractionService;
+pub use service::{
+    AuthInteractionReadModel, AuthInteractionService, DefaultAuthInteractionService,
+};
+pub use types::{
+    AuthGateRecord, AuthInteractionChallengeView, AuthInteractionDecision,
+    AuthInteractionRejectionKind, AuthInteractionScope, ListPendingAuthInteractionsRequest,
+    ListPendingAuthInteractionsResponse, PendingAuthInteractionView, ResolveAuthInteractionRequest,
+    ResolveAuthInteractionResponse, is_auth_gate_ref,
+};
+
+use crate::error::ProductWorkflowError;
+
+fn auth_rejected(kind: AuthInteractionRejectionKind) -> ProductWorkflowError {
+    ProductWorkflowError::AuthInteractionRejected { kind }
+}

--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ironclaw_auth::{AuthFlowManager, AuthFlowStatus, AuthProductError};
+use ironclaw_auth::{
+    AuthChallenge, AuthFlowId, AuthFlowManager, AuthFlowStatus, AuthProductError,
+    CredentialAccountId, CredentialSelectionInput,
+};
 use ironclaw_turns::{
     CancelRunRequest, GateRef, GetRunStateRequest, ResumeTurnPrecondition, ResumeTurnRequest,
     SanitizedCancelReason, TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
@@ -188,6 +191,31 @@ impl DefaultAuthInteractionService {
         Ok(ResolveAuthInteractionResponse::Resumed(response))
     }
 
+    async fn complete_selected_credential(
+        &self,
+        gate: AuthGateRecord,
+        credential_ref: CredentialAccountId,
+    ) -> Result<AuthGateRecord, ProductWorkflowError> {
+        if gate.status() == AuthFlowStatus::Completed {
+            return Ok(gate);
+        }
+        let Some(AuthChallenge::AccountSelectionRequired { .. }) = &gate.flow().challenge else {
+            return Ok(gate);
+        };
+        let completed = self
+            .flow_manager
+            .complete_credential_selection(
+                &gate.flow().scope,
+                CredentialSelectionInput {
+                    flow_id: gate.flow().id,
+                    credential_account_id: credential_ref,
+                },
+            )
+            .await
+            .map_err(map_credential_selection_error)?;
+        AuthGateRecord::new(gate.run_id(), gate.gate_ref().clone(), completed)
+    }
+
     async fn cancel_auth(
         &self,
         request: ResolveAuthInteractionRequest,
@@ -273,20 +301,43 @@ impl AuthInteractionService for DefaultAuthInteractionService {
             }
             (
                 AuthTurnGateState::ParkedOnGate,
+                AuthInteractionDecision::CredentialProvided { credential_ref },
+            ) => {
+                let gate = self.refresh_gate(&gate).await?;
+                let gate = self
+                    .complete_selected_credential(gate, credential_ref)
+                    .await?;
+                self.resume_completed_auth(request, gate, run_id).await
+            }
+            (
+                AuthTurnGateState::ParkedOnGate,
+                AuthInteractionDecision::CallbackCompleted { .. },
+            ) => {
+                let gate = self.refresh_gate(&gate).await?;
+                self.resume_completed_auth(request, gate, run_id).await
+            }
+            (
+                AuthTurnGateState::NotParkedOnGate,
                 AuthInteractionDecision::CredentialProvided { .. }
                 | AuthInteractionDecision::CallbackCompleted { .. },
             ) => {
                 let gate = self.refresh_gate(&gate).await?;
                 self.resume_completed_auth(request, gate, run_id).await
             }
-            _ => Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth)),
+            (AuthTurnGateState::NotParkedOnGate, AuthInteractionDecision::Deny) => {
+                let gate = self.refresh_gate(&gate).await?;
+                if gate.status() != AuthFlowStatus::Canceled {
+                    return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
+                }
+                self.cancel_auth(request, gate, run_id).await
+            }
         }
     }
 }
 
 enum AuthCompletionRef<'a> {
-    CredentialProvided(&'a str),
-    CallbackCompleted(&'a str),
+    CredentialProvided(&'a CredentialAccountId),
+    CallbackCompleted(&'a AuthFlowId),
 }
 
 fn validate_completion_ref(
@@ -301,7 +352,7 @@ fn validate_completion_ref(
             let Some(account_id) = gate.flow().credential_account_id else {
                 return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
             };
-            if credential_ref != account_id.to_string() {
+            if credential_ref != &account_id {
                 return Err(auth_rejected(
                     AuthInteractionRejectionKind::InvalidCredentialRef,
                 ));
@@ -309,7 +360,7 @@ fn validate_completion_ref(
             Ok(())
         }
         AuthCompletionRef::CallbackCompleted(callback_ref) => {
-            if callback_ref != gate.flow().id.to_string() {
+            if callback_ref != &gate.flow().id {
                 return Err(auth_rejected(
                     AuthInteractionRejectionKind::InvalidCallbackRef,
                 ));
@@ -353,6 +404,32 @@ fn map_auth_product_error(error: AuthProductError) -> ProductWorkflowError {
         | AuthProductError::CredentialMissing
         | AuthProductError::AccountSelectionRequired
         | AuthProductError::InvalidRequest { .. } => {
+            auth_rejected(AuthInteractionRejectionKind::UnsupportedResult)
+        }
+    }
+}
+
+fn map_credential_selection_error(error: AuthProductError) -> ProductWorkflowError {
+    match error {
+        AuthProductError::UnknownOrExpiredFlow => {
+            auth_rejected(AuthInteractionRejectionKind::MissingAuth)
+        }
+        AuthProductError::CrossScopeDenied => {
+            auth_rejected(AuthInteractionRejectionKind::CrossScopeDenied)
+        }
+        AuthProductError::BackendUnavailable => {
+            auth_rejected(AuthInteractionRejectionKind::FlowUnavailable)
+        }
+        AuthProductError::CredentialMissing
+        | AuthProductError::AccountSelectionRequired
+        | AuthProductError::InvalidRequest { .. } => {
+            auth_rejected(AuthInteractionRejectionKind::InvalidCredentialRef)
+        }
+        AuthProductError::Canceled
+        | AuthProductError::FlowAlreadyTerminal
+        | AuthProductError::ProviderDenied
+        | AuthProductError::RefreshFailed => auth_rejected(AuthInteractionRejectionKind::StaleAuth),
+        AuthProductError::MalformedCallback | AuthProductError::TokenExchangeFailed => {
             auth_rejected(AuthInteractionRejectionKind::UnsupportedResult)
         }
     }

--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -3,9 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use ironclaw_auth::{AuthFlowManager, AuthFlowStatus, AuthProductError};
 use ironclaw_turns::{
-    CancelRunRequest, GateRef, GetRunStateRequest, ReplyTargetBindingRef, ResumeTurnPrecondition,
-    ResumeTurnRequest, SanitizedCancelReason, SourceBindingRef, TurnCoordinator, TurnError,
-    TurnErrorCategory, TurnRunId, TurnStatus,
+    CancelRunRequest, GateRef, GetRunStateRequest, ResumeTurnPrecondition, ResumeTurnRequest,
+    SanitizedCancelReason, TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
 };
 
 use super::types::is_pending_auth_status;
@@ -13,11 +12,9 @@ use super::{
     AuthGateRecord, AuthInteractionDecision, AuthInteractionRejectionKind, AuthInteractionScope,
     ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse,
     ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, auth_rejected,
+    auth_reply_binding_ref, auth_source_binding_ref,
 };
-use crate::binding_ref::{
-    DEFAULT_BINDING_REF_RAW_MAX_BYTES, binding_ref_segment, bounded_reply_target_binding_ref,
-    bounded_source_binding_ref,
-};
+use crate::binding_ref::binding_ref_segment;
 use crate::error::ProductWorkflowError;
 
 #[async_trait]
@@ -159,7 +156,20 @@ impl DefaultAuthInteractionService {
         gate: AuthGateRecord,
         run_id: TurnRunId,
     ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
-        validate_completion_ref(&gate, &request.decision)?;
+        let completion = match &request.decision {
+            AuthInteractionDecision::CredentialProvided { credential_ref } => {
+                AuthCompletionRef::CredentialProvided(credential_ref)
+            }
+            AuthInteractionDecision::CallbackCompleted { callback_ref } => {
+                AuthCompletionRef::CallbackCompleted(callback_ref)
+            }
+            AuthInteractionDecision::Deny => {
+                return Err(auth_rejected(
+                    AuthInteractionRejectionKind::UnsupportedResult,
+                ));
+            }
+        };
+        validate_completion_ref(&gate, completion)?;
         let binding_id = auth_interaction_binding_id(gate.flow().id, &run_id, gate.gate_ref());
         let response = self
             .turn_coordinator
@@ -227,7 +237,7 @@ impl AuthInteractionService for DefaultAuthInteractionService {
             .await?
             .into_iter()
             .filter(|gate| gate.scope() == &scope && is_pending_auth_status(gate.status()))
-            .map(|gate| gate.to_view())
+            .filter_map(|gate| gate.to_view())
             .collect::<Vec<_>>();
         auth.sort_by(|left, right| {
             left.run_id
@@ -239,7 +249,9 @@ impl AuthInteractionService for DefaultAuthInteractionService {
                         .cmp(right.auth_request_ref.as_str())
                 })
         });
-        Ok(ListPendingAuthInteractionsResponse { auth })
+        Ok(ListPendingAuthInteractionsResponse {
+            auth_interactions: auth,
+        })
     }
 
     async fn resolve(
@@ -272,36 +284,38 @@ impl AuthInteractionService for DefaultAuthInteractionService {
     }
 }
 
+enum AuthCompletionRef<'a> {
+    CredentialProvided(&'a str),
+    CallbackCompleted(&'a str),
+}
+
 fn validate_completion_ref(
     gate: &AuthGateRecord,
-    decision: &AuthInteractionDecision,
+    completion: AuthCompletionRef<'_>,
 ) -> Result<(), ProductWorkflowError> {
     if gate.status() != AuthFlowStatus::Completed {
         return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
     }
-    match decision {
-        AuthInteractionDecision::CredentialProvided { credential_ref } => {
+    match completion {
+        AuthCompletionRef::CredentialProvided(credential_ref) => {
             let Some(account_id) = gate.flow().credential_account_id else {
                 return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
             };
-            if credential_ref != &account_id.to_string() {
+            if credential_ref != account_id.to_string() {
                 return Err(auth_rejected(
                     AuthInteractionRejectionKind::InvalidCredentialRef,
                 ));
             }
             Ok(())
         }
-        AuthInteractionDecision::CallbackCompleted { callback_ref } => {
-            if callback_ref != &gate.flow().id.to_string() {
+        AuthCompletionRef::CallbackCompleted(callback_ref) => {
+            if callback_ref != gate.flow().id.to_string() {
                 return Err(auth_rejected(
                     AuthInteractionRejectionKind::InvalidCallbackRef,
                 ));
             }
             Ok(())
         }
-        AuthInteractionDecision::Deny => Err(auth_rejected(
-            AuthInteractionRejectionKind::UnsupportedResult,
-        )),
     }
 }
 
@@ -317,24 +331,6 @@ fn auth_interaction_binding_id(
         binding_ref_segment("run", &run_id.to_string()),
         binding_ref_segment("gate", gate_ref.as_str())
     )
-}
-
-fn auth_source_binding_ref(binding_id: &str) -> Result<SourceBindingRef, ProductWorkflowError> {
-    bounded_source_binding_ref(
-        "auth-interaction-src",
-        binding_id,
-        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
-    )
-    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
-}
-
-fn auth_reply_binding_ref(binding_id: &str) -> Result<ReplyTargetBindingRef, ProductWorkflowError> {
-    bounded_reply_target_binding_ref(
-        "auth-interaction-reply",
-        binding_id,
-        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
-    )
-    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
 }
 
 fn map_auth_product_error(error: AuthProductError) -> ProductWorkflowError {

--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -1,0 +1,396 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_auth::{AuthFlowManager, AuthFlowStatus, AuthProductError};
+use ironclaw_turns::{
+    CancelRunRequest, GateRef, GetRunStateRequest, ReplyTargetBindingRef, ResumeTurnPrecondition,
+    ResumeTurnRequest, SanitizedCancelReason, SourceBindingRef, TurnCoordinator, TurnError,
+    TurnErrorCategory, TurnRunId, TurnStatus,
+};
+
+use super::types::is_pending_auth_status;
+use super::{
+    AuthGateRecord, AuthInteractionDecision, AuthInteractionRejectionKind, AuthInteractionScope,
+    ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse,
+    ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, auth_rejected,
+};
+use crate::binding_ref::{
+    DEFAULT_BINDING_REF_RAW_MAX_BYTES, binding_ref_segment, bounded_reply_target_binding_ref,
+    bounded_source_binding_ref,
+};
+use crate::error::ProductWorkflowError;
+
+#[async_trait]
+pub trait AuthInteractionReadModel: Send + Sync {
+    async fn auth_gates(
+        &self,
+        scope: &AuthInteractionScope,
+    ) -> Result<Vec<AuthGateRecord>, ProductWorkflowError>;
+
+    async fn auth_gate(
+        &self,
+        scope: &AuthInteractionScope,
+        run_id_hint: Option<TurnRunId>,
+        gate_ref: &GateRef,
+    ) -> Result<Option<AuthGateRecord>, ProductWorkflowError>;
+}
+
+/// Auth-required service consumed by product/WebUI surfaces.
+#[async_trait]
+pub trait AuthInteractionService: Send + Sync {
+    async fn list_pending(
+        &self,
+        request: ListPendingAuthInteractionsRequest,
+    ) -> Result<ListPendingAuthInteractionsResponse, ProductWorkflowError>;
+
+    async fn resolve(
+        &self,
+        request: ResolveAuthInteractionRequest,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError>;
+}
+
+pub(crate) struct RejectingAuthInteractionService;
+
+#[async_trait]
+impl AuthInteractionService for RejectingAuthInteractionService {
+    async fn list_pending(
+        &self,
+        _request: ListPendingAuthInteractionsRequest,
+    ) -> Result<ListPendingAuthInteractionsResponse, ProductWorkflowError> {
+        Err(auth_rejected(AuthInteractionRejectionKind::FlowUnavailable))
+    }
+
+    async fn resolve(
+        &self,
+        _request: ResolveAuthInteractionRequest,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        Err(auth_rejected(AuthInteractionRejectionKind::FlowUnavailable))
+    }
+}
+
+pub struct DefaultAuthInteractionService {
+    read_model: Arc<dyn AuthInteractionReadModel>,
+    flow_manager: Arc<dyn AuthFlowManager>,
+    turn_coordinator: Arc<dyn TurnCoordinator>,
+}
+
+#[derive(Clone, Copy)]
+enum AuthTurnGateState {
+    ParkedOnGate,
+    NotParkedOnGate,
+}
+
+impl DefaultAuthInteractionService {
+    pub fn new(
+        read_model: Arc<dyn AuthInteractionReadModel>,
+        flow_manager: Arc<dyn AuthFlowManager>,
+        turn_coordinator: Arc<dyn TurnCoordinator>,
+    ) -> Self {
+        Self {
+            read_model,
+            flow_manager,
+            turn_coordinator,
+        }
+    }
+
+    async fn find_gate(
+        &self,
+        scope: &AuthInteractionScope,
+        run_id_hint: Option<TurnRunId>,
+        gate_ref: &GateRef,
+    ) -> Result<AuthGateRecord, ProductWorkflowError> {
+        let gate = self
+            .read_model
+            .auth_gate(scope, run_id_hint, gate_ref)
+            .await?
+            .ok_or_else(|| auth_rejected(AuthInteractionRejectionKind::MissingAuth))?;
+        if gate.scope() != scope {
+            return Err(auth_rejected(
+                AuthInteractionRejectionKind::CrossScopeDenied,
+            ));
+        }
+        Ok(gate)
+    }
+
+    async fn refresh_gate(
+        &self,
+        gate: &AuthGateRecord,
+    ) -> Result<AuthGateRecord, ProductWorkflowError> {
+        let Some(flow) = self
+            .flow_manager
+            .get_flow(&gate.flow().scope, gate.flow().id)
+            .await
+            .map_err(map_auth_product_error)?
+        else {
+            return Err(auth_rejected(AuthInteractionRejectionKind::MissingAuth));
+        };
+        AuthGateRecord::new(gate.run_id(), gate.gate_ref().clone(), flow)
+    }
+
+    async fn turn_gate_state(
+        &self,
+        request: &ResolveAuthInteractionRequest,
+        run_id: TurnRunId,
+    ) -> Result<AuthTurnGateState, ProductWorkflowError> {
+        let state = self
+            .turn_coordinator
+            .get_run_state(GetRunStateRequest {
+                scope: request.scope.clone(),
+                run_id,
+            })
+            .await
+            .map_err(map_gate_state_error)?;
+        if state.actor.as_ref() != Some(&request.actor) {
+            return Err(auth_rejected(
+                AuthInteractionRejectionKind::CrossScopeDenied,
+            ));
+        }
+        if state.status != TurnStatus::BlockedAuth
+            || state.gate_ref.as_ref() != Some(&request.gate_ref)
+        {
+            return Ok(AuthTurnGateState::NotParkedOnGate);
+        }
+        Ok(AuthTurnGateState::ParkedOnGate)
+    }
+
+    async fn resume_completed_auth(
+        &self,
+        request: ResolveAuthInteractionRequest,
+        gate: AuthGateRecord,
+        run_id: TurnRunId,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        validate_completion_ref(&gate, &request.decision)?;
+        let binding_id = auth_interaction_binding_id(gate.flow().id, &run_id, gate.gate_ref());
+        let response = self
+            .turn_coordinator
+            .resume_turn(ResumeTurnRequest {
+                scope: request.scope,
+                actor: request.actor,
+                run_id,
+                gate_resolution_ref: request.gate_ref,
+                precondition: ResumeTurnPrecondition::BlockedAuthGate,
+                source_binding_ref: auth_source_binding_ref(&binding_id)?,
+                reply_target_binding_ref: auth_reply_binding_ref(&binding_id)?,
+                idempotency_key: request.idempotency_key,
+            })
+            .await
+            .map_err(map_auth_resume_error)?;
+        Ok(ResolveAuthInteractionResponse::Resumed(response))
+    }
+
+    async fn cancel_auth(
+        &self,
+        request: ResolveAuthInteractionRequest,
+        gate: AuthGateRecord,
+        run_id: TurnRunId,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        match gate.status() {
+            AuthFlowStatus::Pending
+            | AuthFlowStatus::AwaitingUser
+            | AuthFlowStatus::CallbackReceived
+            | AuthFlowStatus::Completing => {
+                self.flow_manager
+                    .cancel_flow(&gate.flow().scope, gate.flow().id)
+                    .await
+                    .map_err(map_auth_product_error)?;
+            }
+            AuthFlowStatus::Failed | AuthFlowStatus::Expired | AuthFlowStatus::Canceled => {}
+            AuthFlowStatus::Completed => {
+                return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
+            }
+        }
+        let response = self
+            .turn_coordinator
+            .cancel_run(CancelRunRequest {
+                scope: request.scope,
+                actor: request.actor,
+                run_id,
+                reason: SanitizedCancelReason::UserRequested,
+                idempotency_key: request.idempotency_key,
+            })
+            .await
+            .map_err(map_auth_resume_error)?;
+        Ok(ResolveAuthInteractionResponse::Canceled(response))
+    }
+}
+
+#[async_trait]
+impl AuthInteractionService for DefaultAuthInteractionService {
+    async fn list_pending(
+        &self,
+        request: ListPendingAuthInteractionsRequest,
+    ) -> Result<ListPendingAuthInteractionsResponse, ProductWorkflowError> {
+        let scope = AuthInteractionScope::from_turn(&request.scope, &request.actor);
+        let mut auth = self
+            .read_model
+            .auth_gates(&scope)
+            .await?
+            .into_iter()
+            .filter(|gate| gate.scope() == &scope && is_pending_auth_status(gate.status()))
+            .map(|gate| gate.to_view())
+            .collect::<Vec<_>>();
+        auth.sort_by(|left, right| {
+            left.run_id
+                .as_uuid()
+                .cmp(&right.run_id.as_uuid())
+                .then_with(|| {
+                    left.auth_request_ref
+                        .as_str()
+                        .cmp(right.auth_request_ref.as_str())
+                })
+        });
+        Ok(ListPendingAuthInteractionsResponse { auth })
+    }
+
+    async fn resolve(
+        &self,
+        request: ResolveAuthInteractionRequest,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        let scope = AuthInteractionScope::from_turn(&request.scope, &request.actor);
+        let gate = self
+            .find_gate(&scope, request.run_id_hint, &request.gate_ref)
+            .await?;
+        let run_id = request.run_id_hint.unwrap_or_else(|| gate.run_id());
+        match (
+            self.turn_gate_state(&request, run_id).await?,
+            request.decision.clone(),
+        ) {
+            (AuthTurnGateState::ParkedOnGate, AuthInteractionDecision::Deny) => {
+                let gate = self.refresh_gate(&gate).await?;
+                self.cancel_auth(request, gate, run_id).await
+            }
+            (
+                AuthTurnGateState::ParkedOnGate,
+                AuthInteractionDecision::CredentialProvided { .. }
+                | AuthInteractionDecision::CallbackCompleted { .. },
+            ) => {
+                let gate = self.refresh_gate(&gate).await?;
+                self.resume_completed_auth(request, gate, run_id).await
+            }
+            _ => Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth)),
+        }
+    }
+}
+
+fn validate_completion_ref(
+    gate: &AuthGateRecord,
+    decision: &AuthInteractionDecision,
+) -> Result<(), ProductWorkflowError> {
+    if gate.status() != AuthFlowStatus::Completed {
+        return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
+    }
+    match decision {
+        AuthInteractionDecision::CredentialProvided { credential_ref } => {
+            let Some(account_id) = gate.flow().credential_account_id else {
+                return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
+            };
+            if credential_ref != &account_id.to_string() {
+                return Err(auth_rejected(
+                    AuthInteractionRejectionKind::InvalidCredentialRef,
+                ));
+            }
+            Ok(())
+        }
+        AuthInteractionDecision::CallbackCompleted { callback_ref } => {
+            if callback_ref != &gate.flow().id.to_string() {
+                return Err(auth_rejected(
+                    AuthInteractionRejectionKind::InvalidCallbackRef,
+                ));
+            }
+            Ok(())
+        }
+        AuthInteractionDecision::Deny => Err(auth_rejected(
+            AuthInteractionRejectionKind::UnsupportedResult,
+        )),
+    }
+}
+
+fn auth_interaction_binding_id(
+    flow_id: ironclaw_auth::AuthFlowId,
+    run_id: &TurnRunId,
+    gate_ref: &GateRef,
+) -> String {
+    format!(
+        "{}{}{}{}",
+        binding_ref_segment("surface", "auth-interaction"),
+        binding_ref_segment("flow", &flow_id.to_string()),
+        binding_ref_segment("run", &run_id.to_string()),
+        binding_ref_segment("gate", gate_ref.as_str())
+    )
+}
+
+fn auth_source_binding_ref(binding_id: &str) -> Result<SourceBindingRef, ProductWorkflowError> {
+    bounded_source_binding_ref(
+        "auth-interaction-src",
+        binding_id,
+        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
+    )
+    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
+}
+
+fn auth_reply_binding_ref(binding_id: &str) -> Result<ReplyTargetBindingRef, ProductWorkflowError> {
+    bounded_reply_target_binding_ref(
+        "auth-interaction-reply",
+        binding_id,
+        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
+    )
+    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
+}
+
+fn map_auth_product_error(error: AuthProductError) -> ProductWorkflowError {
+    match error {
+        AuthProductError::UnknownOrExpiredFlow => {
+            auth_rejected(AuthInteractionRejectionKind::MissingAuth)
+        }
+        AuthProductError::CrossScopeDenied => {
+            auth_rejected(AuthInteractionRejectionKind::CrossScopeDenied)
+        }
+        AuthProductError::BackendUnavailable => {
+            auth_rejected(AuthInteractionRejectionKind::FlowUnavailable)
+        }
+        AuthProductError::Canceled
+        | AuthProductError::FlowAlreadyTerminal
+        | AuthProductError::ProviderDenied
+        | AuthProductError::RefreshFailed => auth_rejected(AuthInteractionRejectionKind::StaleAuth),
+        AuthProductError::MalformedCallback
+        | AuthProductError::TokenExchangeFailed
+        | AuthProductError::CredentialMissing
+        | AuthProductError::AccountSelectionRequired
+        | AuthProductError::InvalidRequest { .. } => {
+            auth_rejected(AuthInteractionRejectionKind::UnsupportedResult)
+        }
+    }
+}
+
+fn map_gate_state_error(error: TurnError) -> ProductWorkflowError {
+    match error.category() {
+        TurnErrorCategory::ScopeNotFound => {
+            auth_rejected(AuthInteractionRejectionKind::MissingAuth)
+        }
+        TurnErrorCategory::Unauthorized => {
+            auth_rejected(AuthInteractionRejectionKind::CrossScopeDenied)
+        }
+        TurnErrorCategory::Unavailable => {
+            auth_rejected(AuthInteractionRejectionKind::FlowUnavailable)
+        }
+        _ => ProductWorkflowError::TurnResumeDenied { error },
+    }
+}
+
+fn map_auth_resume_error(error: TurnError) -> ProductWorkflowError {
+    match error.category() {
+        TurnErrorCategory::ScopeNotFound => {
+            auth_rejected(AuthInteractionRejectionKind::MissingAuth)
+        }
+        TurnErrorCategory::Unauthorized => {
+            auth_rejected(AuthInteractionRejectionKind::CrossScopeDenied)
+        }
+        TurnErrorCategory::InvalidRequest | TurnErrorCategory::Conflict => {
+            auth_rejected(AuthInteractionRejectionKind::StaleAuth)
+        }
+        TurnErrorCategory::Unavailable => {
+            auth_rejected(AuthInteractionRejectionKind::FlowUnavailable)
+        }
+        _ => ProductWorkflowError::TurnResumeDenied { error },
+    }
+}

--- a/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
@@ -1,6 +1,6 @@
 use ironclaw_auth::{
     AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowRecord, AuthFlowStatus,
-    AuthProductScope, CredentialAccountProjection, Timestamp,
+    AuthProductScope, CredentialAccountStatus, Timestamp,
 };
 use ironclaw_product_adapters::ProductWorkflowRejectionKind;
 use ironclaw_turns::{CancelRunResponse, GateRef, IdempotencyKey, ResumeTurnResponse, TurnActor};
@@ -10,9 +10,6 @@ use serde::{Deserialize, Serialize};
 use super::auth_rejected;
 use crate::error::ProductWorkflowError;
 
-const AUTH_GATE_REF: &str = "gate:auth";
-const AUTH_GATE_PREFIX: &str = "gate:auth-";
-const HOOK_AUTH_GATE_PREFIX: &str = "gate:hook-auth-";
 const FALLBACK_AUTH_SUMMARY: &str = "Authentication required";
 
 /// Stable reject reasons for product auth interactions.
@@ -59,24 +56,21 @@ impl AuthInteractionRejectionKind {
     }
 
     pub fn status_code(self) -> u16 {
-        match self.workflow_rejection_kind() {
-            ProductWorkflowRejectionKind::ScopeNotFound => 404,
-            ProductWorkflowRejectionKind::Unauthorized => 403,
-            ProductWorkflowRejectionKind::Conflict => 409,
-            ProductWorkflowRejectionKind::Unavailable => 503,
-            ProductWorkflowRejectionKind::InvalidRequest => 400,
-            ProductWorkflowRejectionKind::ThreadBusy
-            | ProductWorkflowRejectionKind::AdmissionRejected => 429,
+        match self {
+            Self::MissingAuth => 404,
+            Self::CrossScopeDenied => 403,
+            Self::StaleAuth => 409,
+            Self::FlowUnavailable => 503,
+            Self::InvalidGateRef
+            | Self::InvalidCredentialRef
+            | Self::InvalidCallbackRef
+            | Self::UnsupportedResult
+            | Self::InvalidBindingRef => 400,
         }
     }
 
     pub fn retryable(self) -> bool {
-        matches!(
-            self.workflow_rejection_kind(),
-            ProductWorkflowRejectionKind::Unavailable
-                | ProductWorkflowRejectionKind::AdmissionRejected
-                | ProductWorkflowRejectionKind::ThreadBusy
-        )
+        matches!(self, Self::FlowUnavailable)
     }
 }
 
@@ -123,19 +117,17 @@ impl AuthInteractionScope {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AuthInteractionChallengeView {
-    OAuthUrl {
-        authorization_url: ironclaw_auth::OAuthAuthorizationUrl,
+    OAuthRedirectRequired {
         expires_at: Timestamp,
     },
     ManualTokenRequired {
         interaction_id: ironclaw_auth::AuthInteractionId,
         provider: ironclaw_auth::AuthProviderId,
-        label: ironclaw_auth::CredentialAccountLabel,
         expires_at: Timestamp,
     },
     AccountSelectionRequired {
         provider: ironclaw_auth::AuthProviderId,
-        accounts: Vec<CredentialAccountProjection>,
+        accounts: Vec<AuthCredentialAccountChoiceView>,
     },
     SetupRequired {
         provider: ironclaw_auth::AuthProviderId,
@@ -146,31 +138,62 @@ pub enum AuthInteractionChallengeView {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthCredentialAccountChoiceView {
+    pub credential_ref: String,
+    pub status: CredentialAccountStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthInteractionStatus {
+    Pending,
+    AwaitingUser,
+    CallbackReceived,
+    Completing,
+}
+
+impl AuthInteractionStatus {
+    fn from_flow_status(status: AuthFlowStatus) -> Option<Self> {
+        match status {
+            AuthFlowStatus::Pending => Some(Self::Pending),
+            AuthFlowStatus::AwaitingUser => Some(Self::AwaitingUser),
+            AuthFlowStatus::CallbackReceived => Some(Self::CallbackReceived),
+            AuthFlowStatus::Completing => Some(Self::Completing),
+            AuthFlowStatus::Completed
+            | AuthFlowStatus::Failed
+            | AuthFlowStatus::Expired
+            | AuthFlowStatus::Canceled => None,
+        }
+    }
+}
+
 impl AuthInteractionChallengeView {
     fn from_challenge(challenge: &AuthChallenge) -> Self {
         match challenge {
-            AuthChallenge::OAuthUrl {
-                authorization_url,
-                expires_at,
-            } => Self::OAuthUrl {
-                authorization_url: authorization_url.clone(),
+            AuthChallenge::OAuthUrl { expires_at, .. } => Self::OAuthRedirectRequired {
                 expires_at: *expires_at,
             },
             AuthChallenge::ManualTokenRequired {
                 interaction_id,
                 provider,
-                label,
                 expires_at,
+                ..
             } => Self::ManualTokenRequired {
                 interaction_id: *interaction_id,
                 provider: provider.clone(),
-                label: label.clone(),
                 expires_at: *expires_at,
             },
             AuthChallenge::AccountSelectionRequired { provider, accounts } => {
                 Self::AccountSelectionRequired {
                     provider: provider.clone(),
-                    accounts: accounts.clone(),
+                    accounts: accounts
+                        .iter()
+                        .map(|account| AuthCredentialAccountChoiceView {
+                            credential_ref: account.id.to_string(),
+                            status: account.status,
+                        })
+                        .collect(),
                 }
             }
             AuthChallenge::SetupRequired { provider, .. } => Self::SetupRequired {
@@ -194,7 +217,7 @@ pub struct PendingAuthInteractionView {
     pub run_id: TurnRunId,
     pub auth_request_ref: GateRef,
     pub flow_id: AuthFlowId,
-    pub status: AuthFlowStatus,
+    pub status: AuthInteractionStatus,
     pub provider: ironclaw_auth::AuthProviderId,
     pub summary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -262,22 +285,23 @@ impl AuthGateRecord {
         self.flow.status
     }
 
-    pub(super) fn to_view(&self) -> PendingAuthInteractionView {
-        PendingAuthInteractionView {
+    pub(super) fn to_view(&self) -> Option<PendingAuthInteractionView> {
+        let status = AuthInteractionStatus::from_flow_status(self.flow.status)?;
+        Some(PendingAuthInteractionView {
             scope: self.scope.clone(),
             run_id: self.run_id,
             auth_request_ref: self.gate_ref.clone(),
             flow_id: self.flow.id,
-            status: self.flow.status,
+            status,
             provider: self.flow.provider.clone(),
-            summary: FALLBACK_AUTH_SUMMARY.to_string(),
+            summary: display_safe_auth_summary(),
             challenge: self
                 .flow
                 .challenge
                 .as_ref()
                 .map(AuthInteractionChallengeView::from_challenge),
             expires_at: self.flow.expires_at,
-        }
+        })
     }
 }
 
@@ -289,7 +313,7 @@ pub struct ListPendingAuthInteractionsRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListPendingAuthInteractionsResponse {
-    pub auth: Vec<PendingAuthInteractionView>,
+    pub auth_interactions: Vec<PendingAuthInteractionView>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -316,20 +340,10 @@ pub enum ResolveAuthInteractionResponse {
     Canceled(CancelRunResponse),
 }
 
-pub fn is_auth_gate_ref(gate_ref: &GateRef) -> bool {
-    let value = gate_ref.as_str();
-    value == AUTH_GATE_REF
-        || value.starts_with(AUTH_GATE_PREFIX)
-        || value.starts_with(HOOK_AUTH_GATE_PREFIX)
+pub(super) fn is_pending_auth_status(status: AuthFlowStatus) -> bool {
+    AuthInteractionStatus::from_flow_status(status).is_some()
 }
 
-pub(super) fn is_pending_auth_status(status: AuthFlowStatus) -> bool {
-    matches!(
-        status,
-        AuthFlowStatus::Pending
-            | AuthFlowStatus::AwaitingUser
-            | AuthFlowStatus::CallbackReceived
-            | AuthFlowStatus::Completing
-            | AuthFlowStatus::Failed
-    )
+fn display_safe_auth_summary() -> String {
+    FALLBACK_AUTH_SUMMARY.to_string()
 }

--- a/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
@@ -1,6 +1,6 @@
 use ironclaw_auth::{
     AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowRecord, AuthFlowStatus,
-    AuthProductScope, CredentialAccountStatus, Timestamp,
+    AuthProductScope, CredentialAccountId, CredentialAccountStatus, Timestamp,
 };
 use ironclaw_product_adapters::ProductWorkflowRejectionKind;
 use ironclaw_turns::{CancelRunResponse, GateRef, IdempotencyKey, ResumeTurnResponse, TurnActor};
@@ -319,8 +319,8 @@ pub struct ListPendingAuthInteractionsResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "result")]
 pub enum AuthInteractionDecision {
-    CredentialProvided { credential_ref: String },
-    CallbackCompleted { callback_ref: String },
+    CredentialProvided { credential_ref: CredentialAccountId },
+    CallbackCompleted { callback_ref: AuthFlowId },
     Deny,
 }
 

--- a/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
@@ -1,0 +1,335 @@
+use ironclaw_auth::{
+    AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowRecord, AuthFlowStatus,
+    AuthProductScope, CredentialAccountProjection, Timestamp,
+};
+use ironclaw_product_adapters::ProductWorkflowRejectionKind;
+use ironclaw_turns::{CancelRunResponse, GateRef, IdempotencyKey, ResumeTurnResponse, TurnActor};
+use ironclaw_turns::{TurnRunId, TurnScope};
+use serde::{Deserialize, Serialize};
+
+use super::auth_rejected;
+use crate::error::ProductWorkflowError;
+
+const AUTH_GATE_REF: &str = "gate:auth";
+const AUTH_GATE_PREFIX: &str = "gate:auth-";
+const HOOK_AUTH_GATE_PREFIX: &str = "gate:hook-auth-";
+const FALLBACK_AUTH_SUMMARY: &str = "Authentication required";
+
+/// Stable reject reasons for product auth interactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthInteractionRejectionKind {
+    MissingAuth,
+    StaleAuth,
+    CrossScopeDenied,
+    InvalidGateRef,
+    InvalidCredentialRef,
+    InvalidCallbackRef,
+    UnsupportedResult,
+    FlowUnavailable,
+    InvalidBindingRef,
+}
+
+impl AuthInteractionRejectionKind {
+    pub fn sanitized_reason(self) -> &'static str {
+        match self {
+            Self::MissingAuth => "auth interaction was not found",
+            Self::StaleAuth => "auth interaction is stale",
+            Self::CrossScopeDenied => "auth interaction is not visible to this caller",
+            Self::InvalidGateRef => "auth gate reference is invalid",
+            Self::InvalidCredentialRef => "credential reference is invalid",
+            Self::InvalidCallbackRef => "callback reference is invalid",
+            Self::UnsupportedResult => "auth interaction result is not supported",
+            Self::FlowUnavailable => "auth interaction service is unavailable",
+            Self::InvalidBindingRef => "auth resume binding is invalid",
+        }
+    }
+
+    pub fn workflow_rejection_kind(self) -> ProductWorkflowRejectionKind {
+        match self {
+            Self::MissingAuth => ProductWorkflowRejectionKind::ScopeNotFound,
+            Self::StaleAuth => ProductWorkflowRejectionKind::Conflict,
+            Self::CrossScopeDenied => ProductWorkflowRejectionKind::Unauthorized,
+            Self::InvalidGateRef
+            | Self::InvalidCredentialRef
+            | Self::InvalidCallbackRef
+            | Self::UnsupportedResult
+            | Self::InvalidBindingRef => ProductWorkflowRejectionKind::InvalidRequest,
+            Self::FlowUnavailable => ProductWorkflowRejectionKind::Unavailable,
+        }
+    }
+
+    pub fn status_code(self) -> u16 {
+        match self.workflow_rejection_kind() {
+            ProductWorkflowRejectionKind::ScopeNotFound => 404,
+            ProductWorkflowRejectionKind::Unauthorized => 403,
+            ProductWorkflowRejectionKind::Conflict => 409,
+            ProductWorkflowRejectionKind::Unavailable => 503,
+            ProductWorkflowRejectionKind::InvalidRequest => 400,
+            ProductWorkflowRejectionKind::ThreadBusy
+            | ProductWorkflowRejectionKind::AdmissionRejected => 429,
+        }
+    }
+
+    pub fn retryable(self) -> bool {
+        matches!(
+            self.workflow_rejection_kind(),
+            ProductWorkflowRejectionKind::Unavailable
+                | ProductWorkflowRejectionKind::AdmissionRejected
+                | ProductWorkflowRejectionKind::ThreadBusy
+        )
+    }
+}
+
+/// Caller-visible scope for auth interactions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthInteractionScope {
+    pub tenant_id: ironclaw_host_api::TenantId,
+    pub user_id: ironclaw_host_api::UserId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<ironclaw_host_api::AgentId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ironclaw_host_api::ProjectId>,
+    pub thread_id: ironclaw_host_api::ThreadId,
+}
+
+impl AuthInteractionScope {
+    pub fn from_turn(scope: &TurnScope, actor: &TurnActor) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: actor.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            thread_id: scope.thread_id.clone(),
+        }
+    }
+
+    fn from_auth_scope(scope: &AuthProductScope) -> Result<Self, ProductWorkflowError> {
+        let Some(thread_id) = scope.resource.thread_id.clone() else {
+            return Err(auth_rejected(
+                AuthInteractionRejectionKind::CrossScopeDenied,
+            ));
+        };
+        Ok(Self {
+            tenant_id: scope.resource.tenant_id.clone(),
+            user_id: scope.resource.user_id.clone(),
+            agent_id: scope.resource.agent_id.clone(),
+            project_id: scope.resource.project_id.clone(),
+            thread_id,
+        })
+    }
+}
+
+/// Redacted challenge shape safe for product/UI display.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AuthInteractionChallengeView {
+    OAuthUrl {
+        authorization_url: ironclaw_auth::OAuthAuthorizationUrl,
+        expires_at: Timestamp,
+    },
+    ManualTokenRequired {
+        interaction_id: ironclaw_auth::AuthInteractionId,
+        provider: ironclaw_auth::AuthProviderId,
+        label: ironclaw_auth::CredentialAccountLabel,
+        expires_at: Timestamp,
+    },
+    AccountSelectionRequired {
+        provider: ironclaw_auth::AuthProviderId,
+        accounts: Vec<CredentialAccountProjection>,
+    },
+    SetupRequired {
+        provider: ironclaw_auth::AuthProviderId,
+    },
+    ReauthorizeRequired {
+        account_id: ironclaw_auth::CredentialAccountId,
+        provider: ironclaw_auth::AuthProviderId,
+    },
+}
+
+impl AuthInteractionChallengeView {
+    fn from_challenge(challenge: &AuthChallenge) -> Self {
+        match challenge {
+            AuthChallenge::OAuthUrl {
+                authorization_url,
+                expires_at,
+            } => Self::OAuthUrl {
+                authorization_url: authorization_url.clone(),
+                expires_at: *expires_at,
+            },
+            AuthChallenge::ManualTokenRequired {
+                interaction_id,
+                provider,
+                label,
+                expires_at,
+            } => Self::ManualTokenRequired {
+                interaction_id: *interaction_id,
+                provider: provider.clone(),
+                label: label.clone(),
+                expires_at: *expires_at,
+            },
+            AuthChallenge::AccountSelectionRequired { provider, accounts } => {
+                Self::AccountSelectionRequired {
+                    provider: provider.clone(),
+                    accounts: accounts.clone(),
+                }
+            }
+            AuthChallenge::SetupRequired { provider, .. } => Self::SetupRequired {
+                provider: provider.clone(),
+            },
+            AuthChallenge::ReauthorizeRequired {
+                account_id,
+                provider,
+            } => Self::ReauthorizeRequired {
+                account_id: *account_id,
+                provider: provider.clone(),
+            },
+        }
+    }
+}
+
+/// Product/UI-safe pending auth DTO.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingAuthInteractionView {
+    pub scope: AuthInteractionScope,
+    pub run_id: TurnRunId,
+    pub auth_request_ref: GateRef,
+    pub flow_id: AuthFlowId,
+    pub status: AuthFlowStatus,
+    pub provider: ironclaw_auth::AuthProviderId,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub challenge: Option<AuthInteractionChallengeView>,
+    pub expires_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthGateRecord {
+    scope: AuthInteractionScope,
+    run_id: TurnRunId,
+    gate_ref: GateRef,
+    flow: AuthFlowRecord,
+}
+
+impl AuthGateRecord {
+    pub fn new(
+        run_id: TurnRunId,
+        gate_ref: GateRef,
+        flow: AuthFlowRecord,
+    ) -> Result<Self, ProductWorkflowError> {
+        let scope = AuthInteractionScope::from_auth_scope(&flow.scope)?;
+        let AuthContinuationRef::TurnGateResume {
+            turn_run_ref,
+            gate_ref: continuation_gate_ref,
+        } = &flow.continuation
+        else {
+            return Err(auth_rejected(
+                AuthInteractionRejectionKind::UnsupportedResult,
+            ));
+        };
+        if turn_run_ref.as_str() != run_id.to_string() {
+            return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
+        }
+        let expected_gate = GateRef::new(continuation_gate_ref.as_str().to_string())
+            .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidGateRef))?;
+        if gate_ref != expected_gate {
+            return Err(auth_rejected(AuthInteractionRejectionKind::InvalidGateRef));
+        }
+        Ok(Self {
+            scope,
+            run_id,
+            gate_ref,
+            flow,
+        })
+    }
+
+    pub fn scope(&self) -> &AuthInteractionScope {
+        &self.scope
+    }
+
+    pub fn run_id(&self) -> TurnRunId {
+        self.run_id
+    }
+
+    pub fn gate_ref(&self) -> &GateRef {
+        &self.gate_ref
+    }
+
+    pub fn flow(&self) -> &AuthFlowRecord {
+        &self.flow
+    }
+
+    pub fn status(&self) -> AuthFlowStatus {
+        self.flow.status
+    }
+
+    pub(super) fn to_view(&self) -> PendingAuthInteractionView {
+        PendingAuthInteractionView {
+            scope: self.scope.clone(),
+            run_id: self.run_id,
+            auth_request_ref: self.gate_ref.clone(),
+            flow_id: self.flow.id,
+            status: self.flow.status,
+            provider: self.flow.provider.clone(),
+            summary: FALLBACK_AUTH_SUMMARY.to_string(),
+            challenge: self
+                .flow
+                .challenge
+                .as_ref()
+                .map(AuthInteractionChallengeView::from_challenge),
+            expires_at: self.flow.expires_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListPendingAuthInteractionsRequest {
+    pub scope: TurnScope,
+    pub actor: TurnActor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListPendingAuthInteractionsResponse {
+    pub auth: Vec<PendingAuthInteractionView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "result")]
+pub enum AuthInteractionDecision {
+    CredentialProvided { credential_ref: String },
+    CallbackCompleted { callback_ref: String },
+    Deny,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolveAuthInteractionRequest {
+    pub scope: TurnScope,
+    pub actor: TurnActor,
+    pub run_id_hint: Option<TurnRunId>,
+    pub gate_ref: GateRef,
+    pub decision: AuthInteractionDecision,
+    pub idempotency_key: IdempotencyKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveAuthInteractionResponse {
+    Resumed(ResumeTurnResponse),
+    Canceled(CancelRunResponse),
+}
+
+pub fn is_auth_gate_ref(gate_ref: &GateRef) -> bool {
+    let value = gate_ref.as_str();
+    value == AUTH_GATE_REF
+        || value.starts_with(AUTH_GATE_PREFIX)
+        || value.starts_with(HOOK_AUTH_GATE_PREFIX)
+}
+
+pub(super) fn is_pending_auth_status(status: AuthFlowStatus) -> bool {
+    matches!(
+        status,
+        AuthFlowStatus::Pending
+            | AuthFlowStatus::AwaitingUser
+            | AuthFlowStatus::CallbackReceived
+            | AuthFlowStatus::Completing
+            | AuthFlowStatus::Failed
+    )
+}

--- a/crates/ironclaw_product_workflow/src/error.rs
+++ b/crates/ironclaw_product_workflow/src/error.rs
@@ -11,6 +11,7 @@ use ironclaw_turns::{TurnError, TurnErrorCategory};
 use thiserror::Error;
 
 use crate::approval_interaction::ApprovalInteractionRejectionKind;
+use crate::auth_interaction::AuthInteractionRejectionKind;
 
 /// Stable reasons for rejecting an auth continuation before or during turn resume.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +85,10 @@ pub enum ProductWorkflowError {
     ApprovalInteractionRejected {
         kind: ApprovalInteractionRejectionKind,
     },
+
+    /// Auth interaction was rejected with a stable sanitized reason.
+    #[error("auth interaction rejected: {kind:?}")]
+    AuthInteractionRejected { kind: AuthInteractionRejectionKind },
 
     /// Turn coordinator rejected a resume with typed category/status information.
     #[error("turn resume denied: {error}")]
@@ -183,6 +188,14 @@ impl From<ProductWorkflowError> for ProductAdapterError {
                 }
             }
             ProductWorkflowError::ApprovalInteractionRejected { kind } => {
+                ProductAdapterError::WorkflowRejected {
+                    kind: kind.workflow_rejection_kind(),
+                    status_code: kind.status_code(),
+                    retryable: kind.retryable(),
+                    reason: RedactedString::new(kind.sanitized_reason()),
+                }
+            }
+            ProductWorkflowError::AuthInteractionRejected { kind } => {
                 ProductAdapterError::WorkflowRejected {
                     kind: kind.workflow_rejection_kind(),
                     status_code: kind.status_code(),

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -27,6 +27,7 @@
 mod action;
 mod approval_interaction;
 mod auth_continuation;
+mod auth_interaction;
 mod binding;
 mod binding_ref;
 mod command_dispatch;
@@ -61,6 +62,13 @@ pub use approval_interaction::{
 /// Concrete turn-gate resume dispatcher used by the Reborn composition crate to
 /// bridge product-auth continuations into the workflow-owned turn boundary.
 pub use auth_continuation::ProductAuthTurnGateResumeDispatcher;
+pub use auth_interaction::{
+    AuthGateRecord, AuthInteractionChallengeView, AuthInteractionDecision,
+    AuthInteractionReadModel, AuthInteractionRejectionKind, AuthInteractionScope,
+    AuthInteractionService, DefaultAuthInteractionService, ListPendingAuthInteractionsRequest,
+    ListPendingAuthInteractionsResponse, PendingAuthInteractionView, ResolveAuthInteractionRequest,
+    ResolveAuthInteractionResponse, is_auth_gate_ref,
+};
 pub use binding::{
     ConversationBindingService, ProductConversationRouteKind, ResolveBindingRequest,
     ResolvedBinding,

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -63,9 +63,10 @@ pub use approval_interaction::{
 /// bridge product-auth continuations into the workflow-owned turn boundary.
 pub use auth_continuation::ProductAuthTurnGateResumeDispatcher;
 pub use auth_interaction::{
-    AuthGateRecord, AuthInteractionChallengeView, AuthInteractionDecision,
-    AuthInteractionReadModel, AuthInteractionRejectionKind, AuthInteractionScope,
-    AuthInteractionService, DefaultAuthInteractionService, ListPendingAuthInteractionsRequest,
+    AuthCredentialAccountChoiceView, AuthGateRecord, AuthInteractionChallengeView,
+    AuthInteractionDecision, AuthInteractionReadModel, AuthInteractionRejectionKind,
+    AuthInteractionScope, AuthInteractionService, AuthInteractionStatus,
+    DefaultAuthInteractionService, ListPendingAuthInteractionsRequest,
     ListPendingAuthInteractionsResponse, PendingAuthInteractionView, ResolveAuthInteractionRequest,
     ResolveAuthInteractionResponse, is_auth_gate_ref,
 };

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
+use ironclaw_auth::CredentialAccountId;
 use ironclaw_common::ExtensionName;
 use ironclaw_host_api::{AgentId, ThreadId};
 use ironclaw_product_adapters::{
@@ -22,14 +23,14 @@ use ironclaw_threads::{
 use ironclaw_turns::{
     AcceptedMessageRef, GateRef, GetRunStateRequest, IdempotencyKey, ResumeTurnPrecondition,
     ResumeTurnRequest, SanitizedCancelReason, SubmitTurnRequest, SubmitTurnResponse, TurnActor,
-    TurnCoordinator, TurnError, TurnRunId, TurnScope,
+    TurnCoordinator, TurnError, TurnRunId, TurnScope, TurnStatus,
 };
 use uuid::Uuid;
 
 use crate::{
     ApprovalInteractionDecision, ApprovalInteractionService, AuthInteractionDecision,
-    AuthInteractionService, LifecycleProductFacade, ProductWorkflowError,
-    ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
+    AuthInteractionRejectionKind, AuthInteractionService, LifecycleProductFacade,
+    ProductWorkflowError, ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
     ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
     UnsupportedLifecycleProductFacade, WebUiAuthenticatedCaller, WebUiCancelRunRequest,
     WebUiCreateThreadRequest, WebUiGateResolution, WebUiInboundCommand, WebUiInboundValidationCode,
@@ -960,7 +961,10 @@ impl RebornServices {
     ) -> Result<RebornResolveGateResponse, RebornServicesError> {
         let decision = match resolution {
             WebUiGateResolution::CredentialProvided { credential_ref } => {
-                AuthInteractionDecision::CredentialProvided { credential_ref }
+                AuthInteractionDecision::CredentialProvided {
+                    credential_ref: parse_credential_account_id(&credential_ref)
+                        .map_err(map_auth_interaction_error)?,
+                }
             }
             WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
                 AuthInteractionDecision::Deny
@@ -1002,6 +1006,8 @@ impl RebornServices {
     ) -> Result<RebornResolveGateResponse, RebornServicesError> {
         match resolution {
             WebUiGateResolution::Approved { always } => {
+                reject_generic_auth_gate_resolution(self.turn_coordinator.as_ref(), &scope, run_id)
+                    .await?;
                 // `always: true` requests a *persistent* approval but this
                 // facade has only one-shot `resume_turn` and no approval-policy
                 // port. Fail loud rather than silently downgrade.
@@ -1035,16 +1041,16 @@ impl RebornServices {
                 Err(blocked_authentication_unavailable())
             }
             WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
-                // `cancel_run` is not gate-aware, so without this check a
-                // denied/cancelled resolution for a stale or attacker-supplied
-                // gate_ref would terminate any non-terminal run sharing run_id.
-                assert_run_parked_on_gate(
+                assert_generic_run_parked_on_gate(
                     self.turn_coordinator.as_ref(),
                     &scope,
                     run_id,
                     &gate_ref,
                 )
                 .await?;
+                // `cancel_run` is not gate-aware, so without this check a
+                // denied/cancelled resolution for a stale or attacker-supplied
+                // gate_ref would terminate any non-terminal run sharing run_id.
                 let response = self
                     .turn_coordinator
                     .cancel_run(ironclaw_turns::CancelRunRequest {
@@ -1078,11 +1084,11 @@ fn map_ownership_probe_error(error: SessionThreadError) -> RebornServicesError {
     }
 }
 
-/// Reject denied/cancelled gate resolutions whose `gate_ref` does not match the
-/// gate the run is actually parked on. `cancel_run` is not gate-aware, so
-/// without this guard a stale or attacker-supplied `gate_ref` would cancel any
-/// non-terminal run sharing the same `run_id`.
-async fn assert_run_parked_on_gate(
+/// Reject denied/cancelled generic gate resolutions whose `gate_ref` does not
+/// match the gate the run is actually parked on. `cancel_run` is not gate-aware,
+/// so without this guard a stale or attacker-supplied `gate_ref` would cancel
+/// any non-terminal run sharing the same `run_id`.
+async fn assert_generic_run_parked_on_gate(
     turn_coordinator: &dyn TurnCoordinator,
     scope: &TurnScope,
     run_id: TurnRunId,
@@ -1095,6 +1101,9 @@ async fn assert_run_parked_on_gate(
         })
         .await
         .map_err(map_turn_error)?;
+    if state.status == TurnStatus::BlockedAuth {
+        return Err(blocked_authentication_unavailable());
+    }
     match state.gate_ref.as_ref() {
         Some(parked) if parked == expected_gate_ref => Ok(()),
         _ => Err(RebornServicesError::from_status_kind(
@@ -1104,6 +1113,36 @@ async fn assert_run_parked_on_gate(
             false,
         )),
     }
+}
+
+/// Generic WebUI gate handling is intentionally not allowed to resume or
+/// cancel auth-blocked runs. Auth gates must pass through
+/// AuthInteractionService so completed-flow/credential validation and
+/// BlockedAuthGate preconditions are enforced.
+async fn reject_generic_auth_gate_resolution(
+    turn_coordinator: &dyn TurnCoordinator,
+    scope: &TurnScope,
+    run_id: TurnRunId,
+) -> Result<(), RebornServicesError> {
+    let state = turn_coordinator
+        .get_run_state(GetRunStateRequest {
+            scope: scope.clone(),
+            run_id,
+        })
+        .await
+        .map_err(map_turn_error)?;
+    if state.status == TurnStatus::BlockedAuth {
+        return Err(blocked_authentication_unavailable());
+    }
+    Ok(())
+}
+
+fn parse_credential_account_id(value: &str) -> Result<CredentialAccountId, ProductWorkflowError> {
+    uuid::Uuid::parse_str(value)
+        .map(CredentialAccountId::from_uuid)
+        .map_err(|_| ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidCredentialRef,
+        })
 }
 
 fn thread_scope_from_turn_scope(

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -62,6 +62,27 @@ type SkillActivationRecorder =
 type SkillActivationClearer =
     dyn Fn(&TurnScope, &AcceptedMessageRef) -> Result<(), RebornServicesError> + Send + Sync;
 
+#[derive(Clone, Copy)]
+enum GateResolutionRoute {
+    Approval,
+    Auth,
+    Generic,
+}
+
+impl GateResolutionRoute {
+    fn classify(gate_ref: &GateRef, resolution: &WebUiGateResolution) -> Self {
+        if is_approval_gate_ref(gate_ref) {
+            Self::Approval
+        } else if is_auth_gate_ref(gate_ref)
+            || matches!(resolution, WebUiGateResolution::CredentialProvided { .. })
+        {
+            Self::Auth
+        } else {
+            Self::Generic
+        }
+    }
+}
+
 /// Stable WebUI-facing facade surface for beta Reborn routes.
 #[async_trait]
 pub trait RebornServicesApi: Send + Sync {
@@ -597,153 +618,32 @@ impl RebornServicesApi for RebornServices {
         // the message transcript and the load would be wasted work.
         self.resolve_webui_thread_metadata(scope.clone(), &actor)
             .await?;
-        if is_approval_gate_ref(&gate_ref) {
-            let decision = match resolution {
-                WebUiGateResolution::Approved { always } => {
-                    // `always: true` requests a *persistent* approval but this
-                    // facade has only one-shot approval interaction routing and
-                    // no approval-policy port. Fail loud rather than silently
-                    // downgrade.
-                    if always {
-                        return Err(persistent_approval_unavailable());
-                    }
-                    ApprovalInteractionDecision::ApproveOnce
-                }
-                WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
-                    ApprovalInteractionDecision::Deny
-                }
-                WebUiGateResolution::CredentialProvided { .. } => {
-                    return Err(RebornServicesError::from_status_kind(
-                        RebornServicesErrorCode::Unavailable,
-                        RebornServicesErrorKind::BlockedAuthentication,
-                        503,
-                        false,
-                    ));
-                }
-            };
-            let response = self
-                .approval_interactions
-                .resolve(ResolveApprovalInteractionRequest {
+        match GateResolutionRoute::classify(&gate_ref, &resolution) {
+            GateResolutionRoute::Approval => {
+                self.resolve_approval_gate(
                     scope,
                     actor,
-                    run_id_hint: Some(run_id),
-                    gate_ref,
-                    decision,
-                    idempotency_key: client_action_id,
-                })
-                .await
-                .map_err(|error| map_adapter_error(error.into()))?;
-            return match response {
-                ResolveApprovalInteractionResponse::Approved(response) => {
-                    Ok(RebornResolveGateResponse::Resumed(response.into()))
-                }
-                ResolveApprovalInteractionResponse::Denied(response) => {
-                    Ok(RebornResolveGateResponse::Cancelled(response.into()))
-                }
-            };
-        }
-        let is_credential_resolution =
-            matches!(&resolution, WebUiGateResolution::CredentialProvided { .. });
-        if is_credential_resolution || is_auth_gate_ref(&gate_ref) {
-            let decision = match resolution {
-                WebUiGateResolution::CredentialProvided { credential_ref } => {
-                    AuthInteractionDecision::CredentialProvided { credential_ref }
-                }
-                WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
-                    AuthInteractionDecision::Deny
-                }
-                WebUiGateResolution::Approved { .. } => {
-                    return Err(RebornServicesError::from_status_kind(
-                        RebornServicesErrorCode::Unavailable,
-                        RebornServicesErrorKind::BlockedAuthentication,
-                        503,
-                        false,
-                    ));
-                }
-            };
-            let response = self
-                .auth_interactions
-                .resolve(ResolveAuthInteractionRequest {
-                    scope,
-                    actor,
-                    run_id_hint: Some(run_id),
-                    gate_ref,
-                    decision,
-                    idempotency_key: client_action_id,
-                })
-                .await
-                .map_err(map_auth_interaction_error)?;
-            return match response {
-                ResolveAuthInteractionResponse::Resumed(response) => {
-                    Ok(RebornResolveGateResponse::Resumed(response.into()))
-                }
-                ResolveAuthInteractionResponse::Canceled(response) => {
-                    Ok(RebornResolveGateResponse::Cancelled(response.into()))
-                }
-            };
-        }
-        match resolution {
-            WebUiGateResolution::Approved { always } => {
-                // `always: true` requests a *persistent* approval but this
-                // facade has only one-shot `resume_turn` and no approval-policy
-                // port. Fail loud rather than silently downgrade.
-                if always {
-                    return Err(persistent_approval_unavailable());
-                }
-                let binding_id = webui_gate_binding_id(&scope, &gate_ref_string(&gate_ref));
-                let response = self
-                    .turn_coordinator
-                    .resume_turn(ResumeTurnRequest {
-                        scope,
-                        actor,
-                        run_id,
-                        gate_resolution_ref: gate_ref,
-                        precondition: ResumeTurnPrecondition::AnyBlockedGate,
-                        source_binding_ref: webui_source_binding_ref_from_raw(
-                            "webui-gate-src",
-                            &binding_id,
-                        )?,
-                        reply_target_binding_ref: webui_reply_target_binding_ref_from_raw(
-                            "webui-gate-reply",
-                            &binding_id,
-                        )?,
-                        idempotency_key: client_action_id,
-                    })
-                    .await
-                    .map_err(map_turn_error)?;
-                Ok(RebornResolveGateResponse::Resumed(response.into()))
-            }
-            WebUiGateResolution::CredentialProvided { .. } => {
-                Err(RebornServicesError::from_status_kind(
-                    RebornServicesErrorCode::Unavailable,
-                    RebornServicesErrorKind::BlockedAuthentication,
-                    503,
-                    false,
-                ))
-            }
-            WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
-                // `cancel_run` is not gate-aware, so without this check a
-                // denied/cancelled resolution for a stale or attacker-supplied
-                // gate_ref would terminate any non-terminal run sharing run_id.
-                assert_run_parked_on_gate(
-                    self.turn_coordinator.as_ref(),
-                    &scope,
                     run_id,
-                    &gate_ref,
+                    gate_ref,
+                    client_action_id,
+                    resolution,
                 )
-                .await?;
-                let response = self
-                    .turn_coordinator
-                    .cancel_run(ironclaw_turns::CancelRunRequest {
-                        scope,
-                        actor,
-                        run_id,
-                        reason: SanitizedCancelReason::UserRequested,
-                        idempotency_key: client_action_id,
-                    })
+                .await
+            }
+            GateResolutionRoute::Auth => {
+                self.resolve_auth_gate(scope, actor, run_id, gate_ref, client_action_id, resolution)
                     .await
-                    .map_err(map_turn_error)?;
-                Ok(RebornResolveGateResponse::Cancelled(response.into()))
+            }
+            GateResolutionRoute::Generic => {
+                self.resolve_generic_gate(
+                    scope,
+                    actor,
+                    run_id,
+                    gate_ref,
+                    client_action_id,
+                    resolution,
+                )
+                .await
             }
         }
     }
@@ -999,6 +899,166 @@ impl RebornServices {
             .await
             .map_err(map_ownership_probe_error)?;
         Ok((scope, thread_scope))
+    }
+
+    async fn resolve_approval_gate(
+        &self,
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+        gate_ref: GateRef,
+        client_action_id: IdempotencyKey,
+        resolution: WebUiGateResolution,
+    ) -> Result<RebornResolveGateResponse, RebornServicesError> {
+        let decision = match resolution {
+            WebUiGateResolution::Approved { always } => {
+                // `always: true` requests a *persistent* approval but this
+                // facade has only one-shot approval interaction routing and no
+                // approval-policy port. Fail loud rather than silently downgrade.
+                if always {
+                    return Err(persistent_approval_unavailable());
+                }
+                ApprovalInteractionDecision::ApproveOnce
+            }
+            WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
+                ApprovalInteractionDecision::Deny
+            }
+            WebUiGateResolution::CredentialProvided { .. } => {
+                return Err(blocked_authentication_unavailable());
+            }
+        };
+        let response = self
+            .approval_interactions
+            .resolve(ResolveApprovalInteractionRequest {
+                scope,
+                actor,
+                run_id_hint: Some(run_id),
+                gate_ref,
+                decision,
+                idempotency_key: client_action_id,
+            })
+            .await
+            .map_err(|error| map_adapter_error(error.into()))?;
+        match response {
+            ResolveApprovalInteractionResponse::Approved(response) => {
+                Ok(RebornResolveGateResponse::Resumed(response.into()))
+            }
+            ResolveApprovalInteractionResponse::Denied(response) => {
+                Ok(RebornResolveGateResponse::Cancelled(response.into()))
+            }
+        }
+    }
+
+    async fn resolve_auth_gate(
+        &self,
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+        gate_ref: GateRef,
+        client_action_id: IdempotencyKey,
+        resolution: WebUiGateResolution,
+    ) -> Result<RebornResolveGateResponse, RebornServicesError> {
+        let decision = match resolution {
+            WebUiGateResolution::CredentialProvided { credential_ref } => {
+                AuthInteractionDecision::CredentialProvided { credential_ref }
+            }
+            WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
+                AuthInteractionDecision::Deny
+            }
+            WebUiGateResolution::Approved { .. } => {
+                return Err(blocked_authentication_unavailable());
+            }
+        };
+        let response = self
+            .auth_interactions
+            .resolve(ResolveAuthInteractionRequest {
+                scope,
+                actor,
+                run_id_hint: Some(run_id),
+                gate_ref,
+                decision,
+                idempotency_key: client_action_id,
+            })
+            .await
+            .map_err(map_auth_interaction_error)?;
+        match response {
+            ResolveAuthInteractionResponse::Resumed(response) => {
+                Ok(RebornResolveGateResponse::Resumed(response.into()))
+            }
+            ResolveAuthInteractionResponse::Canceled(response) => {
+                Ok(RebornResolveGateResponse::Cancelled(response.into()))
+            }
+        }
+    }
+
+    async fn resolve_generic_gate(
+        &self,
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+        gate_ref: GateRef,
+        client_action_id: IdempotencyKey,
+        resolution: WebUiGateResolution,
+    ) -> Result<RebornResolveGateResponse, RebornServicesError> {
+        match resolution {
+            WebUiGateResolution::Approved { always } => {
+                // `always: true` requests a *persistent* approval but this
+                // facade has only one-shot `resume_turn` and no approval-policy
+                // port. Fail loud rather than silently downgrade.
+                if always {
+                    return Err(persistent_approval_unavailable());
+                }
+                let binding_id = webui_gate_binding_id(&scope, &gate_ref_string(&gate_ref));
+                let response = self
+                    .turn_coordinator
+                    .resume_turn(ResumeTurnRequest {
+                        scope,
+                        actor,
+                        run_id,
+                        gate_resolution_ref: gate_ref,
+                        precondition: ResumeTurnPrecondition::AnyBlockedGate,
+                        source_binding_ref: webui_source_binding_ref_from_raw(
+                            "webui-gate-src",
+                            &binding_id,
+                        )?,
+                        reply_target_binding_ref: webui_reply_target_binding_ref_from_raw(
+                            "webui-gate-reply",
+                            &binding_id,
+                        )?,
+                        idempotency_key: client_action_id,
+                    })
+                    .await
+                    .map_err(map_turn_error)?;
+                Ok(RebornResolveGateResponse::Resumed(response.into()))
+            }
+            WebUiGateResolution::CredentialProvided { .. } => {
+                Err(blocked_authentication_unavailable())
+            }
+            WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
+                // `cancel_run` is not gate-aware, so without this check a
+                // denied/cancelled resolution for a stale or attacker-supplied
+                // gate_ref would terminate any non-terminal run sharing run_id.
+                assert_run_parked_on_gate(
+                    self.turn_coordinator.as_ref(),
+                    &scope,
+                    run_id,
+                    &gate_ref,
+                )
+                .await?;
+                let response = self
+                    .turn_coordinator
+                    .cancel_run(ironclaw_turns::CancelRunRequest {
+                        scope,
+                        actor,
+                        run_id,
+                        reason: SanitizedCancelReason::UserRequested,
+                        idempotency_key: client_action_id,
+                    })
+                    .await
+                    .map_err(map_turn_error)?;
+                Ok(RebornResolveGateResponse::Cancelled(response.into()))
+            }
+        }
     }
 }
 
@@ -1303,6 +1363,15 @@ fn persistent_approval_unavailable() -> RebornServicesError {
     RebornServicesError::from_status_kind(
         RebornServicesErrorCode::Unavailable,
         RebornServicesErrorKind::BlockedApproval,
+        503,
+        false,
+    )
+}
+
+fn blocked_authentication_unavailable() -> RebornServicesError {
+    RebornServicesError::from_status_kind(
+        RebornServicesErrorCode::Unavailable,
+        RebornServicesErrorKind::BlockedAuthentication,
         503,
         false,
     )

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -27,18 +27,21 @@ use ironclaw_turns::{
 use uuid::Uuid;
 
 use crate::{
-    ApprovalInteractionDecision, ApprovalInteractionService, LifecycleProductFacade,
+    ApprovalInteractionDecision, ApprovalInteractionService, AuthInteractionDecision,
+    AuthInteractionService, LifecycleProductFacade, ProductWorkflowError,
     ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
+    ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
     UnsupportedLifecycleProductFacade, WebUiAuthenticatedCaller, WebUiCancelRunRequest,
     WebUiCreateThreadRequest, WebUiGateResolution, WebUiInboundCommand, WebUiInboundValidationCode,
     WebUiInboundValidationError, WebUiListThreadsRequest, WebUiResolveGateRequest,
     WebUiSendMessageRequest, WebUiSetupExtensionRequest,
     approval_interaction::RejectingApprovalInteractionService,
+    auth_interaction::RejectingAuthInteractionService,
     binding_ref::{
         DEFAULT_BINDING_REF_RAW_MAX_BYTES, bounded_reply_target_binding_ref,
         bounded_source_binding_ref,
     },
-    is_approval_gate_ref,
+    is_approval_gate_ref, is_auth_gate_ref,
 };
 
 mod error;
@@ -146,6 +149,7 @@ pub struct RebornServices {
     event_stream: Option<Arc<dyn ProjectionStream>>,
     lifecycle_facade: Arc<dyn LifecycleProductFacade>,
     approval_interactions: Arc<dyn ApprovalInteractionService>,
+    auth_interactions: Arc<dyn AuthInteractionService>,
     skill_activation_recorder: Option<Arc<SkillActivationRecorder>>,
     skill_activation_clearer: Option<Arc<SkillActivationClearer>>,
 }
@@ -163,6 +167,7 @@ impl RebornServices {
                 "reborn_lifecycle_facade_unwired",
             )),
             approval_interactions: Arc::new(RejectingApprovalInteractionService),
+            auth_interactions: Arc::new(RejectingAuthInteractionService),
             skill_activation_recorder: None,
             skill_activation_clearer: None,
         }
@@ -186,6 +191,14 @@ impl RebornServices {
         approval_interactions: Arc<dyn ApprovalInteractionService>,
     ) -> Self {
         self.approval_interactions = approval_interactions;
+        self
+    }
+
+    pub fn with_auth_interactions(
+        mut self,
+        auth_interactions: Arc<dyn AuthInteractionService>,
+    ) -> Self {
+        self.auth_interactions = auth_interactions;
         self
     }
 
@@ -625,6 +638,46 @@ impl RebornServicesApi for RebornServices {
                     Ok(RebornResolveGateResponse::Resumed(response.into()))
                 }
                 ResolveApprovalInteractionResponse::Denied(response) => {
+                    Ok(RebornResolveGateResponse::Cancelled(response.into()))
+                }
+            };
+        }
+        let is_credential_resolution =
+            matches!(&resolution, WebUiGateResolution::CredentialProvided { .. });
+        if is_credential_resolution || is_auth_gate_ref(&gate_ref) {
+            let decision = match resolution {
+                WebUiGateResolution::CredentialProvided { credential_ref } => {
+                    AuthInteractionDecision::CredentialProvided { credential_ref }
+                }
+                WebUiGateResolution::Denied | WebUiGateResolution::Cancelled => {
+                    AuthInteractionDecision::Deny
+                }
+                WebUiGateResolution::Approved { .. } => {
+                    return Err(RebornServicesError::from_status_kind(
+                        RebornServicesErrorCode::Unavailable,
+                        RebornServicesErrorKind::BlockedAuthentication,
+                        503,
+                        false,
+                    ));
+                }
+            };
+            let response = self
+                .auth_interactions
+                .resolve(ResolveAuthInteractionRequest {
+                    scope,
+                    actor,
+                    run_id_hint: Some(run_id),
+                    gate_ref,
+                    decision,
+                    idempotency_key: client_action_id,
+                })
+                .await
+                .map_err(map_auth_interaction_error)?;
+            return match response {
+                ResolveAuthInteractionResponse::Resumed(response) => {
+                    Ok(RebornResolveGateResponse::Resumed(response.into()))
+                }
+                ResolveAuthInteractionResponse::Canceled(response) => {
                     Ok(RebornResolveGateResponse::Cancelled(response.into()))
                 }
             };
@@ -1391,6 +1444,20 @@ fn map_adapter_error(error: ProductAdapterError) -> RebornServicesError {
         ProductAdapterError::Internal { .. } => {
             RebornServicesError::from_status(RebornServicesErrorCode::Internal, 500, false)
         }
+    }
+}
+
+fn map_auth_interaction_error(error: ProductWorkflowError) -> RebornServicesError {
+    match error {
+        ProductWorkflowError::AuthInteractionRejected { kind } => {
+            RebornServicesError::from_status_kind(
+                code_for_status(kind.status_code()),
+                RebornServicesErrorKind::BlockedAuthentication,
+                kind.status_code(),
+                kind.retryable(),
+            )
+        }
+        error => map_adapter_error(error.into()),
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
@@ -59,6 +59,7 @@ fn map_lifecycle_error(error: ProductWorkflowError) -> RebornServicesError {
         | ProductWorkflowError::TurnResumeRejected { .. }
         | ProductWorkflowError::TurnResumeDenied { .. }
         | ProductWorkflowError::ApprovalInteractionRejected { .. }
+        | ProductWorkflowError::AuthInteractionRejected { .. }
         | ProductWorkflowError::AuthContinuationRejected { .. }
         | ProductWorkflowError::BeforeInboundPolicyFailed { .. }
         | ProductWorkflowError::DuplicateAction { .. }

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -22,6 +22,10 @@ use crate::approval_interaction::{
     ApprovalInteractionDecision, ApprovalInteractionRejectionKind, ApprovalInteractionService,
     RejectingApprovalInteractionService, ResolveApprovalInteractionRequest,
 };
+use crate::auth_interaction::{
+    AuthInteractionDecision, AuthInteractionRejectionKind, AuthInteractionService,
+    RejectingAuthInteractionService, ResolveAuthInteractionRequest,
+};
 use crate::binding::{
     ConversationBindingService, ProductConversationRouteKind, ResolveBindingRequest,
     ResolvedBinding,
@@ -50,6 +54,7 @@ pub struct DefaultProductWorkflow {
     command_admission_service: Arc<dyn ProductCommandAdmissionService>,
     command_service: Arc<dyn ProductCommandService>,
     approval_interaction_service: Arc<dyn ApprovalInteractionService>,
+    auth_interaction_service: Arc<dyn AuthInteractionService>,
 }
 
 impl DefaultProductWorkflow {
@@ -66,6 +71,7 @@ impl DefaultProductWorkflow {
             command_admission_service: Arc::new(RejectingProductCommandAdmissionService),
             command_service: Arc::new(RejectingProductCommandService),
             approval_interaction_service: Arc::new(RejectingApprovalInteractionService),
+            auth_interaction_service: Arc::new(RejectingAuthInteractionService),
         }
     }
 
@@ -98,6 +104,14 @@ impl DefaultProductWorkflow {
         approval_interaction_service: Arc<dyn ApprovalInteractionService>,
     ) -> Self {
         self.approval_interaction_service = approval_interaction_service;
+        self
+    }
+
+    pub fn with_auth_interaction_service(
+        mut self,
+        auth_interaction_service: Arc<dyn AuthInteractionService>,
+    ) -> Self {
+        self.auth_interaction_service = auth_interaction_service;
         self
     }
 }
@@ -155,6 +169,7 @@ impl ProductWorkflow for DefaultProductWorkflow {
                         command_admission_service: &*self.command_admission_service,
                         command_service: &*self.command_service,
                         approval_interaction_service: &*self.approval_interaction_service,
+                        auth_interaction_service: &*self.auth_interaction_service,
                     },
                 )
                 .await;
@@ -254,6 +269,7 @@ struct DispatchPorts<'a> {
     command_admission_service: &'a dyn ProductCommandAdmissionService,
     command_service: &'a dyn ProductCommandService,
     approval_interaction_service: &'a dyn ApprovalInteractionService,
+    auth_interaction_service: &'a dyn AuthInteractionService,
 }
 
 fn resolve_binding_request(envelope: &ProductInboundEnvelope) -> ResolveBindingRequest {
@@ -379,10 +395,15 @@ async fn dispatch_payload(
             )
             .await
         }
-        ProductInboundPayload::AuthResolution(_) => {
-            Err(ProductWorkflowError::UnsupportedActionKind {
-                kind: "auth_resolution".into(),
-            })
+        ProductInboundPayload::AuthResolution(payload) => {
+            dispatch_auth_resolution(
+                envelope,
+                payload,
+                action_fingerprint,
+                ports.binding_service,
+                ports.auth_interaction_service,
+            )
+            .await
         }
         ProductInboundPayload::SubscriptionRequest(_) => {
             Err(ProductWorkflowError::UnsupportedActionKind {
@@ -444,6 +465,53 @@ async fn dispatch_approval_resolution(
     })
 }
 
+async fn dispatch_auth_resolution(
+    envelope: &ProductInboundEnvelope,
+    payload: &ironclaw_product_adapters::AuthResolutionPayload,
+    action_fingerprint: ActionFingerprintKey,
+    binding_service: &dyn ConversationBindingService,
+    auth_interaction_service: &dyn AuthInteractionService,
+) -> Result<DispatchedAction, ProductWorkflowError> {
+    let decision = match &payload.result {
+        ironclaw_product_adapters::AuthResolutionResult::CredentialProvided { credential_ref } => {
+            AuthInteractionDecision::CredentialProvided {
+                credential_ref: credential_ref.clone(),
+            }
+        }
+        ironclaw_product_adapters::AuthResolutionResult::CallbackCompleted { callback_ref } => {
+            AuthInteractionDecision::CallbackCompleted {
+                callback_ref: callback_ref.clone(),
+            }
+        }
+        ironclaw_product_adapters::AuthResolutionResult::Denied => AuthInteractionDecision::Deny,
+    };
+    let binding = binding_service
+        .lookup_binding(resolve_binding_request(envelope))
+        .await?;
+    let scope = turn_scope_from_binding(&binding);
+    let actor = TurnActor::new(binding.user_id.clone());
+    let gate_ref = GateRef::new(payload.auth_request_ref.clone()).map_err(|_| {
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidGateRef,
+        }
+    })?;
+    let idempotency_key = auth_resolution_idempotency_key(&action_fingerprint)?;
+    auth_interaction_service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: None,
+            gate_ref,
+            decision,
+            idempotency_key,
+        })
+        .await?;
+    Ok(DispatchedAction {
+        ack: ProductInboundAck::NoOp,
+        dispatch_kind: ActionDispatchKind::try_from_payload(envelope.payload())?,
+    })
+}
+
 fn approval_resolution_idempotency_key(
     fingerprint: &ActionFingerprintKey,
 ) -> Result<IdempotencyKey, ProductWorkflowError> {
@@ -461,6 +529,25 @@ fn approval_resolution_idempotency_key(
             kind: ApprovalInteractionRejectionKind::InvalidBindingRef,
         },
     )
+}
+
+fn auth_resolution_idempotency_key(
+    fingerprint: &ActionFingerprintKey,
+) -> Result<IdempotencyKey, ProductWorkflowError> {
+    let raw = format!(
+        "{}{}{}{}{}{}",
+        binding_ref_segment("adapter", fingerprint.adapter_id.as_str()),
+        binding_ref_segment("installation", fingerprint.installation_id.as_str()),
+        binding_ref_segment("actor_kind", fingerprint.external_actor_ref.kind()),
+        binding_ref_segment("actor_id", fingerprint.external_actor_ref.id()),
+        binding_ref_segment("source", fingerprint.source_binding_key.as_str()),
+        binding_ref_segment("event", fingerprint.external_event_id.as_str())
+    );
+    bounded_idempotency_key("product-auth", &raw, DEFAULT_BINDING_REF_RAW_MAX_BYTES).map_err(|_| {
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidBindingRef,
+        }
+    })
 }
 
 fn turn_scope_from_binding(binding: &ResolvedBinding) -> TurnScope {
@@ -578,6 +665,12 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
                 kind.sanitized_reason(),
             )))
         }
+        ProductWorkflowError::AuthInteractionRejected { kind } if !kind.retryable() => {
+            Some(ProductInboundAck::Rejected(ProductRejection::permanent(
+                rejection_kind_for_auth_interaction(*kind),
+                kind.sanitized_reason(),
+            )))
+        }
         ProductWorkflowError::TurnSubmissionFailed { error } if !turn_error_is_retryable(error) => {
             Some(ProductInboundAck::Rejected(ProductRejection::permanent(
                 rejection_kind_for_turn_error(error),
@@ -597,12 +690,27 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
         | ProductWorkflowError::TurnResumeRejected { .. }
         | ProductWorkflowError::AuthContinuationRejected { .. }
         | ProductWorkflowError::ApprovalInteractionRejected { .. }
+        | ProductWorkflowError::AuthInteractionRejected { .. }
         | ProductWorkflowError::TurnResumeDenied { .. }
         | ProductWorkflowError::Transient { .. }
         | ProductWorkflowError::BeforeInboundPolicyFailed {
             permanent: false, ..
         }
         | ProductWorkflowError::DuplicateAction { .. } => None,
+    }
+}
+
+fn rejection_kind_for_auth_interaction(kind: AuthInteractionRejectionKind) -> ProductRejectionKind {
+    match kind {
+        AuthInteractionRejectionKind::MissingAuth => ProductRejectionKind::BindingRequired,
+        AuthInteractionRejectionKind::CrossScopeDenied => ProductRejectionKind::AccessDenied,
+        AuthInteractionRejectionKind::StaleAuth
+        | AuthInteractionRejectionKind::InvalidGateRef
+        | AuthInteractionRejectionKind::InvalidCredentialRef
+        | AuthInteractionRejectionKind::InvalidCallbackRef
+        | AuthInteractionRejectionKind::UnsupportedResult
+        | AuthInteractionRejectionKind::FlowUnavailable
+        | AuthInteractionRejectionKind::InvalidBindingRef => ProductRejectionKind::PolicyDenied,
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use ironclaw_auth::{AuthFlowId, CredentialAccountId};
 use ironclaw_product_adapters::{
     ApprovalDecision, ProductAdapterError, ProductInboundAck, ProductInboundEnvelope,
     ProductInboundPayload, ProductRejection, ProductRejectionKind, ProductTriggerReason,
@@ -475,12 +476,12 @@ async fn dispatch_auth_resolution(
     let decision = match &payload.result {
         ironclaw_product_adapters::AuthResolutionResult::CredentialProvided { credential_ref } => {
             AuthInteractionDecision::CredentialProvided {
-                credential_ref: credential_ref.clone(),
+                credential_ref: parse_credential_account_id(credential_ref)?,
             }
         }
         ironclaw_product_adapters::AuthResolutionResult::CallbackCompleted { callback_ref } => {
             AuthInteractionDecision::CallbackCompleted {
-                callback_ref: callback_ref.clone(),
+                callback_ref: parse_auth_flow_id(callback_ref)?,
             }
         }
         ironclaw_product_adapters::AuthResolutionResult::Denied => AuthInteractionDecision::Deny,
@@ -530,6 +531,22 @@ fn auth_resolution_idempotency_key(
             kind: AuthInteractionRejectionKind::InvalidBindingRef,
         }
     })
+}
+
+fn parse_credential_account_id(value: &str) -> Result<CredentialAccountId, ProductWorkflowError> {
+    uuid::Uuid::parse_str(value)
+        .map(CredentialAccountId::from_uuid)
+        .map_err(|_| ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidCredentialRef,
+        })
+}
+
+fn parse_auth_flow_id(value: &str) -> Result<AuthFlowId, ProductWorkflowError> {
+    uuid::Uuid::parse_str(value)
+        .map(AuthFlowId::from_uuid)
+        .map_err(|_| ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidCallbackRef,
+        })
 }
 
 fn interaction_resolution_idempotency_key(

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -515,24 +515,27 @@ async fn dispatch_auth_resolution(
 fn approval_resolution_idempotency_key(
     fingerprint: &ActionFingerprintKey,
 ) -> Result<IdempotencyKey, ProductWorkflowError> {
-    let raw = format!(
-        "{}{}{}{}{}{}",
-        binding_ref_segment("adapter", fingerprint.adapter_id.as_str()),
-        binding_ref_segment("installation", fingerprint.installation_id.as_str()),
-        binding_ref_segment("actor_kind", fingerprint.external_actor_ref.kind()),
-        binding_ref_segment("actor_id", fingerprint.external_actor_ref.id()),
-        binding_ref_segment("source", fingerprint.source_binding_key.as_str()),
-        binding_ref_segment("event", fingerprint.external_event_id.as_str())
-    );
-    bounded_idempotency_key("product-approval", &raw, DEFAULT_BINDING_REF_RAW_MAX_BYTES).map_err(
-        |_| ProductWorkflowError::ApprovalInteractionRejected {
+    interaction_resolution_idempotency_key("product-approval", fingerprint, || {
+        ProductWorkflowError::ApprovalInteractionRejected {
             kind: ApprovalInteractionRejectionKind::InvalidBindingRef,
-        },
-    )
+        }
+    })
 }
 
 fn auth_resolution_idempotency_key(
     fingerprint: &ActionFingerprintKey,
+) -> Result<IdempotencyKey, ProductWorkflowError> {
+    interaction_resolution_idempotency_key("product-auth", fingerprint, || {
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidBindingRef,
+        }
+    })
+}
+
+fn interaction_resolution_idempotency_key(
+    prefix: &str,
+    fingerprint: &ActionFingerprintKey,
+    invalid_binding_error: impl FnOnce() -> ProductWorkflowError,
 ) -> Result<IdempotencyKey, ProductWorkflowError> {
     let raw = format!(
         "{}{}{}{}{}{}",
@@ -543,11 +546,8 @@ fn auth_resolution_idempotency_key(
         binding_ref_segment("source", fingerprint.source_binding_key.as_str()),
         binding_ref_segment("event", fingerprint.external_event_id.as_str())
     );
-    bounded_idempotency_key("product-auth", &raw, DEFAULT_BINDING_REF_RAW_MAX_BYTES).map_err(|_| {
-        ProductWorkflowError::AuthInteractionRejected {
-            kind: AuthInteractionRejectionKind::InvalidBindingRef,
-        }
-    })
+    bounded_idempotency_key(prefix, &raw, DEFAULT_BINDING_REF_RAW_MAX_BYTES)
+        .map_err(|_| invalid_binding_error())
 }
 
 fn turn_scope_from_binding(binding: &ResolvedBinding) -> TurnScope {

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -1,0 +1,573 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{Duration, Utc};
+use ironclaw_auth::{
+    AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowKind, AuthFlowManager, AuthFlowRecord,
+    AuthFlowStatus, AuthGateRef, AuthProductError, AuthProductScope, AuthSurface,
+    CredentialAccountId, CredentialAccountUpdateBinding, NewAuthFlow, OAuthCallbackClaimRequest,
+    OAuthCallbackFailureInput, OAuthCallbackInput, TurnRunRef,
+};
+use ironclaw_host_api::{
+    AgentId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
+};
+use ironclaw_product_workflow::{
+    AuthGateRecord, AuthInteractionDecision, AuthInteractionReadModel,
+    AuthInteractionRejectionKind, AuthInteractionScope, AuthInteractionService,
+    DefaultAuthInteractionService, ListPendingAuthInteractionsRequest, ProductWorkflowError,
+    ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
+};
+use ironclaw_turns::{
+    AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
+    GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnPrecondition,
+    ResumeTurnRequest, ResumeTurnResponse, RunProfileId, RunProfileVersion, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnId,
+    TurnRunId, TurnRunState, TurnScope, TurnStatus,
+};
+
+#[derive(Default)]
+struct FakeAuthReadModel {
+    gates: Mutex<Vec<AuthGateRecord>>,
+}
+
+impl FakeAuthReadModel {
+    fn with_gates(gates: Vec<AuthGateRecord>) -> Self {
+        Self {
+            gates: Mutex::new(gates),
+        }
+    }
+}
+
+#[async_trait]
+impl AuthInteractionReadModel for FakeAuthReadModel {
+    async fn auth_gates(
+        &self,
+        _scope: &AuthInteractionScope,
+    ) -> Result<Vec<AuthGateRecord>, ProductWorkflowError> {
+        Ok(self.gates.lock().expect("lock").clone())
+    }
+
+    async fn auth_gate(
+        &self,
+        _scope: &AuthInteractionScope,
+        run_id_hint: Option<TurnRunId>,
+        gate_ref: &GateRef,
+    ) -> Result<Option<AuthGateRecord>, ProductWorkflowError> {
+        Ok(self
+            .gates
+            .lock()
+            .expect("lock")
+            .iter()
+            .find(|gate| {
+                gate.gate_ref() == gate_ref
+                    && run_id_hint.is_none_or(|run_id| gate.run_id() == run_id)
+            })
+            .cloned())
+    }
+}
+
+struct RecordingFlowManager {
+    flow: Mutex<Option<AuthFlowRecord>>,
+    cancellations: Mutex<Vec<AuthFlowId>>,
+}
+
+impl RecordingFlowManager {
+    fn new(flow: AuthFlowRecord) -> Self {
+        Self {
+            flow: Mutex::new(Some(flow)),
+            cancellations: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn cancellations(&self) -> Vec<AuthFlowId> {
+        self.cancellations.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl AuthFlowManager for RecordingFlowManager {
+    async fn create_flow(&self, _request: NewAuthFlow) -> Result<AuthFlowRecord, AuthProductError> {
+        Err(AuthProductError::BackendUnavailable)
+    }
+
+    async fn get_flow(
+        &self,
+        scope: &AuthProductScope,
+        flow_id: AuthFlowId,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        let flow = self.flow.lock().expect("lock").clone();
+        let Some(flow) = flow else {
+            return Ok(None);
+        };
+        if flow.id != flow_id {
+            return Ok(None);
+        }
+        if &flow.scope != scope {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        Ok(Some(flow))
+    }
+
+    async fn claim_oauth_callback(
+        &self,
+        _scope: &AuthProductScope,
+        _request: OAuthCallbackClaimRequest,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        Err(AuthProductError::BackendUnavailable)
+    }
+
+    async fn complete_oauth_callback(
+        &self,
+        _scope: &AuthProductScope,
+        _input: OAuthCallbackInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        Err(AuthProductError::BackendUnavailable)
+    }
+
+    async fn fail_oauth_callback(
+        &self,
+        _scope: &AuthProductScope,
+        _input: OAuthCallbackFailureInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        Err(AuthProductError::BackendUnavailable)
+    }
+
+    async fn cancel_flow(
+        &self,
+        scope: &AuthProductScope,
+        flow_id: AuthFlowId,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        let mut flow = self.flow.lock().expect("lock");
+        let Some(record) = flow.as_mut() else {
+            return Err(AuthProductError::UnknownOrExpiredFlow);
+        };
+        if record.id != flow_id {
+            return Err(AuthProductError::UnknownOrExpiredFlow);
+        }
+        if &record.scope != scope {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        record.status = AuthFlowStatus::Canceled;
+        record.updated_at = Utc::now();
+        self.cancellations.lock().expect("lock").push(flow_id);
+        Ok(record.clone())
+    }
+}
+
+struct RecordingTurnCoordinator {
+    actor: TurnActor,
+    status: Mutex<TurnStatus>,
+    gate_ref: Mutex<Option<GateRef>>,
+    resumes: Mutex<Vec<ResumeTurnRequest>>,
+    cancellations: Mutex<Vec<CancelRunRequest>>,
+}
+
+impl RecordingTurnCoordinator {
+    fn blocked_auth(actor: TurnActor, gate_ref: GateRef) -> Self {
+        Self {
+            actor,
+            status: Mutex::new(TurnStatus::BlockedAuth),
+            gate_ref: Mutex::new(Some(gate_ref)),
+            resumes: Mutex::new(Vec::new()),
+            cancellations: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn resumes(&self) -> Vec<ResumeTurnRequest> {
+        self.resumes.lock().expect("lock").clone()
+    }
+
+    fn cancellations(&self) -> Vec<CancelRunRequest> {
+        self.cancellations.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl TurnCoordinator for RecordingTurnCoordinator {
+    async fn prepare_turn(&self, _scope: TurnScope) -> Result<TurnRunId, TurnError> {
+        Ok(TurnRunId::new())
+    }
+
+    async fn submit_turn(
+        &self,
+        _request: SubmitTurnRequest,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        panic!("auth interactions must not submit a turn")
+    }
+
+    async fn resume_turn(
+        &self,
+        request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        let run_id = request.run_id;
+        self.resumes.lock().expect("lock").push(request);
+        Ok(ResumeTurnResponse {
+            run_id,
+            status: TurnStatus::Queued,
+            event_cursor: EventCursor(41),
+        })
+    }
+
+    async fn cancel_run(&self, request: CancelRunRequest) -> Result<CancelRunResponse, TurnError> {
+        let run_id = request.run_id;
+        self.cancellations.lock().expect("lock").push(request);
+        Ok(CancelRunResponse {
+            run_id,
+            status: TurnStatus::Cancelled,
+            event_cursor: EventCursor(43),
+            already_terminal: false,
+            actor: None,
+        })
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        Ok(TurnRunState {
+            scope: request.scope,
+            actor: Some(self.actor.clone()),
+            turn_id: TurnId::new(),
+            run_id: request.run_id,
+            status: *self.status.lock().expect("lock"),
+            accepted_message_ref: AcceptedMessageRef::new("msg:auth").expect("valid"),
+            source_binding_ref: SourceBindingRef::new("src:auth").expect("valid"),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply:auth").expect("valid"),
+            resolved_run_profile_id: RunProfileId::default_profile(),
+            resolved_run_profile_version: RunProfileVersion::new(1),
+            resolved_model_route: None,
+            received_at: Utc::now(),
+            checkpoint_id: None,
+            gate_ref: self.gate_ref.lock().expect("lock").clone(),
+            failure: None,
+            event_cursor: EventCursor(47),
+        })
+    }
+}
+
+#[tokio::test]
+async fn list_pending_auth_redacts_setup_message_and_filters_scope() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-setup");
+    let flow = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        AuthChallenge::SetupRequired {
+            provider: provider(),
+            message: "RAW_PROMPT_SENTINEL_3094 /tmp/private-auth-path sk-live".to_string(),
+        },
+    );
+    let other = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &turn_scope("bob", "thread-b"),
+        &TurnActor::new(UserId::new("bob").unwrap()),
+        TurnRunId::new(),
+        &make_gate_ref("gate:auth-other"),
+        None,
+        setup_challenge(),
+    );
+    let service = service(flow.clone(), vec![flow, other], actor.clone(), gate_ref);
+
+    let response = service
+        .list_pending(ListPendingAuthInteractionsRequest { scope, actor })
+        .await
+        .expect("list pending auth");
+
+    assert_eq!(response.auth.len(), 1);
+    let serialized = serde_json::to_string(&response).expect("serialize");
+    assert!(!serialized.contains("RAW_PROMPT_SENTINEL_3094"));
+    assert!(!serialized.contains("/tmp/private-auth-path"));
+    assert!(!serialized.contains("sk-live"));
+}
+
+#[tokio::test]
+async fn credential_provided_resumes_completed_auth_gate() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-manual");
+    let account_id = CredentialAccountId::new();
+    let flow = auth_flow(
+        AuthFlowStatus::Completed,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        Some(account_id),
+        setup_challenge(),
+    );
+    let (service, flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    let response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CredentialProvided {
+                credential_ref: account_id.to_string(),
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-1").unwrap(),
+        })
+        .await
+        .expect("resolve auth");
+
+    assert!(matches!(
+        response,
+        ResolveAuthInteractionResponse::Resumed(_)
+    ));
+    assert!(flow_manager.cancellations().is_empty());
+    let resumes = coordinator.resumes();
+    assert_eq!(resumes.len(), 1);
+    assert_eq!(
+        resumes[0].precondition,
+        ResumeTurnPrecondition::BlockedAuthGate
+    );
+}
+
+#[tokio::test]
+async fn denied_auth_cancels_flow_and_run() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-deny");
+    let flow = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    let response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("auth-action-deny").unwrap(),
+        })
+        .await
+        .expect("deny auth");
+
+    assert!(matches!(
+        response,
+        ResolveAuthInteractionResponse::Canceled(_)
+    ));
+    assert_eq!(flow_manager.cancellations().len(), 1);
+    assert_eq!(coordinator.cancellations().len(), 1);
+    assert!(coordinator.resumes().is_empty());
+}
+
+#[tokio::test]
+async fn credential_resolution_requires_completed_flow() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-stale");
+    let account_id = CredentialAccountId::new();
+    let flow = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        Some(account_id),
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    let error = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CredentialProvided {
+                credential_ref: account_id.to_string(),
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-stale").unwrap(),
+        })
+        .await
+        .expect_err("pending auth must not resume");
+
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::StaleAuth
+        }
+    ));
+    assert!(coordinator.resumes().is_empty());
+}
+
+#[tokio::test]
+async fn cross_scope_auth_gate_is_denied_before_resume() {
+    let owner = TurnActor::new(UserId::new("alice").unwrap());
+    let owner_scope = turn_scope("alice", "thread-a");
+    let caller = TurnActor::new(UserId::new("bob").unwrap());
+    let caller_scope = turn_scope("bob", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-cross-scope");
+    let account_id = CredentialAccountId::new();
+    let flow = auth_flow(
+        AuthFlowStatus::Completed,
+        &owner_scope,
+        &owner,
+        run_id,
+        &gate_ref,
+        Some(account_id),
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], caller.clone(), gate_ref.clone());
+
+    let error = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope: caller_scope,
+            actor: caller,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CredentialProvided {
+                credential_ref: account_id.to_string(),
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-cross-scope").unwrap(),
+        })
+        .await
+        .expect_err("cross-scope auth must be denied");
+
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::CrossScopeDenied
+        }
+    ));
+    assert!(coordinator.resumes().is_empty());
+}
+
+fn service(
+    flow: AuthFlowRecord,
+    gates: Vec<AuthFlowRecord>,
+    actor: TurnActor,
+    gate_ref: GateRef,
+) -> DefaultAuthInteractionService {
+    service_parts(flow, gates, actor, gate_ref).0
+}
+
+fn service_parts(
+    flow: AuthFlowRecord,
+    gates: Vec<AuthFlowRecord>,
+    actor: TurnActor,
+    gate_ref: GateRef,
+) -> (
+    DefaultAuthInteractionService,
+    Arc<RecordingFlowManager>,
+    Arc<RecordingTurnCoordinator>,
+) {
+    let read_model = Arc::new(FakeAuthReadModel::with_gates(
+        gates
+            .into_iter()
+            .map(|flow| {
+                let AuthContinuationRef::TurnGateResume { turn_run_ref, .. } = &flow.continuation
+                else {
+                    panic!("test flow must be turn-gate resume");
+                };
+                let run_id = uuid::Uuid::parse_str(turn_run_ref.as_str())
+                    .map(TurnRunId::from_uuid)
+                    .expect("run ref");
+                let AuthContinuationRef::TurnGateResume { gate_ref, .. } = &flow.continuation
+                else {
+                    panic!("test flow must be turn-gate resume");
+                };
+                AuthGateRecord::new(run_id, GateRef::new(gate_ref.as_str()).unwrap(), flow)
+                    .expect("auth gate")
+            })
+            .collect(),
+    ));
+    let flow_manager = Arc::new(RecordingFlowManager::new(flow));
+    let coordinator = Arc::new(RecordingTurnCoordinator::blocked_auth(actor, gate_ref));
+    (
+        DefaultAuthInteractionService::new(read_model, flow_manager.clone(), coordinator.clone()),
+        flow_manager,
+        coordinator,
+    )
+}
+
+fn auth_flow(
+    status: AuthFlowStatus,
+    scope: &TurnScope,
+    actor: &TurnActor,
+    run_id: TurnRunId,
+    gate_ref: &GateRef,
+    credential_account_id: Option<CredentialAccountId>,
+    challenge: AuthChallenge,
+) -> AuthFlowRecord {
+    let now = Utc::now();
+    AuthFlowRecord {
+        id: AuthFlowId::new(),
+        scope: auth_scope(scope, actor),
+        kind: AuthFlowKind::IntegrationCredential,
+        status,
+        provider: provider(),
+        challenge: Some(challenge),
+        continuation: AuthContinuationRef::TurnGateResume {
+            turn_run_ref: TurnRunRef::new(run_id.to_string()).unwrap(),
+            gate_ref: AuthGateRef::new(gate_ref.as_str()).unwrap(),
+        },
+        credential_account_id,
+        update_binding: Option::<CredentialAccountUpdateBinding>::None,
+        opaque_state_hash: None,
+        pkce_verifier_hash: None,
+        authorization_code_hash: None,
+        error: None,
+        created_at: now,
+        updated_at: now,
+        expires_at: now + Duration::minutes(10),
+    }
+}
+
+fn auth_scope(scope: &TurnScope, actor: &TurnActor) -> AuthProductScope {
+    let resource = ResourceScope {
+        tenant_id: scope.tenant_id.clone(),
+        user_id: actor.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: None,
+        thread_id: Some(scope.thread_id.clone()),
+        invocation_id: InvocationId::new(),
+    };
+    AuthProductScope::new(resource, AuthSurface::Web)
+}
+
+fn turn_scope(user: &str, thread: &str) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant-1").unwrap(),
+        Some(AgentId::new("agent-1").unwrap()),
+        Some(ProjectId::new("project-1").unwrap()),
+        ThreadId::new(format!("{thread}-{user}")).unwrap(),
+    )
+}
+
+fn make_gate_ref(value: &str) -> GateRef {
+    GateRef::new(value).unwrap()
+}
+
+fn provider() -> ironclaw_auth::AuthProviderId {
+    ironclaw_auth::AuthProviderId::new("gmail").unwrap()
+}
+
+fn setup_challenge() -> AuthChallenge {
+    AuthChallenge::SetupRequired {
+        provider: provider(),
+        message: "Authenticate to continue".to_string(),
+    }
+}

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -6,9 +6,9 @@ use ironclaw_auth::{
     AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowKind, AuthFlowManager, AuthFlowRecord,
     AuthFlowStatus, AuthGateRef, AuthProductError, AuthProductScope, AuthSurface,
     CredentialAccountId, CredentialAccountLabel, CredentialAccountProjection,
-    CredentialAccountStatus, CredentialAccountUpdateBinding, CredentialOwnership, NewAuthFlow,
-    OAuthAuthorizationUrl, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
-    OAuthCallbackInput, TurnRunRef,
+    CredentialAccountStatus, CredentialAccountUpdateBinding, CredentialOwnership,
+    CredentialSelectionInput, NewAuthFlow, OAuthAuthorizationUrl, OAuthCallbackClaimRequest,
+    OAuthCallbackFailureInput, OAuthCallbackInput, TurnRunRef,
 };
 use ironclaw_host_api::{
     AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
@@ -126,6 +126,37 @@ impl AuthFlowManager for RecordingFlowManager {
         Err(AuthProductError::BackendUnavailable)
     }
 
+    async fn complete_credential_selection(
+        &self,
+        scope: &AuthProductScope,
+        input: CredentialSelectionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        let mut flow = self.flow.lock().expect("lock");
+        let Some(record) = flow.as_mut() else {
+            return Err(AuthProductError::UnknownOrExpiredFlow);
+        };
+        if record.id != input.flow_id {
+            return Err(AuthProductError::UnknownOrExpiredFlow);
+        }
+        if &record.scope != scope {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        let Some(AuthChallenge::AccountSelectionRequired { accounts, .. }) = &record.challenge
+        else {
+            return Err(AuthProductError::AccountSelectionRequired);
+        };
+        if !accounts
+            .iter()
+            .any(|account| account.id == input.credential_account_id)
+        {
+            return Err(AuthProductError::CredentialMissing);
+        }
+        record.status = AuthFlowStatus::Completed;
+        record.credential_account_id = Some(input.credential_account_id);
+        record.updated_at = Utc::now();
+        Ok(record.clone())
+    }
+
     async fn fail_oauth_callback(
         &self,
         _scope: &AuthProductScope,
@@ -181,6 +212,10 @@ impl RecordingTurnCoordinator {
 
     fn cancellations(&self) -> Vec<CancelRunRequest> {
         self.cancellations.lock().expect("lock").clone()
+    }
+
+    fn set_status(&self, status: TurnStatus) {
+        *self.status.lock().expect("lock") = status;
     }
 }
 
@@ -428,12 +463,70 @@ async fn credential_provided_resumes_completed_auth_gate() {
             run_id_hint: Some(run_id),
             gate_ref,
             decision: AuthInteractionDecision::CredentialProvided {
-                credential_ref: account_id.to_string(),
+                credential_ref: account_id,
             },
             idempotency_key: IdempotencyKey::new("auth-action-1").unwrap(),
         })
         .await
         .expect("resolve auth");
+
+    assert!(matches!(
+        response,
+        ResolveAuthInteractionResponse::Resumed(_)
+    ));
+    assert!(flow_manager.cancellations().is_empty());
+    let resumes = coordinator.resumes();
+    assert_eq!(resumes.len(), 1);
+    assert_eq!(
+        resumes[0].precondition,
+        ResumeTurnPrecondition::BlockedAuthGate
+    );
+}
+
+#[tokio::test]
+async fn credential_selection_completes_pending_auth_gate_before_resume() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-account-selection");
+    let account_id = CredentialAccountId::new();
+    let flow = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        AuthChallenge::AccountSelectionRequired {
+            provider: provider(),
+            accounts: vec![CredentialAccountProjection {
+                id: account_id,
+                provider: provider(),
+                label: CredentialAccountLabel::new("alice@example.test").expect("label"),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: vec![],
+                secret_handle_count: 1,
+            }],
+        },
+    );
+    let (service, flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    let response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CredentialProvided {
+                credential_ref: account_id,
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-selection").unwrap(),
+        })
+        .await
+        .expect("credential selection resumes auth");
 
     assert!(matches!(
         response,
@@ -463,7 +556,7 @@ async fn callback_completed_resumes_completed_auth_gate() {
         None,
         setup_challenge(),
     );
-    let callback_ref = flow.id.to_string();
+    let callback_ref = flow.id;
     let (service, flow_manager, coordinator) =
         service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
 
@@ -512,7 +605,7 @@ async fn callback_completed_rejects_mismatched_callback_ref() {
             run_id_hint: Some(run_id),
             gate_ref,
             decision: AuthInteractionDecision::CallbackCompleted {
-                callback_ref: AuthFlowId::new().to_string(),
+                callback_ref: AuthFlowId::new(),
             },
             idempotency_key: IdempotencyKey::new("auth-action-callback-wrong").unwrap(),
         })
@@ -553,7 +646,7 @@ async fn credential_provided_rejects_completed_flow_without_account_id() {
             run_id_hint: Some(run_id),
             gate_ref,
             decision: AuthInteractionDecision::CredentialProvided {
-                credential_ref: CredentialAccountId::new().to_string(),
+                credential_ref: CredentialAccountId::new(),
             },
             idempotency_key: IdempotencyKey::new("auth-action-missing-account").unwrap(),
         })
@@ -609,6 +702,87 @@ async fn denied_auth_cancels_flow_and_run() {
 }
 
 #[tokio::test]
+async fn duplicate_completed_auth_resolution_replays_through_turn_coordinator() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-replay-completed");
+    let account_id = CredentialAccountId::new();
+    let flow = auth_flow(
+        AuthFlowStatus::Completed,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        Some(account_id),
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+    coordinator.set_status(TurnStatus::Queued);
+
+    let response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CredentialProvided {
+                credential_ref: account_id,
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-replay-completed").unwrap(),
+        })
+        .await
+        .expect("duplicate completed auth resolution replays");
+
+    assert!(matches!(
+        response,
+        ResolveAuthInteractionResponse::Resumed(_)
+    ));
+    assert_eq!(coordinator.resumes().len(), 1);
+    assert_eq!(coordinator.cancellations().len(), 0);
+}
+
+#[tokio::test]
+async fn duplicate_denied_auth_resolution_replays_through_turn_coordinator() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-replay-denied");
+    let flow = auth_flow(
+        AuthFlowStatus::Canceled,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+    coordinator.set_status(TurnStatus::Queued);
+
+    let response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("auth-action-replay-denied").unwrap(),
+        })
+        .await
+        .expect("duplicate denied auth resolution replays");
+
+    assert!(matches!(
+        response,
+        ResolveAuthInteractionResponse::Canceled(_)
+    ));
+    assert_eq!(coordinator.cancellations().len(), 1);
+    assert_eq!(coordinator.resumes().len(), 0);
+}
+
+#[tokio::test]
 async fn credential_resolution_requires_completed_flow() {
     let actor = TurnActor::new(UserId::new("alice").unwrap());
     let scope = turn_scope("alice", "thread-a");
@@ -634,7 +808,7 @@ async fn credential_resolution_requires_completed_flow() {
             run_id_hint: Some(run_id),
             gate_ref,
             decision: AuthInteractionDecision::CredentialProvided {
-                credential_ref: account_id.to_string(),
+                credential_ref: account_id,
             },
             idempotency_key: IdempotencyKey::new("auth-action-stale").unwrap(),
         })
@@ -678,7 +852,7 @@ async fn cross_scope_auth_gate_is_denied_before_resume() {
             run_id_hint: Some(run_id),
             gate_ref,
             decision: AuthInteractionDecision::CredentialProvided {
-                credential_ref: account_id.to_string(),
+                credential_ref: account_id,
             },
             idempotency_key: IdempotencyKey::new("auth-action-cross-scope").unwrap(),
         })
@@ -692,6 +866,50 @@ async fn cross_scope_auth_gate_is_denied_before_resume() {
         }
     ));
     assert!(coordinator.resumes().is_empty());
+}
+
+#[tokio::test]
+async fn auth_resolution_rejects_run_state_actor_mismatch() {
+    let caller = TurnActor::new(UserId::new("alice").unwrap());
+    let state_actor = TurnActor::new(UserId::new("bob").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-actor-mismatch");
+    let account_id = CredentialAccountId::new();
+    let flow = auth_flow(
+        AuthFlowStatus::Completed,
+        &scope,
+        &caller,
+        run_id,
+        &gate_ref,
+        Some(account_id),
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], state_actor, gate_ref.clone());
+
+    let error = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor: caller,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CredentialProvided {
+                credential_ref: account_id,
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-actor-mismatch").unwrap(),
+        })
+        .await
+        .expect_err("run-state actor mismatch must be denied");
+
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::CrossScopeDenied
+        }
+    ));
+    assert!(coordinator.resumes().is_empty());
+    assert!(coordinator.cancellations().is_empty());
 }
 
 #[test]

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -5,17 +5,19 @@ use chrono::{Duration, Utc};
 use ironclaw_auth::{
     AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowKind, AuthFlowManager, AuthFlowRecord,
     AuthFlowStatus, AuthGateRef, AuthProductError, AuthProductScope, AuthSurface,
-    CredentialAccountId, CredentialAccountUpdateBinding, NewAuthFlow, OAuthCallbackClaimRequest,
-    OAuthCallbackFailureInput, OAuthCallbackInput, TurnRunRef,
+    CredentialAccountId, CredentialAccountLabel, CredentialAccountProjection,
+    CredentialAccountStatus, CredentialAccountUpdateBinding, CredentialOwnership, NewAuthFlow,
+    OAuthAuthorizationUrl, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
+    OAuthCallbackInput, TurnRunRef,
 };
 use ironclaw_host_api::{
-    AgentId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
+    AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
 };
 use ironclaw_product_workflow::{
-    AuthGateRecord, AuthInteractionDecision, AuthInteractionReadModel,
-    AuthInteractionRejectionKind, AuthInteractionScope, AuthInteractionService,
-    DefaultAuthInteractionService, ListPendingAuthInteractionsRequest, ProductWorkflowError,
-    ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
+    AuthGateRecord, AuthInteractionChallengeView, AuthInteractionDecision,
+    AuthInteractionReadModel, AuthInteractionRejectionKind, AuthInteractionScope,
+    AuthInteractionService, DefaultAuthInteractionService, ListPendingAuthInteractionsRequest,
+    ProductWorkflowError, ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
 };
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
@@ -269,18 +271,135 @@ async fn list_pending_auth_redacts_setup_message_and_filters_scope() {
         None,
         setup_challenge(),
     );
-    let service = service(flow.clone(), vec![flow, other], actor.clone(), gate_ref);
+    let failed = auth_flow(
+        AuthFlowStatus::Failed,
+        &scope,
+        &actor,
+        TurnRunId::new(),
+        &make_gate_ref("gate:auth-failed"),
+        None,
+        setup_challenge(),
+    );
+    let service = service(
+        flow.clone(),
+        vec![flow, other, failed],
+        actor.clone(),
+        gate_ref,
+    );
 
     let response = service
         .list_pending(ListPendingAuthInteractionsRequest { scope, actor })
         .await
         .expect("list pending auth");
 
-    assert_eq!(response.auth.len(), 1);
+    assert_eq!(response.auth_interactions.len(), 1);
     let serialized = serde_json::to_string(&response).expect("serialize");
     assert!(!serialized.contains("RAW_PROMPT_SENTINEL_3094"));
     assert!(!serialized.contains("/tmp/private-auth-path"));
     assert!(!serialized.contains("sk-live"));
+    assert!(!serialized.contains("gate:auth-failed"));
+}
+
+#[tokio::test]
+async fn list_pending_auth_projects_challenges_to_minimal_safe_views() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let oauth_gate = make_gate_ref("gate:auth-oauth");
+    let manual_gate = make_gate_ref("gate:auth-manual");
+    let account_gate = make_gate_ref("gate:auth-account");
+    let now = Utc::now();
+    let account_id = CredentialAccountId::new();
+    let flows = vec![
+        auth_flow(
+            AuthFlowStatus::AwaitingUser,
+            &scope,
+            &actor,
+            TurnRunId::new(),
+            &oauth_gate,
+            None,
+            AuthChallenge::OAuthUrl {
+                authorization_url: OAuthAuthorizationUrl::new(
+                    "https://auth.example.test/authorize?state=secret-state&code_challenge=pkce"
+                        .to_string(),
+                )
+                .expect("oauth url"),
+                expires_at: now + Duration::minutes(5),
+            },
+        ),
+        auth_flow(
+            AuthFlowStatus::AwaitingUser,
+            &scope,
+            &actor,
+            TurnRunId::new(),
+            &manual_gate,
+            None,
+            AuthChallenge::ManualTokenRequired {
+                interaction_id: ironclaw_auth::AuthInteractionId::new(),
+                provider: provider(),
+                label: CredentialAccountLabel::new("private user token label").expect("label"),
+                expires_at: now + Duration::minutes(5),
+            },
+        ),
+        auth_flow(
+            AuthFlowStatus::AwaitingUser,
+            &scope,
+            &actor,
+            TurnRunId::new(),
+            &account_gate,
+            None,
+            AuthChallenge::AccountSelectionRequired {
+                provider: provider(),
+                accounts: vec![CredentialAccountProjection {
+                    id: account_id,
+                    provider: provider(),
+                    label: CredentialAccountLabel::new("alice@example.test").expect("label"),
+                    status: CredentialAccountStatus::Configured,
+                    ownership: CredentialOwnership::UserReusable,
+                    owner_extension: Some(ExtensionId::new("private.extension").unwrap()),
+                    granted_extensions: vec![ExtensionId::new("granted.extension").unwrap()],
+                    secret_handle_count: 2,
+                }],
+            },
+        ),
+    ];
+    let service = service(
+        flows[0].clone(),
+        flows.clone(),
+        actor.clone(),
+        oauth_gate.clone(),
+    );
+
+    let response = service
+        .list_pending(ListPendingAuthInteractionsRequest { scope, actor })
+        .await
+        .expect("list pending auth");
+
+    assert_eq!(response.auth_interactions.len(), 3);
+    assert!(response.auth_interactions.iter().any(|pending| matches!(
+        pending.challenge,
+        Some(AuthInteractionChallengeView::OAuthRedirectRequired { .. })
+    )));
+    let account_view = response
+        .auth_interactions
+        .iter()
+        .find_map(|pending| match &pending.challenge {
+            Some(AuthInteractionChallengeView::AccountSelectionRequired { accounts, .. }) => {
+                Some(accounts)
+            }
+            _ => None,
+        })
+        .expect("account choices");
+    assert_eq!(account_view.len(), 1);
+    assert_eq!(account_view[0].credential_ref, account_id.to_string());
+    assert_eq!(account_view[0].status, CredentialAccountStatus::Configured);
+    let serialized = serde_json::to_string(&response).expect("serialize");
+    assert!(!serialized.contains("secret-state"));
+    assert!(!serialized.contains("code_challenge"));
+    assert!(!serialized.contains("private user token label"));
+    assert!(!serialized.contains("alice@example.test"));
+    assert!(!serialized.contains("private.extension"));
+    assert!(!serialized.contains("granted.extension"));
+    assert!(!serialized.contains("secret_handle_count"));
 }
 
 #[tokio::test]
@@ -327,6 +446,127 @@ async fn credential_provided_resumes_completed_auth_gate() {
         resumes[0].precondition,
         ResumeTurnPrecondition::BlockedAuthGate
     );
+}
+
+#[tokio::test]
+async fn callback_completed_resumes_completed_auth_gate() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-callback");
+    let flow = auth_flow(
+        AuthFlowStatus::Completed,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let callback_ref = flow.id.to_string();
+    let (service, flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    let response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CallbackCompleted { callback_ref },
+            idempotency_key: IdempotencyKey::new("auth-action-callback").unwrap(),
+        })
+        .await
+        .expect("resolve callback auth");
+
+    assert!(matches!(
+        response,
+        ResolveAuthInteractionResponse::Resumed(_)
+    ));
+    assert!(flow_manager.cancellations().is_empty());
+    assert_eq!(coordinator.resumes().len(), 1);
+}
+
+#[tokio::test]
+async fn callback_completed_rejects_mismatched_callback_ref() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-callback-mismatch");
+    let flow = auth_flow(
+        AuthFlowStatus::Completed,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    let error = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CallbackCompleted {
+                callback_ref: AuthFlowId::new().to_string(),
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-callback-wrong").unwrap(),
+        })
+        .await
+        .expect_err("wrong callback ref must be rejected");
+
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidCallbackRef
+        }
+    ));
+    assert!(coordinator.resumes().is_empty());
+}
+
+#[tokio::test]
+async fn credential_provided_rejects_completed_flow_without_account_id() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-missing-account");
+    let flow = auth_flow(
+        AuthFlowStatus::Completed,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow.clone(), vec![flow], actor.clone(), gate_ref.clone());
+
+    let error = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::CredentialProvided {
+                credential_ref: CredentialAccountId::new().to_string(),
+            },
+            idempotency_key: IdempotencyKey::new("auth-action-missing-account").unwrap(),
+        })
+        .await
+        .expect_err("missing account id must be stale");
+
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::StaleAuth
+        }
+    ));
+    assert!(coordinator.resumes().is_empty());
 }
 
 #[tokio::test]
@@ -452,6 +692,52 @@ async fn cross_scope_auth_gate_is_denied_before_resume() {
         }
     ));
     assert!(coordinator.resumes().is_empty());
+}
+
+#[test]
+fn auth_gate_record_new_rejects_invalid_continuation_run_and_gate() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-record");
+    let valid = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+
+    let mut wrong_continuation = valid.clone();
+    wrong_continuation.continuation = AuthContinuationRef::SetupOnly;
+    let error = AuthGateRecord::new(run_id, gate_ref.clone(), wrong_continuation)
+        .expect_err("non turn-gate continuation rejected");
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::UnsupportedResult
+        }
+    ));
+
+    let error = AuthGateRecord::new(TurnRunId::new(), gate_ref.clone(), valid.clone())
+        .expect_err("mismatched run rejected");
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::StaleAuth
+        }
+    ));
+
+    let error = AuthGateRecord::new(run_id, make_gate_ref("gate:auth-wrong"), valid)
+        .expect_err("mismatched gate rejected");
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::InvalidGateRef
+        }
+    ));
 }
 
 fn service(

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -5,6 +5,7 @@ use std::time::Duration as StdDuration;
 
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
+use ironclaw_auth::{AuthFlowId, CredentialAccountId};
 use ironclaw_conversations::InMemoryConversationServices;
 use ironclaw_host_api::{AgentId, ApprovalRequestId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_product_adapters::{
@@ -628,6 +629,7 @@ async fn auth_resolution_payload_routes_through_auth_interaction_service() {
     let binding = Arc::new(FakeConversationBindingService::new());
     let gate_ref = GateRef::new("gate:auth-product").expect("auth gate ref");
     let run_id = TurnRunId::new();
+    let credential_ref = CredentialAccountId::new();
     let auth_service = Arc::new(RecordingAuthInteractionService::new(
         gate_ref.clone(),
         run_id,
@@ -640,7 +642,7 @@ async fn auth_resolution_payload_routes_through_auth_interaction_service() {
             AuthResolutionPayload::new(
                 gate_ref.as_str(),
                 AuthResolutionResult::CredentialProvided {
-                    credential_ref: "credential-account-1".to_string(),
+                    credential_ref: credential_ref.to_string(),
                 },
             )
             .expect("auth payload"),
@@ -662,10 +664,53 @@ async fn auth_resolution_payload_routes_through_auth_interaction_service() {
     );
     assert_eq!(
         resolutions[0].decision,
-        AuthInteractionDecision::CredentialProvided {
-            credential_ref: "credential-account-1".to_string()
-        }
+        AuthInteractionDecision::CredentialProvided { credential_ref }
     );
+}
+
+#[tokio::test]
+async fn auth_callback_and_denied_payloads_route_through_auth_interaction_service() {
+    let callback_ref = AuthFlowId::new();
+    for (event_suffix, result, expected) in [
+        (
+            "auth-callback-resolution",
+            AuthResolutionResult::CallbackCompleted {
+                callback_ref: callback_ref.to_string(),
+            },
+            AuthInteractionDecision::CallbackCompleted { callback_ref },
+        ),
+        (
+            "auth-denied-resolution",
+            AuthResolutionResult::Denied,
+            AuthInteractionDecision::Deny,
+        ),
+    ] {
+        let inbound = Arc::new(FakeInboundTurnService::new());
+        let ledger = Arc::new(FakeIdempotencyLedger::new());
+        let binding = Arc::new(FakeConversationBindingService::new());
+        let gate_ref = GateRef::new(format!("gate:{event_suffix}")).expect("auth gate ref");
+        let run_id = TurnRunId::new();
+        let auth_service = Arc::new(RecordingAuthInteractionService::new(
+            gate_ref.clone(),
+            run_id,
+        ));
+        let workflow = DefaultProductWorkflow::new(inbound, ledger, binding)
+            .with_auth_interaction_service(auth_service.clone());
+        let envelope = sample_envelope_with_payload(
+            event_suffix,
+            ProductInboundPayload::AuthResolution(
+                AuthResolutionPayload::new(gate_ref.as_str(), result).expect("auth payload"),
+            ),
+        );
+
+        let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+        assert_eq!(ack, ProductInboundAck::NoOp);
+        let resolutions = auth_service.resolutions();
+        assert_eq!(resolutions.len(), 1);
+        assert_eq!(resolutions[0].gate_ref, gate_ref);
+        assert_eq!(resolutions[0].decision, expected);
+    }
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -19,16 +19,17 @@ use ironclaw_product_adapters::{
 use ironclaw_product_workflow::{
     ActionDispatchKind, ActionFingerprintKey, ApprovalInteractionDecision,
     ApprovalInteractionScope, ApprovalInteractionService, AuthInteractionDecision,
-    AuthInteractionScope, AuthInteractionService, AuthRequestRef, BeforeInboundPolicy,
-    BeforeInboundPolicyOutcome, BeforeInboundPolicyRequest, DefaultInboundTurnService,
-    DefaultProductWorkflow, FakeBeforeInboundPolicy, FakeConversationBindingService,
-    FakeIdempotencyLedger, FakeInboundTurnService, IdempotencyDecision, IdempotencyLedger,
-    InMemoryIdempotencyLedger, InboundTurnOutcome, InboundTurnService, InboundUserMessageDispatch,
-    LinkedThreadActionId, ListPendingApprovalsRequest, ListPendingApprovalsResponse,
-    ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse,
-    PendingApprovalInteractionView, PendingAuthInteractionView, ProductCommandName,
-    ProductConversationBindingService, ProductInstallationKey, ProductInstallationScope,
-    ProductWorkflowError, ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
+    AuthInteractionScope, AuthInteractionService, AuthInteractionStatus, AuthRequestRef,
+    BeforeInboundPolicy, BeforeInboundPolicyOutcome, BeforeInboundPolicyRequest,
+    DefaultInboundTurnService, DefaultProductWorkflow, FakeBeforeInboundPolicy,
+    FakeConversationBindingService, FakeIdempotencyLedger, FakeInboundTurnService,
+    IdempotencyDecision, IdempotencyLedger, InMemoryIdempotencyLedger, InboundTurnOutcome,
+    InboundTurnService, InboundUserMessageDispatch, LinkedThreadActionId,
+    ListPendingApprovalsRequest, ListPendingApprovalsResponse, ListPendingAuthInteractionsRequest,
+    ListPendingAuthInteractionsResponse, PendingApprovalInteractionView,
+    PendingAuthInteractionView, ProductCommandName, ProductConversationBindingService,
+    ProductInstallationKey, ProductInstallationScope, ProductWorkflowError,
+    ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
     ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, ResolvedBinding,
     SourceBindingKey, StaticProductInstallationResolver, approval_gate_ref,
 };
@@ -267,12 +268,12 @@ impl AuthInteractionService for RecordingAuthInteractionService {
     ) -> Result<ListPendingAuthInteractionsResponse, ProductWorkflowError> {
         let scope = AuthInteractionScope::from_turn(&request.scope, &request.actor);
         Ok(ListPendingAuthInteractionsResponse {
-            auth: vec![PendingAuthInteractionView {
+            auth_interactions: vec![PendingAuthInteractionView {
                 scope,
                 run_id: self.run_id,
                 auth_request_ref: self.gate_ref.clone(),
                 flow_id: ironclaw_auth::AuthFlowId::new(),
-                status: ironclaw_auth::AuthFlowStatus::AwaitingUser,
+                status: AuthInteractionStatus::AwaitingUser,
                 provider: ironclaw_auth::AuthProviderId::new("gmail").expect("provider"),
                 summary: "Authentication required".to_string(),
                 challenge: None,

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -18,15 +18,18 @@ use ironclaw_product_adapters::{
 };
 use ironclaw_product_workflow::{
     ActionDispatchKind, ActionFingerprintKey, ApprovalInteractionDecision,
-    ApprovalInteractionScope, ApprovalInteractionService, AuthRequestRef, BeforeInboundPolicy,
+    ApprovalInteractionScope, ApprovalInteractionService, AuthInteractionDecision,
+    AuthInteractionScope, AuthInteractionService, AuthRequestRef, BeforeInboundPolicy,
     BeforeInboundPolicyOutcome, BeforeInboundPolicyRequest, DefaultInboundTurnService,
     DefaultProductWorkflow, FakeBeforeInboundPolicy, FakeConversationBindingService,
     FakeIdempotencyLedger, FakeInboundTurnService, IdempotencyDecision, IdempotencyLedger,
     InMemoryIdempotencyLedger, InboundTurnOutcome, InboundTurnService, InboundUserMessageDispatch,
     LinkedThreadActionId, ListPendingApprovalsRequest, ListPendingApprovalsResponse,
-    PendingApprovalInteractionView, ProductCommandName, ProductConversationBindingService,
-    ProductInstallationKey, ProductInstallationScope, ProductWorkflowError,
-    ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse, ResolvedBinding,
+    ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse,
+    PendingApprovalInteractionView, PendingAuthInteractionView, ProductCommandName,
+    ProductConversationBindingService, ProductInstallationKey, ProductInstallationScope,
+    ProductWorkflowError, ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
+    ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, ResolvedBinding,
     SourceBindingKey, StaticProductInstallationResolver, approval_gate_ref,
 };
 use ironclaw_threads::InMemorySessionThreadService;
@@ -233,6 +236,77 @@ impl ApprovalInteractionService for RecordingApprovalInteractionService {
                 }
             },
         )
+    }
+}
+
+struct RecordingAuthInteractionService {
+    gate_ref: GateRef,
+    run_id: TurnRunId,
+    resolutions: Mutex<Vec<ResolveAuthInteractionRequest>>,
+}
+
+impl RecordingAuthInteractionService {
+    fn new(gate_ref: GateRef, run_id: TurnRunId) -> Self {
+        Self {
+            gate_ref,
+            run_id,
+            resolutions: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn resolutions(&self) -> Vec<ResolveAuthInteractionRequest> {
+        self.resolutions.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl AuthInteractionService for RecordingAuthInteractionService {
+    async fn list_pending(
+        &self,
+        request: ListPendingAuthInteractionsRequest,
+    ) -> Result<ListPendingAuthInteractionsResponse, ProductWorkflowError> {
+        let scope = AuthInteractionScope::from_turn(&request.scope, &request.actor);
+        Ok(ListPendingAuthInteractionsResponse {
+            auth: vec![PendingAuthInteractionView {
+                scope,
+                run_id: self.run_id,
+                auth_request_ref: self.gate_ref.clone(),
+                flow_id: ironclaw_auth::AuthFlowId::new(),
+                status: ironclaw_auth::AuthFlowStatus::AwaitingUser,
+                provider: ironclaw_auth::AuthProviderId::new("gmail").expect("provider"),
+                summary: "Authentication required".to_string(),
+                challenge: None,
+                expires_at: Utc::now(),
+            }],
+        })
+    }
+
+    async fn resolve(
+        &self,
+        request: ResolveAuthInteractionRequest,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        let run_id = request.run_id_hint.unwrap_or(self.run_id);
+        let decision = request.decision.clone();
+        self.resolutions.lock().expect("lock").push(request);
+        Ok(match decision {
+            AuthInteractionDecision::CredentialProvided { .. }
+            | AuthInteractionDecision::CallbackCompleted { .. } => {
+                ResolveAuthInteractionResponse::Resumed(ResumeTurnResponse {
+                    run_id,
+                    status: TurnStatus::Queued,
+                    event_cursor: EventCursor(31),
+                })
+            }
+            AuthInteractionDecision::Deny => {
+                ResolveAuthInteractionResponse::Canceled(CancelRunResponse {
+                    run_id,
+                    status: TurnStatus::Cancelled,
+                    event_cursor: EventCursor(32),
+                    already_terminal: false,
+                    actor: None,
+                })
+            }
+        })
     }
 }
 
@@ -543,6 +617,53 @@ async fn approval_resolution_payload_routes_through_approval_interaction_service
     assert_eq!(
         resolutions[0].decision,
         ApprovalInteractionDecision::ApproveOnce
+    );
+}
+
+#[tokio::test]
+async fn auth_resolution_payload_routes_through_auth_interaction_service() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let gate_ref = GateRef::new("gate:auth-product").expect("auth gate ref");
+    let run_id = TurnRunId::new();
+    let auth_service = Arc::new(RecordingAuthInteractionService::new(
+        gate_ref.clone(),
+        run_id,
+    ));
+    let workflow = DefaultProductWorkflow::new(inbound, ledger, binding)
+        .with_auth_interaction_service(auth_service.clone());
+    let envelope = sample_envelope_with_payload(
+        "auth-resolution",
+        ProductInboundPayload::AuthResolution(
+            AuthResolutionPayload::new(
+                gate_ref.as_str(),
+                AuthResolutionResult::CredentialProvided {
+                    credential_ref: "credential-account-1".to_string(),
+                },
+            )
+            .expect("auth payload"),
+        ),
+    );
+
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    assert_eq!(ack, ProductInboundAck::NoOp);
+    let resolutions = auth_service.resolutions();
+    assert_eq!(resolutions.len(), 1);
+    assert_eq!(resolutions[0].gate_ref, gate_ref);
+    assert_eq!(resolutions[0].run_id_hint, None);
+    assert!(
+        resolutions[0]
+            .idempotency_key
+            .as_str()
+            .contains("auth-resolution")
+    );
+    assert_eq!(
+        resolutions[0].decision,
+        AuthInteractionDecision::CredentialProvided {
+            credential_ref: "credential-account-1".to_string()
+        }
     );
 }
 
@@ -2638,12 +2759,8 @@ async fn unsupported_action_is_settled_as_terminal_rejection() {
         ExternalEventId::new("evt:unsupported").expect("valid"),
         ExternalActorRef::new("test", "user1", Option::<String>::None).expect("valid"),
         ExternalConversationRef::new(None, "conv1", None, None).expect("valid"),
-        ProductInboundPayload::AuthResolution(
-            ironclaw_product_adapters::AuthResolutionPayload::new(
-                "auth:1",
-                ironclaw_product_adapters::AuthResolutionResult::Denied,
-            )
-            .expect("valid"),
+        ProductInboundPayload::LinkedThreadAction(
+            LinkedThreadActionPayload::new("action:unsupported", None, None).expect("valid"),
         ),
     )
     .expect("parsed");

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -10,16 +10,19 @@ use ironclaw_product_adapters::{
     ProjectionStream, ProjectionSubscriptionRequest, ProtocolAuthFailure, RedactedString,
 };
 use ironclaw_product_workflow::{
-    ApprovalInteractionDecision, ApprovalInteractionService, LifecyclePackageKind,
-    LifecyclePackageRef, LifecyclePhase, LifecycleProductContext, LifecycleProductFacade,
-    LifecycleProductResponse, LifecycleReadinessBlocker, ListPendingApprovalsRequest,
-    ListPendingApprovalsResponse, RebornGetRunStateRequest, RebornResolveGateResponse,
-    RebornServices, RebornServicesApi, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind, RebornStreamEventsRequest, RebornSubmitTurnResponse,
-    RebornTimelineRequest, ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
-    WebUiAuthenticatedCaller, WebUiCancelRunRequest, WebUiCreateThreadRequest,
-    WebUiInboundValidationCode, WebUiListThreadsRequest, WebUiResolveGateRequest,
-    WebUiSendMessageRequest, WebUiSetupExtensionRequest, approval_gate_ref,
+    ApprovalInteractionDecision, ApprovalInteractionService, AuthInteractionDecision,
+    AuthInteractionService, LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase,
+    LifecycleProductContext, LifecycleProductFacade, LifecycleProductResponse,
+    LifecycleReadinessBlocker, ListPendingApprovalsRequest, ListPendingApprovalsResponse,
+    ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse,
+    RebornGetRunStateRequest, RebornResolveGateResponse, RebornServices, RebornServicesApi,
+    RebornServicesError, RebornServicesErrorCode, RebornServicesErrorKind,
+    RebornStreamEventsRequest, RebornSubmitTurnResponse, RebornTimelineRequest,
+    ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
+    ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, WebUiAuthenticatedCaller,
+    WebUiCancelRunRequest, WebUiCreateThreadRequest, WebUiInboundValidationCode,
+    WebUiListThreadsRequest, WebUiResolveGateRequest, WebUiSendMessageRequest,
+    WebUiSetupExtensionRequest, approval_gate_ref,
 };
 use ironclaw_threads::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageReplay,
@@ -348,6 +351,61 @@ impl ApprovalInteractionService for RecordingApprovalInteractionService {
                     run_id,
                     status: TurnStatus::Cancelled,
                     event_cursor: EventCursor(23),
+                    already_terminal: false,
+                    actor: None,
+                })
+            }
+        })
+    }
+}
+
+#[derive(Default)]
+struct RecordingAuthInteractionService {
+    resolutions: Mutex<Vec<ResolveAuthInteractionRequest>>,
+}
+
+impl RecordingAuthInteractionService {
+    fn resolution_count(&self) -> usize {
+        self.resolutions.lock().expect("lock").len()
+    }
+
+    fn last_resolution(&self) -> Option<ResolveAuthInteractionRequest> {
+        self.resolutions.lock().expect("lock").last().cloned()
+    }
+}
+
+#[async_trait]
+impl AuthInteractionService for RecordingAuthInteractionService {
+    async fn list_pending(
+        &self,
+        _request: ListPendingAuthInteractionsRequest,
+    ) -> Result<ListPendingAuthInteractionsResponse, ironclaw_product_workflow::ProductWorkflowError>
+    {
+        Ok(ListPendingAuthInteractionsResponse { auth: vec![] })
+    }
+
+    async fn resolve(
+        &self,
+        request: ResolveAuthInteractionRequest,
+    ) -> Result<ResolveAuthInteractionResponse, ironclaw_product_workflow::ProductWorkflowError>
+    {
+        let run_id = request.run_id_hint.expect("webui passes run_id");
+        let decision = request.decision.clone();
+        self.resolutions.lock().expect("lock").push(request);
+        Ok(match decision {
+            AuthInteractionDecision::CredentialProvided { .. }
+            | AuthInteractionDecision::CallbackCompleted { .. } => {
+                ResolveAuthInteractionResponse::Resumed(ResumeTurnResponse {
+                    run_id,
+                    status: TurnStatus::Queued,
+                    event_cursor: EventCursor(29),
+                })
+            }
+            AuthInteractionDecision::Deny => {
+                ResolveAuthInteractionResponse::Canceled(CancelRunResponse {
+                    run_id,
+                    status: TurnStatus::Cancelled,
+                    event_cursor: EventCursor(31),
                     already_terminal: false,
                     actor: None,
                 })
@@ -2411,6 +2469,80 @@ async fn credential_gate_resolution_returns_sanitized_stable_error_until_gate_po
     assert_eq!(coordinator.resumption_count(), 0);
     let rendered = format!("{err:?} {}", serde_json::to_string(&err).expect("json"));
     assert!(!rendered.contains("credential-alpha"));
+}
+
+#[tokio::test]
+async fn auth_gate_credential_resolution_uses_auth_interaction_service() {
+    let coordinator = Arc::new(FakeTurnCoordinator::default());
+    let auth_interactions = Arc::new(RecordingAuthInteractionService::default());
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        coordinator.clone(),
+    )
+    .with_auth_interactions(auth_interactions.clone());
+    create_thread_for(&services, caller(), "thread-alpha").await;
+
+    let response = services
+        .resolve_gate(
+            caller(),
+            serde_json::from_value::<WebUiResolveGateRequest>(json!({
+                "client_action_id": "gate-credential",
+                "thread_id": "thread-alpha",
+                "run_id": run_id_string(),
+                "gate_ref": "gate:auth-alpha",
+                "resolution": "credential_provided",
+                "credential_ref": "credential-alpha"
+            }))
+            .expect("request"),
+        )
+        .await
+        .expect("credential resolution routes through auth interaction service");
+
+    assert!(matches!(response, RebornResolveGateResponse::Resumed(_)));
+    assert_eq!(auth_interactions.resolution_count(), 1);
+    let resolution = auth_interactions.last_resolution().expect("resolution");
+    assert_eq!(resolution.gate_ref.as_str(), "gate:auth-alpha");
+    assert_eq!(
+        resolution.decision,
+        AuthInteractionDecision::CredentialProvided {
+            credential_ref: "credential-alpha".to_string()
+        }
+    );
+    assert_eq!(coordinator.resumption_count(), 0);
+}
+
+#[tokio::test]
+async fn hook_auth_gate_denial_uses_auth_interaction_service() {
+    let coordinator = Arc::new(FakeTurnCoordinator::default());
+    let auth_interactions = Arc::new(RecordingAuthInteractionService::default());
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        coordinator.clone(),
+    )
+    .with_auth_interactions(auth_interactions.clone());
+    create_thread_for(&services, caller(), "thread-alpha").await;
+
+    let response = services
+        .resolve_gate(
+            caller(),
+            serde_json::from_value::<WebUiResolveGateRequest>(json!({
+                "client_action_id": "gate-auth-deny",
+                "thread_id": "thread-alpha",
+                "run_id": run_id_string(),
+                "gate_ref": "gate:hook-auth-alpha",
+                "resolution": "denied"
+            }))
+            .expect("request"),
+        )
+        .await
+        .expect("auth denial routes through auth interaction service");
+
+    assert!(matches!(response, RebornResolveGateResponse::Cancelled(_)));
+    assert_eq!(auth_interactions.resolution_count(), 1);
+    let resolution = auth_interactions.last_resolution().expect("resolution");
+    assert_eq!(resolution.gate_ref.as_str(), "gate:hook-auth-alpha");
+    assert_eq!(resolution.decision, AuthInteractionDecision::Deny);
+    assert_eq!(coordinator.cancellation_count(), 0);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::Utc;
+use ironclaw_auth::CredentialAccountId;
 use ironclaw_host_api::{AgentId, ApprovalRequestId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_product_adapters::{
     ProductAdapterError, ProductOutboundEnvelope, ProductWorkflowRejectionKind, ProjectionCursor,
@@ -160,6 +161,7 @@ struct FakeTurnCoordinator {
     submit_error: Mutex<Option<TurnError>>,
     run_state_error: Mutex<Option<TurnError>>,
     parked_gate_ref: Mutex<Option<GateRef>>,
+    parked_auth_gate: Mutex<bool>,
 }
 
 impl FakeTurnCoordinator {
@@ -183,6 +185,12 @@ impl FakeTurnCoordinator {
     /// on the supplied gate before issuing cancellation.
     fn set_parked_gate(&self, gate_ref: GateRef) {
         *self.parked_gate_ref.lock().expect("lock") = Some(gate_ref);
+        *self.parked_auth_gate.lock().expect("lock") = false;
+    }
+
+    fn set_parked_auth_gate(&self, gate_ref: GateRef) {
+        *self.parked_gate_ref.lock().expect("lock") = Some(gate_ref);
+        *self.parked_auth_gate.lock().expect("lock") = true;
     }
 
     fn submission_count(&self) -> usize {
@@ -281,6 +289,11 @@ impl TurnCoordinator for FakeTurnCoordinator {
             return Err(error);
         }
         let gate_ref = self.parked_gate_ref.lock().expect("lock").clone();
+        let status = if *self.parked_auth_gate.lock().expect("lock") {
+            TurnStatus::BlockedAuth
+        } else {
+            TurnStatus::Queued
+        };
         let scope = request.scope.clone();
         let run_id = request.run_id;
         self.run_state_requests.lock().expect("lock").push(request);
@@ -289,7 +302,7 @@ impl TurnCoordinator for FakeTurnCoordinator {
             actor: None,
             turn_id: TurnId::new(),
             run_id,
-            status: TurnStatus::Queued,
+            status,
             accepted_message_ref: AcceptedMessageRef::new("msg:replayed").expect("valid ref"),
             source_binding_ref: SourceBindingRef::new("webui-src:replayed").expect("valid ref"),
             reply_target_binding_ref: ReplyTargetBindingRef::new("webui-reply:replayed")
@@ -2363,6 +2376,36 @@ async fn approved_gate_resolution_resumes_turn() {
 }
 
 #[tokio::test]
+async fn generic_gate_resolution_rejects_blocked_auth_run() {
+    let coordinator = Arc::new(FakeTurnCoordinator::default());
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        coordinator.clone(),
+    );
+    create_thread_for(&services, caller(), "thread-alpha").await;
+    coordinator.set_parked_auth_gate(GateRef::new("custom-auth-gate").expect("gate"));
+
+    let err = services
+        .resolve_gate(
+            caller(),
+            serde_json::from_value::<WebUiResolveGateRequest>(json!({
+                "client_action_id": "gate-auth-fallback",
+                "thread_id": "thread-alpha",
+                "run_id": run_id_string(),
+                "gate_ref": "custom-auth-gate",
+                "resolution": "approved"
+            }))
+            .expect("request"),
+        )
+        .await
+        .expect_err("generic resolver must not resume auth gate");
+
+    assert_eq!(err.code, RebornServicesErrorCode::Unavailable);
+    assert_eq!(err.kind, RebornServicesErrorKind::BlockedAuthentication);
+    assert_eq!(coordinator.resumption_count(), 0);
+}
+
+#[tokio::test]
 async fn approval_gate_resolution_uses_approval_interaction_service() {
     let coordinator = Arc::new(FakeTurnCoordinator::default());
     let approval_interactions = Arc::new(RecordingApprovalInteractionService::default());
@@ -2448,6 +2491,7 @@ async fn credential_gate_resolution_returns_sanitized_stable_error_until_gate_po
         coordinator.clone(),
     );
     create_thread_for(&services, caller(), "thread-alpha").await;
+    let credential_ref = CredentialAccountId::new();
 
     let err = services
         .resolve_gate(
@@ -2458,7 +2502,7 @@ async fn credential_gate_resolution_returns_sanitized_stable_error_until_gate_po
                 "run_id": run_id_string(),
                 "gate_ref": "gate-alpha",
                 "resolution": "credential_provided",
-                "credential_ref": "credential-alpha"
+                "credential_ref": credential_ref.to_string()
             }))
             .expect("request"),
         )
@@ -2470,7 +2514,7 @@ async fn credential_gate_resolution_returns_sanitized_stable_error_until_gate_po
     assert_eq!(err.status_code, 503);
     assert_eq!(coordinator.resumption_count(), 0);
     let rendered = format!("{err:?} {}", serde_json::to_string(&err).expect("json"));
-    assert!(!rendered.contains("credential-alpha"));
+    assert!(!rendered.contains(credential_ref.to_string().as_str()));
 }
 
 #[tokio::test]
@@ -2483,6 +2527,7 @@ async fn auth_gate_credential_resolution_uses_auth_interaction_service() {
     )
     .with_auth_interactions(auth_interactions.clone());
     create_thread_for(&services, caller(), "thread-alpha").await;
+    let credential_ref = CredentialAccountId::new();
 
     let response = services
         .resolve_gate(
@@ -2493,7 +2538,7 @@ async fn auth_gate_credential_resolution_uses_auth_interaction_service() {
                 "run_id": run_id_string(),
                 "gate_ref": "gate:auth-alpha",
                 "resolution": "credential_provided",
-                "credential_ref": "credential-alpha"
+                "credential_ref": credential_ref.to_string()
             }))
             .expect("request"),
         )
@@ -2506,9 +2551,7 @@ async fn auth_gate_credential_resolution_uses_auth_interaction_service() {
     assert_eq!(resolution.gate_ref.as_str(), "gate:auth-alpha");
     assert_eq!(
         resolution.decision,
-        AuthInteractionDecision::CredentialProvided {
-            credential_ref: "credential-alpha".to_string()
-        }
+        AuthInteractionDecision::CredentialProvided { credential_ref }
     );
     assert_eq!(coordinator.resumption_count(), 0);
 }

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -381,7 +381,9 @@ impl AuthInteractionService for RecordingAuthInteractionService {
         _request: ListPendingAuthInteractionsRequest,
     ) -> Result<ListPendingAuthInteractionsResponse, ironclaw_product_workflow::ProductWorkflowError>
     {
-        Ok(ListPendingAuthInteractionsResponse { auth: vec![] })
+        Ok(ListPendingAuthInteractionsResponse {
+            auth_interactions: vec![],
+        })
     }
 
     async fn resolve(

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -850,6 +850,14 @@ mod tests {
             unreachable!("constructor tests do not call auth-flow methods")
         }
 
+        async fn complete_credential_selection(
+            &self,
+            _scope: &AuthProductScope,
+            _input: ironclaw_auth::CredentialSelectionInput,
+        ) -> Result<AuthFlowRecord, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
         async fn fail_oauth_callback(
             &self,
             _scope: &AuthProductScope,

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -40,6 +40,10 @@ impl RebornAuthContinuationDispatcher for NoopAuthContinuationDispatcher {
     }
 }
 
+pub(crate) trait RebornAuthFlowRecordSource: Send + Sync {
+    fn flow_records_snapshot(&self) -> Vec<AuthFlowRecord>;
+}
+
 #[async_trait]
 impl RebornAuthContinuationDispatcher for ProductAuthTurnGateResumeDispatcher {
     async fn dispatch_auth_continuation(
@@ -333,6 +337,7 @@ pub struct RebornProductAuthServices {
     provider_client: Arc<dyn AuthProviderClient>,
     cleanup_service: Arc<dyn SecretCleanupService>,
     continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
+    flow_record_source: Option<Arc<dyn RebornAuthFlowRecordSource>>,
 }
 
 impl std::fmt::Debug for RebornProductAuthServices {
@@ -355,6 +360,7 @@ impl std::fmt::Debug for RebornProductAuthServices {
                 "continuation_dispatcher",
                 &"Arc<dyn RebornAuthContinuationDispatcher>",
             )
+            .field("flow_record_source", &self.flow_record_source.is_some())
             .finish()
     }
 }
@@ -377,6 +383,7 @@ impl RebornProductAuthServices {
             provider_client,
             cleanup_service,
             continuation_dispatcher,
+            flow_record_source: None,
         }
     }
 
@@ -435,6 +442,10 @@ impl RebornProductAuthServices {
         self.flow_manager.clone()
     }
 
+    pub(crate) fn flow_record_source(&self) -> Option<Arc<dyn RebornAuthFlowRecordSource>> {
+        self.flow_record_source.clone()
+    }
+
     pub fn interaction_service(&self) -> Arc<dyn AuthInteractionService> {
         self.interaction_service.clone()
     }
@@ -465,6 +476,14 @@ impl RebornProductAuthServices {
         dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
     ) -> Self {
         self.continuation_dispatcher = dispatcher;
+        self
+    }
+
+    pub(crate) fn with_flow_record_source(
+        mut self,
+        source: Arc<dyn RebornAuthFlowRecordSource>,
+    ) -> Self {
+        self.flow_record_source = Some(source);
         self
     }
 
@@ -579,6 +598,7 @@ impl RebornProductAuthServices {
         })
     }
 
+    #[expect(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
     pub(crate) async fn ensure_oauth_callback_flow_known(
         &self,
         scope: &AuthProductScope,
@@ -598,6 +618,7 @@ impl RebornProductAuthServices {
         Ok(())
     }
 
+    #[expect(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
     pub(crate) async fn start_setup_oauth_flow(
         &self,
         request: RebornOAuthStartFlowRequest,
@@ -682,8 +703,26 @@ impl RebornProductAuthServices {
     pub(crate) fn local_dev_in_memory(
         continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
     ) -> Self {
-        RebornProductAuthServicePorts::from_shared(Arc::new(InMemoryAuthProductServices::new()))
+        let services = Arc::new(InMemoryAuthProductServices::new());
+        RebornProductAuthServicePorts::from_shared(services.clone())
             .into_services(continuation_dispatcher)
+            .with_flow_record_source(Arc::new(InMemoryAuthFlowRecordSource::new(services)))
+    }
+}
+
+struct InMemoryAuthFlowRecordSource {
+    services: Arc<InMemoryAuthProductServices>,
+}
+
+impl InMemoryAuthFlowRecordSource {
+    fn new(services: Arc<InMemoryAuthProductServices>) -> Self {
+        Self { services }
+    }
+}
+
+impl RebornAuthFlowRecordSource for InMemoryAuthFlowRecordSource {
+    fn flow_records_snapshot(&self) -> Vec<AuthFlowRecord> {
+        self.services.flow_records_snapshot()
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -598,7 +598,7 @@ impl RebornProductAuthServices {
         })
     }
 
-    #[expect(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
+    #[allow(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
     pub(crate) async fn ensure_oauth_callback_flow_known(
         &self,
         scope: &AuthProductScope,
@@ -618,7 +618,7 @@ impl RebornProductAuthServices {
         Ok(())
     }
 
-    #[expect(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
+    #[allow(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
     pub(crate) async fn start_setup_oauth_flow(
         &self,
         request: RebornOAuthStartFlowRequest,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -48,7 +48,8 @@ use ironclaw_loop_support::{
 use ironclaw_product_adapters::ProjectionStream;
 use ironclaw_product_workflow::{
     ApprovalBlockedTurnRun, ApprovalInteractionScope, ApprovalInteractionService,
-    ApprovalResolverPort, ApprovalTurnRunLocator, DefaultApprovalInteractionService,
+    ApprovalResolverPort, ApprovalTurnRunLocator, AuthInteractionService,
+    DefaultApprovalInteractionService, DefaultAuthInteractionService,
     RunStateApprovalInteractionReadModel,
 };
 use ironclaw_reborn::loop_exit_applier::ThreadCheckpointLoopExitEvidencePort;
@@ -87,6 +88,7 @@ use crate::runtime_input::{PollSettings, RebornRuntimeIdentity, RebornRuntimeInp
 use crate::{RebornBuildError, RebornCompositionProfile, RebornServices, build_reborn_services};
 
 mod approval;
+mod auth_interaction;
 #[cfg(test)]
 #[path = "runtime/tests/default_system_prompt.rs"]
 mod default_system_prompt_tests;
@@ -192,6 +194,7 @@ pub struct RebornRuntime {
     reply_target_binding_ref: ReplyTargetBindingRef,
     projection_services: RebornProjectionServices,
     approval_interaction_service: Arc<dyn ApprovalInteractionService>,
+    auth_interaction_service: Arc<dyn AuthInteractionService>,
     #[cfg(test)]
     approval_audit_sink: Arc<InMemoryAuditSink>,
     webui_event_log: Arc<dyn DurableEventLog>,
@@ -367,6 +370,10 @@ impl RebornRuntime {
 
     pub(crate) fn webui_approval_interaction_service(&self) -> Arc<dyn ApprovalInteractionService> {
         self.approval_interaction_service.clone()
+    }
+
+    pub(crate) fn webui_auth_interaction_service(&self) -> Arc<dyn AuthInteractionService> {
+        self.auth_interaction_service.clone()
     }
 
     #[cfg(test)]
@@ -1081,6 +1088,23 @@ pub async fn build_reborn_runtime(
             approval_resolver,
             Arc::clone(&planned_turn_coordinator),
         ));
+    let auth_interaction_service: Arc<dyn AuthInteractionService> =
+        if let Some(product_auth) = services.product_auth.as_ref() {
+            if let Some(flow_records) = product_auth.flow_record_source() {
+                Arc::new(DefaultAuthInteractionService::new(
+                    Arc::new(auth_interaction::LocalDevAuthInteractionReadModel::new(
+                        Arc::clone(&turn_state_store),
+                        flow_records,
+                    )),
+                    product_auth.flow_manager(),
+                    Arc::clone(&planned_turn_coordinator),
+                ))
+            } else {
+                Arc::new(auth_interaction::UnavailableAuthInteractionService)
+            }
+        } else {
+            Arc::new(auth_interaction::UnavailableAuthInteractionService)
+        };
     let turn_event_source: Arc<dyn TurnEventProjectionSource> = turn_state_store.clone();
     let projection_services = projection_services
         .with_turn_events(turn_event_source, Arc::clone(&planned_turn_coordinator))
@@ -1109,6 +1133,7 @@ pub async fn build_reborn_runtime(
         reply_target_binding_ref: validated_identity.reply_target_binding_ref,
         projection_services,
         approval_interaction_service,
+        auth_interaction_service,
         #[cfg(test)]
         approval_audit_sink,
         webui_event_log: event_log,
@@ -3072,6 +3097,72 @@ mod tests {
 
         assert_eq!(err.code, RebornServicesErrorCode::NotFound);
         assert_eq!(err.kind, RebornServicesErrorKind::NotFound);
+        assert_eq!(err.status_code, 404);
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn local_dev_webui_bundle_routes_auth_gates_into_interaction_service() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let gateway = Arc::new(RecordingGateway {
+            reply: "unused".to_string(),
+            requests: Arc::new(StdMutex::new(Vec::new())),
+        });
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev("runtime-webui-auth-owner", root.path().join("local-dev"))
+                .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-webui-auth-tenant".to_string(),
+            agent_id: "runtime-webui-auth-agent".to_string(),
+            source_binding_id: "runtime-webui-auth-source".to_string(),
+            reply_target_binding_id: "runtime-webui-auth-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: Duration::from_millis(10),
+            max_total: Duration::from_secs(3),
+        })
+        .with_model_gateway_override(gateway);
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let bundle = build_webui_services(&runtime, None).expect("webui bundle");
+        let caller = WebUiAuthenticatedCaller::new(
+            TenantId::new("runtime-webui-auth-tenant").unwrap(),
+            UserId::new("runtime-webui-auth-owner").unwrap(),
+            Some(AgentId::new("runtime-webui-auth-agent").unwrap()),
+            None,
+        );
+        let created = bundle
+            .api
+            .create_thread(
+                caller.clone(),
+                WebUiCreateThreadRequest {
+                    client_action_id: Some("create-webui-auth-thread".to_string()),
+                    requested_thread_id: None,
+                },
+            )
+            .await
+            .expect("create thread");
+
+        let err = bundle
+            .api
+            .resolve_gate(
+                caller,
+                WebUiResolveGateRequest {
+                    client_action_id: Some("resolve-webui-auth-gate".to_string()),
+                    thread_id: Some(created.thread.thread_id.to_string()),
+                    run_id: Some(TurnRunId::new().to_string()),
+                    gate_ref: Some("gate:hook-auth-missing".to_string()),
+                    resolution: Some("denied".to_string()),
+                    always: None,
+                    credential_ref: None,
+                },
+            )
+            .await
+            .expect_err("missing auth gate should reach auth interaction service");
+
+        assert_eq!(err.code, RebornServicesErrorCode::NotFound);
+        assert_eq!(err.kind, RebornServicesErrorKind::BlockedAuthentication);
         assert_eq!(err.status_code, 404);
         runtime.shutdown().await.expect("runtime shutdown");
     }

--- a/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
@@ -1,0 +1,248 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_auth::{AuthContinuationRef, AuthFlowRecord};
+use ironclaw_product_workflow::{
+    AuthGateRecord, AuthInteractionReadModel, AuthInteractionRejectionKind, AuthInteractionScope,
+    AuthInteractionService, ListPendingAuthInteractionsRequest,
+    ListPendingAuthInteractionsResponse, ProductWorkflowError, ResolveAuthInteractionRequest,
+    ResolveAuthInteractionResponse,
+};
+use ironclaw_turns::{
+    GateRef, TurnActor, TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnScope, TurnStatus,
+};
+
+use crate::auth::RebornAuthFlowRecordSource;
+use crate::factory::LocalDevTurnStateStore;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BlockedAuthRun {
+    run_id: TurnRunId,
+    gate_ref: GateRef,
+}
+
+pub(super) struct LocalDevAuthInteractionReadModel {
+    turn_state: Arc<LocalDevTurnStateStore>,
+    flow_records: Arc<dyn RebornAuthFlowRecordSource>,
+}
+
+pub(super) struct UnavailableAuthInteractionService;
+
+#[async_trait]
+impl AuthInteractionService for UnavailableAuthInteractionService {
+    async fn list_pending(
+        &self,
+        _request: ListPendingAuthInteractionsRequest,
+    ) -> Result<ListPendingAuthInteractionsResponse, ProductWorkflowError> {
+        Err(auth_read_model_unavailable())
+    }
+
+    async fn resolve(
+        &self,
+        _request: ResolveAuthInteractionRequest,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        Err(auth_read_model_unavailable())
+    }
+}
+
+impl LocalDevAuthInteractionReadModel {
+    pub(super) fn new(
+        turn_state: Arc<LocalDevTurnStateStore>,
+        flow_records: Arc<dyn RebornAuthFlowRecordSource>,
+    ) -> Self {
+        Self {
+            turn_state,
+            flow_records,
+        }
+    }
+
+    async fn snapshot(&self) -> Result<TurnPersistenceSnapshot, ProductWorkflowError> {
+        #[cfg(feature = "libsql")]
+        {
+            self.turn_state
+                .persistence_snapshot()
+                .await
+                .map_err(|_| auth_read_model_unavailable())
+        }
+        #[cfg(not(feature = "libsql"))]
+        {
+            Ok(self.turn_state.persistence_snapshot())
+        }
+    }
+
+    async fn blocked_auth_runs(
+        &self,
+        scope: &AuthInteractionScope,
+    ) -> Result<Vec<BlockedAuthRun>, ProductWorkflowError> {
+        let turn_scope = turn_scope_for_interaction(scope);
+        let actor = TurnActor::new(scope.user_id.clone());
+        let snapshot = self.snapshot().await?;
+        let mut runs = snapshot
+            .runs
+            .iter()
+            .filter(|run| {
+                run.scope == turn_scope
+                    && run.status == TurnStatus::BlockedAuth
+                    && run.gate_ref.is_some()
+                    && snapshot_run_actor_matches(&snapshot, run, &actor)
+            })
+            .filter_map(|run| {
+                run.gate_ref.clone().map(|gate_ref| BlockedAuthRun {
+                    run_id: run.run_id,
+                    gate_ref,
+                })
+            })
+            .collect::<Vec<_>>();
+        runs.sort_by_key(|run| run.run_id.as_uuid());
+        Ok(runs)
+    }
+
+    async fn auth_run_for_gate(
+        &self,
+        scope: &AuthInteractionScope,
+        gate_ref: &GateRef,
+    ) -> Result<Option<TurnRunId>, ProductWorkflowError> {
+        let turn_scope = turn_scope_for_interaction(scope);
+        let actor = TurnActor::new(scope.user_id.clone());
+        let snapshot = self.snapshot().await?;
+        let active = snapshot
+            .runs
+            .iter()
+            .find(|run| {
+                run.scope == turn_scope
+                    && run.status == TurnStatus::BlockedAuth
+                    && run.gate_ref.as_ref() == Some(gate_ref)
+                    && snapshot_run_actor_matches(&snapshot, run, &actor)
+            })
+            .map(|run| run.run_id);
+        if active.is_some() {
+            return Ok(active);
+        }
+
+        let mut historical = snapshot
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| {
+                checkpoint.status == TurnStatus::BlockedAuth
+                    && &checkpoint.gate_ref == gate_ref
+                    && checkpoint
+                        .scope
+                        .as_ref()
+                        .is_none_or(|stored| stored == &turn_scope)
+            })
+            .filter_map(|checkpoint| {
+                snapshot
+                    .runs
+                    .iter()
+                    .find(|run| {
+                        run.run_id == checkpoint.run_id
+                            && run.scope == turn_scope
+                            && snapshot_run_actor_matches(&snapshot, run, &actor)
+                    })
+                    .map(|run| run.run_id)
+            })
+            .collect::<Vec<_>>();
+        historical.sort_by_key(|run_id| run_id.as_uuid());
+        historical.dedup();
+        Ok(historical.into_iter().next())
+    }
+
+    fn flow_for_gate(
+        &self,
+        scope: &AuthInteractionScope,
+        run_id: TurnRunId,
+        gate_ref: &GateRef,
+    ) -> Option<AuthFlowRecord> {
+        self.flow_records
+            .flow_records_snapshot()
+            .into_iter()
+            .find(|flow| same_auth_owner(flow, scope) && flow_matches_gate(flow, run_id, gate_ref))
+    }
+}
+
+#[async_trait]
+impl AuthInteractionReadModel for LocalDevAuthInteractionReadModel {
+    async fn auth_gates(
+        &self,
+        scope: &AuthInteractionScope,
+    ) -> Result<Vec<AuthGateRecord>, ProductWorkflowError> {
+        let mut gates = Vec::new();
+        for run in self.blocked_auth_runs(scope).await? {
+            if let Some(flow) = self.flow_for_gate(scope, run.run_id, &run.gate_ref) {
+                gates.push(AuthGateRecord::new(run.run_id, run.gate_ref, flow)?);
+            }
+        }
+        Ok(gates)
+    }
+
+    async fn auth_gate(
+        &self,
+        scope: &AuthInteractionScope,
+        run_id_hint: Option<TurnRunId>,
+        gate_ref: &GateRef,
+    ) -> Result<Option<AuthGateRecord>, ProductWorkflowError> {
+        let run_id = match run_id_hint {
+            Some(run_id) => run_id,
+            None => {
+                let Some(run_id) = self.auth_run_for_gate(scope, gate_ref).await? else {
+                    return Ok(None);
+                };
+                run_id
+            }
+        };
+        let Some(flow) = self.flow_for_gate(scope, run_id, gate_ref) else {
+            return Ok(None);
+        };
+        Ok(Some(AuthGateRecord::new(run_id, gate_ref.clone(), flow)?))
+    }
+}
+
+fn turn_scope_for_interaction(scope: &AuthInteractionScope) -> TurnScope {
+    TurnScope::new(
+        scope.tenant_id.clone(),
+        scope.agent_id.clone(),
+        scope.project_id.clone(),
+        scope.thread_id.clone(),
+    )
+}
+
+fn same_auth_owner(flow: &AuthFlowRecord, scope: &AuthInteractionScope) -> bool {
+    let resource = &flow.scope.resource;
+    // Surface/session/invocation are not authority for this UI bridge; the
+    // caller must own the tenant/user/agent/project/thread that is blocked.
+    resource.tenant_id == scope.tenant_id
+        && resource.user_id == scope.user_id
+        && resource.agent_id == scope.agent_id
+        && resource.project_id == scope.project_id
+        && resource.mission_id.is_none()
+        && resource.thread_id.as_ref() == Some(&scope.thread_id)
+}
+
+fn flow_matches_gate(flow: &AuthFlowRecord, run_id: TurnRunId, gate_ref: &GateRef) -> bool {
+    let AuthContinuationRef::TurnGateResume {
+        turn_run_ref,
+        gate_ref: continuation_gate_ref,
+    } = &flow.continuation
+    else {
+        return false;
+    };
+    turn_run_ref.as_str() == run_id.to_string()
+        && continuation_gate_ref.as_str() == gate_ref.as_str()
+}
+
+fn snapshot_run_actor_matches(
+    snapshot: &TurnPersistenceSnapshot,
+    run: &TurnRunRecord,
+    actor: &TurnActor,
+) -> bool {
+    snapshot
+        .turns
+        .iter()
+        .any(|turn| turn.turn_id == run.turn_id && turn.scope == run.scope && turn.actor == *actor)
+}
+
+fn auth_read_model_unavailable() -> ProductWorkflowError {
+    ProductWorkflowError::AuthInteractionRejected {
+        kind: AuthInteractionRejectionKind::FlowUnavailable,
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -53,7 +53,8 @@ pub fn build_webui_services(
         runtime.webui_thread_service(),
         runtime.webui_turn_coordinator(),
     )
-    .with_approval_interactions(runtime.webui_approval_interaction_service());
+    .with_approval_interactions(runtime.webui_approval_interaction_service())
+    .with_auth_interactions(runtime.webui_auth_interaction_service());
     if let Some(skill_activation_source) = runtime.webui_skill_activation_source() {
         let activation_recorder = Arc::clone(&skill_activation_source);
         let activation_clearer = skill_activation_source;

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -84,6 +84,9 @@ adapter/UI-safe DTOs, and routes credential/callback/cancel decisions back
 through `AuthFlowManager` and `TurnCoordinator` with the `BlockedAuthGate`
 precondition. It consumes the auth-flow boundary here for auth gates; it must
 not create a second credential-account or OAuth-flow model.
+Only non-terminal auth-flow states are listed as pending interactions. Terminal
+states such as `failed`, `completed`, `expired`, and `canceled` must not be
+rendered as actionable auth gates.
 
 Legacy web/CLI/channel auth UX may remain behavior-compatible during
 migration, but Reborn paths should enter through `ProductWorkflow` or the

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -77,11 +77,20 @@ continuation dispatch. Setup-only, lifecycle-activation, and product-action
 continuations remain explicit non-turn cases for their owning handlers and must
 not be performed inline by the OAuth callback route.
 
-The blocked-run interaction loop is separate: #3094 owns listing/rendering
-approval/auth gates from blocked run-state and routing user decisions back into
-the trusted resume path. That issue should consume the auth-flow boundary here
-for auth gates; it must not create a second credential-account or OAuth-flow
-model.
+`ironclaw_product_workflow::AuthInteractionService` owns the product/WebUI
+blocked-auth interaction loop from #3094. It reads auth-required gates from
+scoped blocked run-state plus auth-flow records, returns redacted
+adapter/UI-safe DTOs, and routes credential/callback/cancel decisions back
+through `AuthFlowManager` and `TurnCoordinator` with the `BlockedAuthGate`
+precondition. It consumes the auth-flow boundary here for auth gates; it must
+not create a second credential-account or OAuth-flow model.
+
+Legacy web/CLI/channel auth UX may remain behavior-compatible during
+migration, but Reborn paths should enter through `ProductWorkflow` or the
+WebUI-facing `RebornServicesApi` facade. They must not call V1 pending maps,
+V1 OAuth routes, extension-manager authority, or route-local credential state.
+Dedicated HTTP route mounting for manual-token and OAuth callback transports
+remains a host-composition concern around `RebornProductAuthServices`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Added `ironclaw_product_workflow::AuthInteractionService` and a default implementation for listing redacted pending auth gates and resolving credential/callback/deny decisions.
- Routed `ProductInboundPayload::AuthResolution` and WebUI auth gate/credential resolution through the product/WebUI auth interaction boundary.
- Wired local-dev Reborn composition to a runtime-owned auth interaction service backed by blocked run-state plus auth-flow records.
- Documented the #3094 auth interaction boundary and the rule that Reborn paths must not use v1 routes, pending maps, or route-local credential state.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Closes #3094

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_auth --locked`, `cargo test -p ironclaw_product_workflow --locked`, `cargo test -p ironclaw_reborn_composition local_dev_webui_bundle_routes_auth_gates_into_interaction_service --locked`, `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold --locked`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: Not applicable; contract/service behavior covered by tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo clippy -p ironclaw_auth -p ironclaw_product_workflow -p ironclaw_reborn_composition --all-targets -- -D warnings`
- `git diff --check`

## Security Impact

Yes. This touches auth-required gate interaction boundaries. It improves the Reborn/Product/WebUI path by resolving auth gates through typed auth-flow manager and turn coordinator ports with scoped caller validation, redacted DTOs, and `BlockedAuthGate` resume preconditions. It does not add new network listeners, HTTP route mounting, secret storage, outbound network calls, file access, tool execution, or sandbox policy changes.

## Database Impact

None. This PR adds service boundaries, local-dev in-memory read-model wiring, and tests only; no migrations or schema changes.

## Blast Radius

Limited to `ironclaw_auth` fake snapshots, `ironclaw_product_workflow` auth interaction/ProductWorkflow/WebUI facade routing, and `ironclaw_reborn_composition` local-dev wiring. Existing approval and non-auth gate behavior should remain unchanged.

## Rollback Plan

Revert this PR to restore `AuthResolution` as unsupported and return WebUI credential/auth gate resolution to the previous unavailable path.

## Review Follow-Through

Reviewer judgment requested on whether the auth interaction DTO shape is the right stable WebUI/product surface for #3094. This PR intentionally does not mount new manual-token or OAuth HTTP routes; route mounting remains a host-composition concern around `RebornProductAuthServices`.

---

**Review track**: C