### PR TITLE
[codex] fix reply completion stop strategy

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor.rs
+++ b/crates/ironclaw_agent_loop/src/executor.rs
@@ -48,7 +48,7 @@ use mapping::{
 use model::{ModelInput, ModelStage, ModelStep};
 use pipeline::{DefaultExecutorPipeline, ExecutorStage, StageContext};
 use prompt::{PromptInput, PromptStage, PromptStep};
-use turn_stop::{StopInput, StopStage, StopStep};
+use turn_stop::{StopInput, StopObservationInput, StopObservationStep, StopStage, StopStep};
 
 use async_trait::async_trait;
 use ironclaw_turns::{

--- a/crates/ironclaw_agent_loop/src/executor/canonical.rs
+++ b/crates/ironclaw_agent_loop/src/executor/canonical.rs
@@ -10,8 +10,8 @@ use super::{
     AgentLoopExecutorError, AssistantReplyInput, BudgetInput, BudgetStep, CancelCheck,
     CapabilityInput, CheckpointInput, CheckpointKind, CheckpointStage, DefaultExecutorPipeline,
     DrainInput, ExecutorStage, ExitInput, InputStep, ModelInput, ModelStep, PendingInputAck,
-    PromptInput, PromptStep, StageContext, StopInput, StopStep, TurnCompletedStep,
-    UserFacingInputDrainMode, completed_exit,
+    PromptInput, PromptStep, StageContext, StopInput, StopObservationInput, StopObservationStep,
+    StopStep, TurnCompletedStep, UserFacingInputDrainMode,
 };
 
 impl DefaultExecutorPipeline {
@@ -159,9 +159,62 @@ impl DefaultExecutorPipeline {
             };
             let completed_kind = summary.kind;
 
+            let (mut next_state, summary) = match self
+                .stop
+                .observe(
+                    ctx,
+                    StopObservationInput {
+                        state: next_state,
+                        summary,
+                    },
+                )
+                .await?
+            {
+                StopObservationStep::Continue { state, summary } => (*state, summary),
+                StopObservationStep::Exit(exit) => return Ok(exit),
+            };
+
+            if completed_kind == TurnEndKind::ReplyOnly {
+                debug!(
+                    iteration = next_state.iteration,
+                    "agent loop checking follow-up input after reply-only turn end"
+                );
+                match self
+                    .input
+                    .process(
+                        ctx,
+                        DrainInput {
+                            state: next_state,
+                            pending_input_ack: std::mem::take(&mut pending_input_ack),
+                            mode: UserFacingInputDrainMode::FollowUp,
+                        },
+                    )
+                    .await?
+                {
+                    InputStep::Continue {
+                        state: next,
+                        pending_input_ack: ack,
+                        drained,
+                    } => {
+                        next_state = *next;
+                        pending_input_ack = ack;
+                        if drained {
+                            debug!(
+                                iteration = next_state.iteration,
+                                "agent loop continuing after queued follow-up input"
+                            );
+                            next_state.iteration = next_state.iteration.saturating_add(1);
+                            state = next_state;
+                            continue;
+                        }
+                    }
+                    InputStep::Exit(exit) => return Ok(exit),
+                }
+            }
+
             match self
                 .stop
-                .process(
+                .decide(
                     ctx,
                     StopInput {
                         state: next_state,
@@ -190,64 +243,7 @@ impl DefaultExecutorPipeline {
                 StopStep::Exit(exit) => return Ok(exit),
             }
 
-            match completed_kind {
-                TurnEndKind::ReplyOnly => {
-                    debug!(
-                        iteration = state.iteration,
-                        "agent loop handling reply-only turn end"
-                    );
-                    match self
-                        .input
-                        .process(
-                            ctx,
-                            DrainInput {
-                                state,
-                                pending_input_ack: std::mem::take(&mut pending_input_ack),
-                                mode: UserFacingInputDrainMode::FollowUp,
-                            },
-                        )
-                        .await?
-                    {
-                        InputStep::Continue {
-                            state: next,
-                            pending_input_ack: ack,
-                            drained,
-                        } => {
-                            state = *next;
-                            pending_input_ack = ack;
-                            if drained {
-                                debug!(
-                                    iteration = state.iteration,
-                                    "agent loop continuing after queued follow-up input"
-                                );
-                                state.iteration = state.iteration.saturating_add(1);
-                                continue;
-                            }
-                        }
-                        InputStep::Exit(exit) => return Ok(exit),
-                    }
-
-                    let checked = CheckpointStage
-                        .process(
-                            ctx,
-                            CheckpointInput {
-                                state,
-                                kind: CheckpointKind::Final,
-                            },
-                        )
-                        .await?;
-                    debug!(
-                        iteration = checked.state.iteration,
-                        checkpoint_id = %checked.checkpoint_id.as_uuid(),
-                        "agent loop exiting after reply-only model output"
-                    );
-                    pending_input_ack.ack(host).await?;
-                    return completed_exit(host, checked.state, Some(checked.checkpoint_id));
-                }
-                TurnEndKind::AfterCapabilityBatch => {
-                    state.iteration = state.iteration.saturating_add(1);
-                }
-            }
+            state.iteration = state.iteration.saturating_add(1);
         }
     }
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -105,6 +105,78 @@ async fn progress_port_failure_does_not_abort_reply_only_run() {
 }
 
 #[tokio::test]
+async fn reply_only_drains_follow_up_before_stop_strategy_completes() {
+    let host = MockHost::new(vec![reply_response(), reply_response()]);
+    let run_context = host.run_context().clone();
+    let host = host.with_input_batches(vec![
+        LoopInputBatch {
+            inputs: Vec::new(),
+            input_acks: Vec::new(),
+            next_cursor: input_cursor(&run_context, "input-cursor:no-input"),
+        },
+        LoopInputBatch {
+            inputs: vec![LoopInput::FollowUp {
+                message_ref: message_ref("msg:follow-up"),
+            }],
+            input_acks: vec![input_ack(
+                &run_context,
+                "input-cursor:after-follow-up",
+                "input-ack:after-follow-up",
+            )],
+            next_cursor: input_cursor(&run_context, "input-cursor:after-follow-up"),
+        },
+    ]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
+    assert_eq!(host.model_requests().len(), 2);
+    assert_eq!(
+        host.acked_input_tokens(),
+        vec![LoopInputAckToken::new("input-ack:after-follow-up").expect("valid")]
+    );
+    assert_eq!(
+        host.checkpoint_kinds(),
+        vec![
+            LoopCheckpointKind::BeforeModel,
+            LoopCheckpointKind::BeforeModel,
+            LoopCheckpointKind::Final,
+        ]
+    );
+    assert_eq!(final_staged_state(&host).stop_state.turns_completed, 2);
+}
+
+#[tokio::test]
+async fn reply_only_uses_configured_stop_strategy_decision() {
+    let host = MockHost::new(vec![reply_response(), reply_response()]);
+    let family = family_with_stop_after_observed_turns(2);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&family, &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
+    assert_eq!(host.model_requests().len(), 2);
+    assert_eq!(
+        host.checkpoint_kinds(),
+        vec![
+            LoopCheckpointKind::BeforeModel,
+            LoopCheckpointKind::BeforeModel,
+            LoopCheckpointKind::Final,
+        ]
+    );
+    assert_eq!(final_staged_state(&host).stop_state.turns_completed, 2);
+}
+
+#[tokio::test]
 async fn budget_stage_exits_at_iteration_limit() {
     let host = MockHost::new(Vec::new());
     let family = crate::families::default();

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -27,11 +27,12 @@ use ironclaw_turns::{
 use crate::{
     default_planner::DefaultPlanner,
     family::{ComponentDigest, ComponentIdentity, LoopFamily, LoopFamilyId},
-    state::{CheckpointKind, GateStrategyState, LoopExecutionState},
+    state::{CheckpointKind, GateStrategyState, LoopExecutionState, StopStrategyState},
     strategies::{
         CapabilityErrorClass, CapabilityErrorSummary, CapabilityFilter, CapabilityStrategy,
         GateHandlingStrategy, GateOutcome, GateSummary, InputDrainStrategy, ModelErrorSummary,
-        RecoveryOutcome, RecoveryStrategy, RetryScope,
+        RecoveryOutcome, RecoveryStrategy, RetryScope, StopConditionStrategy, StopKind,
+        StopOutcome, TurnSummary,
     },
 };
 
@@ -282,6 +283,38 @@ pub(super) struct FixedGateStrategy {
 impl GateHandlingStrategy for FixedGateStrategy {
     async fn handle(&self, _state: &LoopExecutionState, _gate: &GateSummary) -> GateOutcome {
         self.outcome.clone()
+    }
+}
+
+pub(super) struct StopAfterObservedTurns {
+    turns_completed: u32,
+}
+
+#[async_trait]
+impl StopConditionStrategy for StopAfterObservedTurns {
+    async fn observe_completed_turn(
+        &self,
+        state: &LoopExecutionState,
+        _just_completed: &TurnSummary,
+    ) -> StopStrategyState {
+        StopStrategyState {
+            turns_completed: state.stop_state.turns_completed.saturating_add(1),
+            ..state.stop_state.clone()
+        }
+    }
+
+    async fn should_stop_after_observed_turn(
+        &self,
+        state: &LoopExecutionState,
+        _just_completed: &TurnSummary,
+    ) -> StopOutcome {
+        if state.stop_state.turns_completed >= self.turns_completed {
+            StopOutcome::Stop {
+                kind: StopKind::GracefulStop,
+            }
+        } else {
+            StopOutcome::Continue {}
+        }
     }
 }
 
@@ -815,6 +848,14 @@ pub(super) fn family_with_gate_outcome(outcome: GateOutcome) -> LoopFamily {
         DefaultPlanner::compose_default().with_gate(Arc::new(FixedGateStrategy { outcome }));
     let id = LoopFamilyId::new("executor-gate-test").expect("valid test family id");
     let version = ComponentIdentity::from_static("executor-gate-test", ComponentDigest([4; 32]));
+    LoopFamily::new(id, version, Arc::new(planner))
+}
+
+pub(super) fn family_with_stop_after_observed_turns(turns_completed: u32) -> LoopFamily {
+    let planner = DefaultPlanner::compose_default()
+        .with_stop(Arc::new(StopAfterObservedTurns { turns_completed }));
+    let id = LoopFamilyId::new("executor-stop-test").expect("valid test family id");
+    let version = ComponentIdentity::from_static("executor-stop-test", ComponentDigest([5; 32]));
     LoopFamily::new(id, version, Arc::new(planner))
 }
 

--- a/crates/ironclaw_agent_loop/src/executor/turn_stop.rs
+++ b/crates/ironclaw_agent_loop/src/executor/turn_stop.rs
@@ -11,6 +11,11 @@ use super::{
     StageContext,
 };
 
+/// Stop-stage helper for callers that can observe and decide back-to-back.
+///
+/// Reply-only executor paths that need to drain queued follow-up input before
+/// the terminal stop decision must call `observe`, perform the drain, then
+/// call `decide` instead of using the combined `process` entry point.
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct StopStage;
 
@@ -110,6 +115,8 @@ impl StopStage {
     ) -> Result<StopStep, AgentLoopExecutorError> {
         let mut state = input.state;
         let pending_input_ack = input.pending_input_ack;
+        // `decide` is also a cancellation boundary for callers that split
+        // observation from the terminal decision.
         match ctx
             .planner
             .stop()

--- a/crates/ironclaw_agent_loop/src/executor/turn_stop.rs
+++ b/crates/ironclaw_agent_loop/src/executor/turn_stop.rs
@@ -20,6 +20,19 @@ pub(super) struct StopInput {
     pub(super) pending_input_ack: PendingInputAck,
 }
 
+pub(super) struct StopObservationInput {
+    pub(super) state: LoopExecutionState,
+    pub(super) summary: TurnSummary,
+}
+
+pub(super) enum StopObservationStep {
+    Continue {
+        state: Box<LoopExecutionState>,
+        summary: TurnSummary,
+    },
+    Exit(LoopExit),
+}
+
 pub(super) enum StopStep {
     Continue {
         state: LoopExecutionState,
@@ -42,16 +55,68 @@ impl ExecutorStage<StopInput> for StopStage {
         ctx: StageContext<'_>,
         input: StopInput,
     ) -> Result<StopStep, AgentLoopExecutorError> {
+        match self
+            .observe(
+                ctx,
+                StopObservationInput {
+                    state: input.state,
+                    summary: input.summary,
+                },
+            )
+            .await?
+        {
+            StopObservationStep::Continue { state, summary } => {
+                self.decide(
+                    ctx,
+                    StopInput {
+                        state: *state,
+                        summary,
+                        pending_input_ack: input.pending_input_ack,
+                    },
+                )
+                .await
+            }
+            StopObservationStep::Exit(exit) => Ok(StopStep::Exit(exit)),
+        }
+    }
+}
+
+impl StopStage {
+    pub(super) async fn observe(
+        &self,
+        ctx: StageContext<'_>,
+        input: StopObservationInput,
+    ) -> Result<StopObservationStep, AgentLoopExecutorError> {
+        let mut state = input.state;
+        state.stop_state = ctx
+            .planner
+            .stop()
+            .observe_completed_turn(&state, &input.summary)
+            .await;
+        state = match CheckpointStage.cancel_if_requested(ctx, state).await? {
+            CancelCheck::Continue(state) => *state,
+            CancelCheck::Exit(exit) => return Ok(StopObservationStep::Exit(exit)),
+        };
+        Ok(StopObservationStep::Continue {
+            state: Box::new(state),
+            summary: input.summary,
+        })
+    }
+
+    pub(super) async fn decide(
+        &self,
+        ctx: StageContext<'_>,
+        input: StopInput,
+    ) -> Result<StopStep, AgentLoopExecutorError> {
         let mut state = input.state;
         let pending_input_ack = input.pending_input_ack;
         match ctx
             .planner
             .stop()
-            .should_stop_after_turn(&state, &input.summary)
+            .should_stop_after_observed_turn(&state, &input.summary)
             .await
         {
-            StopOutcome::Stop { stop, kind } => {
-                state.stop_state = stop;
+            StopOutcome::Stop { kind } => {
                 state = match CheckpointStage.cancel_if_requested(ctx, state).await? {
                     CancelCheck::Continue(state) => *state,
                     CancelCheck::Exit(exit) => return Ok(StopStep::Exit(exit)),
@@ -62,8 +127,7 @@ impl ExecutorStage<StopInput> for StopStage {
                     pending_input_ack,
                 })
             }
-            StopOutcome::Continue { stop } => {
-                state.stop_state = stop;
+            StopOutcome::Continue {} => {
                 state = match CheckpointStage.cancel_if_requested(ctx, state).await? {
                     CancelCheck::Continue(state) => *state,
                     CancelCheck::Exit(exit) => return Ok(StopStep::Exit(exit)),

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -1,8 +1,9 @@
 //! Strategy trait contracts for the Reborn agent loop.
 //!
-//! Each strategy receives `&LoopExecutionState` and returns an outcome enum
-//! that carries the new value of its own slot. The executor swaps the slot
-//! into the next whole state.
+//! Most strategies receive `&LoopExecutionState` and return an outcome enum
+//! that carries the new value of their own slot. Stop handling is split into
+//! completed-turn observation, which updates `stop_state`, and terminal
+//! decision, which is state-read-only.
 //!
 //! Checkpoint/observability wire enums are `#[non_exhaustive]`; later
 //! changes should extend them without forcing consumers to assume the current
@@ -64,12 +65,10 @@ mod tests {
     };
 
     use super::*;
-    use crate::state::{
-        GateStrategyState, LoopExecutionState, RecoveryStrategyState, StopStrategyState,
-    };
+    use crate::state::{GateStrategyState, LoopExecutionState, RecoveryStrategyState};
 
     #[test]
-    fn strategy_outcomes_compose_through_loop_state_slots() {
+    fn strategy_outcomes_compose_through_owned_loop_state_slots() {
         let state = LoopExecutionState::initial_for_run(&test_run_context());
 
         let gate_outcome = GateOutcome::Block {
@@ -84,11 +83,6 @@ mod tests {
             alter: Some(RetryAlteration::ShrinkContext { drop_messages: 1 }),
         };
         let stop_outcome = StopOutcome::Stop {
-            stop: StopStrategyState {
-                turns_completed: 1,
-                terminate_hints_in_last_batch: 1,
-                last_batch_total: 1,
-            },
             kind: StopKind::NoProgressDetected,
         };
 
@@ -99,9 +93,8 @@ mod tests {
         if let RecoveryOutcome::Retry { recovery, .. } = recovery_outcome {
             next_state.recovery_state = recovery;
         }
-        if let StopOutcome::Stop { stop, kind } = stop_outcome {
+        if let StopOutcome::Stop { kind } = stop_outcome {
             assert_eq!(kind, StopKind::NoProgressDetected);
-            next_state.stop_state = stop;
         }
 
         let value = serde_json::to_value(&next_state).expect("serialize loop state");
@@ -109,7 +102,7 @@ mod tests {
             value["recovery_state"]["attempts_by_class"]["model_transient"],
             2
         );
-        assert_eq!(value["stop_state"]["turns_completed"], 1);
+        assert_eq!(value["stop_state"]["turns_completed"], 0);
         assert_eq!(value["gate_state"], serde_json::json!({}));
 
         let restored: LoopExecutionState =
@@ -121,14 +114,7 @@ mod tests {
                 2,
             )
         );
-        assert_eq!(
-            restored.stop_state,
-            StopStrategyState {
-                turns_completed: 1,
-                terminate_hints_in_last_batch: 1,
-                last_batch_total: 1,
-            }
-        );
+        assert_eq!(restored.stop_state, Default::default());
         assert_eq!(restored.gate_state, GateStrategyState::default());
     }
 

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -5,14 +5,24 @@ use ironclaw_turns::{LoopFailureKind, LoopMessageRef, LoopResultRef};
 
 use crate::state::{LoopExecutionState, StopStrategyState};
 
-/// Decides whether the loop should stop after the current turn finishes.
+/// Observes completed turns and decides whether the loop should stop.
 ///
-/// Implementations return a new `stop_state` slot value. Async because
-/// future strategies may consult host state for milestone tracking.
+/// Observation and terminal decision are split so the executor can always
+/// account for a completed turn before any follow-up input preempts final exit.
+/// Async because future strategies may consult host state for milestone
+/// tracking.
 #[async_trait]
 pub(crate) trait StopConditionStrategy: Send + Sync {
-    /// Called after a turn completes.
-    async fn should_stop_after_turn(
+    /// Called exactly once after a turn completes to update resumable stop
+    /// state.
+    async fn observe_completed_turn(
+        &self,
+        state: &LoopExecutionState,
+        just_completed: &TurnSummary,
+    ) -> StopStrategyState;
+
+    /// Called after `observe_completed_turn` has been applied to `state`.
+    async fn should_stop_after_observed_turn(
         &self,
         state: &LoopExecutionState,
         just_completed: &TurnSummary,
@@ -62,20 +72,14 @@ pub(crate) enum TurnEndKind {
     AfterCapabilityBatch,
 }
 
-/// Strategy decision plus the new `stop_state` slot value.
+/// Strategy decision after completed-turn observation has already updated
+/// `stop_state`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum StopOutcome {
-    Continue {
-        stop: StopStrategyState,
-    },
-    /// Carries the final stop slot for checkpoint, observability, and final
-    /// state assembly even though no later strategy consumes it after exit.
-    Stop {
-        stop: StopStrategyState,
-        kind: StopKind,
-    },
+    Continue {},
+    Stop { kind: StopKind },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -92,19 +96,21 @@ pub(crate) enum StopKind {
     Aborted(LoopFailureKind),
 }
 
-/// Reference baseline `StopConditionStrategy`, including repetition and
-/// no-progress safety-net escapes:
+/// Reference baseline `StopConditionStrategy`, including normal completion,
+/// repetition, and no-progress safety-net escapes:
 ///
-/// 1. **Graceful terminate-hint**: every result in the just-completed batch
+/// 1. **Reply completion**: a reply-only turn means the model returned its
+///    assistant answer → `Stop { GracefulStop }`.
+/// 2. **Graceful terminate-hint**: every result in the just-completed batch
 ///    asked to terminate → `Stop { GracefulStop }`.
-/// 2. **Repetition escape**: the same `CapabilityCallSignature` is observed
+/// 3. **Repetition escape**: the same `CapabilityCallSignature` is observed
 ///    in `repetition_threshold` (default 3) of the last `repetition_window`
 ///    (default 5) iterations → `Stop { NoProgressDetected }`.
-/// 3. **Failure-run escape**: the same `LoopFailureKind` appears
+/// 4. **Failure-run escape**: the same `LoopFailureKind` appears
 ///    `failure_run_threshold` (default 3) times in a row →
 ///    `Stop { NoProgressDetected }`.
 ///
-/// On no signal, returns `Continue` with `turns_completed += 1`.
+/// On no signal, returns `Continue`.
 #[derive(Debug, Clone, Copy)]
 pub struct DefaultStopConditionStrategy {
     /// Window size for the "same call signature ≥ N times" check.
@@ -128,31 +134,45 @@ impl Default for DefaultStopConditionStrategy {
 
 #[async_trait]
 impl StopConditionStrategy for DefaultStopConditionStrategy {
-    async fn should_stop_after_turn(
+    async fn observe_completed_turn(
+        &self,
+        state: &LoopExecutionState,
+        _just_completed: &TurnSummary,
+    ) -> StopStrategyState {
+        // Bump `turns_completed` regardless of stop/continue — every
+        // completed turn counts.
+        StopStrategyState {
+            turns_completed: state.stop_state.turns_completed.saturating_add(1),
+            ..state.stop_state.clone()
+        }
+    }
+
+    async fn should_stop_after_observed_turn(
         &self,
         state: &LoopExecutionState,
         just_completed: &TurnSummary,
     ) -> StopOutcome {
-        // Bump `turns_completed` regardless of stop/continue — every
-        // completed turn counts.
-        let next = StopStrategyState {
-            turns_completed: state.stop_state.turns_completed.saturating_add(1),
-            ..state.stop_state.clone()
-        };
+        // (a) reply completion: the executor already drained queued follow-up
+        // input before asking the stop strategy, so a reply-only turn is
+        // terminal for the default family.
+        if just_completed.kind == TurnEndKind::ReplyOnly {
+            return StopOutcome::Stop {
+                kind: StopKind::GracefulStop,
+            };
+        }
 
-        // (a) graceful terminate-hint: every result in the just-completed
+        // (b) graceful terminate-hint: every result in the just-completed
         // batch said terminate.
         if just_completed.kind == TurnEndKind::AfterCapabilityBatch
             && state.stop_state.last_batch_total > 0
             && state.stop_state.terminate_hints_in_last_batch == state.stop_state.last_batch_total
         {
             return StopOutcome::Stop {
-                stop: next,
                 kind: StopKind::GracefulStop,
             };
         }
 
-        // (b) repetition escape — same call signature observed in
+        // (c) repetition escape — same call signature observed in
         // `repetition_threshold` of the last `repetition_window` iterations.
         if state
             .recent_call_signatures
@@ -160,20 +180,18 @@ impl StopConditionStrategy for DefaultStopConditionStrategy {
             >= self.repetition_threshold
         {
             return StopOutcome::Stop {
-                stop: next,
                 kind: StopKind::NoProgressDetected,
             };
         }
 
-        // (c) failure-run escape — same failure kind ≥ threshold in a row.
+        // (d) failure-run escape — same failure kind ≥ threshold in a row.
         if state.recent_failure_kinds.same_run_length() >= self.failure_run_threshold {
             return StopOutcome::Stop {
-                stop: next,
                 kind: StopKind::NoProgressDetected,
             };
         }
 
-        StopOutcome::Continue { stop: next }
+        StopOutcome::Continue {}
     }
 }
 
@@ -191,14 +209,20 @@ mod tests {
 
         #[async_trait]
         impl StopConditionStrategy for AlwaysContinue {
-            async fn should_stop_after_turn(
+            async fn observe_completed_turn(
                 &self,
-                _: &LoopExecutionState,
+                state: &LoopExecutionState,
+                _: &TurnSummary,
+            ) -> StopStrategyState {
+                state.stop_state.clone()
+            }
+
+            async fn should_stop_after_observed_turn(
+                &self,
+                _state: &LoopExecutionState,
                 _: &TurnSummary,
             ) -> StopOutcome {
-                StopOutcome::Continue {
-                    stop: StopStrategyState::default(),
-                }
+                StopOutcome::Continue {}
             }
         }
 
@@ -225,11 +249,6 @@ mod tests {
     #[test]
     fn stop_outcome_round_trips_through_json() {
         let outcome = StopOutcome::Stop {
-            stop: StopStrategyState {
-                turns_completed: 3,
-                terminate_hints_in_last_batch: 1,
-                last_batch_total: 2,
-            },
             kind: StopKind::NoProgressDetected,
         };
 
@@ -247,9 +266,7 @@ mod tests {
         let deserialized = serde_json::from_value::<StopOutcome>(value).unwrap();
         assert_eq!(deserialized, outcome);
 
-        let continue_outcome = StopOutcome::Continue {
-            stop: StopStrategyState::default(),
-        };
+        let continue_outcome = StopOutcome::Continue {};
         let continue_value = serde_json::to_value(&continue_outcome).unwrap();
         assert!(
             continue_value.get("continue").is_some(),
@@ -381,6 +398,18 @@ mod tests {
             }
         }
 
+        async fn observe_and_decide(
+            strategy: &DefaultStopConditionStrategy,
+            mut state: LoopExecutionState,
+            summary: TurnSummary,
+        ) -> (LoopExecutionState, StopOutcome) {
+            state.stop_state = strategy.observe_completed_turn(&state, &summary).await;
+            let outcome = strategy
+                .should_stop_after_observed_turn(&state, &summary)
+                .await;
+            (state, outcome)
+        }
+
         #[test]
         fn defaults_match_documented_baseline() {
             let strategy = DefaultStopConditionStrategy::default();
@@ -399,16 +428,10 @@ mod tests {
                 last_batch_total: 0,
             };
 
-            let outcome = strategy
-                .should_stop_after_turn(&state, &after_batch())
-                .await;
+            let (state, outcome) = observe_and_decide(&strategy, state, after_batch()).await;
 
-            match outcome {
-                StopOutcome::Continue { stop } => {
-                    assert_eq!(stop.turns_completed, 5);
-                }
-                other => panic!("expected Continue, got {other:?}"),
-            }
+            assert_eq!(state.stop_state.turns_completed, 5);
+            assert!(matches!(outcome, StopOutcome::Continue { .. }));
         }
 
         #[tokio::test]
@@ -421,13 +444,38 @@ mod tests {
                 last_batch_total: 3,
             };
 
-            let outcome = strategy
-                .should_stop_after_turn(&state, &after_batch())
-                .await;
+            let (state, outcome) = observe_and_decide(&strategy, state, after_batch()).await;
 
             match outcome {
-                StopOutcome::Stop { stop, kind } => {
-                    assert_eq!(stop.turns_completed, 2);
+                StopOutcome::Stop { kind } => {
+                    assert_eq!(state.stop_state.turns_completed, 2);
+                    assert_eq!(kind, StopKind::GracefulStop);
+                }
+                other => panic!("expected Stop GracefulStop, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn reply_only_returns_graceful_stop() {
+            let strategy = DefaultStopConditionStrategy::default();
+            let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+            let (state, outcome) = observe_and_decide(
+                &strategy,
+                state,
+                TurnSummary {
+                    kind: TurnEndKind::ReplyOnly,
+                    assistant_message_ref: Some(
+                        LoopMessageRef::new("msg:default-stop").expect("valid"),
+                    ),
+                    batch_result_refs: Vec::new(),
+                },
+            )
+            .await;
+
+            match outcome {
+                StopOutcome::Stop { kind } => {
+                    assert_eq!(state.stop_state.turns_completed, 1);
                     assert_eq!(kind, StopKind::GracefulStop);
                 }
                 other => panic!("expected Stop GracefulStop, got {other:?}"),
@@ -446,16 +494,16 @@ mod tests {
                 last_batch_total: 0,
             };
 
-            let outcome = strategy
-                .should_stop_after_turn(
-                    &state,
-                    &TurnSummary {
-                        kind: TurnEndKind::ReplyOnly,
-                        assistant_message_ref: None,
-                        batch_result_refs: Vec::new(),
-                    },
-                )
-                .await;
+            let (_state, outcome) = observe_and_decide(
+                &strategy,
+                state,
+                TurnSummary {
+                    kind: TurnEndKind::AfterCapabilityBatch,
+                    assistant_message_ref: None,
+                    batch_result_refs: Vec::new(),
+                },
+            )
+            .await;
 
             assert!(matches!(outcome, StopOutcome::Continue { .. }));
         }
@@ -473,15 +521,12 @@ mod tests {
                 state.recent_call_signatures.push(signature.clone());
             }
 
-            let outcome = strategy
-                .should_stop_after_turn(&state, &after_batch())
-                .await;
+            let (_state, outcome) = observe_and_decide(&strategy, state, after_batch()).await;
 
             assert!(matches!(
                 outcome,
                 StopOutcome::Stop {
-                    kind: StopKind::NoProgressDetected,
-                    ..
+                    kind: StopKind::NoProgressDetected
                 }
             ));
         }
@@ -494,15 +539,12 @@ mod tests {
                 state.recent_failure_kinds.push(LoopFailureKind::ModelError);
             }
 
-            let outcome = strategy
-                .should_stop_after_turn(&state, &after_batch())
-                .await;
+            let (_state, outcome) = observe_and_decide(&strategy, state, after_batch()).await;
 
             assert!(matches!(
                 outcome,
                 StopOutcome::Stop {
-                    kind: StopKind::NoProgressDetected,
-                    ..
+                    kind: StopKind::NoProgressDetected
                 }
             ));
         }


### PR DESCRIPTION
## Summary

- route reply-only turn completion through the existing stop strategy instead of a canonical executor bypass
- preserve queued follow-up draining before the stop decision
- add caller-level and strategy coverage for reply-only graceful stop behavior

## Root Cause

Reply-only model output had a separate completion branch in the canonical executor, so the most common terminal path bypassed `StopConditionStrategy`. That split task completion across two layers and made later completion policy harder to land cleanly.

## Validation

- `cargo test -p ironclaw_agent_loop`
- `cargo clippy -p ironclaw_agent_loop --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_reborn_composition send_user_message_returns_completed_assistant_text_with_recording_gateway -- --nocapture`
- `cargo test -p ironclaw_reborn_cli run_message_exits_nonzero_when_runtime_does_not_produce_reply -- --nocapture`
- `git diff --check`