### PR TITLE
Ship bundled skills with Reborn CLI

### DIFF
--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -1,5 +1,6 @@
 use std::{
     io::Write,
+    path::Path,
     process::{Command, Stdio},
 };
 
@@ -7,6 +8,24 @@ const INVALID_PROFILE_MESSAGE: &str = "IRONCLAW_REBORN_PROFILE must be one of";
 
 fn reborn_bin() -> &'static str {
     env!("CARGO_BIN_EXE_ironclaw-reborn")
+}
+
+fn isolated_no_llm_command(workspace: &Path, reborn_home: &Path) -> Command {
+    let mut command = Command::new(reborn_bin());
+    command
+        .current_dir(workspace)
+        .env_clear()
+        .env("HOME", workspace.join("isolated-home"))
+        .env("LLM_USE_CODEX_AUTH", "false")
+        .env("LLM_BACKEND", "")
+        .env("LLM_MODEL", "")
+        .env("OPENAI_MODEL", "")
+        .env("OPENAI_CODEX_MODEL", "")
+        .env("OPENAI_API_KEY", "")
+        .env("ANTHROPIC_API_KEY", "")
+        .env("OLLAMA_BASE_URL", "")
+        .env("IRONCLAW_REBORN_HOME", reborn_home);
+    command
 }
 
 #[test]
@@ -176,6 +195,7 @@ fn hooks_list_json_verbose_includes_status_details() {
 fn skills_list_reports_reborn_skill_data() {
     let temp = tempfile::tempdir().expect("tempdir");
     let reborn_home = temp.path().join("reborn-home");
+    let v1_home = temp.path().join("v1-home");
     write_reborn_skill(&reborn_home, "catalog-helper", "catalog helper");
 
     let output = Command::new(reborn_bin())
@@ -183,6 +203,7 @@ fn skills_list_reports_reborn_skill_data() {
         .arg("list")
         .env_clear()
         .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_BASE_DIR", &v1_home)
         .output()
         .expect("ironclaw-reborn skills list should run");
 
@@ -196,9 +217,13 @@ fn skills_list_reports_reborn_skill_data() {
         stdout.contains("IronClaw Reborn skills"),
         "stdout: {stdout}"
     );
-    assert!(stdout.contains("configured: 1"), "stdout: {stdout}");
+    assert!(stdout.contains("configured:"), "stdout: {stdout}");
     assert!(
         stdout.contains("source: reborn-local-dev"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("- code-review (system)"),
         "stdout: {stdout}"
     );
     assert!(
@@ -207,6 +232,16 @@ fn skills_list_reports_reborn_skill_data() {
     );
     assert!(!stdout.contains("not-wired"), "stdout: {stdout}");
     assert!(!stdout.contains("v1_state"), "stdout: {stdout}");
+    assert!(
+        !reborn_home
+            .join("local-dev/system/skills/code-review/SKILL.md")
+            .exists(),
+        "skills list should report bundled skills without installing them"
+    );
+    assert!(
+        !v1_home.exists(),
+        "skills list must not create or read v1 state"
+    );
 }
 
 #[test]
@@ -269,16 +304,28 @@ fn skills_list_json_reports_reborn_skill_data() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
-    assert_eq!(json["configured"], 1);
+    assert!(
+        json["configured"].as_u64().expect("configured count") > 1,
+        "json: {json}"
+    );
     assert_eq!(json["source"], "reborn-local-dev");
-    assert_eq!(json["skills"][0]["name"], "json-helper");
-    assert_eq!(json["skills"][0]["source"], "user");
+    assert_skill_source(&json, "code-review", "system");
+    assert_skill_source(&json, "json-helper", "user");
     assert_eq!(json["details"]["profile"], "local-dev");
     assert_eq!(json["details"]["owner_id"], "reborn-cli");
     assert!(json.get("limit").is_none(), "json: {json}");
     assert!(json.get("truncated").is_none(), "json: {json}");
     assert!(json.get("status").is_none(), "json: {json}");
     assert!(json.get("v1_state").is_none(), "json: {json}");
+}
+
+fn assert_skill_source(json: &serde_json::Value, name: &str, source: &str) {
+    let skills = json["skills"].as_array().expect("skills array");
+    let skill = skills
+        .iter()
+        .find(|skill| skill["name"] == name)
+        .unwrap_or_else(|| panic!("missing skill {name}: {json}"));
+    assert_eq!(skill["source"], source);
 }
 
 #[test]
@@ -1676,13 +1723,8 @@ api_key_env = "sk-proj-1234567890abcdef12345678"
 "#;
     std::fs::write(reborn_home.join("config.toml"), bad_config).expect("write bad config");
 
-    let output = Command::new(reborn_bin())
+    let output = isolated_no_llm_command(temp.path(), &reborn_home)
         .args(["run", "-m", "ping"])
-        .env_remove("USERPROFILE")
-        .env_remove("OPENAI_API_KEY")
-        .env_remove("ANTHROPIC_API_KEY")
-        .env_remove("OLLAMA_BASE_URL")
-        .env("IRONCLAW_REBORN_HOME", &reborn_home)
         .output()
         .expect("ironclaw-reborn run should not crash");
     assert!(
@@ -1702,21 +1744,24 @@ api_key_env = "sk-proj-1234567890abcdef12345678"
 fn run_warns_when_falling_back_to_stub_gateway() {
     let temp = tempfile::tempdir().expect("tempdir");
     let reborn_home = temp.path().join("reborn-home");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace dir");
     std::fs::create_dir_all(&reborn_home).expect("mkdir");
 
-    let output = Command::new(reborn_bin())
+    let output = isolated_no_llm_command(&workspace, &reborn_home)
         .args(["run", "-m", "ping"])
-        .env_remove("USERPROFILE")
-        .env_remove("OPENAI_API_KEY")
-        .env_remove("ANTHROPIC_API_KEY")
-        .env_remove("OLLAMA_BASE_URL")
-        .env("IRONCLAW_REBORN_HOME", &reborn_home)
         .output()
         .expect("ironclaw-reborn run should not crash");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("no LLM selection configured") && stderr.contains("Runs will fail"),
         "stderr should warn about degraded stub-gateway boot; got: {stderr}"
+    );
+    assert!(
+        reborn_home
+            .join("local-dev/system/skills/code-review/SKILL.md")
+            .is_file(),
+        "runtime bootstrap should install bundled Reborn skills"
     );
 }
 
@@ -1989,10 +2034,8 @@ provider_id = " {secret} "
     )
     .expect("write config");
 
-    let output = Command::new(reborn_bin())
+    let output = isolated_no_llm_command(temp.path(), &reborn_home)
         .args(["run", "-m", "ping"])
-        .env_remove("USERPROFILE")
-        .env("IRONCLAW_REBORN_HOME", &reborn_home)
         .output()
         .expect("ironclaw-reborn run should not crash");
     assert!(!output.status.success(), "inline secret must fail");
@@ -2011,6 +2054,8 @@ provider_id = " {secret} "
 fn run_accepts_configured_cli_tenant_and_agent_identity() {
     let temp = tempfile::tempdir().expect("tempdir");
     let reborn_home = temp.path().join("reborn-home");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace dir");
     std::fs::create_dir_all(&reborn_home).expect("mkdir");
     std::fs::write(
         reborn_home.join("config.toml"),
@@ -2023,10 +2068,8 @@ default_owner = "operator"
     )
     .expect("write config");
 
-    let output = Command::new(reborn_bin())
+    let output = isolated_no_llm_command(&workspace, &reborn_home)
         .args(["run", "-m", "ping"])
-        .env_remove("USERPROFILE")
-        .env("IRONCLAW_REBORN_HOME", &reborn_home)
         .output()
         .expect("ironclaw-reborn run should not crash");
     assert!(

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -136,5 +136,9 @@ tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread", "
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect"] }
 tower = { version = "0.5", features = ["util"] }
 
+[build-dependencies]
+ironclaw_skills = { path = "../ironclaw_skills" }
+serde_json = "1"
+
 [lints]
 workspace = true

--- a/crates/ironclaw_reborn_composition/build.rs
+++ b/crates/ironclaw_reborn_composition/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::fs;
+use std::fs::{self, FileType};
 use std::path::{Path, PathBuf};
 
 use ironclaw_skills::{normalize_safe_relative_path, parse_skill_md, validate_skill_name};
@@ -19,7 +19,7 @@ fn embed_reborn_skills(repo_root: &Path) {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("out dir"));
     let out_path = out_dir.join("embedded_reborn_skills.json");
-    if !skills_dir.is_dir() {
+    if !path_is_real_dir(&skills_dir) {
         fs::write(out_path, "[]").expect("write empty embedded skills");
         return;
     }
@@ -29,13 +29,16 @@ fn embed_reborn_skills(repo_root: &Path) {
         .expect("read skills dir")
         .collect::<Result<Vec<_>, _>>()
         .expect("read skills dir entries");
-    entries.retain(|entry| entry.path().is_dir());
+    entries.retain(|entry| {
+        let file_type = non_symlink_file_type(entry);
+        file_type.is_dir()
+    });
     entries.sort_by_key(|entry| entry.file_name());
 
     for entry in entries {
         let skill_dir = entry.path();
         let skill_md = skill_dir.join("SKILL.md");
-        if !skill_md.is_file() {
+        if !path_is_real_file(&skill_md) {
             continue;
         }
 
@@ -94,13 +97,55 @@ fn collect_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
 
     for entry in entries {
         let path = entry.path();
-        if path.is_dir() {
+        let file_type = non_symlink_file_type(&entry);
+        if file_type.is_dir() {
             collect_files_recursive(&path, paths);
-        } else if path.is_file() {
+        } else if file_type.is_file() {
             println!("cargo:rerun-if-changed={}", path.display());
             paths.push(path);
         }
     }
+}
+
+fn path_is_real_dir(path: &Path) -> bool {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            panic!(
+                "bundled Reborn skills path must not be a symlink: {}",
+                path.display()
+            );
+        }
+        Ok(metadata) => metadata.is_dir(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => panic!("inspect bundled Reborn skills path: {error}"),
+    }
+}
+
+fn path_is_real_file(path: &Path) -> bool {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            panic!(
+                "bundled Reborn skill file must not be a symlink: {}",
+                path.display()
+            );
+        }
+        Ok(metadata) => metadata.is_file(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => panic!("inspect bundled Reborn skill file: {error}"),
+    }
+}
+
+fn non_symlink_file_type(entry: &fs::DirEntry) -> FileType {
+    let file_type = entry
+        .file_type()
+        .unwrap_or_else(|error| panic!("inspect bundled Reborn skill entry: {error}"));
+    if file_type.is_symlink() {
+        panic!(
+            "bundled Reborn skill entry must not be a symlink: {}",
+            entry.path().display()
+        );
+    }
+    file_type
 }
 
 fn skill_file_json(skill_dir: &Path, source_path: &Path) -> serde_json::Value {

--- a/crates/ironclaw_reborn_composition/build.rs
+++ b/crates/ironclaw_reborn_composition/build.rs
@@ -18,13 +18,16 @@ fn embed_reborn_skills(repo_root: &Path) {
     println!("cargo:rerun-if-changed={}", skills_dir.display());
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("out dir"));
-    let out_path = out_dir.join("embedded_reborn_skills.json");
+    let summaries_out_path = out_dir.join("embedded_reborn_skill_summaries.json");
+    let bundles_out_path = out_dir.join("embedded_reborn_skill_bundles.json");
     if !path_is_real_dir(&skills_dir) {
-        fs::write(out_path, "[]").expect("write empty embedded skills");
+        fs::write(summaries_out_path, "[]").expect("write empty embedded skill summaries");
+        fs::write(bundles_out_path, "[]").expect("write empty embedded skill bundles");
         return;
     }
 
-    let mut skill_entries = Vec::new();
+    let mut skill_summaries = Vec::new();
+    let mut skill_bundles = Vec::new();
     let mut entries = fs::read_dir(&skills_dir)
         .expect("read skills dir")
         .collect::<Result<Vec<_>, _>>()
@@ -60,22 +63,30 @@ fn embed_reborn_skills(repo_root: &Path) {
         }
 
         let files = collect_skill_files(&skill_dir);
-        skill_entries.push(serde_json::json!({
+        skill_summaries.push(serde_json::json!({
             "name": parsed.manifest.name,
             "version": parsed.manifest.version,
             "description": parsed.manifest.description,
             "keywords": parsed.manifest.activation.keywords,
             "tags": parsed.manifest.activation.tags,
             "requires_skills": parsed.manifest.requires.skills,
+        }));
+        skill_bundles.push(serde_json::json!({
+            "name": parsed.manifest.name,
             "files": files,
         }));
     }
 
     fs::write(
-        out_path,
-        serde_json::to_string(&skill_entries).expect("serialize embedded skills"),
+        summaries_out_path,
+        serde_json::to_string(&skill_summaries).expect("serialize embedded skill summaries"),
     )
-    .expect("write embedded skills");
+    .expect("write embedded skill summaries");
+    fs::write(
+        bundles_out_path,
+        serde_json::to_string(&skill_bundles).expect("serialize embedded skill bundles"),
+    )
+    .expect("write embedded skill bundles");
 }
 
 fn collect_skill_files(skill_dir: &Path) -> Vec<serde_json::Value> {

--- a/crates/ironclaw_reborn_composition/build.rs
+++ b/crates/ironclaw_reborn_composition/build.rs
@@ -4,65 +4,71 @@ use std::path::{Path, PathBuf};
 
 use ironclaw_skills::{normalize_safe_relative_path, parse_skill_md, validate_skill_name};
 
-fn main() {
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("manifest dir"));
+type BuildResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> BuildResult<()> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     let repo_root = manifest_dir
         .parent()
         .and_then(Path::parent)
-        .expect("ironclaw_reborn_composition lives under crates/");
-    embed_reborn_skills(repo_root);
+        .ok_or_else(|| build_error("ironclaw_reborn_composition lives under crates/"))?;
+    embed_reborn_skills(repo_root)
 }
 
-fn embed_reborn_skills(repo_root: &Path) {
+fn embed_reborn_skills(repo_root: &Path) -> BuildResult<()> {
     let skills_dir = repo_root.join("skills");
     println!("cargo:rerun-if-changed={}", skills_dir.display());
 
-    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("out dir"));
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
     let summaries_out_path = out_dir.join("embedded_reborn_skill_summaries.json");
     let bundles_out_path = out_dir.join("embedded_reborn_skill_bundles.json");
-    if !path_is_real_dir(&skills_dir) {
-        fs::write(summaries_out_path, "[]").expect("write empty embedded skill summaries");
-        fs::write(bundles_out_path, "[]").expect("write empty embedded skill bundles");
-        return;
+    if !path_is_real_dir(&skills_dir)? {
+        fs::write(summaries_out_path, "[]")?;
+        fs::write(bundles_out_path, "[]")?;
+        return Ok(());
     }
 
     let mut skill_summaries = Vec::new();
     let mut skill_bundles = Vec::new();
-    let mut entries = fs::read_dir(&skills_dir)
-        .expect("read skills dir")
-        .collect::<Result<Vec<_>, _>>()
-        .expect("read skills dir entries");
-    entries.retain(|entry| {
-        let file_type = non_symlink_file_type(entry);
-        file_type.is_dir()
-    });
+    let mut entries = fs::read_dir(&skills_dir)?.collect::<Result<Vec<_>, _>>()?;
+    entries = entries
+        .into_iter()
+        .filter_map(|entry| match non_symlink_file_type(&entry) {
+            Ok(file_type) if file_type.is_dir() => Some(Ok(entry)),
+            Ok(_) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect::<BuildResult<Vec<_>>>()?;
     entries.sort_by_key(|entry| entry.file_name());
 
     for entry in entries {
         let skill_dir = entry.path();
         let skill_md = skill_dir.join("SKILL.md");
-        if !path_is_real_file(&skill_md) {
+        if !path_is_real_file(&skill_md)? {
             continue;
         }
 
         let dir_name = entry
             .file_name()
             .into_string()
-            .expect("skill directory name must be UTF-8");
+            .map_err(|_| build_error("skill directory name must be UTF-8"))?;
         if !validate_skill_name(&dir_name) {
-            panic!("bundled Reborn skill directory has invalid name `{dir_name}`");
+            return Err(build_error(format!(
+                "bundled Reborn skill directory has invalid name `{dir_name}`"
+            )));
         }
 
-        let skill_md_content = fs::read_to_string(&skill_md).expect("read bundled SKILL.md");
-        let parsed = parse_skill_md(&skill_md_content).expect("parse bundled SKILL.md");
+        let skill_md_content = fs::read_to_string(&skill_md)?;
+        let parsed = parse_skill_md(&skill_md_content)
+            .map_err(|error| build_error(format!("parse bundled SKILL.md: {error}")))?;
         if parsed.manifest.name != dir_name {
-            panic!(
+            return Err(build_error(format!(
                 "bundled Reborn skill `{}` manifest name `{}` must match directory name",
                 dir_name, parsed.manifest.name
-            );
+            )));
         }
 
-        let files = collect_skill_files(&skill_dir);
+        let files = collect_skill_files(&skill_dir)?;
         skill_summaries.push(serde_json::json!({
             "name": parsed.manifest.name,
             "version": parsed.manifest.version,
@@ -77,21 +83,14 @@ fn embed_reborn_skills(repo_root: &Path) {
         }));
     }
 
-    fs::write(
-        summaries_out_path,
-        serde_json::to_string(&skill_summaries).expect("serialize embedded skill summaries"),
-    )
-    .expect("write embedded skill summaries");
-    fs::write(
-        bundles_out_path,
-        serde_json::to_string(&skill_bundles).expect("serialize embedded skill bundles"),
-    )
-    .expect("write embedded skill bundles");
+    fs::write(summaries_out_path, serde_json::to_string(&skill_summaries)?)?;
+    fs::write(bundles_out_path, serde_json::to_string(&skill_bundles)?)?;
+    Ok(())
 }
 
-fn collect_skill_files(skill_dir: &Path) -> Vec<serde_json::Value> {
+fn collect_skill_files(skill_dir: &Path) -> BuildResult<Vec<serde_json::Value>> {
     let mut paths = Vec::new();
-    collect_files_recursive(skill_dir, &mut paths);
+    collect_files_recursive(skill_dir, &mut paths)?;
     paths.sort();
     paths
         .into_iter()
@@ -99,79 +98,76 @@ fn collect_skill_files(skill_dir: &Path) -> Vec<serde_json::Value> {
         .collect()
 }
 
-fn collect_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
-    let mut entries = fs::read_dir(dir)
-        .expect("read skill bundle dir")
-        .collect::<Result<Vec<_>, _>>()
-        .expect("read skill bundle entries");
+fn collect_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) -> BuildResult<()> {
+    let mut entries = fs::read_dir(dir)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(|entry| entry.file_name());
 
     for entry in entries {
         let path = entry.path();
-        let file_type = non_symlink_file_type(&entry);
+        let file_type = non_symlink_file_type(&entry)?;
         if file_type.is_dir() {
-            collect_files_recursive(&path, paths);
+            collect_files_recursive(&path, paths)?;
         } else if file_type.is_file() {
             println!("cargo:rerun-if-changed={}", path.display());
             paths.push(path);
         }
     }
+    Ok(())
 }
 
-fn path_is_real_dir(path: &Path) -> bool {
+fn path_is_real_dir(path: &Path) -> BuildResult<bool> {
     match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => {
-            panic!(
-                "bundled Reborn skills path must not be a symlink: {}",
-                path.display()
-            );
-        }
-        Ok(metadata) => metadata.is_dir(),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => panic!("inspect bundled Reborn skills path: {error}"),
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(build_error(format!(
+            "bundled Reborn skills path must not be a symlink: {}",
+            path.display()
+        ))),
+        Ok(metadata) => Ok(metadata.is_dir()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
     }
 }
 
-fn path_is_real_file(path: &Path) -> bool {
+fn path_is_real_file(path: &Path) -> BuildResult<bool> {
     match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => {
-            panic!(
-                "bundled Reborn skill file must not be a symlink: {}",
-                path.display()
-            );
-        }
-        Ok(metadata) => metadata.is_file(),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => panic!("inspect bundled Reborn skill file: {error}"),
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(build_error(format!(
+            "bundled Reborn skill file must not be a symlink: {}",
+            path.display()
+        ))),
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
     }
 }
 
-fn non_symlink_file_type(entry: &fs::DirEntry) -> FileType {
-    let file_type = entry
-        .file_type()
-        .unwrap_or_else(|error| panic!("inspect bundled Reborn skill entry: {error}"));
+fn non_symlink_file_type(entry: &fs::DirEntry) -> BuildResult<FileType> {
+    let file_type = entry.file_type()?;
     if file_type.is_symlink() {
-        panic!(
+        return Err(build_error(format!(
             "bundled Reborn skill entry must not be a symlink: {}",
             entry.path().display()
-        );
+        )));
     }
-    file_type
+    Ok(file_type)
 }
 
-fn skill_file_json(skill_dir: &Path, source_path: &Path) -> serde_json::Value {
-    let relative_path = source_path
-        .strip_prefix(skill_dir)
-        .expect("skill file under root");
-    let normalized =
-        normalize_safe_relative_path(relative_path).expect("skill bundle file path must be safe");
+fn skill_file_json(skill_dir: &Path, source_path: &Path) -> BuildResult<serde_json::Value> {
+    let relative_path = source_path.strip_prefix(skill_dir)?;
+    let normalized = normalize_safe_relative_path(relative_path)
+        .map_err(|error| build_error(format!("skill bundle file path must be safe: {error:?}")))?;
     let path = normalized
         .to_str()
-        .expect("skill bundle file path must be UTF-8")
+        .ok_or_else(|| build_error("skill bundle file path must be UTF-8"))?
         .replace('\\', "/");
-    let bytes = fs::read(source_path).expect("read skill bundle file");
-    serde_json::json!({
+    let bytes = fs::read(source_path)?;
+    Ok(serde_json::json!({
         "path": path,
         "bytes": bytes,
-    })
+    }))
+}
+
+fn build_error(reason: impl Into<String>) -> Box<dyn std::error::Error> {
+    Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        reason.into(),
+    ))
 }

--- a/crates/ironclaw_reborn_composition/build.rs
+++ b/crates/ironclaw_reborn_composition/build.rs
@@ -1,0 +1,121 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use ironclaw_skills::{normalize_safe_relative_path, parse_skill_md, validate_skill_name};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    let repo_root = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("ironclaw_reborn_composition lives under crates/");
+    embed_reborn_skills(repo_root);
+}
+
+fn embed_reborn_skills(repo_root: &Path) {
+    let skills_dir = repo_root.join("skills");
+    println!("cargo:rerun-if-changed={}", skills_dir.display());
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("out dir"));
+    let out_path = out_dir.join("embedded_reborn_skills.json");
+    if !skills_dir.is_dir() {
+        fs::write(out_path, "[]").expect("write empty embedded skills");
+        return;
+    }
+
+    let mut skill_entries = Vec::new();
+    let mut entries = fs::read_dir(&skills_dir)
+        .expect("read skills dir")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("read skills dir entries");
+    entries.retain(|entry| entry.path().is_dir());
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let skill_dir = entry.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        if !skill_md.is_file() {
+            continue;
+        }
+
+        let dir_name = entry
+            .file_name()
+            .into_string()
+            .expect("skill directory name must be UTF-8");
+        if !validate_skill_name(&dir_name) {
+            panic!("bundled Reborn skill directory has invalid name `{dir_name}`");
+        }
+
+        let skill_md_content = fs::read_to_string(&skill_md).expect("read bundled SKILL.md");
+        let parsed = parse_skill_md(&skill_md_content).expect("parse bundled SKILL.md");
+        if parsed.manifest.name != dir_name {
+            panic!(
+                "bundled Reborn skill `{}` manifest name `{}` must match directory name",
+                dir_name, parsed.manifest.name
+            );
+        }
+
+        let files = collect_skill_files(&skill_dir);
+        skill_entries.push(serde_json::json!({
+            "name": parsed.manifest.name,
+            "version": parsed.manifest.version,
+            "description": parsed.manifest.description,
+            "keywords": parsed.manifest.activation.keywords,
+            "tags": parsed.manifest.activation.tags,
+            "requires_skills": parsed.manifest.requires.skills,
+            "files": files,
+        }));
+    }
+
+    fs::write(
+        out_path,
+        serde_json::to_string(&skill_entries).expect("serialize embedded skills"),
+    )
+    .expect("write embedded skills");
+}
+
+fn collect_skill_files(skill_dir: &Path) -> Vec<serde_json::Value> {
+    let mut paths = Vec::new();
+    collect_files_recursive(skill_dir, &mut paths);
+    paths.sort();
+    paths
+        .into_iter()
+        .map(|path| skill_file_json(skill_dir, &path))
+        .collect()
+}
+
+fn collect_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
+    let mut entries = fs::read_dir(dir)
+        .expect("read skill bundle dir")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("read skill bundle entries");
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files_recursive(&path, paths);
+        } else if path.is_file() {
+            println!("cargo:rerun-if-changed={}", path.display());
+            paths.push(path);
+        }
+    }
+}
+
+fn skill_file_json(skill_dir: &Path, source_path: &Path) -> serde_json::Value {
+    let relative_path = source_path
+        .strip_prefix(skill_dir)
+        .expect("skill file under root");
+    let normalized =
+        normalize_safe_relative_path(relative_path).expect("skill bundle file path must be safe");
+    let path = normalized
+        .to_str()
+        .expect("skill bundle file path must be UTF-8")
+        .replace('\\', "/");
+    let bytes = fs::read(source_path).expect("read skill bundle file");
+    serde_json::json!({
+        "path": path,
+        "bytes": bytes,
+    })
+}

--- a/crates/ironclaw_reborn_composition/src/bundled_skills.rs
+++ b/crates/ironclaw_reborn_composition/src/bundled_skills.rs
@@ -1,0 +1,310 @@
+use std::collections::HashSet;
+use std::fs;
+use std::hash::Hasher;
+use std::path::{Path, PathBuf};
+
+use ironclaw_loop_support::SkillFilePath;
+use ironclaw_skills::{ManagedSkillSource, SkillSummary};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::RebornBuildError;
+
+const EMBEDDED_REBORN_SKILLS_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/embedded_reborn_skills.json"));
+const BUNDLED_MARKER_FILE: &str = ".ironclaw-reborn-bundled.json";
+const BUNDLED_MARKER_OWNER: &str = "ironclaw_reborn_composition_bundled_skill";
+
+#[derive(Debug, Deserialize)]
+struct EmbeddedRebornSkill {
+    name: String,
+    version: String,
+    description: String,
+    keywords: Vec<String>,
+    tags: Vec<String>,
+    requires_skills: Vec<String>,
+    files: Vec<EmbeddedRebornSkillFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbeddedRebornSkillFile {
+    path: String,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct BundledSkillMarker {
+    owner: String,
+    format: u8,
+    content_hash: String,
+}
+
+pub(crate) fn ensure_bundled_reborn_skills_installed(
+    local_dev_storage_root: &Path,
+) -> Result<(), RebornBuildError> {
+    let bundled_skills = embedded_reborn_skills()?;
+    fs::create_dir_all(local_dev_storage_root).map_err(invalid_config)?;
+
+    let system_skills_root = local_dev_storage_root.join("system").join("skills");
+    fs::create_dir_all(&system_skills_root).map_err(invalid_config)?;
+
+    let bundled_names = bundled_skills
+        .iter()
+        .map(|skill| skill.name.as_str())
+        .collect::<HashSet<_>>();
+    remove_stale_managed_skills(&system_skills_root, &bundled_names)?;
+
+    for skill in bundled_skills {
+        install_bundled_skill(&system_skills_root, skill)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn bundled_reborn_skill_summaries() -> Result<Vec<SkillSummary>, RebornBuildError> {
+    Ok(embedded_reborn_skills()?
+        .into_iter()
+        .map(|skill| SkillSummary {
+            name: skill.name,
+            version: skill.version,
+            description: skill.description,
+            source: ManagedSkillSource::System,
+            keywords: skill.keywords,
+            tags: skill.tags,
+            requires_skills: skill.requires_skills,
+        })
+        .collect())
+}
+
+fn embedded_reborn_skills() -> Result<Vec<EmbeddedRebornSkill>, RebornBuildError> {
+    serde_json::from_str(EMBEDDED_REBORN_SKILLS_JSON)
+        .map_err(|error| invalid_config(format!("failed to parse embedded Reborn skills: {error}")))
+}
+
+fn remove_stale_managed_skills(
+    system_skills_root: &Path,
+    bundled_names: &HashSet<&str>,
+) -> Result<(), RebornBuildError> {
+    let entries = fs::read_dir(system_skills_root).map_err(invalid_config)?;
+    for entry in entries {
+        let entry = entry.map_err(invalid_config)?;
+        if !entry.file_type().map_err(invalid_config)?.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if bundled_names.contains(name.as_str()) || read_managed_marker(&entry.path()).is_none() {
+            continue;
+        }
+        fs::remove_dir_all(entry.path()).map_err(|error| {
+            invalid_config(format!(
+                "failed to remove stale bundled skill {name}: {error}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn install_bundled_skill(
+    system_skills_root: &Path,
+    skill: EmbeddedRebornSkill,
+) -> Result<(), RebornBuildError> {
+    let skill_dir = system_skills_root.join(&skill.name);
+    let content_hash = bundled_skill_hash(&skill);
+    if skill_dir.exists() {
+        let Some(marker) = read_managed_marker(&skill_dir) else {
+            tracing::warn!(
+                skill_name = %skill.name,
+                path = %skill_dir.display(),
+                "skipping bundled Reborn skill because an unmanaged system skill already exists"
+            );
+            return Ok(());
+        };
+        if marker.content_hash == content_hash {
+            return Ok(());
+        }
+    }
+
+    let staging_dir = system_skills_root.join(format!(".{}.tmp-{}", skill.name, Uuid::new_v4()));
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir).map_err(invalid_config)?;
+    }
+    write_bundled_skill_dir(&staging_dir, &skill, &content_hash)?;
+    replace_skill_dir(&skill_dir, &staging_dir, &skill.name)
+}
+
+fn write_bundled_skill_dir(
+    staging_dir: &Path,
+    skill: &EmbeddedRebornSkill,
+    content_hash: &str,
+) -> Result<(), RebornBuildError> {
+    fs::create_dir_all(staging_dir).map_err(invalid_config)?;
+    for file in &skill.files {
+        let relative_path = validated_bundle_file_path(&file.path)?;
+        let target = staging_dir.join(relative_path);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(invalid_config)?;
+        }
+        fs::write(&target, &file.bytes).map_err(|error| {
+            invalid_config(format!(
+                "failed to write bundled skill file {}: {error}",
+                target.display()
+            ))
+        })?;
+    }
+    write_marker(staging_dir, content_hash)
+}
+
+fn replace_skill_dir(
+    skill_dir: &Path,
+    staging_dir: &Path,
+    skill_name: &str,
+) -> Result<(), RebornBuildError> {
+    if !skill_dir.exists() {
+        return fs::rename(staging_dir, skill_dir).map_err(invalid_config);
+    }
+
+    let backup_dir = skill_dir.with_file_name(format!(".{skill_name}.previous-{}", Uuid::new_v4()));
+    fs::rename(skill_dir, &backup_dir).map_err(invalid_config)?;
+    if let Err(error) = fs::rename(staging_dir, skill_dir) {
+        if let Err(restore_error) = fs::rename(&backup_dir, skill_dir) {
+            return Err(invalid_config(format!(
+                "failed to replace bundled skill {skill_name}: {error}; restore failed: {restore_error}"
+            )));
+        }
+        return Err(invalid_config(format!(
+            "failed to replace bundled skill {skill_name}: {error}"
+        )));
+    }
+    fs::remove_dir_all(&backup_dir).map_err(invalid_config)
+}
+
+fn read_managed_marker(skill_dir: &Path) -> Option<BundledSkillMarker> {
+    let marker_path = skill_dir.join(BUNDLED_MARKER_FILE);
+    let bytes = fs::read(marker_path).ok()?;
+    let marker = serde_json::from_slice::<BundledSkillMarker>(&bytes).ok()?;
+    (marker.owner == BUNDLED_MARKER_OWNER).then_some(marker)
+}
+
+fn write_marker(skill_dir: &Path, content_hash: &str) -> Result<(), RebornBuildError> {
+    let marker = BundledSkillMarker {
+        owner: BUNDLED_MARKER_OWNER.to_string(),
+        format: 1,
+        content_hash: content_hash.to_string(),
+    };
+    let marker_path = skill_dir.join(BUNDLED_MARKER_FILE);
+    let bytes = serde_json::to_vec_pretty(&marker).map_err(invalid_config)?;
+    fs::write(&marker_path, bytes).map_err(|error| {
+        invalid_config(format!(
+            "failed to write bundled skill marker {}: {error}",
+            marker_path.display()
+        ))
+    })
+}
+
+fn validated_bundle_file_path(path: &str) -> Result<PathBuf, RebornBuildError> {
+    let path = SkillFilePath::new(path)
+        .map_err(|error| invalid_config(format!("invalid bundled skill file path: {error}")))?;
+    Ok(Path::new(path.as_str()).to_path_buf())
+}
+
+fn bundled_skill_hash(skill: &EmbeddedRebornSkill) -> String {
+    let mut hasher = StableFnv64::default();
+    hasher.write(skill.name.as_bytes());
+    for file in &skill.files {
+        hasher.write(file.path.as_bytes());
+        hasher.write(&[0]);
+        hasher.write(&file.bytes);
+        hasher.write(&[0]);
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+#[derive(Default)]
+struct StableFnv64(u64);
+
+impl Hasher for StableFnv64 {
+    fn finish(&self) -> u64 {
+        if self.0 == 0 {
+            0xcbf29ce484222325
+        } else {
+            self.0
+        }
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        let mut hash = self.finish();
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        self.0 = hash;
+    }
+}
+
+fn invalid_config(reason: impl std::fmt::Display) -> RebornBuildError {
+    RebornBuildError::InvalidConfig {
+        reason: reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_reborn_skills_include_current_repo_bundles_and_assets() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_dev_root = dir.path().join("local-dev");
+
+        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+
+        assert!(
+            local_dev_root
+                .join("system/skills/code-review/SKILL.md")
+                .is_file()
+        );
+        assert!(
+            local_dev_root
+                .join("system/skills/portfolio/scripts/backtest_strategy.py")
+                .is_file()
+        );
+    }
+
+    #[test]
+    fn bundled_reborn_skills_do_not_overwrite_unmanaged_system_skills() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_dev_root = dir.path().join("local-dev");
+        let skill_dir = local_dev_root.join("system/skills/code-review");
+        fs::create_dir_all(&skill_dir).expect("mkdir");
+        fs::write(skill_dir.join("SKILL.md"), "operator-owned").expect("write");
+
+        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+
+        assert_eq!(
+            fs::read_to_string(skill_dir.join("SKILL.md")).expect("read"),
+            "operator-owned"
+        );
+    }
+
+    #[test]
+    fn bundled_reborn_skills_skip_unchanged_managed_dirs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_dev_root = dir.path().join("local-dev");
+        let skill_md = local_dev_root.join("system/skills/code-review/SKILL.md");
+
+        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        let first_modified = fs::metadata(&skill_md)
+            .expect("metadata")
+            .modified()
+            .expect("modified");
+
+        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+
+        assert_eq!(
+            fs::metadata(&skill_md)
+                .expect("metadata")
+                .modified()
+                .expect("modified"),
+            first_modified
+        );
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/bundled_skills.rs
+++ b/crates/ironclaw_reborn_composition/src/bundled_skills.rs
@@ -1,7 +1,10 @@
 use std::collections::HashSet;
 use std::fs;
 use std::hash::Hasher;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use ironclaw_loop_support::SkillFilePath;
 use ironclaw_skills::{ManagedSkillSource, SkillSummary};
@@ -13,7 +16,10 @@ use crate::RebornBuildError;
 const EMBEDDED_REBORN_SKILLS_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/embedded_reborn_skills.json"));
 const BUNDLED_MARKER_FILE: &str = ".ironclaw-reborn-bundled.json";
+const BUNDLED_INSTALL_LOCK_DIR: &str = ".ironclaw-reborn-bundled.lock";
 const BUNDLED_MARKER_OWNER: &str = "ironclaw_reborn_composition_bundled_skill";
+const BUNDLED_INSTALL_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+const BUNDLED_INSTALL_LOCK_RETRY: Duration = Duration::from_millis(25);
 
 #[derive(Debug, Deserialize)]
 struct EmbeddedRebornSkill {
@@ -43,10 +49,8 @@ pub(crate) fn ensure_bundled_reborn_skills_installed(
     local_dev_storage_root: &Path,
 ) -> Result<(), RebornBuildError> {
     let bundled_skills = embedded_reborn_skills()?;
-    fs::create_dir_all(local_dev_storage_root).map_err(invalid_config)?;
-
-    let system_skills_root = local_dev_storage_root.join("system").join("skills");
-    fs::create_dir_all(&system_skills_root).map_err(invalid_config)?;
+    let system_skills_root = prepare_system_skills_root(local_dev_storage_root)?;
+    let _install_lock = BundledSkillInstallLock::acquire(&system_skills_root)?;
 
     let bundled_names = bundled_skills
         .iter()
@@ -78,6 +82,89 @@ pub(crate) fn bundled_reborn_skill_summaries() -> Result<Vec<SkillSummary>, Rebo
 fn embedded_reborn_skills() -> Result<Vec<EmbeddedRebornSkill>, RebornBuildError> {
     serde_json::from_str(EMBEDDED_REBORN_SKILLS_JSON)
         .map_err(|error| invalid_config(format!("failed to parse embedded Reborn skills: {error}")))
+}
+
+fn prepare_system_skills_root(local_dev_storage_root: &Path) -> Result<PathBuf, RebornBuildError> {
+    fs::create_dir_all(local_dev_storage_root).map_err(invalid_config)?;
+    ensure_real_directory(local_dev_storage_root, "local-dev skill storage root")?;
+    let storage_root = local_dev_storage_root
+        .canonicalize()
+        .map_err(invalid_config)?;
+
+    let system_root = local_dev_storage_root.join("system");
+    ensure_real_directory(&system_root, "local-dev system skill storage root")?;
+    let system_skills_root = system_root.join("skills");
+    ensure_real_directory(
+        &system_skills_root,
+        "local-dev system skill storage skills root",
+    )?;
+
+    let canonical_system_skills_root = system_skills_root.canonicalize().map_err(invalid_config)?;
+    if !canonical_system_skills_root.starts_with(&storage_root) {
+        return Err(invalid_config(format!(
+            "local-dev system skills root escapes storage root: {}",
+            system_skills_root.display()
+        )));
+    }
+    Ok(canonical_system_skills_root)
+}
+
+fn ensure_real_directory(path: &Path, label: &str) -> Result<(), RebornBuildError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(invalid_config(format!(
+            "{label} must not be a symlink: {}",
+            path.display()
+        ))),
+        Ok(metadata) if !metadata.is_dir() => Err(invalid_config(format!(
+            "{label} is not a directory: {}",
+            path.display()
+        ))),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            if let Err(error) = fs::create_dir(path)
+                && error.kind() != ErrorKind::AlreadyExists
+            {
+                return Err(invalid_config(error));
+            }
+            ensure_real_directory(path, label)
+        }
+        Err(error) => Err(invalid_config(error)),
+    }
+}
+
+struct BundledSkillInstallLock {
+    path: PathBuf,
+}
+
+impl BundledSkillInstallLock {
+    fn acquire(system_skills_root: &Path) -> Result<Self, RebornBuildError> {
+        let path = system_skills_root.join(BUNDLED_INSTALL_LOCK_DIR);
+        let started_at = Instant::now();
+        loop {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(error)
+                    if error.kind() == ErrorKind::AlreadyExists
+                        && started_at.elapsed() < BUNDLED_INSTALL_LOCK_TIMEOUT =>
+                {
+                    thread::sleep(BUNDLED_INSTALL_LOCK_RETRY);
+                }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    return Err(invalid_config(format!(
+                        "timed out waiting for bundled skill install lock: {}",
+                        path.display()
+                    )));
+                }
+                Err(error) => return Err(invalid_config(error)),
+            }
+        }
+    }
+}
+
+impl Drop for BundledSkillInstallLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
 }
 
 fn remove_stale_managed_skills(
@@ -306,5 +393,63 @@ mod tests {
                 .expect("modified"),
             first_modified
         );
+    }
+
+    #[test]
+    fn bundled_reborn_skills_replace_changed_managed_dirs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_dev_root = dir.path().join("local-dev");
+        let skill_dir = local_dev_root.join("system/skills/code-review");
+        let skill_md = skill_dir.join("SKILL.md");
+
+        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        let bundled_skill_md = fs::read_to_string(&skill_md).expect("read bundled skill");
+        fs::write(&skill_md, "old managed skill").expect("write old skill");
+        fs::write(skill_dir.join("OLD_SENTINEL"), "old").expect("write old sentinel");
+        write_marker(&skill_dir, "stale-content-hash").expect("write stale marker");
+
+        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("replace bundled skills");
+
+        assert_eq!(
+            fs::read_to_string(&skill_md).expect("read replaced skill"),
+            bundled_skill_md
+        );
+        assert!(!skill_dir.join("OLD_SENTINEL").exists());
+        assert_no_bundle_scratch_dirs(&local_dev_root.join("system/skills"));
+    }
+
+    #[test]
+    fn bundled_reborn_skills_remove_stale_managed_dirs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_dev_root = dir.path().join("local-dev");
+        let system_skills_root = local_dev_root.join("system/skills");
+        let obsolete_dir = system_skills_root.join("obsolete-managed");
+        let operator_dir = system_skills_root.join("operator-owned");
+        fs::create_dir_all(&obsolete_dir).expect("obsolete dir");
+        fs::write(obsolete_dir.join("SKILL.md"), "obsolete").expect("obsolete skill");
+        write_marker(&obsolete_dir, "obsolete-hash").expect("obsolete marker");
+        fs::create_dir_all(&operator_dir).expect("operator dir");
+        fs::write(operator_dir.join("SKILL.md"), "operator").expect("operator skill");
+        fs::write(
+            operator_dir.join(BUNDLED_MARKER_FILE),
+            r#"{"owner":"operator","format":1,"content_hash":"operator-hash"}"#,
+        )
+        .expect("operator marker");
+
+        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+
+        assert!(!obsolete_dir.exists());
+        assert!(operator_dir.join("SKILL.md").is_file());
+    }
+
+    fn assert_no_bundle_scratch_dirs(system_skills_root: &Path) {
+        for entry in fs::read_dir(system_skills_root).expect("read system skills") {
+            let entry = entry.expect("system skill entry");
+            let name = entry.file_name().to_string_lossy().to_string();
+            assert!(
+                !name.contains(".tmp-") && !name.contains(".previous-"),
+                "unexpected bundled skill scratch dir: {name}"
+            );
+        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/bundled_skills.rs
+++ b/crates/ironclaw_reborn_composition/src/bundled_skills.rs
@@ -3,32 +3,47 @@ use std::fs;
 use std::hash::Hasher;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::thread;
 use std::time::{Duration, Instant};
 
+use ironclaw_filesystem::{
+    CasExpectation, Entry, FileType, FilesystemError, LocalFilesystem, RootFilesystem,
+};
+use ironclaw_host_api::{HostPath, VirtualPath};
 use ironclaw_loop_support::SkillFilePath;
 use ironclaw_skills::{ManagedSkillSource, SkillSummary};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+use tokio::time::sleep;
 
 use crate::RebornBuildError;
 
-const EMBEDDED_REBORN_SKILLS_JSON: &str =
-    include_str!(concat!(env!("OUT_DIR"), "/embedded_reborn_skills.json"));
+const EMBEDDED_REBORN_SKILL_SUMMARIES_JSON: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/embedded_reborn_skill_summaries.json"
+));
+const EMBEDDED_REBORN_SKILL_BUNDLES_JSON: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/embedded_reborn_skill_bundles.json"
+));
 const BUNDLED_MARKER_FILE: &str = ".ironclaw-reborn-bundled.json";
-const BUNDLED_INSTALL_LOCK_DIR: &str = ".ironclaw-reborn-bundled.lock";
+const BUNDLED_INSTALL_LOCK_FILE: &str = ".ironclaw-reborn-bundled.lock";
 const BUNDLED_MARKER_OWNER: &str = "ironclaw_reborn_composition_bundled_skill";
 const BUNDLED_INSTALL_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 const BUNDLED_INSTALL_LOCK_RETRY: Duration = Duration::from_millis(25);
+const SYSTEM_SKILLS_ROOT: &str = "/projects/system/skills";
 
 #[derive(Debug, Deserialize)]
-struct EmbeddedRebornSkill {
+struct EmbeddedRebornSkillSummary {
     name: String,
     version: String,
     description: String,
     keywords: Vec<String>,
     tags: Vec<String>,
     requires_skills: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbeddedRebornSkillBundle {
+    name: String,
     files: Vec<EmbeddedRebornSkillFile>,
 }
 
@@ -45,27 +60,39 @@ struct BundledSkillMarker {
     content_hash: String,
 }
 
-pub(crate) fn ensure_bundled_reborn_skills_installed(
+pub(crate) async fn ensure_bundled_reborn_skills_installed(
     local_dev_storage_root: &Path,
 ) -> Result<(), RebornBuildError> {
-    let bundled_skills = embedded_reborn_skills()?;
-    let system_skills_root = prepare_system_skills_root(local_dev_storage_root)?;
-    let _install_lock = BundledSkillInstallLock::acquire(&system_skills_root)?;
+    let bundled_skills = embedded_reborn_skill_bundles()?;
+    let filesystem = local_dev_storage_filesystem(local_dev_storage_root)?;
+    let system_skills_root = system_skills_root_path()?;
+    create_dir_all(&filesystem, &system_skills_root).await?;
+    let install_lock = BundledSkillInstallLock::acquire(&filesystem, &system_skills_root).await?;
 
-    let bundled_names = bundled_skills
-        .iter()
-        .map(|skill| skill.name.as_str())
-        .collect::<HashSet<_>>();
-    remove_stale_managed_skills(&system_skills_root, &bundled_names)?;
+    let result = async {
+        let bundled_names = bundled_skills
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect::<HashSet<_>>();
+        remove_stale_managed_skills(&filesystem, &system_skills_root, &bundled_names).await?;
 
-    for skill in bundled_skills {
-        install_bundled_skill(&system_skills_root, skill)?;
+        for skill in bundled_skills {
+            install_bundled_skill(&filesystem, &system_skills_root, skill).await?;
+        }
+        Ok(())
     }
-    Ok(())
+    .await;
+
+    let release_result = install_lock.release(&filesystem).await;
+    match (result, release_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
 }
 
 pub(crate) fn bundled_reborn_skill_summaries() -> Result<Vec<SkillSummary>, RebornBuildError> {
-    Ok(embedded_reborn_skills()?
+    Ok(embedded_reborn_skill_summaries()?
         .into_iter()
         .map(|skill| SkillSummary {
             name: skill.name,
@@ -79,128 +106,155 @@ pub(crate) fn bundled_reborn_skill_summaries() -> Result<Vec<SkillSummary>, Rebo
         .collect())
 }
 
-fn embedded_reborn_skills() -> Result<Vec<EmbeddedRebornSkill>, RebornBuildError> {
-    serde_json::from_str(EMBEDDED_REBORN_SKILLS_JSON)
-        .map_err(|error| invalid_config(format!("failed to parse embedded Reborn skills: {error}")))
+fn embedded_reborn_skill_summaries() -> Result<Vec<EmbeddedRebornSkillSummary>, RebornBuildError> {
+    serde_json::from_str(EMBEDDED_REBORN_SKILL_SUMMARIES_JSON).map_err(|error| {
+        invalid_config(format!(
+            "failed to parse embedded Reborn skill summaries: {error}"
+        ))
+    })
 }
 
-fn prepare_system_skills_root(local_dev_storage_root: &Path) -> Result<PathBuf, RebornBuildError> {
-    fs::create_dir_all(local_dev_storage_root).map_err(invalid_config)?;
-    ensure_real_directory(local_dev_storage_root, "local-dev skill storage root")?;
-    let storage_root = local_dev_storage_root
-        .canonicalize()
+fn embedded_reborn_skill_bundles() -> Result<Vec<EmbeddedRebornSkillBundle>, RebornBuildError> {
+    serde_json::from_str(EMBEDDED_REBORN_SKILL_BUNDLES_JSON).map_err(|error| {
+        invalid_config(format!(
+            "failed to parse embedded Reborn skill bundles: {error}"
+        ))
+    })
+}
+
+fn local_dev_storage_filesystem(
+    local_dev_storage_root: &Path,
+) -> Result<LocalFilesystem, RebornBuildError> {
+    let storage_root = prepare_local_dev_storage_root(local_dev_storage_root)?;
+    let mut filesystem = LocalFilesystem::new();
+    filesystem
+        .mount_local(
+            VirtualPath::new("/projects")?,
+            HostPath::from_path_buf(storage_root),
+        )
         .map_err(invalid_config)?;
+    Ok(filesystem)
+}
 
-    let system_root = local_dev_storage_root.join("system");
-    ensure_real_directory(&system_root, "local-dev system skill storage root")?;
-    let system_skills_root = system_root.join("skills");
-    ensure_real_directory(
-        &system_skills_root,
-        "local-dev system skill storage skills root",
-    )?;
-
-    let canonical_system_skills_root = system_skills_root.canonicalize().map_err(invalid_config)?;
-    if !canonical_system_skills_root.starts_with(&storage_root) {
+fn prepare_local_dev_storage_root(
+    local_dev_storage_root: &Path,
+) -> Result<PathBuf, RebornBuildError> {
+    reject_existing_symlink(local_dev_storage_root, "local-dev skill storage root")?;
+    fs::create_dir_all(local_dev_storage_root).map_err(invalid_config)?;
+    reject_existing_symlink(local_dev_storage_root, "local-dev skill storage root")?;
+    let metadata = fs::metadata(local_dev_storage_root).map_err(invalid_config)?;
+    if !metadata.is_dir() {
         return Err(invalid_config(format!(
-            "local-dev system skills root escapes storage root: {}",
-            system_skills_root.display()
+            "local-dev skill storage root is not a directory: {}",
+            local_dev_storage_root.display()
         )));
     }
-    Ok(canonical_system_skills_root)
+    local_dev_storage_root
+        .canonicalize()
+        .map_err(invalid_config)
 }
 
-fn ensure_real_directory(path: &Path, label: &str) -> Result<(), RebornBuildError> {
+fn reject_existing_symlink(path: &Path, label: &str) -> Result<(), RebornBuildError> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => Err(invalid_config(format!(
             "{label} must not be a symlink: {}",
             path.display()
         ))),
-        Ok(metadata) if !metadata.is_dir() => Err(invalid_config(format!(
-            "{label} is not a directory: {}",
-            path.display()
-        ))),
         Ok(_) => Ok(()),
-        Err(error) if error.kind() == ErrorKind::NotFound => {
-            if let Err(error) = fs::create_dir(path)
-                && error.kind() != ErrorKind::AlreadyExists
-            {
-                return Err(invalid_config(error));
-            }
-            ensure_real_directory(path, label)
-        }
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(invalid_config(error)),
     }
 }
 
+fn system_skills_root_path() -> Result<VirtualPath, RebornBuildError> {
+    VirtualPath::new(SYSTEM_SKILLS_ROOT).map_err(invalid_config)
+}
+
 struct BundledSkillInstallLock {
-    path: PathBuf,
+    path: VirtualPath,
 }
 
 impl BundledSkillInstallLock {
-    fn acquire(system_skills_root: &Path) -> Result<Self, RebornBuildError> {
-        let path = system_skills_root.join(BUNDLED_INSTALL_LOCK_DIR);
+    async fn acquire(
+        filesystem: &dyn RootFilesystem,
+        system_skills_root: &VirtualPath,
+    ) -> Result<Self, RebornBuildError> {
+        let path = child_path(system_skills_root, BUNDLED_INSTALL_LOCK_FILE)?;
         let started_at = Instant::now();
         loop {
-            match fs::create_dir(&path) {
-                Ok(()) => return Ok(Self { path }),
+            match filesystem
+                .put(
+                    &path,
+                    Entry::bytes(format!("{:?}", started_at).into_bytes()),
+                    CasExpectation::Absent,
+                )
+                .await
+            {
+                Ok(_) => return Ok(Self { path }),
                 Err(error)
-                    if error.kind() == ErrorKind::AlreadyExists
+                    if matches!(error, FilesystemError::VersionMismatch { .. })
                         && started_at.elapsed() < BUNDLED_INSTALL_LOCK_TIMEOUT =>
                 {
-                    thread::sleep(BUNDLED_INSTALL_LOCK_RETRY);
+                    sleep(BUNDLED_INSTALL_LOCK_RETRY).await;
                 }
-                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                Err(FilesystemError::VersionMismatch { .. }) => {
                     return Err(invalid_config(format!(
                         "timed out waiting for bundled skill install lock: {}",
-                        path.display()
+                        path
                     )));
                 }
                 Err(error) => return Err(invalid_config(error)),
             }
         }
     }
-}
 
-impl Drop for BundledSkillInstallLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir(&self.path);
+    async fn release(self, filesystem: &dyn RootFilesystem) -> Result<(), RebornBuildError> {
+        delete_if_exists(filesystem, &self.path).await
     }
 }
 
-fn remove_stale_managed_skills(
-    system_skills_root: &Path,
+async fn remove_stale_managed_skills(
+    filesystem: &dyn RootFilesystem,
+    system_skills_root: &VirtualPath,
     bundled_names: &HashSet<&str>,
 ) -> Result<(), RebornBuildError> {
-    let entries = fs::read_dir(system_skills_root).map_err(invalid_config)?;
+    let entries = filesystem
+        .list_dir(system_skills_root)
+        .await
+        .map_err(invalid_config)?;
     for entry in entries {
-        let entry = entry.map_err(invalid_config)?;
-        if !entry.file_type().map_err(invalid_config)?.is_dir() {
+        if entry.file_type != FileType::Directory {
             continue;
         }
-        let name = entry.file_name().to_string_lossy().to_string();
-        if bundled_names.contains(name.as_str()) || read_managed_marker(&entry.path()).is_none() {
+        if bundled_names.contains(entry.name.as_str())
+            || read_managed_marker(filesystem, &entry.path)
+                .await?
+                .is_none()
+        {
             continue;
         }
-        fs::remove_dir_all(entry.path()).map_err(|error| {
+        filesystem.delete(&entry.path).await.map_err(|error| {
             invalid_config(format!(
-                "failed to remove stale bundled skill {name}: {error}"
+                "failed to remove stale bundled skill {}: {error}",
+                entry.name
             ))
         })?;
     }
     Ok(())
 }
 
-fn install_bundled_skill(
-    system_skills_root: &Path,
-    skill: EmbeddedRebornSkill,
+async fn install_bundled_skill(
+    filesystem: &dyn RootFilesystem,
+    system_skills_root: &VirtualPath,
+    skill: EmbeddedRebornSkillBundle,
 ) -> Result<(), RebornBuildError> {
-    let skill_dir = system_skills_root.join(&skill.name);
+    let skill_dir = child_path(system_skills_root, &skill.name)?;
     let content_hash = bundled_skill_hash(&skill);
-    if skill_dir.exists() {
-        let Some(marker) = read_managed_marker(&skill_dir) else {
+    if path_exists(filesystem, &skill_dir).await? {
+        let Some(marker) = read_managed_marker(filesystem, &skill_dir).await? else {
             tracing::warn!(
                 skill_name = %skill.name,
-                path = %skill_dir.display(),
+                path = %skill_dir,
                 "skipping bundled Reborn skill because an unmanaged system skill already exists"
             );
             return Ok(());
@@ -208,83 +262,142 @@ fn install_bundled_skill(
         if marker.content_hash == content_hash {
             return Ok(());
         }
-    }
-
-    let staging_dir = system_skills_root.join(format!(".{}.tmp-{}", skill.name, Uuid::new_v4()));
-    if staging_dir.exists() {
-        fs::remove_dir_all(&staging_dir).map_err(invalid_config)?;
-    }
-    write_bundled_skill_dir(&staging_dir, &skill, &content_hash)?;
-    replace_skill_dir(&skill_dir, &staging_dir, &skill.name)
-}
-
-fn write_bundled_skill_dir(
-    staging_dir: &Path,
-    skill: &EmbeddedRebornSkill,
-    content_hash: &str,
-) -> Result<(), RebornBuildError> {
-    fs::create_dir_all(staging_dir).map_err(invalid_config)?;
-    for file in &skill.files {
-        let relative_path = validated_bundle_file_path(&file.path)?;
-        let target = staging_dir.join(relative_path);
-        if let Some(parent) = target.parent() {
-            fs::create_dir_all(parent).map_err(invalid_config)?;
-        }
-        fs::write(&target, &file.bytes).map_err(|error| {
+        filesystem.delete(&skill_dir).await.map_err(|error| {
             invalid_config(format!(
-                "failed to write bundled skill file {}: {error}",
-                target.display()
+                "failed to remove changed bundled skill {}: {error}",
+                skill.name
             ))
         })?;
     }
-    write_marker(staging_dir, content_hash)
-}
 
-fn replace_skill_dir(
-    skill_dir: &Path,
-    staging_dir: &Path,
-    skill_name: &str,
-) -> Result<(), RebornBuildError> {
-    if !skill_dir.exists() {
-        return fs::rename(staging_dir, skill_dir).map_err(invalid_config);
-    }
-
-    let backup_dir = skill_dir.with_file_name(format!(".{skill_name}.previous-{}", Uuid::new_v4()));
-    fs::rename(skill_dir, &backup_dir).map_err(invalid_config)?;
-    if let Err(error) = fs::rename(staging_dir, skill_dir) {
-        if let Err(restore_error) = fs::rename(&backup_dir, skill_dir) {
+    if let Err(error) = write_bundled_skill_dir(filesystem, &skill_dir, &skill, &content_hash).await
+    {
+        let cleanup_result = delete_if_exists(filesystem, &skill_dir).await;
+        if let Err(cleanup_error) = cleanup_result {
             return Err(invalid_config(format!(
-                "failed to replace bundled skill {skill_name}: {error}; restore failed: {restore_error}"
+                "failed to install bundled skill {}; cleanup failed after {error}: {cleanup_error}",
+                skill.name
             )));
         }
-        return Err(invalid_config(format!(
-            "failed to replace bundled skill {skill_name}: {error}"
-        )));
+        return Err(error);
     }
-    fs::remove_dir_all(&backup_dir).map_err(invalid_config)
+    Ok(())
 }
 
-fn read_managed_marker(skill_dir: &Path) -> Option<BundledSkillMarker> {
-    let marker_path = skill_dir.join(BUNDLED_MARKER_FILE);
-    let bytes = fs::read(marker_path).ok()?;
-    let marker = serde_json::from_slice::<BundledSkillMarker>(&bytes).ok()?;
-    (marker.owner == BUNDLED_MARKER_OWNER).then_some(marker)
+async fn write_bundled_skill_dir(
+    filesystem: &dyn RootFilesystem,
+    skill_dir: &VirtualPath,
+    skill: &EmbeddedRebornSkillBundle,
+    content_hash: &str,
+) -> Result<(), RebornBuildError> {
+    for file in &skill.files {
+        let relative_path = validated_bundle_file_path(&file.path)?;
+        let target = bundle_file_path(skill_dir, &relative_path)?;
+        filesystem
+            .put(
+                &target,
+                Entry::bytes(file.bytes.clone()),
+                CasExpectation::Any,
+            )
+            .await
+            .map_err(|error| {
+                invalid_config(format!(
+                    "failed to write bundled skill file {}: {error}",
+                    target
+                ))
+            })?;
+    }
+    write_marker(filesystem, skill_dir, content_hash).await
 }
 
-fn write_marker(skill_dir: &Path, content_hash: &str) -> Result<(), RebornBuildError> {
+async fn read_managed_marker(
+    filesystem: &dyn RootFilesystem,
+    skill_dir: &VirtualPath,
+) -> Result<Option<BundledSkillMarker>, RebornBuildError> {
+    let marker_path = child_path(skill_dir, BUNDLED_MARKER_FILE)?;
+    let Some(entry) = filesystem.get(&marker_path).await.map_err(invalid_config)? else {
+        return Ok(None);
+    };
+    let Some(marker) = serde_json::from_slice::<BundledSkillMarker>(&entry.entry.body).ok() else {
+        return Ok(None);
+    };
+    Ok((marker.owner == BUNDLED_MARKER_OWNER).then_some(marker))
+}
+
+async fn write_marker(
+    filesystem: &dyn RootFilesystem,
+    skill_dir: &VirtualPath,
+    content_hash: &str,
+) -> Result<(), RebornBuildError> {
     let marker = BundledSkillMarker {
         owner: BUNDLED_MARKER_OWNER.to_string(),
         format: 1,
         content_hash: content_hash.to_string(),
     };
-    let marker_path = skill_dir.join(BUNDLED_MARKER_FILE);
+    let marker_path = child_path(skill_dir, BUNDLED_MARKER_FILE)?;
     let bytes = serde_json::to_vec_pretty(&marker).map_err(invalid_config)?;
-    fs::write(&marker_path, bytes).map_err(|error| {
-        invalid_config(format!(
-            "failed to write bundled skill marker {}: {error}",
-            marker_path.display()
-        ))
-    })
+    filesystem
+        .put(&marker_path, Entry::bytes(bytes), CasExpectation::Any)
+        .await
+        .map(|_| ())
+        .map_err(|error| {
+            invalid_config(format!(
+                "failed to write bundled skill marker {}: {error}",
+                marker_path
+            ))
+        })
+}
+
+async fn create_dir_all(
+    filesystem: &dyn RootFilesystem,
+    path: &VirtualPath,
+) -> Result<(), RebornBuildError> {
+    filesystem
+        .create_dir_all(path)
+        .await
+        .map_err(invalid_config)
+}
+
+async fn path_exists(
+    filesystem: &dyn RootFilesystem,
+    path: &VirtualPath,
+) -> Result<bool, RebornBuildError> {
+    match filesystem.stat(path).await {
+        Ok(_) => Ok(true),
+        Err(FilesystemError::NotFound { .. }) => Ok(false),
+        Err(error) => Err(invalid_config(error)),
+    }
+}
+
+async fn delete_if_exists(
+    filesystem: &dyn RootFilesystem,
+    path: &VirtualPath,
+) -> Result<(), RebornBuildError> {
+    match filesystem.delete(path).await {
+        Ok(()) => Ok(()),
+        Err(FilesystemError::NotFound { .. }) => Ok(()),
+        Err(error) => Err(invalid_config(error)),
+    }
+}
+
+fn child_path(parent: &VirtualPath, child: &str) -> Result<VirtualPath, RebornBuildError> {
+    VirtualPath::new(format!(
+        "{}/{}",
+        parent.as_str().trim_end_matches('/'),
+        child
+    ))
+    .map_err(invalid_config)
+}
+
+fn bundle_file_path(
+    skill_dir: &VirtualPath,
+    relative_path: &Path,
+) -> Result<VirtualPath, RebornBuildError> {
+    let relative_path = relative_path
+        .to_str()
+        .ok_or_else(|| invalid_config("bundled skill file path must be UTF-8"))?
+        .replace('\\', "/");
+    child_path(skill_dir, &relative_path)
 }
 
 fn validated_bundle_file_path(path: &str) -> Result<PathBuf, RebornBuildError> {
@@ -293,7 +406,7 @@ fn validated_bundle_file_path(path: &str) -> Result<PathBuf, RebornBuildError> {
     Ok(Path::new(path.as_str()).to_path_buf())
 }
 
-fn bundled_skill_hash(skill: &EmbeddedRebornSkill) -> String {
+fn bundled_skill_hash(skill: &EmbeddedRebornSkillBundle) -> String {
     let mut hasher = StableFnv64::default();
     hasher.write(skill.name.as_bytes());
     for file in &skill.files {
@@ -337,12 +450,14 @@ fn invalid_config(reason: impl std::fmt::Display) -> RebornBuildError {
 mod tests {
     use super::*;
 
-    #[test]
-    fn bundled_reborn_skills_include_current_repo_bundles_and_assets() {
+    #[tokio::test]
+    async fn bundled_reborn_skills_include_current_repo_bundles_and_assets() {
         let dir = tempfile::tempdir().expect("tempdir");
         let local_dev_root = dir.path().join("local-dev");
 
-        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        ensure_bundled_reborn_skills_installed(&local_dev_root)
+            .await
+            .expect("install bundled skills");
 
         assert!(
             local_dev_root
@@ -356,15 +471,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn bundled_reborn_skills_do_not_overwrite_unmanaged_system_skills() {
+    #[tokio::test]
+    async fn bundled_reborn_skills_do_not_overwrite_unmanaged_system_skills() {
         let dir = tempfile::tempdir().expect("tempdir");
         let local_dev_root = dir.path().join("local-dev");
         let skill_dir = local_dev_root.join("system/skills/code-review");
         fs::create_dir_all(&skill_dir).expect("mkdir");
         fs::write(skill_dir.join("SKILL.md"), "operator-owned").expect("write");
 
-        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        ensure_bundled_reborn_skills_installed(&local_dev_root)
+            .await
+            .expect("install bundled skills");
 
         assert_eq!(
             fs::read_to_string(skill_dir.join("SKILL.md")).expect("read"),
@@ -372,19 +489,23 @@ mod tests {
         );
     }
 
-    #[test]
-    fn bundled_reborn_skills_skip_unchanged_managed_dirs() {
+    #[tokio::test]
+    async fn bundled_reborn_skills_skip_unchanged_managed_dirs() {
         let dir = tempfile::tempdir().expect("tempdir");
         let local_dev_root = dir.path().join("local-dev");
         let skill_md = local_dev_root.join("system/skills/code-review/SKILL.md");
 
-        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        ensure_bundled_reborn_skills_installed(&local_dev_root)
+            .await
+            .expect("install bundled skills");
         let first_modified = fs::metadata(&skill_md)
             .expect("metadata")
             .modified()
             .expect("modified");
 
-        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        ensure_bundled_reborn_skills_installed(&local_dev_root)
+            .await
+            .expect("install bundled skills");
 
         assert_eq!(
             fs::metadata(&skill_md)
@@ -395,20 +516,24 @@ mod tests {
         );
     }
 
-    #[test]
-    fn bundled_reborn_skills_replace_changed_managed_dirs() {
+    #[tokio::test]
+    async fn bundled_reborn_skills_replace_changed_managed_dirs() {
         let dir = tempfile::tempdir().expect("tempdir");
         let local_dev_root = dir.path().join("local-dev");
         let skill_dir = local_dev_root.join("system/skills/code-review");
         let skill_md = skill_dir.join("SKILL.md");
 
-        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        ensure_bundled_reborn_skills_installed(&local_dev_root)
+            .await
+            .expect("install bundled skills");
         let bundled_skill_md = fs::read_to_string(&skill_md).expect("read bundled skill");
         fs::write(&skill_md, "old managed skill").expect("write old skill");
         fs::write(skill_dir.join("OLD_SENTINEL"), "old").expect("write old sentinel");
-        write_marker(&skill_dir, "stale-content-hash").expect("write stale marker");
+        write_marker_file(&skill_dir, "stale-content-hash");
 
-        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("replace bundled skills");
+        ensure_bundled_reborn_skills_installed(&local_dev_root)
+            .await
+            .expect("replace bundled skills");
 
         assert_eq!(
             fs::read_to_string(&skill_md).expect("read replaced skill"),
@@ -418,8 +543,8 @@ mod tests {
         assert_no_bundle_scratch_dirs(&local_dev_root.join("system/skills"));
     }
 
-    #[test]
-    fn bundled_reborn_skills_remove_stale_managed_dirs() {
+    #[tokio::test]
+    async fn bundled_reborn_skills_remove_stale_managed_dirs() {
         let dir = tempfile::tempdir().expect("tempdir");
         let local_dev_root = dir.path().join("local-dev");
         let system_skills_root = local_dev_root.join("system/skills");
@@ -427,7 +552,7 @@ mod tests {
         let operator_dir = system_skills_root.join("operator-owned");
         fs::create_dir_all(&obsolete_dir).expect("obsolete dir");
         fs::write(obsolete_dir.join("SKILL.md"), "obsolete").expect("obsolete skill");
-        write_marker(&obsolete_dir, "obsolete-hash").expect("obsolete marker");
+        write_marker_file(&obsolete_dir, "obsolete-hash");
         fs::create_dir_all(&operator_dir).expect("operator dir");
         fs::write(operator_dir.join("SKILL.md"), "operator").expect("operator skill");
         fs::write(
@@ -436,7 +561,9 @@ mod tests {
         )
         .expect("operator marker");
 
-        ensure_bundled_reborn_skills_installed(&local_dev_root).expect("install bundled skills");
+        ensure_bundled_reborn_skills_installed(&local_dev_root)
+            .await
+            .expect("install bundled skills");
 
         assert!(!obsolete_dir.exists());
         assert!(operator_dir.join("SKILL.md").is_file());
@@ -451,5 +578,15 @@ mod tests {
                 "unexpected bundled skill scratch dir: {name}"
             );
         }
+    }
+
+    fn write_marker_file(skill_dir: &Path, content_hash: &str) {
+        let marker = BundledSkillMarker {
+            owner: BUNDLED_MARKER_OWNER.to_string(),
+            format: 1,
+            content_hash: content_hash.to_string(),
+        };
+        let bytes = serde_json::to_vec_pretty(&marker).expect("marker json");
+        fs::write(skill_dir.join(BUNDLED_MARKER_FILE), bytes).expect("write marker");
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -351,6 +351,7 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
             reason: error.to_string(),
         }
     })?;
+    crate::bundled_skills::ensure_bundled_reborn_skills_installed(&root)?;
     let filesystem =
         build_local_dev_root_filesystem(&root, &workspace_root, host_home_root.as_ref()).await?;
     let (skill_filesystem, workspace_filesystem, runtime_workspace_mounts) =

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -351,7 +351,7 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
             reason: error.to_string(),
         }
     })?;
-    crate::bundled_skills::ensure_bundled_reborn_skills_installed(&root)?;
+    crate::bundled_skills::ensure_bundled_reborn_skills_installed(&root).await?;
     let filesystem =
         build_local_dev_root_filesystem(&root, &workspace_root, host_home_root.as_ref()).await?;
     let (skill_filesystem, workspace_filesystem, runtime_workspace_mounts) =

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 mod auth;
 mod available_extensions;
+mod bundled_skills;
 mod default_system_prompt;
 mod error;
 mod extension_installation_store;

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2531,20 +2531,20 @@ mod tests {
     async fn local_dev_runtime_suppresses_explicit_setup_skill_when_workspace_marker_exists() {
         let root = tempfile::tempdir().expect("tempdir");
         let storage_root = root.path().join("local-dev");
-        std::fs::create_dir_all(storage_root.join("skills/setup-helper")).expect("user skill dir");
+        std::fs::create_dir_all(storage_root.join("skills/marker-helper")).expect("user skill dir");
         std::fs::create_dir_all(storage_root.join("workspace/markers")).expect("marker dir");
         std::fs::write(
-            storage_root.join("skills/setup-helper/SKILL.md"),
+            storage_root.join("skills/marker-helper/SKILL.md"),
             skill_md_with_setup_marker(
-                "setup-helper",
-                "setup helper description",
-                "markers/setup-helper.done",
-                "SETUP_HELPER_PROMPT_SENTINEL",
+                "marker-helper",
+                "marker helper description",
+                "markers/marker-helper.done",
+                "MARKER_HELPER_PROMPT_SENTINEL",
             ),
         )
-        .expect("write setup helper skill");
+        .expect("write marker helper skill");
         std::fs::write(
-            storage_root.join("workspace/markers/setup-helper.done"),
+            storage_root.join("workspace/markers/marker-helper.done"),
             "done",
         )
         .expect("write setup marker");
@@ -2573,7 +2573,7 @@ mod tests {
         let conversation = runtime.new_conversation().await.expect("conversation");
         let result = tokio::time::timeout(
             Duration::from_secs(3),
-            runtime.execute_skill_message(&conversation, "$setup-helper"),
+            runtime.execute_skill_message(&conversation, "$marker-helper"),
         )
         .await
         .expect("skill execution should finish")
@@ -2606,17 +2606,17 @@ mod tests {
     async fn local_dev_runtime_activates_setup_skill_when_workspace_marker_is_absent() {
         let root = tempfile::tempdir().expect("tempdir");
         let storage_root = root.path().join("local-dev");
-        std::fs::create_dir_all(storage_root.join("skills/setup-helper")).expect("user skill dir");
+        std::fs::create_dir_all(storage_root.join("skills/marker-helper")).expect("user skill dir");
         std::fs::write(
-            storage_root.join("skills/setup-helper/SKILL.md"),
+            storage_root.join("skills/marker-helper/SKILL.md"),
             skill_md_with_setup_marker(
-                "setup-helper",
-                "setup helper description",
-                "markers/setup-helper.done",
-                "SETUP_HELPER_PROMPT_SENTINEL",
+                "marker-helper",
+                "marker helper description",
+                "markers/marker-helper.done",
+                "MARKER_HELPER_PROMPT_SENTINEL",
             ),
         )
-        .expect("write setup helper skill");
+        .expect("write marker helper skill");
         let requests = Arc::new(StdMutex::new(Vec::new()));
         let gateway = Arc::new(RecordingGateway {
             reply: "setup marker absent ok".to_string(),
@@ -2642,7 +2642,7 @@ mod tests {
         let conversation = runtime.new_conversation().await.expect("conversation");
         let result = tokio::time::timeout(
             Duration::from_secs(3),
-            runtime.execute_skill_message(&conversation, "$setup-helper"),
+            runtime.execute_skill_message(&conversation, "$marker-helper"),
         )
         .await
         .expect("skill execution should finish")
@@ -2650,7 +2650,7 @@ mod tests {
 
         assert_eq!(result.reply.status, TurnStatus::Completed);
         assert_eq!(result.plan.activations().len(), 1);
-        assert_eq!(result.plan.activations()[0].name, "setup-helper");
+        assert_eq!(result.plan.activations()[0].name, "marker-helper");
         let skill_context = {
             let requests = requests
                 .lock()
@@ -2669,8 +2669,8 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join("\n")
         };
-        assert!(skill_context.contains("setup helper description"));
-        assert!(skill_context.contains("SETUP_HELPER_PROMPT_SENTINEL"));
+        assert!(skill_context.contains("marker helper description"));
+        assert!(skill_context.contains("MARKER_HELPER_PROMPT_SENTINEL"));
 
         runtime.shutdown().await.expect("runtime shutdown");
     }
@@ -2753,7 +2753,7 @@ mod tests {
         let conversation = runtime.new_conversation().await.expect("conversation");
         let reply = tokio::time::timeout(
             Duration::from_secs(3),
-            runtime.send_user_message(&conversation, "review this"),
+            runtime.send_user_message(&conversation, "hello with no matching skill"),
         )
         .await
         .expect("runtime send should finish")

--- a/crates/ironclaw_reborn_composition/src/skill_listing.rs
+++ b/crates/ironclaw_reborn_composition/src/skill_listing.rs
@@ -1,4 +1,6 @@
-use ironclaw_skills::{SkillManagementError, SkillManagementErrorKind};
+use std::collections::HashSet;
+
+use ironclaw_skills::{ManagedSkillSource, SkillManagementError, SkillManagementErrorKind};
 
 use crate::{
     RebornBuildError,
@@ -18,16 +20,29 @@ pub async fn list_reborn_local_skills(
                 .map_err(map_local_skill_management_error)?,
             None => Vec::new(),
         };
-    let existing_names = skills
+    let bundled_skills = bundled_reborn_skill_summaries()?;
+    let bundled_names = bundled_skills
         .iter()
         .map(|skill| skill.name.clone())
-        .collect::<std::collections::HashSet<_>>();
+        .collect::<HashSet<_>>();
+    skills.retain(|skill| {
+        !(skill.source == ManagedSkillSource::System && bundled_names.contains(&skill.name))
+    });
+
+    let existing_keys = skills
+        .iter()
+        .map(|skill| (skill.name.clone(), skill.source.as_str()))
+        .collect::<HashSet<_>>();
     skills.extend(
-        bundled_reborn_skill_summaries()?
+        bundled_skills
             .into_iter()
-            .filter(|skill| !existing_names.contains(&skill.name)),
+            .filter(|skill| !existing_keys.contains(&(skill.name.clone(), skill.source.as_str()))),
     );
-    skills.sort_by(|left, right| left.name.cmp(&right.name));
+    skills.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.source.as_str().cmp(right.source.as_str()))
+    });
     Ok(skills)
 }
 
@@ -170,12 +185,88 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn local_skill_list_prefers_user_skill_over_bundled_duplicate_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_root = dir.path().join("local-dev");
+        write_skill(&storage_root, "code-review");
+
+        let result = list_reborn_local_skills("list-owner", &storage_root)
+            .await
+            .expect("list skills");
+
+        let code_review_skills = result
+            .iter()
+            .filter(|skill| skill.name == "code-review")
+            .collect::<Vec<_>>();
+        assert_eq!(code_review_skills.len(), 2);
+        assert!(
+            code_review_skills
+                .iter()
+                .any(|skill| skill.source == ManagedSkillSource::User)
+        );
+        assert!(
+            code_review_skills
+                .iter()
+                .any(|skill| skill.source == ManagedSkillSource::System)
+        );
+
+        let mut seen = std::collections::HashSet::new();
+        for skill in result {
+            assert!(
+                seen.insert((skill.name.clone(), skill.source.as_str())),
+                "duplicate skill entry for {} from {}",
+                skill.name,
+                skill.source.as_str()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn local_skill_list_prefers_embedded_bundled_summary_over_storage_system_skill() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_root = dir.path().join("local-dev");
+        write_system_skill(&storage_root, "code-review", "old system description");
+        let bundled_code_review = bundled_reborn_skill_summaries()
+            .expect("bundled summaries")
+            .into_iter()
+            .find(|skill| skill.name == "code-review")
+            .expect("bundled code-review");
+
+        let result = list_reborn_local_skills("list-owner", &storage_root)
+            .await
+            .expect("list skills");
+
+        let system_code_reviews = result
+            .iter()
+            .filter(|skill| {
+                skill.name == "code-review" && skill.source == ManagedSkillSource::System
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(system_code_reviews.len(), 1);
+        assert_eq!(
+            system_code_reviews[0].description,
+            bundled_code_review.description
+        );
+        assert_ne!(system_code_reviews[0].description, "old system description");
+    }
+
     fn write_skill(storage_root: &std::path::Path, name: &str) {
         let skill_dir = storage_root.join("skills").join(name);
         std::fs::create_dir_all(&skill_dir).expect("skill dir");
         std::fs::write(
             skill_dir.join("SKILL.md"),
             format!("---\nname: {name}\ndescription: list test\n---\nUse list.\n"),
+        )
+        .expect("skill file");
+    }
+
+    fn write_system_skill(storage_root: &std::path::Path, name: &str, description: &str) {
+        let skill_dir = storage_root.join("system/skills").join(name);
+        std::fs::create_dir_all(&skill_dir).expect("skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\nUse system.\n"),
         )
         .expect("skill file");
     }

--- a/crates/ironclaw_reborn_composition/src/skill_listing.rs
+++ b/crates/ironclaw_reborn_composition/src/skill_listing.rs
@@ -2,6 +2,7 @@ use ironclaw_skills::{SkillManagementError, SkillManagementErrorKind};
 
 use crate::{
     RebornBuildError,
+    bundled_skills::bundled_reborn_skill_summaries,
     lifecycle::{RebornLocalSkillManagementError, build_existing_local_dev_skill_management_port},
 };
 
@@ -9,15 +10,25 @@ pub async fn list_reborn_local_skills(
     owner_id: impl Into<String>,
     local_dev_storage_root: impl Into<std::path::PathBuf>,
 ) -> Result<Vec<ironclaw_skills::SkillSummary>, RebornSkillListError> {
-    let Some(skill_management) =
-        build_existing_local_dev_skill_management_port(owner_id, local_dev_storage_root)?
-    else {
-        return Ok(Vec::new());
-    };
-    skill_management
-        .list()
-        .await
-        .map_err(map_local_skill_management_error)
+    let mut skills =
+        match build_existing_local_dev_skill_management_port(owner_id, local_dev_storage_root)? {
+            Some(skill_management) => skill_management
+                .list()
+                .await
+                .map_err(map_local_skill_management_error)?,
+            None => Vec::new(),
+        };
+    let existing_names = skills
+        .iter()
+        .map(|skill| skill.name.clone())
+        .collect::<std::collections::HashSet<_>>();
+    skills.extend(
+        bundled_reborn_skill_summaries()?
+            .into_iter()
+            .filter(|skill| !existing_names.contains(&skill.name)),
+    );
+    skills.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(skills)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -78,17 +89,23 @@ mod tests {
             .await
             .expect("list skills");
 
-        assert_eq!(result.len(), 55);
         assert!(result.iter().any(|skill| skill.name == "list-skill-54"));
         assert!(
             result
                 .iter()
+                .any(|skill| skill.name == "code-review"
+                    && skill.source == ManagedSkillSource::System)
+        );
+        assert!(
+            result
+                .iter()
+                .filter(|skill| skill.name.starts_with("list-skill-"))
                 .all(|skill| skill.source == ManagedSkillSource::User)
         );
     }
 
     #[tokio::test]
-    async fn local_skill_list_missing_storage_is_empty_without_creating_state() {
+    async fn local_skill_list_missing_storage_reports_bundled_without_creating_state() {
         let dir = tempfile::tempdir().expect("tempdir");
         let storage_root = dir.path().join("missing-local-dev");
 
@@ -96,7 +113,12 @@ mod tests {
             .await
             .expect("list skills");
 
-        assert!(result.is_empty());
+        assert!(
+            result
+                .iter()
+                .any(|skill| skill.name == "code-review"
+                    && skill.source == ManagedSkillSource::System)
+        );
         assert!(!storage_root.exists());
     }
 

--- a/crates/ironclaw_reborn_composition/tests/runtime.rs
+++ b/crates/ironclaw_reborn_composition/tests/runtime.rs
@@ -137,18 +137,18 @@ async fn send_user_message_with_cancellation_cancels_submitted_run() {
 async fn skill_execution_adapter_prepares_filesystem_bundles_end_to_end() {
     let root = tempfile::tempdir().unwrap();
     let storage_root = root.path().join("local-dev");
-    std::fs::create_dir_all(storage_root.join("skills/code-review/references")).unwrap();
+    std::fs::create_dir_all(storage_root.join("skills/filesystem-review/references")).unwrap();
     std::fs::write(
-        storage_root.join("skills/code-review/SKILL.md"),
+        storage_root.join("skills/filesystem-review/SKILL.md"),
         skill_md(
-            "code-review",
-            "review",
+            "filesystem-review",
+            "filesystem-review",
             "Use filesystem-backed review guidance.",
         ),
     )
     .unwrap();
     std::fs::write(
-        storage_root.join("skills/code-review/references/policy.md"),
+        storage_root.join("skills/filesystem-review/references/policy.md"),
         "filesystem policy",
     )
     .unwrap();
@@ -171,20 +171,23 @@ async fn skill_execution_adapter_prepares_filesystem_bundles_end_to_end() {
     let conversation = runtime.new_conversation().await.unwrap();
     let result = tokio::time::timeout(
         Duration::from_secs(3),
-        runtime.execute_skill_message(&conversation, "please review this"),
+        runtime.execute_skill_message(&conversation, "$filesystem-review"),
     )
     .await
     .unwrap()
     .unwrap();
 
     assert_eq!(result.plan.activations().len(), 1);
-    assert_eq!(result.plan.activations()[0].name, "code-review");
+    assert_eq!(result.plan.activations()[0].name, "filesystem-review");
     assert_eq!(result.plan.active_bundles().len(), 1);
     assert_eq!(
         result.plan.active_bundles()[0].source,
         RebornSkillSourceKind::User
     );
-    assert_eq!(result.plan.active_bundles()[0].skill_name, "code-review");
+    assert_eq!(
+        result.plan.active_bundles()[0].skill_name,
+        "filesystem-review"
+    );
 
     let asset = runtime
         .read_skill_execution_asset(


### PR DESCRIPTION
## Summary
- embed repo skills into the Reborn composition crate at build time
- install bundled system skills during local runtime bootstrap, with managed markers and staged replacement
- make `ironclaw-reborn skills list` report bundled skills without mutating local-dev storage

## Verification
- `cargo test -p ironclaw_reborn_composition`
- `cargo test -p ironclaw_reborn_cli`
- `cargo test -p ironclaw_reborn_cli skills_list`
- `cargo test -p ironclaw_architecture reborn`
- `cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`