### PR TITLE
[codex] Allow reborn skill management cleanup deletes

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/skill_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/skill_management.rs
@@ -41,6 +41,7 @@ pub(super) fn manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {
             vec![
                 EffectKind::ReadFilesystem,
                 EffectKind::WriteFilesystem,
+                EffectKind::DeleteFilesystem,
                 EffectKind::Network,
             ],
             PermissionMode::Ask,
@@ -49,7 +50,11 @@ pub(super) fn manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {
         first_party_capability_manifest(
             SKILL_REMOVE_CAPABILITY_ID,
             "Remove a user-installed Reborn filesystem skill",
-            vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
+            vec![
+                EffectKind::ReadFilesystem,
+                EffectKind::WriteFilesystem,
+                EffectKind::DeleteFilesystem,
+            ],
             PermissionMode::Ask,
             resource_profile(),
         )?,

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -86,7 +86,21 @@ async fn builtin_first_party_package_declares_expected_capabilities() {
         vec![
             EffectKind::ReadFilesystem,
             EffectKind::WriteFilesystem,
+            EffectKind::DeleteFilesystem,
             EffectKind::Network
+        ]
+    );
+    let skill_remove = package
+        .capabilities
+        .iter()
+        .find(|descriptor| descriptor.id.as_str() == SKILL_REMOVE_CAPABILITY_ID)
+        .expect("skill_remove manifest");
+    assert_eq!(
+        skill_remove.effects,
+        vec![
+            EffectKind::ReadFilesystem,
+            EffectKind::WriteFilesystem,
+            EffectKind::DeleteFilesystem
         ]
     );
     let http = package
@@ -4615,6 +4629,7 @@ fn builtin_effects() -> Vec<EffectKind> {
         EffectKind::DispatchCapability,
         EffectKind::ReadFilesystem,
         EffectKind::WriteFilesystem,
+        EffectKind::DeleteFilesystem,
         EffectKind::Network,
         EffectKind::SpawnProcess,
         EffectKind::ExecuteCode,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2052,6 +2052,7 @@ mod tests {
             EffectKind::DispatchCapability,
             EffectKind::ReadFilesystem,
             EffectKind::WriteFilesystem,
+            EffectKind::DeleteFilesystem,
             EffectKind::Network,
         ]
     }

--- a/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.rs
@@ -389,6 +389,7 @@ mod tests {
                 EffectKind::DispatchCapability,
                 EffectKind::ReadFilesystem,
                 EffectKind::WriteFilesystem,
+                EffectKind::DeleteFilesystem,
                 EffectKind::SpawnProcess,
                 EffectKind::ExecuteCode,
                 EffectKind::Network,

--- a/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
+++ b/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.toml
@@ -5,6 +5,7 @@ authority_effects = [
     "dispatch_capability",
     "read_filesystem",
     "write_filesystem",
+    "delete_filesystem",
     "spawn_process",
     "execute_code",
     "network",
@@ -134,12 +135,12 @@ network = "default"
 
 [[grants]]
 capability = "builtin.skill_install"
-effects = ["dispatch_capability", "read_filesystem", "write_filesystem", "network"]
+effects = ["dispatch_capability", "read_filesystem", "write_filesystem", "delete_filesystem", "network"]
 mounts = "skill_management"
 network = "local_dev_wildcard"
 
 [[grants]]
 capability = "builtin.skill_remove"
-effects = ["dispatch_capability", "read_filesystem", "write_filesystem"]
+effects = ["dispatch_capability", "read_filesystem", "write_filesystem", "delete_filesystem"]
 mounts = "skill_management"
 network = "default"

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -365,6 +365,7 @@ mod tests {
                 EffectKind::DispatchCapability,
                 EffectKind::ReadFilesystem,
                 EffectKind::WriteFilesystem,
+                EffectKind::DeleteFilesystem,
                 EffectKind::SpawnProcess,
                 EffectKind::ExecuteCode,
                 EffectKind::Network
@@ -491,6 +492,7 @@ mod tests {
                 EffectKind::DispatchCapability,
                 EffectKind::ReadFilesystem,
                 EffectKind::WriteFilesystem,
+                EffectKind::DeleteFilesystem,
                 EffectKind::Network
             ]
         );
@@ -498,6 +500,22 @@ mod tests {
         assert_eq!(
             skill_install_grant.constraints.network,
             local_dev_shell_network_policy
+        );
+
+        let skill_remove_grant = grant_for(SKILL_REMOVE_CAPABILITY_ID);
+        assert_eq!(
+            skill_remove_grant.constraints.allowed_effects,
+            vec![
+                EffectKind::DispatchCapability,
+                EffectKind::ReadFilesystem,
+                EffectKind::WriteFilesystem,
+                EffectKind::DeleteFilesystem
+            ]
+        );
+        assert_eq!(skill_remove_grant.constraints.mounts, skill_mounts);
+        assert_eq!(
+            skill_remove_grant.constraints.network,
+            NetworkPolicy::default()
         );
     }
 

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -778,6 +778,7 @@ async fn local_dev_adapter_exposes_skill_install_provider_tool_schema_requires_s
     let skill_install_effects = vec![
         EffectKind::ReadFilesystem,
         EffectKind::WriteFilesystem,
+        EffectKind::DeleteFilesystem,
         EffectKind::Network,
     ];
     let adapters = ProductLivePlannedRuntimeAdapters::from_services(


### PR DESCRIPTION
## Summary

- Declare `DeleteFilesystem` for `builtin.skill_install` and `builtin.skill_remove`.
- Grant delete authority to reborn local-dev skill-management capabilities on the `/skills` mount only.
- Extend manifest, policy, and local-dev grant tests so cleanup/remove authority stays covered.

## Root Cause

`skill_install` can delete during rollback: if install creates `/skills/<name>` and a later write or validation step fails, it calls partial-install cleanup to remove the half-created skill directory. The reborn first-party manifest and local-dev grant policy declared read/write authority but not delete, so rollback surfaced as `filesystem_denied` and the agent loop collapsed the tool failure into host unavailability.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_host_runtime builtin_first_party_package_declares_expected_capabilities`
- `cargo test -p ironclaw_host_runtime builtin_skill_install_accepts_named_plain_markdown_content`
- `cargo test -p ironclaw_reborn_composition local_dev_skill_management_invokes_through_first_party_runtime`
- `cargo test -p ironclaw_reborn_composition bundled_local_dev_capability_policy_parses`
- `cargo test -p ironclaw_reborn_composition local_dev_builtin_surface_grants_capability_classes`
- `git diff --check`

## Notes

Two existing unrelated checks still fail and are not fixed here:

- `builtin_skill_install_accepts_content_when_network_is_denied` fails because `skill_install` statically declares `Network` even for content-only installs.
- `install_bundle_failure_cleans_up_partial_directory` fails because the simulated backend write maps to `InvalidSkill` while the test expects `FilesystemDenied`.
