### PR TITLE
[codex] fix apply_patch after write_file

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/coding/file.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/file.rs
@@ -79,7 +79,6 @@ pub(super) async fn read_file(
     read_state.write().await.record_read(
         read_scope_key(request),
         resolved.virtual_path.as_str().to_string(),
-        stat.modified,
         content_hash(&bytes),
         partial,
     );
@@ -124,11 +123,10 @@ pub(super) async fn write_file(
         .write_file(&resolved.virtual_path, content.as_bytes())
         .await
         .map_err(filesystem_error)?;
-    if let Some(stat) = stat_optional(request, &resolved.virtual_path).await? {
+    if stat_optional(request, &resolved.virtual_path).await?.is_some() {
         read_state.write().await.update_after_write(
             &scope,
             resolved.virtual_path.as_str(),
-            stat.modified,
             content_hash(content.as_bytes()),
         );
     }
@@ -323,11 +321,10 @@ pub(super) async fn apply_patch(
         .write_file(&resolved.virtual_path, &output)
         .await
         .map_err(filesystem_error)?;
-    if let Some(stat) = stat_optional(request, &resolved.virtual_path).await? {
+    if stat_optional(request, &resolved.virtual_path).await?.is_some() {
         read_state.write().await.update_after_write(
             &scope,
             resolved.virtual_path.as_str(),
-            stat.modified,
             content_hash(&output),
         );
     }

--- a/crates/ironclaw_first_party_extensions/src/coding/state.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/state.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashMap,
     hash::{DefaultHasher, Hash, Hasher},
     sync::Arc,
-    time::SystemTime,
 };
 
 use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
@@ -65,7 +64,6 @@ pub(super) struct CodingReadScopeKey {
 
 #[derive(Debug, Clone)]
 struct CodingReadEntry {
-    modified: Option<SystemTime>,
     content_hash: String,
     partial: bool,
 }
@@ -75,14 +73,12 @@ impl CodingReadState {
         &mut self,
         scope: CodingReadScopeKey,
         path: String,
-        modified: Option<SystemTime>,
         content_hash: String,
         partial: bool,
     ) {
         self.entries.insert(
             (scope, path),
             CodingReadEntry {
-                modified,
                 content_hash,
                 partial,
             },
@@ -109,15 +105,16 @@ impl CodingReadState {
         &mut self,
         scope: &CodingReadScopeKey,
         path: &str,
-        modified: Option<SystemTime>,
         content_hash: String,
     ) {
         let key = (scope.clone(), path.to_string());
-        if let Some(entry) = self.entries.get_mut(&key) {
-            entry.modified = modified;
-            entry.content_hash = content_hash;
-            entry.partial = false;
-        }
+        self.entries.insert(
+            key,
+            CodingReadEntry {
+                content_hash,
+                partial: false,
+            },
+        );
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -3817,6 +3817,44 @@ async fn builtin_apply_patch_requires_full_fresh_read_like_v1() {
 }
 
 #[tokio::test]
+async fn builtin_apply_patch_accepts_file_content_written_by_same_scope() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(all_builtin_capability_ids(), mounts);
+
+    invoke_with_context(
+        &runtime,
+        WRITE_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/math_utils.py", "content": "def multiply(a, b):\n    return a + b\n"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    let patched = invoke_with_context(
+        &runtime,
+        APPLY_PATCH_CAPABILITY_ID,
+        json!({
+            "path": "/workspace/math_utils.py",
+            "old_string": "    return a + b",
+            "new_string": "    return a * b"
+        }),
+        context,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(patched["success"], json!(true));
+    assert_eq!(patched["replacements"], json!(1));
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("math_utils.py")).unwrap(),
+        "def multiply(a, b):\n    return a * b\n"
+    );
+}
+
+#[tokio::test]
 async fn builtin_apply_patch_rejects_same_second_content_changes_after_read() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(temp.path().join("code.rs"), "old\n").unwrap();


### PR DESCRIPTION
## Summary

Fixes the Reborn first-party coding tool state so `builtin.apply_patch` works immediately after `builtin.write_file` creates or rewrites a file in the same scope.

## Root Cause

`apply_patch` correctly requires known fresh full-file contents before editing, but `write_file` only updated existing read state. If a file was created via `write_file`, a following `apply_patch` failed with `OperationFailed` even though the caller had just provided the complete file contents.

## Changes

- Treat successful `write_file` output as known full-file content for the same scope/path.
- Keep the existing content-hash freshness guard for stale external changes.
- Remove unused modified-time bookkeeping from coding read state.
- Add a host-runtime regression test for `write_file` followed by `apply_patch`.

## Validation

- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_apply_patch`
- `cargo test -p ironclaw_first_party_extensions`