### PR TITLE
Remove per-skill snippet budget

### DIFF
--- a/crates/ironclaw_turns/src/run_profile/skill_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/skill_context.rs
@@ -129,35 +129,28 @@ impl SkillTrustLevel {
 // ---------------------------------------------------------------------------
 
 const EMPTY_SNAPSHOT_VERSION: &str = "empty";
-const DEFAULT_MAX_SKILL_SNIPPET_BYTES: usize = 8 * 1024;
 const DEFAULT_MAX_SKILL_CONTEXT_BYTES: usize = 32 * 1024;
 
 /// Byte budgets for model-visible skill context produced by [`SkillContextService`].
 ///
 /// Hosts can map a run's context profile to these limits via
-/// [`SkillContextService::with_budget`]. Both limits fail closed when exceeded.
+/// [`SkillContextService::with_budget`]. The aggregate limit fails closed when exceeded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SkillContextBudget {
-    /// Maximum bytes for one snippet summary.
-    pub max_snippet_bytes: usize,
     /// Maximum aggregate bytes across emitted snippet refs and summaries.
     pub max_context_bytes: usize,
 }
 
 impl SkillContextBudget {
     /// Create explicit skill-context budget limits.
-    pub const fn new(max_snippet_bytes: usize, max_context_bytes: usize) -> Self {
-        Self {
-            max_snippet_bytes,
-            max_context_bytes,
-        }
+    pub const fn new(max_context_bytes: usize) -> Self {
+        Self { max_context_bytes }
     }
 }
 
 impl Default for SkillContextBudget {
     fn default() -> Self {
         Self {
-            max_snippet_bytes: DEFAULT_MAX_SKILL_SNIPPET_BYTES,
             max_context_bytes: DEFAULT_MAX_SKILL_CONTEXT_BYTES,
         }
     }
@@ -346,10 +339,6 @@ impl SkillContextSource for SkillContextService {
                 SkillTrustLevel::Installed => entry.safe_description.clone(),
             };
 
-            if safe_summary.len() > self.budget.max_snippet_bytes {
-                return Err(SkillContextError::ContextBudgetExceeded);
-            }
-
             validate_model_visible_skill_name(&entry.name)?;
             validate_model_visible_text(&safe_summary)?;
 
@@ -482,10 +471,7 @@ fn validate_snapshot(snapshot: &SkillRunSnapshot) -> Result<(), SkillContextErro
 }
 
 fn validate_budget(budget: SkillContextBudget) -> Result<(), SkillContextError> {
-    if budget.max_snippet_bytes == 0
-        || budget.max_context_bytes == 0
-        || budget.max_snippet_bytes > budget.max_context_bytes
-    {
+    if budget.max_context_bytes == 0 {
         return Err(SkillContextError::BudgetMisconfigured);
     }
 

--- a/crates/ironclaw_turns/tests/skill_context_service_contract.rs
+++ b/crates/ironclaw_turns/tests/skill_context_service_contract.rs
@@ -256,14 +256,14 @@ async fn tampered_snapshot_version_fails_closed() {
 }
 
 #[tokio::test]
-async fn oversized_single_snippet_fails_budget() {
+async fn oversized_single_snippet_is_allowed_within_aggregate_budget() {
     let snapshot =
         SkillRunSnapshot::from_entries(vec![visible_trusted("alpha", "desc", &"x".repeat(128))]);
-    let service =
-        SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(64, 512));
+    let service = SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(512));
 
-    let err = service.skill_snippets(&snapshot).await.unwrap_err();
-    assert_eq!(err, SkillContextError::ContextBudgetExceeded);
+    let snippets = service.skill_snippets(&snapshot).await.unwrap();
+    assert_eq!(snippets.len(), 1);
+    assert!(snippets[0].safe_summary.contains(&"x".repeat(128)));
 }
 
 #[tokio::test]
@@ -272,8 +272,7 @@ async fn aggregate_skill_context_fails_budget() {
         visible_trusted("alpha", "first description", "first prompt"),
         visible_trusted("beta", "second description", "second prompt"),
     ]);
-    let service =
-        SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(40, 64));
+    let service = SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(64));
 
     let err = service.skill_snippets(&snapshot).await.unwrap_err();
     assert_eq!(err, SkillContextError::ContextBudgetExceeded);
@@ -281,11 +280,7 @@ async fn aggregate_skill_context_fails_budget() {
 
 #[tokio::test]
 async fn invalid_budget_configuration_is_distinct_from_exceeded_budget() {
-    for budget in [
-        SkillContextBudget::new(0, 64),
-        SkillContextBudget::new(64, 0),
-        SkillContextBudget::new(128, 64),
-    ] {
+    for budget in [SkillContextBudget::new(0)] {
         let snapshot =
             SkillRunSnapshot::from_entries(vec![visible_trusted("alpha", "desc", "prompt")]);
         let service = SkillContextService::with_budget(snapshot.clone(), budget);


### PR DESCRIPTION
## Summary
- remove the hard per-skill snippet byte budget from SkillContextBudget
- keep the aggregate skill-context byte budget fail-closed
- update the skill context contract test so oversized individual snippets are allowed when the aggregate budget has room

## Tests
- cargo test -p ironclaw_turns --test skill_context_service_contract
- cargo check -p ironclaw_loop_support
- rustfmt --edition 2024 --check crates/ironclaw_turns/src/run_profile/skill_context.rs crates/ironclaw_turns/tests/skill_context_service_contract.rs

Note: full cargo fmt --check still reports an unrelated existing formatting diff in crates/ironclaw_reborn/src/model_gateway.rs.