### PR TITLE
Expose active Reborn extensions to local agent surface

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -7,7 +7,10 @@ use ironclaw_extensions::{
     ManifestHash, ManifestSource, SharedExtensionRegistry,
 };
 use ironclaw_filesystem::RootFilesystem;
-use ironclaw_host_api::{CapabilityDescriptor, ExtensionId, VirtualPath, sha256_digest_token};
+use ironclaw_host_api::{
+    CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, RuntimeCredentialRequirement,
+    VirtualPath, sha256_digest_token,
+};
 use ironclaw_product_workflow::{
     LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase, LifecycleProductPayload,
     LifecycleProductResponse, ProductWorkflowError,
@@ -34,6 +37,25 @@ pub(crate) struct RebornLocalExtensionManagementPort {
     lifecycle_service: Arc<Mutex<ExtensionLifecycleService>>,
     active_registry: Arc<SharedExtensionRegistry>,
     operation_lock: Arc<Mutex<()>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ActiveExtensionCapability {
+    pub(crate) id: CapabilityId,
+    pub(crate) provider: ExtensionId,
+    pub(crate) effects: Vec<EffectKind>,
+    pub(crate) runtime_credentials: Vec<RuntimeCredentialRequirement>,
+}
+
+impl ActiveExtensionCapability {
+    fn from_descriptor(descriptor: &CapabilityDescriptor) -> Self {
+        Self {
+            id: descriptor.id.clone(),
+            provider: descriptor.provider.clone(),
+            effects: descriptor.effects.clone(),
+            runtime_credentials: descriptor.runtime_credentials.clone(),
+        }
+    }
 }
 
 pub(crate) async fn restore_extension_lifecycle_state(
@@ -120,7 +142,7 @@ impl RebornLocalExtensionManagementPort {
         ))
     }
 
-    pub(crate) fn active_model_visible_capabilities(&self) -> Vec<CapabilityDescriptor> {
+    pub(crate) fn active_model_visible_capabilities(&self) -> Vec<ActiveExtensionCapability> {
         let registry = self.active_registry.snapshot();
         registry
             .capabilities()
@@ -130,7 +152,7 @@ impl RebornLocalExtensionManagementPort {
                     .unwrap_or(CapabilityVisibility::Model)
                     == CapabilityVisibility::Model
             })
-            .cloned()
+            .map(ActiveExtensionCapability::from_descriptor)
             .collect()
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use ironclaw_extensions::{
     CapabilityVisibility, ExtensionActivationState, ExtensionError, ExtensionInstallation,
@@ -142,10 +142,21 @@ impl RebornLocalExtensionManagementPort {
         ))
     }
 
-    pub(crate) fn active_model_visible_capabilities(&self) -> Vec<ActiveExtensionCapability> {
+    pub(crate) async fn active_model_visible_capabilities(
+        &self,
+    ) -> Result<Vec<ActiveExtensionCapability>, ProductWorkflowError> {
+        let enabled_extension_ids = self
+            .installation_store
+            .list_enabled_installations()
+            .await
+            .map_err(map_extension_installation_error)?
+            .into_iter()
+            .map(|installation| installation.extension_id().clone())
+            .collect::<BTreeSet<_>>();
         let registry = self.active_registry.snapshot();
-        registry
+        Ok(registry
             .capabilities()
+            .filter(|descriptor| enabled_extension_ids.contains(&descriptor.provider))
             .filter(|descriptor| {
                 registry
                     .capability_visibility(&descriptor.id)
@@ -153,7 +164,7 @@ impl RebornLocalExtensionManagementPort {
                     == CapabilityVisibility::Model
             })
             .map(ActiveExtensionCapability::from_descriptor)
-            .collect()
+            .collect())
     }
 
     pub(crate) async fn install(
@@ -701,9 +712,10 @@ mod tests {
     };
     use ironclaw_filesystem::LocalFilesystem;
     use ironclaw_host_api::{
-        ExtensionLifecycleOperation, HostPath, HostPortCatalog, MountAlias, MountGrant,
-        MountPermissions, MountView, TenantId, UserId,
+        CapabilityId, ExtensionLifecycleOperation, HostPath, HostPortCatalog, MountAlias,
+        MountGrant, MountPermissions, MountView, TenantId, UserId,
     };
+    use ironclaw_host_runtime::{SPAWN_SUBAGENT_CAPABILITY_ID, builtin_first_party_package};
     use ironclaw_product_workflow::{
         LifecycleProductAction, LifecycleProductContext, LifecycleProductFacade,
         LifecycleProductSurfaceContext, LifecycleReadinessBlocker,
@@ -815,6 +827,40 @@ mod tests {
             !storage_root
                 .join("system/extensions/fixture/wasm/fixture.wasm")
                 .exists()
+        );
+    }
+
+    #[tokio::test]
+    async fn active_model_visible_capabilities_only_include_enabled_lifecycle_extensions() {
+        let (_dir, _storage_root, port, active_registry, _installation_store) =
+            extension_management_port_fixture_with_catalog_and_service(
+                AvailableExtensionCatalog::from_packages(vec![fixture_extension_package()]),
+                ExtensionLifecycleService::new(ExtensionRegistry::new()),
+            );
+        active_registry
+            .upsert(builtin_first_party_package().expect("builtin package"))
+            .expect("seed builtin package");
+        let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture")
+            .expect("valid ref");
+        port.install(package_ref.clone())
+            .await
+            .expect("install fixture extension");
+        port.activate(package_ref)
+            .await
+            .expect("activate fixture extension");
+
+        let capability_ids = port
+            .active_model_visible_capabilities()
+            .await
+            .expect("active capabilities")
+            .into_iter()
+            .map(|capability| capability.id)
+            .collect::<Vec<_>>();
+
+        assert!(capability_ids.contains(&CapabilityId::new("fixture.search").unwrap()));
+        assert!(!capability_ids.contains(&CapabilityId::new("fixture.write").unwrap()));
+        assert!(
+            !capability_ids.contains(&CapabilityId::new(SPAWN_SUBAGENT_CAPABILITY_ID).unwrap())
         );
     }
 
@@ -1226,6 +1272,53 @@ mod tests {
             AvailableExtensionCatalog::from_first_party_assets()
                 .expect("first-party GitHub catalog"),
             ExtensionLifecycleService::new(ExtensionRegistry::new()),
+        )
+    }
+
+    fn extension_management_port_fixture_with_catalog_and_service(
+        catalog: AvailableExtensionCatalog,
+        lifecycle_service: ExtensionLifecycleService,
+    ) -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        Arc<RebornLocalExtensionManagementPort>,
+        Arc<SharedExtensionRegistry>,
+        Arc<InMemoryExtensionInstallationStore>,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_root = dir.path().join("local-dev");
+        std::fs::create_dir_all(storage_root.join("system/extensions")).expect("storage root");
+
+        let mut filesystem = LocalFilesystem::new();
+        filesystem
+            .mount_local(
+                VirtualPath::new("/projects").expect("valid virtual path"),
+                HostPath::from_path_buf(storage_root.clone()),
+            )
+            .expect("mount storage root");
+        filesystem
+            .mount_local(
+                VirtualPath::new("/system/extensions").expect("valid virtual path"),
+                HostPath::from_path_buf(storage_root.join("system/extensions")),
+            )
+            .expect("mount system extensions");
+        let filesystem = Arc::new(filesystem);
+        let root_filesystem: Arc<dyn RootFilesystem> = filesystem.clone();
+        let active_registry = Arc::new(SharedExtensionRegistry::new(ExtensionRegistry::new()));
+        let installation_store = Arc::new(InMemoryExtensionInstallationStore::default());
+        let extension_management = Arc::new(RebornLocalExtensionManagementPort::new(
+            root_filesystem,
+            catalog,
+            installation_store.clone(),
+            Arc::new(Mutex::new(lifecycle_service)),
+            Arc::clone(&active_registry),
+        ));
+        (
+            dir,
+            storage_root,
+            extension_management,
+            active_registry,
+            installation_store,
         )
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use ironclaw_extensions::{
-    ExtensionActivationState, ExtensionError, ExtensionInstallation, ExtensionInstallationError,
-    ExtensionInstallationId, ExtensionInstallationStore, ExtensionLifecycleService,
-    ExtensionManifestRecord, ExtensionManifestRef, ExtensionPackage, ManifestHash, ManifestSource,
-    SharedExtensionRegistry,
+    CapabilityVisibility, ExtensionActivationState, ExtensionError, ExtensionInstallation,
+    ExtensionInstallationError, ExtensionInstallationId, ExtensionInstallationStore,
+    ExtensionLifecycleService, ExtensionManifestRecord, ExtensionManifestRef, ExtensionPackage,
+    ManifestHash, ManifestSource, SharedExtensionRegistry,
 };
 use ironclaw_filesystem::RootFilesystem;
-use ironclaw_host_api::{ExtensionId, VirtualPath, sha256_digest_token};
+use ironclaw_host_api::{CapabilityDescriptor, ExtensionId, VirtualPath, sha256_digest_token};
 use ironclaw_product_workflow::{
     LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase, LifecycleProductPayload,
     LifecycleProductResponse, ProductWorkflowError,
@@ -118,6 +118,20 @@ impl RebornLocalExtensionManagementPort {
                 count,
             },
         ))
+    }
+
+    pub(crate) fn active_model_visible_capabilities(&self) -> Vec<CapabilityDescriptor> {
+        let registry = self.active_registry.snapshot();
+        registry
+            .capabilities()
+            .filter(|descriptor| {
+                registry
+                    .capability_visibility(&descriptor.id)
+                    .unwrap_or(CapabilityVisibility::Model)
+                    == CapabilityVisibility::Model
+            })
+            .cloned()
+            .collect()
     }
 
     pub(crate) async fn install(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -7,9 +7,9 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use ironclaw_host_api::{
-    CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind, ExecutionContext,
-    ExtensionId, GrantConstraints, InvocationId, MountView, NetworkPolicy, NetworkTargetPattern,
-    Principal, RuntimeKind, TrustClass, UserId,
+    CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet,
+    EffectKind, ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountView,
+    NetworkPolicy, NetworkTargetPattern, Principal, RuntimeKind, TrustClass, UserId,
 };
 use ironclaw_host_runtime::{
     APPLY_PATCH_CAPABILITY_ID, CapabilitySurfacePolicy, ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID,
@@ -63,10 +63,13 @@ pub(super) fn capability_wiring(
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
 ) -> Option<LocalDevCapabilityWiring> {
     let runtime = services.host_runtime.clone()?;
-    let workspace_mounts = services
-        .local_runtime
+    let local_runtime = services.local_runtime.as_ref()?;
+    let workspace_mounts = local_runtime.workspace_mounts.clone();
+    let active_extension_capabilities = local_runtime
+        .extension_management
         .as_ref()
-        .map(|runtime| runtime.workspace_mounts.clone())?;
+        .map(|extension_management| extension_management.active_model_visible_capabilities())
+        .unwrap_or_default();
     let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
     let capability_io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
         Arc::clone(&display_previews),
@@ -80,6 +83,7 @@ pub(super) fn capability_wiring(
             runtime,
             user_id,
             workspace_mounts,
+            active_extension_capabilities,
             Arc::clone(&capability_input_resolver),
             Arc::clone(&capability_result_writer),
             milestone_sink,
@@ -102,6 +106,7 @@ struct LocalDevLoopCapabilityPortFactory {
     runtime: Arc<dyn HostRuntime>,
     user_id: UserId,
     workspace_mounts: MountView,
+    active_extension_capabilities: Vec<CapabilityDescriptor>,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
@@ -112,6 +117,7 @@ impl LocalDevLoopCapabilityPortFactory {
         runtime: Arc<dyn HostRuntime>,
         user_id: UserId,
         workspace_mounts: MountView,
+        active_extension_capabilities: Vec<CapabilityDescriptor>,
         input_resolver: Arc<dyn LoopCapabilityInputResolver>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
         milestone_sink: Arc<dyn LoopHostMilestoneSink>,
@@ -120,6 +126,7 @@ impl LocalDevLoopCapabilityPortFactory {
             runtime,
             user_id,
             workspace_mounts,
+            active_extension_capabilities,
             input_resolver,
             result_writer,
             milestone_sink,
@@ -140,6 +147,7 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             self.user_id.clone(),
             workspace_mounts.clone(),
             skill_mounts.clone(),
+            &self.active_extension_capabilities,
         )?;
         let mut factory = HostRuntimeLoopCapabilityPortFactory::new(
             Arc::clone(&self.runtime),
@@ -684,9 +692,14 @@ fn local_dev_visible_capability_request(
     user_id: UserId,
     workspace_mounts: MountView,
     skill_mounts: MountView,
+    active_extension_capabilities: &[CapabilityDescriptor],
 ) -> Result<HostVisibleCapabilityRequest, AgentLoopHostError> {
     let extension_id = loop_driver_execution_extension_id(run_context)?;
-    let grants = local_dev_builtin_grants(&extension_id, &workspace_mounts, &skill_mounts)?;
+    let mut grants = local_dev_builtin_grants(&extension_id, &workspace_mounts, &skill_mounts)?;
+    grants.grants.extend(local_dev_extension_grants(
+        &extension_id,
+        active_extension_capabilities,
+    ));
     let mut context = ExecutionContext::local_default(
         user_id,
         extension_id,
@@ -720,6 +733,9 @@ fn local_dev_visible_capability_request(
             evaluated_at: Utc::now(),
         },
     );
+    provider_trust.extend(local_dev_extension_provider_trust(
+        active_extension_capabilities,
+    ));
 
     Ok(HostVisibleCapabilityRequest::new(
         context,
@@ -727,6 +743,87 @@ fn local_dev_visible_capability_request(
     )
     .with_policy(CapabilitySurfacePolicy::allow_all())
     .with_provider_trust(provider_trust))
+}
+
+fn local_dev_extension_grants(
+    grantee: &ExtensionId,
+    active_extension_capabilities: &[CapabilityDescriptor],
+) -> Vec<CapabilityGrant> {
+    active_extension_capabilities
+        .iter()
+        .map(|descriptor| CapabilityGrant {
+            id: CapabilityGrantId::new(),
+            capability: descriptor.id.clone(),
+            grantee: Principal::Extension(grantee.clone()),
+            issued_by: Principal::HostRuntime,
+            constraints: local_dev_extension_grant_constraints(descriptor),
+        })
+        .collect()
+}
+
+fn local_dev_extension_grant_constraints(descriptor: &CapabilityDescriptor) -> GrantConstraints {
+    GrantConstraints {
+        allowed_effects: descriptor.effects.clone(),
+        mounts: MountView::default(),
+        network: NetworkPolicy {
+            allowed_targets: descriptor.runtime_credentials.iter().fold(
+                Vec::new(),
+                |mut targets, credential| {
+                    if !targets.contains(&credential.audience) {
+                        targets.push(credential.audience.clone());
+                    }
+                    targets
+                },
+            ),
+            deny_private_ip_ranges: true,
+            max_egress_bytes: None,
+        },
+        secrets: descriptor.runtime_credentials.iter().fold(
+            Vec::new(),
+            |mut handles, credential| {
+                if !handles.contains(&credential.handle) {
+                    handles.push(credential.handle.clone());
+                }
+                handles
+            },
+        ),
+        resource_ceiling: None,
+        expires_at: None,
+        max_invocations: None,
+    }
+}
+
+fn local_dev_extension_provider_trust(
+    active_extension_capabilities: &[CapabilityDescriptor],
+) -> BTreeMap<ExtensionId, TrustDecision> {
+    let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
+    for descriptor in active_extension_capabilities {
+        let effects = effects_by_provider
+            .entry(descriptor.provider.clone())
+            .or_default();
+        for effect in &descriptor.effects {
+            if !effects.contains(effect) {
+                effects.push(*effect);
+            }
+        }
+    }
+    effects_by_provider
+        .into_iter()
+        .map(|(provider, allowed_effects)| {
+            (
+                provider,
+                TrustDecision {
+                    effective_trust: EffectiveTrustClass::user_trusted(),
+                    authority_ceiling: AuthorityCeiling {
+                        allowed_effects,
+                        max_resource_ceiling: None,
+                    },
+                    provenance: TrustProvenance::AdminConfig,
+                    evaluated_at: Utc::now(),
+                },
+            )
+        })
+        .collect()
 }
 
 fn local_dev_builtin_grants(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -7,9 +7,9 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use ironclaw_host_api::{
-    CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet,
-    EffectKind, ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountView,
-    NetworkPolicy, NetworkTargetPattern, Principal, RuntimeKind, TrustClass, UserId,
+    CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind, ExecutionContext,
+    ExtensionId, GrantConstraints, InvocationId, MountView, NetworkPolicy, NetworkTargetPattern,
+    Principal, RuntimeKind, TrustClass, UserId,
 };
 use ironclaw_host_runtime::{
     APPLY_PATCH_CAPABILITY_ID, CapabilitySurfacePolicy, ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID,
@@ -46,6 +46,10 @@ use crate::{
     projection::{CapabilityDisplayPreviewResult, CapabilityDisplayPreviewStore},
 };
 
+mod extension_surface;
+
+use extension_surface::{LocalDevExtensionSurface, LocalDevExtensionSurfaceSource};
+
 pub(super) struct LocalDevCapabilityWiring {
     pub(super) capability_factory: Arc<dyn LoopCapabilityPortFactory>,
     pub(super) capability_input_resolver: Arc<dyn LoopCapabilityInputResolver>,
@@ -65,11 +69,8 @@ pub(super) fn capability_wiring(
     let runtime = services.host_runtime.clone()?;
     let local_runtime = services.local_runtime.as_ref()?;
     let workspace_mounts = local_runtime.workspace_mounts.clone();
-    let active_extension_capabilities = local_runtime
-        .extension_management
-        .as_ref()
-        .map(|extension_management| extension_management.active_model_visible_capabilities())
-        .unwrap_or_default();
+    let extension_surface_source =
+        LocalDevExtensionSurfaceSource::new(local_runtime.extension_management.clone());
     let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
     let capability_io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
         Arc::clone(&display_previews),
@@ -83,7 +84,7 @@ pub(super) fn capability_wiring(
             runtime,
             user_id,
             workspace_mounts,
-            active_extension_capabilities,
+            extension_surface_source,
             Arc::clone(&capability_input_resolver),
             Arc::clone(&capability_result_writer),
             milestone_sink,
@@ -106,7 +107,7 @@ struct LocalDevLoopCapabilityPortFactory {
     runtime: Arc<dyn HostRuntime>,
     user_id: UserId,
     workspace_mounts: MountView,
-    active_extension_capabilities: Vec<CapabilityDescriptor>,
+    extension_surface_source: LocalDevExtensionSurfaceSource,
     input_resolver: Arc<dyn LoopCapabilityInputResolver>,
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
@@ -117,7 +118,7 @@ impl LocalDevLoopCapabilityPortFactory {
         runtime: Arc<dyn HostRuntime>,
         user_id: UserId,
         workspace_mounts: MountView,
-        active_extension_capabilities: Vec<CapabilityDescriptor>,
+        extension_surface_source: LocalDevExtensionSurfaceSource,
         input_resolver: Arc<dyn LoopCapabilityInputResolver>,
         result_writer: Arc<dyn LoopCapabilityResultWriter>,
         milestone_sink: Arc<dyn LoopHostMilestoneSink>,
@@ -126,7 +127,7 @@ impl LocalDevLoopCapabilityPortFactory {
             runtime,
             user_id,
             workspace_mounts,
-            active_extension_capabilities,
+            extension_surface_source,
             input_resolver,
             result_writer,
             milestone_sink,
@@ -142,12 +143,13 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
     ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
         let workspace_mounts = self.workspace_mounts.clone();
         let skill_mounts = skill_management_mount_view().map_err(host_api_agent_loop_error)?;
+        let extension_surface = self.extension_surface_source.snapshot();
         let visible_request = local_dev_visible_capability_request(
             run_context,
             self.user_id.clone(),
             workspace_mounts.clone(),
             skill_mounts.clone(),
-            &self.active_extension_capabilities,
+            &extension_surface,
         )?;
         let mut factory = HostRuntimeLoopCapabilityPortFactory::new(
             Arc::clone(&self.runtime),
@@ -692,14 +694,13 @@ fn local_dev_visible_capability_request(
     user_id: UserId,
     workspace_mounts: MountView,
     skill_mounts: MountView,
-    active_extension_capabilities: &[CapabilityDescriptor],
+    extension_surface: &LocalDevExtensionSurface,
 ) -> Result<HostVisibleCapabilityRequest, AgentLoopHostError> {
     let extension_id = loop_driver_execution_extension_id(run_context)?;
     let mut grants = local_dev_builtin_grants(&extension_id, &workspace_mounts, &skill_mounts)?;
-    grants.grants.extend(local_dev_extension_grants(
-        &extension_id,
-        active_extension_capabilities,
-    ));
+    grants
+        .grants
+        .extend(extension_surface.grants(&extension_id));
     let mut context = ExecutionContext::local_default(
         user_id,
         extension_id,
@@ -733,9 +734,7 @@ fn local_dev_visible_capability_request(
             evaluated_at: Utc::now(),
         },
     );
-    provider_trust.extend(local_dev_extension_provider_trust(
-        active_extension_capabilities,
-    ));
+    provider_trust.extend(extension_surface.provider_trust());
 
     Ok(HostVisibleCapabilityRequest::new(
         context,
@@ -743,87 +742,6 @@ fn local_dev_visible_capability_request(
     )
     .with_policy(CapabilitySurfacePolicy::allow_all())
     .with_provider_trust(provider_trust))
-}
-
-fn local_dev_extension_grants(
-    grantee: &ExtensionId,
-    active_extension_capabilities: &[CapabilityDescriptor],
-) -> Vec<CapabilityGrant> {
-    active_extension_capabilities
-        .iter()
-        .map(|descriptor| CapabilityGrant {
-            id: CapabilityGrantId::new(),
-            capability: descriptor.id.clone(),
-            grantee: Principal::Extension(grantee.clone()),
-            issued_by: Principal::HostRuntime,
-            constraints: local_dev_extension_grant_constraints(descriptor),
-        })
-        .collect()
-}
-
-fn local_dev_extension_grant_constraints(descriptor: &CapabilityDescriptor) -> GrantConstraints {
-    GrantConstraints {
-        allowed_effects: descriptor.effects.clone(),
-        mounts: MountView::default(),
-        network: NetworkPolicy {
-            allowed_targets: descriptor.runtime_credentials.iter().fold(
-                Vec::new(),
-                |mut targets, credential| {
-                    if !targets.contains(&credential.audience) {
-                        targets.push(credential.audience.clone());
-                    }
-                    targets
-                },
-            ),
-            deny_private_ip_ranges: true,
-            max_egress_bytes: None,
-        },
-        secrets: descriptor.runtime_credentials.iter().fold(
-            Vec::new(),
-            |mut handles, credential| {
-                if !handles.contains(&credential.handle) {
-                    handles.push(credential.handle.clone());
-                }
-                handles
-            },
-        ),
-        resource_ceiling: None,
-        expires_at: None,
-        max_invocations: None,
-    }
-}
-
-fn local_dev_extension_provider_trust(
-    active_extension_capabilities: &[CapabilityDescriptor],
-) -> BTreeMap<ExtensionId, TrustDecision> {
-    let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
-    for descriptor in active_extension_capabilities {
-        let effects = effects_by_provider
-            .entry(descriptor.provider.clone())
-            .or_default();
-        for effect in &descriptor.effects {
-            if !effects.contains(effect) {
-                effects.push(*effect);
-            }
-        }
-    }
-    effects_by_provider
-        .into_iter()
-        .map(|(provider, allowed_effects)| {
-            (
-                provider,
-                TrustDecision {
-                    effective_trust: EffectiveTrustClass::user_trusted(),
-                    authority_ceiling: AuthorityCeiling {
-                        allowed_effects,
-                        max_resource_ceiling: None,
-                    },
-                    provenance: TrustProvenance::AdminConfig,
-                    evaluated_at: Utc::now(),
-                },
-            )
-        })
-        .collect()
 }
 
 fn local_dev_builtin_grants(

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -143,7 +143,11 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
     ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
         let workspace_mounts = self.workspace_mounts.clone();
         let skill_mounts = skill_management_mount_view().map_err(host_api_agent_loop_error)?;
-        let extension_surface = self.extension_surface_source.snapshot();
+        let extension_surface = self
+            .extension_surface_source
+            .snapshot()
+            .await
+            .map_err(host_api_agent_loop_error)?;
         let visible_request = local_dev_visible_capability_request(
             run_context,
             self.user_id.clone(),

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -8,6 +8,7 @@ use ironclaw_host_api::{
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 use crate::extension_lifecycle::{ActiveExtensionCapability, RebornLocalExtensionManagementPort};
+use ironclaw_product_workflow::ProductWorkflowError;
 
 #[derive(Clone, Default)]
 pub(super) struct LocalDevExtensionSurfaceSource {
@@ -23,11 +24,11 @@ impl LocalDevExtensionSurfaceSource {
         }
     }
 
-    pub(super) fn snapshot(&self) -> LocalDevExtensionSurface {
-        self.extension_management
-            .as_deref()
-            .map(LocalDevExtensionSurface::from_extension_management)
-            .unwrap_or_default()
+    pub(super) async fn snapshot(&self) -> Result<LocalDevExtensionSurface, ProductWorkflowError> {
+        let Some(extension_management) = self.extension_management.as_deref() else {
+            return Ok(LocalDevExtensionSurface::default());
+        };
+        LocalDevExtensionSurface::from_extension_management(extension_management).await
     }
 }
 
@@ -37,12 +38,14 @@ pub(super) struct LocalDevExtensionSurface {
 }
 
 impl LocalDevExtensionSurface {
-    pub(super) fn from_extension_management(
+    pub(super) async fn from_extension_management(
         extension_management: &RebornLocalExtensionManagementPort,
-    ) -> Self {
-        Self {
-            active_capabilities: extension_management.active_model_visible_capabilities(),
-        }
+    ) -> Result<Self, ProductWorkflowError> {
+        Ok(Self {
+            active_capabilities: extension_management
+                .active_model_visible_capabilities()
+                .await?,
+        })
     }
 
     pub(super) fn grants(&self, grantee: &ExtensionId) -> Vec<CapabilityGrant> {

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -100,27 +100,27 @@ impl LocalDevExtensionSurface {
             network: NetworkPolicy {
                 // Installed extensions get only their declared credential audiences as
                 // egress targets; missing audiences intentionally fail closed.
-                allowed_targets: capability.runtime_credentials.iter().fold(
-                    Vec::new(),
-                    |mut targets, credential| {
+                allowed_targets: {
+                    let mut targets = Vec::new();
+                    for credential in &capability.runtime_credentials {
                         if !targets.contains(&credential.audience) {
                             targets.push(credential.audience.clone());
                         }
-                        targets
-                    },
-                ),
+                    }
+                    targets
+                },
                 deny_private_ip_ranges: true,
                 max_egress_bytes: None,
             },
-            secrets: capability.runtime_credentials.iter().fold(
-                Vec::new(),
-                |mut handles, credential| {
+            secrets: {
+                let mut handles = Vec::new();
+                for credential in &capability.runtime_credentials {
                     if !handles.contains(&credential.handle) {
                         handles.push(credential.handle.clone());
                     }
-                    handles
-                },
-            ),
+                }
+                handles
+            },
             resource_ceiling: None,
             expires_at: None,
             max_invocations: None,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/extension_surface.rs
@@ -1,0 +1,126 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use chrono::Utc;
+use ironclaw_host_api::{
+    CapabilityGrant, CapabilityGrantId, EffectKind, ExtensionId, GrantConstraints, MountView,
+    NetworkPolicy, Principal,
+};
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+
+use crate::extension_lifecycle::{ActiveExtensionCapability, RebornLocalExtensionManagementPort};
+
+#[derive(Clone, Default)]
+pub(super) struct LocalDevExtensionSurfaceSource {
+    extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
+}
+
+impl LocalDevExtensionSurfaceSource {
+    pub(super) fn new(
+        extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
+    ) -> Self {
+        Self {
+            extension_management,
+        }
+    }
+
+    pub(super) fn snapshot(&self) -> LocalDevExtensionSurface {
+        self.extension_management
+            .as_deref()
+            .map(LocalDevExtensionSurface::from_extension_management)
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct LocalDevExtensionSurface {
+    active_capabilities: Vec<ActiveExtensionCapability>,
+}
+
+impl LocalDevExtensionSurface {
+    pub(super) fn from_extension_management(
+        extension_management: &RebornLocalExtensionManagementPort,
+    ) -> Self {
+        Self {
+            active_capabilities: extension_management.active_model_visible_capabilities(),
+        }
+    }
+
+    pub(super) fn grants(&self, grantee: &ExtensionId) -> Vec<CapabilityGrant> {
+        self.active_capabilities
+            .iter()
+            .map(|capability| CapabilityGrant {
+                id: CapabilityGrantId::new(),
+                capability: capability.id.clone(),
+                grantee: Principal::Extension(grantee.clone()),
+                issued_by: Principal::HostRuntime,
+                constraints: Self::grant_constraints(capability),
+            })
+            .collect()
+    }
+
+    pub(super) fn provider_trust(&self) -> BTreeMap<ExtensionId, TrustDecision> {
+        let mut effects_by_provider: BTreeMap<ExtensionId, Vec<EffectKind>> = BTreeMap::new();
+        for capability in &self.active_capabilities {
+            let effects = effects_by_provider
+                .entry(capability.provider.clone())
+                .or_default();
+            for effect in &capability.effects {
+                if !effects.contains(effect) {
+                    effects.push(*effect);
+                }
+            }
+        }
+
+        effects_by_provider
+            .into_iter()
+            .map(|(provider, allowed_effects)| {
+                (
+                    provider,
+                    TrustDecision {
+                        effective_trust: EffectiveTrustClass::user_trusted(),
+                        authority_ceiling: AuthorityCeiling {
+                            allowed_effects,
+                            max_resource_ceiling: None,
+                        },
+                        provenance: TrustProvenance::AdminConfig,
+                        evaluated_at: Utc::now(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn grant_constraints(capability: &ActiveExtensionCapability) -> GrantConstraints {
+        GrantConstraints {
+            allowed_effects: capability.effects.clone(),
+            mounts: MountView::default(),
+            network: NetworkPolicy {
+                // Installed extensions get only their declared credential audiences as
+                // egress targets; missing audiences intentionally fail closed.
+                allowed_targets: capability.runtime_credentials.iter().fold(
+                    Vec::new(),
+                    |mut targets, credential| {
+                        if !targets.contains(&credential.audience) {
+                            targets.push(credential.audience.clone());
+                        }
+                        targets
+                    },
+                ),
+                deny_private_ip_ranges: true,
+                max_egress_bytes: None,
+            },
+            secrets: capability.runtime_credentials.iter().fold(
+                Vec::new(),
+                |mut handles, credential| {
+                    if !handles.contains(&credential.handle) {
+                        handles.push(credential.handle.clone());
+                    }
+                    handles
+                },
+            ),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -77,6 +77,30 @@ mod tests {
         }
     }
 
+    async fn assert_github_capabilities_visible(
+        wiring: &LocalDevCapabilityWiring,
+        run_context: &LoopRunContext,
+    ) {
+        let port = wiring
+            .capability_factory
+            .create_capability_port(run_context)
+            .await
+            .expect("capability port");
+        let surface = port
+            .visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible surface");
+        let capability_ids = surface
+            .descriptors
+            .iter()
+            .map(|descriptor| descriptor.capability_id.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(capability_ids.contains(&"github.search_issues"));
+        assert!(capability_ids.contains(&"github.get_issue"));
+        assert!(capability_ids.contains(&"github.comment_issue"));
+    }
+
     #[tokio::test]
     async fn capability_io_writes_durable_preview_message_and_live_upsert_id() {
         let run_context = run_context("durable-preview").await;
@@ -541,24 +565,69 @@ mod tests {
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
         )
         .expect("local-dev capability wiring");
-        let port = wiring
-            .capability_factory
-            .create_capability_port(&run_context)
-            .await
-            .expect("capability port");
-        let surface = port
-            .visible_capabilities(VisibleCapabilityRequest {})
-            .await
-            .expect("visible surface");
-        let capability_ids = surface
-            .descriptors
-            .iter()
-            .map(|descriptor| descriptor.capability_id.as_str())
-            .collect::<Vec<_>>();
+        assert_github_capabilities_visible(&wiring, &run_context).await;
+    }
 
-        assert!(capability_ids.contains(&"github.search_issues"));
-        assert!(capability_ids.contains(&"github.get_issue"));
-        assert!(capability_ids.contains(&"github.comment_issue"));
+    #[tokio::test]
+    async fn local_dev_capability_port_snapshots_extensions_when_port_is_created() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_root = dir.path().join("local-dev");
+        let services = crate::build_reborn_services(crate::RebornBuildInput::local_dev(
+            "local-dev-live-github-surface-owner",
+            storage_root,
+        ))
+        .await
+        .expect("local-dev services build");
+        let run_context = run_context("github-live-surface").await;
+        let thread_scope = ThreadScope {
+            tenant_id: run_context.scope.tenant_id.clone(),
+            agent_id: run_context.scope.agent_id.clone().expect("agent id"),
+            project_id: run_context.scope.project_id.clone(),
+            owner_user_id: None,
+            mission_id: None,
+        };
+        let wiring = capability_wiring(
+            &services,
+            Arc::new(InMemorySessionThreadService::default()),
+            thread_scope,
+            UserId::new("local-dev-live-github-user").expect("user id"),
+            Arc::new(UnavailableModelGateway),
+            Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        )
+        .expect("local-dev capability wiring");
+        let local_runtime = services
+            .local_runtime
+            .as_ref()
+            .expect("local runtime substrate");
+        let extension_management = local_runtime
+            .extension_management
+            .as_ref()
+            .expect("extension management")
+            .clone();
+        let facade = crate::lifecycle::RebornLocalLifecycleFacade::new(
+            local_runtime.skill_management.clone(),
+        )
+        .with_extension_management(extension_management);
+        let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "github")
+            .expect("valid github ref");
+        facade
+            .execute(
+                lifecycle_context("github-live-install"),
+                LifecycleProductAction::ExtensionInstall {
+                    package_ref: package_ref.clone(),
+                },
+            )
+            .await
+            .expect("install github extension");
+        facade
+            .execute(
+                lifecycle_context("github-live-activate"),
+                LifecycleProductAction::ExtensionActivate { package_ref },
+            )
+            .await
+            .expect("activate github extension");
+
+        assert_github_capabilities_visible(&wiring, &run_context).await;
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -61,6 +61,22 @@ mod tests {
         })
     }
 
+    #[derive(Debug, Default)]
+    struct UnavailableModelGateway;
+
+    #[async_trait::async_trait]
+    impl HostManagedModelGateway for UnavailableModelGateway {
+        async fn stream_model(
+            &self,
+            _request: HostManagedModelRequest,
+        ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+            Err(HostManagedModelError::safe(
+                HostManagedModelErrorKind::Unavailable,
+                "test gateway is not wired",
+            ))
+        }
+    }
+
     #[tokio::test]
     async fn capability_io_writes_durable_preview_message_and_live_upsert_id() {
         let run_context = run_context("durable-preview").await;
@@ -413,7 +429,7 @@ mod tests {
             runtime,
             UserId::new("local-yolo-host-user").expect("user id"), // safety: literal test id is valid.
             workspace_mounts,
-            Vec::new(),
+            LocalDevExtensionSurfaceSource::default(),
             input_resolver,
             result_writer,
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -508,31 +524,26 @@ mod tests {
         ))
         .await
         .expect("local-dev services rebuild");
-        let runtime = services.host_runtime.clone().expect("host runtime");
-        let local_runtime = services
-            .local_runtime
-            .as_ref()
-            .expect("local runtime substrate");
-        let active_extension_capabilities = local_runtime
-            .extension_management
-            .as_ref()
-            .expect("extension management")
-            .active_model_visible_capabilities();
-        let workspace_mounts = local_runtime.workspace_mounts.clone();
-        let capability_io = Arc::new(LocalDevCapabilityIo::default());
-        let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
-        let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
-        let factory = LocalDevLoopCapabilityPortFactory::new(
-            runtime,
+        let run_context = run_context("github-surface").await;
+        let thread_scope = ThreadScope {
+            tenant_id: run_context.scope.tenant_id.clone(),
+            agent_id: run_context.scope.agent_id.clone().expect("agent id"),
+            project_id: run_context.scope.project_id.clone(),
+            owner_user_id: None,
+            mission_id: None,
+        };
+        let wiring = capability_wiring(
+            &services,
+            Arc::new(InMemorySessionThreadService::default()),
+            thread_scope,
             UserId::new("local-dev-github-user").expect("user id"),
-            workspace_mounts,
-            active_extension_capabilities,
-            input_resolver,
-            result_writer,
+            Arc::new(UnavailableModelGateway),
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        );
-        let port = factory
-            .create_capability_port(&run_context("github-surface").await)
+        )
+        .expect("local-dev capability wiring");
+        let port = wiring
+            .capability_factory
+            .create_capability_port(&run_context)
             .await
             .expect("capability port");
         let surface = port

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -5,6 +5,7 @@ mod tests {
     use super::super::*;
 
     use ironclaw_host_api::{AgentId, MountPermissions, ProjectId, TenantId, ThreadId};
+    use ironclaw_host_runtime::SPAWN_SUBAGENT_CAPABILITY_ID;
     use ironclaw_product_workflow::{
         LifecyclePackageKind, LifecyclePackageRef, LifecycleProductAction, LifecycleProductContext,
         LifecycleProductFacade, LifecycleProductSurfaceContext,
@@ -99,6 +100,7 @@ mod tests {
         assert!(capability_ids.contains(&"github.search_issues"));
         assert!(capability_ids.contains(&"github.get_issue"));
         assert!(capability_ids.contains(&"github.comment_issue"));
+        assert!(!capability_ids.contains(&SPAWN_SUBAGENT_CAPABILITY_ID));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -5,6 +5,10 @@ mod tests {
     use super::super::*;
 
     use ironclaw_host_api::{AgentId, MountPermissions, ProjectId, TenantId, ThreadId};
+    use ironclaw_product_workflow::{
+        LifecyclePackageKind, LifecyclePackageRef, LifecycleProductAction, LifecycleProductContext,
+        LifecycleProductFacade, LifecycleProductSurfaceContext,
+    };
     use ironclaw_threads::{
         EnsureThreadRequest, InMemorySessionThreadService, MessageKind, ThreadHistoryRequest,
     };
@@ -46,6 +50,15 @@ mod tests {
             reasoning: None,
             signature: None,
         }
+    }
+
+    fn lifecycle_context(label: &str) -> LifecycleProductContext {
+        LifecycleProductContext::Surface(LifecycleProductSurfaceContext {
+            tenant_id: TenantId::new(format!("tenant-{label}")).expect("tenant id"),
+            user_id: UserId::new(format!("user-{label}")).expect("user id"),
+            agent_id: None,
+            project_id: None,
+        })
     }
 
     #[tokio::test]
@@ -400,6 +413,7 @@ mod tests {
             runtime,
             UserId::new("local-yolo-host-user").expect("user id"), // safety: literal test id is valid.
             workspace_mounts,
+            Vec::new(),
             input_resolver,
             result_writer,
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -441,6 +455,99 @@ mod tests {
             output["content"],
             serde_json::json!("     1│ safe host file")
         );
+    }
+
+    #[tokio::test]
+    async fn local_dev_capability_port_restores_activated_github_extension_surface() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_root = dir.path().join("local-dev");
+        let owner_id = "local-dev-github-surface-owner";
+        {
+            let services = crate::build_reborn_services(crate::RebornBuildInput::local_dev(
+                owner_id,
+                storage_root.clone(),
+            ))
+            .await
+            .expect("local-dev services build");
+            let local_runtime = services
+                .local_runtime
+                .as_ref()
+                .expect("local runtime substrate");
+            let extension_management = local_runtime
+                .extension_management
+                .as_ref()
+                .expect("extension management")
+                .clone();
+            let facade = crate::lifecycle::RebornLocalLifecycleFacade::new(
+                local_runtime.skill_management.clone(),
+            )
+            .with_extension_management(extension_management);
+            let package_ref = LifecyclePackageRef::new(LifecyclePackageKind::Extension, "github")
+                .expect("valid github ref");
+            facade
+                .execute(
+                    lifecycle_context("github-install"),
+                    LifecycleProductAction::ExtensionInstall {
+                        package_ref: package_ref.clone(),
+                    },
+                )
+                .await
+                .expect("install github extension");
+            facade
+                .execute(
+                    lifecycle_context("github-activate"),
+                    LifecycleProductAction::ExtensionActivate { package_ref },
+                )
+                .await
+                .expect("activate github extension");
+        }
+
+        let services = crate::build_reborn_services(crate::RebornBuildInput::local_dev(
+            owner_id,
+            storage_root,
+        ))
+        .await
+        .expect("local-dev services rebuild");
+        let runtime = services.host_runtime.clone().expect("host runtime");
+        let local_runtime = services
+            .local_runtime
+            .as_ref()
+            .expect("local runtime substrate");
+        let active_extension_capabilities = local_runtime
+            .extension_management
+            .as_ref()
+            .expect("extension management")
+            .active_model_visible_capabilities();
+        let workspace_mounts = local_runtime.workspace_mounts.clone();
+        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
+        let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
+        let factory = LocalDevLoopCapabilityPortFactory::new(
+            runtime,
+            UserId::new("local-dev-github-user").expect("user id"),
+            workspace_mounts,
+            active_extension_capabilities,
+            input_resolver,
+            result_writer,
+            Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        );
+        let port = factory
+            .create_capability_port(&run_context("github-surface").await)
+            .await
+            .expect("capability port");
+        let surface = port
+            .visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible surface");
+        let capability_ids = surface
+            .descriptors
+            .iter()
+            .map(|descriptor| descriptor.capability_id.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(capability_ids.contains(&"github.search_issues"));
+        assert!(capability_ids.contains(&"github.get_issue"));
+        assert!(capability_ids.contains(&"github.comment_issue"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose activated Reborn extensions to the local-dev agent capability surface
- derive local-dev extension grants/provider trust through a focused extension surface module
- cover restored and live activation paths for GitHub extension visibility

## Root Cause
Installed and activated extensions were restored into the active registry, but local-dev capability wiring only granted/trusted builtin providers. The agent capability surface therefore filtered activated GitHub capabilities out before the model could see them.

## Validation
- cargo fmt
- git diff --check
- CARGO_BUILD_JOBS=2 cargo test -p ironclaw_reborn_composition local_dev_capability_port --lib
- CARGO_BUILD_JOBS=2 cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings
