### PR TITLE
[codex] Update skill context tests for safe summaries

### DIFF
--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -177,18 +177,14 @@ async fn thread_context_port_builds_skill_instruction_snippets_from_real_skill_m
         .unwrap();
 
     assert_eq!(bundle.instruction_snippets.len(), 1);
-    assert_eq!(bundle.instruction_snippets[0].snippet_ref, "skill:alpha");
-    assert!(
-        bundle.instruction_snippets[0]
-            .safe_summary
-            .contains("safe alpha description")
-    );
-    assert!(
-        bundle.instruction_snippets[0]
-            .safe_summary
-            .contains("Use alpha prompt content.")
-    );
-    assert!(!bundle.instruction_snippets[0].safe_summary.contains("/tmp"));
+    let snippet = &bundle.instruction_snippets[0];
+    assert_eq!(snippet.snippet_ref, "skill:alpha");
+    assert!(snippet.safe_summary.contains("safe alpha description"));
+    assert!(!snippet.safe_summary.contains("Use alpha prompt content."));
+    assert!(snippet.model_content.contains("safe alpha description"));
+    assert!(snippet.model_content.contains("Use alpha prompt content."));
+    assert!(!snippet.safe_summary.contains("/tmp"));
+    assert!(!snippet.model_content.contains("/tmp"));
 }
 
 #[tokio::test]
@@ -262,8 +258,18 @@ async fn thread_context_port_builds_skill_instruction_snippets_from_skill_bundle
             .contains("safe alpha description")
     );
     assert!(
-        bundle.instruction_snippets[0]
+        !bundle.instruction_snippets[0]
             .safe_summary
+            .contains("Use trusted alpha prompt content.")
+    );
+    assert!(
+        bundle.instruction_snippets[0]
+            .model_content
+            .contains("safe alpha description")
+    );
+    assert!(
+        bundle.instruction_snippets[0]
+            .model_content
             .contains("Use trusted alpha prompt content.")
     );
     assert!(
@@ -274,6 +280,11 @@ async fn thread_context_port_builds_skill_instruction_snippets_from_skill_bundle
     assert!(
         !bundle.instruction_snippets[1]
             .safe_summary
+            .contains("RAW_INSTALLED_PROMPT_SENTINEL")
+    );
+    assert!(
+        !bundle.instruction_snippets[1]
+            .model_content
             .contains("RAW_INSTALLED_PROMPT_SENTINEL")
     );
     assert_eq!(
@@ -1110,12 +1121,12 @@ async fn thread_context_port_ignores_malformed_hidden_skill_content() {
         .unwrap();
 
     assert_eq!(bundle.instruction_snippets.len(), 1);
-    assert_eq!(bundle.instruction_snippets[0].snippet_ref, "skill:alpha");
-    assert!(
-        bundle.instruction_snippets[0]
-            .safe_summary
-            .contains("visible prompt")
-    );
+    let snippet = &bundle.instruction_snippets[0];
+    assert_eq!(snippet.snippet_ref, "skill:alpha");
+    assert!(snippet.safe_summary.contains("visible description"));
+    assert!(!snippet.safe_summary.contains("visible prompt"));
+    assert!(snippet.model_content.contains("visible description"));
+    assert!(snippet.model_content.contains("visible prompt"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/skill_context_service_contract.rs
+++ b/crates/ironclaw_turns/tests/skill_context_service_contract.rs
@@ -292,7 +292,10 @@ async fn oversized_single_snippet_is_allowed_within_aggregate_budget() {
 
     let snippets = service.skill_snippets(&snapshot).await.unwrap();
     assert_eq!(snippets.len(), 1);
-    assert!(snippets[0].safe_summary.contains(&"x".repeat(128)));
+    assert_eq!(snippets[0].safe_summary, "desc");
+    assert!(!snippets[0].safe_summary.contains(&"x".repeat(128)));
+    assert!(snippets[0].model_content.contains("desc"));
+    assert!(snippets[0].model_content.contains(&"x".repeat(128)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- update stale skill-context contract assertions after the safe_summary/model_content split
- assert trusted prompt text is absent from safe_summary and present in model_content
- keep installed skill prompt content filtered from both safe_summary and model_content

## Root Cause

#4140 separated safe descriptions from model-visible trusted prompt content, but several older tests still expected prompt content in safe_summary.

Closes #4171

## Validation

- cargo fmt
- cargo test -p ironclaw_loop_support --test thread_loop_support_contract
- cargo test -p ironclaw_turns --test skill_context_service_contract