### PR TITLE
[codex] debug prompt snippet validation failures

### DIFF
--- a/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
+++ b/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
@@ -277,6 +277,7 @@ impl InstructionBundleBuilder {
                     &mut materialized_messages,
                     &mut fingerprint,
                     "skill",
+                    skill_ordinal,
                     content_ref,
                     &snippet,
                 )?;
@@ -288,17 +289,15 @@ impl InstructionBundleBuilder {
                 skill_ordinal += 1;
             } else {
                 requires_materialization_store = true;
-                let content_ref = snippet_message_ref(
-                    "instruction",
-                    &snippet,
-                    messages.len(),
-                    &mut synthetic_refs,
-                )?;
+                let ordinal = messages.len();
+                let content_ref =
+                    snippet_message_ref("instruction", &snippet, ordinal, &mut synthetic_refs)?;
                 push_snippet_message(
                     &mut messages,
                     &mut materialized_messages,
                     &mut fingerprint,
                     "instruction",
+                    ordinal,
                     content_ref,
                     &snippet,
                 )?;
@@ -318,6 +317,7 @@ impl InstructionBundleBuilder {
                 &mut materialized_messages,
                 &mut fingerprint,
                 "memory",
+                ordinal,
                 content_ref,
                 &snippet,
             )?;
@@ -445,12 +445,27 @@ fn push_snippet_message(
     materialized_messages: &mut Vec<InstructionBundleMaterializedMessage>,
     fingerprint: &mut Sha256,
     section: &'static str,
+    ordinal: usize,
     content_ref: LoopMessageRef,
     snippet: &LoopContextSnippet,
 ) -> Result<(), AgentLoopHostError> {
     validate_context_ref(snippet.snippet_ref.clone(), "context snippet ref")?;
     let safe_summary =
-        validate_model_safe_text(snippet.safe_summary.clone(), "context snippet summary")?;
+        validate_model_safe_text(snippet.safe_summary.clone(), "context snippet summary").map_err(
+            |error| {
+                tracing::debug!(
+                    section,
+                    ordinal,
+                    snippet_ref = %snippet.snippet_ref,
+                    content_ref = %content_ref.as_str(),
+                    safe_summary_bytes = snippet.safe_summary.len(),
+                    error_kind = ?error.kind,
+                    error_safe_summary = %error.safe_summary,
+                    "instruction bundle rejected context snippet safe summary"
+                );
+                error
+            },
+        )?;
     feed_field(fingerprint, b"section", section.as_bytes());
     feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
     feed_field(fingerprint, b"source", snippet.snippet_ref.as_bytes());


### PR DESCRIPTION
## Summary

- Add debug logging at the instruction-bundle snippet validation boundary.
- Include non-content snippet identifiers needed to identify rejected prompt context: section, ordinal, validated snippet ref, generated content ref, and safe summary byte length.
- Prevent oversized trusted skill prompt bodies from blocking unrelated turns by falling back to the skill description when `description + prompt` exceeds the model-safe snippet budget.

## Why

A request to remove the GitHub extension selected `skill:github` as advisory model context because the text mentioned GitHub. The selected skill prompt was 5,597 bytes, larger than the instruction-bundle model-safe limit, so prompt assembly failed before `builtin.extension_remove` could run.

This keeps unsafe skill content fail-closed, but treats safe oversized trusted prompt content as optional context rather than a fatal prompt-build dependency.

## Validation

- `cargo test -p ironclaw_turns --test skill_context_service_contract`
- `cargo test -p ironclaw_turns instruction_bundle`
- `cargo test -p ironclaw_agent_loop prompt_stage_host_unavailable_on_build_prompt_bundle_propagates_error`
