### PR TITLE
[codex] Fix Reborn LLM gateway NEAR replay handling

### DIFF
--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use ironclaw_host_api::sha256_digest_token;
 use ironclaw_llm::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider,
-    ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
+    Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
 };
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
@@ -1041,10 +1041,15 @@ fn convert_messages(
             HostManagedModelMessageRole::ToolResult => {
                 let replay = tool_result_replay_message(message)?;
                 let Some(provider_call) = replay.provider_call else {
-                    converted.push(ChatMessage::system(replay.safe_summary));
+                    converted.push(ChatMessage::user(tool_summary_message(replay.safe_summary)));
                     index += 1;
                     continue;
                 };
+                if !provider_replay_matches_identity(&provider_call, replay_identity) {
+                    converted.push(ChatMessage::user(tool_summary_message(replay.safe_summary)));
+                    index += 1;
+                    continue;
+                }
                 validate_provider_replay_identity(&provider_call, replay_identity)?;
                 let provider_turn_id = provider_call.provider_turn_id.clone();
                 let mut provider_results = vec![(provider_call, replay.safe_summary)];
@@ -1059,6 +1064,11 @@ fn convert_messages(
                         index += 1;
                         continue;
                     };
+                    if !provider_replay_matches_identity(&next_provider_call, replay_identity) {
+                        plain_tool_summaries.push(next.safe_summary);
+                        index += 1;
+                        continue;
+                    }
                     validate_provider_replay_identity(&next_provider_call, replay_identity)?;
                     if next_provider_call.provider_turn_id != provider_turn_id {
                         break;
@@ -1067,13 +1077,50 @@ fn convert_messages(
                     index += 1;
                 }
                 converted.extend(provider_tool_roundtrip_messages(provider_results));
-                converted.extend(plain_tool_summaries.into_iter().map(ChatMessage::system));
+                converted.extend(
+                    plain_tool_summaries
+                        .into_iter()
+                        .map(tool_summary_message)
+                        .map(ChatMessage::user),
+                );
                 continue;
             }
         }
         index += 1;
     }
-    Ok(converted)
+    Ok(coalesce_system_messages_at_start(converted))
+}
+
+fn coalesce_system_messages_at_start(messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+    let mut system_content = Vec::new();
+    let mut transcript = Vec::with_capacity(messages.len());
+    for message in messages {
+        if message.role == Role::System {
+            system_content.push(message.content);
+        } else {
+            transcript.push(message);
+        }
+    }
+    if system_content.is_empty() {
+        return transcript;
+    }
+
+    let mut normalized = Vec::with_capacity(transcript.len() + 1);
+    normalized.push(ChatMessage::system(system_content.join("\n\n")));
+    normalized.extend(transcript);
+    normalized
+}
+
+fn tool_summary_message(summary: String) -> String {
+    format!("[Tool result summary]: {summary}")
+}
+
+fn provider_replay_matches_identity(
+    provider_call: &ProviderToolCallReferenceEnvelope,
+    expected: &ProviderReplayIdentity,
+) -> bool {
+    provider_call.provider_id == expected.provider_id
+        && provider_call.provider_model_id == expected.provider_model_id
 }
 
 fn validate_provider_replay_identity(

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -81,6 +81,37 @@ async fn gateway_calls_llm_provider_for_allowed_model_profile() {
 }
 
 #[tokio::test]
+async fn gateway_coalesces_late_system_messages_before_provider_call() {
+    let provider = Arc::new(RecordingLlmProvider::reply("assistant response"));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let mut request = model_request(interactive_model());
+    request.messages.push(HostManagedModelMessage {
+        role: HostManagedModelMessageRole::System,
+        content: "host summary after user".to_string(),
+        content_ref: LoopMessageRef::new("msg:33333333-3333-3333-3333-333333333333").unwrap(),
+        tool_result_provider_call: None,
+    });
+
+    gateway.stream_model(request).await.unwrap();
+
+    let requests = provider.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].messages.len(), 2);
+    assert_eq!(requests[0].messages[0].role, Role::System);
+    assert_eq!(
+        requests[0].messages[0].content,
+        "system instructions\n\nhost summary after user"
+    );
+    assert_eq!(requests[0].messages[1].role, Role::User);
+    assert_eq!(requests[0].messages[1].content, "hello model");
+}
+
+#[tokio::test]
 async fn gateway_preserves_text_only_provider_reasoning() {
     let provider = Arc::new(RecordingLlmProvider::reply_with_reasoning(
         "assistant response",
@@ -668,12 +699,15 @@ async fn gateway_keeps_same_turn_provider_roundtrip_when_plain_tool_result_is_in
         requests[0].messages[2].tool_call_id.as_deref(),
         Some("call_2")
     );
-    assert_eq!(requests[0].messages[3].role, Role::System);
-    assert_eq!(requests[0].messages[3].content, "plain tool completed");
+    assert_eq!(requests[0].messages[3].role, Role::User);
+    assert_eq!(
+        requests[0].messages[3].content,
+        "[Tool result summary]: plain tool completed"
+    );
 }
 
 #[tokio::test]
-async fn gateway_rejects_provider_tool_replay_from_different_provider_route() {
+async fn gateway_degrades_provider_tool_replay_from_different_provider_route_to_summary() {
     let provider = Arc::new(ToolAwareProvider::plain_reply("assistant response"));
     let gateway = LlmProviderModelGateway::with_provider_identity(
         STATIC_PROVIDER_ID,
@@ -706,10 +740,20 @@ async fn gateway_rejects_provider_tool_replay_from_different_provider_route() {
         tool_result_provider_call: Some(provider_call),
     }];
 
-    let error = gateway.stream_model(request).await.unwrap_err();
+    let response = gateway.stream_model(request).await.unwrap();
 
-    assert_eq!(error.kind, HostManagedModelErrorKind::PolicyDenied);
-    assert!(provider.complete_requests.lock().unwrap().is_empty());
+    assert_eq!(
+        response.safe_text_deltas,
+        vec!["assistant response".to_string()]
+    );
+    let requests = provider.complete_requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].messages.len(), 1);
+    assert_eq!(requests[0].messages[0].role, Role::User);
+    assert_eq!(
+        requests[0].messages[0].content,
+        "[Tool result summary]: tool completed"
+    );
     assert!(provider.tool_requests.lock().unwrap().is_empty());
 }
 


### PR DESCRIPTION
## Summary
- coalesce host-managed system messages into a single leading provider system message
- send plain or route-mismatched tool replay summaries as user context instead of provider-specific replay
- add gateway regression coverage for late system messages and provider route switches

## Root Cause
NEAR rejects chat requests where system messages appear after the first position. Reborn could also fail closed when old transcript tool-call replay metadata came from a different provider/model route than the currently selected NEAR route.

## Validation
- cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway