### PR TITLE
fix(reborn): disable background subagent mode

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -341,7 +341,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 | Tool inventory cache | ✅ | ❌ | Coalesced effective-tool inventory cache with channel-registry invalidation |
 | Pending exec approval `errorMessage` cleanup | ✅ | ❌ | Failed restart-interrupted approval-pending sessions instead of replaying stale ids |
 | Elevated mode | ✅ | ❌ | Privileged execution |
-| Subagent support | ✅ | ✅ | Task framework; spawn-by-account-aware bindings, model overrides preserved |
+| Subagent support | ✅ | ✅ | Task framework; spawn-by-account-aware bindings, model overrides preserved; Reborn `spawn_subagent` is blocking-only while background delivery is deferred (#4147) |
 | `/subagents spawn` command | ✅ | ❌ | Spawn from chat |
 | Auth profiles | ✅ | ❌ | Multiple auth strategies; replaceDefaultModels migration semantics |
 | Generic API key rotation | ✅ | ❌ | Rotate keys across providers |

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -103,15 +103,6 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
                 "handoff": {
                     "type": "string",
                     "description": "Optional context to pass to the child subagent"
-                },
-                "mode": {
-                    "type": "string",
-                    "enum": ["blocking", "background"],
-                    "description": "Whether the parent waits for completion"
-                },
-                "run_in_background": {
-                    "type": "boolean",
-                    "description": "Legacy background-mode flag"
                 }
             },
             "required": ["flavor_id", "task"],

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -166,6 +166,23 @@ async fn builtin_first_party_surface_lists_allowed_tools_in_registry_order() {
         .find(|capability| capability.descriptor.id.as_str() == SHELL_CAPABILITY_ID)
         .expect("shell capability must be visible");
     assert_eq!(shell.estimated_resources.process_count, Some(1));
+
+    let spawn = surface
+        .capabilities
+        .iter()
+        .find(|capability| capability.descriptor.id.as_str() == SPAWN_SUBAGENT_CAPABILITY_ID)
+        .expect("spawn_subagent capability must be visible");
+    let properties = spawn
+        .descriptor
+        .parameters_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("spawn_subagent schema properties");
+    assert!(properties.contains_key("flavor_id"));
+    assert!(properties.contains_key("task"));
+    assert!(properties.contains_key("handoff"));
+    assert!(!properties.contains_key("mode"));
+    assert!(!properties.contains_key("run_in_background"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -146,8 +146,10 @@ struct SpawnSubagentWireArgs {
     run_in_background: bool,
 }
 
-impl From<SpawnSubagentWireArgs> for SpawnSubagentArgs {
-    fn from(value: SpawnSubagentWireArgs) -> Self {
+impl TryFrom<SpawnSubagentWireArgs> for SpawnSubagentArgs {
+    type Error = AgentLoopHostError;
+
+    fn try_from(value: SpawnSubagentWireArgs) -> Result<Self, Self::Error> {
         let mode = value.mode.unwrap_or({
             if value.run_in_background {
                 SpawnSubagentMode::Background
@@ -155,12 +157,15 @@ impl From<SpawnSubagentWireArgs> for SpawnSubagentArgs {
                 SpawnSubagentMode::Blocking
             }
         });
-        Self {
+        if mode == SpawnSubagentMode::Background {
+            return Err(background_subagents_disabled());
+        }
+        Ok(Self {
             subagent_kind: value.subagent_kind,
             task: value.task,
             handoff: value.handoff,
             mode,
-        }
+        })
     }
 }
 
@@ -860,6 +865,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 .spawn_input_codec
                 .decode(&self.run_context, &request.input_ref)
                 .await?;
+            reject_background_mode(args.spawn_mode())?;
             return self.handle_spawn_with_gate(&request, args, None).await;
         }
         self.inner.invoke_capability(request).await
@@ -885,6 +891,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 .spawn_input_codec
                 .decode(&self.run_context, &invocation.input_ref)
                 .await?;
+            reject_background_mode(args.spawn_mode())?;
             if args.spawn_mode() == SpawnSubagentMode::Blocking {
                 blocking_count += 1;
             }
@@ -988,13 +995,13 @@ impl SpawnSubagentInputCodec for JsonSpawnSubagentInputCodec {
             .resolve_capability_input(run_context, input_ref)
             .await?;
         serde_json::from_value::<SpawnSubagentWireArgs>(value)
-            .map(Into::into)
             .map_err(|error| {
                 AgentLoopHostError::new(
                     AgentLoopHostErrorKind::InvalidInvocation,
                     format!("invalid spawn_subagent input: {error}"),
                 )
-            })
+            })?
+            .try_into()
     }
 
     async fn register_provider_tool_call_input(
@@ -1041,6 +1048,20 @@ fn spawn_rejected(reason: &'static str) -> CapabilityOutcome {
             .unwrap_or(CapabilityDeniedReasonKind::EmptySurface),
         safe_summary: format!("subagent spawn rejected: {reason}"),
     })
+}
+
+fn reject_background_mode(mode: SpawnSubagentMode) -> Result<(), AgentLoopHostError> {
+    if mode == SpawnSubagentMode::Background {
+        return Err(background_subagents_disabled());
+    }
+    Ok(())
+}
+
+fn background_subagents_disabled() -> AgentLoopHostError {
+    AgentLoopHostError::new(
+        AgentLoopHostErrorKind::InvalidInvocation,
+        "background subagents are disabled pending durable completion delivery design (#4147)",
+    )
 }
 
 fn map_turn_error(error: TurnError) -> AgentLoopHostError {

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -124,13 +124,6 @@ pub struct SpawnSubagentArgs {
     pub task: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub handoff: Option<String>,
-    pub mode: SpawnSubagentMode,
-}
-
-impl SpawnSubagentArgs {
-    pub fn spawn_mode(&self) -> SpawnSubagentMode {
-        self.mode
-    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,30 +134,32 @@ struct SpawnSubagentWireArgs {
     #[serde(default)]
     handoff: Option<String>,
     #[serde(default)]
-    mode: Option<SpawnSubagentMode>,
+    mode: Option<SpawnSubagentWireMode>,
     #[serde(default)]
     run_in_background: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SpawnSubagentWireMode {
+    Blocking,
+    Background,
 }
 
 impl TryFrom<SpawnSubagentWireArgs> for SpawnSubagentArgs {
     type Error = AgentLoopHostError;
 
     fn try_from(value: SpawnSubagentWireArgs) -> Result<Self, Self::Error> {
-        let mode = value.mode.unwrap_or({
-            if value.run_in_background {
-                SpawnSubagentMode::Background
-            } else {
-                SpawnSubagentMode::Blocking
-            }
-        });
-        if mode == SpawnSubagentMode::Background {
+        if value.run_in_background {
+            return Err(background_subagents_disabled());
+        }
+        if value.mode == Some(SpawnSubagentWireMode::Background) {
             return Err(background_subagents_disabled());
         }
         Ok(Self {
             subagent_kind: value.subagent_kind,
             task: value.task,
             handoff: value.handoff,
-            mode,
         })
     }
 }
@@ -602,17 +597,14 @@ impl SubagentSpawnCapabilityPort {
         let child_thread_id =
             ThreadId::new(format!("subagent-{}", child_run_id.as_uuid().simple()))
                 .map_err(invalid_static_ref)?;
-        let mode = args.spawn_mode();
+        let mode = SpawnSubagentMode::Blocking;
         // The gate ref is also returned as a `LoopGateRef`; keep the opaque
         // suffix colon-free so it satisfies the model-visible loop ref
         // contract (`gate:<ascii-id>` with only alnum/underscore/dash/dot).
-        let gate_ref = match gate_override {
-            Some(gate_ref) => gate_ref,
-            None => GateRef::new(match mode {
-                SpawnSubagentMode::Blocking => format!("gate:subagent-{child_run_id}"),
-                SpawnSubagentMode::Background => format!("gate:subagent-bg-{child_run_id}"),
-            })
-            .map_err(invalid_static_ref)?,
+        let gate_ref = if let Some(gate_ref) = gate_override {
+            gate_ref
+        } else {
+            GateRef::new(format!("gate:subagent-{child_run_id}")).map_err(invalid_static_ref)?
         };
         let payload = spawn_result_payload(
             child_run_id,
@@ -758,22 +750,12 @@ impl SubagentSpawnCapabilityPort {
             return Err(map_thread_error(error));
         }
 
-        match mode {
-            SpawnSubagentMode::Blocking => {
-                let loop_gate_ref =
-                    LoopGateRef::new(gate_ref.as_str()).map_err(invalid_static_ref)?;
-                Ok(CapabilityOutcome::AwaitDependentRun {
-                    gate_ref: loop_gate_ref,
-                    result_ref,
-                    safe_summary: safe_summary("subagent spawned; waiting for completion"),
-                })
-            }
-            SpawnSubagentMode::Background => Ok(CapabilityOutcome::SpawnedChildRun {
-                child_run_id,
-                result_ref,
-                safe_summary: safe_summary("subagent spawned in background"),
-            }),
-        }
+        let loop_gate_ref = LoopGateRef::new(gate_ref.as_str()).map_err(invalid_static_ref)?;
+        Ok(CapabilityOutcome::AwaitDependentRun {
+            gate_ref: loop_gate_ref,
+            result_ref,
+            safe_summary: safe_summary("subagent spawned; waiting for completion"),
+        })
     }
 
     async fn cancel_child_after_submission_failure(
@@ -857,15 +839,14 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         request: CapabilityInvocation,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         if self.is_spawn(&request.capability_id) {
-            if let Some(outcome) = self.authorize_spawn(&request).await? {
-                return Ok(outcome);
-            }
             let args = self
                 .deps
                 .spawn_input_codec
                 .decode(&self.run_context, &request.input_ref)
                 .await?;
-            reject_background_mode(args.spawn_mode())?;
+            if let Some(outcome) = self.authorize_spawn(&request).await? {
+                return Ok(outcome);
+            }
             return self.handle_spawn_with_gate(&request, args, None).await;
         }
         self.inner.invoke_capability(request).await
@@ -876,10 +857,10 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         request: CapabilityBatchInvocation,
     ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
         let mut outcomes = Vec::with_capacity(request.invocations.len());
-        // Pre-decode every spawn invocation so we know how many are Blocking
-        // before allocating the shared batch gate. Only batches with at least
-        // two Blocking spawns benefit from gate coalescing; otherwise the gate
-        // would be created and never registered, wasting a TurnRunId.
+        // Pre-decode every spawn invocation before allocating the shared batch
+        // gate. Only batches with at least two valid blocking spawns benefit
+        // from gate coalescing; otherwise the gate would be created and never
+        // registered, wasting a TurnRunId.
         let mut spawn_args: HashMap<usize, SpawnSubagentArgs> = HashMap::new();
         let mut blocking_count = 0_usize;
         for (idx, invocation) in request.invocations.iter().enumerate() {
@@ -891,10 +872,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 .spawn_input_codec
                 .decode(&self.run_context, &invocation.input_ref)
                 .await?;
-            reject_background_mode(args.spawn_mode())?;
-            if args.spawn_mode() == SpawnSubagentMode::Blocking {
-                blocking_count += 1;
-            }
+            blocking_count += 1;
             spawn_args.insert(idx, args);
         }
         let batch_blocking_gate = if blocking_count > 1 {
@@ -918,9 +896,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                             "subagent spawn args missing from pre-decode pass",
                         )
                     })?;
-                    let gate_override = (args.spawn_mode() == SpawnSubagentMode::Blocking)
-                        .then(|| batch_blocking_gate.clone())
-                        .flatten();
+                    let gate_override = batch_blocking_gate.clone();
                     self.handle_spawn_with_gate(invocation, args, gate_override)
                         .await?
                 };
@@ -1048,13 +1024,6 @@ fn spawn_rejected(reason: &'static str) -> CapabilityOutcome {
             .unwrap_or(CapabilityDeniedReasonKind::EmptySurface),
         safe_summary: format!("subagent spawn rejected: {reason}"),
     })
-}
-
-fn reject_background_mode(mode: SpawnSubagentMode) -> Result<(), AgentLoopHostError> {
-    if mode == SpawnSubagentMode::Background {
-        return Err(background_subagents_disabled());
-    }
-    Ok(())
 }
 
 fn background_subagents_disabled() -> AgentLoopHostError {

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -1167,7 +1167,7 @@ async fn invoke_spawn_rejects_subagent_parent_without_resolved_parent_flavor() {
 }
 
 #[tokio::test]
-async fn json_spawn_input_codec_decodes_legacy_background_flag() {
+async fn json_spawn_input_codec_rejects_legacy_background_flag() {
     let codec = JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver {
         value: Ok(json!({
             "flavor_id": "general",
@@ -1177,11 +1177,193 @@ async fn json_spawn_input_codec_decodes_legacy_background_flag() {
     }));
     let context = test_run_context("spawn-codec").await;
 
+    let error = codec.decode(&context, &input_ref()).await.unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("background subagents are disabled")
+    );
+}
+
+#[tokio::test]
+async fn json_spawn_input_codec_rejects_background_mode() {
+    let codec = JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver {
+        value: Ok(json!({
+            "flavor_id": "general",
+            "task": "investigate",
+            "mode": "background"
+        })),
+    }));
+    let context = test_run_context("spawn-codec-background").await;
+
+    let error = codec.decode(&context, &input_ref()).await.unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("background subagents are disabled")
+    );
+}
+
+#[tokio::test]
+async fn json_spawn_input_codec_defaults_to_blocking_when_mode_is_absent() {
+    let codec = JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver {
+        value: Ok(json!({
+            "flavor_id": "general",
+            "task": "investigate"
+        })),
+    }));
+    let context = test_run_context("spawn-codec-default").await;
+
     let args = codec.decode(&context, &input_ref()).await.unwrap();
 
     assert_eq!(args.subagent_kind.as_str(), "general");
     assert_eq!(args.task, "investigate");
-    assert_eq!(args.spawn_mode(), SpawnSubagentMode::Background);
+    assert_eq!(args.spawn_mode(), SpawnSubagentMode::Blocking);
+}
+
+#[tokio::test]
+async fn json_spawn_input_codec_accepts_legacy_blocking_inputs() {
+    for value in [
+        json!({
+            "flavor_id": "general",
+            "task": "investigate",
+            "mode": "blocking"
+        }),
+        json!({
+            "flavor_id": "general",
+            "task": "investigate",
+            "run_in_background": false
+        }),
+    ] {
+        let codec =
+            JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver { value: Ok(value) }));
+        let context = test_run_context("spawn-codec-legacy-blocking").await;
+
+        let args = codec.decode(&context, &input_ref()).await.unwrap();
+
+        assert_eq!(args.spawn_mode(), SpawnSubagentMode::Blocking);
+    }
+}
+
+#[tokio::test]
+async fn invoke_spawn_rejects_background_mode_before_side_effects() {
+    let context = test_run_context_with_agent_actor("spawn-background-disabled").await;
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let goal_store = Arc::new(RecordingGoalStore::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0)))),
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        goal_store: goal_store.clone(),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: SpawnSubagentArgs {
+                subagent_kind: SubagentKindId::new("general").unwrap(),
+                task: "task".to_string(),
+                handoff: None,
+                mode: SpawnSubagentMode::Background,
+            },
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+    port.auth_input_refs
+        .lock()
+        .unwrap()
+        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+
+    let error = port
+        .invoke_capability(CapabilityInvocation {
+            surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+            capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+            input_ref: input_ref(),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("background subagents are disabled")
+    );
+    assert!(child_runs.requests().is_empty());
+    assert!(goal_store.puts().is_empty());
+    assert!(gate_store.records().is_empty());
+}
+
+#[tokio::test]
+async fn invoke_spawn_batch_rejects_background_mode_before_side_effects() {
+    let context = test_run_context_with_agent_actor("spawn-background-disabled-batch").await;
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let goal_store = Arc::new(RecordingGoalStore::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0)))),
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        goal_store: goal_store.clone(),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: SpawnSubagentArgs {
+                subagent_kind: SubagentKindId::new("general").unwrap(),
+                task: "task".to_string(),
+                handoff: None,
+                mode: SpawnSubagentMode::Background,
+            },
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+
+    let error = port
+        .invoke_capability_batch(CapabilityBatchInvocation {
+            invocations: vec![CapabilityInvocation {
+                surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+                capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+                input_ref: input_ref(),
+            }],
+            stop_on_first_suspension: true,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("background subagents are disabled")
+    );
+    assert!(child_runs.requests().is_empty());
+    assert!(goal_store.puts().is_empty());
+    assert!(gate_store.records().is_empty());
 }
 
 #[tokio::test]

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -30,6 +30,10 @@ struct StaticSpawnInputCodec {
     args: SpawnSubagentArgs,
 }
 
+struct RejectingSpawnInputCodec {
+    error: AgentLoopHostError,
+}
+
 struct StaticDefinitionResolver {
     resolved: Option<SubagentDefinition>,
     parent: Option<SubagentDefinition>,
@@ -119,6 +123,17 @@ impl SpawnSubagentInputCodec for StaticSpawnInputCodec {
         _input_ref: &CapabilityInputRef,
     ) -> Result<SpawnSubagentArgs, AgentLoopHostError> {
         Ok(self.args.clone())
+    }
+}
+
+#[async_trait]
+impl SpawnSubagentInputCodec for RejectingSpawnInputCodec {
+    async fn decode(
+        &self,
+        _run_context: &LoopRunContext,
+        _input_ref: &CapabilityInputRef,
+    ) -> Result<SpawnSubagentArgs, AgentLoopHostError> {
+        Err(self.error.clone())
     }
 }
 
@@ -626,7 +641,6 @@ fn default_spawn_args() -> SpawnSubagentArgs {
         subagent_kind: SubagentKindId::new("general").unwrap(),
         task: "task".to_string(),
         handoff: None,
-        mode: SpawnSubagentMode::Blocking,
     }
 }
 
@@ -704,6 +718,56 @@ async fn spawn_test_port(
     port
 }
 
+struct SpawnPortWithRecorders {
+    port: SubagentSpawnCapabilityPort,
+    child_runs: Arc<RecordingChildRuns>,
+    goal_store: Arc<RecordingGoalStore>,
+    gate_store: Arc<InMemorySubagentGateResolutionStore>,
+}
+
+fn spawn_test_port_with_codec_and_recorders(
+    run_context: LoopRunContext,
+    codec: Arc<dyn SpawnSubagentInputCodec>,
+) -> SpawnPortWithRecorders {
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let goal_store = Arc::new(RecordingGoalStore::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: Arc::new(StaticTurnStateStore::new(Some(turn_record(
+            &run_context,
+            0,
+        )))),
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        goal_store: goal_store.clone(),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: codec,
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(AuthPassPort),
+        run_context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+    port.auth_input_refs
+        .lock()
+        .unwrap()
+        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+    SpawnPortWithRecorders {
+        port,
+        child_runs,
+        goal_store,
+        gate_store,
+    }
+}
+
 async fn invoke_spawn(port: &SubagentSpawnCapabilityPort) -> CapabilityOutcome {
     port.invoke_capability(CapabilityInvocation {
         surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
@@ -730,14 +794,15 @@ fn denied_reason(outcome: CapabilityOutcome) -> String {
 }
 
 #[test]
-fn spawn_args_store_normalized_mode() {
+fn spawn_args_hold_blocking_runtime_request() {
     let args = SpawnSubagentArgs {
         subagent_kind: SubagentKindId::new("general").unwrap(),
         task: "task".to_string(),
         handoff: None,
-        mode: SpawnSubagentMode::Blocking,
     };
-    assert_eq!(args.spawn_mode(), SpawnSubagentMode::Blocking);
+    assert_eq!(args.subagent_kind.as_str(), "general");
+    assert_eq!(args.task, "task");
+    assert_eq!(args.handoff, None);
 }
 
 #[tokio::test]
@@ -887,7 +952,6 @@ async fn invoke_spawn_submits_child_run_through_spawn_tree_port() {
                 subagent_kind: SubagentKindId::new("general").unwrap(),
                 task: "inspect the logs".to_string(),
                 handoff: Some("return concise notes".to_string()),
-                mode: SpawnSubagentMode::Blocking,
             },
         }),
         result_writer: Arc::new(NoopResultWriter),
@@ -1188,6 +1252,28 @@ async fn json_spawn_input_codec_rejects_legacy_background_flag() {
 }
 
 #[tokio::test]
+async fn json_spawn_input_codec_rejects_legacy_background_flag_even_with_blocking_mode() {
+    let codec = JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver {
+        value: Ok(json!({
+            "flavor_id": "general",
+            "task": "investigate",
+            "mode": "blocking",
+            "run_in_background": true
+        })),
+    }));
+    let context = test_run_context("spawn-codec-background-conflict").await;
+
+    let error = codec.decode(&context, &input_ref()).await.unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("background subagents are disabled")
+    );
+}
+
+#[tokio::test]
 async fn json_spawn_input_codec_rejects_background_mode() {
     let codec = JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver {
         value: Ok(json!({
@@ -1222,7 +1308,6 @@ async fn json_spawn_input_codec_defaults_to_blocking_when_mode_is_absent() {
 
     assert_eq!(args.subagent_kind.as_str(), "general");
     assert_eq!(args.task, "investigate");
-    assert_eq!(args.spawn_mode(), SpawnSubagentMode::Blocking);
 }
 
 #[tokio::test]
@@ -1245,50 +1330,23 @@ async fn json_spawn_input_codec_accepts_legacy_blocking_inputs() {
 
         let args = codec.decode(&context, &input_ref()).await.unwrap();
 
-        assert_eq!(args.spawn_mode(), SpawnSubagentMode::Blocking);
+        assert_eq!(args.subagent_kind.as_str(), "general");
+        assert_eq!(args.task, "investigate");
     }
 }
 
 #[tokio::test]
-async fn invoke_spawn_rejects_background_mode_before_side_effects() {
+async fn invoke_spawn_propagates_decode_rejection_before_side_effects() {
     let context = test_run_context_with_agent_actor("spawn-background-disabled").await;
-    let child_runs = Arc::new(RecordingChildRuns::default());
-    let goal_store = Arc::new(RecordingGoalStore::default());
-    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
-    let deps = Arc::new(SubagentSpawnDeps {
-        coordinator: Arc::new(StaticCoordinator),
-        child_runs: child_runs.clone(),
-        turn_state_store: Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0)))),
-        thread_service: Arc::new(InMemorySessionThreadService::default()),
-        goal_store: goal_store.clone(),
-        gate_store: gate_store.clone(),
-        definition_resolver: Arc::new(StaticDefinitionResolver {
-            resolved: Some(subagent_definition(false)),
-            parent: None,
-        }),
-        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
-            args: SpawnSubagentArgs {
-                subagent_kind: SubagentKindId::new("general").unwrap(),
-                task: "task".to_string(),
-                handoff: None,
-                mode: SpawnSubagentMode::Background,
-            },
-        }),
-        result_writer: Arc::new(NoopResultWriter),
-    });
-    let port = SubagentSpawnCapabilityPort::new(
-        Arc::new(AuthPassPort),
+    let harness = spawn_test_port_with_codec_and_recorders(
         context,
-        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
-        SubagentSpawnLimits::default(),
-        deps,
+        Arc::new(RejectingSpawnInputCodec {
+            error: background_subagents_disabled(),
+        }),
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
 
-    let error = port
+    let error = harness
+        .port
         .invoke_capability(CapabilityInvocation {
             surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
             capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
@@ -1303,47 +1361,23 @@ async fn invoke_spawn_rejects_background_mode_before_side_effects() {
             .safe_summary
             .contains("background subagents are disabled")
     );
-    assert!(child_runs.requests().is_empty());
-    assert!(goal_store.puts().is_empty());
-    assert!(gate_store.records().is_empty());
+    assert!(harness.child_runs.requests().is_empty());
+    assert!(harness.goal_store.puts().is_empty());
+    assert!(harness.gate_store.records().is_empty());
 }
 
 #[tokio::test]
-async fn invoke_spawn_batch_rejects_background_mode_before_side_effects() {
+async fn invoke_spawn_batch_propagates_decode_rejection_before_side_effects() {
     let context = test_run_context_with_agent_actor("spawn-background-disabled-batch").await;
-    let child_runs = Arc::new(RecordingChildRuns::default());
-    let goal_store = Arc::new(RecordingGoalStore::default());
-    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
-    let deps = Arc::new(SubagentSpawnDeps {
-        coordinator: Arc::new(StaticCoordinator),
-        child_runs: child_runs.clone(),
-        turn_state_store: Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0)))),
-        thread_service: Arc::new(InMemorySessionThreadService::default()),
-        goal_store: goal_store.clone(),
-        gate_store: gate_store.clone(),
-        definition_resolver: Arc::new(StaticDefinitionResolver {
-            resolved: Some(subagent_definition(false)),
-            parent: None,
-        }),
-        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
-            args: SpawnSubagentArgs {
-                subagent_kind: SubagentKindId::new("general").unwrap(),
-                task: "task".to_string(),
-                handoff: None,
-                mode: SpawnSubagentMode::Background,
-            },
-        }),
-        result_writer: Arc::new(NoopResultWriter),
-    });
-    let port = SubagentSpawnCapabilityPort::new(
-        Arc::new(AuthPassPort),
+    let harness = spawn_test_port_with_codec_and_recorders(
         context,
-        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
-        SubagentSpawnLimits::default(),
-        deps,
+        Arc::new(RejectingSpawnInputCodec {
+            error: background_subagents_disabled(),
+        }),
     );
 
-    let error = port
+    let error = harness
+        .port
         .invoke_capability_batch(CapabilityBatchInvocation {
             invocations: vec![CapabilityInvocation {
                 surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
@@ -1361,9 +1395,9 @@ async fn invoke_spawn_batch_rejects_background_mode_before_side_effects() {
             .safe_summary
             .contains("background subagents are disabled")
     );
-    assert!(child_runs.requests().is_empty());
-    assert!(goal_store.puts().is_empty());
-    assert!(gate_store.records().is_empty());
+    assert!(harness.child_runs.requests().is_empty());
+    assert!(harness.goal_store.puts().is_empty());
+    assert!(harness.gate_store.records().is_empty());
 }
 
 #[tokio::test]
@@ -1456,7 +1490,6 @@ async fn invoke_batch_coalesces_blocking_spawns_under_single_gate() {
                 subagent_kind: SubagentKindId::new("general").unwrap(),
                 task: "shared task".to_string(),
                 handoff: None,
-                mode: SpawnSubagentMode::Blocking,
             },
         }),
         result_writer: Arc::new(NoopResultWriter),
@@ -1547,7 +1580,6 @@ async fn invoke_batch_mixed_spawn_and_non_spawn_capabilities() {
                 subagent_kind: SubagentKindId::new("general").unwrap(),
                 task: "shared task".to_string(),
                 handoff: None,
-                mode: SpawnSubagentMode::Blocking,
             },
         }),
         result_writer: Arc::new(NoopResultWriter),
@@ -1653,7 +1685,6 @@ async fn invoke_batch_skips_shared_gate_for_single_blocking_spawn() {
                 subagent_kind: SubagentKindId::new("general").unwrap(),
                 task: "task".to_string(),
                 handoff: None,
-                mode: SpawnSubagentMode::Blocking,
             },
         }),
         result_writer: Arc::new(NoopResultWriter),

--- a/docs/reborn/subagent-spawn/README.md
+++ b/docs/reborn/subagent-spawn/README.md
@@ -524,11 +524,12 @@ Detailed per-phase docs with pseudo code:
   parallel-blocking E2E, early-completion (all children terminate
   before the parent blocks), child-authority (a child cannot use a lease the
   parent holds), child-approval-by-parent-owner, fork-bomb (caps reject — incl.
-  per-tree atomic), autonomous-continuation-budget-stop, cancellation subtree
-  + tombstone, restart-reconciliation (kill process between child terminal and
-  observer dispatch, restart, assert delivery), blocking-interruption, and
-  no-deadlock regression (child `thread_id` ≠ parent). Background E2E coverage
-  is deferred until #4147 defines durable delivery.
+  per-tree atomic), cancellation subtree + tombstone, restart-reconciliation
+  (kill process between child terminal and observer dispatch, restart, assert
+  delivery), blocking-interruption, and no-deadlock regression (child
+  `thread_id` ≠ parent). Background E2E coverage, including
+  autonomous-continuation-budget-stop, is deferred until #4147 defines durable
+  delivery.
 - **Quality gate:** `cargo fmt`; `cargo clippy --all --benches --tests --examples
   --all-features` (zero warnings); `cargo test`.
 - **Architecture guardrails:** `cargo test -p ironclaw_architecture --test

--- a/docs/reborn/subagent-spawn/README.md
+++ b/docs/reborn/subagent-spawn/README.md
@@ -1,6 +1,6 @@
 # Subagent Spawn for the Reborn Agent Loop — Design
 
-**Status:** Proposed
+**Status:** Implemented for blocking mode; background mode deferred
 **Date:** 2026-05-19
 **Branch:** `subagent-spawn-design`
 **Scope:** `crates/ironclaw_agent_loop`, `crates/ironclaw_turns`,
@@ -26,9 +26,16 @@ become additive later (each is a new `LoopFamily` plus a new turn *submitter*,
 with no rework of what this design ships).
 
 A **subagent** is a child agent loop with a fresh context, an attenuated tool set,
-its own model and "direction" (persona), spawned by a parent loop, returning a
-result to the parent either **blocking** (parent waits) or **background** (parent
-continues, result delivered later).
+its own model and "direction" (persona), spawned by a parent loop. The current
+implementation exposes **blocking** behavior only: the parent waits until the
+child reaches a terminal state and then resumes with the child result.
+
+Background subagents are deliberately disabled pending the durable completion
+delivery design tracked in [#4147](https://github.com/nearai/ironclaw/issues/4147).
+The public `spawn_subagent` schema does not expose a mode field. Omitted mode
+defaults to blocking, legacy explicit `mode: "blocking"` and
+`run_in_background: false` inputs are accepted for compatibility, and explicit
+background requests are rejected before child-run side effects.
 
 This design was produced through an iterative review process and hardened by a
 four-reviewer pass (design / bugs / conventions / security) against the live
@@ -47,7 +54,9 @@ exist because of that review.
 - A running agent loop can spawn one or more child agent loops via a tool call.
 - Child loops have a fresh context, an attenuated capability surface, their own
   model, iteration/cost budget, and "direction" (persona prompt).
-- Results return to the parent blocking *or* background.
+- Results return to the parent through the blocking path.
+- Preserve compatibility for legacy explicit blocking inputs while rejecting
+  explicit background requests until durable completion delivery is designed.
 - Parallel spawns: one parent turn may spawn N children that run concurrently.
 - The design generalises: missions/cron/triggers slot in as new families +
   submitters without reworking subagents.
@@ -116,23 +125,21 @@ gate, or turn side effect. That service performs the same fail-closed checks a
 first-party host capability must perform: grant/lease or approval policy,
 resource admission, scope consistency, owner/project binding, spawn-tree
 reservation, and redacted denial. Only after those checks pass does it create
-the child thread/run state and return a **new `CapabilityOutcome` variant**:
+the child thread/run state and return the blocking outcome:
 
-- **background** →
-  `CapabilityOutcome::SpawnedChildRun { child_run_id, result_ref, safe_summary }`
-  — a normal capability result; the executor pushes `result_ref` exactly like a
-  `Completed(CapabilityResultMessage)` result while preserving the child-run id
-  for observability.
 - **blocking** →
   `CapabilityOutcome::AwaitDependentRun { gate_ref, safe_summary }` — a gate
   outcome; the executor maps it to `GateKind::AwaitDependentRun` and then follows
   the existing `checkpoint BeforeBlock → LoopExit::Blocked` path.
 
+The earlier background outcome
+`CapabilityOutcome::SpawnedChildRun { child_run_id, result_ref, safe_summary }`
+is not exposed while #4147 is open.
+
 No `EffectKind` change and no new executor routing. The executor only gains the
-mechanical `CapabilityOutcome` arms that map background spawns to a result ref
-and blocking spawns to the existing gate path. The authority boundary is the
-kernel-mediated subagent-spawn service behind the loop capability port, not the
-capability surface allowlist.
+mechanical `CapabilityOutcome` arm that maps blocking spawns to the existing
+gate path. The authority boundary is the kernel-mediated subagent-spawn service
+behind the loop capability port, not the capability surface allowlist.
 
 The `result_ref` payload schema is **defined** (not implicit) — see §6 row
 "Spawn-result payload".
@@ -144,7 +151,8 @@ ironclaw_agent_loop    + `subagent` LoopFamily (static composition)
 (sealed framework)     + GateKind::AwaitDependentRun (pub(crate), wire-stable)
                        (executor: unchanged)
 
-ironclaw_turns         + CapabilityOutcome::{SpawnedChildRun, AwaitDependentRun}
+ironclaw_turns         + CapabilityOutcome::AwaitDependentRun
+                         (`SpawnedChildRun` reserved for deferred background)
 (coordination)         + AwaitDependentRun across LoopGateKind / LoopBlockedKind /
                          BlockedReason  and  TurnStatus::BlockedDependentRun
                        ~ SubmitTurnRequest and TurnRunRecord:
@@ -243,16 +251,16 @@ spawn time and keyed by the coordinator-minted `TurnRunId`.
 | Area | Decision |
 |---|---|
 | Execution | In-process child runs, runner-worker driven. |
-| Result modes | Blocking and background (`run_in_background` arg on the capability). |
-| Spawn surface | `spawn_subagent` capability; host port returns `SpawnedChildRun { child_run_id, result_ref, safe_summary }` (background) or `AwaitDependentRun { gate_ref, safe_summary }` (blocking). |
-| **Spawn-result payload (schema)** | `result_ref` resolves to a typed JSON document the parent's model receives as the tool result. Fields: `child_run_id: TurnRunId`, `child_thread_id: ThreadId`, `flavor: SubagentFlavorId`, `mode: "blocking" \| "background"`, `status: "spawned" \| "completed" \| "failed" \| "cancelled"`, `output_available: bool` (false for fresh background spawns — result will arrive later as an inbound message), `final_text: Option<String>` (populated for blocking + sanitised), `failure_summary: Option<SanitizedFailure>`. The schema is wire-stable, snake_case serde, round-trip tested. |
+| Result modes | Blocking only in the public schema. Background is deferred pending #4147. |
+| Spawn surface | `spawn_subagent` capability with `flavor_id`, `task`, and optional `handoff`; host port returns `AwaitDependentRun { gate_ref, safe_summary }` for blocking. Legacy explicit blocking inputs are accepted; explicit background inputs are rejected before child-run side effects. |
+| **Spawn-result payload (schema)** | For blocking mode, `result_ref` resolves to a typed JSON document the parent's model receives as the tool result. Fields: `child_run_id: TurnRunId`, `child_thread_id: ThreadId`, `flavor: SubagentFlavorId`, `mode: "blocking"`, `status: "completed" \| "failed" \| "cancelled"`, `output_available: bool`, `final_text: Option<String>` (sanitised), `failure_summary: Option<SanitizedFailure>`. Background payload shape is deferred with #4147. |
 | **`requested_run_id` / `prepare_turn`** | A `TurnCoordinator::prepare_turn(scope) -> TurnRunId` API mints a `TurnRunId` **before** any side-effect; `SubmitTurnRequest.requested_run_id: Option<TurnRunId>` lets the submitter pass it in so the coordinator binds the prepared id rather than minting a new one. The spawn handler uses this to **persist the goal under the real child run id from the start** — no staging key, no rekey. Generalises to missions/cron/triggers (any submitter that needs to "persist dependent state before submit"). |
 | Blocking | The `AwaitDependentRun` gate and its awaited child-run **set** are recorded **at spawn time, before `submit_turn`** — durable. The gate awaits a set; the parent resumes once, after the **last** child is terminal. If every child is already terminal when the parent would block, the gate resolves **inline** (no `Blocked`). |
-| **Blocking interruptibility** | A parent blocked on `AwaitDependentRun` is interruptible by the normal `cancel_run(parent)` path — propagates a recursive subtree cancel (§7.5). **Blocking subagents are for short, bounded work**; for long-running children prefer background mode so the parent can do other work meanwhile. |
+| **Blocking interruptibility** | A parent blocked on `AwaitDependentRun` is interruptible by the normal `cancel_run(parent)` path — propagates a recursive subtree cancel (§7.5). **Blocking subagents are for short, bounded work**; long-running detached children require the deferred background design. |
 | Resume payload | One synthetic `GateRef`; a host-side gate-resolution store holds all N child results, mapped back to the N pending tool calls. |
 | Child failure | Failed/cancelled children produce a typed result entry; the gate waits for **all** children to reach terminal — no early resume, no sibling cancellation. |
-| Background delivery | Each child result is `accept_inbound_message`'d into the parent thread (idempotent, provenance-tagged `SubagentResult`). The follow-up parent turn is **coalescing** — `submit_turn` only if none pending; `ThreadBusy` means "already pending, message will be consumed". |
-| **Autonomous-continuation budget** | To bound self-amplifying spawn cascades (parent wake → spawn more → child completes → wake again → …), a per-spawn-tree budget caps **background-wake turns per tree** and **wakes per rolling time window** (e.g. ≤16 wake-turns per tree, ≤4 per minute). Exceeding the cap suspends further wake submissions for that tree and emits a typed `AutonomousContinuationStopped` observability event for triage. Distinct from per-spawn caps (§8): a tree under the spawn cap can still go wake-loopy. |
+| Background delivery | Deferred pending #4147. The historical design was `accept_inbound_message` plus coalescing parent wake, but this is not exposed until durable delivery semantics are settled. |
+| **Autonomous-continuation budget** | Deferred with background delivery (#4147). The historical design bounded self-amplifying background wake cascades with per-tree and per-time-window wake quotas. |
 | Child authority | The child run starts with an **empty grant/lease set** — no inheritance of parent grants/leases. The capability allowlist is a surface *ceiling*, not authority. The child re-acquires every lease via its own `Approval` gate on its own thread. |
 | **Child approval ownership** | Child runs inherit the parent's `owner_user_id` AND `project_id` — **enforced in spawn code** (the child `ensure_thread` + `SubmitTurnRequest` copy both verbatim from the parent run record; deviation = typed error, not silently filled). A child's `Approval` gate surfaces on the **child thread** addressed to that owner — the parent user is the approver. The child thread is user-visible in the same surface as any other thread under that user; UI nesting is the deferred linkage. |
 | **Approval surfacing (projection, not bridge)** | A turn transitioning to `TurnStatus::BlockedApproval` does NOT currently populate the engine's `PendingGateStore` that the UI queries — they are two disconnected systems. **A direct write-hook bridge in `block_run()` is fragile** (matches the split-brain shape `.claude/rules/gateway-events.md` exists to prevent). Instead: `PendingGateStore` becomes a **derived projection** of `TurnLifecycleEvent` — a projection consumer reads turn events and materialises the same read model the UI already queries. One source of truth (turn events), replayable from a cursor, restart-safe, idempotent. The UI surface is unchanged. Affects every blocked turn (not subagent-specific) — landed as prerequisite **P0** (see §11). |
@@ -264,7 +272,7 @@ spawn time and keyed by the coordinator-minted `TurnRunId`.
 | Goal placement | The parent-injected goal + `Handoff` blob are the child's **first user message**, delimited as task data (`## Task (from parent)` / `## Context from parent`). **Never** the system message — the goal is model-generated and may carry upstream-tainted content. |
 | **Goal durability (DB-backed)** | Persisted in a **durable, DB-backed** subagent goal store keyed by the child `TurnRunId`. Implementation piggybacks on turn-state persistence (the same backend that stores `TurnRunRecord`). The child run id is **known before** `submit_turn` via `prepare_turn` — no staging key, no rekey. Survives process restart by construction. A store miss **fails the child run loudly**. |
 | Lineage | `parent_run_id`, `subagent_depth`, and `spawn_tree_root_run_id` fields on `SubmitTurnRequest` and `TurnRunRecord` (durable). `children_of` and `get_run_record` are store queries — no in-memory index as source of truth. |
-| **Restart reconciliation** | `with_event_sink` gives live delivery, but a process crash between *child terminal commit* and *observer dispatch* would strand a parent gate or background result. `RestartReconciler` runs at startup and on a periodic timer: scans terminal child runs whose lineage points at a parent with an unresolved `AwaitDependentRun` gate or an undelivered `SubagentResult` inbound, and replays the observer action (resume / accept_inbound + submit). Idempotent via the same `external_event_id` keying the live path uses. |
+| **Restart reconciliation** | `with_event_sink` gives live delivery, but a process crash between *child terminal commit* and *observer dispatch* would strand a parent gate. `RestartReconciler` runs at startup and on a periodic timer: scans terminal child runs whose lineage points at a parent with an unresolved `AwaitDependentRun` gate and replays the observer resume action. Background-result reconciliation is deferred with #4147. Idempotent via the same `external_event_id` keying the live path uses. |
 | **Cancellation tombstone** | A child completing terminal during a subtree cancel **does not silently drop**. It writes a typed `SubagentResultTombstone { child_run_id, disposition: "discarded_by_parent_cancel", terminal_status }` so reconciliation can distinguish "intentionally discarded" from "lost in the gap". |
 | Idempotency | Child `submit_turn` key = `(parent_run_id, parent_turn_id, spawn-call ordinal)` — deterministic for replay, unique per spawn call even for identical-argument siblings. The `requested_run_id` further pins which `TurnRunId` the coordinator binds for replay. |
 | Tenancy | The child `TurnScope` copies `tenant_id`/`agent_id`/`project_id` **verbatim**; only `thread_id` differs (fresh). Test-enforced invariant. |
@@ -283,11 +291,12 @@ that approvals already use.
 
 ![Loop execution — checkpoint and exit points](diagrams/loop-execution.svg)
 
-### 7.2 Spawn flow — background & blocking
+### 7.2 Spawn flow — blocking
 
 `spawn_subagent` is an ordinary capability; the `ironclaw_loop_support` capability
-port handles it and returns either `SpawnedChildRun` (background) or an
-`AwaitDependentRun` gate (blocking).
+port handles it and returns an `AwaitDependentRun` gate. Background branches in
+the diagram are historical design context and are not exposed by the current
+schema.
 
 ![Subagent spawn flow](diagrams/spawn-flow.svg)
 
@@ -301,6 +310,9 @@ blocking is not "stuck", it is "waiting under cancellation".
 ![Blocking subagent lifecycle](diagrams/blocking-lifecycle.svg)
 
 ### 7.4 Autonomous wake (background)
+
+Background autonomous wake is not active in the current implementation. This
+section captures the deferred design space for #4147.
 
 When a background subagent completes and **the parent is idle / no user is
 interacting**, the parent still runs — `SubagentCompletionObserver`'s
@@ -351,13 +363,12 @@ parent CancelRequested
 
 The live observer path (`with_event_sink`) handles steady-state delivery. A
 process crash between a child's terminal commit and the observer's dispatch would
-otherwise strand a parent gate or background result. `RestartReconciler` closes
-that hole:
+otherwise strand a parent gate. `RestartReconciler` closes that hole:
 
 - **Startup sweep:** scan terminal child runs whose lineage points at a parent
-  with an unresolved `AwaitDependentRun` gate or an undelivered `SubagentResult`
-  inbound; replay the observer action (resume for blocking, accept_inbound +
-  submit for background). Idempotent via the same `external_event_id` key.
+  with an unresolved `AwaitDependentRun` gate; replay the observer resume action.
+  Background result reconciliation is deferred with #4147. Idempotent via the
+  same `external_event_id` key.
 - **Periodic poll** (every N seconds, configurable): same query, catches any
   in-flight event loss.
 
@@ -409,7 +420,7 @@ mitigations below are **load-bearing**, not optional.
 | Child completes before the parent blocks (lost wakeup) | The `AwaitDependentRun` gate + awaited set are recorded **before `submit_turn`**, durably. On entering the gate the parent reconciles against `get_run_state`. |
 | All children finish before the parent blocks | Gate resolves **inline** — the parent never emits `Blocked`. |
 | One child fails mid-flight | Failed/cancelled child = a typed result entry; the gate still waits for all children; siblings are not cancelled. |
-| Two background completions race on the parent thread | Results are `accept_inbound_message`'d (idempotent); the follow-up turn is coalescing; `ThreadBusy` is expected, not an error. |
+| Two background completions race on the parent thread | Deferred pending #4147; background is not currently exposed. |
 | Process restart **between child terminal commit and observer dispatch** | `RestartReconciler` (§7.6) sweeps at startup + periodically and replays observer actions; idempotent via `external_event_id`. The live event sink covers steady state; the reconciler covers the gap. |
 | Process restart **general state** | Goal store is **DB-backed durable**; lineage (`parent_run_id`/`subagent_depth`/`spawn_tree_root_run_id`) is durable; `children_of` is a store query. No in-memory source of truth. A goal-store miss fails the child loudly. |
 | Identical-argument sibling spawns | Distinct idempotency keys via the per-turn ordinal; `requested_run_id` pins the bound run id. |
@@ -418,8 +429,8 @@ mitigations below are **load-bearing**, not optional.
 | Child completes with no assistant message | Typed "completed, no output" result — the parent always receives N well-formed results. |
 | Partial spawn (`submit_turn` fails after `prepare_turn` + reservation) | The reservation + awaited-set entry are the source of truth, written first; the half-spawn is reconciled (child absent or marked failed) and the reservation is released; fail loud. |
 | **Per-tree descendant over-admit** | `reserve_tree_descendants(scope, root, delta, cap)` is **atomic at the store** and runs before `submit_turn`. Concurrent admit across subtrees (different threads) cannot over-admit. Concurrent admit on the same parent thread is precluded by the per-`TurnScope` active-run lock. |
-| **Autonomous-continuation runaway** | Per-tree wake-turn quota + per-time-window rate-limit; exceeded → wake submissions suspended for that tree + `AutonomousContinuationStopped` event emitted (§7.4). |
-| **Blocking parent waiting indefinitely** | Parent is interruptible: `cancel_run(parent)` cascades through the subtree (§7.5). Blocking subagents are *for short bounded work*; long children should be background. |
+| **Autonomous-continuation runaway** | Deferred with background autonomous wake (#4147). |
+| **Blocking parent waiting indefinitely** | Parent is interruptible: `cancel_run(parent)` cascades through the subtree (§7.5). Blocking subagents are *for short bounded work*; long detached children require the deferred background design. |
 | **Approval invisible to UI** (today, every blocked turn) | `block_run()` only writes `TurnStatus::BlockedApproval` + a `TurnLifecycleEvent` scoped to `TurnScope`; the engine's `PendingGateStore` (where the UI queries) is not populated. Fix is **prerequisite P0** (§11): make `PendingGateStore` a derived projection of `TurnLifecycleEvent`. Single source log; replayable from cursor; restart-safe; no `block_run()` dual-write. |
 
 ## 10. Crate boundary verification
@@ -428,14 +439,15 @@ mitigations below are **load-bearing**, not optional.
 |---|---|---|---|
 | `ironclaw_agent_loop` | sealed; product-agnostic; refs not raw prompts | one `subagent` family; `GateKind::AwaitDependentRun` is neutral; executor gains only outcome-to-existing-gate/result mapping | ✅ |
 | `ironclaw_turns` | coordination contracts; lifecycle metadata + refs | `CapabilityOutcome` variants, blocked-kind variants, lineage fields, `prepare_turn` API, atomic descendant reservation query | ✅ |
-| `ironclaw_loop_support` | host-port adapter glue; no stateful stores | spawn handling in the capability port; concrete stores, projection sinks, and background tasks are injected by composition | ✅ |
+| `ironclaw_loop_support` | host-port adapter glue; no stateful stores | blocking spawn handling in the capability port; concrete stores and projection sinks are injected by composition | ✅ |
 | `ironclaw_reborn` | generic loop library; driver/profile/readiness; no root `src/` adapters | family driver, profiles, flavors, directions, Reborn-neutral goal/tombstone traits, observer/reconciler logic, and readiness metadata | ✅ |
-| `ironclaw_reborn_composition` | concrete product-live assembly; still no root `src/` imports | DB-backed store construction, root-provided `PendingGateProjectionSink`, composite event sink, runtime assembly, and background task spawning | ✅ |
+| `ironclaw_reborn_composition` | concrete product-live assembly; still no root `src/` imports | DB-backed store construction, root-provided `PendingGateProjectionSink`, composite event sink, and runtime assembly | ✅ |
 | `ironclaw_host_runtime` / `ironclaw_host_api` | — | untouched | ✅ |
 
-Five wire-stable enums gain `AwaitDependentRun` / `BlockedDependentRun` /
-`SpawnedChildRun` variants: `CapabilityOutcome`, `LoopGateKind`,
-`LoopBlockedKind`, `BlockedReason`, `TurnStatus`. Each new variant **matches the existing serde
+Five wire-stable enums gain `AwaitDependentRun` / `BlockedDependentRun`
+variants, with `SpawnedChildRun` reserved for deferred background support:
+`CapabilityOutcome`, `LoopGateKind`, `LoopBlockedKind`, `BlockedReason`,
+`TurnStatus`. Each new variant **matches the existing serde
 convention of its enum** — `LoopGateKind`/`LoopBlockedKind`/`CapabilityOutcome`
 are snake_case; **`TurnStatus` and `BlockedReason` serialize PascalCase today**
 (no `#[serde(rename_all)]`) and their new variants stay PascalCase to avoid
@@ -508,14 +520,15 @@ Detailed per-phase docs with pseudo code:
 ## 12. Verification strategy
 
 - **Unit tests** per crate — see each phase doc.
-- **Integration tests** (`crates/ironclaw_reborn_composition/tests/`): background E2E,
-  blocking E2E, parallel-blocking E2E, early-completion (all children terminate
+- **Integration tests** (`tests/reborn_subagent_spawn_e2e.rs`): blocking E2E,
+  parallel-blocking E2E, early-completion (all children terminate
   before the parent blocks), child-authority (a child cannot use a lease the
   parent holds), child-approval-by-parent-owner, fork-bomb (caps reject — incl.
   per-tree atomic), autonomous-continuation-budget-stop, cancellation subtree
   + tombstone, restart-reconciliation (kill process between child terminal and
   observer dispatch, restart, assert delivery), blocking-interruption, and
-  no-deadlock regression (child `thread_id` ≠ parent).
+  no-deadlock regression (child `thread_id` ≠ parent). Background E2E coverage
+  is deferred until #4147 defines durable delivery.
 - **Quality gate:** `cargo fmt`; `cargo clippy --all --benches --tests --examples
   --all-features` (zero warnings); `cargo test`.
 - **Architecture guardrails:** `cargo test -p ironclaw_architecture --test
@@ -523,16 +536,17 @@ Detailed per-phase docs with pseudo code:
   must pass, with any intentional boundary-rule changes reviewed in the same PR.
 - **Replay/snapshot evidence:** add deterministic subagent trace fixtures and run
   `scripts/replay-snap.sh test` (or the current replay command for those
-  fixtures) before claiming product compatibility for background delivery,
-  blocking result payloads, and idempotent replay. Until those fixtures land,
-  implementation PRs must say subagent spawn is not yet product-compatible even
-  if unit and integration tests pass.
+  fixtures) before claiming product compatibility for blocking result payloads
+  and idempotent replay. Background delivery fixtures are deferred with #4147.
+  Until those fixtures land, implementation PRs must say subagent spawn is not
+  yet product-compatible even if unit and integration tests pass.
 
 ## 13. Follow-ups (explicitly deferred)
 
-Mission / cron / trigger loop families + their submitters; parent↔child UI/event
-linkage (nested thread display); `Fork` seed mode; relaying a child's approval
-into the parent conversation; file-discovered user-defined flavors.
+Mission / cron / trigger loop families + their submitters; durable background
+subagent completion delivery (#4147); parent↔child UI/event linkage (nested
+thread display); `Fork` seed mode; relaying a child's approval into the parent
+conversation; file-discovered user-defined flavors.
 
 (The goal-store durability question is **resolved** in v1: DB-backed via
 turn-state persistence — see §6 "Goal durability (DB-backed)".)

--- a/docs/reborn/subagent-spawn/phase-2-mechanisms.md
+++ b/docs/reborn/subagent-spawn/phase-2-mechanisms.md
@@ -5,6 +5,13 @@
 **Parent doc:** [`README.md`](./README.md) — read §5, §6, §8, §9, §11 first.
 **Depends on:** Phase 1 ([`phase-1-contracts.md`](./phase-1-contracts.md)).
 
+> **Current implementation note.** Background subagents are disabled pending the
+> durable completion delivery design in
+> [#4147](https://github.com/nearai/ironclaw/issues/4147). The active public
+> `spawn_subagent` schema exposes `flavor_id`, `task`, and optional `handoff`;
+> omitted mode defaults to blocking. Background-related mechanisms below are
+> historical design context, not active behavior.
+
 Phase 2 builds the four *mechanisms* of subagent spawn on top of the Phase 1
 contracts. The four workstreams are independently reviewable PRs and run in
 parallel after Phase 1 lands:

--- a/docs/reborn/subagent-spawn/phase-3-integration.md
+++ b/docs/reborn/subagent-spawn/phase-3-integration.md
@@ -9,6 +9,12 @@
 DB-backed store construction, root-provided projection sink wiring, and
 background task spawning.
 
+> **Current implementation note.** Background subagents are disabled pending the
+> durable completion delivery design in
+> [#4147](https://github.com/nearai/ironclaw/issues/4147). The active public
+> `spawn_subagent` surface is blocking-only; background integration and E2E
+> items below are deferred design context, not active behavior.
+
 This is the wiring-and-verification phase. Phases 1 and 2 produce the
 *components* — contracts, the `subagent` `LoopFamily`, the `subagent`
 `PlannedDriver`, the spawn-handling capability port, the prompt composition,

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -20,88 +20,6 @@ use reborn_support::{
 };
 
 #[tokio::test]
-async fn background_spawn_delivers_child_result_and_parent_followup_runs() {
-    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
-        RebornModelReplayStep::ProviderToolCalls {
-            calls: vec![spawn_call(
-                "spawn_background",
-                serde_json::json!({
-                    "flavor_id": "general",
-                    "task": "summarize the fixture",
-                    "handoff": "parent context",
-                    "mode": "background",
-                }),
-            )],
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("parent continued"),
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("child finished"),
-            expected_tool_results: Vec::new(),
-        },
-    ]);
-    let mut harness = spawn_harness("room-subagent-background", model_gateway).await;
-    harness.start();
-
-    let submitted = harness
-        .submit_text("event-subagent-background", "delegate in background")
-        .await
-        .expect("submit root turn");
-    harness
-        .wait_for_status(submitted.run_id, TurnStatus::Completed)
-        .await
-        .expect("parent completes without blocking on background child");
-    harness
-        .assert_final_reply("parent continued")
-        .await
-        .expect("parent final reply");
-
-    let child = await_single_child(&harness, &submitted).await;
-    harness
-        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
-        .await
-        .expect("background child completes");
-    assert_child_thread_invariants(&submitted, &child);
-
-    let child_history = harness
-        .history_for_thread_in_scope(
-            child_thread_scope(&submitted, &child),
-            child.scope.thread_id.clone(),
-        )
-        .await
-        .expect("child history");
-    assert!(
-        child_history.iter().any(|message| message
-            .content
-            .as_deref()
-            .is_some_and(|content| content.contains("summarize the fixture"))),
-        "child receives the parent task as an inbound message"
-    );
-    assert!(
-        child_history
-            .iter()
-            .any(|message| message.content.as_deref() == Some("child finished")),
-        "child writes its own final reply"
-    );
-
-    assert!(
-        harness.model_requests()[1]
-            .messages
-            .iter()
-            .any(
-                |message| message.role == HostManagedModelMessageRole::ToolResult
-                    && message.content.contains("subagent spawned in background")
-            ),
-        "parent follow-up request includes the background spawn tool result"
-    );
-    harness.assert_model_exhausted();
-    harness.shutdown().await;
-}
-
-#[tokio::test]
 async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -110,7 +28,6 @@ async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
                 serde_json::json!({
                     "flavor_id": "general",
                     "task": "answer for the parent",
-                    "mode": "blocking",
                 }),
             )],
             expected_tool_results: Vec::new(),
@@ -175,7 +92,6 @@ async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() 
                 serde_json::json!({
                     "flavor_id": "general",
                     "task": "call an approval-gated tool",
-                    "mode": "blocking",
                 }),
             )],
             expected_tool_results: Vec::new(),
@@ -277,226 +193,6 @@ async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() 
 }
 
 #[tokio::test]
-async fn background_spawn_surfaces_child_approval_without_blocking_parent() {
-    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
-        RebornModelReplayStep::ProviderToolCalls {
-            calls: vec![spawn_call(
-                "spawn_background_child_approval",
-                serde_json::json!({
-                    "flavor_id": "general",
-                    "task": "call an approval-gated tool in background",
-                    "mode": "background",
-                }),
-            )],
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply(
-                "parent continued while child approval pending",
-            ),
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::ProviderToolCalls {
-            calls: vec![subagent_allowed_tool_call("background_child_approval_tool")],
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("background child approved output"),
-            expected_tool_results: Vec::new(),
-        },
-    ]);
-    let mut harness = tokio::time::timeout(
-        WaitConfig::default().timeout,
-        RebornBinaryE2EHarness::with_harness_blocked_evidence_unscoped_worker(
-            "room-subagent-background-child-approval",
-            model_gateway,
-            RecordingTestCapabilityPort::spawn_auth_then_approval_then_allowed_tool_with_spawn_subagent(),
-        ),
-    )
-    .await
-    .expect("spawn harness timed out")
-    .expect("spawn harness");
-    harness.start();
-
-    let submitted = harness
-        .submit_text(
-            "event-subagent-background-child-approval",
-            "spawn a background child that needs approval",
-        )
-        .await
-        .expect("submit root turn");
-    harness
-        .wait_for_status(submitted.run_id, TurnStatus::Completed)
-        .await
-        .expect("background parent completes before child approval resolves");
-    harness
-        .assert_final_reply("parent continued while child approval pending")
-        .await
-        .expect("parent final reply");
-
-    let child = await_single_child(&harness, &submitted).await;
-    assert_child_thread_invariants(&submitted, &child);
-    harness
-        .wait_for_status_in_scope(
-            child.scope.clone(),
-            child.run_id,
-            TurnStatus::BlockedApproval,
-        )
-        .await
-        .expect("background child blocks on approval");
-    assert_eq!(
-        harness
-            .run_state(submitted.run_id)
-            .await
-            .expect("parent run state")
-            .status,
-        TurnStatus::Completed,
-        "background child approval must not reopen or block the completed parent"
-    );
-
-    harness
-        .resume_blocked_turn_in_scope(child.scope.clone(), submitted.actor.clone(), child.run_id)
-        .await
-        .expect("resume background child approval");
-    harness
-        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
-        .await
-        .expect("background child completes after approval");
-    let child_history = harness
-        .history_for_thread_in_scope(
-            child_thread_scope(&submitted, &child),
-            child.scope.thread_id.clone(),
-        )
-        .await
-        .expect("child history");
-    assert!(
-        child_history.iter().any(|message| {
-            message.content.as_deref() == Some("background child approved output")
-        }),
-        "approved background child writes its final reply"
-    );
-    assert_eq!(
-        harness.capability_invocations().len(),
-        2,
-        "spawn auth plus the child approval gate should reach the inner capability port"
-    );
-    harness.assert_model_exhausted();
-    harness.shutdown().await;
-}
-
-#[tokio::test]
-async fn background_child_approval_surfaces_while_parent_is_still_running() {
-    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
-        RebornModelReplayStep::ProviderToolCalls {
-            calls: vec![spawn_call(
-                "spawn_concurrent_background_child_approval",
-                serde_json::json!({
-                    "flavor_id": "general",
-                    "task": "approval while parent runs",
-                    "mode": "background",
-                }),
-            )],
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::DelayedResponseForRequest {
-            request_contains: "parent keeps running while child waits".to_string(),
-            response: HostManagedModelResponse::assistant_reply("parent eventually finished"),
-            delay: Duration::from_secs(2),
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::ProviderToolCallsForRequest {
-            request_contains: "approval while parent runs".to_string(),
-            calls: vec![subagent_allowed_tool_call("concurrent_child_approval_tool")],
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::ResponseForRequest {
-            request_contains: "approval while parent runs".to_string(),
-            response: HostManagedModelResponse::assistant_reply(
-                "concurrent background child approved output",
-            ),
-            expected_tool_results: Vec::new(),
-        },
-    ]);
-    let mut harness = tokio::time::timeout(
-        WaitConfig::default().timeout,
-        RebornBinaryE2EHarness::with_harness_blocked_evidence_unscoped_worker(
-            "room-subagent-concurrent-background-child-approval",
-            model_gateway,
-            RecordingTestCapabilityPort::spawn_auth_then_approval_then_allowed_tool_with_spawn_subagent(),
-        ),
-    )
-    .await
-    .expect("spawn harness timed out")
-    .expect("spawn harness");
-    harness.start_workers(2);
-
-    let submitted = harness
-        .submit_text(
-            "event-subagent-concurrent-background-child-approval",
-            "parent keeps running while child waits",
-        )
-        .await
-        .expect("submit root turn");
-    let child = await_single_child(&harness, &submitted).await;
-    assert_child_thread_invariants(&submitted, &child);
-    harness
-        .wait_for_status_in_scope(
-            child.scope.clone(),
-            child.run_id,
-            TurnStatus::BlockedApproval,
-        )
-        .await
-        .expect("background child approval surfaces");
-    assert_eq!(
-        harness
-            .run_state(submitted.run_id)
-            .await
-            .expect("parent run state")
-            .status,
-        TurnStatus::Running,
-        "background child approval must surface while the parent turn is still running"
-    );
-
-    harness
-        .resume_blocked_turn_in_scope(child.scope.clone(), submitted.actor.clone(), child.run_id)
-        .await
-        .expect("resume background child approval");
-    harness
-        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
-        .await
-        .expect("background child completes after approval");
-    harness
-        .wait_for_status(submitted.run_id, TurnStatus::Completed)
-        .await
-        .expect("parent completes after its long-running model call");
-    harness
-        .assert_final_reply("parent eventually finished")
-        .await
-        .expect("parent final reply");
-
-    let child_history = harness
-        .history_for_thread_in_scope(
-            child_thread_scope(&submitted, &child),
-            child.scope.thread_id.clone(),
-        )
-        .await
-        .expect("child history");
-    assert!(
-        child_history.iter().any(|message| {
-            message.content.as_deref() == Some("concurrent background child approved output")
-        }),
-        "approved background child writes its final reply while parent is independently running"
-    );
-    assert_eq!(
-        harness.capability_invocations().len(),
-        2,
-        "spawn auth plus the child approval gate should reach the inner capability port"
-    );
-    harness.assert_model_exhausted();
-    harness.shutdown().await;
-}
-
-#[tokio::test]
 async fn parallel_blocking_spawn_resumes_once_after_last_child() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {
@@ -506,7 +202,6 @@ async fn parallel_blocking_spawn_resumes_once_after_last_child() {
                     serde_json::json!({
                         "flavor_id": "general",
                         "task": "same goal",
-                        "mode": "blocking",
                     }),
                 ),
                 spawn_call(
@@ -514,7 +209,6 @@ async fn parallel_blocking_spawn_resumes_once_after_last_child() {
                     serde_json::json!({
                         "flavor_id": "general",
                         "task": "same goal",
-                        "mode": "blocking",
                     }),
                 ),
                 spawn_call(
@@ -522,7 +216,6 @@ async fn parallel_blocking_spawn_resumes_once_after_last_child() {
                     serde_json::json!({
                         "flavor_id": "general",
                         "task": "same goal",
-                        "mode": "blocking",
                     }),
                 ),
             ],
@@ -588,88 +281,6 @@ async fn parallel_blocking_spawn_resumes_once_after_last_child() {
             .count()
             >= 3,
         "parent resume request contains all child completion results"
-    );
-    harness.assert_model_exhausted();
-    harness.shutdown().await;
-}
-
-#[tokio::test]
-async fn fork_bomb_fanout_cap_rejects_before_submit_turn() {
-    let calls = (0..5)
-        .map(|index| {
-            spawn_call(
-                format!("spawn_background_{index}"),
-                serde_json::json!({
-                    "flavor_id": "general",
-                    "task": format!("child {index}"),
-                    "mode": "background",
-                }),
-            )
-        })
-        .collect::<Vec<_>>();
-    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
-        RebornModelReplayStep::ProviderToolCalls {
-            calls,
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("fanout handled"),
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("child 0"),
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("child 1"),
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("child 2"),
-            expected_tool_results: Vec::new(),
-        },
-        RebornModelReplayStep::Response {
-            response: HostManagedModelResponse::assistant_reply("child 3"),
-            expected_tool_results: Vec::new(),
-        },
-    ]);
-    let mut harness = spawn_harness("room-subagent-fanout-cap", model_gateway).await;
-    harness.start();
-
-    let submitted = harness
-        .submit_text("event-subagent-fanout-cap", "try too many children")
-        .await
-        .expect("submit root turn");
-    harness
-        .wait_for_status(submitted.run_id, TurnStatus::Completed)
-        .await
-        .expect("parent completes after denial");
-    harness
-        .assert_final_reply("fanout handled")
-        .await
-        .expect("parent final reply");
-
-    let children = await_children(&harness, &submitted, 4).await;
-    assert_eq!(
-        children.len(),
-        4,
-        "fifth spawn is rejected before child submission"
-    );
-    for child in &children {
-        harness
-            .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
-            .await
-            .expect("accepted background child completes");
-    }
-    assert!(
-        harness.model_requests()[1]
-            .messages
-            .iter()
-            .any(
-                |message| message.role == HostManagedModelMessageRole::ToolResult
-                    && message.content.contains("fanout_cap_exceeded")
-            ),
-        "denied spawn is returned to the parent as a tool result"
     );
     harness.assert_model_exhausted();
     harness.shutdown().await;
@@ -755,17 +366,4 @@ fn assert_child_thread_invariants(parent: &SubmittedTurn, child: &ironclaw_turns
         child.scope.thread_id, parent.scope.thread_id,
         "child must run on a distinct thread"
     );
-}
-
-fn child_thread_scope(
-    parent: &SubmittedTurn,
-    child: &ironclaw_turns::TurnRunRecord,
-) -> ironclaw_threads::ThreadScope {
-    ironclaw_threads::ThreadScope {
-        tenant_id: child.scope.tenant_id.clone(),
-        agent_id: child.scope.agent_id.clone().expect("agent-scoped turn"),
-        project_id: child.scope.project_id.clone(),
-        owner_user_id: parent.thread_scope.owner_user_id.clone(),
-        mission_id: None,
-    }
 }

--- a/tests/reborn_subagent_spawn_e2e.rs
+++ b/tests/reborn_subagent_spawn_e2e.rs
@@ -84,6 +84,114 @@ async fn blocking_spawn_parks_parent_then_resumes_with_child_result() {
 }
 
 #[tokio::test]
+async fn legacy_explicit_blocking_spawn_still_parks_parent_and_resumes() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![spawn_call(
+                "spawn_legacy_explicit_blocking",
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": "answer with legacy blocking fields",
+                    "mode": "blocking",
+                    "run_in_background": false,
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::DelayedResponse {
+            response: HostManagedModelResponse::assistant_reply("legacy blocking child output"),
+            delay: Duration::from_millis(50),
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply("legacy blocking parent resumed"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = spawn_harness("room-subagent-legacy-blocking", model_gateway).await;
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-subagent-legacy-blocking",
+            "delegate with legacy blocking",
+        )
+        .await
+        .expect("submit root turn");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::BlockedDependentRun)
+        .await
+        .expect("parent parks on legacy blocking child");
+
+    let child = await_single_child(&harness, &submitted).await;
+    assert_child_thread_invariants(&submitted, &child);
+    harness
+        .wait_for_status_in_scope(child.scope.clone(), child.run_id, TurnStatus::Completed)
+        .await
+        .expect("legacy blocking child completes");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("parent resumes after legacy blocking child completion");
+    harness
+        .assert_final_reply("legacy blocking parent resumed")
+        .await
+        .expect("parent final reply");
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn background_spawn_is_rejected_before_child_run_or_auth_invocation() {
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![spawn_call(
+                "spawn_background_disabled",
+                serde_json::json!({
+                    "flavor_id": "general",
+                    "task": "run in the background",
+                    "mode": "background",
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = spawn_harness("room-subagent-background-disabled", model_gateway).await;
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-subagent-background-disabled",
+            "try background delegation",
+        )
+        .await
+        .expect("submit root turn");
+    let state = harness
+        .wait_for_status(submitted.run_id, TurnStatus::RecoveryRequired)
+        .await
+        .expect("background spawn rejects the parent turn");
+
+    assert_eq!(
+        state.failure.expect("failure category").category(),
+        "driver_unavailable"
+    );
+    assert!(
+        harness
+            .children_of(&submitted.scope, submitted.run_id)
+            .await
+            .expect("children")
+            .is_empty(),
+        "disabled background spawn must not create a child run"
+    );
+    assert!(
+        harness.capability_invocations().is_empty(),
+        "disabled background spawn must reject before inner authorization invocation"
+    );
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+#[tokio::test]
 async fn blocking_spawn_waits_while_child_is_blocked_on_approval_then_resumes() {
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
         RebornModelReplayStep::ProviderToolCalls {

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -2158,9 +2158,7 @@ impl LoopCapabilityPort for RecordingTestCapabilityPort {
                     "properties": {
                         "flavor_id": {"type": "string"},
                         "task": {"type": "string"},
-                        "handoff": {"type": "string"},
-                        "mode": {"type": "string", "enum": ["blocking", "background"]},
-                        "run_in_background": {"type": "boolean"}
+                        "handoff": {"type": "string"}
                     },
                     "required": ["flavor_id", "task"]
                 }),


### PR DESCRIPTION
## Summary

- removes `mode` and `run_in_background` from the public `spawn_subagent` schema and Reborn E2E harness surface
- defaults omitted spawn mode to blocking, while accepting legacy explicit `mode: "blocking"` and `run_in_background: false`
- rejects explicit background requests before child-run, goal-store, or gate side effects
- marks background subagent delivery as deferred in the Reborn subagent docs and FEATURE_PARITY

Supersedes #4089. Durable background completion delivery is tracked separately in #4147.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_loop_support subagent_spawn_port`
- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_first_party_surface_lists_allowed_tools_in_registry_order`
- `cargo test --test reborn_subagent_spawn_e2e`
- `cargo clippy -p ironclaw_loop_support -p ironclaw_host_runtime --tests -- -D warnings`
