### PR TITLE
[codex] Add Reborn provider admin facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4923,6 +4923,7 @@ dependencies = [
 name = "ironclaw_reborn_config"
 version = "0.1.0"
 dependencies = [
+ "fs4",
  "serde",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,6 +4927,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -225,7 +225,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `config` | ✅ | ✅ | - | Read/write config plus validate/path helpers |
 | `backup` | ✅ | ❌ | P3 | Create/verify local backup archives |
 | `channels` | ✅ | 🚧 | P2 | `list` implemented; `enable`/`disable`/`status` deferred pending config source unification |
-| `models` | ✅ | 🚧 | P1 | `models list [<provider>]` (`--verbose`, `--json`; fetches live model list when provider specified), `models status` (`--json`), `models set <model>`, `models set-provider <provider> [--model model]` (alias normalization, config.toml + .env persistence). Remaining: `set` doesn't validate model against live list. |
+| `models` | ✅ | 🚧 | P1 | Reborn now uses a shared composition provider-admin facade for CLI `models list [<provider>]` (`--verbose`, `--json`), `models status`, `models set <model>`, `models set-provider <provider> [--model model]`, plus Product Workflow typed `model set-provider ...` parsing without touching v1 state. Remaining: live model fetching, OAuth/API-key login flows, and wiring the provider-admin ProductCommandService into product surfaces. |
 | `status` | ✅ | ✅ | - | System status (enriched session details) |
 | `agents` | ✅ | ❌ | P3 | Multi-agent management |
 | `sessions` | ✅ | ❌ | P3 | Session listing (shows subagent models) |

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -165,7 +165,7 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
             "ironclaw_reborn_traces",
             "ironclaw_reborn_webui_ingress",
         ],
-        "ironclaw_reborn_cli should enter Reborn through ironclaw_reborn_composition (assembled-runtime facade), ironclaw_reborn_config (boot-config contract), ironclaw_reborn_traces (contributor-side TraceCommons client extracted from the legacy monolith), and ironclaw_reborn_webui_ingress (host-owned WebUI serve lifecycle) only. Adding any other workspace crate here re-opens speculative public API access to internal Reborn types.",
+        "ironclaw_reborn_cli should enter Reborn through ironclaw_reborn_composition (assembled-runtime and provider-admin facade), ironclaw_reborn_config (boot-config contract), ironclaw_reborn_traces (contributor-side TraceCommons client extracted from the legacy monolith), and ironclaw_reborn_webui_ingress (host-owned WebUI serve lifecycle) only. Adding any other workspace crate here re-opens speculative public API access to internal Reborn types.",
     );
     assert_workspace_deps_exactly(
         &dependencies_all_kinds,
@@ -1530,12 +1530,13 @@ fn boundary_rules() -> Vec<BoundaryRule> {
             ],
         },
         BoundaryRule {
-            // The standalone CLI must reach the assembled runtime only
-            // through `ironclaw_reborn_composition`. Adding any of the
-            // forbidden deps here re-opens "speculative public API" access
-            // to internal Reborn types (turn coordinator, session thread
-            // service, loop drivers, LLM provider, etc.) and re-introduces
-            // the narrow-surface regression this rule exists to prevent.
+            // The standalone CLI reaches runtime and provider/admin UX through
+            // `ironclaw_reborn_composition` facades. Adding any of the
+            // forbidden deps here re-opens "speculative public API" access to
+            // internal Reborn types (turn coordinator, session thread service,
+            // loop drivers, LLM registry/auth internals, etc.) and
+            // re-introduces the narrow-surface regression this rule exists to
+            // prevent.
             crate_name: "ironclaw_reborn_cli",
             forbidden: vec![
                 "ironclaw",

--- a/crates/ironclaw_product_workflow/src/commands.rs
+++ b/crates/ironclaw_product_workflow/src/commands.rs
@@ -132,24 +132,44 @@ fn parse_model_command(payload: &InboundCommandPayload) -> ProductCommandParseRe
             action: ProductModelCommand::Status,
         });
     };
-    if matches!(first, "set-provider" | "provider") {
-        let Some(provider) = args.next() else {
-            return invalid_lifecycle_command("model set-provider requires a provider id");
-        };
-        let remaining = args.collect::<Vec<_>>();
-        let model = parse_model_option(&remaining)?;
-        return Ok(ProductCommand::Model {
-            action: ProductModelCommand::SetProvider {
-                provider: provider.to_string(),
-                model,
+    match ModelCommandHead::parse(first)? {
+        ModelCommandHead::SetProvider => {
+            let Some(provider) = args.next() else {
+                return invalid_lifecycle_command("model set-provider requires a provider id");
+            };
+            let remaining = args.collect::<Vec<_>>();
+            let model = parse_model_option(&remaining)?;
+            Ok(ProductCommand::Model {
+                action: ProductModelCommand::SetProvider {
+                    provider: provider.to_string(),
+                    model,
+                },
+            })
+        }
+        ModelCommandHead::SetModel(model) => Ok(ProductCommand::Model {
+            action: ProductModelCommand::Set {
+                model: model.to_string(),
             },
-        });
+        }),
     }
-    Ok(ProductCommand::Model {
-        action: ProductModelCommand::Set {
-            model: first.to_string(),
-        },
-    })
+}
+
+enum ModelCommandHead<'a> {
+    SetProvider,
+    SetModel(&'a str),
+}
+
+impl<'a> ModelCommandHead<'a> {
+    fn parse(value: &'a str) -> Result<Self, ProductRejection> {
+        match value {
+            "set-provider" | "provider" => Ok(Self::SetProvider),
+            flag if flag.starts_with('-') => Err(ProductRejection::permanent(
+                ProductRejectionKind::InvalidRequest,
+                "model set requires a model name; flags are only valid after `set-provider`",
+            )),
+            model => Ok(Self::SetModel(model)),
+        }
+    }
 }
 
 fn parse_status_command(_payload: &InboundCommandPayload) -> ProductCommandParseResult {

--- a/crates/ironclaw_product_workflow/src/commands.rs
+++ b/crates/ironclaw_product_workflow/src/commands.rs
@@ -80,7 +80,13 @@ pub enum ProductCommand {
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum ProductModelCommand {
     Status,
-    Set { model: String },
+    Set {
+        model: String,
+    },
+    SetProvider {
+        provider: String,
+        model: Option<String>,
+    },
 }
 
 impl ProductCommand {
@@ -120,21 +126,47 @@ fn command_spec_for_name(name: &str) -> Option<&'static ProductCommandSpec> {
 }
 
 fn parse_model_command(payload: &InboundCommandPayload) -> ProductCommandParseResult {
-    let model = payload.arguments.split_whitespace().next();
-    Ok(match model {
-        Some(model) => ProductCommand::Model {
-            action: ProductModelCommand::Set {
-                model: model.to_string(),
-            },
-        },
-        None => ProductCommand::Model {
+    let mut args = payload.arguments.split_whitespace();
+    let Some(first) = args.next() else {
+        return Ok(ProductCommand::Model {
             action: ProductModelCommand::Status,
+        });
+    };
+    if matches!(first, "set-provider" | "provider") {
+        let Some(provider) = args.next() else {
+            return invalid_lifecycle_command("model set-provider requires a provider id");
+        };
+        let remaining = args.collect::<Vec<_>>();
+        let model = parse_model_option(&remaining)?;
+        return Ok(ProductCommand::Model {
+            action: ProductModelCommand::SetProvider {
+                provider: provider.to_string(),
+                model,
+            },
+        });
+    }
+    Ok(ProductCommand::Model {
+        action: ProductModelCommand::Set {
+            model: first.to_string(),
         },
     })
 }
 
 fn parse_status_command(_payload: &InboundCommandPayload) -> ProductCommandParseResult {
     Ok(ProductCommand::Status)
+}
+
+fn parse_model_option(args: &[&str]) -> Result<Option<String>, ProductRejection> {
+    if args.is_empty() {
+        return Ok(None);
+    }
+    if args.len() == 2 && args[0] == "--model" {
+        return Ok(Some(args[1].to_string()));
+    }
+    Err(ProductRejection::permanent(
+        ProductRejectionKind::InvalidRequest,
+        "model set-provider accepts only `--model <model>` after provider",
+    ))
 }
 
 pub struct LifecycleProductCommandService {

--- a/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
@@ -25,6 +25,26 @@ fn command_payload_maps_to_typed_model_command_without_v1_parser() {
 }
 
 #[test]
+fn model_command_maps_provider_selection_without_cli_shelling_contract() {
+    let payload = InboundCommandPayload::new(
+        "model",
+        "set-provider openai --model gpt-5-mini",
+        ProductTriggerReason::BotCommand,
+    )
+    .expect("valid command");
+
+    assert_eq!(
+        ProductCommand::from_payload(&payload).expect("parse model provider command"),
+        ProductCommand::Model {
+            action: ProductModelCommand::SetProvider {
+                provider: "openai".to_string(),
+                model: Some("gpt-5-mini".to_string()),
+            }
+        }
+    );
+}
+
+#[test]
 fn command_payload_maps_all_declared_commands_and_unknown_fallback() {
     let cases = [
         (

--- a/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
@@ -70,6 +70,16 @@ fn model_provider_command_rejects_unsupported_option() {
 }
 
 #[test]
+fn model_command_rejects_flag_shaped_model_name() {
+    let payload = InboundCommandPayload::new("model", "--json", ProductTriggerReason::BotCommand)
+        .expect("valid command");
+
+    let rejection = ProductCommand::from_payload(&payload).expect_err("flag-shaped model");
+
+    assert_eq!(rejection.kind, ProductRejectionKind::InvalidRequest);
+}
+
+#[test]
 fn command_payload_maps_all_declared_commands_and_unknown_fallback() {
     let cases = [
         (

--- a/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_commands_contract.rs
@@ -45,6 +45,31 @@ fn model_command_maps_provider_selection_without_cli_shelling_contract() {
 }
 
 #[test]
+fn model_provider_command_rejects_missing_provider() {
+    let payload =
+        InboundCommandPayload::new("model", "set-provider", ProductTriggerReason::BotCommand)
+            .expect("valid command");
+
+    let rejection = ProductCommand::from_payload(&payload).expect_err("missing provider");
+
+    assert_eq!(rejection.kind, ProductRejectionKind::InvalidRequest);
+}
+
+#[test]
+fn model_provider_command_rejects_unsupported_option() {
+    let payload = InboundCommandPayload::new(
+        "model",
+        "set-provider openai --foo bar",
+        ProductTriggerReason::BotCommand,
+    )
+    .expect("valid command");
+
+    let rejection = ProductCommand::from_payload(&payload).expect_err("unsupported option");
+
+    assert_eq!(rejection.kind, ProductRejectionKind::InvalidRequest);
+}
+
+#[test]
 fn command_payload_maps_all_declared_commands_and_unknown_fallback() {
     let cases = [
         (

--- a/crates/ironclaw_reborn_cli/AGENTS.md
+++ b/crates/ironclaw_reborn_cli/AGENTS.md
@@ -15,7 +15,7 @@ This crate owns the standalone `ironclaw-reborn` command surface. Keep it small,
 - Keep commands side-effect free unless the command name and issue explicitly require mutation.
 - Use `IRONCLAW_REBORN_HOME` / `~/.ironclaw/reborn`; do not write current v1 state.
 - no v1 runtime imports: do not depend on root `ironclaw`, `src/agent`, channels, worker, DB, setup, service, sandbox, or `ironclaw_engine`.
-- Do not add workspace dependencies beyond `ironclaw_reborn_composition`, `ironclaw_reborn_config`, and `ironclaw_reborn_webui_ingress` (host-owned WebUI serve lifecycle) without an architecture test update and explicit PR rationale.
+- Do not add workspace dependencies beyond `ironclaw_reborn_composition`, `ironclaw_reborn_config`, `ironclaw_reborn_traces`, and `ironclaw_reborn_webui_ingress` (host-owned WebUI serve lifecycle) without an architecture test update and explicit PR rationale. Provider registry/auth/model UX should enter through the Reborn composition provider-admin facade, not a separate CLI-only path.
 
 ## Adding a command
 

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -22,7 +22,9 @@ default = ["root-llm-provider"]
 # `ironclaw_reborn`, so building without it produces a CLI binary that
 # can still boot the runtime substrate but will surface an "LLM gateway
 # not wired" error on the first `send_user_message`.
-root-llm-provider = ["ironclaw_reborn_composition/root-llm-provider"]
+root-llm-provider = [
+    "ironclaw_reborn_composition/root-llm-provider",
+]
 # Compile in the WebChat v2 beta HTTP gateway subcommand
 # (`ironclaw-reborn serve`). Off by default so a default binary build
 # does not link the auth/HTTP middleware stack at all — production

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -68,7 +68,9 @@ impl Command {
             }
             Self::Hooks(command) => command.execute(),
             Self::Logs(command) => command.execute(),
-            Self::Models(command) => command.execute(),
+            Self::Models(command) => {
+                command.execute(crate::context::RebornCliContext::resolve_from_env()?)
+            }
             Self::Profile(command) => command.execute(),
             Self::Repl(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -68,9 +68,7 @@ impl Command {
             }
             Self::Hooks(command) => command.execute(),
             Self::Logs(command) => command.execute(),
-            Self::Models(command) => {
-                command.execute(crate::context::RebornCliContext::resolve_from_env()?)
-            }
+            Self::Models(command) => command.execute(),
             Self::Profile(command) => command.execute(),
             Self::Repl(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -144,7 +144,7 @@ impl ModelsSetCommand {
         let admin =
             ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
         let outcome = admin.set_model(&self.model)?;
-        print_write_outcome("Model", &outcome);
+        print_write_outcome(WriteOutcomeKind::Model, &outcome);
         Ok(())
     }
 }
@@ -152,10 +152,7 @@ impl ModelsSetCommand {
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsSetCommand {
     fn execute(self) -> anyhow::Result<()> {
-        anyhow::bail!(
-            "`models set {}` requires the root-llm-provider feature; v1_state: not-used",
-            self.model
-        )
+        Err(feature_not_available(&format!("set {}", self.model)))
     }
 }
 
@@ -166,7 +163,7 @@ impl ModelsSetProviderCommand {
         let admin =
             ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
         let outcome = admin.set_provider(&self.provider, self.model.as_deref())?;
-        print_write_outcome("Provider", &outcome);
+        print_write_outcome(WriteOutcomeKind::Provider, &outcome);
         Ok(())
     }
 }
@@ -174,11 +171,16 @@ impl ModelsSetProviderCommand {
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsSetProviderCommand {
     fn execute(self) -> anyhow::Result<()> {
-        anyhow::bail!(
-            "`models set-provider {}` requires the root-llm-provider feature; v1_state: not-used",
+        Err(feature_not_available(&format!(
+            "set-provider {}",
             self.provider
-        )
+        )))
     }
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+fn feature_not_available(command: &str) -> anyhow::Error {
+    anyhow::anyhow!("`models {command}` requires the root-llm-provider feature; v1_state: not-used")
 }
 
 #[cfg(not(feature = "root-llm-provider"))]
@@ -233,7 +235,7 @@ fn print_provider_list(list: &ironclaw_reborn_composition::RebornProviderList, v
     println!();
 
     for provider in &list.providers {
-        let marker = provider.active.then_some(" *").unwrap_or("");
+        let marker = if provider.active { " *" } else { "" };
         if verbose {
             println!("{}{}", provider.id, marker);
             println!("  description: {}", provider.description);
@@ -353,20 +355,30 @@ fn print_status(status: &ironclaw_reborn_composition::RebornProviderStatus) {
 }
 
 #[cfg(feature = "root-llm-provider")]
+#[derive(Debug, Clone, Copy)]
+enum WriteOutcomeKind {
+    Model,
+    Provider,
+}
+
+#[cfg(feature = "root-llm-provider")]
 fn print_write_outcome(
-    label: &str,
+    kind: WriteOutcomeKind,
     outcome: &ironclaw_reborn_composition::RebornProviderWriteOutcome,
 ) {
-    if label == "Model" {
-        println!(
-            "Model set to `{}` for provider `{}`",
-            outcome.model, outcome.provider_id
-        );
-    } else {
-        println!(
-            "{label} set to `{}`, model set to `{}`",
-            outcome.provider_id, outcome.model
-        );
+    match kind {
+        WriteOutcomeKind::Model => {
+            println!(
+                "Model set to `{}` for provider `{}`",
+                outcome.model, outcome.provider_id
+            );
+        }
+        WriteOutcomeKind::Provider => {
+            println!(
+                "Provider set to `{}`, model set to `{}`",
+                outcome.provider_id, outcome.model
+            );
+        }
     }
     println!("Saved to {}", outcome.config_file.display());
     if outcome.missing_api_key

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use crate::context::RebornCliContext;
+
 #[derive(Debug, Args)]
 pub(crate) struct ModelsCommand {
     #[command(subcommand)]
@@ -8,15 +10,24 @@ pub(crate) struct ModelsCommand {
 
 #[derive(Debug, Subcommand)]
 enum ModelsSubcommand {
-    /// List Reborn model purpose slots.
+    /// List Reborn LLM providers, or show one provider.
     List(ModelsListCommand),
     /// Show Reborn model route status.
     Status(ModelsStatusCommand),
+    /// Set the default Reborn model for the active provider.
+    Set(ModelsSetCommand),
+    /// Set the default Reborn LLM provider.
+    SetProvider(ModelsSetProviderCommand),
 }
 
 #[derive(Debug, Args)]
 struct ModelsListCommand {
-    /// Output model slots as JSON.
+    /// Show only a specific provider by id or alias.
+    provider: Option<String>,
+    /// Show provider protocol and credential metadata.
+    #[arg(short, long)]
+    verbose: bool,
+    /// Output providers as JSON.
     #[arg(long)]
     json: bool,
 }
@@ -28,17 +39,57 @@ struct ModelsStatusCommand {
     json: bool,
 }
 
+#[derive(Debug, Args)]
+struct ModelsSetCommand {
+    /// Model name (for example, gpt-5-mini or claude-sonnet-4-6-20250514).
+    model: String,
+}
+
+#[derive(Debug, Args)]
+struct ModelsSetProviderCommand {
+    /// Provider id or alias (for example, openai, anthropic, ollama).
+    provider: String,
+    /// Also set the model. Defaults to the provider's catalog default.
+    #[arg(long)]
+    model: Option<String>,
+}
+
 impl ModelsCommand {
-    pub(crate) fn execute(self) -> anyhow::Result<()> {
+    pub(crate) fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
         match self.command {
-            ModelsSubcommand::List(command) => command.execute(),
-            ModelsSubcommand::Status(command) => command.execute(),
+            ModelsSubcommand::List(command) => command.execute(context),
+            ModelsSubcommand::Status(command) => command.execute(context),
+            ModelsSubcommand::Set(command) => command.execute(context),
+            ModelsSubcommand::SetProvider(command) => command.execute(context),
         }
     }
 }
 
+#[cfg(feature = "root-llm-provider")]
 impl ModelsListCommand {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        let admin =
+            ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
+        let list = admin.list(
+            self.provider.as_deref(),
+            self.verbose || self.provider.is_some(),
+        )?;
+        if self.json {
+            println!("{}", serde_json::to_string_pretty(&list)?);
+            return Ok(());
+        }
+        if self.provider.is_some() {
+            print_provider_detail(&list);
+        } else {
+            print_provider_list(&list, self.verbose);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+impl ModelsListCommand {
+    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
         let slots = ironclaw_reborn_composition::reborn_model_slot_names();
 
         if self.json {
@@ -67,8 +118,67 @@ impl ModelsListCommand {
     }
 }
 
+#[cfg(feature = "root-llm-provider")]
 impl ModelsStatusCommand {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        let admin =
+            ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
+        let status = admin.status()?;
+
+        if self.json {
+            println!("{}", serde_json::to_string_pretty(&status)?);
+            return Ok(());
+        }
+        print_status(&status);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "root-llm-provider")]
+impl ModelsSetCommand {
+    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        let admin =
+            ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
+        let outcome = admin.set_model(&self.model)?;
+        print_write_outcome("Model", &outcome);
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+impl ModelsSetCommand {
+    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
+        anyhow::bail!(
+            "`models set {}` requires the root-llm-provider feature; v1_state: not-used",
+            self.model
+        )
+    }
+}
+
+#[cfg(feature = "root-llm-provider")]
+impl ModelsSetProviderCommand {
+    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        let admin =
+            ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
+        let outcome = admin.set_provider(&self.provider, self.model.as_deref())?;
+        print_write_outcome("Provider", &outcome);
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+impl ModelsSetProviderCommand {
+    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
+        anyhow::bail!(
+            "`models set-provider {}` requires the root-llm-provider feature; v1_state: not-used",
+            self.provider
+        )
+    }
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+impl ModelsStatusCommand {
+    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
         let slots = ironclaw_reborn_composition::reborn_model_slot_names();
 
         if self.json {
@@ -100,4 +210,167 @@ impl ModelsStatusCommand {
         println!("v1_state: not-used");
         Ok(())
     }
+}
+
+#[cfg(feature = "root-llm-provider")]
+fn print_provider_list(list: &ironclaw_reborn_composition::RebornProviderList, verbose: bool) {
+    println!("IronClaw Reborn LLM providers");
+    println!("config_file: {}", list.config_file.display());
+    println!("providers_file: {}", list.providers_file.display());
+    match list.providers.iter().find(|provider| provider.active) {
+        Some(provider) => println!(
+            "active: {} ({})",
+            provider.id,
+            provider.active_model.as_deref().unwrap_or("default model")
+        ),
+        None => println!("active: not-configured"),
+    }
+    println!();
+
+    for provider in &list.providers {
+        let marker = provider.active.then_some(" *").unwrap_or("");
+        if verbose {
+            println!("{}{}", provider.id, marker);
+            println!("  description: {}", provider.description);
+            println!("  default_model: {}", provider.default_model);
+            let Some(metadata) = provider.metadata.as_ref() else {
+                println!();
+                continue;
+            };
+            println!("  protocol: {}", metadata.protocol);
+            println!("  model_env: {}", metadata.model_env);
+            if let Some(env) = metadata.api_key_env.as_deref() {
+                println!(
+                    "  api_key_env: {} ({})",
+                    env,
+                    if metadata.api_key_required {
+                        "required"
+                    } else {
+                        "optional"
+                    }
+                );
+            }
+            if let Some(base_url) = metadata.base_url.as_deref() {
+                println!("  base_url: {base_url}");
+            }
+            if let Some(kind) = metadata.credential_kind {
+                println!("  credential_kind: {kind}");
+            }
+            println!("  can_list_models: {}", metadata.can_list_models);
+            println!();
+        } else {
+            println!(
+                "{:<24} {:<36} {}",
+                format!("{}{marker}", provider.id),
+                provider
+                    .active_model
+                    .as_deref()
+                    .unwrap_or(&provider.default_model),
+                provider.description
+            );
+        }
+    }
+    println!();
+    println!("* = active provider. v1_state: {}", list.v1_state);
+}
+
+#[cfg(feature = "root-llm-provider")]
+fn print_provider_detail(list: &ironclaw_reborn_composition::RebornProviderList) {
+    let Some(provider) = list.providers.first() else {
+        return;
+    };
+    println!("Provider: {}", provider.id);
+    println!("Description: {}", provider.description);
+    println!("Default model: {}", provider.default_model);
+    println!("Active: {}", if provider.active { "yes" } else { "no" });
+    let Some(metadata) = provider.metadata.as_ref() else {
+        println!("Provider catalog: {}", list.providers_file.display());
+        println!("v1_state: {}", list.v1_state);
+        return;
+    };
+    println!("Protocol: {}", metadata.protocol);
+    println!("Model env: {}", metadata.model_env);
+    if let Some(api_key_env) = metadata.api_key_env.as_deref() {
+        println!(
+            "API key env: {} ({})",
+            api_key_env,
+            if metadata.api_key_required {
+                "required"
+            } else {
+                "optional"
+            }
+        );
+    }
+    if let Some(base_url) = metadata.base_url.as_deref() {
+        println!("Base URL: {base_url}");
+    }
+    if let Some(kind) = metadata.credential_kind {
+        println!("Credential kind: {kind}");
+    }
+    println!("Can list models: {}", metadata.can_list_models);
+    println!("Provider catalog: {}", list.providers_file.display());
+    println!("v1_state: {}", list.v1_state);
+}
+
+#[cfg(feature = "root-llm-provider")]
+fn print_status(status: &ironclaw_reborn_composition::RebornProviderStatus) {
+    println!("IronClaw Reborn model status");
+    println!("config_file: {}", status.config_file.display());
+    println!("providers_file: {}", status.providers_file.display());
+    match status.default.as_ref() {
+        Some(selection) => {
+            println!(
+                "default.provider: {}",
+                selection.provider_id.as_deref().unwrap_or("not-configured")
+            );
+            println!(
+                "default.provider_known: {}",
+                if selection.provider_known {
+                    "yes"
+                } else {
+                    "no"
+                }
+            );
+            println!(
+                "default.model: {}",
+                selection.model.as_deref().unwrap_or("provider default")
+            );
+            if let Some(api_key_env) = selection.api_key_env.as_deref() {
+                println!("default.api_key_env: {api_key_env}");
+            }
+            if let Some(base_url) = selection.base_url.as_deref() {
+                println!("default.base_url: {base_url}");
+            }
+        }
+        None => println!("routes: {}", status.routes),
+    }
+    println!("v1_state: {}", status.v1_state);
+}
+
+#[cfg(feature = "root-llm-provider")]
+fn print_write_outcome(
+    label: &str,
+    outcome: &ironclaw_reborn_composition::RebornProviderWriteOutcome,
+) {
+    if label == "Model" {
+        println!(
+            "Model set to `{}` for provider `{}`",
+            outcome.model, outcome.provider_id
+        );
+    } else {
+        println!(
+            "{label} set to `{}`, model set to `{}`",
+            outcome.provider_id, outcome.model
+        );
+    }
+    println!("Saved to {}", outcome.config_file.display());
+    if outcome.missing_api_key
+        && let Some(api_key_env) = outcome.api_key_env.as_deref()
+    {
+        println!(
+            "Note: `{}` requires credentials. Set {api_key_env} before running with this provider.",
+            outcome.provider_id
+        );
+    }
+    println!("v1_state: {}", outcome.v1_state);
 }

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Subcommand};
 
+#[cfg(feature = "root-llm-provider")]
 use crate::context::RebornCliContext;
 
 #[derive(Debug, Args)]
@@ -55,19 +56,20 @@ struct ModelsSetProviderCommand {
 }
 
 impl ModelsCommand {
-    pub(crate) fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
         match self.command {
-            ModelsSubcommand::List(command) => command.execute(context),
-            ModelsSubcommand::Status(command) => command.execute(context),
-            ModelsSubcommand::Set(command) => command.execute(context),
-            ModelsSubcommand::SetProvider(command) => command.execute(context),
+            ModelsSubcommand::List(command) => command.execute(),
+            ModelsSubcommand::Status(command) => command.execute(),
+            ModelsSubcommand::Set(command) => command.execute(),
+            ModelsSubcommand::SetProvider(command) => command.execute(),
         }
     }
 }
 
 #[cfg(feature = "root-llm-provider")]
 impl ModelsListCommand {
-    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
+        let context = RebornCliContext::resolve_from_env()?;
         let admin =
             ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
         let list = admin.list(
@@ -89,7 +91,7 @@ impl ModelsListCommand {
 
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsListCommand {
-    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
         let slots = ironclaw_reborn_composition::reborn_model_slot_names();
 
         if self.json {
@@ -120,7 +122,8 @@ impl ModelsListCommand {
 
 #[cfg(feature = "root-llm-provider")]
 impl ModelsStatusCommand {
-    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
+        let context = RebornCliContext::resolve_from_env()?;
         let admin =
             ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
         let status = admin.status()?;
@@ -136,7 +139,8 @@ impl ModelsStatusCommand {
 
 #[cfg(feature = "root-llm-provider")]
 impl ModelsSetCommand {
-    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
+        let context = RebornCliContext::resolve_from_env()?;
         let admin =
             ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
         let outcome = admin.set_model(&self.model)?;
@@ -147,7 +151,7 @@ impl ModelsSetCommand {
 
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsSetCommand {
-    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
         anyhow::bail!(
             "`models set {}` requires the root-llm-provider feature; v1_state: not-used",
             self.model
@@ -157,7 +161,8 @@ impl ModelsSetCommand {
 
 #[cfg(feature = "root-llm-provider")]
 impl ModelsSetProviderCommand {
-    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
+        let context = RebornCliContext::resolve_from_env()?;
         let admin =
             ironclaw_reborn_composition::RebornProviderAdmin::new(context.boot_config().clone());
         let outcome = admin.set_provider(&self.provider, self.model.as_deref())?;
@@ -168,7 +173,7 @@ impl ModelsSetProviderCommand {
 
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsSetProviderCommand {
-    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
         anyhow::bail!(
             "`models set-provider {}` requires the root-llm-provider feature; v1_state: not-used",
             self.provider
@@ -178,7 +183,7 @@ impl ModelsSetProviderCommand {
 
 #[cfg(not(feature = "root-llm-provider"))]
 impl ModelsStatusCommand {
-    fn execute(self, _context: RebornCliContext) -> anyhow::Result<()> {
+    fn execute(self) -> anyhow::Result<()> {
         let slots = ironclaw_reborn_composition::reborn_model_slot_names();
 
         if self.json {

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -331,11 +331,13 @@ fn logs_json_verbose_includes_status_details() {
 }
 
 #[test]
-fn models_list_reports_reborn_slots_without_reborn_home() {
+fn models_list_reports_reborn_provider_catalog_without_v1_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
     let output = Command::new(reborn_bin())
         .arg("models")
         .arg("list")
         .env_clear()
+        .env("HOME", temp.path())
         .output()
         .expect("ironclaw-reborn models list should run");
 
@@ -346,25 +348,27 @@ fn models_list_reports_reborn_slots_without_reborn_home() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("IronClaw Reborn model slots"),
+        stdout.contains("IronClaw Reborn LLM providers"),
         "stdout: {stdout}"
     );
-    assert!(stdout.contains("- default"), "stdout: {stdout}");
-    assert!(stdout.contains("- mission"), "stdout: {stdout}");
+    assert!(stdout.contains("providers_file:"), "stdout: {stdout}");
     assert!(
-        stdout.contains("routes: not-configured"),
+        stdout.contains("active: not-configured"),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("openai"), "stdout: {stdout}");
     assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
 }
 
 #[test]
-fn models_status_json_reports_routes_not_configured() {
+fn models_status_json_reports_routes_not_configured_without_v1_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
     let output = Command::new(reborn_bin())
         .arg("models")
         .arg("status")
         .arg("--json")
         .env_clear()
+        .env("HOME", temp.path())
         .output()
         .expect("ironclaw-reborn models status --json should run");
 
@@ -376,9 +380,158 @@ fn models_status_json_reports_routes_not_configured() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     assert_eq!(json["routes"], "not-configured");
-    assert_eq!(json["slots"]["default"], "not-configured");
-    assert_eq!(json["slots"]["mission"], "not-configured");
+    assert_eq!(json["default"], serde_json::Value::Null);
     assert_eq!(json["v1_state"], "not-used");
+}
+
+#[test]
+fn models_status_reads_reborn_default_llm_slot() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("mkdir");
+    std::fs::write(
+        reborn_home.join("config.toml"),
+        r#"
+[llm.default]
+provider_id = "openai"
+model = "gpt-5-mini"
+api_key_env = "OPENAI_API_KEY"
+"#,
+    )
+    .expect("write config");
+
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("status")
+        .arg("--json")
+        .env_clear()
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .output()
+        .expect("ironclaw-reborn models status --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["routes"], "configured");
+    assert_eq!(json["default"]["provider_id"], "openai");
+    assert_eq!(json["default"]["provider_known"], true);
+    assert_eq!(json["default"]["model"], "gpt-5-mini");
+    assert_eq!(json["default"]["api_key_env"], "OPENAI_API_KEY");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+#[test]
+fn models_set_provider_writes_reborn_config_without_v1_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("set-provider")
+        .arg("openai")
+        .arg("--model")
+        .arg("gpt-5-mini")
+        .env_clear()
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .output()
+        .expect("ironclaw-reborn models set-provider should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Provider set to `openai`"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+
+    let config = std::fs::read_to_string(reborn_home.join("config.toml")).expect("read config");
+    assert!(config.contains("[llm.default]"), "config: {config}");
+    assert!(
+        config.contains("provider_id = \"openai\""),
+        "config: {config}"
+    );
+    assert!(
+        config.contains("model = \"gpt-5-mini\""),
+        "config: {config}"
+    );
+    assert!(
+        config.contains("api_key_env = \"OPENAI_API_KEY\""),
+        "config: {config}"
+    );
+    assert!(
+        !temp.path().join(".ironclaw").join(".env").exists(),
+        "Reborn models set-provider must not write v1 bootstrap .env"
+    );
+}
+
+#[test]
+fn models_set_updates_reborn_default_model() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("mkdir");
+    std::fs::write(
+        reborn_home.join("config.toml"),
+        r#"
+[llm.default]
+provider_id = "openai"
+model = "gpt-5-mini"
+api_key_env = "OPENAI_API_KEY"
+"#,
+    )
+    .expect("write config");
+
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("set")
+        .arg("gpt-5.3-codex")
+        .env_clear()
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .output()
+        .expect("ironclaw-reborn models set should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let config = std::fs::read_to_string(reborn_home.join("config.toml")).expect("read config");
+    assert!(
+        config.contains("provider_id = \"openai\""),
+        "config: {config}"
+    );
+    assert!(
+        config.contains("model = \"gpt-5.3-codex\""),
+        "config: {config}"
+    );
+}
+
+#[test]
+fn models_set_without_provider_fails_without_panicking() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("set")
+        .arg("gpt-5.3-codex")
+        .env_clear()
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .output()
+        .expect("ironclaw-reborn models set should run");
+
+    assert!(!output.status.success(), "models set should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no default Reborn provider is configured"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("panicked"), "stderr: {stderr}");
 }
 
 fn assert_empty_not_wired_surface(

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -330,6 +330,7 @@ fn logs_json_verbose_includes_status_details() {
     );
 }
 
+#[cfg(feature = "root-llm-provider")]
 #[test]
 fn models_list_reports_reborn_provider_catalog_without_v1_state() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -360,6 +361,7 @@ fn models_list_reports_reborn_provider_catalog_without_v1_state() {
     assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
 }
 
+#[cfg(feature = "root-llm-provider")]
 #[test]
 fn models_status_json_reports_routes_not_configured_without_v1_state() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -384,6 +386,7 @@ fn models_status_json_reports_routes_not_configured_without_v1_state() {
     assert_eq!(json["v1_state"], "not-used");
 }
 
+#[cfg(feature = "root-llm-provider")]
 #[test]
 fn models_status_reads_reborn_default_llm_slot() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -424,6 +427,7 @@ api_key_env = "OPENAI_API_KEY"
     assert_eq!(json["v1_state"], "not-used");
 }
 
+#[cfg(feature = "root-llm-provider")]
 #[test]
 fn models_set_provider_writes_reborn_config_without_v1_state() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -471,6 +475,7 @@ fn models_set_provider_writes_reborn_config_without_v1_state() {
     );
 }
 
+#[cfg(feature = "root-llm-provider")]
 #[test]
 fn models_set_updates_reborn_default_model() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -512,6 +517,7 @@ api_key_env = "OPENAI_API_KEY"
     );
 }
 
+#[cfg(feature = "root-llm-provider")]
 #[test]
 fn models_set_without_provider_fails_without_panicking() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -532,6 +538,78 @@ fn models_set_without_provider_fails_without_panicking() {
         "stderr: {stderr}"
     );
     assert!(!stderr.contains("panicked"), "stderr: {stderr}");
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+#[test]
+fn models_list_no_default_features_does_not_resolve_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn model slots"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+#[test]
+fn models_status_no_default_features_does_not_resolve_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("status")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models status should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["routes"], "not-configured");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+#[cfg(not(feature = "root-llm-provider"))]
+#[test]
+fn models_write_commands_report_root_llm_provider_required_without_default_features() {
+    for args in [
+        &["models", "set", "gpt-5.3-codex"][..],
+        &["models", "set-provider", "openai"][..],
+    ] {
+        let output = Command::new(reborn_bin())
+            .args(args)
+            .env_clear()
+            .output()
+            .expect("ironclaw-reborn models write command should run");
+
+        assert!(!output.status.success(), "command should fail: {args:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("requires the root-llm-provider feature"),
+            "stderr: {stderr}"
+        );
+        assert!(stderr.contains("v1_state: not-used"), "stderr: {stderr}");
+        assert!(
+            !stderr.contains("HOME or USERPROFILE"),
+            "must not resolve Reborn home before feature error: {stderr}"
+        );
+    }
 }
 
 fn assert_empty_not_wired_surface(

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -107,9 +107,9 @@ pub use production_runtime_policy::RebornProductionRuntimePolicy;
 pub use profile::{RebornCompositionProfile, RebornCompositionProfileParseError};
 #[cfg(feature = "root-llm-provider")]
 pub use provider_admin::{
-    RebornProviderAdmin, RebornProviderAdminError, RebornProviderInfo, RebornProviderList,
-    RebornProviderMetadata, RebornProviderSelection, RebornProviderStatus,
-    RebornProviderWriteOutcome,
+    RebornModelRoutesState, RebornProviderAdmin, RebornProviderAdminError, RebornProviderInfo,
+    RebornProviderList, RebornProviderMetadata, RebornProviderSelection, RebornProviderStatus,
+    RebornProviderWriteOutcome, RebornV1State,
 };
 #[cfg(feature = "root-llm-provider")]
 pub use provider_admin_product_command::RebornProviderAdminProductCommandService;

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -43,6 +43,10 @@ mod product_live_adapters;
 mod production_runtime_policy;
 mod profile;
 mod projection;
+#[cfg(feature = "root-llm-provider")]
+mod provider_admin;
+#[cfg(feature = "root-llm-provider")]
+mod provider_admin_product_command;
 mod readiness;
 mod runtime;
 mod runtime_input;
@@ -101,6 +105,14 @@ pub use product_live_adapters::{
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub use production_runtime_policy::RebornProductionRuntimePolicy;
 pub use profile::{RebornCompositionProfile, RebornCompositionProfileParseError};
+#[cfg(feature = "root-llm-provider")]
+pub use provider_admin::{
+    RebornProviderAdmin, RebornProviderAdminError, RebornProviderInfo, RebornProviderList,
+    RebornProviderMetadata, RebornProviderSelection, RebornProviderStatus,
+    RebornProviderWriteOutcome,
+};
+#[cfg(feature = "root-llm-provider")]
+pub use provider_admin_product_command::RebornProviderAdminProductCommandService;
 pub use readiness::{RebornFacadeReadiness, RebornReadiness, RebornReadinessState};
 pub use runtime::{
     AssistantReply, ConversationId, RebornRuntime, RebornRuntimeError, RebornSkillActivation,

--- a/crates/ironclaw_reborn_composition/src/provider_admin.rs
+++ b/crates/ironclaw_reborn_composition/src/provider_admin.rs
@@ -5,7 +5,7 @@
 //! Reborn `$IRONCLAW_REBORN_HOME/config.toml` and reads the shared provider
 //! catalog through `ironclaw_llm`.
 
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use ironclaw_reborn_config::{
     DefaultLlmSlotUpdate, LlmSlotFieldUpdate, LlmSlotSelection, RebornBootConfig, RebornConfigFile,
@@ -34,7 +34,7 @@ impl RebornProviderAdmin {
         let config = RebornConfigFile::load(&home.config_file_path()).map_err(|source| {
             RebornProviderAdminError::LoadConfig {
                 path: home.config_file_path(),
-                source,
+                source: Box::new(source),
             }
         })?;
         let active = active_llm_selection(config.as_ref(), &registry);
@@ -59,7 +59,7 @@ impl RebornProviderAdmin {
             providers,
             config_file: home.config_file_path(),
             providers_file: home.providers_file_path(),
-            v1_state: "not-used",
+            v1_state: RebornV1State::NotUsed,
         })
     }
 
@@ -69,15 +69,15 @@ impl RebornProviderAdmin {
         let config = RebornConfigFile::load(&home.config_file_path()).map_err(|source| {
             RebornProviderAdminError::LoadConfig {
                 path: home.config_file_path(),
-                source,
+                source: Box::new(source),
             }
         })?;
         let active = active_llm_selection(config.as_ref(), &registry);
         Ok(RebornProviderStatus {
             routes: if active.is_some() {
-                "configured"
+                RebornModelRoutesState::Configured
             } else {
-                "not-configured"
+                RebornModelRoutesState::NotConfigured
             },
             default: active.map(|selection| RebornProviderSelection {
                 provider_id: selection.provider_id,
@@ -88,7 +88,7 @@ impl RebornProviderAdmin {
             }),
             config_file: home.config_file_path(),
             providers_file: home.providers_file_path(),
-            v1_state: "not-used",
+            v1_state: RebornV1State::NotUsed,
         })
     }
 
@@ -108,14 +108,14 @@ impl RebornProviderAdmin {
         let session = begin_default_llm_slot_update(&config_path).map_err(|source| {
             RebornProviderAdminError::UpdateConfig {
                 path: config_path.clone(),
-                source,
+                source: Box::new(source),
             }
         })?;
         let provider_id = session
             .default_llm_slot()
             .map_err(|source| RebornProviderAdminError::UpdateConfig {
                 path: config_path.clone(),
-                source,
+                source: Box::new(source),
             })?
             .as_ref()
             .and_then(|selection| selection.provider_id.as_deref())
@@ -126,8 +126,8 @@ impl RebornProviderAdmin {
             .to_string();
 
         let registry = self.load_registry()?;
-        let canonical_id = registry
-            .find(&provider_id)
+        let provider_def = registry.find(&provider_id);
+        let canonical_id = provider_def
             .map(|def| def.id.clone())
             .unwrap_or_else(|| provider_id.to_string());
         session
@@ -138,17 +138,21 @@ impl RebornProviderAdmin {
             })
             .map_err(|source| RebornProviderAdminError::UpdateConfig {
                 path: config_path.clone(),
-                source,
+                source: Box::new(source),
             })?;
 
         Ok(RebornProviderWriteOutcome {
             provider_id: canonical_id,
             model: model.to_string(),
-            api_key_env: None,
-            api_key_required: false,
-            missing_api_key: false,
+            api_key_env: provider_def.and_then(|def| def.api_key_env.clone()),
+            api_key_required: provider_def.is_some_and(|def| def.api_key_required),
+            missing_api_key: provider_def.is_some_and(|def| {
+                def.api_key_env.as_deref().is_some_and(|api_key_env| {
+                    def.api_key_required && std::env::var_os(api_key_env).is_none()
+                })
+            }),
             config_file: config_path,
-            v1_state: "not-used",
+            v1_state: RebornV1State::NotUsed,
         })
     }
 
@@ -195,7 +199,7 @@ impl RebornProviderAdmin {
         )
         .map_err(|source| RebornProviderAdminError::UpdateConfig {
             path: config_path.clone(),
-            source,
+            source: Box::new(source),
         })?;
 
         Ok(RebornProviderWriteOutcome {
@@ -207,7 +211,7 @@ impl RebornProviderAdmin {
                 def.api_key_required && std::env::var_os(api_key_env).is_none()
             }),
             config_file: config_path,
-            v1_state: "not-used",
+            v1_state: RebornV1State::NotUsed,
         })
     }
 
@@ -225,9 +229,11 @@ impl RebornProviderAdmin {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RebornProviderList {
     pub providers: Vec<RebornProviderInfo>,
+    #[serde(skip_serializing)]
     pub config_file: PathBuf,
+    #[serde(skip_serializing)]
     pub providers_file: PathBuf,
-    pub v1_state: &'static str,
+    pub v1_state: RebornV1State,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -259,11 +265,13 @@ pub struct RebornProviderMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RebornProviderStatus {
-    pub routes: &'static str,
+    pub routes: RebornModelRoutesState,
     pub default: Option<RebornProviderSelection>,
+    #[serde(skip_serializing)]
     pub config_file: PathBuf,
+    #[serde(skip_serializing)]
     pub providers_file: PathBuf,
-    pub v1_state: &'static str,
+    pub v1_state: RebornV1State,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -282,8 +290,52 @@ pub struct RebornProviderWriteOutcome {
     pub api_key_env: Option<String>,
     pub api_key_required: bool,
     pub missing_api_key: bool,
+    #[serde(skip_serializing)]
     pub config_file: PathBuf,
-    pub v1_state: &'static str,
+    pub v1_state: RebornV1State,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum RebornV1State {
+    #[serde(rename = "not-used")]
+    NotUsed,
+}
+
+impl RebornV1State {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotUsed => "not-used",
+        }
+    }
+}
+
+impl fmt::Display for RebornV1State {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum RebornModelRoutesState {
+    #[serde(rename = "configured")]
+    Configured,
+    #[serde(rename = "not-configured")]
+    NotConfigured,
+}
+
+impl RebornModelRoutesState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Configured => "configured",
+            Self::NotConfigured => "not-configured",
+        }
+    }
+}
+
+impl fmt::Display for RebornModelRoutesState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
 }
 
 #[derive(Debug, Error)]
@@ -293,7 +345,7 @@ pub enum RebornProviderAdminError {
     #[error("load Reborn config `{}`: {source}", path.display())]
     LoadConfig {
         path: PathBuf,
-        source: ironclaw_reborn_config::RebornConfigFileError,
+        source: Box<ironclaw_reborn_config::RebornConfigFileError>,
     },
     #[error("unknown Reborn LLM provider `{provider}` in {}; available providers: {}", providers_file.display(), known.join(", "))]
     UnknownProvider {
@@ -306,7 +358,7 @@ pub enum RebornProviderAdminError {
     #[error("update Reborn config `{}`: {source}", path.display())]
     UpdateConfig {
         path: PathBuf,
-        source: ironclaw_reborn_config::RebornConfigFileUpdateError,
+        source: Box<ironclaw_reborn_config::RebornConfigFileUpdateError>,
     },
 }
 
@@ -391,7 +443,7 @@ fn provider_info(
         active_model,
         metadata: verbose.then(|| RebornProviderMetadata {
             aliases: def.aliases.clone(),
-            protocol: format!("{:?}", def.protocol),
+            protocol: provider_protocol_wire_name(def.protocol),
             model_env: def.model_env.clone(),
             api_key_env: def.api_key_env.clone(),
             api_key_required: def.api_key_required,
@@ -403,4 +455,11 @@ fn provider_info(
                 .is_some_and(ironclaw_llm::registry::SetupHint::can_list_models),
         }),
     }
+}
+
+fn provider_protocol_wire_name(protocol: ironclaw_llm::registry::ProviderProtocol) -> String {
+    serde_json::to_value(protocol)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/crates/ironclaw_reborn_composition/src/provider_admin.rs
+++ b/crates/ironclaw_reborn_composition/src/provider_admin.rs
@@ -1,0 +1,415 @@
+//! Reborn provider-admin facade.
+//!
+//! This is the typed provider/model administration surface shared by the
+//! standalone CLI and product command workflow. It deliberately edits only
+//! Reborn `$IRONCLAW_REBORN_HOME/config.toml` and reads the shared provider
+//! catalog through `ironclaw_llm`.
+
+use std::path::PathBuf;
+
+use ironclaw_reborn_config::{
+    DefaultLlmSlotUpdate, LlmSlotFieldUpdate, LlmSlotSelection, RebornBootConfig, RebornConfigFile,
+    update_default_llm_slot,
+};
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct RebornProviderAdmin {
+    boot: RebornBootConfig,
+}
+
+impl RebornProviderAdmin {
+    pub fn new(boot: RebornBootConfig) -> Self {
+        Self { boot }
+    }
+
+    pub fn list(
+        &self,
+        provider: Option<&str>,
+        verbose: bool,
+    ) -> Result<RebornProviderList, RebornProviderAdminError> {
+        let home = self.boot.home();
+        let registry = self.load_registry()?;
+        let config = RebornConfigFile::load(&home.config_file_path()).map_err(|source| {
+            RebornProviderAdminError::LoadConfig {
+                path: home.config_file_path(),
+                source,
+            }
+        })?;
+        let active = active_llm_selection(config.as_ref(), &registry);
+
+        let providers = if let Some(provider) = provider {
+            let def = registry.find(provider).ok_or_else(|| {
+                RebornProviderAdminError::UnknownProvider {
+                    provider: provider.to_string(),
+                    providers_file: home.providers_file_path(),
+                    known: known_provider_ids(&registry),
+                }
+            })?;
+            vec![provider_info(def, active.as_ref(), true)]
+        } else {
+            unique_provider_definitions(&registry)
+                .into_iter()
+                .map(|def| provider_info(def, active.as_ref(), verbose))
+                .collect()
+        };
+
+        Ok(RebornProviderList {
+            providers,
+            config_file: home.config_file_path(),
+            providers_file: home.providers_file_path(),
+            v1_state: "not-used",
+        })
+    }
+
+    pub fn status(&self) -> Result<RebornProviderStatus, RebornProviderAdminError> {
+        let home = self.boot.home();
+        let registry = self.load_registry()?;
+        let config = RebornConfigFile::load(&home.config_file_path()).map_err(|source| {
+            RebornProviderAdminError::LoadConfig {
+                path: home.config_file_path(),
+                source,
+            }
+        })?;
+        let active = active_llm_selection(config.as_ref(), &registry);
+        Ok(RebornProviderStatus {
+            routes: if active.is_some() {
+                "configured"
+            } else {
+                "not-configured"
+            },
+            default: active.map(|selection| RebornProviderSelection {
+                provider_id: selection.provider_id,
+                provider_known: selection.canonical_provider_id.is_some(),
+                model: selection.model,
+                api_key_env: selection.api_key_env,
+                base_url: selection.base_url,
+            }),
+            config_file: home.config_file_path(),
+            providers_file: home.providers_file_path(),
+            v1_state: "not-used",
+        })
+    }
+
+    pub fn set_model(
+        &self,
+        model: &str,
+    ) -> Result<RebornProviderWriteOutcome, RebornProviderAdminError> {
+        let model = model.trim();
+        if model.is_empty() {
+            return Err(RebornProviderAdminError::InvalidRequest {
+                reason: "model name cannot be empty".to_string(),
+            });
+        }
+
+        let home = self.boot.home();
+        let config_path = home.config_file_path();
+        let config = RebornConfigFile::load(&config_path).map_err(|source| {
+            RebornProviderAdminError::LoadConfig {
+                path: config_path.clone(),
+                source,
+            }
+        })?;
+        let provider_id = config
+            .as_ref()
+            .and_then(RebornConfigFile::default_llm_slot)
+            .and_then(|selection| selection.provider_id.as_deref())
+            .ok_or_else(|| RebornProviderAdminError::InvalidRequest {
+                reason: format!(
+                    "no default Reborn provider is configured in {}; set a provider first",
+                    config_path.display()
+                ),
+            })?
+            .to_string();
+
+        let registry = self.load_registry()?;
+        let canonical_id = registry
+            .find(&provider_id)
+            .map(|def| def.id.clone())
+            .unwrap_or_else(|| provider_id.to_string());
+        update_default_llm_slot(
+            &config_path,
+            &DefaultLlmSlotUpdate {
+                provider_id: LlmSlotFieldUpdate::Set(canonical_id.clone()),
+                model: LlmSlotFieldUpdate::Set(model.to_string()),
+                ..Default::default()
+            },
+        )
+        .map_err(|source| RebornProviderAdminError::UpdateConfig {
+            path: config_path.clone(),
+            source,
+        })?;
+
+        Ok(RebornProviderWriteOutcome {
+            provider_id: canonical_id,
+            model: model.to_string(),
+            api_key_env: None,
+            api_key_required: false,
+            missing_api_key: false,
+            config_file: config_path,
+            v1_state: "not-used",
+        })
+    }
+
+    pub fn set_provider(
+        &self,
+        provider: &str,
+        model: Option<&str>,
+    ) -> Result<RebornProviderWriteOutcome, RebornProviderAdminError> {
+        let provider = provider.trim();
+        if provider.is_empty() {
+            return Err(RebornProviderAdminError::InvalidRequest {
+                reason: "provider id cannot be empty".to_string(),
+            });
+        }
+
+        let home = self.boot.home();
+        let config_path = home.config_file_path();
+        let registry = self.load_registry()?;
+        let def =
+            registry
+                .find(provider)
+                .ok_or_else(|| RebornProviderAdminError::UnknownProvider {
+                    provider: provider.to_string(),
+                    providers_file: home.providers_file_path(),
+                    known: known_provider_ids(&registry),
+                })?;
+        let model = model
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .unwrap_or(&def.default_model);
+
+        update_default_llm_slot(
+            &config_path,
+            &DefaultLlmSlotUpdate {
+                provider_id: LlmSlotFieldUpdate::Set(def.id.clone()),
+                model: LlmSlotFieldUpdate::Set(model.to_string()),
+                api_key_env: def
+                    .api_key_env
+                    .clone()
+                    .map(LlmSlotFieldUpdate::Set)
+                    .unwrap_or(LlmSlotFieldUpdate::Remove),
+                base_url: LlmSlotFieldUpdate::Remove,
+            },
+        )
+        .map_err(|source| RebornProviderAdminError::UpdateConfig {
+            path: config_path.clone(),
+            source,
+        })?;
+
+        Ok(RebornProviderWriteOutcome {
+            provider_id: def.id.clone(),
+            model: model.to_string(),
+            api_key_env: def.api_key_env.clone(),
+            api_key_required: def.api_key_required,
+            missing_api_key: def.api_key_env.as_deref().is_some_and(|api_key_env| {
+                def.api_key_required && std::env::var_os(api_key_env).is_none()
+            }),
+            config_file: config_path,
+            v1_state: "not-used",
+        })
+    }
+
+    fn load_registry(&self) -> Result<ironclaw_llm::ProviderRegistry, RebornProviderAdminError> {
+        let providers_path = self.boot.home().providers_file_path();
+        ironclaw_llm::ProviderRegistry::try_load_from_path(Some(providers_path.as_path())).map_err(
+            |error| RebornProviderAdminError::LoadRegistry {
+                path: providers_path,
+                reason: error.to_string(),
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RebornProviderList {
+    pub providers: Vec<RebornProviderInfo>,
+    pub config_file: PathBuf,
+    pub providers_file: PathBuf,
+    pub v1_state: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RebornProviderInfo {
+    pub id: String,
+    pub description: String,
+    pub default_model: String,
+    pub active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<RebornProviderMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RebornProviderMetadata {
+    pub aliases: Vec<String>,
+    pub protocol: String,
+    pub model_env: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key_env: Option<String>,
+    pub api_key_required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_kind: Option<&'static str>,
+    pub can_list_models: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RebornProviderStatus {
+    pub routes: &'static str,
+    pub default: Option<RebornProviderSelection>,
+    pub config_file: PathBuf,
+    pub providers_file: PathBuf,
+    pub v1_state: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RebornProviderSelection {
+    pub provider_id: Option<String>,
+    pub provider_known: bool,
+    pub model: Option<String>,
+    pub api_key_env: Option<String>,
+    pub base_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RebornProviderWriteOutcome {
+    pub provider_id: String,
+    pub model: String,
+    pub api_key_env: Option<String>,
+    pub api_key_required: bool,
+    pub missing_api_key: bool,
+    pub config_file: PathBuf,
+    pub v1_state: &'static str,
+}
+
+#[derive(Debug, Error)]
+pub enum RebornProviderAdminError {
+    #[error("load Reborn provider catalog `{}`: {reason}", path.display())]
+    LoadRegistry { path: PathBuf, reason: String },
+    #[error("load Reborn config `{}`: {source}", path.display())]
+    LoadConfig {
+        path: PathBuf,
+        source: ironclaw_reborn_config::RebornConfigFileError,
+    },
+    #[error("unknown Reborn LLM provider `{provider}` in {}; available providers: {}", providers_file.display(), known.join(", "))]
+    UnknownProvider {
+        provider: String,
+        providers_file: PathBuf,
+        known: Vec<String>,
+    },
+    #[error("{reason}")]
+    InvalidRequest { reason: String },
+    #[error("update Reborn config `{}`: {source}", path.display())]
+    UpdateConfig {
+        path: PathBuf,
+        source: ironclaw_reborn_config::RebornConfigFileUpdateError,
+    },
+}
+
+impl RebornProviderAdminError {
+    pub(crate) fn is_invalid_request(&self) -> bool {
+        matches!(
+            self,
+            Self::UnknownProvider { .. } | Self::InvalidRequest { .. }
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ActiveLlmSelection {
+    provider_id: Option<String>,
+    canonical_provider_id: Option<String>,
+    model: Option<String>,
+    api_key_env: Option<String>,
+    base_url: Option<String>,
+}
+
+fn active_llm_selection(
+    config: Option<&RebornConfigFile>,
+    registry: &ironclaw_llm::ProviderRegistry,
+) -> Option<ActiveLlmSelection> {
+    let selection = config.and_then(RebornConfigFile::default_llm_slot)?;
+    Some(active_selection_from_slot(selection, registry))
+}
+
+fn active_selection_from_slot(
+    selection: &LlmSlotSelection,
+    registry: &ironclaw_llm::ProviderRegistry,
+) -> ActiveLlmSelection {
+    let canonical_provider_id = selection
+        .provider_id
+        .as_deref()
+        .and_then(|provider_id| registry.find(provider_id))
+        .map(|def| def.id.clone());
+    ActiveLlmSelection {
+        provider_id: selection.provider_id.clone(),
+        canonical_provider_id,
+        model: selection.model.clone(),
+        api_key_env: selection.api_key_env.clone(),
+        base_url: selection.base_url.clone(),
+    }
+}
+
+fn unique_provider_definitions(
+    registry: &ironclaw_llm::ProviderRegistry,
+) -> Vec<&ironclaw_llm::registry::ProviderDefinition> {
+    let mut emitted = std::collections::HashSet::new();
+    registry
+        .all()
+        .iter()
+        .filter_map(|candidate| {
+            let final_def = registry.find(&candidate.id)?;
+            if emitted.insert(final_def.id.as_str()) {
+                Some(final_def)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn known_provider_ids(registry: &ironclaw_llm::ProviderRegistry) -> Vec<String> {
+    unique_provider_definitions(registry)
+        .into_iter()
+        .map(|def| def.id.clone())
+        .collect()
+}
+
+fn provider_info(
+    def: &ironclaw_llm::registry::ProviderDefinition,
+    active: Option<&ActiveLlmSelection>,
+    verbose: bool,
+) -> RebornProviderInfo {
+    let active_for_provider = active
+        .and_then(|selection| selection.canonical_provider_id.as_deref())
+        .is_some_and(|provider_id| provider_id.eq_ignore_ascii_case(&def.id));
+    let active_model = active_for_provider.then(|| {
+        active
+            .and_then(|selection| selection.model.clone())
+            .unwrap_or_else(|| def.default_model.clone())
+    });
+    RebornProviderInfo {
+        id: def.id.clone(),
+        description: def.description.clone(),
+        default_model: def.default_model.clone(),
+        active: active_for_provider,
+        active_model,
+        metadata: verbose.then(|| RebornProviderMetadata {
+            aliases: def.aliases.clone(),
+            protocol: format!("{:?}", def.protocol),
+            model_env: def.model_env.clone(),
+            api_key_env: def.api_key_env.clone(),
+            api_key_required: def.api_key_required,
+            base_url: def.default_base_url.clone(),
+            credential_kind: def.setup.as_ref().map(|setup| setup.kind()),
+            can_list_models: def
+                .setup
+                .as_ref()
+                .is_some_and(ironclaw_llm::registry::SetupHint::can_list_models),
+        }),
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/provider_admin.rs
+++ b/crates/ironclaw_reborn_composition/src/provider_admin.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use ironclaw_reborn_config::{
     DefaultLlmSlotUpdate, LlmSlotFieldUpdate, LlmSlotSelection, RebornBootConfig, RebornConfigFile,
-    update_default_llm_slot,
+    begin_default_llm_slot_update, update_default_llm_slot,
 };
 use serde::Serialize;
 use thiserror::Error;
@@ -105,21 +105,23 @@ impl RebornProviderAdmin {
 
         let home = self.boot.home();
         let config_path = home.config_file_path();
-        let config = RebornConfigFile::load(&config_path).map_err(|source| {
-            RebornProviderAdminError::LoadConfig {
+        let session = begin_default_llm_slot_update(&config_path).map_err(|source| {
+            RebornProviderAdminError::UpdateConfig {
                 path: config_path.clone(),
                 source,
             }
         })?;
-        let provider_id = config
+        let provider_id = session
+            .default_llm_slot()
+            .map_err(|source| RebornProviderAdminError::UpdateConfig {
+                path: config_path.clone(),
+                source,
+            })?
             .as_ref()
-            .and_then(RebornConfigFile::default_llm_slot)
             .and_then(|selection| selection.provider_id.as_deref())
             .ok_or_else(|| RebornProviderAdminError::InvalidRequest {
-                reason: format!(
-                    "no default Reborn provider is configured in {}; set a provider first",
-                    config_path.display()
-                ),
+                reason: "no default Reborn provider is configured; set a provider first"
+                    .to_string(),
             })?
             .to_string();
 
@@ -128,18 +130,16 @@ impl RebornProviderAdmin {
             .find(&provider_id)
             .map(|def| def.id.clone())
             .unwrap_or_else(|| provider_id.to_string());
-        update_default_llm_slot(
-            &config_path,
-            &DefaultLlmSlotUpdate {
+        session
+            .apply(&DefaultLlmSlotUpdate {
                 provider_id: LlmSlotFieldUpdate::Set(canonical_id.clone()),
                 model: LlmSlotFieldUpdate::Set(model.to_string()),
                 ..Default::default()
-            },
-        )
-        .map_err(|source| RebornProviderAdminError::UpdateConfig {
-            path: config_path.clone(),
-            source,
-        })?;
+            })
+            .map_err(|source| RebornProviderAdminError::UpdateConfig {
+                path: config_path.clone(),
+                source,
+            })?;
 
         Ok(RebornProviderWriteOutcome {
             provider_id: canonical_id,
@@ -308,15 +308,6 @@ pub enum RebornProviderAdminError {
         path: PathBuf,
         source: ironclaw_reborn_config::RebornConfigFileUpdateError,
     },
-}
-
-impl RebornProviderAdminError {
-    pub(crate) fn is_invalid_request(&self) -> bool {
-        matches!(
-            self,
-            Self::UnknownProvider { .. } | Self::InvalidRequest { .. }
-        )
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ironclaw_reborn_composition/src/provider_admin_product_command.rs
+++ b/crates/ironclaw_reborn_composition/src/provider_admin_product_command.rs
@@ -9,8 +9,8 @@ use ironclaw_product_workflow::{
 use serde::Serialize;
 
 use crate::{
-    RebornProviderAdmin, RebornProviderAdminError, RebornProviderSelection, RebornProviderStatus,
-    RebornProviderWriteOutcome,
+    RebornModelRoutesState, RebornProviderAdmin, RebornProviderAdminError, RebornProviderSelection,
+    RebornProviderStatus, RebornProviderWriteOutcome, RebornV1State,
 };
 
 pub struct RebornProviderAdminProductCommandService {
@@ -82,9 +82,9 @@ fn provider_admin_payload(
 
 #[derive(Serialize)]
 struct ProductSafeProviderStatus {
-    routes: &'static str,
+    routes: RebornModelRoutesState,
     default: Option<ProductSafeProviderSelection>,
-    v1_state: &'static str,
+    v1_state: RebornV1State,
 }
 
 impl From<RebornProviderStatus> for ProductSafeProviderStatus {
@@ -126,7 +126,7 @@ struct ProductSafeProviderWriteOutcome {
     model: String,
     api_key_required: bool,
     missing_api_key: bool,
-    v1_state: &'static str,
+    v1_state: RebornV1State,
 }
 
 impl From<RebornProviderWriteOutcome> for ProductSafeProviderWriteOutcome {
@@ -149,22 +149,76 @@ impl ProductSafeProviderWriteOutcome {
 
 fn provider_admin_workflow_error(error: RebornProviderAdminError) -> ProductWorkflowError {
     match error {
-        RebornProviderAdminError::UnknownProvider {
-            provider, known, ..
-        } => ProductWorkflowError::InvalidBindingRequest {
-            reason: format!(
-                "unknown Reborn LLM provider `{}`; available providers: {}",
-                provider,
-                known.join(", ")
-            ),
-        },
+        RebornProviderAdminError::UnknownProvider { provider, .. } => {
+            ProductWorkflowError::InvalidBindingRequest {
+                reason: format!("unknown Reborn LLM provider `{provider}`"),
+            }
+        }
         RebornProviderAdminError::InvalidRequest { reason } => {
             ProductWorkflowError::InvalidBindingRequest { reason }
         }
-        RebornProviderAdminError::LoadRegistry { .. }
-        | RebornProviderAdminError::LoadConfig { .. }
-        | RebornProviderAdminError::UpdateConfig { .. } => ProductWorkflowError::Transient {
-            reason: "provider-admin operation failed".to_string(),
+        RebornProviderAdminError::LoadRegistry { reason, .. } => ProductWorkflowError::Transient {
+            reason: format!("load Reborn provider catalog failed: {reason}"),
         },
+        RebornProviderAdminError::LoadConfig { source, .. } => ProductWorkflowError::Transient {
+            reason: format!(
+                "load Reborn config failed: {}",
+                config_load_error_reason(source.as_ref())
+            ),
+        },
+        RebornProviderAdminError::UpdateConfig { source, .. } => ProductWorkflowError::Transient {
+            reason: format!(
+                "update Reborn config failed: {}",
+                config_update_error_reason(source.as_ref())
+            ),
+        },
+    }
+}
+
+fn config_load_error_reason(error: &ironclaw_reborn_config::RebornConfigFileError) -> String {
+    match error {
+        ironclaw_reborn_config::RebornConfigFileError::Io { source, .. } => {
+            format!("read failed: {source}")
+        }
+        ironclaw_reborn_config::RebornConfigFileError::Toml { source, .. } => {
+            format!("TOML parse failed: {source}")
+        }
+        ironclaw_reborn_config::RebornConfigFileError::IncompatibleApiVersion {
+            found,
+            expected,
+            ..
+        } => {
+            format!("api_version `{found}` is incompatible with `{expected}`")
+        }
+        ironclaw_reborn_config::RebornConfigFileError::InlineSecret { source, .. } => {
+            format!("field validation failed: {source}")
+        }
+        ironclaw_reborn_config::RebornConfigFileError::InvalidApiVersion {
+            found, reason, ..
+        } => {
+            format!("api_version `{found}` could not be parsed: {reason}")
+        }
+    }
+}
+
+fn config_update_error_reason(
+    error: &ironclaw_reborn_config::RebornConfigFileUpdateError,
+) -> String {
+    match error {
+        ironclaw_reborn_config::RebornConfigFileUpdateError::Lock { source, .. } => {
+            format!("lock failed: {source}")
+        }
+        ironclaw_reborn_config::RebornConfigFileUpdateError::Read { source, .. } => {
+            format!("read failed: {source}")
+        }
+        ironclaw_reborn_config::RebornConfigFileUpdateError::Parse { source, .. } => {
+            format!("TOML parse failed: {source}")
+        }
+        ironclaw_reborn_config::RebornConfigFileUpdateError::Validate { source, .. } => {
+            format!("validation failed: {}", config_load_error_reason(source))
+        }
+        ironclaw_reborn_config::RebornConfigFileUpdateError::Write { source, .. } => {
+            format!("write failed: {source}")
+        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/provider_admin_product_command.rs
+++ b/crates/ironclaw_reborn_composition/src/provider_admin_product_command.rs
@@ -1,0 +1,72 @@
+use async_trait::async_trait;
+use ironclaw_product_adapters::{
+    ProductCommandResultPayload, ProductInboundAck, ProductRejection, ProductRejectionKind,
+};
+use ironclaw_product_workflow::{
+    ProductCommand, ProductCommandContext, ProductCommandService, ProductModelCommand,
+    ProductWorkflowError,
+};
+
+use crate::{RebornProviderAdmin, RebornProviderAdminError};
+
+pub struct RebornProviderAdminProductCommandService {
+    admin: RebornProviderAdmin,
+}
+
+impl RebornProviderAdminProductCommandService {
+    pub fn new(admin: RebornProviderAdmin) -> Self {
+        Self { admin }
+    }
+}
+
+#[async_trait]
+impl ProductCommandService for RebornProviderAdminProductCommandService {
+    async fn execute(
+        &self,
+        _context: ProductCommandContext,
+        command: ProductCommand,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        let ProductCommand::Model { action } = command else {
+            return Ok(ProductInboundAck::Rejected(ProductRejection::permanent(
+                ProductRejectionKind::PolicyDenied,
+                format!("command routing unavailable: {}", command.name()),
+            )));
+        };
+
+        let payload = match action {
+            ProductModelCommand::Status => {
+                serde_json::to_value(self.admin.status().map_err(provider_admin_workflow_error)?)
+            }
+            ProductModelCommand::Set { model } => serde_json::to_value(
+                self.admin
+                    .set_model(&model)
+                    .map_err(provider_admin_workflow_error)?,
+            ),
+            ProductModelCommand::SetProvider { provider, model } => serde_json::to_value(
+                self.admin
+                    .set_provider(&provider, model.as_deref())
+                    .map_err(provider_admin_workflow_error)?,
+            ),
+        }
+        .map_err(|error| ProductWorkflowError::Transient {
+            reason: format!("provider-admin response serialization failed: {error}"),
+        })?;
+
+        Ok(ProductInboundAck::CommandResult {
+            command: "model".to_string(),
+            payload: ProductCommandResultPayload::new(payload),
+        })
+    }
+}
+
+fn provider_admin_workflow_error(error: RebornProviderAdminError) -> ProductWorkflowError {
+    if error.is_invalid_request() {
+        ProductWorkflowError::InvalidBindingRequest {
+            reason: error.to_string(),
+        }
+    } else {
+        ProductWorkflowError::Transient {
+            reason: error.to_string(),
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/provider_admin_product_command.rs
+++ b/crates/ironclaw_reborn_composition/src/provider_admin_product_command.rs
@@ -6,8 +6,12 @@ use ironclaw_product_workflow::{
     ProductCommand, ProductCommandContext, ProductCommandService, ProductModelCommand,
     ProductWorkflowError,
 };
+use serde::Serialize;
 
-use crate::{RebornProviderAdmin, RebornProviderAdminError};
+use crate::{
+    RebornProviderAdmin, RebornProviderAdminError, RebornProviderSelection, RebornProviderStatus,
+    RebornProviderWriteOutcome,
+};
 
 pub struct RebornProviderAdminProductCommandService {
     admin: RebornProviderAdmin,
@@ -33,24 +37,12 @@ impl ProductCommandService for RebornProviderAdminProductCommandService {
             )));
         };
 
-        let payload = match action {
-            ProductModelCommand::Status => {
-                serde_json::to_value(self.admin.status().map_err(provider_admin_workflow_error)?)
-            }
-            ProductModelCommand::Set { model } => serde_json::to_value(
-                self.admin
-                    .set_model(&model)
-                    .map_err(provider_admin_workflow_error)?,
-            ),
-            ProductModelCommand::SetProvider { provider, model } => serde_json::to_value(
-                self.admin
-                    .set_provider(&provider, model.as_deref())
-                    .map_err(provider_admin_workflow_error)?,
-            ),
-        }
-        .map_err(|error| ProductWorkflowError::Transient {
-            reason: format!("provider-admin response serialization failed: {error}"),
-        })?;
+        let admin = self.admin.clone();
+        let payload = tokio::task::spawn_blocking(move || provider_admin_payload(admin, action))
+            .await
+            .map_err(|error| ProductWorkflowError::Transient {
+                reason: format!("provider-admin task failed: {error}"),
+            })??;
 
         Ok(ProductInboundAck::CommandResult {
             command: "model".to_string(),
@@ -59,14 +51,120 @@ impl ProductCommandService for RebornProviderAdminProductCommandService {
     }
 }
 
+fn provider_admin_payload(
+    admin: RebornProviderAdmin,
+    action: ProductModelCommand,
+) -> Result<serde_json::Value, ProductWorkflowError> {
+    let payload = match action {
+        ProductModelCommand::Status => {
+            ProductSafeProviderStatus::from(admin.status().map_err(provider_admin_workflow_error)?)
+                .to_value()
+        }
+        ProductModelCommand::Set { model } => ProductSafeProviderWriteOutcome::from(
+            admin
+                .set_model(&model)
+                .map_err(provider_admin_workflow_error)?,
+        )
+        .to_value(),
+        ProductModelCommand::SetProvider { provider, model } => {
+            ProductSafeProviderWriteOutcome::from(
+                admin
+                    .set_provider(&provider, model.as_deref())
+                    .map_err(provider_admin_workflow_error)?,
+            )
+            .to_value()
+        }
+    };
+    payload.map_err(|error| ProductWorkflowError::Transient {
+        reason: format!("provider-admin response serialization failed: {error}"),
+    })
+}
+
+#[derive(Serialize)]
+struct ProductSafeProviderStatus {
+    routes: &'static str,
+    default: Option<ProductSafeProviderSelection>,
+    v1_state: &'static str,
+}
+
+impl From<RebornProviderStatus> for ProductSafeProviderStatus {
+    fn from(status: RebornProviderStatus) -> Self {
+        Self {
+            routes: status.routes,
+            default: status.default.map(ProductSafeProviderSelection::from),
+            v1_state: status.v1_state,
+        }
+    }
+}
+
+impl ProductSafeProviderStatus {
+    fn to_value(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+#[derive(Serialize)]
+struct ProductSafeProviderSelection {
+    provider_id: Option<String>,
+    provider_known: bool,
+    model: Option<String>,
+}
+
+impl From<RebornProviderSelection> for ProductSafeProviderSelection {
+    fn from(selection: RebornProviderSelection) -> Self {
+        Self {
+            provider_id: selection.provider_id,
+            provider_known: selection.provider_known,
+            model: selection.model,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ProductSafeProviderWriteOutcome {
+    provider_id: String,
+    model: String,
+    api_key_required: bool,
+    missing_api_key: bool,
+    v1_state: &'static str,
+}
+
+impl From<RebornProviderWriteOutcome> for ProductSafeProviderWriteOutcome {
+    fn from(outcome: RebornProviderWriteOutcome) -> Self {
+        Self {
+            provider_id: outcome.provider_id,
+            model: outcome.model,
+            api_key_required: outcome.api_key_required,
+            missing_api_key: outcome.missing_api_key,
+            v1_state: outcome.v1_state,
+        }
+    }
+}
+
+impl ProductSafeProviderWriteOutcome {
+    fn to_value(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
 fn provider_admin_workflow_error(error: RebornProviderAdminError) -> ProductWorkflowError {
-    if error.is_invalid_request() {
-        ProductWorkflowError::InvalidBindingRequest {
-            reason: error.to_string(),
+    match error {
+        RebornProviderAdminError::UnknownProvider {
+            provider, known, ..
+        } => ProductWorkflowError::InvalidBindingRequest {
+            reason: format!(
+                "unknown Reborn LLM provider `{}`; available providers: {}",
+                provider,
+                known.join(", ")
+            ),
+        },
+        RebornProviderAdminError::InvalidRequest { reason } => {
+            ProductWorkflowError::InvalidBindingRequest { reason }
         }
-    } else {
-        ProductWorkflowError::Transient {
-            reason: error.to_string(),
-        }
+        RebornProviderAdminError::LoadRegistry { .. }
+        | RebornProviderAdminError::LoadConfig { .. }
+        | RebornProviderAdminError::UpdateConfig { .. } => ProductWorkflowError::Transient {
+            reason: "provider-admin operation failed".to_string(),
+        },
     }
 }

--- a/crates/ironclaw_reborn_composition/tests/provider_admin.rs
+++ b/crates/ironclaw_reborn_composition/tests/provider_admin.rs
@@ -1,0 +1,101 @@
+#![cfg(feature = "root-llm-provider")]
+
+use ironclaw_reborn_composition::{RebornProviderAdmin, RebornProviderAdminError, RebornV1State};
+use ironclaw_reborn_config::{RebornBootConfig, RebornHome, RebornProfile};
+
+fn admin_for_home(reborn_home: &std::path::Path) -> RebornProviderAdmin {
+    let home = RebornHome::resolve_from_env_parts(
+        Some(reborn_home.as_os_str().to_os_string()),
+        None,
+        None,
+    )
+    .expect("valid reborn home");
+    RebornProviderAdmin::new(RebornBootConfig::new(home, RebornProfile::LocalDev))
+}
+
+#[test]
+fn list_unknown_provider_returns_known_provider_context() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let admin = admin_for_home(&temp.path().join("reborn-home"));
+
+    let err = admin
+        .list(Some("missing-provider"), false)
+        .expect_err("unknown provider should reject");
+
+    let RebornProviderAdminError::UnknownProvider {
+        provider, known, ..
+    } = err
+    else {
+        panic!("expected unknown provider error");
+    };
+    assert_eq!(provider, "missing-provider");
+    assert!(known.contains(&"openai".to_string()), "known: {known:?}");
+}
+
+#[test]
+fn set_model_empty_string_returns_invalid_request() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let admin = admin_for_home(&temp.path().join("reborn-home"));
+
+    for model in ["", "   "] {
+        let err = admin
+            .set_model(model)
+            .expect_err("empty model should reject before config access");
+        assert!(matches!(
+            err,
+            RebornProviderAdminError::InvalidRequest { reason }
+                if reason == "model name cannot be empty"
+        ));
+    }
+}
+
+#[test]
+fn set_model_reports_active_provider_credential_metadata() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("mkdir");
+    std::fs::write(
+        reborn_home.join("config.toml"),
+        r#"
+[llm.default]
+provider_id = "openai"
+model = "gpt-5-mini"
+api_key_env = "OPENAI_API_KEY"
+"#,
+    )
+    .expect("write config");
+    let admin = admin_for_home(&reborn_home);
+
+    let outcome = admin.set_model("gpt-5.3-codex").expect("set model");
+
+    assert_eq!(outcome.provider_id, "openai");
+    assert_eq!(outcome.model, "gpt-5.3-codex");
+    assert_eq!(outcome.api_key_env.as_deref(), Some("OPENAI_API_KEY"));
+    assert!(outcome.api_key_required);
+}
+
+#[test]
+fn provider_admin_json_omits_absolute_host_paths() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let admin = admin_for_home(&temp.path().join("reborn-home"));
+
+    let list_json = serde_json::to_value(admin.list(None, false).expect("list")).expect("json");
+    assert!(list_json.get("config_file").is_none(), "json: {list_json}");
+    assert!(
+        list_json.get("providers_file").is_none(),
+        "json: {list_json}"
+    );
+    assert_eq!(list_json["v1_state"], RebornV1State::NotUsed.as_str());
+
+    let status_json = serde_json::to_value(admin.status().expect("status")).expect("json");
+    assert!(
+        status_json.get("config_file").is_none(),
+        "json: {status_json}"
+    );
+    assert!(
+        status_json.get("providers_file").is_none(),
+        "json: {status_json}"
+    );
+    assert_eq!(status_json["routes"], "not-configured");
+    assert_eq!(status_json["v1_state"], RebornV1State::NotUsed.as_str());
+}

--- a/crates/ironclaw_reborn_composition/tests/provider_admin_product_command.rs
+++ b/crates/ironclaw_reborn_composition/tests/provider_admin_product_command.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use chrono::Utc;
 use ironclaw_product_adapters::{
     AdapterInstallationId, AuthRequirement, ExternalActorRef, ExternalConversationRef,
-    ExternalEventId, InboundCommandPayload, ProductAdapterId, ProductInboundAck,
-    ProductInboundEnvelope, ProductInboundPayload, ProductTriggerReason, ProductWorkflow,
-    ProtocolAuthEvidence, TrustedInboundContext,
+    ExternalEventId, InboundCommandPayload, ProductAdapterError, ProductAdapterId,
+    ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload, ProductTriggerReason,
+    ProductWorkflow, ProductWorkflowRejectionKind, ProtocolAuthEvidence, TrustedInboundContext,
 };
 use ironclaw_product_workflow::{
     DefaultProductWorkflow, FakeConversationBindingService, FakeIdempotencyLedger,
@@ -93,6 +93,8 @@ async fn model_provider_command_executes_through_reborn_provider_admin_service()
     assert_eq!(command, "model");
     assert_eq!(payload.as_value()["provider_id"], "openai");
     assert_eq!(payload.as_value()["model"], "gpt-5-mini");
+    assert!(payload.as_value().get("config_file").is_none());
+    assert!(payload.as_value().get("api_key_env").is_none());
     assert_eq!(inbound.accepted_count(), 0);
     let config = std::fs::read_to_string(reborn_home.join("config.toml")).expect("read config");
     assert!(
@@ -103,4 +105,41 @@ async fn model_provider_command_executes_through_reborn_provider_admin_service()
         config.contains("model = \"gpt-5-mini\""),
         "config: {config}"
     );
+}
+
+#[tokio::test]
+async fn model_provider_command_rejects_unknown_provider_as_invalid_binding() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home = RebornHome::resolve_from_env_parts(Some(reborn_home.into_os_string()), None, None)
+        .expect("valid reborn home");
+    let admin = RebornProviderAdmin::new(RebornBootConfig::new(home, RebornProfile::LocalDev));
+    let command_service = Arc::new(RebornProviderAdminProductCommandService::new(admin));
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger, binding)
+        .with_product_command_admission_service(Arc::new(AllowingCommandAdmissionService))
+        .with_product_command_service(command_service);
+    let envelope = sample_command_envelope(
+        "command-model-provider-unknown",
+        "model",
+        "set-provider missing-provider",
+    );
+
+    let err = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("unknown provider should reject");
+
+    assert!(matches!(
+        err,
+        ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::InvalidRequest,
+            status_code: 400,
+            retryable: false,
+            ..
+        }
+    ));
+    assert_eq!(inbound.accepted_count(), 0);
 }

--- a/crates/ironclaw_reborn_composition/tests/provider_admin_product_command.rs
+++ b/crates/ironclaw_reborn_composition/tests/provider_admin_product_command.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "root-llm-provider")]
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use ironclaw_product_adapters::{
+    AdapterInstallationId, AuthRequirement, ExternalActorRef, ExternalConversationRef,
+    ExternalEventId, InboundCommandPayload, ProductAdapterId, ProductInboundAck,
+    ProductInboundEnvelope, ProductInboundPayload, ProductTriggerReason, ProductWorkflow,
+    ProtocolAuthEvidence, TrustedInboundContext,
+};
+use ironclaw_product_workflow::{
+    DefaultProductWorkflow, FakeConversationBindingService, FakeIdempotencyLedger,
+    FakeInboundTurnService, ProductCommandAdmission, ProductCommandAdmissionService,
+    ProductCommandContext, ProductWorkflowError,
+};
+use ironclaw_reborn_composition::{RebornProviderAdmin, RebornProviderAdminProductCommandService};
+use ironclaw_reborn_config::{RebornBootConfig, RebornHome, RebornProfile};
+
+fn sample_command_envelope(
+    event_suffix: &str,
+    command: &str,
+    arguments: &str,
+) -> ProductInboundEnvelope {
+    let adapter_id = ProductAdapterId::new("test_adapter").expect("valid adapter");
+    let installation_id = AdapterInstallationId::new("install_alpha").expect("valid installation");
+    let evidence = ProtocolAuthEvidence::test_verified(
+        AuthRequirement::SharedSecretHeader {
+            header_name: "X-Secret".into(),
+        },
+        installation_id.as_str(),
+    );
+    let context = TrustedInboundContext::from_verified_evidence(
+        adapter_id,
+        installation_id,
+        Utc::now(),
+        &evidence,
+    )
+    .expect("verified");
+    let parsed = ironclaw_product_adapters::ParsedProductInbound::new(
+        ExternalEventId::new(format!("evt:{event_suffix}")).expect("valid event"),
+        ExternalActorRef::new("test", "user1", Option::<String>::None).expect("valid actor"),
+        ExternalConversationRef::new(None, "conv1", None, None).expect("valid conversation"),
+        ProductInboundPayload::Command(
+            InboundCommandPayload::new(command, arguments, ProductTriggerReason::BotCommand)
+                .expect("valid command"),
+        ),
+    )
+    .expect("parsed");
+
+    ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("envelope")
+}
+
+struct AllowingCommandAdmissionService;
+
+#[async_trait::async_trait]
+impl ProductCommandAdmissionService for AllowingCommandAdmissionService {
+    async fn admit(
+        &self,
+        _context: &ProductCommandContext,
+        _command: &ironclaw_product_workflow::ProductCommand,
+    ) -> Result<ProductCommandAdmission, ProductWorkflowError> {
+        Ok(ProductCommandAdmission::Allowed)
+    }
+}
+
+#[tokio::test]
+async fn model_provider_command_executes_through_reborn_provider_admin_service() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home =
+        RebornHome::resolve_from_env_parts(Some(reborn_home.clone().into_os_string()), None, None)
+            .expect("valid reborn home");
+    let admin = RebornProviderAdmin::new(RebornBootConfig::new(home, RebornProfile::LocalDev));
+    let command_service = Arc::new(RebornProviderAdminProductCommandService::new(admin));
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger, binding)
+        .with_product_command_admission_service(Arc::new(AllowingCommandAdmissionService))
+        .with_product_command_service(command_service);
+    let envelope = sample_command_envelope(
+        "command-model-provider",
+        "model",
+        "set-provider openai --model gpt-5-mini",
+    );
+
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    let ProductInboundAck::CommandResult { command, payload } = ack else {
+        panic!("expected provider-admin command result");
+    };
+    assert_eq!(command, "model");
+    assert_eq!(payload.as_value()["provider_id"], "openai");
+    assert_eq!(payload.as_value()["model"], "gpt-5-mini");
+    assert_eq!(inbound.accepted_count(), 0);
+    let config = std::fs::read_to_string(reborn_home.join("config.toml")).expect("read config");
+    assert!(
+        config.contains("provider_id = \"openai\""),
+        "config: {config}"
+    );
+    assert!(
+        config.contains("model = \"gpt-5-mini\""),
+        "config: {config}"
+    );
+}

--- a/crates/ironclaw_reborn_composition/tests/provider_admin_product_command.rs
+++ b/crates/ironclaw_reborn_composition/tests/provider_admin_product_command.rs
@@ -64,13 +64,15 @@ impl ProductCommandAdmissionService for AllowingCommandAdmissionService {
     }
 }
 
-#[tokio::test]
-async fn model_provider_command_executes_through_reborn_provider_admin_service() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let reborn_home = temp.path().join("reborn-home");
-    let home =
-        RebornHome::resolve_from_env_parts(Some(reborn_home.clone().into_os_string()), None, None)
-            .expect("valid reborn home");
+fn workflow_for_reborn_home(
+    reborn_home: &std::path::Path,
+) -> (DefaultProductWorkflow, Arc<FakeInboundTurnService>) {
+    let home = RebornHome::resolve_from_env_parts(
+        Some(reborn_home.as_os_str().to_os_string()),
+        None,
+        None,
+    )
+    .expect("valid reborn home");
     let admin = RebornProviderAdmin::new(RebornBootConfig::new(home, RebornProfile::LocalDev));
     let command_service = Arc::new(RebornProviderAdminProductCommandService::new(admin));
     let inbound = Arc::new(FakeInboundTurnService::new());
@@ -79,6 +81,14 @@ async fn model_provider_command_executes_through_reborn_provider_admin_service()
     let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger, binding)
         .with_product_command_admission_service(Arc::new(AllowingCommandAdmissionService))
         .with_product_command_service(command_service);
+    (workflow, inbound)
+}
+
+#[tokio::test]
+async fn model_provider_command_executes_through_reborn_provider_admin_service() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let (workflow, inbound) = workflow_for_reborn_home(&reborn_home);
     let envelope = sample_command_envelope(
         "command-model-provider",
         "model",
@@ -108,19 +118,47 @@ async fn model_provider_command_executes_through_reborn_provider_admin_service()
 }
 
 #[tokio::test]
+async fn model_set_command_executes_through_reborn_provider_admin_service() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    std::fs::create_dir_all(&reborn_home).expect("mkdir");
+    std::fs::write(
+        reborn_home.join("config.toml"),
+        r#"
+[llm.default]
+provider_id = "openai"
+model = "gpt-5-mini"
+api_key_env = "OPENAI_API_KEY"
+"#,
+    )
+    .expect("write config");
+    let (workflow, inbound) = workflow_for_reborn_home(&reborn_home);
+    let envelope = sample_command_envelope("command-model-set", "model", "gpt-5.3-codex");
+
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    let ProductInboundAck::CommandResult { command, payload } = ack else {
+        panic!("expected provider-admin command result");
+    };
+    assert_eq!(command, "model");
+    assert_eq!(payload.as_value()["provider_id"], "openai");
+    assert_eq!(payload.as_value()["model"], "gpt-5.3-codex");
+    assert_eq!(payload.as_value()["api_key_required"], true);
+    assert!(payload.as_value().get("config_file").is_none());
+    assert!(payload.as_value().get("api_key_env").is_none());
+    assert_eq!(inbound.accepted_count(), 0);
+    let config = std::fs::read_to_string(reborn_home.join("config.toml")).expect("read config");
+    assert!(
+        config.contains("model = \"gpt-5.3-codex\""),
+        "config: {config}"
+    );
+}
+
+#[tokio::test]
 async fn model_provider_command_rejects_unknown_provider_as_invalid_binding() {
     let temp = tempfile::tempdir().expect("tempdir");
     let reborn_home = temp.path().join("reborn-home");
-    let home = RebornHome::resolve_from_env_parts(Some(reborn_home.into_os_string()), None, None)
-        .expect("valid reborn home");
-    let admin = RebornProviderAdmin::new(RebornBootConfig::new(home, RebornProfile::LocalDev));
-    let command_service = Arc::new(RebornProviderAdminProductCommandService::new(admin));
-    let inbound = Arc::new(FakeInboundTurnService::new());
-    let ledger = Arc::new(FakeIdempotencyLedger::new());
-    let binding = Arc::new(FakeConversationBindingService::new());
-    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger, binding)
-        .with_product_command_admission_service(Arc::new(AllowingCommandAdmissionService))
-        .with_product_command_service(command_service);
+    let (workflow, inbound) = workflow_for_reborn_home(&reborn_home);
     let envelope = sample_command_envelope(
         "command-model-provider-unknown",
         "model",
@@ -141,5 +179,27 @@ async fn model_provider_command_rejects_unknown_provider_as_invalid_binding() {
             ..
         }
     ));
+    assert_eq!(inbound.accepted_count(), 0);
+}
+
+#[tokio::test]
+async fn non_model_command_is_rejected_by_provider_admin_service() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let (workflow, inbound) = workflow_for_reborn_home(&reborn_home);
+    let envelope = sample_command_envelope("command-status-provider-admin", "status", "");
+
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("non-model command should produce rejection ack");
+
+    let ProductInboundAck::Rejected(rejection) = ack else {
+        panic!("expected provider-admin rejection");
+    };
+    assert_eq!(
+        rejection.kind,
+        ironclaw_product_adapters::ProductRejectionKind::PolicyDenied
+    );
     assert_eq!(inbound.accepted_count(), 0);
 }

--- a/crates/ironclaw_reborn_config/Cargo.toml
+++ b/crates/ironclaw_reborn_config/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 dist = false
 
 [dependencies]
+fs4 = "0.6"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 thiserror = "2"

--- a/crates/ironclaw_reborn_config/Cargo.toml
+++ b/crates/ironclaw_reborn_config/Cargo.toml
@@ -17,8 +17,7 @@ dist = false
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+tempfile = "3"
 thiserror = "2"
 toml = "0.8"
-
-[dev-dependencies]
-tempfile = "3"
+toml_edit = "0.22"

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -34,7 +34,8 @@
 
 use std::borrow::Cow;
 use std::fs;
-use std::path::Path;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use thiserror::Error;
@@ -260,6 +261,27 @@ pub struct LlmSlotSelection {
     pub base_url: Option<String>,
 }
 
+/// Field update for an existing LLM slot selection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum LlmSlotFieldUpdate {
+    /// Preserve the field exactly as it appears in the current document.
+    #[default]
+    Keep,
+    /// Set the field to a new string value.
+    Set(String),
+    /// Remove the field from the slot selection.
+    Remove,
+}
+
+/// Typed patch for `[llm.default]` in the operator config file.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DefaultLlmSlotUpdate {
+    pub provider_id: LlmSlotFieldUpdate,
+    pub model: LlmSlotFieldUpdate,
+    pub api_key_env: LlmSlotFieldUpdate,
+    pub base_url: LlmSlotFieldUpdate,
+}
+
 // ─── Errors ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Error)]
@@ -296,6 +318,30 @@ pub enum RebornConfigFileError {
         path: String,
         found: String,
         reason: String,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum RebornConfigFileUpdateError {
+    #[error("read Reborn config `{}`: {source}", path.display())]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("parse Reborn config `{}` as TOML: {source}", path.display())]
+    Parse {
+        path: PathBuf,
+        source: toml_edit::TomlError,
+    },
+    #[error("validate Reborn config `{}`: {source}", path.display())]
+    Validate {
+        path: PathBuf,
+        source: RebornConfigFileError,
+    },
+    #[error("write Reborn config `{}`: {source}", path.display())]
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
     },
 }
 
@@ -508,8 +554,107 @@ impl RebornConfigFile {
     }
 }
 
+/// Apply a typed patch to `[llm.default]` while preserving unrelated TOML.
+pub fn update_default_llm_slot(
+    path: &Path,
+    update: &DefaultLlmSlotUpdate,
+) -> Result<(), RebornConfigFileUpdateError> {
+    let mut doc = load_edit_document(path)?;
+    apply_llm_slot_field(&mut doc, "provider_id", &update.provider_id);
+    apply_llm_slot_field(&mut doc, "model", &update.model);
+    apply_llm_slot_field(&mut doc, "api_key_env", &update.api_key_env);
+    apply_llm_slot_field(&mut doc, "base_url", &update.base_url);
+    write_edit_document(path, &doc)
+}
+
 fn llm_slot_field_label(slot: &str, field: &str) -> Cow<'static, str> {
     Cow::Owned(format!("llm.{slot}.{field}"))
+}
+
+fn load_edit_document(path: &Path) -> Result<toml_edit::DocumentMut, RebornConfigFileUpdateError> {
+    match fs::read_to_string(path) {
+        Ok(text) => text.parse::<toml_edit::DocumentMut>().map_err(|source| {
+            RebornConfigFileUpdateError::Parse {
+                path: path.to_path_buf(),
+                source,
+            }
+        }),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            Ok(toml_edit::DocumentMut::new())
+        }
+        Err(source) => Err(RebornConfigFileUpdateError::Read {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn apply_llm_slot_field(
+    doc: &mut toml_edit::DocumentMut,
+    field: &str,
+    update: &LlmSlotFieldUpdate,
+) {
+    match update {
+        LlmSlotFieldUpdate::Keep => {}
+        LlmSlotFieldUpdate::Set(value) => {
+            ensure_llm_default_table(doc);
+            doc["llm"]["default"][field] = toml_edit::value(value);
+        }
+        LlmSlotFieldUpdate::Remove => {
+            ensure_llm_default_table(doc);
+            if let Some(table) = doc["llm"]["default"].as_table_like_mut() {
+                table.remove(field);
+            }
+        }
+    }
+}
+
+fn ensure_llm_default_table(doc: &mut toml_edit::DocumentMut) {
+    let root = doc.as_table_mut();
+    if root.get("llm").is_none_or(|item| !item.is_table()) {
+        root.insert("llm", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    if let Some(llm) = doc["llm"].as_table_mut()
+        && llm.get("default").is_none_or(|item| !item.is_table())
+    {
+        llm.insert("default", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+}
+
+fn write_edit_document(
+    path: &Path,
+    doc: &toml_edit::DocumentMut,
+) -> Result<(), RebornConfigFileUpdateError> {
+    let text = doc.to_string();
+    RebornConfigFile::parse_text(&text, path).map_err(|source| {
+        RebornConfigFileUpdateError::Validate {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| RebornConfigFileUpdateError::Write {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let mut tmp = tempfile::NamedTempFile::new_in(path.parent().unwrap_or_else(|| Path::new(".")))
+        .map_err(|source| RebornConfigFileUpdateError::Write {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    tmp.write_all(text.as_bytes())
+        .map_err(|source| RebornConfigFileUpdateError::Write {
+            path: tmp.path().to_path_buf(),
+            source,
+        })?;
+    tmp.persist(path)
+        .map_err(|error| RebornConfigFileUpdateError::Write {
+            path: path.to_path_buf(),
+            source: error.error,
+        })?;
+    Ok(())
 }
 
 fn validate_api_version(found: &str, path: &Path) -> Result<(), RebornConfigFileError> {
@@ -650,6 +795,54 @@ api_key_env = "ANTHROPIC_API_KEY"
         assert_eq!(default_slot.api_key_env.as_deref(), Some("OPENAI_API_KEY"));
         let llm = cfg.llm.as_ref().unwrap();
         assert!(llm.contains_key("mission"));
+    }
+
+    #[test]
+    fn default_llm_update_preserves_unrelated_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[identity]
+tenant = "acme"
+
+[llm.default]
+provider_id = "openai"
+model = "gpt-5-mini"
+api_key_env = "OPENAI_API_KEY"
+base_url = "https://example.test/v1"
+
+[llm.mission]
+provider_id = "anthropic"
+"#,
+        )
+        .expect("write config");
+
+        update_default_llm_slot(
+            &path,
+            &DefaultLlmSlotUpdate {
+                provider_id: LlmSlotFieldUpdate::Keep,
+                model: LlmSlotFieldUpdate::Set("gpt-5.3-codex".to_string()),
+                api_key_env: LlmSlotFieldUpdate::Keep,
+                base_url: LlmSlotFieldUpdate::Remove,
+            },
+        )
+        .expect("update config");
+
+        let text = fs::read_to_string(&path).expect("read config");
+        assert!(text.contains("[identity]"), "config: {text}");
+        assert!(text.contains("tenant = \"acme\""), "config: {text}");
+        assert!(text.contains("[llm.mission]"), "config: {text}");
+        assert!(text.contains("model = \"gpt-5.3-codex\""), "config: {text}");
+        assert!(
+            text.contains("api_key_env = \"OPENAI_API_KEY\""),
+            "config: {text}"
+        );
+        assert!(!text.contains("base_url"), "config: {text}");
+        RebornConfigFile::load(&path)
+            .expect("valid config")
+            .expect("config present");
     }
 
     #[test]

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -293,14 +293,33 @@ impl DefaultLlmSlotUpdateSession {
     pub fn default_llm_slot(
         &self,
     ) -> Result<Option<LlmSlotSelection>, RebornConfigFileUpdateError> {
-        let text = self.doc.to_string();
-        let config = RebornConfigFile::parse_text(&text, &self.path).map_err(|source| {
-            RebornConfigFileUpdateError::Validate {
-                path: self.path.clone(),
-                source: Box::new(source),
-            }
-        })?;
-        Ok(config.default_llm_slot().cloned())
+        let Some(default_slot) = self
+            .doc
+            .get("llm")
+            .and_then(|llm| llm.get("default"))
+            .and_then(toml_edit::Item::as_table_like)
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(LlmSlotSelection {
+            provider_id: default_slot
+                .get("provider_id")
+                .and_then(toml_edit::Item::as_str)
+                .map(str::to_string),
+            model: default_slot
+                .get("model")
+                .and_then(toml_edit::Item::as_str)
+                .map(str::to_string),
+            api_key_env: default_slot
+                .get("api_key_env")
+                .and_then(toml_edit::Item::as_str)
+                .map(str::to_string),
+            base_url: default_slot
+                .get("base_url")
+                .and_then(toml_edit::Item::as_str)
+                .map(str::to_string),
+        }))
     }
 
     pub fn apply(

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -282,6 +282,39 @@ pub struct DefaultLlmSlotUpdate {
     pub base_url: LlmSlotFieldUpdate,
 }
 
+/// Held exclusive lock plus editable config document for one config update.
+pub struct DefaultLlmSlotUpdateSession {
+    path: PathBuf,
+    doc: toml_edit::DocumentMut,
+    _lock_file: fs::File,
+}
+
+impl DefaultLlmSlotUpdateSession {
+    pub fn default_llm_slot(
+        &self,
+    ) -> Result<Option<LlmSlotSelection>, RebornConfigFileUpdateError> {
+        let text = self.doc.to_string();
+        let config = RebornConfigFile::parse_text(&text, &self.path).map_err(|source| {
+            RebornConfigFileUpdateError::Validate {
+                path: self.path.clone(),
+                source: Box::new(source),
+            }
+        })?;
+        Ok(config.default_llm_slot().cloned())
+    }
+
+    pub fn apply(
+        mut self,
+        update: &DefaultLlmSlotUpdate,
+    ) -> Result<(), RebornConfigFileUpdateError> {
+        apply_llm_slot_field(&mut self.doc, "provider_id", &update.provider_id);
+        apply_llm_slot_field(&mut self.doc, "model", &update.model);
+        apply_llm_slot_field(&mut self.doc, "api_key_env", &update.api_key_env);
+        apply_llm_slot_field(&mut self.doc, "base_url", &update.base_url);
+        write_edit_document(&self.path, &self.doc)
+    }
+}
+
 // ─── Errors ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Error)]
@@ -323,6 +356,11 @@ pub enum RebornConfigFileError {
 
 #[derive(Debug, Error)]
 pub enum RebornConfigFileUpdateError {
+    #[error("lock Reborn config `{}`: {source}", path.display())]
+    Lock {
+        path: PathBuf,
+        source: std::io::Error,
+    },
     #[error("read Reborn config `{}`: {source}", path.display())]
     Read {
         path: PathBuf,
@@ -336,7 +374,7 @@ pub enum RebornConfigFileUpdateError {
     #[error("validate Reborn config `{}`: {source}", path.display())]
     Validate {
         path: PathBuf,
-        source: RebornConfigFileError,
+        source: Box<RebornConfigFileError>,
     },
     #[error("write Reborn config `{}`: {source}", path.display())]
     Write {
@@ -559,16 +597,60 @@ pub fn update_default_llm_slot(
     path: &Path,
     update: &DefaultLlmSlotUpdate,
 ) -> Result<(), RebornConfigFileUpdateError> {
-    let mut doc = load_edit_document(path)?;
-    apply_llm_slot_field(&mut doc, "provider_id", &update.provider_id);
-    apply_llm_slot_field(&mut doc, "model", &update.model);
-    apply_llm_slot_field(&mut doc, "api_key_env", &update.api_key_env);
-    apply_llm_slot_field(&mut doc, "base_url", &update.base_url);
-    write_edit_document(path, &doc)
+    begin_default_llm_slot_update(path)?.apply(update)
 }
 
 fn llm_slot_field_label(slot: &str, field: &str) -> Cow<'static, str> {
     Cow::Owned(format!("llm.{slot}.{field}"))
+}
+
+pub fn begin_default_llm_slot_update(
+    path: &Path,
+) -> Result<DefaultLlmSlotUpdateSession, RebornConfigFileUpdateError> {
+    let lock_file = acquire_update_lock(path)?;
+    let doc = load_edit_document(path)?;
+    Ok(DefaultLlmSlotUpdateSession {
+        path: path.to_path_buf(),
+        doc,
+        _lock_file: lock_file,
+    })
+}
+
+fn acquire_update_lock(path: &Path) -> Result<fs::File, RebornConfigFileUpdateError> {
+    use fs4::FileExt as _;
+
+    let lock_path = config_update_lock_path(path);
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).map_err(|source| RebornConfigFileUpdateError::Lock {
+            path: lock_path.clone(),
+            source,
+        })?;
+    }
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|source| RebornConfigFileUpdateError::Lock {
+            path: lock_path.clone(),
+            source,
+        })?;
+    file.lock_exclusive()
+        .map_err(|source| RebornConfigFileUpdateError::Lock {
+            path: lock_path,
+            source,
+        })?;
+    Ok(file)
+}
+
+fn config_update_lock_path(path: &Path) -> PathBuf {
+    let Some(file_name) = path.file_name() else {
+        return path.with_extension("lock");
+    };
+    let mut lock_name = file_name.to_os_string();
+    lock_name.push(".lock");
+    path.with_file_name(lock_name)
 }
 
 fn load_edit_document(path: &Path) -> Result<toml_edit::DocumentMut, RebornConfigFileUpdateError> {
@@ -629,7 +711,7 @@ fn write_edit_document(
     RebornConfigFile::parse_text(&text, path).map_err(|source| {
         RebornConfigFileUpdateError::Validate {
             path: path.to_path_buf(),
-            source,
+            source: Box::new(source),
         }
     })?;
 
@@ -843,6 +925,54 @@ provider_id = "anthropic"
         RebornConfigFile::load(&path)
             .expect("valid config")
             .expect("config present");
+    }
+
+    #[test]
+    fn default_llm_update_rejects_malformed_existing_toml() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("config.toml");
+        fs::write(&path, "[llm.default\nprovider_id = \"openai\"").expect("write config");
+
+        let err = update_default_llm_slot(
+            &path,
+            &DefaultLlmSlotUpdate {
+                model: LlmSlotFieldUpdate::Set("gpt-5-mini".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect_err("malformed existing TOML should reject");
+
+        assert!(matches!(err, RebornConfigFileUpdateError::Parse { .. }));
+    }
+
+    #[test]
+    fn default_llm_update_rejects_inline_secret_value_without_writing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[llm.default]
+provider_id = "openai"
+model = "gpt-5-mini"
+"#,
+        )
+        .expect("write config");
+        let before = fs::read_to_string(&path).expect("read config");
+
+        let err = update_default_llm_slot(
+            &path,
+            &DefaultLlmSlotUpdate {
+                api_key_env: LlmSlotFieldUpdate::Set(
+                    "sk-proj-1234567890abcdef1234567890".to_string(),
+                ),
+                ..Default::default()
+            },
+        )
+        .expect_err("inline secret should reject");
+
+        assert!(matches!(err, RebornConfigFileUpdateError::Validate { .. }));
+        assert_eq!(fs::read_to_string(&path).expect("read config"), before);
     }
 
     #[test]

--- a/crates/ironclaw_reborn_config/src/lib.rs
+++ b/crates/ironclaw_reborn_config/src/lib.rs
@@ -35,9 +35,10 @@ pub use budget::{
     ROUTINE_LIGHTWEIGHT_USD_ENV, ROUTINE_STANDARD_USD_ENV, USER_DAILY_USD_ENV,
 };
 pub use config_file::{
-    BootSection, BudgetSection, DriversSection, HarnessSection, IdentitySection, LlmSlotSelection,
-    PolicySection, REBORN_CONFIG_API_VERSION, RebornConfigFile, RebornConfigFileError,
-    RunnerSection,
+    BootSection, BudgetSection, DefaultLlmSlotUpdate, DriversSection, HarnessSection,
+    IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection, PolicySection,
+    REBORN_CONFIG_API_VERSION, RebornConfigFile, RebornConfigFileError,
+    RebornConfigFileUpdateError, RunnerSection, update_default_llm_slot,
 };
 pub use doctor::RebornDoctorReport;
 pub use home::{REBORN_HOME_ENV, RebornConfigError, RebornHome, RebornHomeSource};

--- a/crates/ironclaw_reborn_config/src/lib.rs
+++ b/crates/ironclaw_reborn_config/src/lib.rs
@@ -35,10 +35,11 @@ pub use budget::{
     ROUTINE_LIGHTWEIGHT_USD_ENV, ROUTINE_STANDARD_USD_ENV, USER_DAILY_USD_ENV,
 };
 pub use config_file::{
-    BootSection, BudgetSection, DefaultLlmSlotUpdate, DriversSection, HarnessSection,
-    IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection, PolicySection,
+    BootSection, BudgetSection, DefaultLlmSlotUpdate, DefaultLlmSlotUpdateSession, DriversSection,
+    HarnessSection, IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection, PolicySection,
     REBORN_CONFIG_API_VERSION, RebornConfigFile, RebornConfigFileError,
-    RebornConfigFileUpdateError, RunnerSection, update_default_llm_slot,
+    RebornConfigFileUpdateError, RunnerSection, begin_default_llm_slot_update,
+    update_default_llm_slot,
 };
 pub use doctor::RebornDoctorReport;
 pub use home::{REBORN_HOME_ENV, RebornConfigError, RebornHome, RebornHomeSource};


### PR DESCRIPTION
## Summary
- add a Reborn composition provider-admin facade for shared provider catalog/status/write operations
- route `ironclaw-reborn models` list/status/set/set-provider through that facade without touching v1 state
- add Product Workflow typed `model set-provider ...` parsing and a workflow test proving the product path calls the provider-admin service directly

## Validation
- `cargo check -p ironclaw_reborn_cli --bin ironclaw-reborn`
- `cargo check -p ironclaw_reborn_cli --no-default-features --bin ironclaw-reborn`
- `cargo check -p ironclaw_reborn_composition --features root-llm-provider`
- `cargo test -p ironclaw_reborn_cli models_ --tests`
- `cargo test -p ironclaw_product_workflow --test product_commands_contract`
- `cargo test -p ironclaw_product_workflow --test product_command_workflow_contract`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries reborn_crate_dependency_boundaries_hold`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries reborn_cli_binary_crate_stays_separate_from_v1_root`

## Notes
- Broad `cargo test -p ironclaw_architecture reborn` still fails on the existing unrelated `HostHttpEgressService::network()` escape-hatch assertion.