### PR TITLE
[codex] Skip incomplete local extension catalog entries

### DIFF
--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -647,11 +647,17 @@ where
             entry.path.as_str().trim_end_matches('/')
         ))
         .map_err(map_binding_error)?;
-        let manifest_bytes = fs.read_file(&manifest_path).await.map_err(|error| {
-            ProductWorkflowError::Transient {
-                reason: format!("failed to read available extension manifest: {error}"),
+        let manifest_bytes = match fs.read_file(&manifest_path).await {
+            Ok(bytes) => bytes,
+            Err(FilesystemError::NotFound { .. }) | Err(FilesystemError::MountNotFound { .. }) => {
+                continue;
             }
-        })?;
+            Err(error) => {
+                return Err(ProductWorkflowError::Transient {
+                    reason: format!("failed to read available extension manifest: {error}"),
+                });
+            }
+        };
         let manifest_toml = String::from_utf8(manifest_bytes).map_err(|error| {
             ProductWorkflowError::InvalidBindingRequest {
                 reason: format!("available extension manifest is not UTF-8: {error}"),
@@ -869,6 +875,26 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["manifest.toml", "wasm/fixture.wasm"]
         );
+    }
+
+    #[tokio::test]
+    async fn filesystem_catalog_skips_extension_dirs_without_manifest() {
+        let fs = InMemoryBackend::default();
+        fs.write_file(
+            &VirtualPath::new("/system/extensions/incomplete/cache/leftover").unwrap(),
+            b"stale",
+        )
+        .await
+        .unwrap();
+
+        let catalog = AvailableExtensionCatalog::from_filesystem_root(
+            &fs,
+            &VirtualPath::new("/system/extensions").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(catalog.search("").count(), 0);
     }
 
     #[derive(Default)]


### PR DESCRIPTION
## Summary
- Skip local available-extension directories that no longer contain `manifest.toml`
- Keep real filesystem/backend failures fatal, while treating missing package manifests as incomplete local state
- Add regression coverage for a stale `/system/extensions/<id>/` directory with leftover files but no manifest

## Root Cause
`serve` scans `/system/extensions` while building the local available-extension catalog. A stale directory such as `/system/extensions/github/` can remain after failed install/remove cleanup, even after `manifest.toml` has been deleted. The catalog loader treated that missing manifest as a transient startup failure, so Reborn failed before it could continue to the bundled GitHub package.

## Validation
- cargo fmt --check -p ironclaw_reborn_composition
- cargo test -p ironclaw_reborn_composition available_extensions::tests