### PR TITLE
[codex] fix builtin null sentinel handling

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -344,14 +344,13 @@ fn bounded_output_bytes(
     Ok(bytes)
 }
 
-/// Treat the literal string `"null"` as absent for declared optional fields.
+/// Treat null sentinels as absent for declared optional fields.
 ///
 /// Weaker models (notably quantized local models) routinely populate every
 /// optional parameter with the string `"null"` instead of omitting it. Without
 /// this normalization an optional `"null"` reaches a typed parser (e.g. an IANA
 /// timezone) and aborts an otherwise valid call with `InputEncode`. Required
-/// fields are left untouched so a legitimate `"null"` payload is preserved, and
-/// only declared optional properties are normalized.
+/// fields are left untouched so a legitimate `"null"` payload is preserved.
 fn normalize_optional_null_sentinels(request: &mut FirstPartyCapabilityRequest) {
     let schema_name = request
         .capability_id
@@ -364,11 +363,27 @@ fn normalize_optional_null_sentinels(request: &mut FirstPartyCapabilityRequest) 
     else {
         return;
     };
-    let required: std::collections::HashSet<&str> = schema
+    let mut required: std::collections::HashSet<String> = schema
         .get("required")
         .and_then(|value| value.as_array())
-        .map(|values| values.iter().filter_map(|value| value.as_str()).collect())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(ToString::to_string))
+                .collect()
+        })
         .unwrap_or_default();
+    if let Some(branches) = schema.get("oneOf").and_then(|value| value.as_array()) {
+        for branch in branches {
+            if let Some(values) = branch.get("required").and_then(|value| value.as_array()) {
+                required.extend(
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str().map(ToString::to_string)),
+                );
+            }
+        }
+    }
     let declared: std::collections::HashSet<&str> = schema
         .get("properties")
         .and_then(|value| value.as_object())
@@ -377,14 +392,11 @@ fn normalize_optional_null_sentinels(request: &mut FirstPartyCapabilityRequest) 
     let Some(object) = request.input.as_object_mut() else {
         return;
     };
-    for (key, value) in object.iter_mut() {
-        if declared.contains(key.as_str())
-            && !required.contains(key.as_str())
-            && value.as_str() == Some("null")
-        {
-            *value = serde_json::Value::Null;
-        }
-    }
+    object.retain(|key, value| {
+        !(declared.contains(key.as_str())
+            && !required.contains(key)
+            && (value.as_str() == Some("null") || value.is_null()))
+    });
 }
 
 fn resource_profile() -> Option<ResourceProfile> {

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -309,6 +309,69 @@ async fn builtin_echo_preserves_null_string_in_required_field() {
 }
 
 #[tokio::test]
+async fn builtin_coding_tools_tolerate_null_sentinels_in_optional_fields() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("qa-builtins.md"), "Alpha\nBeta\nGamma\n").unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(
+        [
+            LIST_DIR_CAPABILITY_ID,
+            GLOB_CAPABILITY_ID,
+            GREP_CAPABILITY_ID,
+        ],
+        mounts,
+    );
+
+    let listed = invoke_with_context(
+        &runtime,
+        LIST_DIR_CAPABILITY_ID,
+        json!({
+            "path": "/workspace",
+            "recursive": "null",
+            "max_depth": "null"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(listed["entries"], json!(["qa-builtins.md (17B)"]));
+
+    let globbed = invoke_with_context(
+        &runtime,
+        GLOB_CAPABILITY_ID,
+        json!({
+            "path": "/workspace",
+            "pattern": "qa-*.md",
+            "max_results": "null"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(globbed["files"], json!(["qa-builtins.md"]));
+
+    let grepped = invoke_with_context(
+        &runtime,
+        GREP_CAPABILITY_ID,
+        json!({
+            "path": "/workspace",
+            "pattern": "Beta",
+            "context": "null",
+            "before_context": "null",
+            "after_context": "null",
+            "head_limit": "null",
+            "offset": "null"
+        }),
+        context,
+    )
+    .await
+    .unwrap();
+    assert_eq!(grepped["files"], json!(["qa-builtins.md"]));
+}
+
+#[tokio::test]
 async fn builtin_spawn_subagent_authorization_invokes_through_host_runtime() {
     let output = invoke(SPAWN_SUBAGENT_CAPABILITY_ID, json!({}))
         .await


### PR DESCRIPTION
## Summary
- remove optional null sentinel fields before dispatching built-in first-party tool inputs
- preserve required fields, including schema requirements expressed through oneOf
- add a host-runtime regression test for list_dir, glob, and grep with optional "null" sentinels

## Root Cause
The built-in null-sentinel normalizer converted optional "null" strings to JSON null. Coding tool parsers then saw present non-numeric optional fields such as max_depth, max_results, context, and offset and returned InputEncode before touching the filesystem.

## Validation
- cargo fmt
- cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_coding_tools_tolerate_null_sentinels_in_optional_fields
- cargo test -p ironclaw_host_runtime --test first_party_builtin_tools (104 passed; 2 existing skill_install authorization tests fail: builtin_skill_install_accepts_content_when_network_is_denied, builtin_skill_install_rejects_hidden_url_install_fields)