### PR TITLE
fix(reborn): treat "null" string as absent for optional builtin tool args

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -227,9 +227,10 @@ pub struct BuiltinFirstPartyTools {
 impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
     async fn dispatch(
         &self,
-        request: FirstPartyCapabilityRequest,
+        mut request: FirstPartyCapabilityRequest,
     ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
         bounded_input_size(request.capability_id.as_str(), &request.input)?;
+        normalize_optional_null_sentinels(&mut request);
         let start = Instant::now();
         let mut network_egress_bytes = 0;
         let output = match request.capability_id.as_str() {
@@ -339,6 +340,49 @@ fn bounded_output_bytes(
         ));
     }
     Ok(bytes)
+}
+
+/// Treat the literal string `"null"` as absent for declared optional fields.
+///
+/// Weaker models (notably quantized local models) routinely populate every
+/// optional parameter with the string `"null"` instead of omitting it. Without
+/// this normalization an optional `"null"` reaches a typed parser (e.g. an IANA
+/// timezone) and aborts an otherwise valid call with `InputEncode`. Required
+/// fields are left untouched so a legitimate `"null"` payload is preserved, and
+/// only declared optional properties are normalized.
+fn normalize_optional_null_sentinels(request: &mut FirstPartyCapabilityRequest) {
+    let schema_name = request
+        .capability_id
+        .as_str()
+        .strip_prefix("builtin.")
+        .unwrap_or(request.capability_id.as_str())
+        .replace('.', "-");
+    let Some(schema) =
+        resolve_builtin_input_schema_ref(&format!("schemas/builtin/{schema_name}.input.v1.json"))
+    else {
+        return;
+    };
+    let required: std::collections::HashSet<&str> = schema
+        .get("required")
+        .and_then(|value| value.as_array())
+        .map(|values| values.iter().filter_map(|value| value.as_str()).collect())
+        .unwrap_or_default();
+    let declared: std::collections::HashSet<&str> = schema
+        .get("properties")
+        .and_then(|value| value.as_object())
+        .map(|properties| properties.keys().map(String::as_str).collect())
+        .unwrap_or_default();
+    let Some(object) = request.input.as_object_mut() else {
+        return;
+    };
+    for (key, value) in object.iter_mut() {
+        if declared.contains(key.as_str())
+            && !required.contains(key.as_str())
+            && value.as_str() == Some("null")
+        {
+            *value = serde_json::Value::Null;
+        }
+    }
 }
 
 fn resource_profile() -> Option<ResourceProfile> {

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -236,6 +236,38 @@ async fn builtin_echo_invokes_through_host_runtime() {
 }
 
 #[tokio::test]
+async fn builtin_time_tolerates_null_string_sentinels_in_optional_fields() {
+    // Weaker models (e.g. quantized local models) tend to fill every optional
+    // parameter with the literal string "null" instead of omitting it. Those
+    // sentinels in optional fields must be treated as absent, not abort the run.
+    let output = invoke(
+        TIME_CAPABILITY_ID,
+        json!({
+            "operation": "now",
+            "timezone": "null",
+            "from_timezone": "null",
+            "format": "null"
+        }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        output.get("iso").and_then(Value::as_str).is_some(),
+        "time `now` should return an iso timestamp, got {output:?}"
+    );
+}
+
+#[tokio::test]
+async fn builtin_echo_preserves_null_string_in_required_field() {
+    // The optional-sentinel normalization must never touch required fields, so a
+    // deliberate "null" payload still round-trips unchanged.
+    let output = invoke(ECHO_CAPABILITY_ID, json!({"message": "null"}))
+        .await
+        .unwrap();
+    assert_eq!(output, Value::String("null".to_string()));
+}
+
+#[tokio::test]
 async fn builtin_spawn_subagent_authorization_invokes_through_host_runtime() {
     let output = invoke(SPAWN_SUBAGENT_CAPABILITY_ID, json!({}))
         .await


### PR DESCRIPTION
## Problem

Weaker models (notably quantized local models) tend to fill every optional tool
parameter with the literal string `"null"` instead of omitting it. `builtin.time`
has nine optional params, so a model commonly emits something like:

```json
{"operation":"now","timezone":"null","from_timezone":"null","format":"null"}
```

`"null"` then reaches a typed parser (`"null".parse::<Tz>()`) and the call fails
with `InputEncode`. The model retries the same arguments, gets the same error,
and the planned-loop stop strategy can end the run (`RecoveryRequired`) before
the model recovers by inspecting the schema via `capability_info`. The net
effect is a run that loops on a trivial tool call and never answers.

## Fix

Normalize the `"null"` string sentinel to JSON `null` for declared optional
fields at the first-party dispatch boundary (`BuiltinFirstPartyTools::dispatch`).
Tool handlers already treat a null or absent optional as unset, so no per-tool
changes are needed. Required fields are never touched, so a deliberate `"null"`
payload (for example `echo` with `message="null"`) still round-trips unchanged.

## Test plan

- New regression test: `builtin.time` with `"null"` in optional fields now
  returns a timestamp. Confirmed it fails before the change (`InvalidInput`) and
  passes after.
- New guard test: `echo` with required `message="null"` still echoes the literal
  string, proving required fields are not coerced.
- `first_party_builtin_tools` (98 tests) and `product_live_adapters` (23 tests)
  pass; `cargo fmt` and `cargo clippy` clean.
- Manual: ran a local quantized model (Qwen3.5 via MLX) through `ironclaw-reborn`
  against the time tool. Before, calls with `"null"` optionals failed
  `InputEncode` and the run hit `RecoveryRequired`. After, the runs complete and
  return the time.

## Note on the broader test suite

This change is scoped to `crates/ironclaw_host_runtime`; that crate's tests,
`cargo fmt`, and `cargo clippy` are clean. The repository-wide `cargo test --lib`
currently fails independently of this change. On a clean `reborn-integration`
base (this PR not applied, `f48e417e1`), the root `ironclaw` crate's lib suite
reports pre-existing failures (7 failing tests in one run) and intermittently
aborts with `SIGABRT` under parallel execution; `tools::builtin` passes 485/485
single-threaded, so this is a pre-existing flaky/parallel issue in the v1-engine
crate, not introduced here. Flagging so a red full-suite run is not attributed
to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
