### PR TITLE
[codex] debug prompt host failures

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor.rs
+++ b/crates/ironclaw_agent_loop/src/executor.rs
@@ -54,7 +54,8 @@ use async_trait::async_trait;
 use ironclaw_turns::{
     LoopCancelledReasonKind, LoopDiagnosticRef, LoopExit,
     run_profile::{
-        AgentLoopDriverHost, AgentLoopHostErrorKind, LoopInputAckToken, LoopSafeSummary,
+        AgentLoopDriverHost, AgentLoopHostError, AgentLoopHostErrorKind, LoopInputAckToken,
+        LoopSafeSummary,
     },
 };
 
@@ -119,6 +120,25 @@ pub enum HostStage {
     Transcript,
     Checkpoint,
     Input,
+}
+
+fn debug_host_unavailable(stage: HostStage, error: &AgentLoopHostError) {
+    match LoopSafeSummary::new(error.safe_summary.clone()) {
+        Ok(safe_summary) => tracing::debug!(
+            stage = ?stage,
+            kind = ?error.kind,
+            diagnostic_ref = ?error.diagnostic_ref,
+            safe_summary = %safe_summary,
+            "agent loop host call unavailable"
+        ),
+        Err(validation_error) => tracing::debug!(
+            stage = ?stage,
+            kind = ?error.kind,
+            diagnostic_ref = ?error.diagnostic_ref,
+            validation_error = %validation_error,
+            "agent loop host call unavailable with invalid safe summary"
+        ),
+    }
 }
 
 /// Reference executor for the Reborn skeleton loop.

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -12,7 +12,7 @@ use crate::state::LoopExecutionState;
 
 use super::{
     AgentLoopExecutorError, CancelCheck, CheckpointStage, ExecutorStage, HostStage,
-    PendingInputAck, StageContext, apply_capability_filter,
+    PendingInputAck, StageContext, apply_capability_filter, debug_host_unavailable,
 };
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -134,8 +134,11 @@ pub(super) async fn build_prompt_bundle_for_surface(
         .host
         .build_prompt_bundle(context_request)
         .await
-        .map_err(|_| AgentLoopExecutorError::HostUnavailable {
-            stage: HostStage::Prompt,
+        .map_err(|error| {
+            debug_host_unavailable(HostStage::Prompt, &error);
+            AgentLoopExecutorError::HostUnavailable {
+                stage: HostStage::Prompt,
+            }
         })?;
     CheckpointStage
         .emit_progress(


### PR DESCRIPTION
## Summary

- Add debug logging for prompt-host failures before they are mapped to sanitized executor errors.
- Include prompt stage, host error kind, diagnostic ref, and validated safe summary in Rust debug logs.
- Preserve existing product-facing `Prompt: unavailable` / `recovery_required` behavior.

## Root Cause

Prompt bundle host errors were mapped to `HostUnavailable { stage: Prompt }` without logging the underlying safe host diagnostic, making prompt-stage recovery incidents difficult to diagnose from Rust logs.

## Validation

- `cargo test -p ironclaw_agent_loop prompt_stage_host_unavailable_on_build_prompt_bundle_propagates_error`
- `cargo test -p ironclaw_reborn planned_driver_executor_error_maps_to_unavailable`
