### PR TITLE
fix(reborn): disclose local yolo host mounts to model

### DIFF
--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -15,8 +15,8 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_host_api::sha256_digest_token;
 use ironclaw_llm::{
-    ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider,
-    Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
+    ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider, Role,
+    ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
 };
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -52,8 +52,10 @@ use crate::{
 };
 
 mod extension_surface;
+mod surface_disclosure;
 
 use extension_surface::{LocalDevExtensionSurface, LocalDevExtensionSurfaceSource};
+use surface_disclosure::wrap_local_dev_surface_disclosure;
 
 pub(super) struct LocalDevCapabilityWiring {
     pub(super) capability_factory: Arc<dyn LoopCapabilityPortFactory>,
@@ -160,6 +162,7 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             skill_mounts.clone(),
             &extension_surface,
         )?;
+        let disclosure_mounts = workspace_mounts.clone();
         let mut factory = HostRuntimeLoopCapabilityPortFactory::new(
             Arc::clone(&self.runtime),
             visible_request,
@@ -174,7 +177,8 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
                 skill_mounts.clone(),
             );
         }
-        Ok(factory.for_run_context(run_context.clone()))
+        let port = factory.for_run_context(run_context.clone());
+        Ok(wrap_local_dev_surface_disclosure(port, &disclosure_mounts))
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/surface_disclosure.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/surface_disclosure.rs
@@ -1,0 +1,248 @@
+use std::sync::Arc;
+
+use ironclaw_host_api::{CapabilityId, MountView};
+use ironclaw_host_runtime::{
+    APPLY_PATCH_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID,
+    READ_FILE_CAPABILITY_ID, SHELL_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
+};
+use ironclaw_turns::run_profile::{
+    AgentLoopHostError, CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityCallCandidate,
+    CapabilityDescriptorView, CapabilityInvocation, CapabilityOutcome, LoopCapabilityPort,
+    ProviderToolCall, ProviderToolCallCapabilityIds, ProviderToolDefinition,
+    VisibleCapabilityRequest, VisibleCapabilitySurface,
+};
+
+pub(super) fn wrap_local_dev_surface_disclosure(
+    inner: Arc<dyn LoopCapabilityPort>,
+    workspace_mounts: &MountView,
+) -> Arc<dyn LoopCapabilityPort> {
+    let disclosure = LocalDevSurfaceDisclosure::from_workspace_mounts(workspace_mounts);
+    if !disclosure.enabled() {
+        return inner;
+    }
+    Arc::new(LocalDevSurfaceDisclosurePort { inner, disclosure })
+}
+
+struct LocalDevSurfaceDisclosurePort {
+    inner: Arc<dyn LoopCapabilityPort>,
+    disclosure: LocalDevSurfaceDisclosure,
+}
+
+#[async_trait::async_trait]
+impl LoopCapabilityPort for LocalDevSurfaceDisclosurePort {
+    fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
+        let mut definitions = self.inner.tool_definitions()?;
+        for definition in &mut definitions {
+            self.disclosure.apply_to_tool_definition(definition);
+        }
+        Ok(definitions)
+    }
+
+    fn provider_tool_call_capability_ids(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<ProviderToolCallCapabilityIds, AgentLoopHostError> {
+        self.inner.provider_tool_call_capability_ids(tool_call)
+    }
+
+    fn validate_provider_tool_call(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<(), AgentLoopHostError> {
+        self.inner.validate_provider_tool_call(tool_call)
+    }
+
+    async fn register_provider_tool_call(
+        &self,
+        tool_call: ProviderToolCall,
+    ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
+        self.inner.register_provider_tool_call(tool_call).await
+    }
+
+    async fn visible_capabilities(
+        &self,
+        request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        let mut surface = self.inner.visible_capabilities(request).await?;
+        for descriptor in &mut surface.descriptors {
+            self.disclosure.apply_to_descriptor(descriptor);
+        }
+        Ok(surface)
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        self.inner.invoke_capability(request).await
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        self.inner.invoke_capability_batch(request).await
+    }
+}
+
+struct LocalDevSurfaceDisclosure {
+    scoped_roots_note: Option<String>,
+}
+
+impl LocalDevSurfaceDisclosure {
+    fn from_workspace_mounts(workspace_mounts: &MountView) -> Self {
+        let aliases = model_visible_workspace_aliases(workspace_mounts);
+        Self {
+            scoped_roots_note: confirmed_host_roots_note(&aliases),
+        }
+    }
+
+    fn enabled(&self) -> bool {
+        self.scoped_roots_note.is_some()
+    }
+
+    fn apply_to_descriptor(&self, descriptor: &mut CapabilityDescriptorView) {
+        self.apply_to_surface_fields(
+            &descriptor.capability_id,
+            &mut descriptor.safe_description,
+            &mut descriptor.parameters_schema,
+        );
+    }
+
+    fn apply_to_tool_definition(&self, definition: &mut ProviderToolDefinition) {
+        self.apply_to_surface_fields(
+            &definition.capability_id,
+            &mut definition.description,
+            &mut definition.parameters,
+        );
+    }
+
+    fn apply_to_surface_fields(
+        &self,
+        capability_id: &CapabilityId,
+        description: &mut String,
+        parameters_schema: &mut serde_json::Value,
+    ) {
+        if capability_id.as_str() == SHELL_CAPABILITY_ID {
+            append_description_note(description, LOCAL_DEV_YOLO_SHELL_NOTE);
+            return;
+        }
+        if !local_dev_scoped_path_capability(capability_id.as_str()) {
+            return;
+        }
+        let Some(note) = self.scoped_roots_note.as_deref() else {
+            return;
+        };
+        append_description_note(description, note);
+        append_path_schema_note(parameters_schema, note);
+    }
+}
+
+const LOCAL_DEV_YOLO_SHELL_NOTE: &str =
+    "Runs on the local host with local-dev shell process and network access.";
+
+fn local_dev_scoped_path_capability(capability_id: &str) -> bool {
+    matches!(
+        capability_id,
+        READ_FILE_CAPABILITY_ID
+            | WRITE_FILE_CAPABILITY_ID
+            | LIST_DIR_CAPABILITY_ID
+            | GLOB_CAPABILITY_ID
+            | GREP_CAPABILITY_ID
+            | APPLY_PATCH_CAPABILITY_ID
+    )
+}
+
+fn model_visible_workspace_aliases(workspace_mounts: &MountView) -> Vec<&str> {
+    let mut aliases = Vec::new();
+    for mount in &workspace_mounts.mounts {
+        let alias = mount.alias.as_str();
+        if matches!(alias, "/workspace" | "/host") && !aliases.contains(&alias) {
+            aliases.push(alias);
+        }
+    }
+    aliases
+}
+
+fn confirmed_host_roots_note(aliases: &[&str]) -> Option<String> {
+    if !aliases.contains(&"/host") {
+        return None;
+    }
+    let roots = aliases.join(", ");
+    let mut note = format!("Available scoped roots: {roots}.");
+    note.push_str(" /host is the confirmed host home mount; prefer /host over raw home paths.");
+    Some(note)
+}
+
+fn append_description_note(description: &mut String, note: &str) {
+    if description.contains(note) {
+        return;
+    }
+    if !description.ends_with('.') {
+        description.push('.');
+    }
+    description.push(' ');
+    description.push_str(note);
+}
+
+fn append_path_schema_note(schema: &mut serde_json::Value, note: &str) {
+    let Some(path) = schema
+        .get_mut("properties")
+        .and_then(serde_json::Value::as_object_mut)
+        .and_then(|properties| properties.get_mut("path"))
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    let Some(description) = path
+        .get("description")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+    else {
+        return;
+    };
+    if description.contains(note) {
+        return;
+    }
+    path.insert(
+        "description".to_string(),
+        serde_json::Value::String(format!("{description} {note}")),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use ironclaw_host_api::MountPermissions;
+
+    use super::*;
+
+    #[test]
+    fn disclosure_is_disabled_without_confirmed_host_mount() {
+        let workspace_mounts =
+            crate::local_dev_mounts::workspace_mount_view(MountPermissions::read_write(), &[])
+                .expect("workspace mounts build");
+
+        let disclosure = LocalDevSurfaceDisclosure::from_workspace_mounts(&workspace_mounts);
+
+        assert!(disclosure.scoped_roots_note.is_none());
+    }
+
+    #[test]
+    fn disclosure_redacts_raw_host_home_aliases() {
+        let workspace_mounts = crate::local_dev_mounts::workspace_mount_view(
+            MountPermissions::read_write(),
+            &[Path::new("/Users/alice")],
+        )
+        .expect("workspace mounts build");
+
+        let disclosure = LocalDevSurfaceDisclosure::from_workspace_mounts(&workspace_mounts);
+        let note = disclosure
+            .scoped_roots_note
+            .expect("confirmed host mount is disclosed");
+
+        assert!(note.contains("/workspace, /host"));
+        assert!(!note.contains("/Users/alice"));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -452,6 +452,11 @@ mod tests {
         let host_home = dir.path().join("home");
         std::fs::create_dir_all(&host_home).expect("host home"); // safety: test-only setup in #[cfg(test)] module.
         std::fs::write(host_home.join("safe.txt"), "safe host file\n").expect("host file"); // safety: test-only setup in #[cfg(test)] module.
+        let raw_host_home = host_home
+            .canonicalize()
+            .expect("canonical host home")
+            .to_string_lossy()
+            .into_owned();
 
         let services = crate::build_reborn_services(
             crate::RebornBuildInput::local_dev_with_profile(
@@ -462,7 +467,7 @@ mod tests {
             .with_runtime_policy(
                 crate::local_dev_yolo_runtime_policy(true).expect("local-yolo policy resolves"), // safety: test-only helper in #[cfg(test)] module.
             )
-            .with_local_dev_confirmed_host_home_root(host_home),
+            .with_local_dev_confirmed_host_home_root(host_home.clone()),
         )
         .await
         .expect("local-dev-yolo services build"); // safety: test-only assertion in #[cfg(test)] module.
@@ -494,6 +499,101 @@ mod tests {
             .visible_capabilities(VisibleCapabilityRequest {})
             .await
             .expect("visible surface"); // safety: test-only assertion in #[cfg(test)] module.
+        for capability_id in [
+            READ_FILE_CAPABILITY_ID,
+            WRITE_FILE_CAPABILITY_ID,
+            LIST_DIR_CAPABILITY_ID,
+            GLOB_CAPABILITY_ID,
+            GREP_CAPABILITY_ID,
+            APPLY_PATCH_CAPABILITY_ID,
+        ] {
+            let descriptor = surface
+                .descriptors
+                .iter()
+                .find(|descriptor| descriptor.capability_id.as_str() == capability_id)
+                .unwrap_or_else(|| panic!("{capability_id} descriptor visible"));
+            assert!(
+                descriptor.safe_description.contains("/host"),
+                "{capability_id} description should disclose confirmed host mount: {}",
+                descriptor.safe_description
+            );
+            assert!(
+                !descriptor.safe_description.contains(&raw_host_home),
+                "model-visible description must not disclose raw host home path"
+            );
+            let path_description =
+                descriptor.parameters_schema["properties"]["path"]["description"]
+                    .as_str()
+                    .unwrap_or_else(|| panic!("{capability_id} path description"));
+            assert!(
+                path_description.contains("/host"),
+                "{capability_id} path schema should disclose confirmed host mount: {path_description}"
+            );
+            assert!(
+                !path_description.contains(&raw_host_home),
+                "model-visible schema must not disclose raw host home path"
+            );
+        }
+        let shell_descriptor = surface
+            .descriptors
+            .iter()
+            .find(|descriptor| descriptor.capability_id.as_str() == SHELL_CAPABILITY_ID)
+            .expect("shell descriptor visible");
+        assert!(
+            !shell_descriptor.safe_description.contains("/host"),
+            "shell does not receive scoped filesystem disclosure"
+        );
+        assert!(
+            shell_descriptor.safe_description.contains("local host")
+                && shell_descriptor
+                    .safe_description
+                    .contains("shell process and network access"),
+            "shell should disclose local-dev host shell authority: {}",
+            shell_descriptor.safe_description
+        );
+        let tool_definitions = port.tool_definitions().expect("tool definitions");
+        for capability_id in [
+            READ_FILE_CAPABILITY_ID,
+            WRITE_FILE_CAPABILITY_ID,
+            LIST_DIR_CAPABILITY_ID,
+            GLOB_CAPABILITY_ID,
+            GREP_CAPABILITY_ID,
+            APPLY_PATCH_CAPABILITY_ID,
+        ] {
+            let tool = tool_definitions
+                .iter()
+                .find(|definition| definition.capability_id.as_str() == capability_id)
+                .unwrap_or_else(|| panic!("{capability_id} tool definition visible"));
+            assert!(
+                tool.description.contains("/host"),
+                "{capability_id} provider tool description should disclose confirmed host mount: {}",
+                tool.description
+            );
+            let tool_path_description = tool.parameters["properties"]["path"]["description"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{capability_id} tool path description"));
+            assert!(
+                tool_path_description.contains("/host"),
+                "{capability_id} provider tool path schema should disclose confirmed host mount: {tool_path_description}"
+            );
+            assert!(
+                !tool.description.contains(&raw_host_home)
+                    && !tool_path_description.contains(&raw_host_home),
+                "provider-visible tool surface must not disclose raw host home path"
+            );
+        }
+        let shell_tool = tool_definitions
+            .iter()
+            .find(|definition| definition.capability_id.as_str() == SHELL_CAPABILITY_ID)
+            .expect("shell tool definition visible");
+        assert!(
+            shell_tool.description.contains("local host")
+                && shell_tool
+                    .description
+                    .contains("shell process and network access"),
+            "provider tool shell description should disclose local-dev host shell authority: {}",
+            shell_tool.description
+        );
         let input_ref = capability_io
             .register_provider_tool_call_input(
                 &run_context,
@@ -521,6 +621,95 @@ mod tests {
         assert_eq!(
             output["content"],
             serde_json::json!("     1│ safe host file")
+        );
+    }
+
+    #[tokio::test]
+    async fn local_dev_capability_port_omits_host_disclosure_without_confirmed_host_mount() {
+        let dir = tempfile::tempdir().expect("tempdir"); // safety: test-only setup in #[cfg(test)] module.
+        let storage_root = dir.path().join("local-dev");
+        let services = crate::build_reborn_services(crate::RebornBuildInput::local_dev(
+            "local-dev-no-host-owner",
+            storage_root,
+        ))
+        .await
+        .expect("local-dev services build"); // safety: test-only assertion in #[cfg(test)] module.
+        let runtime = services.host_runtime.clone().expect("host runtime"); // safety: test-only assertion in #[cfg(test)] module.
+        let workspace_mounts = services
+            .local_runtime
+            .as_ref()
+            .expect("local runtime substrate") // safety: test-only assertion in #[cfg(test)] module.
+            .workspace_mounts
+            .clone();
+        let capability_io = Arc::new(LocalDevCapabilityIo::default());
+        let input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
+        let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
+        let factory = LocalDevLoopCapabilityPortFactory::new(
+            runtime,
+            UserId::new("local-dev-no-host-user").expect("user id"), // safety: literal test id is valid.
+            workspace_mounts,
+            LocalDevExtensionSurfaceSource::default(),
+            input_resolver,
+            result_writer,
+            Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        );
+        let run_context = run_context("no-host-disclosure").await;
+        let port = factory
+            .create_capability_port(&run_context)
+            .await
+            .expect("capability port"); // safety: test-only assertion in #[cfg(test)] module.
+        let surface = port
+            .visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible surface"); // safety: test-only assertion in #[cfg(test)] module.
+        let read_descriptor = surface
+            .descriptors
+            .iter()
+            .find(|descriptor| descriptor.capability_id.as_str() == READ_FILE_CAPABILITY_ID)
+            .expect("read_file descriptor visible");
+        assert!(
+            !read_descriptor.safe_description.contains("/host")
+                && !read_descriptor
+                    .safe_description
+                    .contains("Available scoped roots"),
+            "normal local-dev read_file description must not disclose host roots: {}",
+            read_descriptor.safe_description
+        );
+        let shell_descriptor = surface
+            .descriptors
+            .iter()
+            .find(|descriptor| descriptor.capability_id.as_str() == SHELL_CAPABILITY_ID)
+            .expect("shell descriptor visible");
+        assert!(
+            !shell_descriptor
+                .safe_description
+                .contains("shell process and network access"),
+            "normal local-dev shell description should not receive yolo disclosure: {}",
+            shell_descriptor.safe_description
+        );
+        let tool_definitions = port.tool_definitions().expect("tool definitions");
+        let read_file_tool = tool_definitions
+            .iter()
+            .find(|definition| definition.capability_id.as_str() == READ_FILE_CAPABILITY_ID)
+            .expect("read_file tool definition visible");
+        assert!(
+            !read_file_tool.description.contains("/host")
+                && !read_file_tool
+                    .description
+                    .contains("Available scoped roots"),
+            "normal local-dev provider tool description must not disclose host roots: {}",
+            read_file_tool.description
+        );
+        let shell_tool = tool_definitions
+            .iter()
+            .find(|definition| definition.capability_id.as_str() == SHELL_CAPABILITY_ID)
+            .expect("shell tool definition visible");
+        assert!(
+            !shell_tool
+                .description
+                .contains("shell process and network access"),
+            "normal local-dev shell provider tool should not receive yolo disclosure: {}",
+            shell_tool.description
         );
     }
 

--- a/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
+++ b/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
@@ -451,8 +451,8 @@ fn push_snippet_message(
 ) -> Result<(), AgentLoopHostError> {
     validate_context_ref(snippet.snippet_ref.clone(), "context snippet ref")?;
     let safe_summary =
-        validate_model_safe_text(snippet.safe_summary.clone(), "context snippet summary").map_err(
-            |error| {
+        validate_model_safe_text(snippet.safe_summary.clone(), "context snippet summary")
+            .inspect_err(|error| {
                 tracing::debug!(
                     section,
                     ordinal,
@@ -463,9 +463,7 @@ fn push_snippet_message(
                     error_safe_summary = %error.safe_summary,
                     "instruction bundle rejected context snippet safe summary"
                 );
-                error
-            },
-        )?;
+            })?;
     feed_field(fingerprint, b"section", section.as_bytes());
     feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
     feed_field(fingerprint, b"source", snippet.snippet_ref.as_bytes());


### PR DESCRIPTION
## Summary
- add a Reborn local-dev capability surface disclosure wrapper instead of modifying generic host-runtime surface projection
- disclose `/host` for confirmed local-dev-yolo host home access on scoped filesystem tool descriptions/schemas without leaking raw home aliases
- disclose local-dev-yolo shell process/network authority on the shell tool surface without adding scoped filesystem roots to shell
- leave normal local-dev surfaces unchanged when no confirmed host mount exists

## Testing
- cargo fmt --check && git diff --check
- cargo test -p ironclaw_reborn_composition surface_disclosure
- cargo test -p ironclaw_reborn_composition local_yolo_capability_port_reads_confirmed_host_mount
- cargo test -p ironclaw_reborn_composition local_dev_capability_port_omits_host_disclosure_without_confirmed_host_mount
- cargo test -p ironclaw_host_runtime --lib builtin_surface_descriptor_requires_input_schema_ref

Note: `ironclaw_reborn_composition` tests still emit existing dead-code warnings for `RebornOAuthStartFlowRequest`, `ensure_oauth_callback_flow_known`, and `start_setup_oauth_flow`.
