### PR TITLE
Accept named plain Markdown skill installs

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -220,7 +220,7 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
                 },
                 "content": {
                     "type": "string",
-                    "description": "Raw SKILL.md content to install"
+                    "description": "Raw SKILL.md content to install, or plain Markdown when name is provided"
                 },
                 "url": {
                     "type": "string",

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -761,6 +761,8 @@ async fn builtin_skill_install_accepts_named_plain_markdown_content() {
             "name": "qa-smoke-skill",
             "content": "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n"
         }),
+        // skill_install currently declares Network for URL installs too, so the
+        // first-party harness needs a non-empty policy even for content input.
         execution_context_with_mounts_and_network(
             [SKILL_INSTALL_CAPABILITY_ID],
             mounts.clone(),

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -749,6 +749,44 @@ async fn builtin_skill_install_accepts_content_when_network_is_denied() {
 }
 
 #[tokio::test]
+async fn builtin_skill_install_accepts_named_plain_markdown_content() {
+    let temp = tempfile::tempdir().unwrap();
+    let (filesystem, mounts) = mounted_skill_filesystem(temp.path());
+    let runtime = runtime_with_filesystem(filesystem);
+
+    let installed = invoke_with_context(
+        &runtime,
+        SKILL_INSTALL_CAPABILITY_ID,
+        json!({
+            "name": "qa-smoke-skill",
+            "content": "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n"
+        }),
+        execution_context_with_mounts_and_network(
+            [SKILL_INSTALL_CAPABILITY_ID],
+            mounts.clone(),
+            http_test_policy(),
+        ),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(installed["installed"], json!(true));
+    assert_eq!(installed["name"], json!("qa-smoke-skill"));
+    assert_eq!(installed["source"], json!("user"));
+
+    let listed = invoke_with_context(
+        &runtime,
+        SKILL_LIST_CAPABILITY_ID,
+        json!({}),
+        execution_context_with_mounts([SKILL_LIST_CAPABILITY_ID], mounts),
+    )
+    .await
+    .unwrap();
+    assert_eq!(listed["count"], json!(1));
+    assert_eq!(listed["skills"][0]["name"], json!("qa-smoke-skill"));
+}
+
+#[tokio::test]
 async fn builtin_skill_install_rejects_hidden_url_install_fields() {
     let cases = [
         json!({

--- a/crates/ironclaw_reborn_composition/src/lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/lifecycle.rs
@@ -545,7 +545,7 @@ mod tests {
         let invalid_install = facade
             .execute_action(LifecycleProductAction::SkillInstall {
                 name: Some(LifecyclePackageId::new("broken-skill").expect("valid skill id")),
-                content: "not a skill manifest".to_string(),
+                content: "---\nname: broken-skill\n\nmissing closing delimiter".to_string(),
             })
             .await
             .expect_err("invalid skill content should fail");

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    MAX_PROMPT_FILE_SIZE, SkillParseError, normalize_line_endings, parse_skill_md,
+    MAX_PROMPT_FILE_SIZE, ParsedSkill, SkillParseError, normalize_line_endings, parse_skill_md,
     validate_skill_name,
 };
 use async_trait::async_trait;

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -3,7 +3,10 @@ use std::{
     sync::{Arc, LazyLock, Mutex, Weak},
 };
 
-use crate::{MAX_PROMPT_FILE_SIZE, normalize_line_endings, parse_skill_md, validate_skill_name};
+use crate::{
+    MAX_PROMPT_FILE_SIZE, SkillParseError, normalize_line_endings, parse_skill_md,
+    validate_skill_name,
+};
 use async_trait::async_trait;
 use ironclaw_filesystem::{
     BackendCapabilities, DirEntry, FileStat, FileType, FilesystemError, RootFilesystem,
@@ -302,12 +305,10 @@ pub async fn install_skill(
     }
 
     let normalized = normalize_line_endings(request.content);
-    let parsed = parse_skill_md(&normalized).map_err(|error| {
+    let install_content = normalize_install_content(&normalized, request.name)?;
+    let parsed = parse_skill_md(&install_content).map_err(|error| {
         tracing::debug!(%error, "skill install failed to parse SKILL.md content");
-        SkillManagementError::with_reason(
-            SkillManagementErrorKind::InvalidInput,
-            format!("skill content failed to parse: {error}"),
-        )
+        skill_parse_error(error)
     })?;
     if let Some(requested_name) = request.name
         && requested_name != parsed.manifest.name
@@ -356,7 +357,7 @@ pub async fn install_skill(
     publish_skill_install(
         context,
         &skill_name,
-        &normalized,
+        &install_content,
         request.files,
         request.source,
         request.source_url,
@@ -374,6 +375,60 @@ pub async fn install_skill(
         scoped_path: format!("{USER_SKILLS_ROOT}/{skill_name}/{SKILL_FILE_NAME}"),
         source: installed_skill_source(request.source),
     })
+}
+
+fn normalize_install_content(
+    normalized_content: &str,
+    requested_name: Option<&str>,
+) -> Result<String, SkillManagementError> {
+    match parse_skill_md(normalized_content) {
+        Ok(_) => Ok(normalized_content.to_string()),
+        Err(SkillParseError::MissingFrontmatter)
+            if !starts_with_frontmatter_delimiter(normalized_content) =>
+        {
+            synthesize_install_frontmatter(normalized_content, requested_name)
+        }
+        Err(error) => {
+            tracing::debug!(%error, "skill install failed to parse SKILL.md content");
+            Err(skill_parse_error(error))
+        }
+    }
+}
+
+fn starts_with_frontmatter_delimiter(content: &str) -> bool {
+    let stripped = content.strip_prefix('\u{feff}').unwrap_or(content);
+    stripped.trim_start_matches(['\n', '\r']).starts_with("---")
+}
+
+fn synthesize_install_frontmatter(
+    normalized_content: &str,
+    requested_name: Option<&str>,
+) -> Result<String, SkillManagementError> {
+    let Some(requested_name) = requested_name else {
+        let error = SkillParseError::MissingFrontmatter;
+        tracing::debug!(%error, "skill install failed to parse SKILL.md content");
+        return Err(skill_parse_error(error));
+    };
+    if !validate_skill_name(requested_name) {
+        tracing::debug!(
+            requested_name,
+            "skill install rejected invalid requested name"
+        );
+        return Err(SkillManagementError::new(
+            SkillManagementErrorKind::InvalidInput,
+        ));
+    }
+
+    let mut rendered = format!("---\nname: {requested_name}\n---\n\n");
+    rendered.push_str(normalized_content);
+    Ok(rendered)
+}
+
+fn skill_parse_error(error: SkillParseError) -> SkillManagementError {
+    SkillManagementError::with_reason(
+        SkillManagementErrorKind::InvalidInput,
+        format!("skill content failed to parse: {error}"),
+    )
 }
 
 #[tracing::instrument(

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, LazyLock, Mutex, Weak},
 };
 
+use crate::parser::starts_with_frontmatter_delimiter;
 use crate::{
     MAX_PROMPT_FILE_SIZE, ParsedSkill, SkillParseError, normalize_line_endings, parse_skill_md,
     validate_skill_name,
@@ -206,6 +207,11 @@ pub struct SkillInstallResult {
     pub source: SkillSource,
 }
 
+struct PreparedSkillInstall {
+    content: String,
+    parsed: ParsedSkill,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SkillRemoveRequest<'a> {
     pub name: &'a str,
@@ -304,18 +310,22 @@ pub async fn install_skill(
         ));
     }
 
-    let normalized = normalize_line_endings(request.content);
-    let install_content = normalize_install_content(&normalized, request.name)?;
-    let parsed = parse_skill_md(&install_content).map_err(|error| {
-        tracing::debug!(%error, "skill install failed to parse SKILL.md content");
-        skill_parse_error(error)
-    })?;
+    let prepared = prepare_install_content(request.content, request.name)?;
+    if prepared.content.len() as u64 > MAX_PROMPT_FILE_SIZE {
+        tracing::debug!(
+            max_bytes = MAX_PROMPT_FILE_SIZE,
+            "skill install rejected oversized persisted content"
+        );
+        return Err(SkillManagementError::new(
+            SkillManagementErrorKind::Resource,
+        ));
+    }
     if let Some(requested_name) = request.name
-        && requested_name != parsed.manifest.name
+        && requested_name != prepared.parsed.manifest.name
     {
         tracing::debug!(
             requested_name,
-            parsed_name = %parsed.manifest.name,
+            parsed_name = %prepared.parsed.manifest.name,
             "skill install rejected name mismatch"
         );
         return Err(SkillManagementError::new(
@@ -324,7 +334,7 @@ pub async fn install_skill(
     }
     validate_install_bundle_files(request.files)?;
 
-    let skill_name = parsed.manifest.name;
+    let skill_name = prepared.parsed.manifest.name;
     let mutation_lock = skill_mutation_lock(&skill_name);
     let _mutation_guard = mutation_lock.lock().await;
     let skill_dir = skill_root_scoped_path(USER_SKILLS_ROOT, &skill_name)?;
@@ -357,7 +367,7 @@ pub async fn install_skill(
     publish_skill_install(
         context,
         &skill_name,
-        &install_content,
+        &prepared.content,
         request.files,
         request.source,
         request.source_url,
@@ -377,27 +387,31 @@ pub async fn install_skill(
     })
 }
 
-fn normalize_install_content(
-    normalized_content: &str,
+fn prepare_install_content(
+    content: &str,
     requested_name: Option<&str>,
-) -> Result<String, SkillManagementError> {
-    match parse_skill_md(normalized_content) {
-        Ok(_) => Ok(normalized_content.to_string()),
+) -> Result<PreparedSkillInstall, SkillManagementError> {
+    let normalized_content = normalize_line_endings(content);
+    match parse_skill_md(&normalized_content) {
+        Ok(parsed) => Ok(PreparedSkillInstall {
+            content: normalized_content,
+            parsed,
+        }),
         Err(SkillParseError::MissingFrontmatter)
-            if !starts_with_frontmatter_delimiter(normalized_content) =>
+            if !starts_with_frontmatter_delimiter(&normalized_content) =>
         {
-            synthesize_install_frontmatter(normalized_content, requested_name)
+            let content = synthesize_install_frontmatter(&normalized_content, requested_name)?;
+            let parsed = parse_skill_md(&content).map_err(|error| {
+                tracing::debug!(%error, "skill install failed to parse synthesized SKILL.md content");
+                skill_parse_error(error)
+            })?;
+            Ok(PreparedSkillInstall { content, parsed })
         }
         Err(error) => {
             tracing::debug!(%error, "skill install failed to parse SKILL.md content");
             Err(skill_parse_error(error))
         }
     }
-}
-
-fn starts_with_frontmatter_delimiter(content: &str) -> bool {
-    let stripped = content.strip_prefix('\u{feff}').unwrap_or(content);
-    stripped.trim_start_matches(['\n', '\r']).starts_with("---")
 }
 
 fn synthesize_install_frontmatter(

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -155,6 +155,34 @@ async fn install_rejects_malformed_frontmatter_even_with_requested_name() {
 }
 
 #[tokio::test]
+async fn install_rejects_plain_markdown_when_synthesized_content_exceeds_prompt_limit() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem.clone(), skill_mounts());
+    let header = "---\nname: qa-smoke-skill\n---\n\n";
+    let content = "x".repeat(MAX_PROMPT_FILE_SIZE as usize - header.len() + 1);
+
+    let error = install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("qa-smoke-skill"),
+            content: &content,
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error.kind(), SkillManagementErrorKind::Resource);
+    assert_missing(
+        filesystem.as_ref(),
+        "/projects/skills/qa-smoke-skill/SKILL.md",
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn install_preserves_parse_error_context() {
     let filesystem = Arc::new(InMemoryBackend::default());
     let context = skill_management_context(filesystem, skill_mounts());

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -96,6 +96,65 @@ async fn install_rejects_name_mismatch() {
 }
 
 #[tokio::test]
+async fn install_accepts_named_plain_markdown_content() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem.clone(), skill_mounts());
+
+    let installed = install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("qa-smoke-skill"),
+            content: "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n",
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(installed.name, "qa-smoke-skill");
+    let written = read_file(
+        filesystem.as_ref(),
+        "/projects/skills/qa-smoke-skill/SKILL.md",
+    )
+    .await;
+    assert!(written.starts_with("---\nname: qa-smoke-skill\n---\n\n"));
+    assert!(written.contains("Say \"qa skill loaded\""));
+
+    let listed = list_skills(&context).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "qa-smoke-skill");
+}
+
+#[tokio::test]
+async fn install_rejects_malformed_frontmatter_even_with_requested_name() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem, skill_mounts());
+
+    let error = install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("qa-smoke-skill"),
+            content: "---\nname: qa-smoke-skill\n\nMissing closing delimiter.\n",
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error.kind(), SkillManagementErrorKind::InvalidInput);
+    assert!(
+        error
+            .reason()
+            .is_some_and(|reason| reason.contains("Missing YAML frontmatter")),
+        "parse context should be preserved in the public error reason: {error:?}"
+    );
+}
+
+#[tokio::test]
 async fn install_preserves_parse_error_context() {
     let filesystem = Arc::new(InMemoryBackend::default());
     let context = skill_management_context(filesystem, skill_mounts());
@@ -641,6 +700,18 @@ async fn write_file(root: &InMemoryBackend, path: &str, body: String) {
     root.write_file(&VirtualPath::new(path).unwrap(), body.as_bytes())
         .await
         .unwrap();
+}
+
+async fn read_file(root: &InMemoryBackend, path: &str) -> String {
+    let bytes = root
+        .read_file_bounded(
+            &VirtualPath::new(path).unwrap(),
+            MAX_PROMPT_FILE_SIZE as usize,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    String::from_utf8(bytes).unwrap()
 }
 
 async fn assert_missing(root: &InMemoryBackend, path: &str) {

--- a/crates/ironclaw_skills/src/parser.rs
+++ b/crates/ironclaw_skills/src/parser.rs
@@ -54,6 +54,12 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkill, SkillParseError> {
     parse_skill_md_impl(content, true)
 }
 
+pub(crate) fn starts_with_frontmatter_delimiter(content: &str) -> bool {
+    let normalized = content.replace("\r\n", "\n").replace('\r', "\n");
+    let stripped = normalized.strip_prefix('\u{feff}').unwrap_or(&normalized);
+    stripped.trim_start_matches(['\n', '\r']).starts_with("---")
+}
+
 /// Parse a SKILL.md file for install recovery without validating the `name` field.
 ///
 /// Used by install paths that need to recover from invalid published names by


### PR DESCRIPTION
## Summary
- synthesize minimal SKILL.md frontmatter for skill_install content when the caller provides a name and the content is otherwise plain Markdown
- preserve parse errors for malformed frontmatter instead of masking them as plain Markdown
- cover the Reborn first-party builtin skill_install path and core skill management behavior

## Tests
- cargo test -p ironclaw_skills management::tests::install_accepts_named_plain_markdown_content
- cargo test -p ironclaw_skills management::tests::install_rejects_malformed_frontmatter_even_with_requested_name
- cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_skill_install_accepts_named_plain_markdown_content

## Notes
- This targets reborn-integration and the Reborn skill management path, not the legacy skill tools path.
