### PR TITLE
[codex] Anchor Reborn turn objective in loop context

### DIFF
--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -30,6 +30,7 @@ mod skill_context;
 mod subagent_prompt_port;
 mod subagent_spawn_port;
 mod turn_event_publisher;
+mod turn_objective_context;
 
 pub use budget_accountant::{
     BudgetSeedingPolicy, GovernorBackedAccountant, ModelCost, ModelCostTable, ZeroCostTable,
@@ -297,7 +298,7 @@ where
             .await
             .map_err(context_read_error)?;
 
-        let instruction_snippets = match self.skill_context_source.as_deref() {
+        let mut instruction_snippets = match self.skill_context_source.as_deref() {
             Some(source) => {
                 skill_context::build_skill_instruction_snippets(source, &self.run_context).await?
             }
@@ -331,13 +332,23 @@ where
             None => Vec::new(),
         };
 
+        let mut messages = context
+            .messages
+            .into_iter()
+            .filter_map(context_message_to_loop_message)
+            .collect::<Vec<_>>();
+        turn_objective_context::apply_turn_objective_context(
+            self.thread_service.as_ref(),
+            &self.thread_scope,
+            &self.run_context,
+            &mut messages,
+            &mut instruction_snippets,
+        )
+        .await?;
+
         Ok(LoopContextBundle {
             identity_messages,
-            messages: context
-                .messages
-                .into_iter()
-                .filter_map(context_message_to_loop_message)
-                .collect(),
+            messages,
             instruction_snippets,
             memory_snippets: Vec::new(),
         })

--- a/crates/ironclaw_loop_support/src/turn_objective_context.rs
+++ b/crates/ironclaw_loop_support/src/turn_objective_context.rs
@@ -1,0 +1,135 @@
+use ironclaw_threads::{
+    LoadContextMessagesRequest, SessionThreadService, ThreadMessageId, ThreadScope,
+};
+use ironclaw_turns::{
+    LoopMessageRef,
+    run_profile::{
+        AgentLoopHostError, AgentLoopHostErrorKind, LoopContextMessage, LoopContextSnippet,
+        LoopRunContext, LoopSafeSummary,
+    },
+};
+
+use crate::{context_message_to_loop_message, context_read_error, message_ref_from_context};
+
+const TURN_OBJECTIVE_SNIPPET_REF: &str = "instruction:system.turn_objective";
+const TURN_OBJECTIVE_SAFE_SUMMARY: &str = concat!(
+    "The accepted user message for this run is the turn objective. ",
+    "Before finalizing, check the final answer or completed work against that objective. ",
+    "If the requested work is incomplete, blocked, or unverified, state that explicitly."
+);
+
+enum AcceptedTurnObjectiveRef {
+    Opaque,
+    TranscriptMessage {
+        message_ref: LoopMessageRef,
+        message_id: ThreadMessageId,
+    },
+}
+
+pub(crate) async fn apply_turn_objective_context<S>(
+    thread_service: &S,
+    thread_scope: &ThreadScope,
+    run_context: &LoopRunContext,
+    messages: &mut Vec<LoopContextMessage>,
+    instruction_snippets: &mut Vec<LoopContextSnippet>,
+) -> Result<(), AgentLoopHostError>
+where
+    S: SessionThreadService + ?Sized + Send + Sync,
+{
+    let Some(objective_ref) = accepted_turn_objective_ref(run_context)? else {
+        return Ok(());
+    };
+    instruction_snippets.push(turn_objective_instruction()?);
+
+    let AcceptedTurnObjectiveRef::TranscriptMessage {
+        message_ref,
+        message_id,
+    } = objective_ref
+    else {
+        return Ok(());
+    };
+    if messages.iter().any(|message| {
+        message
+            .message_ref
+            .as_ref()
+            .is_some_and(|existing_ref| existing_ref == &message_ref)
+    }) {
+        return Ok(());
+    }
+
+    let context_messages = thread_service
+        .load_context_messages(LoadContextMessagesRequest {
+            scope: thread_scope.clone(),
+            thread_id: run_context.thread_id.clone(),
+            message_ids: vec![message_id],
+        })
+        .await
+        .map_err(context_read_error)?;
+    let objective_message = context_messages
+        .messages
+        .into_iter()
+        .find(|message| message_ref_from_context(message).as_ref() == Some(&message_ref))
+        .and_then(context_message_to_loop_message)
+        .ok_or_else(|| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "accepted turn objective message is unavailable",
+            )
+        })?;
+    messages.insert(0, objective_message);
+    Ok(())
+}
+
+fn accepted_turn_objective_ref(
+    run_context: &LoopRunContext,
+) -> Result<Option<AcceptedTurnObjectiveRef>, AgentLoopHostError> {
+    let Some(accepted_ref) = run_context.accepted_message_ref.as_ref() else {
+        return Ok(None);
+    };
+    let value = accepted_ref.as_str();
+    let Some(raw_message_id) = value.strip_prefix("msg:") else {
+        return Ok(Some(AcceptedTurnObjectiveRef::Opaque));
+    };
+    if raw_message_id.is_empty() {
+        return Err(invalid_accepted_message_ref());
+    }
+    let message_ref = LoopMessageRef::new(value.to_string()).map_err(|_| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidInvocation,
+            "accepted turn objective message ref is invalid",
+        )
+    })?;
+    let message_id = ThreadMessageId::parse(raw_message_id).map_err(|_| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidInvocation,
+            "accepted turn objective message id is invalid",
+        )
+    })?;
+    Ok(Some(AcceptedTurnObjectiveRef::TranscriptMessage {
+        message_ref,
+        message_id,
+    }))
+}
+
+fn turn_objective_instruction() -> Result<LoopContextSnippet, AgentLoopHostError> {
+    Ok(LoopContextSnippet {
+        snippet_ref: TURN_OBJECTIVE_SNIPPET_REF.to_string(),
+        safe_summary: LoopSafeSummary::new(TURN_OBJECTIVE_SAFE_SUMMARY)
+            .map_err(|reason| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    format!("turn objective instruction invalid: {reason}"),
+                )
+            })?
+            .as_str()
+            .to_string(),
+        metadata: None,
+    })
+}
+
+fn invalid_accepted_message_ref() -> AgentLoopHostError {
+    AgentLoopHostError::new(
+        AgentLoopHostErrorKind::InvalidInvocation,
+        "accepted turn objective message ref is invalid",
+    )
+}

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -33,8 +33,8 @@ use ironclaw_threads::{
     UpdateToolResultReferenceRequest,
 };
 use ironclaw_turns::{
-    LoopMessageRef, LoopResultRef, RunProfileResolutionRequest, RunProfileResolver, TurnActor,
-    TurnId, TurnRunId, TurnScope,
+    AcceptedMessageRef, LoopMessageRef, LoopResultRef, RunProfileResolutionRequest,
+    RunProfileResolver, TurnActor, TurnId, TurnRunId, TurnScope,
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, AppendCapabilityResultRef, AssistantReply,
         BeginAssistantDraft, CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDenied,
@@ -86,6 +86,195 @@ async fn thread_context_port_loads_policy_filtered_transcript_messages() {
         format!("msg:{}", fixture.user_message_id).as_str()
     );
     assert!(bundle.memory_snippets.is_empty());
+}
+
+#[tokio::test]
+async fn thread_context_port_marks_accepted_message_as_turn_objective() {
+    let fixture = ThreadFixture::new().await;
+    let accepted_message_ref =
+        AcceptedMessageRef::new(format!("msg:{}", fixture.user_message_id)).unwrap();
+    let run_context = fixture
+        .run_context
+        .clone()
+        .with_accepted_message_ref(accepted_message_ref.clone());
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    );
+
+    let bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: ironclaw_turns::run_profile::PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(bundle.messages.len(), 1);
+    assert_eq!(
+        bundle.messages[0].message_ref.as_ref().unwrap().as_str(),
+        accepted_message_ref.as_str()
+    );
+    assert_eq!(bundle.instruction_snippets.len(), 1);
+    assert_eq!(
+        bundle.instruction_snippets[0].snippet_ref,
+        "instruction:system.turn_objective"
+    );
+    assert!(
+        bundle.instruction_snippets[0]
+            .safe_summary
+            .contains("turn objective")
+    );
+}
+
+#[tokio::test]
+async fn thread_context_port_keeps_opaque_accepted_ref_as_instruction_only_objective() {
+    let fixture = ThreadFixture::new().await;
+    let run_context = fixture
+        .run_context
+        .clone()
+        .with_accepted_message_ref(AcceptedMessageRef::new("accepted-opaque").unwrap());
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    );
+
+    let bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: ironclaw_turns::run_profile::PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(bundle.messages.len(), 1);
+    assert_eq!(bundle.instruction_snippets.len(), 1);
+    assert!(
+        bundle.instruction_snippets[0]
+            .safe_summary
+            .contains("turn objective")
+    );
+}
+
+#[tokio::test]
+async fn thread_context_port_rejects_malformed_transcript_objective_ref() {
+    let fixture = ThreadFixture::new().await;
+    let run_context = fixture
+        .run_context
+        .clone()
+        .with_accepted_message_ref(AcceptedMessageRef::new("msg:not-a-uuid").unwrap());
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    );
+
+    let error = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: ironclaw_turns::run_profile::PromptMode::TextOnly,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(
+        error.safe_summary,
+        "accepted turn objective message id is invalid"
+    );
+}
+
+#[tokio::test]
+async fn prompt_and_model_ports_pin_accepted_message_when_outside_context_window() {
+    let fixture = ThreadFixture::new().await;
+    let accepted_message_ref =
+        AcceptedMessageRef::new(format!("msg:{}", fixture.user_message_id)).unwrap();
+    let run_context = fixture
+        .run_context
+        .clone()
+        .with_accepted_message_ref(accepted_message_ref);
+    fixture
+        .thread_service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: fixture.thread_scope.clone(),
+            thread_id: fixture.thread_id.clone(),
+            actor_id: "user-loop-support".to_string(),
+            source_binding_id: Some("source-web".to_string()),
+            reply_target_binding_id: Some("reply-web".to_string()),
+            external_event_id: Some("event-2".to_string()),
+            content: MessageContent::text("newer follow-up"),
+        })
+        .await
+        .unwrap();
+
+    let context_port = Arc::new(ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context.clone(),
+        1,
+    ));
+    let materialization_store = Arc::new(InMemoryInstructionMaterializationStore::default());
+    let prompt_port = HostManagedLoopPromptPort::new(
+        run_context.clone(),
+        context_port,
+        Arc::new(InMemoryLoopHostMilestoneSink::default()),
+    )
+    .with_instruction_materialization_store(materialization_store.clone())
+    .with_default_message_limit(1);
+    let prompt_bundle = prompt_port
+        .build_prompt_bundle(ironclaw_turns::run_profile::LoopPromptBundleRequest {
+            mode: ironclaw_turns::run_profile::PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(1),
+            inline_messages: Vec::new(),
+            capability_view: None,
+        })
+        .await
+        .unwrap();
+
+    let gateway = Arc::new(RecordingGateway::reply("model says hi"));
+    let model_port = ThreadBackedLoopModelPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        gateway.clone(),
+        1,
+    )
+    .with_instruction_materialization_store(materialization_store);
+
+    model_port
+        .stream_model(LoopModelRequest {
+            messages: prompt_bundle.messages,
+            surface_version: None,
+            model_preference: None,
+            capability_view: None,
+        })
+        .await
+        .unwrap();
+
+    let calls = gateway.calls.lock().unwrap();
+    let contents = calls[0]
+        .messages
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        contents
+            .iter()
+            .any(|content| content.contains("turn objective"))
+    );
+    assert!(contents.contains(&"hello reborn"));
+    assert!(contents.contains(&"newer follow-up"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -280,6 +280,68 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
 }
 
 #[tokio::test]
+async fn host_factory_anchors_claimed_accepted_message_as_turn_objective() {
+    let mut fixture =
+        HostFixture::new("thread-host-turn-objective", "complete the requested fix").await;
+    fixture.claimed.state.accepted_message_ref =
+        AcceptedMessageRef::new(format!("msg:{}", fixture.accepted_message_id)).unwrap();
+    fixture
+        .thread_service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: fixture.thread_scope.clone(),
+            thread_id: fixture.thread_id.clone(),
+            actor_id: "user-text-host".to_string(),
+            source_binding_id: Some("source-web".to_string()),
+            reply_target_binding_id: Some("reply-web".to_string()),
+            external_event_id: Some("event-thread-host-turn-objective-follow-up".to_string()),
+            content: MessageContent::text("newer message in context window"),
+        })
+        .await
+        .unwrap();
+    let host = fixture
+        .factory()
+        .create_host(&fixture.claimed)
+        .await
+        .unwrap();
+
+    let prompt_bundle = host
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(1),
+            inline_messages: Vec::new(),
+            capability_view: None,
+        })
+        .await
+        .unwrap();
+
+    host.stream_model(LoopModelRequest {
+        messages: prompt_bundle.messages,
+        surface_version: None,
+        model_preference: None,
+        capability_view: None,
+    })
+    .await
+    .unwrap();
+
+    let calls = fixture.gateway.requests();
+    let contents = calls[0]
+        .messages
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        contents
+            .iter()
+            .any(|content| content.contains("turn objective"))
+    );
+    assert!(contents.contains(&"complete the requested fix"));
+    assert!(contents.contains(&"newer message in context window"));
+}
+
+#[tokio::test]
 async fn text_only_host_factory_sanitizes_gateway_error_summaries() {
     let fixture = HostFixture::new(
         "thread-host-model-error-redaction",


### PR DESCRIPTION
## Summary
- Add a focused turn-objective context source for accepted message refs
- Pin transcript-backed accepted user messages into prompt context when they fall outside the bounded context window
- Keep opaque accepted refs instruction-only and fail loudly on malformed transcript objective refs
- Add regression coverage through loop-support context/model resolution and the Reborn host factory composition path

## Validation
- CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p ironclaw_loop_support
- CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo clippy -p ironclaw_loop_support --all-targets --all-features -- -D warnings
- CARGO_BUILD_JOBS=1 RUSTFLAGS='-C debuginfo=0' cargo test -p ironclaw_reborn --test loop_driver_host host_factory_anchors_claimed_accepted_message_as_turn_objective