### PR TITLE
fix(reborn): type prompt text validation surfaces

### DIFF
--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -77,7 +77,6 @@ pub struct RebornOAuthCallbackRequest {
 /// product-auth semantics stay here with the auth service boundary.
 #[allow(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code, reason = "used by upcoming Reborn OAuth setup route wiring")]
 pub(crate) struct RebornOAuthStartFlowRequest {
     pub(crate) scope: AuthProductScope,
     pub(crate) provider: AuthProviderId,

--- a/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
+++ b/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
@@ -12,14 +12,13 @@ use sha2::{Digest, Sha256};
 use crate::LoopMessageRef;
 
 use super::{
-    AgentLoopHostError, AgentLoopHostErrorKind, CapabilityDescriptorView,
-    LOOP_CONTEXT_SNIPPET_MODEL_CONTENT_MAX_BYTES, LoopContextBundle, LoopContextMessage,
-    LoopContextSnippet, LoopInlineMessage, LoopInlineMessageRole, LoopModelMessage, LoopRunContext,
-    PromptSkillContextMetadata, VisibleCapabilitySurface, skill_snippet_model_message_ref,
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilityDescriptorView, LoopContextBundle,
+    LoopContextMessage, LoopContextSnippet, LoopInlineMessage, LoopInlineMessageRole,
+    LoopModelMessage, LoopRunContext, PromptSkillContextMetadata, SkillTrustLevel,
+    VisibleCapabilitySurface,
+    prompt_text::{PromptTextSurface, validate_model_safe_text, validate_prompt_text},
+    skill_snippet_model_message_ref,
 };
-
-const MODEL_SAFE_SUMMARY_MAX_BYTES: usize = 4096;
-
 /// Stable fingerprint for an instruction bundle rebuild.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InstructionBundleFingerprint(String);
@@ -463,8 +462,11 @@ fn push_snippet_message(
                     "instruction bundle rejected context snippet safe summary"
                 );
             })?;
-    let model_content =
-        validate_model_visible_content(snippet.model_content.clone(), "context snippet content")?;
+    let model_content = validate_prompt_text(
+        snippet.model_content.clone(),
+        "context snippet content",
+        snippet_model_content_surface(section, snippet),
+    )?;
     feed_field(fingerprint, b"section", section.as_bytes());
     feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
     feed_field(fingerprint, b"source", snippet.snippet_ref.as_bytes());
@@ -480,6 +482,18 @@ fn push_snippet_message(
         content_ref,
     });
     Ok(())
+}
+
+fn snippet_model_content_surface(
+    section: &'static str,
+    snippet: &LoopContextSnippet,
+) -> PromptTextSurface {
+    match (section, snippet.metadata.as_ref()) {
+        ("skill", Some(metadata)) if metadata.trust_level == SkillTrustLevel::Trusted.as_str() => {
+            PromptTextSurface::TrustedSkillInstruction
+        }
+        _ => PromptTextSurface::GenericModelContent,
+    }
 }
 
 fn push_safety_context(
@@ -774,136 +788,8 @@ fn validate_context_ref(value: String, label: &'static str) -> Result<String, Ag
             format!("{label} is not model-safe"),
         ));
     }
-    reject_sensitive_text(&value, label)?;
+    validate_prompt_text(value.clone(), label, PromptTextSurface::SafeSummary)?;
     Ok(value)
-}
-
-fn validate_model_safe_text(
-    value: String,
-    label: &'static str,
-) -> Result<String, AgentLoopHostError> {
-    validate_model_text_with_limit(value, label, MODEL_SAFE_SUMMARY_MAX_BYTES, true)
-}
-
-fn validate_model_visible_content(
-    value: String,
-    label: &'static str,
-) -> Result<String, AgentLoopHostError> {
-    validate_model_text_with_limit(
-        value,
-        label,
-        LOOP_CONTEXT_SNIPPET_MODEL_CONTENT_MAX_BYTES,
-        false,
-    )
-}
-
-fn validate_model_text_with_limit(
-    value: String,
-    label: &'static str,
-    max_bytes: usize,
-    reject_sensitive: bool,
-) -> Result<String, AgentLoopHostError> {
-    if value.is_empty() || value.len() > max_bytes {
-        return Err(AgentLoopHostError::new(
-            AgentLoopHostErrorKind::PolicyDenied,
-            format!("{label} is not model-safe"),
-        ));
-    }
-    if value
-        .chars()
-        .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
-    {
-        return Err(AgentLoopHostError::new(
-            AgentLoopHostErrorKind::PolicyDenied,
-            format!("{label} contains control characters"),
-        ));
-    }
-    if reject_sensitive {
-        reject_sensitive_text(&value, label)?;
-    }
-    Ok(value)
-}
-
-fn reject_sensitive_text(value: &str, label: &'static str) -> Result<(), AgentLoopHostError> {
-    let lower = value.to_ascii_lowercase();
-    for forbidden_path in [
-        "/users/",
-        "/home/",
-        "/private/",
-        "/tmp/", // safety: model-safety denylist literal, not a filesystem temp path.
-        "/var/",
-        "/etc/",
-    ] {
-        if lower.contains(forbidden_path) {
-            return Err(AgentLoopHostError::new(
-                AgentLoopHostErrorKind::PolicyDenied,
-                format!("{label} contains non-model-safe content"),
-            ));
-        }
-    }
-    for forbidden_phrase in [
-        "access token",
-        "api key",
-        "api_key",
-        "api secret",
-        "authorization",
-        "bearer",
-        "client secret",
-        "invalid api key",
-        "password",
-        "passwd",
-        "secret key",
-        "secret-key",
-        "secret token",
-        "secret_token",
-        "shared secret",
-    ] {
-        if contains_token_phrase(&lower, forbidden_phrase) {
-            return Err(AgentLoopHostError::new(
-                AgentLoopHostErrorKind::PolicyDenied,
-                format!("{label} contains non-model-safe content"),
-            ));
-        }
-    }
-    if lower
-        .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
-        .any(|token| token.starts_with("sk-"))
-    {
-        return Err(AgentLoopHostError::new(
-            AgentLoopHostErrorKind::PolicyDenied,
-            format!("{label} contains non-model-safe content"),
-        ));
-    }
-    Ok(())
-}
-
-fn contains_token_phrase(value: &str, phrase: &str) -> bool {
-    value.match_indices(phrase).any(|(start, matched)| {
-        let end = start + matched.len();
-        is_token_boundary(char_before(value, start)) && is_token_boundary(char_at(value, end))
-    })
-}
-
-fn char_before(value: &str, byte_index: usize) -> Option<char> {
-    value
-        .char_indices()
-        .take_while(|(index, _)| *index < byte_index)
-        .last()
-        .map(|(_, character)| character)
-}
-
-fn char_at(value: &str, byte_index: usize) -> Option<char> {
-    value
-        .char_indices()
-        .find(|(index, _)| *index == byte_index)
-        .map(|(_, character)| character)
-}
-
-fn is_token_boundary(character: Option<char>) -> bool {
-    match character {
-        Some(character) => !character.is_ascii_alphanumeric() && character != '_',
-        None => true,
-    }
 }
 
 fn sanitize_ref_suffix(value: &str) -> String {

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -16,6 +16,7 @@ mod milestones;
 mod model;
 mod policy;
 mod prompt;
+mod prompt_text;
 mod refs;
 mod resolver;
 mod skill_context;

--- a/crates/ironclaw_turns/src/run_profile/prompt_text.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt_text.rs
@@ -1,0 +1,144 @@
+use super::{
+    AgentLoopHostError, AgentLoopHostErrorKind, LOOP_CONTEXT_SNIPPET_MODEL_CONTENT_MAX_BYTES,
+};
+
+const MODEL_SAFE_SUMMARY_MAX_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PromptTextSurface {
+    SafeSummary,
+    GenericModelContent,
+    TrustedSkillInstruction,
+}
+
+impl PromptTextSurface {
+    const fn max_bytes(self) -> usize {
+        match self {
+            Self::SafeSummary => MODEL_SAFE_SUMMARY_MAX_BYTES,
+            Self::GenericModelContent | Self::TrustedSkillInstruction => {
+                LOOP_CONTEXT_SNIPPET_MODEL_CONTENT_MAX_BYTES
+            }
+        }
+    }
+
+    const fn allows_security_vocabulary(self) -> bool {
+        matches!(self, Self::TrustedSkillInstruction)
+    }
+}
+
+pub(super) fn validate_model_safe_text(
+    value: String,
+    label: &'static str,
+) -> Result<String, AgentLoopHostError> {
+    validate_prompt_text(value, label, PromptTextSurface::SafeSummary)
+}
+
+pub(super) fn validate_prompt_text(
+    value: String,
+    label: &'static str,
+    surface: PromptTextSurface,
+) -> Result<String, AgentLoopHostError> {
+    if value.is_empty() || value.len() > surface.max_bytes() {
+        return Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::PolicyDenied,
+            format!("{label} is not model-safe"),
+        ));
+    }
+    if value
+        .chars()
+        .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
+    {
+        return Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::PolicyDenied,
+            format!("{label} contains control characters"),
+        ));
+    }
+    reject_sensitive_text(&value, label, surface)?;
+    Ok(value)
+}
+
+fn reject_sensitive_text(
+    value: &str,
+    label: &'static str,
+    surface: PromptTextSurface,
+) -> Result<(), AgentLoopHostError> {
+    let lower = value.to_ascii_lowercase();
+    for forbidden_path in [
+        "/users/",
+        "/home/",
+        "/private/",
+        "/tmp/", // safety: model-safety denylist literal, not a filesystem temp path.
+        "/var/",
+        "/etc/",
+    ] {
+        if lower.contains(forbidden_path) {
+            return non_model_safe(label);
+        }
+    }
+    if !surface.allows_security_vocabulary() {
+        for forbidden_phrase in [
+            "access token",
+            "api key",
+            "api_key",
+            "api secret",
+            "authorization",
+            "bearer",
+            "client secret",
+            "invalid api key",
+            "password",
+            "passwd",
+            "secret key",
+            "secret-key",
+            "secret token",
+            "secret_token",
+            "shared secret",
+        ] {
+            if contains_token_phrase(&lower, forbidden_phrase) {
+                return non_model_safe(label);
+            }
+        }
+    }
+    if lower
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
+        .any(|token| token.starts_with("sk-"))
+    {
+        return non_model_safe(label);
+    }
+    Ok(())
+}
+
+fn non_model_safe<T>(label: &'static str) -> Result<T, AgentLoopHostError> {
+    Err(AgentLoopHostError::new(
+        AgentLoopHostErrorKind::PolicyDenied,
+        format!("{label} contains non-model-safe content"),
+    ))
+}
+
+fn contains_token_phrase(value: &str, phrase: &str) -> bool {
+    value.match_indices(phrase).any(|(start, matched)| {
+        let end = start + matched.len();
+        is_token_boundary(char_before(value, start)) && is_token_boundary(char_at(value, end))
+    })
+}
+
+fn char_before(value: &str, byte_index: usize) -> Option<char> {
+    value
+        .char_indices()
+        .take_while(|(index, _)| *index < byte_index)
+        .last()
+        .map(|(_, character)| character)
+}
+
+fn char_at(value: &str, byte_index: usize) -> Option<char> {
+    value
+        .char_indices()
+        .find(|(index, _)| *index == byte_index)
+        .map(|(_, character)| character)
+}
+
+fn is_token_boundary(character: Option<char>) -> bool {
+    match character {
+        Some(character) => !character.is_ascii_alphanumeric() && character != '_',
+        None => true,
+    }
+}

--- a/crates/ironclaw_turns/src/run_profile/prompt_text.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt_text.rs
@@ -23,6 +23,8 @@ const SENSITIVE_TERMS: &[SensitiveTerm] = &[
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SensitiveTerm {
+    /// Some terms, such as "invalid api key", are phrase-only so ordinary
+    /// diagnostic prose after the phrase is not parsed as a credential value.
     phrase: &'static str,
     reject_as_phrase: bool,
     reject_value_after_label: bool,
@@ -273,18 +275,11 @@ fn contains_token_phrase(value: &str, phrase: &str) -> bool {
 }
 
 fn char_before(value: &str, byte_index: usize) -> Option<char> {
-    value
-        .char_indices()
-        .take_while(|(index, _)| *index < byte_index)
-        .last()
-        .map(|(_, character)| character)
+    value.get(..byte_index)?.chars().next_back()
 }
 
 fn char_at(value: &str, byte_index: usize) -> Option<char> {
-    value
-        .char_indices()
-        .find(|(index, _)| *index == byte_index)
-        .map(|(_, character)| character)
+    value.get(byte_index..)?.chars().next()
 }
 
 fn is_token_boundary(character: Option<char>) -> bool {

--- a/crates/ironclaw_turns/src/run_profile/prompt_text.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt_text.rs
@@ -3,6 +3,47 @@ use super::{
 };
 
 const MODEL_SAFE_SUMMARY_MAX_BYTES: usize = 4096;
+const SENSITIVE_TERMS: &[SensitiveTerm] = &[
+    sensitive_term("access token", true, true),
+    sensitive_term("api key", true, true),
+    sensitive_term("api_key", true, true),
+    sensitive_term("api secret", true, true),
+    sensitive_term("authorization", true, true),
+    sensitive_term("bearer", true, true),
+    sensitive_term("client secret", true, true),
+    sensitive_term("invalid api key", true, false),
+    sensitive_term("password", true, true),
+    sensitive_term("passwd", true, true),
+    sensitive_term("secret key", true, true),
+    sensitive_term("secret-key", true, true),
+    sensitive_term("secret token", true, true),
+    sensitive_term("secret_token", true, true),
+    sensitive_term("shared secret", true, true),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SensitiveTerm {
+    phrase: &'static str,
+    reject_as_phrase: bool,
+    reject_value_after_label: bool,
+}
+
+const fn sensitive_term(
+    phrase: &'static str,
+    reject_as_phrase: bool,
+    reject_value_after_label: bool,
+) -> SensitiveTerm {
+    SensitiveTerm {
+        phrase,
+        reject_as_phrase,
+        reject_value_after_label,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PromptTextPolicy {
+    reject_security_vocabulary: bool,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PromptTextSurface {
@@ -21,8 +62,10 @@ impl PromptTextSurface {
         }
     }
 
-    const fn allows_security_vocabulary(self) -> bool {
-        matches!(self, Self::TrustedSkillInstruction)
+    const fn policy(self) -> PromptTextPolicy {
+        PromptTextPolicy {
+            reject_security_vocabulary: !matches!(self, Self::TrustedSkillInstruction),
+        }
     }
 }
 
@@ -63,6 +106,7 @@ fn reject_sensitive_text(
     surface: PromptTextSurface,
 ) -> Result<(), AgentLoopHostError> {
     let lower = value.to_ascii_lowercase();
+    let policy = surface.policy();
     for forbidden_path in [
         "/users/",
         "/home/",
@@ -75,27 +119,17 @@ fn reject_sensitive_text(
             return non_model_safe(label);
         }
     }
-    if !surface.allows_security_vocabulary() {
-        for forbidden_phrase in [
-            "access token",
-            "api key",
-            "api_key",
-            "api secret",
-            "authorization",
-            "bearer",
-            "client secret",
-            "invalid api key",
-            "password",
-            "passwd",
-            "secret key",
-            "secret-key",
-            "secret token",
-            "secret_token",
-            "shared secret",
-        ] {
-            if contains_token_phrase(&lower, forbidden_phrase) {
-                return non_model_safe(label);
-            }
+    for term in SENSITIVE_TERMS {
+        if policy.reject_security_vocabulary
+            && term.reject_as_phrase
+            && contains_token_phrase(&lower, term.phrase)
+        {
+            return non_model_safe(label);
+        }
+        if term.reject_value_after_label
+            && contains_credential_value_after_label(&lower, term.phrase)
+        {
+            return non_model_safe(label);
         }
     }
     if lower
@@ -107,6 +141,123 @@ fn reject_sensitive_text(
     Ok(())
 }
 
+fn contains_credential_value_after_label(value: &str, label: &str) -> bool {
+    value.match_indices(label).any(|(start, matched)| {
+        let end = start + matched.len();
+        if !is_token_boundary(char_before(value, start)) || !is_token_boundary(char_at(value, end))
+        {
+            return false;
+        }
+        let suffix = &value[end..];
+        credential_value_candidate(suffix).is_some_and(is_secret_like_token)
+            || (label == "authorization"
+                && authorization_scheme_value_candidate(suffix).is_some_and(is_secret_like_token))
+    })
+}
+
+fn credential_value_candidate(suffix: &str) -> Option<&str> {
+    credential_value_candidates(suffix).next()
+}
+
+fn authorization_scheme_value_candidate(suffix: &str) -> Option<&str> {
+    let mut candidates = credential_value_candidates(suffix);
+    let scheme = candidates.next()?;
+    is_authorization_scheme(scheme)
+        .then(|| candidates.next())
+        .flatten()
+}
+
+fn credential_value_candidates(suffix: &str) -> impl Iterator<Item = &str> {
+    suffix
+        .trim_start_matches(|character: char| {
+            character.is_ascii_whitespace() || matches!(character, ':' | '=' | '\'' | '"' | '`')
+        })
+        .split(|character: char| character.is_ascii_whitespace() || matches!(character, ',' | ';'))
+        .map(|candidate| {
+            candidate.trim_matches(|character| {
+                matches!(
+                    character,
+                    '\'' | '"'
+                        | '`'
+                        | '.'
+                        | ','
+                        | ';'
+                        | ':'
+                        | '('
+                        | ')'
+                        | '['
+                        | ']'
+                        | '{'
+                        | '}'
+                        | '<'
+                        | '>'
+                )
+            })
+        })
+        .filter(|candidate| !candidate.is_empty())
+}
+
+fn is_authorization_scheme(candidate: &str) -> bool {
+    ["basic", "bearer", "digest", "negotiate", "oauth", "token"].contains(&candidate)
+}
+
+fn is_secret_like_token(candidate: &str) -> bool {
+    if candidate.starts_with('$') {
+        return false;
+    }
+    if [
+        "token",
+        "secret",
+        "password",
+        "key",
+        "value",
+        "example",
+        "placeholder",
+        "redacted",
+        "your-token",
+        "your_token",
+        "api-key",
+        "api_key",
+        "bearer",
+    ]
+    .contains(&candidate)
+        || candidate.contains("redacted")
+        || candidate.contains("placeholder")
+        || candidate.contains("example")
+        || candidate.contains("...")
+    {
+        return false;
+    }
+    if [
+        "ghp_",
+        "github_pat_",
+        "glpat-",
+        "xoxb-",
+        "xoxp-",
+        "akia",
+        "asiai",
+        "sk-",
+        "pk_",
+    ]
+    .iter()
+    .any(|prefix| candidate.starts_with(prefix))
+    {
+        return true;
+    }
+    let contains_alpha = candidate
+        .chars()
+        .any(|character| character.is_ascii_alphabetic());
+    let contains_digit = candidate
+        .chars()
+        .any(|character| character.is_ascii_digit());
+    if candidate.len() >= 6 && contains_alpha && contains_digit {
+        return true;
+    }
+    candidate.len() >= 16
+        && candidate.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+        })
+}
 fn non_model_safe<T>(label: &'static str) -> Result<T, AgentLoopHostError> {
     Err(AgentLoopHostError::new(
         AgentLoopHostErrorKind::PolicyDenied,

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -815,6 +815,31 @@ async fn instruction_bundle_rejects_untrusted_skill_security_vocabulary() {
 }
 
 #[tokio::test]
+async fn instruction_bundle_rejects_generic_model_content_security_vocabulary() {
+    let context = claimed_run_context().await;
+    let error = InstructionBundleBuilder::new(context)
+        .build(InstructionBundleRequest {
+            context_bundle: LoopContextBundle {
+                identity_messages: Vec::new(),
+                messages: Vec::new(),
+                instruction_snippets: vec![LoopContextSnippet {
+                    snippet_ref: "instruction:system".to_string(),
+                    model_content: "Review authorization checks before release".to_string(),
+                    safe_summary: "Release review instruction".to_string(),
+                    metadata: None,
+                }],
+                memory_snippets: Vec::new(),
+            },
+            visible_surface: None,
+            safety_context: None,
+            inline_messages: Vec::new(),
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+}
+
+#[tokio::test]
 async fn instruction_bundle_rejects_trusted_skill_host_path() {
     let context = claimed_run_context().await;
     let error = InstructionBundleBuilder::new(context)

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -642,6 +642,32 @@ async fn instruction_bundle_materializes_oversized_snippet_content_separate_from
     }));
 }
 
+fn skill_instruction_request(
+    model_content: impl Into<String>,
+    safe_summary: impl Into<String>,
+    trust_level: &str,
+) -> InstructionBundleRequest {
+    InstructionBundleRequest {
+        context_bundle: LoopContextBundle {
+            identity_messages: Vec::new(),
+            messages: Vec::new(),
+            instruction_snippets: vec![LoopContextSnippet {
+                snippet_ref: "skill:github".to_string(),
+                model_content: model_content.into(),
+                safe_summary: safe_summary.into(),
+                metadata: Some(LoopContextSnippetMetadata {
+                    source_name: "github".to_string(),
+                    trust_level: trust_level.to_string(),
+                }),
+            }],
+            memory_snippets: Vec::new(),
+        },
+        visible_surface: None,
+        safety_context: None,
+        inline_messages: Vec::new(),
+    }
+}
+
 #[tokio::test]
 async fn instruction_bundle_rejects_empty_model_content() {
     let context = claimed_run_context().await;
@@ -716,25 +742,11 @@ async fn instruction_bundle_allows_security_vocabulary_in_model_content() {
     .to_string();
 
     let bundle = InstructionBundleBuilder::new(context)
-        .build(InstructionBundleRequest {
-            context_bundle: LoopContextBundle {
-                identity_messages: Vec::new(),
-                messages: Vec::new(),
-                instruction_snippets: vec![LoopContextSnippet {
-                    snippet_ref: "skill:security-review".to_string(),
-                    model_content: model_content.clone(),
-                    safe_summary: "Security review skill".to_string(),
-                    metadata: Some(LoopContextSnippetMetadata {
-                        source_name: "security-review".to_string(),
-                        trust_level: "trusted".to_string(),
-                    }),
-                }],
-                memory_snippets: Vec::new(),
-            },
-            visible_surface: None,
-            safety_context: None,
-            inline_messages: Vec::new(),
-        })
+        .build(skill_instruction_request(
+            model_content.clone(),
+            "Security review skill",
+            "trusted",
+        ))
         .unwrap();
 
     assert!(bundle.materialized_messages.iter().any(|message| {
@@ -742,8 +754,64 @@ async fn instruction_bundle_allows_security_vocabulary_in_model_content() {
             && message
                 .content_ref
                 .as_str()
-                .starts_with("msg:snippet.skill.security-review.")
+                .starts_with("msg:snippet.skill.github.")
     }));
+}
+
+#[tokio::test]
+async fn instruction_bundle_rejects_trusted_skill_actual_secret_value() {
+    let context = claimed_run_context().await;
+    let error = InstructionBundleBuilder::new(context)
+        .build(skill_instruction_request(
+            "Use Authorization: Bearer ghp_secretvalue123",
+            "GitHub skill",
+            "trusted",
+        ))
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+}
+
+#[tokio::test]
+async fn instruction_bundle_rejects_trusted_skill_security_vocabulary_in_summary() {
+    let context = claimed_run_context().await;
+    let error = InstructionBundleBuilder::new(context)
+        .build(skill_instruction_request(
+            "Use the GitHub API with an Authorization header.",
+            "Use Authorization: Bearer",
+            "trusted",
+        ))
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+}
+
+#[tokio::test]
+async fn instruction_bundle_rejects_untrusted_skill_security_vocabulary() {
+    let context = claimed_run_context().await;
+    let error = InstructionBundleBuilder::new(context)
+        .build(skill_instruction_request(
+            "Use the GitHub API with an Authorization: Bearer header.",
+            "GitHub skill",
+            "installed",
+        ))
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+}
+
+#[tokio::test]
+async fn instruction_bundle_rejects_trusted_skill_host_path() {
+    let context = claimed_run_context().await;
+    let error = InstructionBundleBuilder::new(context)
+        .build(skill_instruction_request(
+            "Read /Users/alice/.config/token before calling GitHub",
+            "GitHub skill",
+            "trusted",
+        ))
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -773,6 +773,20 @@ async fn instruction_bundle_rejects_trusted_skill_actual_secret_value() {
 }
 
 #[tokio::test]
+async fn instruction_bundle_rejects_trusted_skill_authorization_scheme_secret_value() {
+    let context = claimed_run_context().await;
+    let error = InstructionBundleBuilder::new(context)
+        .build(skill_instruction_request(
+            "Use Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZTEyMzQ",
+            "GitHub skill",
+            "trusted",
+        ))
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+}
+
+#[tokio::test]
 async fn instruction_bundle_rejects_trusted_skill_security_vocabulary_in_summary() {
     let context = claimed_run_context().await;
     let error = InstructionBundleBuilder::new(context)

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -394,7 +394,7 @@ mod reborn_support_tests {
     use ironclaw_threads::ProviderToolCallReferenceEnvelope;
     use ironclaw_threads::{
         AcceptInboundMessageRequest, AppendAssistantDraftRequest, EnsureThreadRequest,
-        MessageContent, SessionThreadService, ThreadScope,
+        MessageContent, SessionThreadService, ThreadScope, ToolResultSafeSummary,
     };
     use ironclaw_turns::{
         CancelRunRequest, CancelRunResponse, GetRunStateRequest, LoopMessageRef,
@@ -2115,7 +2115,9 @@ mod reborn_support_tests {
                 reasoning: None,
                 signature: None,
             }),
-            tool_result_content: Some(HostManagedToolResultContent::Resolved),
+            tool_result_content: Some(HostManagedToolResultContent::Resolved {
+                safe_summary: ToolResultSafeSummary::new("tool completed").unwrap(),
+            }),
         }
     }
 


### PR DESCRIPTION
## Summary
- add typed prompt text surfaces so safe summaries and trusted skill instructions validate under distinct policies
- keep strict credential-vocabulary denial for serialized/display-safe summaries and generic context
- allow trusted skill instructions to mention security vocabulary like Authorization/Bearer while still rejecting actual secret-looking values and host paths
- add regressions using the real GitHub skill text and an actual secret-looking token

## Stacked On
- #4140

## Tests
- cargo fmt --check
- cargo test -p ironclaw_turns --test agent_loop_host_contract instruction_bundle_materializes_trusted_skill_security_vocabulary -- --exact
- cargo test -p ironclaw_turns --test agent_loop_host_contract instruction_bundle_rejects_trusted_skill_actual_secret_value -- --exact
- cargo test -p ironclaw_turns instruction_bundle
- cargo test -p ironclaw_turns --test skill_context_service_contract
- cargo check -p ironclaw_turns
- git diff --check