### PR TITLE
Refactor prompt compaction orchestration

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -13,7 +13,7 @@ use crate::{
     strategies::{ModelErrorSummary, RecoveryOutcome},
 };
 
-use super::prompt::{apply_compaction_index_from_prompt_bundle, build_prompt_bundle_for_surface};
+use super::prompt::build_prompt_bundle_for_surface;
 use super::{
     AgentLoopExecutorError, CancelCheck, CheckpointStage, ExecutorStage, HostStage,
     MAX_MODEL_RETRIES, StageContext, failed_exit, honor_retry_alteration, model_error_class,
@@ -168,11 +168,7 @@ impl ExecutorStage<ModelInput> for ModelStage {
                                 CancelCheck::Continue(next) => state = *next,
                                 CancelCheck::Exit(exit) => return Ok(ModelStep::Exit(exit)),
                             }
-                            apply_compaction_index_from_prompt_bundle(
-                                &mut state,
-                                &bundle.compaction_message_index,
-                            );
-                            request.messages = bundle.messages;
+                            request.messages = bundle.into_model_messages(&mut state);
                         }
                         RecoveryOutcome::ToolErrorResult { .. } => {
                             return Err(AgentLoopExecutorError::PlannerContract {

--- a/crates/ironclaw_agent_loop/src/executor/prompt.rs
+++ b/crates/ironclaw_agent_loop/src/executor/prompt.rs
@@ -52,8 +52,84 @@ pub(super) enum PromptStep {
 }
 
 pub(super) struct BuiltPromptBundle {
-    pub(super) messages: Vec<LoopModelMessage>,
-    pub(super) compaction_message_index: Vec<LoopContextCompactionMetadata>,
+    messages: Vec<LoopModelMessage>,
+    compaction_message_index: Vec<LoopContextCompactionMetadata>,
+}
+
+impl BuiltPromptBundle {
+    async fn build_and_refresh_compaction_prompt(
+        ctx: StageContext<'_>,
+        state: &mut LoopExecutionState,
+        surface_version: CapabilitySurfaceVersion,
+        capability_view: LoopModelCapabilityView,
+    ) -> Result<Self, AgentLoopExecutorError> {
+        let bundle =
+            build_prompt_bundle_for_surface(ctx, state, surface_version, capability_view).await?;
+        refresh_compaction_prompt_from_index(state, &bundle.compaction_message_index);
+        Ok(bundle)
+    }
+
+    pub(super) fn into_model_messages(
+        self,
+        state: &mut LoopExecutionState,
+    ) -> Vec<LoopModelMessage> {
+        refresh_compaction_prompt_from_index(state, &self.compaction_message_index);
+        self.messages
+    }
+}
+
+struct PromptBundleCandidate {
+    bundle: BuiltPromptBundle,
+}
+
+impl PromptBundleCandidate {
+    async fn build(
+        ctx: StageContext<'_>,
+        state: &mut LoopExecutionState,
+        surface_version: CapabilitySurfaceVersion,
+        capability_view: LoopModelCapabilityView,
+    ) -> Result<Self, AgentLoopExecutorError> {
+        let bundle = BuiltPromptBundle::build_and_refresh_compaction_prompt(
+            ctx,
+            state,
+            surface_version,
+            capability_view,
+        )
+        .await?;
+        Ok(Self { bundle })
+    }
+
+    fn into_final_without_rebuild(self) -> FinalPromptBundle {
+        FinalPromptBundle {
+            bundle: self.bundle,
+        }
+    }
+}
+
+struct FinalPromptBundle {
+    bundle: BuiltPromptBundle,
+}
+
+impl FinalPromptBundle {
+    async fn rebuild_after_successful_compaction(
+        ctx: StageContext<'_>,
+        state: &mut LoopExecutionState,
+        surface_version: CapabilitySurfaceVersion,
+        capability_view: LoopModelCapabilityView,
+    ) -> Result<Self, AgentLoopExecutorError> {
+        let bundle = BuiltPromptBundle::build_and_refresh_compaction_prompt(
+            ctx,
+            state,
+            surface_version,
+            capability_view,
+        )
+        .await?;
+        Ok(Self { bundle })
+    }
+
+    fn into_messages(self) -> Vec<LoopModelMessage> {
+        self.bundle.messages
+    }
 }
 
 #[async_trait]
@@ -97,34 +173,35 @@ impl<'a> PromptPlanningPipeline<'a> {
             return Ok(PromptStep::Exit(exit));
         }
 
-        let candidate_bundle = self
-            .build_prompt_bundle(surface.version.clone(), capability_view.clone())
-            .await?;
-        apply_compaction_index_from_prompt_bundle(
+        let candidate_bundle = PromptBundleCandidate::build(
+            self.ctx,
             &mut self.state,
-            &candidate_bundle.compaction_message_index,
-        );
+            surface.version.clone(),
+            capability_view.clone(),
+        )
+        .await?;
         if let Some(exit) = self.cancel_boundary().await? {
             return Ok(PromptStep::Exit(exit));
         }
 
-        let compaction =
-            maybe_compact_prompt_context(self.ctx, self.state, &mut self.pending_input_ack).await?;
+        let compaction = PromptCompactionStep::new(self.ctx, &mut self.pending_input_ack)
+            .run(self.state)
+            .await?;
         let final_bundle = match compaction {
             PromptCompactionOutcome::Exited(exit) => return Ok(PromptStep::Exit(exit)),
             PromptCompactionOutcome::Skipped(state) => {
                 self.state = state;
-                candidate_bundle
+                candidate_bundle.into_final_without_rebuild()
             }
             PromptCompactionOutcome::Compacted(state) => {
                 self.state = state;
-                let bundle = self
-                    .build_prompt_bundle(surface.version.clone(), capability_view.clone())
-                    .await?;
-                apply_compaction_index_from_prompt_bundle(
+                let bundle = FinalPromptBundle::rebuild_after_successful_compaction(
+                    self.ctx,
                     &mut self.state,
-                    &bundle.compaction_message_index,
-                );
+                    surface.version.clone(),
+                    capability_view.clone(),
+                )
+                .await?;
                 if let Some(exit) = self.cancel_boundary().await? {
                     return Ok(PromptStep::Exit(exit));
                 }
@@ -136,7 +213,7 @@ impl<'a> PromptPlanningPipeline<'a> {
             state: self.state,
             pending_input_ack: self.pending_input_ack,
             surface,
-            messages: final_bundle.messages,
+            messages: final_bundle.into_messages(),
             capability_view,
         })))
     }
@@ -195,15 +272,6 @@ impl<'a> PromptPlanningPipeline<'a> {
         }
         Ok(surface)
     }
-
-    async fn build_prompt_bundle(
-        &self,
-        surface_version: CapabilitySurfaceVersion,
-        capability_view: LoopModelCapabilityView,
-    ) -> Result<BuiltPromptBundle, AgentLoopExecutorError> {
-        build_prompt_bundle_for_surface(self.ctx, &self.state, surface_version, capability_view)
-            .await
-    }
 }
 
 enum PromptCompactionOutcome {
@@ -212,106 +280,134 @@ enum PromptCompactionOutcome {
     Exited(LoopExit),
 }
 
-async fn maybe_compact_prompt_context(
-    ctx: StageContext<'_>,
-    mut state: LoopExecutionState,
-    pending_input_ack: &mut PendingInputAck,
-) -> Result<PromptCompactionOutcome, AgentLoopExecutorError> {
-    let decision = ctx
-        .planner
-        .compaction()
-        .should_compact(&state, ctx.host.run_context());
+struct PromptCompactionStep<'a, 'b> {
+    ctx: StageContext<'a>,
+    pending_input_ack: &'b mut PendingInputAck,
+}
 
-    let CompactionDecision::Trigger {
-        drop_through_seq,
-        preserve_tail_tokens,
-        deadline_ms,
-    } = decision
-    else {
-        return Ok(PromptCompactionOutcome::Skipped(state));
-    };
-
-    let task_id = SystemInferenceTaskId::new();
-    CheckpointStage
-        .emit_progress(
+impl<'a, 'b> PromptCompactionStep<'a, 'b> {
+    fn new(ctx: StageContext<'a>, pending_input_ack: &'b mut PendingInputAck) -> Self {
+        Self {
             ctx,
-            LoopProgressEvent::CompactionStarted {
-                task_id,
-                initiator: CompactionInitiator::Auto,
-            },
+            pending_input_ack,
+        }
+    }
+
+    async fn run(
+        self,
+        mut state: LoopExecutionState,
+    ) -> Result<PromptCompactionOutcome, AgentLoopExecutorError> {
+        let decision = self
+            .ctx
+            .planner
+            .compaction()
+            .should_compact(&state, self.ctx.host.run_context());
+
+        let CompactionDecision::Trigger {
+            drop_through_seq,
+            preserve_tail_tokens,
+            deadline_ms,
+        } = decision
+        else {
+            return Ok(PromptCompactionOutcome::Skipped(state));
+        };
+
+        let task_id = SystemInferenceTaskId::new();
+        CheckpointStage
+            .emit_progress(
+                self.ctx,
+                LoopProgressEvent::CompactionStarted {
+                    task_id,
+                    initiator: CompactionInitiator::Auto,
+                },
+            )
+            .await;
+        state = match CheckpointStage
+            .cancel_if_requested_after_pending_input_ack(self.ctx, state, self.pending_input_ack)
+            .await?
+        {
+            CancelCheck::Continue(state) => *state,
+            CancelCheck::Exit(exit) => {
+                return Ok(PromptCompactionOutcome::Exited(exit));
+            }
+        };
+
+        let compaction_request = LoopCompactionRequest {
+            task_id,
+            thread_id: self.ctx.host.run_context().thread_id.clone(),
+            last_compacted_through_seq: state.compaction_state.last_compacted_through_seq,
+            drop_through_seq,
+            preserve_tail_tokens,
+            mode: LoopCompactionMode::Fresh,
+            deadline_ms,
+        };
+        let compaction_result = await_compaction_with_cancellation(
+            self.ctx,
+            Duration::from_millis(deadline_ms),
+            self.ctx.host.compact_loop_context(compaction_request),
         )
         .await;
-    state = match CheckpointStage
-        .cancel_if_requested_after_pending_input_ack(ctx, state, pending_input_ack)
-        .await?
-    {
-        CancelCheck::Continue(state) => *state,
-        CancelCheck::Exit(exit) => {
-            return Ok(PromptCompactionOutcome::Exited(exit));
-        }
-    };
+        let response = match compaction_result {
+            CompactionCallOutcome::Completed(Ok(response)) => response,
+            CompactionCallOutcome::Completed(Err(LoopCompactionError::Cancelled))
+            | CompactionCallOutcome::Cancelled => {
+                return compaction_cancelled_exit(self.ctx, state, self.pending_input_ack).await;
+            }
+            CompactionCallOutcome::Completed(Err(error)) => {
+                return compaction_failed_exit(
+                    self.ctx,
+                    state,
+                    self.pending_input_ack,
+                    task_id,
+                    &error,
+                )
+                .await;
+            }
+            CompactionCallOutcome::TimedOut => {
+                let error = LoopCompactionError::InferenceFailed {
+                    safe_summary: safe("compaction deadline exceeded"),
+                };
+                return compaction_failed_exit(
+                    self.ctx,
+                    state,
+                    self.pending_input_ack,
+                    task_id,
+                    &error,
+                )
+                .await;
+            }
+        };
 
-    let compaction_request = LoopCompactionRequest {
-        task_id,
-        thread_id: ctx.host.run_context().thread_id.clone(),
-        last_compacted_through_seq: state.compaction_state.last_compacted_through_seq,
-        drop_through_seq,
-        preserve_tail_tokens,
-        mode: LoopCompactionMode::Fresh,
-        deadline_ms,
-    };
-    let compaction_result = await_compaction_with_cancellation(
-        ctx,
-        Duration::from_millis(deadline_ms),
-        ctx.host.compact_loop_context(compaction_request),
-    )
-    .await;
-    let response = match compaction_result {
-        CompactionCallOutcome::Completed(Ok(response)) => response,
-        CompactionCallOutcome::Completed(Err(LoopCompactionError::Cancelled))
-        | CompactionCallOutcome::Cancelled => {
-            return compaction_cancelled_exit(ctx, state, pending_input_ack).await;
-        }
-        CompactionCallOutcome::Completed(Err(error)) => {
-            return compaction_failed_exit(ctx, state, pending_input_ack, task_id, &error).await;
-        }
-        CompactionCallOutcome::TimedOut => {
-            let error = LoopCompactionError::InferenceFailed {
-                safe_summary: safe("compaction deadline exceeded"),
-            };
-            return compaction_failed_exit(ctx, state, pending_input_ack, task_id, &error).await;
-        }
-    };
+        state = match CheckpointStage
+            .cancel_if_requested_after_pending_input_ack(self.ctx, state, self.pending_input_ack)
+            .await?
+        {
+            CancelCheck::Continue(state) => *state,
+            CancelCheck::Exit(exit) => {
+                return Ok(PromptCompactionOutcome::Exited(exit));
+            }
+        };
 
-    state = match CheckpointStage
-        .cancel_if_requested_after_pending_input_ack(ctx, state, pending_input_ack)
-        .await?
-    {
-        CancelCheck::Continue(state) => *state,
-        CancelCheck::Exit(exit) => {
-            return Ok(PromptCompactionOutcome::Exited(exit));
-        }
-    };
-
-    state.compaction_state.last_compacted_through_seq = Some(drop_through_seq);
-    state.compaction_state.force_compact_on_next_iteration = false;
-    state
-        .compaction_prompt
-        .retain_after_sequence(drop_through_seq);
-    CheckpointStage
-        .emit_progress(
-            ctx,
-            LoopProgressEvent::CompactionCompleted {
-                task_id,
-                compression_ratio_ppm: response.compression_ratio_ppm,
-            },
-        )
-        .await;
-    let checked = CheckpointStage
-        .write(ctx, state, CheckpointKind::BeforeModel)
-        .await?;
-    pending_input_ack.ack(ctx.host).await?;
-    Ok(PromptCompactionOutcome::Compacted(checked.state))
+        state.compaction_state.last_compacted_through_seq = Some(drop_through_seq);
+        state.compaction_state.force_compact_on_next_iteration = false;
+        state
+            .compaction_prompt
+            .retain_after_sequence(drop_through_seq);
+        CheckpointStage
+            .emit_progress(
+                self.ctx,
+                LoopProgressEvent::CompactionCompleted {
+                    task_id,
+                    compression_ratio_ppm: response.compression_ratio_ppm,
+                },
+            )
+            .await;
+        let checked = CheckpointStage
+            .write(self.ctx, state, CheckpointKind::BeforeModel)
+            .await?;
+        self.pending_input_ack.ack(self.ctx.host).await?;
+        Ok(PromptCompactionOutcome::Compacted(checked.state))
+    }
 }
 
 enum CompactionCallOutcome {
@@ -337,18 +433,14 @@ where
     tokio::pin!(call);
     let timeout = tokio::time::sleep(deadline);
     tokio::pin!(timeout);
-    let mut cancellation_poll = tokio::time::interval(Duration::from_millis(10));
-    cancellation_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let cancellation = ctx.host.cancellation_requested();
+    tokio::pin!(cancellation);
 
-    loop {
-        tokio::select! {
-            result = &mut call => return CompactionCallOutcome::Completed(result),
-            _ = &mut timeout => return CompactionCallOutcome::TimedOut,
-            _ = cancellation_poll.tick() => {
-                if ctx.host.observe_cancellation().is_some() {
-                    return CompactionCallOutcome::Cancelled;
-                }
-            }
+    tokio::select! {
+        result = &mut call => CompactionCallOutcome::Completed(result),
+        _ = &mut timeout => CompactionCallOutcome::TimedOut,
+        _signal = &mut cancellation => {
+            CompactionCallOutcome::Cancelled
         }
     }
 }
@@ -436,7 +528,7 @@ pub(super) async fn build_prompt_bundle_for_surface(
     })
 }
 
-pub(super) fn apply_compaction_index_from_prompt_bundle(
+fn refresh_compaction_prompt_from_index(
     state: &mut LoopExecutionState,
     index: &[LoopContextCompactionMetadata],
 ) {

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -580,6 +580,49 @@ async fn prompt_stage_cancellation_during_compaction_aborts_prompt_planning() {
 }
 
 #[tokio::test]
+async fn prompt_stage_compaction_aborts_immediately_when_cancellation_already_set() {
+    let host = MockHost::new(Vec::new())
+        .with_prompt_compaction_index(vec![compaction_metadata(
+            1,
+            LoopContextCompactionKind::User,
+            10,
+        )])
+        .with_compaction_result(Ok(LoopCompactionResponse {
+            summary_artifact_id: LoopSummaryArtifactId::new("summary-1").unwrap(),
+            compression_ratio_ppm: 250_000,
+        }))
+        .with_compaction_delay(std::time::Duration::from_secs(1))
+        .cancel_on_compaction_start();
+    let family = family_with_compaction_strategy(DefaultCompactionStrategy {
+        deadline_ms: 5_000,
+        ..Default::default()
+    });
+    let ctx = StageContext {
+        planner: family.planner(),
+        host: &host,
+    };
+    let mut state = LoopExecutionState::initial_for_run(host.run_context());
+    state.compaction_state.force_compact_on_next_iteration = true;
+
+    let step = tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        PromptStage.process(
+            ctx,
+            PromptInput {
+                state,
+                pending_input_ack: PendingInputAck::default(),
+            },
+        ),
+    )
+    .await
+    .expect("already-requested cancellation should not wait for compaction")
+    .expect("prompt stage");
+
+    assert!(matches!(step, PromptStep::Exit(LoopExit::Cancelled(_))));
+    assert_eq!(host.checkpoint_kinds(), vec![LoopCheckpointKind::Final]);
+}
+
+#[tokio::test]
 async fn prompt_stage_cancellation_after_compaction_success_skips_final_bundle_rebuild() {
     let host = MockHost::new(Vec::new())
         .with_prompt_compaction_indexes(vec![

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -65,6 +65,7 @@ pub(super) struct MockHost {
     fail_progress_port: bool,
     fail_append_result_ref: bool,
     cancellation: Arc<Mutex<Option<LoopCancellationSignal>>>,
+    cancellation_notify: Arc<tokio::sync::Notify>,
     cancel_after_poll_inputs: Arc<Mutex<bool>>,
     cancel_after_prompt_bundle_count: Arc<Mutex<Option<usize>>>,
     cancel_after_checkpoint: Arc<Mutex<Option<LoopCheckpointKind>>>,
@@ -100,6 +101,7 @@ impl MockHost {
             fail_progress_port: false,
             fail_append_result_ref: false,
             cancellation: Arc::new(Mutex::new(None)),
+            cancellation_notify: Arc::new(tokio::sync::Notify::new()),
             cancel_after_poll_inputs: Arc::new(Mutex::new(false)),
             cancel_after_prompt_bundle_count: Arc::new(Mutex::new(None)),
             cancel_after_checkpoint: Arc::new(Mutex::new(None)),
@@ -214,6 +216,7 @@ impl MockHost {
             reason_kind,
             requested_at: chrono::Utc::now(),
         });
+        self.cancellation_notify.notify_waiters();
     }
 
     pub(super) fn cancel_after_checkpoint(self, kind: LoopCheckpointKind) -> Self {
@@ -643,9 +646,18 @@ impl ironclaw_turns::run_profile::LoopCompactionPort for MockHost {
     }
 }
 
+#[async_trait]
 impl LoopCancellationPort for MockHost {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
         self.cancellation.lock().expect("lock").clone()
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        crate::test_support::wait_for_cancellation_signal(
+            &self.cancellation,
+            &self.cancellation_notify,
+        )
+        .await
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/executor/tests/support/compaction.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support/compaction.rs
@@ -14,6 +14,7 @@ pub(super) struct MockCompactionSupport {
     result: Arc<Mutex<Result<LoopCompactionResponse, LoopCompactionError>>>,
     delay: Arc<Mutex<Option<std::time::Duration>>>,
     cancel_after_success: Arc<Mutex<bool>>,
+    cancel_on_start: Arc<Mutex<bool>>,
 }
 
 impl MockCompactionSupport {
@@ -23,6 +24,7 @@ impl MockCompactionSupport {
             result: Arc::new(Mutex::new(Err(LoopCompactionError::InputTooLarge))),
             delay: Arc::new(Mutex::new(None)),
             cancel_after_success: Arc::new(Mutex::new(false)),
+            cancel_on_start: Arc::new(Mutex::new(false)),
         }
     }
 
@@ -52,6 +54,14 @@ impl MockCompactionSupport {
 
     pub(super) fn set_cancel_after_success(&self) {
         *self.cancel_after_success.lock().expect("lock") = true;
+    }
+
+    pub(super) fn set_cancel_on_start(&self) {
+        *self.cancel_on_start.lock().expect("lock") = true;
+    }
+
+    pub(super) fn take_cancel_on_start(&self) -> bool {
+        std::mem::take(&mut *self.cancel_on_start.lock().expect("lock"))
     }
 
     pub(super) fn take_cancel_after_success(&self) -> bool {
@@ -108,10 +118,18 @@ impl MockHost {
         self
     }
 
+    pub(in crate::executor::tests) fn cancel_on_compaction_start(self) -> Self {
+        self.compaction.set_cancel_on_start();
+        self
+    }
+
     pub(super) async fn compact_loop_context_for_tests(
         &self,
         request: LoopCompactionRequest,
     ) -> Result<LoopCompactionResponse, LoopCompactionError> {
+        if self.compaction.take_cancel_on_start() {
+            self.request_cancellation(LoopCancelReasonKind::UserRequested);
+        }
         let result = self.compaction.compact_loop_context(request).await;
         if result.is_ok() && self.compaction.take_cancel_after_success() {
             self.request_cancellation(LoopCancelReasonKind::UserRequested);

--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -60,6 +60,7 @@ pub struct MockAgentLoopDriverHost {
     progress_events: Mutex<Vec<LoopProgressEvent>>,
     acked_tokens: Mutex<Vec<LoopInputAckToken>>,
     cancellation: Mutex<Option<LoopCancellationSignal>>,
+    cancellation_notify: tokio::sync::Notify,
 }
 
 impl MockAgentLoopDriverHost {
@@ -89,6 +90,12 @@ impl MockAgentLoopDriverHost {
     /// Returns loop progress events emitted through the host progress port.
     pub fn progress_events(&self) -> Vec<LoopProgressEvent> {
         clone_mutex_vec(&self.progress_events)
+    }
+
+    /// Sets the exact cancellation signal and wakes async waiters.
+    pub fn set_cancellation_signal(&self, signal: LoopCancellationSignal) {
+        *lock_or_panic(&self.cancellation) = Some(signal);
+        self.cancellation_notify.notify_waiters();
     }
 
     fn record_call(&self, call: MockHostCall) {
@@ -204,6 +211,7 @@ impl MockAgentLoopDriverHostBuilder {
                 progress_events: Mutex::new(Vec::new()),
                 acked_tokens: Mutex::new(Vec::new()),
                 cancellation: Mutex::new(self.cancellation),
+                cancellation_notify: tokio::sync::Notify::new(),
             },
             checkpoints,
         )
@@ -813,9 +821,14 @@ impl ironclaw_turns::run_profile::LoopCompactionPort for MockAgentLoopDriverHost
     }
 }
 
+#[async_trait]
 impl LoopCancellationPort for MockAgentLoopDriverHost {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
         lock_or_panic(&self.cancellation).clone()
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        wait_for_cancellation_signal(&self.cancellation, &self.cancellation_notify).await
     }
 }
 
@@ -1085,6 +1098,19 @@ fn safe_ref_suffix(value: &str) -> String {
             }
         })
         .collect()
+}
+
+pub(crate) async fn wait_for_cancellation_signal(
+    cancellation: &Mutex<Option<LoopCancellationSignal>>,
+    notify: &tokio::sync::Notify,
+) -> LoopCancellationSignal {
+    loop {
+        let notified = notify.notified();
+        if let Some(signal) = lock_or_panic(cancellation).clone() {
+            return signal;
+        }
+        notified.await;
+    }
 }
 
 fn lock_or_panic<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {

--- a/crates/ironclaw_loop_support/src/cancellation_port.rs
+++ b/crates/ironclaw_loop_support/src/cancellation_port.rs
@@ -18,6 +18,7 @@ use ironclaw_turns::{
     },
 };
 use parking_lot::RwLock;
+use tokio::sync::Notify;
 
 const DEFAULT_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
@@ -25,12 +26,13 @@ const DEFAULT_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(25);
 struct RunCancellationRequester {
     fired: Arc<AtomicBool>,
     signal: Arc<RwLock<Option<LoopCancellationSignal>>>,
+    notify: Arc<Notify>,
     owner: Weak<()>,
 }
 
 impl RunCancellationRequester {
     fn request(&self, reason_kind: LoopCancelReasonKind) {
-        request_cancellation(&self.fired, &self.signal, reason_kind);
+        request_cancellation(&self.fired, &self.signal, &self.notify, reason_kind);
     }
 
     fn is_owner_alive(&self) -> bool {
@@ -41,6 +43,7 @@ impl RunCancellationRequester {
 fn request_cancellation(
     fired: &AtomicBool,
     signal: &RwLock<Option<LoopCancellationSignal>>,
+    notify: &Notify,
     reason_kind: LoopCancelReasonKind,
 ) {
     if fired.load(Ordering::Acquire) {
@@ -60,6 +63,7 @@ fn request_cancellation(
     // populated `signal_lock`, independent of the RwLock's own ordering.
     fired.store(true, Ordering::Release);
     drop(signal_lock);
+    notify.notify_waiters();
 }
 
 /// Snapshot handle the host runtime owns and flips on cancellation.
@@ -67,22 +71,41 @@ fn request_cancellation(
 pub struct RunCancellationHandle {
     fired: Arc<AtomicBool>,
     signal: Arc<RwLock<Option<LoopCancellationSignal>>>,
+    notify: Arc<Notify>,
     owner: Arc<()>,
 }
 
 impl RunCancellationHandle {
     pub fn request(&self, reason_kind: LoopCancelReasonKind) {
-        request_cancellation(&self.fired, &self.signal, reason_kind);
+        request_cancellation(&self.fired, &self.signal, &self.notify, reason_kind);
     }
 
     pub fn is_requested(&self) -> bool {
         self.fired.load(Ordering::Acquire)
     }
 
+    fn observe(&self) -> Option<LoopCancellationSignal> {
+        if !self.fired.load(Ordering::Acquire) {
+            return None;
+        }
+        self.signal.read().clone()
+    }
+
+    async fn requested(&self) -> LoopCancellationSignal {
+        loop {
+            let notified = self.notify.notified();
+            if let Some(signal) = self.observe() {
+                return signal;
+            }
+            notified.await;
+        }
+    }
+
     fn requester(&self) -> RunCancellationRequester {
         RunCancellationRequester {
             fired: Arc::clone(&self.fired),
             signal: Arc::clone(&self.signal),
+            notify: Arc::clone(&self.notify),
             owner: Arc::downgrade(&self.owner),
         }
     }
@@ -99,21 +122,28 @@ impl RunStateLoopCancellationPort {
     }
 }
 
+#[async_trait]
 impl LoopCancellationPort for RunStateLoopCancellationPort {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
-        if !self.handle.fired.load(Ordering::Acquire) {
-            return None;
-        }
-        self.handle.signal.read().clone()
+        self.handle.observe()
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        self.handle.requested().await
     }
 }
 
 /// Always reports "not cancelled".
 pub struct AlwaysAliveLoopCancellationPort;
 
+#[async_trait]
 impl LoopCancellationPort for AlwaysAliveLoopCancellationPort {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
         None
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        std::future::pending().await
     }
 }
 
@@ -618,6 +648,36 @@ mod tests {
         assert_eq!(second.reason_kind, LoopCancelReasonKind::UserRequested);
     }
 
+    #[tokio::test]
+    async fn cancellation_requested_returns_immediately_after_flip() {
+        let handle = RunCancellationHandle::default();
+        let port = RunStateLoopCancellationPort::new(handle.clone());
+        handle.request(LoopCancelReasonKind::UserRequested);
+
+        let signal = tokio::time::timeout(Duration::from_millis(50), port.cancellation_requested())
+            .await
+            .expect("already-requested cancellation should not wait");
+
+        assert_eq!(signal.reason_kind, LoopCancelReasonKind::UserRequested);
+    }
+
+    #[tokio::test]
+    async fn cancellation_requested_wakes_waiter_after_request() {
+        let handle = RunCancellationHandle::default();
+        let port = Arc::new(RunStateLoopCancellationPort::new(handle.clone()));
+        let waiter = Arc::clone(&port);
+        let join = tokio::spawn(async move { waiter.cancellation_requested().await });
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        handle.request(LoopCancelReasonKind::Superseded);
+
+        let signal = tokio::time::timeout(Duration::from_millis(100), join)
+            .await
+            .expect("waiter should be notified")
+            .expect("waiter task should complete");
+        assert_eq!(signal.reason_kind, LoopCancelReasonKind::Superseded);
+    }
+
     #[test]
     fn observe_payload_includes_requested_at() {
         let handle = RunCancellationHandle::default();
@@ -659,6 +719,16 @@ mod tests {
         let port = AlwaysAliveLoopCancellationPort;
 
         assert_eq!(port.observe_cancellation(), None);
+    }
+
+    #[tokio::test]
+    async fn always_alive_cancellation_requested_never_resolves() {
+        let port = AlwaysAliveLoopCancellationPort;
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(10), port.cancellation_requested()).await;
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -1520,9 +1520,14 @@ impl LoopRunInfoPort for RebornLoopDriverHost {
     }
 }
 
+#[async_trait]
 impl LoopCancellationPort for RebornLoopDriverHost {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
         self.cancellation.observe_cancellation()
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        self.cancellation.cancellation_requested().await
     }
 }
 

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -738,9 +738,14 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl LoopCancellationPort for ResumePayloadHost {
         fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
             self.inner.observe_cancellation()
+        }
+
+        async fn cancellation_requested(&self) -> LoopCancellationSignal {
+            self.inner.cancellation_requested().await
         }
     }
 

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -563,9 +563,14 @@ impl ironclaw_turns::run_profile::LoopProgressPort for StubHost {
     }
 }
 
+#[async_trait]
 impl ironclaw_turns::run_profile::LoopCancellationPort for StubHost {
     fn observe_cancellation(&self) -> Option<ironclaw_turns::run_profile::LoopCancellationSignal> {
         None
+    }
+
+    async fn cancellation_requested(&self) -> ironclaw_turns::run_profile::LoopCancellationSignal {
+        std::future::pending().await
     }
 }
 

--- a/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
+++ b/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
@@ -567,8 +567,13 @@ impl LoopCompactionPort for ForbiddenResumeHost {
     }
 }
 
+#[async_trait::async_trait]
 impl LoopCancellationPort for ForbiddenResumeHost {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
         None
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        std::future::pending().await
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -1962,20 +1962,22 @@ pub trait LoopProgressPort: Send + Sync {
 /// intentionally synchronous and non-blocking: implementations should expose a
 /// cheap snapshot, usually backed by an atomic flag plus immutable signal data.
 ///
-/// **Cancellation is cooperative and boundary-observation only — it is not
-/// preempted across in-flight host calls.** `build_prompt_bundle`,
-/// `stream_model`, and `invoke_capability` are awaited to completion before
-/// the next observation point is reached. A stuck model stream or long-running
-/// capability call will not observe cancellation until control returns to the
-/// executor. Implementations of those host methods that need finer-grained
-/// cancellation must integrate their own abort signal internally; this port
-/// only covers the between-call boundaries that the executor controls.
+/// Cancellation is cooperative. Most executor stages observe it only at
+/// explicit boundaries via [`LoopCancellationPort::observe_cancellation`].
+/// Executor-owned waits that can safely race host work, such as prompt
+/// compaction, may also wait on
+/// [`LoopCancellationPort::cancellation_requested`] to avoid timer polling.
+#[async_trait]
 pub trait LoopCancellationPort: Send + Sync {
     /// Returns `Some(signal)` once cancellation has been requested for this run.
     ///
     /// Implementations must be idempotent across reads. After the request fires,
     /// repeated calls must keep returning the same signal.
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal>;
+
+    /// Waits until cancellation has been requested for this run and returns the
+    /// same stable signal reported by [`Self::observe_cancellation`].
+    async fn cancellation_requested(&self) -> LoopCancellationSignal;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -2624,9 +2624,14 @@ impl LoopCompactionPort for RecordingAgentLoopHost {
     }
 }
 
+#[async_trait]
 impl LoopCancellationPort for RecordingAgentLoopHost {
     fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
         None
+    }
+
+    async fn cancellation_requested(&self) -> LoopCancellationSignal {
+        std::future::pending().await
     }
 }
 


### PR DESCRIPTION
## Summary

- split prompt-stage compaction flow into `PromptBundleCandidate`, `PromptCompactionStep`, and `FinalPromptBundle`
- make successful-compaction prompt rebuild explicit through the final-bundle path
- replace fixed 10 ms compaction cancellation polling with an event-driven cancellation wait
- centralize compaction prompt refresh behind the typed bundle path so retry/final prompt callers cannot skip `state.compaction_prompt`

Closes #4162

## Verification

- `cargo fmt`
- `git diff --check`
- `cargo test -p ironclaw_agent_loop prompt_stage_compaction -- --nocapture`
- `cargo test -p ironclaw_loop_support cancellation_requested -- --nocapture`
- Earlier full package checks for `ironclaw_agent_loop`, `ironclaw_reborn`, and clippy over the touched Reborn packages passed locally.

## Known follow-up

Broad `ironclaw_turns` / `ironclaw_loop_support` test runs are currently blocked by stale skill-context assertions after the `safe_summary` / `model_content` split. Tracked separately in #4171.