### PR TITLE
Remove display preview line cap

### DIFF
--- a/crates/ironclaw_product_adapters/src/lib.rs
+++ b/crates/ironclaw_product_adapters/src/lib.rs
@@ -51,11 +51,11 @@ pub use inbound::{
 };
 pub use outbound::{
     AuthPromptView, CAPABILITY_DISPLAY_KIND_MAX_BYTES, CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES,
-    CAPABILITY_DISPLAY_PREVIEW_MAX_LINES, CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES,
-    CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES, CapabilityActivityStatusView, CapabilityActivityView,
-    CapabilityActivityViewInput, CapabilityDisplayPreviewView, CapabilityDisplayPreviewViewInput,
-    FinalReplyView, GatePromptView, ProductOutboundEnvelope, ProductOutboundPayload,
-    ProductOutboundTarget, ProductProjectionItem, ProductProjectionState, ProductRenderOutcome,
+    CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES, CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES,
+    CapabilityActivityStatusView, CapabilityActivityView, CapabilityActivityViewInput,
+    CapabilityDisplayPreviewView, CapabilityDisplayPreviewViewInput, FinalReplyView,
+    GatePromptView, ProductOutboundEnvelope, ProductOutboundPayload, ProductOutboundTarget,
+    ProductProjectionItem, ProductProjectionState, ProductRenderOutcome,
     ProductSynchronousResponse, ProgressKind, ProgressUpdateView, ProjectionCursor,
 };
 pub use projection::{ProjectionStream, ProjectionSubscriptionRequest};

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -21,7 +21,6 @@ const CAPABILITY_ACTIVITY_ERROR_KIND_SEGMENT_MAX_BYTES: usize = 24;
 const CAPABILITY_ACTIVITY_UNCLASSIFIED_ERROR_KIND: &str = "Unclassified";
 pub const CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES: usize = 2 * 1024;
 pub const CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES: usize = 16 * 1024;
-pub const CAPABILITY_DISPLAY_PREVIEW_MAX_LINES: usize = 120;
 pub const CAPABILITY_DISPLAY_KIND_MAX_BYTES: usize = 32;
 pub const CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES: usize = 256;
 
@@ -112,18 +111,7 @@ fn validate_display_preview(value: Option<&str>) -> Result<(), ProductAdapterErr
         "capability_display_output_preview",
         value,
         CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES,
-    )?;
-    if value
-        .lines()
-        .nth(CAPABILITY_DISPLAY_PREVIEW_MAX_LINES)
-        .is_some()
-    {
-        return Err(invalid(
-            "capability_display_output_preview",
-            format!("must be at most {CAPABILITY_DISPLAY_PREVIEW_MAX_LINES} lines"),
-        ));
-    }
-    Ok(())
+    )
 }
 
 fn validate_display_kind(value: Option<&str>) -> Result<(), ProductAdapterError> {
@@ -890,7 +878,7 @@ mod tests {
     }
 
     #[test]
-    fn capability_display_preview_view_rejects_unbounded_preview() {
+    fn capability_display_preview_view_accepts_many_preview_lines() {
         let json = serde_json::json!({
             "invocation_id": InvocationId::new(),
             "thread_id": "thread-tool-preview",
@@ -900,7 +888,35 @@ mod tests {
             "subtitle": "src/main.rs",
             "input_summary": "path: src/main.rs",
             "output_summary": "read file",
-            "output_preview": (0..=CAPABILITY_DISPLAY_PREVIEW_MAX_LINES).map(|_| "line").collect::<Vec<_>>().join("\n"),
+            "output_preview": (0..=240).map(|_| "line").collect::<Vec<_>>().join("\n"),
+            "output_kind": "text",
+            "output_bytes": 12,
+            "result_ref": "result:tool-output",
+            "truncated": true,
+            "updated_at": Utc::now(),
+        });
+
+        let view =
+            serde_json::from_value::<CapabilityDisplayPreviewView>(json).expect("preview is valid");
+        assert!(
+            view.output_preview
+                .as_deref()
+                .is_some_and(|preview| { preview.lines().count() == 241 })
+        );
+    }
+
+    #[test]
+    fn capability_display_preview_view_rejects_preview_over_byte_cap() {
+        let json = serde_json::json!({
+            "invocation_id": InvocationId::new(),
+            "thread_id": "thread-tool-preview",
+            "capability_id": "builtin.read_file",
+            "status": "completed",
+            "title": "read_file",
+            "subtitle": "src/main.rs",
+            "input_summary": "path: src/main.rs",
+            "output_summary": "read file",
+            "output_preview": "x".repeat(CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES + 1),
             "output_kind": "text",
             "output_bytes": 12,
             "result_ref": "result:tool-output",

--- a/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
@@ -4,9 +4,8 @@ use async_trait::async_trait;
 use ironclaw_event_projections::{CapabilityActivityProjection, CapabilityActivityStatus};
 use ironclaw_host_api::{CapabilityId, InvocationId};
 use ironclaw_product_adapters::{
-    CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES, CAPABILITY_DISPLAY_PREVIEW_MAX_LINES,
-    CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES, CapabilityDisplayPreviewView,
-    CapabilityDisplayPreviewViewInput, ProductAdapterError,
+    CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES, CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES,
+    CapabilityDisplayPreviewView, CapabilityDisplayPreviewViewInput, ProductAdapterError,
 };
 use ironclaw_threads::ThreadMessageId;
 use ironclaw_turns::run_profile::CapabilityInputRef;
@@ -467,24 +466,8 @@ fn bounded_display_text(text: &str, max_bytes: usize) -> DisplayText {
 }
 
 fn bounded_preview_text(text: &str) -> DisplayText {
-    let mut sanitized = sanitize_text(text);
-    let mut truncated = false;
-    let mut line_count = 0usize;
-    let mut end = sanitized.len();
-    for (index, _) in sanitized.match_indices('\n') {
-        line_count += 1;
-        if line_count >= CAPABILITY_DISPLAY_PREVIEW_MAX_LINES {
-            end = index;
-            truncated = true;
-            break;
-        }
-    }
-    if truncated {
-        sanitized.truncate(end);
-    }
-    let mut bounded = truncate_bytes(&sanitized, CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES);
-    bounded.truncated |= truncated;
-    bounded
+    let sanitized = sanitize_text(text);
+    truncate_bytes(&sanitized, CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES)
 }
 
 fn non_empty(text: String) -> Option<String> {

--- a/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/display_preview.rs
@@ -524,7 +524,7 @@ async fn capability_display_preview_falls_back_for_failed_tool_without_result() 
 }
 
 #[tokio::test]
-async fn capability_display_preview_store_truncates_long_output_by_lines() {
+async fn capability_display_preview_store_preserves_long_line_counts() {
     let run_id = TurnRunId::new();
     let capability = CapabilityId::new("script.long_output").unwrap();
     let input_ref = preview_input_ref("long-output-input");
@@ -562,16 +562,16 @@ async fn capability_display_preview_store_truncates_long_output_by_lines() {
         .unwrap()
         .unwrap();
 
-    assert!(preview.truncated);
+    assert!(!preview.truncated);
     assert!(
         preview
             .output_preview
             .as_ref()
             .unwrap()
-            .contains("line-119")
+            .contains("line-129")
     );
     assert!(
-        !preview
+        preview
             .output_preview
             .as_ref()
             .unwrap()

--- a/crates/ironclaw_threads/src/capability_display_preview.rs
+++ b/crates/ironclaw_threads/src/capability_display_preview.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 const CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES: usize = 2 * 1024;
 const CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES: usize = 16 * 1024;
-const CAPABILITY_DISPLAY_PREVIEW_MAX_LINES: usize = 120;
 const CAPABILITY_DISPLAY_KIND_MAX_BYTES: usize = 32;
 const CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES: usize = 256;
 
@@ -159,17 +158,7 @@ fn validate_output_preview(value: Option<&str>) -> Result<(), String> {
         "capability display output preview",
         value,
         CAPABILITY_DISPLAY_PREVIEW_MAX_BYTES,
-    )?;
-    if value
-        .lines()
-        .nth(CAPABILITY_DISPLAY_PREVIEW_MAX_LINES)
-        .is_some()
-    {
-        return Err(format!(
-            "capability display output preview must be at most {CAPABILITY_DISPLAY_PREVIEW_MAX_LINES} lines"
-        ));
-    }
-    Ok(())
+    )
 }
 
 fn validate_output_kind(value: Option<&str>) -> Result<(), String> {
@@ -215,6 +204,19 @@ mod tests {
         input.output_preview = Some("line one\nline two".to_string());
 
         CapabilityDisplayPreviewEnvelope::new(input).expect("multiline preview is safe");
+    }
+
+    #[test]
+    fn preview_envelope_accepts_many_preview_lines() {
+        let mut input = preview_input();
+        input.output_preview = Some(
+            (0..=240)
+                .map(|index| format!("line {index}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+
+        CapabilityDisplayPreviewEnvelope::new(input).expect("line count is not capped");
     }
 
     fn preview_input() -> CapabilityDisplayPreviewEnvelopeInput {

--- a/crates/ironclaw_webui_v2/CLAUDE.md
+++ b/crates/ironclaw_webui_v2/CLAUDE.md
@@ -157,8 +157,8 @@ arguments, raw results, command strings, host paths, or provider payloads.
 
 `capability_display_preview` SSE frames are separate sanitized display artifacts
 for WebUI tool blocks. They may carry bounded summaries/previews only: summaries
-are capped at 2 KiB and output previews at 16 KiB or 120 lines, whichever comes
-first. They are not source-of-truth tool results. Full output remains behind the
+are capped at 2 KiB and output previews at 16 KiB. They are not source-of-truth
+tool results. Full output remains behind the
 scoped `result_ref` fetch path; SSE must never carry raw unbounded args/results.
 Preview generation belongs in the Reborn product/composition layer, using
 staged input/result-ref or transcript evidence where available, not in low-level


### PR DESCRIPTION
## Summary
- remove the 120-line validation cap from capability display preview contracts
- keep the 16 KiB preview byte cap as the transport/storage guardrail
- stop Reborn composition from truncating previews by line count and update docs/tests

## Tests
- cargo test -p ironclaw_threads
- cargo test -p ironclaw_product_adapters --features test-support
- cargo test -p ironclaw_reborn_composition capability_display_preview
- cargo test -p ironclaw_reborn_composition

Note: cargo test -p ironclaw_product_adapters without features fails in existing integration tests because they require the test-support fake exports.