### PR TITLE
[codex] Block missing runtime credentials on auth gate

### DIFF
--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -37,6 +37,8 @@ pub enum CapabilityInvocationError {
     },
     #[error("capability {capability} invocation requires approval")]
     AuthorizationRequiresApproval { capability: CapabilityId },
+    #[error("capability {capability} invocation requires authentication")]
+    AuthorizationRequiresAuth { capability: CapabilityId },
     #[error("capability {capability} invocation fingerprint failed: {source}")]
     InvocationFingerprint {
         capability: CapabilityId,

--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -117,6 +117,68 @@ pub(crate) async fn fail_run_if_configured(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CapabilityRunStateTransition {
+    Fail { error_kind: &'static str },
+    BlockAuth { error_kind: &'static str },
+}
+
+impl CapabilityRunStateTransition {
+    pub(crate) fn error_kind(self) -> &'static str {
+        match self {
+            Self::Fail { error_kind } | Self::BlockAuth { error_kind } => error_kind,
+        }
+    }
+}
+
+impl CapabilityInvocationError {
+    pub(crate) fn run_state_transition(&self) -> CapabilityRunStateTransition {
+        match self {
+            Self::UnsupportedObligations { .. } => CapabilityRunStateTransition::Fail {
+                error_kind: "UnsupportedObligations",
+            },
+            Self::ObligationFailed { .. } => CapabilityRunStateTransition::Fail {
+                error_kind: "ObligationFailed",
+            },
+            Self::AuthorizationRequiresAuth { .. } => CapabilityRunStateTransition::BlockAuth {
+                error_kind: "AuthRequired",
+            },
+            _ => CapabilityRunStateTransition::Fail {
+                error_kind: "Obligation",
+            },
+        }
+    }
+}
+
+pub(crate) async fn apply_run_state_transition_if_configured(
+    run_state: Option<&dyn RunStateStore>,
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+    error: &CapabilityInvocationError,
+) {
+    let Some(run_state) = run_state else {
+        return;
+    };
+    match error.run_state_transition() {
+        CapabilityRunStateTransition::Fail { error_kind } => {
+            fail_run_if_configured(Some(run_state), scope, invocation_id, error_kind).await;
+        }
+        CapabilityRunStateTransition::BlockAuth { error_kind } => {
+            if let Err(error) = run_state
+                .block_auth(scope, invocation_id, error_kind.to_string())
+                .await
+            {
+                warn!(
+                    invocation_id = %invocation_id,
+                    error_kind,
+                    transition_error_kind = run_state_error_kind(&error),
+                    "run-state auth block transition failed; original business error is being returned to caller",
+                );
+            }
+        }
+    }
+}
+
 pub(crate) async fn fail_run(
     run_state: &dyn RunStateStore,
     scope: &ResourceScope,

--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -143,7 +143,23 @@ impl CapabilityInvocationError {
             Self::AuthorizationRequiresAuth { .. } => CapabilityRunStateTransition::BlockAuth {
                 error_kind: "AuthRequired",
             },
-            _ => CapabilityRunStateTransition::Fail {
+            Self::UnknownCapability { .. }
+            | Self::AuthorizationDenied { .. }
+            | Self::AuthorizationRequiresApproval { .. }
+            | Self::InvocationFingerprint { .. }
+            | Self::ApprovalRequestMismatch { .. }
+            | Self::ApprovalFingerprintMismatch { .. }
+            | Self::ApprovalNotApproved { .. }
+            | Self::ApprovalStoreMissing { .. }
+            | Self::ApprovalLeaseMissing { .. }
+            | Self::ResumeStoreMissing { .. }
+            | Self::ProcessManagerMissing { .. }
+            | Self::ResumeNotBlocked { .. }
+            | Self::ResumeContextMismatch { .. }
+            | Self::Lease(_)
+            | Self::RunState(_)
+            | Self::Process(_)
+            | Self::Dispatch { .. } => CapabilityRunStateTransition::Fail {
                 error_kind: "Obligation",
             },
         }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -12,7 +12,8 @@ use ironclaw_run_state::{
 use tracing::{debug, warn};
 
 use crate::helpers::{
-    CapabilityActionKind, approval_not_approved_error_kind, capability_lease_error_kind,
+    CapabilityActionKind, apply_run_state_transition_if_configured,
+    approval_not_approved_error_kind, capability_lease_error_kind,
     claim_error_may_be_concurrent_resume, complete_run_after_side_effect, fail_run_if_configured,
     invocation_fingerprint_for_kind, matching_approval_lease, resume_context_mismatch_kind,
     run_state_error_kind, validate_approval_request_matches_invocation,
@@ -229,11 +230,11 @@ where
                             error_kind = obligation_invocation_error_kind(&error),
                             "capability invoke obligation preparation failed"
                         );
-                        fail_run_if_configured(
+                        apply_run_state_transition_if_configured(
                             self.run_state,
                             &scope,
                             invocation_id,
-                            obligation_invocation_error_kind(&error),
+                            &error,
                         )
                         .await;
                         return Err(error);
@@ -759,11 +760,11 @@ where
         {
             Ok(outcome) => outcome,
             Err(error) => {
-                fail_run_if_configured(
+                apply_run_state_transition_if_configured(
                     Some(run_state),
                     &scope,
                     invocation_id,
-                    obligation_invocation_error_kind(&error),
+                    &error,
                 )
                 .await;
                 if let Err(revoke_error) = capability_leases
@@ -1132,11 +1133,11 @@ where
         {
             Ok(outcome) => outcome,
             Err(error) => {
-                fail_run_if_configured(
+                apply_run_state_transition_if_configured(
                     Some(run_state),
                     &scope,
                     invocation_id,
-                    obligation_invocation_error_kind(&error),
+                    &error,
                 )
                 .await;
                 if let Err(revoke_error) = capability_leases
@@ -1310,11 +1311,11 @@ where
                         obligation_outcome = outcome;
                     }
                     Err(error) => {
-                        fail_run_if_configured(
+                        apply_run_state_transition_if_configured(
                             self.run_state,
                             &scope,
                             invocation_id,
-                            obligation_invocation_error_kind(&error),
+                            &error,
                         )
                         .await;
                         return Err(error);
@@ -1638,6 +1639,11 @@ fn obligation_error_to_invocation(
                 obligations,
             }
         }
+        CapabilityObligationError::AuthRequired => {
+            CapabilityInvocationError::AuthorizationRequiresAuth {
+                capability: capability_id.clone(),
+            }
+        }
         CapabilityObligationError::Failed { kind } => CapabilityInvocationError::ObligationFailed {
             capability: capability_id.clone(),
             kind,
@@ -1646,9 +1652,5 @@ fn obligation_error_to_invocation(
 }
 
 fn obligation_invocation_error_kind(error: &CapabilityInvocationError) -> &'static str {
-    match error {
-        CapabilityInvocationError::UnsupportedObligations { .. } => "UnsupportedObligations",
-        CapabilityInvocationError::ObligationFailed { .. } => "ObligationFailed",
-        _ => "Obligation",
-    }
+    error.run_state_transition().error_kind()
 }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -22,9 +22,9 @@ use crate::obligations::post_dispatch_obligations;
 use crate::{
     CapabilityInvocationError, CapabilityInvocationRequest, CapabilityInvocationResult,
     CapabilityObligationAbortRequest, CapabilityObligationCompletionRequest,
-    CapabilityObligationError, CapabilityObligationHandler, CapabilityObligationOutcome,
-    CapabilityObligationPhase, CapabilityObligationRequest, CapabilityResumeRequest,
-    CapabilitySpawnRequest, CapabilitySpawnResult,
+    CapabilityObligationError, CapabilityObligationFailureKind, CapabilityObligationHandler,
+    CapabilityObligationOutcome, CapabilityObligationPhase, CapabilityObligationRequest,
+    CapabilityResumeRequest, CapabilitySpawnRequest, CapabilitySpawnResult,
 };
 
 pub struct CapabilityHost<'a, D>
@@ -1555,7 +1555,7 @@ where
                 obligations: obligations.as_slice(),
             })
             .await
-            .map_err(|error| obligation_error_to_invocation(capability_id, error))
+            .map_err(|error| prepare_obligation_error_to_invocation(capability_id, error))
     }
 
     async fn complete_dispatch_obligations(
@@ -1590,7 +1590,7 @@ where
                 dispatch,
             })
             .await
-            .map_err(|error| obligation_error_to_invocation(capability_id, error))
+            .map_err(|error| completion_obligation_error_to_invocation(capability_id, error))
     }
 
     async fn abort_obligations(
@@ -1628,7 +1628,7 @@ where
     }
 }
 
-fn obligation_error_to_invocation(
+fn prepare_obligation_error_to_invocation(
     capability_id: &ironclaw_host_api::CapabilityId,
     error: CapabilityObligationError,
 ) -> CapabilityInvocationError {
@@ -1648,6 +1648,19 @@ fn obligation_error_to_invocation(
             capability: capability_id.clone(),
             kind,
         },
+    }
+}
+
+fn completion_obligation_error_to_invocation(
+    capability_id: &ironclaw_host_api::CapabilityId,
+    error: CapabilityObligationError,
+) -> CapabilityInvocationError {
+    match error {
+        CapabilityObligationError::AuthRequired => CapabilityInvocationError::ObligationFailed {
+            capability: capability_id.clone(),
+            kind: CapabilityObligationFailureKind::Secret,
+        },
+        other => prepare_obligation_error_to_invocation(capability_id, other),
     }
 }
 

--- a/crates/ironclaw_capabilities/src/obligations.rs
+++ b/crates/ironclaw_capabilities/src/obligations.rs
@@ -78,6 +78,8 @@ impl std::fmt::Display for CapabilityObligationFailureKind {
 pub enum CapabilityObligationError {
     #[error("unsupported authorization obligations: {count} item(s)", count = obligations.len())]
     Unsupported { obligations: Vec<Obligation> },
+    #[error("authorization requires authentication")]
+    AuthRequired,
     #[error("authorization obligation failed: {kind}")]
     Failed {
         kind: CapabilityObligationFailureKind,

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+use ironclaw_capabilities::*;
+use ironclaw_host_api::*;
+use ironclaw_run_state::*;
+use serde_json::json;
+
+mod support;
+use support::*;
+
+#[tokio::test]
+async fn capability_host_blocks_auth_when_obligation_requires_secret_recovery() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let run_state = InMemoryRunStateStore::new();
+    let handler = AuthRequiredObligationHandler;
+    let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
+        .with_run_state(&run_state)
+        .with_obligation_handler(&handler);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+
+    let err = host
+        .invoke_json(CapabilityInvocationRequest {
+            context,
+            capability_id: capability_id(),
+            estimate: ResourceEstimate::default(),
+            input: json!({"message": "needs auth"}),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::AuthorizationRequiresAuth { .. }
+    ));
+    assert!(!dispatcher.has_request());
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::BlockedAuth);
+    assert_eq!(run.error_kind.as_deref(), Some("AuthRequired"));
+}
+
+struct AuthRequiredObligationHandler;
+
+#[async_trait]
+impl CapabilityObligationHandler for AuthRequiredObligationHandler {
+    async fn satisfy(
+        &self,
+        _request: CapabilityObligationRequest<'_>,
+    ) -> Result<(), CapabilityObligationError> {
+        Err(CapabilityObligationError::AuthRequired)
+    }
+
+    async fn prepare(
+        &self,
+        _request: CapabilityObligationRequest<'_>,
+    ) -> Result<CapabilityObligationOutcome, CapabilityObligationError> {
+        Err(CapabilityObligationError::AuthRequired)
+    }
+}

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
@@ -41,6 +41,43 @@ async fn capability_host_blocks_auth_when_obligation_requires_secret_recovery() 
     assert_eq!(run.error_kind.as_deref(), Some("AuthRequired"));
 }
 
+#[tokio::test]
+async fn capability_host_fails_post_dispatch_auth_required_without_retryable_gate() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let run_state = InMemoryRunStateStore::new();
+    let handler = PostDispatchAuthRequiredObligationHandler;
+    let host = CapabilityHost::new(&registry, &dispatcher, &ObligatingAuthorizer)
+        .with_run_state(&run_state)
+        .with_obligation_handler(&handler);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+
+    let err = host
+        .invoke_json(CapabilityInvocationRequest {
+            context,
+            capability_id: capability_id(),
+            estimate: ResourceEstimate::default(),
+            input: json!({"message": "post dispatch auth"}),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::ObligationFailed {
+            kind: CapabilityObligationFailureKind::Secret,
+            ..
+        }
+    ));
+    assert!(dispatcher.has_request());
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.error_kind.as_deref(), Some("ObligationFailed"));
+}
+
 struct AuthRequiredObligationHandler;
 
 #[async_trait]
@@ -56,6 +93,32 @@ impl CapabilityObligationHandler for AuthRequiredObligationHandler {
         &self,
         _request: CapabilityObligationRequest<'_>,
     ) -> Result<CapabilityObligationOutcome, CapabilityObligationError> {
+        Err(CapabilityObligationError::AuthRequired)
+    }
+}
+
+struct PostDispatchAuthRequiredObligationHandler;
+
+#[async_trait]
+impl CapabilityObligationHandler for PostDispatchAuthRequiredObligationHandler {
+    async fn satisfy(
+        &self,
+        _request: CapabilityObligationRequest<'_>,
+    ) -> Result<(), CapabilityObligationError> {
+        Ok(())
+    }
+
+    async fn prepare(
+        &self,
+        _request: CapabilityObligationRequest<'_>,
+    ) -> Result<CapabilityObligationOutcome, CapabilityObligationError> {
+        Ok(CapabilityObligationOutcome::default())
+    }
+
+    async fn complete_dispatch(
+        &self,
+        _request: CapabilityObligationCompletionRequest<'_>,
+    ) -> Result<CapabilityDispatchResult, CapabilityObligationError> {
         Err(CapabilityObligationError::AuthRequired)
     }
 }

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -1084,7 +1084,7 @@ impl BuiltinObligationHandler {
                 .map_err(|_| secret_obligation_failed())?
                 .is_some();
             if !exists {
-                return Err(secret_obligation_failed());
+                return Err(CapabilityObligationError::AuthRequired);
             }
         }
         Ok(())

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -449,10 +449,15 @@ impl HostRuntime for DefaultHostRuntime {
                     idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability resume failed"
                 );
-                Ok(RuntimeCapabilityOutcome::Failed(failure_from(
-                    error,
-                    capability_id,
-                )))
+                match error {
+                    CapabilityInvocationError::AuthorizationRequiresAuth { capability } => {
+                        Ok(auth_required_outcome(capability))
+                    }
+                    other => Ok(RuntimeCapabilityOutcome::Failed(failure_from(
+                        other,
+                        capability_id,
+                    ))),
+                }
             }
         }
     }
@@ -812,12 +817,7 @@ impl DefaultHostRuntime {
                 }
             }
             CapabilityInvocationError::AuthorizationRequiresAuth { capability } => {
-                Ok(RuntimeCapabilityOutcome::AuthRequired(RuntimeAuthGate {
-                    gate_id: RuntimeGateId::new(),
-                    capability_id: capability,
-                    reason: RuntimeBlockedReason::AuthRequired,
-                    required_secrets: Vec::new(),
-                }))
+                Ok(auth_required_outcome(capability))
             }
             other => Ok(RuntimeCapabilityOutcome::Failed(failure_from(
                 other,
@@ -1087,6 +1087,15 @@ fn completed_outcome_from(
         output: result.dispatch.output,
         usage: result.dispatch.usage,
     }
+}
+
+fn auth_required_outcome(capability_id: CapabilityId) -> RuntimeCapabilityOutcome {
+    RuntimeCapabilityOutcome::AuthRequired(RuntimeAuthGate {
+        gate_id: RuntimeGateId::new(),
+        capability_id,
+        reason: RuntimeBlockedReason::AuthRequired,
+        required_secrets: Vec::new(),
+    })
 }
 
 fn failure_from(

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -39,12 +39,12 @@ use ironclaw_trust::{HostTrustPolicy, TrustDecision, TrustError, TrustPolicy, Tr
 use crate::{
     BuiltinObligationHandler, BuiltinObligationServices, CancelRuntimeWorkOutcome,
     CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime, HostRuntimeError,
-    HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate, RuntimeBackendHealth,
-    RuntimeBlockedReason, RuntimeCapabilityCompleted, RuntimeCapabilityFailure,
-    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeCapabilityResumeRequest,
-    RuntimeFailureKind, RuntimeStatusRequest, RuntimeWorkId, RuntimeWorkSummary,
-    VisibleCapabilityRequest, VisibleCapabilitySurface, plan_capability,
-    surface::CapabilityCatalog,
+    HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate, RuntimeAuthGate,
+    RuntimeBackendHealth, RuntimeBlockedReason, RuntimeCapabilityCompleted,
+    RuntimeCapabilityFailure, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    RuntimeCapabilityResumeRequest, RuntimeFailureKind, RuntimeGateId, RuntimeStatusRequest,
+    RuntimeWorkId, RuntimeWorkSummary, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    plan_capability, surface::CapabilityCatalog,
 };
 
 /// Default production wiring for [`HostRuntime`].
@@ -811,6 +811,14 @@ impl DefaultHostRuntime {
                     }
                 }
             }
+            CapabilityInvocationError::AuthorizationRequiresAuth { capability } => {
+                Ok(RuntimeCapabilityOutcome::AuthRequired(RuntimeAuthGate {
+                    gate_id: RuntimeGateId::new(),
+                    capability_id: capability,
+                    reason: RuntimeBlockedReason::AuthRequired,
+                    required_secrets: Vec::new(),
+                }))
+            }
             other => Ok(RuntimeCapabilityOutcome::Failed(failure_from(
                 other,
                 capability_id,
@@ -1105,6 +1113,7 @@ fn sanitized_failure_message(error: &CapabilityInvocationError) -> Option<String
         | AuthorizationDenied { .. }
         | UnsupportedObligations { .. }
         | ObligationFailed { .. }
+        | AuthorizationRequiresAuth { .. }
         | AuthorizationRequiresApproval { .. }
         | ApprovalRequestMismatch { .. }
         | ApprovalFingerprintMismatch { .. }
@@ -1126,6 +1135,9 @@ fn sanitized_failure_message(error: &CapabilityInvocationError) -> Option<String
 pub(crate) fn failure_kind_from(error: &CapabilityInvocationError) -> RuntimeFailureKind {
     match error {
         CapabilityInvocationError::UnknownCapability { .. } => RuntimeFailureKind::MissingRuntime,
+        CapabilityInvocationError::AuthorizationRequiresAuth { .. } => {
+            RuntimeFailureKind::Authorization
+        }
         CapabilityInvocationError::AuthorizationDenied { .. }
         | CapabilityInvocationError::UnsupportedObligations { .. }
         | CapabilityInvocationError::AuthorizationRequiresApproval { .. }

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -127,6 +127,76 @@ async fn host_runtime_services_routes_github_wasm_read_through_runtime_http_egre
     );
 }
 
+#[tokio::test]
+async fn host_runtime_services_missing_github_runtime_secret_blocks_on_auth() {
+    let capability_id = CapabilityId::new("github.search_issues").unwrap();
+    let scope = sample_scope(InvocationId::new());
+    let expected_url =
+        "https://api.github.com/search/issues?q=repo%3Anearai%2Fironclaw%20is%3Aissue&per_page=1";
+    let network = RecordingNetworkHttpEgress::with_body(
+        br#"{"total_count":0,"incomplete_results":false,"items":[]}"#.to_vec(),
+    );
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let secret_handle = SecretHandle::new("github_token").unwrap();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_github_package()),
+        Arc::new(filesystem_with_github_package()),
+        Arc::new(governor_with_default_limit(sample_account())),
+        Arc::new(ObligatingAuthorizer::new(vec![
+            Obligation::ApplyNetworkPolicy {
+                policy: github_policy(),
+            },
+            Obligation::InjectSecretOnce {
+                handle: secret_handle.clone(),
+            },
+        ])),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_trust_policy(Arc::new(github_first_party_trust_policy()))
+    .with_wasm_runtime_credential_provider(Arc::new(WasmStagedRuntimeCredentials::new(vec![
+        WasmStagedRuntimeCredential::for_exact_url(
+            secret_handle.clone(),
+            RuntimeCredentialTarget::Header {
+                name: "authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            true,
+            expected_url.to_string(),
+        ),
+    ])))
+    .try_with_host_http_egress(network.clone())
+    .unwrap()
+    .try_with_wasm_runtime(WitToolRuntimeConfig::default(), WitToolHost::deny_all())
+    .unwrap();
+
+    let outcome = services
+        .host_runtime_for_local_testing()
+        .invoke_capability(wasm_runtime_request_for_scope(
+            capability_id.clone(),
+            scope,
+            json!({"query": "repo:nearai/ironclaw is:issue", "limit": 1}),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::AuthRequired(gate) => {
+            assert_eq!(gate.capability_id, capability_id);
+            assert!(
+                gate.required_secrets.is_empty(),
+                "secret handles are not product-visible until auth recovery projections carry them"
+            );
+        }
+        other => panic!("expected auth-required outcome, got {other:?}"),
+    }
+    assert!(
+        network.requests().is_empty(),
+        "missing credential must block before dispatch"
+    );
+}
+
 #[test]
 fn bundled_github_wasm_executes_search_get_and_comment_operations() {
     let search_http = Arc::new(RecordingWasmHostHttp::ok(WasmHttpResponse {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -2567,6 +2567,86 @@ async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_on
 }
 
 #[tokio::test]
+async fn host_runtime_services_resume_missing_runtime_secret_returns_auth_gate() {
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let secret_handle = SecretHandle::new("approval_resume_token").unwrap();
+    let script_runtime = Arc::new(RecordingScriptExecutor::default());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenSecretObligationAuthorizer {
+            handle: secret_handle,
+        }),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_run_state(Arc::clone(&run_state))
+    .with_approval_requests(Arc::clone(&approval_requests))
+    .with_capability_leases(Arc::clone(&capability_leases))
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_script_runtime(Arc::clone(&script_runtime));
+    let runtime = services.host_runtime_for_local_testing();
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "approval then auth"});
+
+    let gate = block_for_approval(&runtime, context.clone(), estimate.clone(), input.clone()).await;
+    let lease =
+        approve_dispatch_for_services(&services, &scope, gate.approval_request_id, None).await;
+
+    let resumed = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context,
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate,
+            input,
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match resumed {
+        RuntimeCapabilityOutcome::AuthRequired(auth_gate) => {
+            assert_eq!(auth_gate.capability_id, script_capability_id());
+            assert!(
+                auth_gate.required_secrets.is_empty(),
+                "secret handles are not product-visible until auth recovery projections carry them"
+            );
+        }
+        other => panic!("expected auth-required resume outcome, got {other:?}"),
+    }
+    let run = run_state
+        .get(&scope, scope.invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, RunStatus::BlockedAuth);
+    assert_eq!(run.error_kind.as_deref(), Some("AuthRequired"));
+    assert_eq!(
+        capability_leases
+            .get(&scope, lease.grant.id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Revoked
+    );
+    assert!(
+        script_runtime.recorded_mounts().is_empty(),
+        "missing credential must block before dispatch"
+    );
+}
+
+#[tokio::test]
 async fn host_runtime_services_resume_changed_input_fails_before_lease_claim_or_dispatch() {
     let fixture = approval_resume_fixture();
     let runtime = fixture.services.host_runtime_for_local_testing();
@@ -5233,6 +5313,45 @@ impl TrustAwareCapabilityDispatchAuthorizer for ApprovalThenGrantAuthorizer {
             GrantAuthorizer::new()
                 .authorize_dispatch_with_trust(context, descriptor, estimate, trust_decision)
                 .await
+        }
+    }
+}
+
+struct ApprovalThenSecretObligationAuthorizer {
+    handle: SecretHandle,
+}
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for ApprovalThenSecretObligationAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        _trust_decision: &TrustDecision,
+    ) -> Decision {
+        if context.grants.grants.is_empty() {
+            Decision::RequireApproval {
+                request: ApprovalRequest {
+                    id: ApprovalRequestId::new(),
+                    correlation_id: context.correlation_id,
+                    requested_by: Principal::Extension(context.extension_id.clone()),
+                    action: Box::new(Action::Dispatch {
+                        capability: descriptor.id.clone(),
+                        estimated_resources: estimate.clone(),
+                    }),
+                    invocation_fingerprint: None,
+                    reason: "approval required".to_string(),
+                    reusable_scope: None,
+                },
+            }
+        } else {
+            Decision::Allow {
+                obligations: Obligations::new(vec![Obligation::InjectSecretOnce {
+                    handle: self.handle.clone(),
+                }])
+                .unwrap(),
+            }
         }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -74,6 +74,7 @@ pub struct RebornOAuthCallbackRequest {
 ///
 /// The browser-facing route chooses neither flow kind nor continuation. Those
 /// product-auth semantics stay here with the auth service boundary.
+#[allow(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RebornOAuthStartFlowRequest {
     pub(crate) scope: AuthProductScope,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -65,14 +65,15 @@ use ironclaw_turns::{
     InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore, InMemoryTurnStateStore,
 };
 
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use crate::RebornProductAuthServicePorts;
 use crate::default_system_prompt::seed_default_system_prompt;
 use crate::input::{RebornRuntimeProcessBinding, RebornStorageInput};
 use crate::lifecycle::{RebornLocalSkillManagementPort, build_local_skill_management_port};
 use crate::local_dev_mounts::{skill_context_mount_view, workspace_mount_view};
 use crate::{
     RebornAuthContinuationDispatcher, RebornBuildError, RebornBuildInput, RebornCompositionProfile,
-    RebornFacadeReadiness, RebornProductAuthServicePorts, RebornProductAuthServices,
-    RebornReadiness, RebornReadinessState,
+    RebornFacadeReadiness, RebornProductAuthServices, RebornReadiness, RebornReadinessState,
 };
 use crate::{
     available_extensions::{
@@ -270,6 +271,7 @@ fn auth_continuation_dispatcher(
     Arc::new(ProductAuthTurnGateResumeDispatcher::new(turn_coordinator))
 }
 
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 fn compose_product_auth_services(
     ports: RebornProductAuthServicePorts,
     turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator>,
@@ -382,12 +384,13 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> = Arc::new(
         DefaultTurnCoordinator::new(Arc::clone(&store_graph.turn_state)),
     );
-    let product_auth = match product_auth_ports {
-        Some(ports) => compose_product_auth_services(ports, turn_coordinator.clone()),
-        None => Arc::new(RebornProductAuthServices::local_dev_in_memory(
-            auth_continuation_dispatcher(turn_coordinator.clone()),
+    let product_auth_services = match product_auth_ports {
+        Some(ports) => ports.into_services(auth_continuation_dispatcher(turn_coordinator.clone())),
+        None => RebornProductAuthServices::local_dev_in_memory(auth_continuation_dispatcher(
+            turn_coordinator.clone(),
         )),
     };
+    let product_auth = Arc::new(product_auth_services);
     let mut first_party_registry = builtin_first_party_registry()?;
     register_bundled_gsuite_first_party_handlers(
         &mut first_party_registry,


### PR DESCRIPTION
## Summary

- Convert missing runtime credential material from a terminal obligation failure into the existing auth-required gate path.
- Add a typed capability run-state transition model so auth-required obligations block the run as `BlockedAuth` while other obligation errors still fail.
- Keep runtime secret handles out of product-visible auth payloads until the product auth recovery projection carries them end to end.
- Add focused capability-host and GitHub WASM regression coverage.

## Validation

- `cargo check -p ironclaw_reborn_composition -p ironclaw_product_workflow -p ironclaw_host_runtime`
- `cargo check -p ironclaw_reborn_composition --features webui-v2-beta`
- `cargo test -p ironclaw_capabilities capability_host_blocks_auth_when_obligation_requires_secret_recovery`
- `cargo test -p ironclaw_host_runtime host_runtime_services_missing_github_runtime_secret_blocks_on_auth`
- `cargo test -p ironclaw_reborn_composition local_dev_extension_lifecycle_tools_manage_visible_extension_surface`
- `cargo test -p ironclaw_reborn_composition local_dev_agent_surface_exposes_extension_lifecycle_tools`
- `cargo test -p ironclaw_reborn_composition --test manual_tokens`
- `git diff --check`

Note: `cargo fmt --check` currently fails on upstream `crates/ironclaw_reborn/src/model_gateway.rs`, which is outside this PR diff. I left that unrelated formatting churn out of this branch.