### PR TITLE
feat: webui v2 capability preview cards

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useSSE.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useSSE.js
@@ -13,6 +13,8 @@ const V2_EVENT_NAMES = [
   "accepted",
   "running",
   "capability_progress",
+  "capability_activity",
+  "capability_display_preview",
   "gate",
   "auth_required",
   "final_reply",

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
@@ -96,6 +96,7 @@ function toolCardFromPreviewRecord(record) {
 // `CapabilityDisplayPreviewView` (SSE) into the field set
 // `ToolActivityCard` destructures.
 export function toolCardFromPreview(preview) {
+  const failed = preview.status === "failed" || preview.status === "killed";
   return {
     invocationId: preview.invocation_id,
     callId: preview.invocation_id,
@@ -103,9 +104,18 @@ export function toolCardFromPreview(preview) {
     toolStatus: toolStatusFromActivityStatus(preview.status),
     toolDetail: preview.subtitle || null,
     toolParameters: preview.input_summary || null,
-    toolResultPreview:
-      preview.output_preview || preview.output_summary || null,
-    toolError: previewErrorMessage(preview),
+    // On failure the output fields carry the error text — surface it
+    // only through `toolError` so the card renders it once in red,
+    // not twice (once as a teal result preview and once as the error).
+    toolResultPreview: failed
+      ? null
+      : preview.output_preview || preview.output_summary || null,
+    toolError: failed
+      ? preview.output_summary ||
+        preview.output_preview ||
+        preview.result_ref ||
+        null
+      : null,
     toolDurationMs: null,
     updatedAt: preview.updated_at || null,
     resultRef: preview.result_ref || null,
@@ -156,12 +166,3 @@ function toolStatusFromActivityStatus(status) {
   }
 }
 
-function previewErrorMessage(preview) {
-  if (preview.status !== "failed" && preview.status !== "killed") return null;
-  return (
-    preview.output_summary ||
-    preview.output_preview ||
-    preview.result_ref ||
-    null
-  );
-}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
@@ -9,6 +9,30 @@ export function messagesFromTimeline(records, pendingMessages = []) {
   const messages = [];
 
   for (const record of records || []) {
+    if (record.kind === "tool_result_reference") {
+      // LLM-visible transcript artifact (result_ref + safe_summary).
+      // Not a UI message — the matching `capability_display_preview`
+      // record renders the tool card.
+      continue;
+    }
+
+    if (record.kind === "capability_display_preview") {
+      const card = toolCardFromPreviewRecord(record);
+      if (!card) continue;
+      const id = `tool-${card.invocationId}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      messages.push({
+        id,
+        role: "tool_activity",
+        ...card,
+        timestamp: timestampForRecord(record) || card.updatedAt || null,
+        sequence: record.sequence,
+        turnRunId: record.turn_run_id || null,
+      });
+      continue;
+    }
+
     const id = `msg-${record.message_id}`;
     if (seen.has(id)) continue;
     seen.add(id);
@@ -53,4 +77,91 @@ function timestampForRecord(record) {
   // the sequence ordering for now. Browsers render the wall-clock
   // when an event arrives (FinalReplyView.generated_at).
   return record.received_at || record.created_at || null;
+}
+
+function toolCardFromPreviewRecord(record) {
+  if (!record.content) return null;
+  let envelope;
+  try {
+    envelope = JSON.parse(record.content);
+  } catch (err) {
+    console.warn("Failed to parse capability_display_preview envelope", err);
+    return null;
+  }
+  if (!envelope || !envelope.invocation_id) return null;
+  return toolCardFromPreview(envelope);
+}
+
+// Map a `CapabilityDisplayPreviewEnvelope` (timeline) or
+// `CapabilityDisplayPreviewView` (SSE) into the field set
+// `ToolActivityCard` destructures.
+export function toolCardFromPreview(preview) {
+  return {
+    invocationId: preview.invocation_id,
+    callId: preview.invocation_id,
+    toolName: preview.title || preview.capability_id || "tool",
+    toolStatus: toolStatusFromActivityStatus(preview.status),
+    toolDetail: preview.subtitle || null,
+    toolParameters: preview.input_summary || null,
+    toolResultPreview:
+      preview.output_preview || preview.output_summary || null,
+    toolError: previewErrorMessage(preview),
+    toolDurationMs: null,
+    updatedAt: preview.updated_at || null,
+    resultRef: preview.result_ref || null,
+    truncated: Boolean(preview.truncated),
+    outputBytes: preview.output_bytes ?? null,
+    outputKind: preview.output_kind || null,
+  };
+}
+
+// Map a `CapabilityActivityView` (SSE lifecycle frame) into the same
+// card shape. Activity frames carry only metadata — no title, no
+// parameters, no output — so the resulting card is intentionally
+// sparse and is meant to be enriched by the next preview frame.
+export function toolCardFromActivity(activity) {
+  return {
+    invocationId: activity.invocation_id,
+    callId: activity.invocation_id,
+    toolName: activity.capability_id || "tool",
+    toolStatus: toolStatusFromActivityStatus(activity.status),
+    toolDetail: null,
+    toolParameters: null,
+    toolResultPreview: null,
+    toolError: activity.error_kind || null,
+    toolDurationMs: null,
+    updatedAt: activity.updated_at || null,
+    resultRef: null,
+    truncated: false,
+    outputBytes: activity.output_bytes ?? null,
+    outputKind: null,
+  };
+}
+
+export function isTerminalToolStatus(status) {
+  return status === "success" || status === "error";
+}
+
+function toolStatusFromActivityStatus(status) {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "failed":
+    case "killed":
+      return "error";
+    case "started":
+    case "running":
+    default:
+      return "running";
+  }
+}
+
+function previewErrorMessage(preview) {
+  if (preview.status !== "failed" && preview.status !== "killed") return null;
+  return (
+    preview.output_summary ||
+    preview.output_preview ||
+    preview.result_ref ||
+    null
+  );
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -1,5 +1,10 @@
 import { React } from "../../../lib/html.js";
 import { gateFromEvent } from "./gates.js";
+import {
+  isTerminalToolStatus,
+  toolCardFromActivity,
+  toolCardFromPreview,
+} from "./history-messages.js";
 
 // Handler factory for v2 `WebChatV2EventFrame` events.
 //
@@ -71,6 +76,31 @@ export function useChatEvents({
             );
           }
           setIsProcessing(true);
+          return;
+        }
+
+        case "capability_activity": {
+          // Lifecycle metadata for a capability invocation. Used to
+          // render a "running" placeholder card before the richer
+          // `capability_display_preview` frame arrives at terminal
+          // time. Keyed by invocation_id so the preview frame can
+          // upgrade the same bubble in place.
+          const activity = frame.activity;
+          if (!activity || !activity.invocation_id) return;
+          const card = toolCardFromActivity(activity);
+          upsertToolFromActivity(setMessages, activity.invocation_id, card);
+          return;
+        }
+
+        case "capability_display_preview": {
+          // Final sanitized display artifact for a capability
+          // invocation (carries title, input/output summaries, and
+          // truncated preview). Replaces any prior activity-derived
+          // card for the same invocation_id.
+          const preview = frame.preview;
+          if (!preview || !preview.invocation_id) return;
+          const card = toolCardFromPreview(preview);
+          upsertToolFromPreview(setMessages, preview.invocation_id, card);
           return;
         }
 
@@ -281,4 +311,44 @@ function applyProjectionItems({
   if (latestRunIdRef && activeRunId) {
     latestRunIdRef.current = activeRunId;
   }
+}
+
+function upsertToolFromPreview(setMessages, invocationId, card) {
+  const id = `tool-${invocationId}`;
+  const message = { id, role: "tool_activity", ...card };
+  setMessages((prev) => {
+    const existing = prev.findIndex((m) => m.id === id);
+    if (existing >= 0) {
+      const copy = [...prev];
+      copy[existing] = message;
+      return copy;
+    }
+    return [...prev, message];
+  });
+}
+
+function upsertToolFromActivity(setMessages, invocationId, card) {
+  const id = `tool-${invocationId}`;
+  setMessages((prev) => {
+    const existing = prev.findIndex((m) => m.id === id);
+    if (existing >= 0) {
+      const current = prev[existing];
+      // A late lifecycle frame can carry `running` after the preview
+      // already set `success` / `error`. Don't downgrade terminal
+      // state — but do let the next terminal state through.
+      const nextStatus =
+        isTerminalToolStatus(current.toolStatus) && card.toolStatus === "running"
+          ? current.toolStatus
+          : card.toolStatus;
+      const copy = [...prev];
+      copy[existing] = {
+        ...current,
+        toolStatus: nextStatus,
+        toolError: card.toolError || current.toolError,
+        updatedAt: card.updatedAt || current.updatedAt,
+      };
+      return copy;
+    }
+    return [...prev, { id, role: "tool_activity", ...card }];
+  });
 }


### PR DESCRIPTION
## Summary

- Wire the existing `capability_display_preview` SSE frame and the matching
  persisted `MessageKind::CapabilityDisplayPreview` timeline records into the
  webui-v2 chat surface, so tool invocations render as `ToolActivityCard`s
  instead of raw JSON dumps in both live and post-refresh states.
- Upsert tool cards by `invocation_id` so a live `capability_activity`
  "running" placeholder upgrades in place when the terminal
  `capability_display_preview` arrives; a late `running` lifecycle frame
  cannot downgrade a terminal `success`/`error`.
- Filter `MessageKind::ToolResultReference` records out of the rendered
  timeline — they are LLM-visible transcript artifacts, not UI messages.
- Surface the failure path through `toolError` only (red) instead of
  duplicating the same string into `toolResultPreview` (teal).

### Screenshots

<img width="1932" height="790" alt="preview" src="https://github.com/user-attachments/assets/bb404d8d-67dd-43e5-8923-cc34cafd0964" />


## Change Type

- [x] Bug fix
- [x] New feature

## Linked Issue

Related #4073 (backend durable tool preview persistence).

## Validation

- [x] Manual testing: confirmed in browser against the local-dev runtime —
  `echo "hello world"` renders a green "ok echo" card with the output preview;
  `summarize the top stories on edition.cnn.com` renders a red "err http"
  card with the sanitized error text (post-refresh as well).
- [x] `node --check` on the three modified JS files.
- [ ] `cargo fmt --all -- --check` — N/A, no Rust changes.
- [ ] `cargo clippy ... -- -D warnings` — N/A, no Rust changes.
- [ ] `cargo build` — N/A, no Rust changes.

## Security Impact

None. Pure frontend rendering over already-sanitized DTOs
(`CapabilityDisplayPreviewView` / `CapabilityDisplayPreviewEnvelope`); the
2 KiB / 16 KiB / 120-line caps and credential redaction are enforced server-side.

## Reborn Trust-Boundary Checklist

N/A — frontend-only change. No new policy, evidence, or trust-bearing types;
no prompt envelopes; no status/exit/policy variants added. All consumed
values already cross the host trust boundary via the v2 schema.

## Database Impact

None.

## Blast Radius

`crates/ironclaw_webui_v2_static` only — three JS files under
`static/js/pages/chat/`. No other surface or backend touched.

## Rollback Plan

Revert the two commits on the branch. The persisted
`capability_display_preview` records remain valid; the UI simply reverts to
rendering them as raw assistant content (the pre-PR behavior).

## Review Follow-Through

Two backend bugs were surfaced while validating but are out of scope here
and tracked separately:
- `builtin.http` fails with `invalid_input: dispatch failed: InputEncode`.
- Successful `builtin.echo` lands the run in `recovery_required` after the
  tool returns.

---

**Review track**: A (frontend rendering only)