### PR TITLE
[codex] fall back for oversized trusted skill prompts

### DIFF
--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -33,6 +33,8 @@ const FORBIDDEN_MODEL_ROUTE_MARKERS: &[&str] = &[
 
 const FORBIDDEN_EXACT_MODEL_ROUTE_MARKERS: &[&str] = &["bearer"];
 
+pub(super) const MODEL_SAFE_TEXT_MAX_BYTES: usize = 4 * 1024;
+
 fn validate_bounded_loop_string(
     value: String,
     label: &'static str,

--- a/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
+++ b/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
@@ -15,7 +15,7 @@ use super::{
     AgentLoopHostError, AgentLoopHostErrorKind, CapabilityDescriptorView, LoopContextBundle,
     LoopContextMessage, LoopContextSnippet, LoopInlineMessage, LoopInlineMessageRole,
     LoopModelMessage, LoopRunContext, PromptSkillContextMetadata, VisibleCapabilitySurface,
-    skill_snippet_model_message_ref,
+    host::MODEL_SAFE_TEXT_MAX_BYTES, skill_snippet_model_message_ref,
 };
 
 /// Stable fingerprint for an instruction bundle rebuild.
@@ -779,7 +779,7 @@ fn validate_model_safe_text(
     value: String,
     label: &'static str,
 ) -> Result<String, AgentLoopHostError> {
-    if value.is_empty() || value.len() > 4096 {
+    if value.is_empty() || value.len() > MODEL_SAFE_TEXT_MAX_BYTES {
         return Err(AgentLoopHostError::new(
             AgentLoopHostErrorKind::PolicyDenied,
             format!("{label} is not model-safe"),

--- a/crates/ironclaw_turns/src/run_profile/skill_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/skill_context.rs
@@ -129,7 +129,7 @@ impl SkillTrustLevel {
 // ---------------------------------------------------------------------------
 
 const EMPTY_SNAPSHOT_VERSION: &str = "empty";
-const DEFAULT_MAX_SKILL_SNIPPET_BYTES: usize = 8 * 1024;
+const DEFAULT_MAX_SKILL_SNIPPET_BYTES: usize = 4 * 1024;
 const DEFAULT_MAX_SKILL_CONTEXT_BYTES: usize = 32 * 1024;
 
 /// Byte budgets for model-visible skill context produced by [`SkillContextService`].
@@ -335,23 +335,8 @@ impl SkillContextSource for SkillContextService {
         let mut total_bytes = 0usize;
 
         for entry in visible {
-            let safe_summary = match entry.trust {
-                SkillTrustLevel::Trusted => {
-                    if let Some(ref content) = entry.prompt_content {
-                        format!("{}\n\n{}", entry.safe_description, content)
-                    } else {
-                        entry.safe_description.clone()
-                    }
-                }
-                SkillTrustLevel::Installed => entry.safe_description.clone(),
-            };
-
-            if safe_summary.len() > self.budget.max_snippet_bytes {
-                return Err(SkillContextError::ContextBudgetExceeded);
-            }
-
             validate_model_visible_skill_name(&entry.name)?;
-            validate_model_visible_text(&safe_summary)?;
+            let safe_summary = skill_safe_summary(entry, self.budget)?;
 
             let snippet_ref = format!("skill:{}", entry.name);
             total_bytes = checked_context_total_bytes(
@@ -371,6 +356,58 @@ impl SkillContextSource for SkillContextService {
 
         Ok(snippets)
     }
+}
+
+fn skill_safe_summary(
+    entry: &InstalledSkillSnapshot,
+    budget: SkillContextBudget,
+) -> Result<String, SkillContextError> {
+    let description = entry.safe_description.clone();
+    validate_model_visible_text(&description)?;
+
+    match entry.trust {
+        SkillTrustLevel::Installed => {
+            validate_summary_budget(&entry.name, &description, budget.max_snippet_bytes)?;
+            Ok(description)
+        }
+        SkillTrustLevel::Trusted => {
+            let Some(content) = entry.prompt_content.as_ref() else {
+                validate_summary_budget(&entry.name, &description, budget.max_snippet_bytes)?;
+                return Ok(description);
+            };
+            let combined = format!("{description}\n\n{content}");
+            validate_model_visible_text(&combined)?;
+            if combined.len() <= budget.max_snippet_bytes {
+                return Ok(combined);
+            }
+            validate_summary_budget(&entry.name, &description, budget.max_snippet_bytes)?;
+            tracing::debug!(
+                skill_name = %entry.name,
+                combined_safe_summary_bytes = combined.len(),
+                description_bytes = description.len(),
+                max_snippet_bytes = budget.max_snippet_bytes,
+                "trusted skill prompt context exceeded snippet budget; using description only"
+            );
+            Ok(description)
+        }
+    }
+}
+
+fn validate_summary_budget(
+    skill_name: &str,
+    safe_summary: &str,
+    max_snippet_bytes: usize,
+) -> Result<(), SkillContextError> {
+    if safe_summary.len() > max_snippet_bytes {
+        tracing::debug!(
+            skill_name,
+            safe_summary_bytes = safe_summary.len(),
+            max_snippet_bytes,
+            "skill context summary exceeded snippet budget"
+        );
+        return Err(SkillContextError::ContextBudgetExceeded);
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ironclaw_turns/src/run_profile/skill_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/skill_context.rs
@@ -18,9 +18,9 @@
 //! # Fail-closed semantics
 //!
 //! If trust or visibility data is missing, the snapshot version does not match entries,
-//! model-visible fields contain unsafe internal markers, or prompt content exceeds configured
-//! context budgets, the service returns an error rather than silently degrading. This ensures
-//! that an unconfigured or corrupt snapshot never leaks capabilities to the model.
+//! or model-visible fields contain unsafe internal markers, the service returns an error rather
+//! than silently degrading. Safe-but-oversized prompt content is omitted from model context so
+//! advisory skill context cannot block unrelated turns.
 //!
 //! # Determinism
 //!
@@ -38,6 +38,7 @@ use thiserror::Error;
 
 use crate::LoopMessageRef;
 
+use super::host::MODEL_SAFE_TEXT_MAX_BYTES;
 use super::snippet_ref::stable_skill_snippet_display_hash;
 use super::{
     AgentLoopHostError, AgentLoopHostErrorKind, LoopContextSnippet, LoopContextSnippetMetadata,
@@ -72,7 +73,7 @@ pub enum SkillContextError {
     #[error("skill context: budget misconfigured")]
     BudgetMisconfigured,
 
-    /// Model-visible skill context exceeds configured context budgets.
+    /// Model-visible skill context exceeded a budget in a path that cannot degrade.
     #[error("skill context: context budget exceeded")]
     ContextBudgetExceeded,
 
@@ -129,13 +130,14 @@ impl SkillTrustLevel {
 // ---------------------------------------------------------------------------
 
 const EMPTY_SNAPSHOT_VERSION: &str = "empty";
-const DEFAULT_MAX_SKILL_SNIPPET_BYTES: usize = 4 * 1024;
+const DEFAULT_MAX_SKILL_SNIPPET_BYTES: usize = MODEL_SAFE_TEXT_MAX_BYTES;
 const DEFAULT_MAX_SKILL_CONTEXT_BYTES: usize = 32 * 1024;
 
 /// Byte budgets for model-visible skill context produced by [`SkillContextService`].
 ///
 /// Hosts can map a run's context profile to these limits via
-/// [`SkillContextService::with_budget`]. Both limits fail closed when exceeded.
+/// [`SkillContextService::with_budget`]. Valid budgets are enforced by omitting
+/// oversized advisory snippets; invalid budget configuration fails closed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SkillContextBudget {
     /// Maximum bytes for one snippet summary.
@@ -336,15 +338,32 @@ impl SkillContextSource for SkillContextService {
 
         for entry in visible {
             validate_model_visible_skill_name(&entry.name)?;
-            let safe_summary = skill_safe_summary(entry, self.budget)?;
+            let Some(safe_summary) = skill_safe_summary(entry, self.budget)? else {
+                continue;
+            };
 
             let snippet_ref = format!("skill:{}", entry.name);
-            total_bytes = checked_context_total_bytes(
+            let next_total = match checked_context_total_bytes(
                 total_bytes,
                 snippet_ref.len(),
                 safe_summary.len(),
                 self.budget.max_context_bytes,
-            )?;
+            ) {
+                Ok(total) => total,
+                Err(SkillContextError::ContextBudgetExceeded) => {
+                    tracing::debug!(
+                        skill_name = %entry.name,
+                        snippet_ref,
+                        current_context_bytes = total_bytes,
+                        safe_summary_bytes = safe_summary.len(),
+                        max_context_bytes = self.budget.max_context_bytes,
+                        "skill context aggregate budget exhausted; omitting skill snippet"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            total_bytes = next_total;
 
             snippets.push(SkillContextSnippet {
                 snippet_ref,
@@ -361,26 +380,34 @@ impl SkillContextSource for SkillContextService {
 fn skill_safe_summary(
     entry: &InstalledSkillSnapshot,
     budget: SkillContextBudget,
-) -> Result<String, SkillContextError> {
+) -> Result<Option<String>, SkillContextError> {
     let description = entry.safe_description.clone();
     validate_model_visible_text(&description)?;
 
     match entry.trust {
         SkillTrustLevel::Installed => {
-            validate_summary_budget(&entry.name, &description, budget.max_snippet_bytes)?;
-            Ok(description)
+            if summary_fits_budget(&entry.name, &description, budget.max_snippet_bytes) {
+                Ok(Some(description))
+            } else {
+                Ok(None)
+            }
         }
         SkillTrustLevel::Trusted => {
             let Some(content) = entry.prompt_content.as_ref() else {
-                validate_summary_budget(&entry.name, &description, budget.max_snippet_bytes)?;
-                return Ok(description);
+                return if summary_fits_budget(&entry.name, &description, budget.max_snippet_bytes) {
+                    Ok(Some(description))
+                } else {
+                    Ok(None)
+                };
             };
             let combined = format!("{description}\n\n{content}");
             validate_model_visible_text(&combined)?;
             if combined.len() <= budget.max_snippet_bytes {
-                return Ok(combined);
+                return Ok(Some(combined));
             }
-            validate_summary_budget(&entry.name, &description, budget.max_snippet_bytes)?;
+            if !summary_fits_budget(&entry.name, &description, budget.max_snippet_bytes) {
+                return Ok(None);
+            }
             tracing::debug!(
                 skill_name = %entry.name,
                 combined_safe_summary_bytes = combined.len(),
@@ -388,16 +415,12 @@ fn skill_safe_summary(
                 max_snippet_bytes = budget.max_snippet_bytes,
                 "trusted skill prompt context exceeded snippet budget; using description only"
             );
-            Ok(description)
+            Ok(Some(description))
         }
     }
 }
 
-fn validate_summary_budget(
-    skill_name: &str,
-    safe_summary: &str,
-    max_snippet_bytes: usize,
-) -> Result<(), SkillContextError> {
+fn summary_fits_budget(skill_name: &str, safe_summary: &str, max_snippet_bytes: usize) -> bool {
     if safe_summary.len() > max_snippet_bytes {
         tracing::debug!(
             skill_name,
@@ -405,9 +428,9 @@ fn validate_summary_budget(
             max_snippet_bytes,
             "skill context summary exceeded snippet budget"
         );
-        return Err(SkillContextError::ContextBudgetExceeded);
+        return false;
     }
-    Ok(())
+    true
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ironclaw_turns/tests/skill_context_service_contract.rs
+++ b/crates/ironclaw_turns/tests/skill_context_service_contract.rs
@@ -143,6 +143,22 @@ async fn trusted_skill_includes_prompt_content() {
 }
 
 #[tokio::test]
+async fn trusted_skill_uses_description_when_prompt_context_exceeds_budget() {
+    let snapshot = SkillRunSnapshot::from_entries(vec![visible_trusted(
+        "github",
+        "github skill description",
+        &"x".repeat(5 * 1024),
+    )]);
+    let service = SkillContextService::new(snapshot.clone());
+
+    let snippets = service.skill_snippets(&snapshot).await.unwrap();
+
+    assert_eq!(snippets.len(), 1);
+    assert_eq!(snippets[0].snippet_ref, "skill:github");
+    assert_eq!(snippets[0].safe_summary, "github skill description");
+}
+
+#[tokio::test]
 async fn installed_skill_excludes_prompt_content() {
     let snapshot =
         SkillRunSnapshot::from_entries(vec![visible_installed("alpha", "the description")]);
@@ -258,7 +274,7 @@ async fn tampered_snapshot_version_fails_closed() {
 #[tokio::test]
 async fn oversized_single_snippet_fails_budget() {
     let snapshot =
-        SkillRunSnapshot::from_entries(vec![visible_trusted("alpha", "desc", &"x".repeat(128))]);
+        SkillRunSnapshot::from_entries(vec![visible_installed("alpha", &"x".repeat(128))]);
     let service =
         SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(64, 512));
 

--- a/crates/ironclaw_turns/tests/skill_context_service_contract.rs
+++ b/crates/ironclaw_turns/tests/skill_context_service_contract.rs
@@ -272,18 +272,18 @@ async fn tampered_snapshot_version_fails_closed() {
 }
 
 #[tokio::test]
-async fn oversized_single_snippet_fails_budget() {
+async fn oversized_single_snippet_is_omitted_from_context() {
     let snapshot =
         SkillRunSnapshot::from_entries(vec![visible_installed("alpha", &"x".repeat(128))]);
     let service =
         SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(64, 512));
 
-    let err = service.skill_snippets(&snapshot).await.unwrap_err();
-    assert_eq!(err, SkillContextError::ContextBudgetExceeded);
+    let snippets = service.skill_snippets(&snapshot).await.unwrap();
+    assert!(snippets.is_empty());
 }
 
 #[tokio::test]
-async fn aggregate_skill_context_fails_budget() {
+async fn aggregate_skill_context_omits_entries_after_budget_exhaustion() {
     let snapshot = SkillRunSnapshot::from_entries(vec![
         visible_trusted("alpha", "first description", "first prompt"),
         visible_trusted("beta", "second description", "second prompt"),
@@ -291,8 +291,9 @@ async fn aggregate_skill_context_fails_budget() {
     let service =
         SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(40, 64));
 
-    let err = service.skill_snippets(&snapshot).await.unwrap_err();
-    assert_eq!(err, SkillContextError::ContextBudgetExceeded);
+    let snippets = service.skill_snippets(&snapshot).await.unwrap();
+    assert_eq!(snippets.len(), 1);
+    assert_eq!(snippets[0].snippet_ref, "skill:alpha");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add debug logging at the instruction-bundle snippet validation boundary.
- Share one canonical model-safe text byte limit between skill context and instruction-bundle validation.
- Treat safe skill-context budget pressure as advisory: oversized snippets are omitted, oversized trusted prompt bodies fall back to description-only, and aggregate budget exhaustion skips later snippets.
- Keep unsafe model-visible content, corrupt trust data, visibility data issues, and invalid budget configuration fail-closed.

## Why

A user asking to remove the GitHub extension can select `skill:github` as advisory model context because the turn mentions GitHub. The GitHub skill prompt can be larger than the instruction-bundle model-safe limit, which made prompt assembly fail before `builtin.extension_remove` could run.

The fixed contract is: advisory skill context may degrade for size, but unsafe or corrupt context still fails closed.

## Validation

- `cargo test -p ironclaw_turns --test skill_context_service_contract`
- `cargo test -p ironclaw_turns instruction_bundle`
- `cargo test -p ironclaw_agent_loop prompt_stage_host_unavailable_on_build_prompt_bundle_propagates_error`
