### PR TITLE
[codex] Allow local yolo workspaces under home

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -414,7 +414,6 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         (false, None) => None,
     };
     validate_local_dev_workspace_skill_isolation(&root, &workspace_root)?;
-    validate_local_dev_workspace_host_home_isolation(&workspace_root, host_home_root.as_ref())?;
     let default_system_prompt_path = local_dev_default_system_prompt_path(&root);
     seed_default_system_prompt(&root, &default_system_prompt_path).map_err(|error| {
         RebornBuildError::InvalidConfig {
@@ -1044,34 +1043,6 @@ fn validate_local_dev_workspace_skill_isolation(
             });
         }
     }
-    Ok(())
-}
-
-fn validate_local_dev_workspace_host_home_isolation(
-    workspace_root: &Path,
-    host_home_root: Option<&LocalDevHostHomeRoot>,
-) -> Result<(), RebornBuildError> {
-    let Some(host_home_root) = host_home_root else {
-        return Ok(());
-    };
-
-    for (label, host_path) in [
-        (
-            "confirmed host home root",
-            host_home_root.canonical_root.as_path(),
-        ),
-        (
-            "confirmed host home raw alias",
-            host_home_root.raw_alias.as_path(),
-        ),
-    ] {
-        if paths_overlap(workspace_root, host_path) {
-            return Err(RebornBuildError::InvalidConfig {
-                reason: format!("local-dev workspace root must not overlap {label}"),
-            });
-        }
-    }
-
     Ok(())
 }
 
@@ -1917,44 +1888,6 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn local_dev_workspace_root_overlapping_host_home_root_is_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let host_home = dir.path().join("home");
-        let workspace = host_home.join("workspace");
-        let host_home_root = LocalDevHostHomeRoot {
-            canonical_root: host_home.clone(),
-            raw_alias: dir.path().join("home-link"),
-        };
-
-        let error =
-            validate_local_dev_workspace_host_home_isolation(&workspace, Some(&host_home_root))
-                .expect_err("workspace nested under host home should be rejected");
-        assert!(
-            matches!(error, RebornBuildError::InvalidConfig { .. }),
-            "unexpected error: {error:?}"
-        );
-    }
-
-    #[test]
-    fn local_dev_workspace_root_overlapping_host_home_raw_alias_is_rejected() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let raw_alias = dir.path().join("home-link");
-        let workspace = raw_alias.join("workspace");
-        let host_home_root = LocalDevHostHomeRoot {
-            canonical_root: dir.path().join("home"),
-            raw_alias,
-        };
-
-        let error =
-            validate_local_dev_workspace_host_home_isolation(&workspace, Some(&host_home_root))
-                .expect_err("workspace nested under raw host-home alias should be rejected");
-        assert!(
-            matches!(error, RebornBuildError::InvalidConfig { .. }),
-            "unexpected error: {error:?}"
-        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests.rs
@@ -52,6 +52,50 @@ async fn local_yolo_policy_mounts_confirmed_host_home_as_host() {
     );
 }
 
+#[tokio::test]
+async fn local_yolo_policy_allows_workspace_under_confirmed_host_home() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage_root = dir.path().join("local-dev");
+    let host_home = dir.path().join("home");
+    let workspace_root = host_home.join("repo");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root");
+
+    let services = build_reborn_services(
+        RebornBuildInput::local_dev_with_profile(
+            RebornCompositionProfile::LocalDevYolo,
+            "local-dev-yolo-host-owner",
+            storage_root,
+        )
+        .with_runtime_policy(local_yolo_policy())
+        .with_local_dev_workspace_root(workspace_root)
+        .with_local_dev_confirmed_host_home_root(host_home),
+    )
+    .await
+    .expect("local-dev-yolo services build");
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local-dev runtime substrate");
+
+    let workspace_mount = local_runtime
+        .workspace_mounts
+        .mounts
+        .iter()
+        .find(|mount| mount.alias.as_str() == "/workspace")
+        .expect("workspace mount exists");
+    assert_eq!(workspace_mount.target.as_str(), "/projects/workspace");
+    assert_eq!(workspace_mount.permissions, MountPermissions::read_write());
+
+    let host_mount = local_runtime
+        .workspace_mounts
+        .mounts
+        .iter()
+        .find(|mount| mount.alias.as_str() == "/host")
+        .expect("host mount exists");
+    assert_eq!(host_mount.target.as_str(), "/projects/host");
+    assert_eq!(host_mount.permissions, MountPermissions::read_write());
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn local_yolo_policy_keeps_symlinked_host_home_raw_alias() {


### PR DESCRIPTION
## Summary
- Remove the local-dev-yolo composition guard that rejected a workspace nested under the confirmed host home.
- Add a regression covering the normal CLI shape where `/workspace` lives under `$HOME` while `/host` is also mounted.

## Root cause
The CLI resolves the local-dev workspace from `current_dir()` and confirms host access with `$HOME`. On macOS, repo checkouts commonly live under `/Users/...`, so the host-home overlap guard rejected the expected local-dev-yolo setup before the WebUI server could start.

## Validation
- `cargo test -p ironclaw_reborn_composition local_yolo_policy`
- `cargo test -p ironclaw_reborn_cli --features webui-v2-beta serve_confirm_host_access_flag_gates_local_dev_yolo`