### PR TITLE
[codex] simplify apply_patch match semantics

### DIFF
--- a/crates/ironclaw_first_party_extensions/src/coding/file.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/file.rs
@@ -23,14 +23,13 @@ use super::{
         resolve_optional_path, resolve_required_path, scoped_child_path, stat_optional,
         virtual_to_relative,
     },
-    state::{SharedCodingEditLocks, SharedCodingReadState, content_hash, read_scope_key},
+    state::{SharedCodingEditLocks, read_scope_key},
     text::{count_matches, decode_text, encode_text, reject_binary_probe, replace_content},
     types::{ListEntry, MatchMethod, ResolvedPath},
 };
 
 pub(super) async fn read_file(
     request: &CodingCapabilityRequest<'_>,
-    read_state: &SharedCodingReadState,
 ) -> Result<Value, CodingCapabilityError> {
     let resolved = resolve_required_path(request, "path", FilesystemOperation::ReadFile)?;
     let offset = optional_usize(request.input, "offset")?.unwrap_or(0);
@@ -75,14 +74,6 @@ pub(super) async fn read_file(
         .map(|(index, line)| format!("{:>6}│ {}", start_line + index + 1, line))
         .collect();
 
-    let partial = has_explicit_range || truncated_by_default;
-    read_state.write().await.record_read(
-        read_scope_key(request),
-        resolved.virtual_path.as_str().to_string(),
-        content_hash(&bytes),
-        partial,
-    );
-
     Ok(json!({
         "content": selected_lines.join("\n"),
         "total_lines": total_lines,
@@ -94,7 +85,6 @@ pub(super) async fn read_file(
 
 pub(super) async fn write_file(
     request: &CodingCapabilityRequest<'_>,
-    read_state: &SharedCodingReadState,
     edit_locks: &SharedCodingEditLocks,
 ) -> Result<Value, CodingCapabilityError> {
     let path_str = required_str(request.input, "path")?;
@@ -123,16 +113,6 @@ pub(super) async fn write_file(
         .write_file(&resolved.virtual_path, content.as_bytes())
         .await
         .map_err(filesystem_error)?;
-    if stat_optional(request, &resolved.virtual_path)
-        .await?
-        .is_some()
-    {
-        read_state.write().await.update_after_write(
-            &scope,
-            resolved.virtual_path.as_str(),
-            content_hash(content.as_bytes()),
-        );
-    }
     Ok(json!({
         "path": resolved.scoped_path.as_str(),
         "bytes_written": content.len(),
@@ -253,7 +233,6 @@ fn format_size(bytes: u64) -> String {
 
 pub(super) async fn apply_patch(
     request: &CodingCapabilityRequest<'_>,
-    read_state: &SharedCodingReadState,
     edit_locks: &SharedCodingEditLocks,
 ) -> Result<Value, CodingCapabilityError> {
     let path_str = required_str(request.input, "path")?;
@@ -300,12 +279,6 @@ pub(super) async fn apply_patch(
         .read_file(&resolved.virtual_path)
         .await
         .map_err(filesystem_error)?;
-    let current_hash = content_hash(&bytes);
-    read_state.read().await.check_before_edit(
-        &scope,
-        resolved.virtual_path.as_str(),
-        &current_hash,
-    )?;
     reject_binary_probe(&bytes)?;
     let (content, encoding, line_ending) = decode_text(&bytes)?;
     let (match_count, match_method) = count_matches(&content, old_string);
@@ -324,16 +297,6 @@ pub(super) async fn apply_patch(
         .write_file(&resolved.virtual_path, &output)
         .await
         .map_err(filesystem_error)?;
-    if stat_optional(request, &resolved.virtual_path)
-        .await?
-        .is_some()
-    {
-        read_state.write().await.update_after_write(
-            &scope,
-            resolved.virtual_path.as_str(),
-            content_hash(&output),
-        );
-    }
     let mut result = json!({
         "path": resolved.scoped_path.as_str(),
         "replacements": replacements,

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -20,7 +20,7 @@ use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{MountView, ResourceScope, RuntimeDispatchErrorKind};
 use serde_json::Value;
 
-use state::{SharedCodingEditLocks, SharedCodingReadState};
+use state::SharedCodingEditLocks;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodingCapabilityKind {
@@ -77,7 +77,6 @@ impl CodingCapabilityError {
 
 #[derive(Debug, Default)]
 pub struct CodingCapabilityState {
-    read_state: SharedCodingReadState,
     edit_locks: SharedCodingEditLocks,
 }
 
@@ -86,24 +85,21 @@ impl CodingCapabilityState {
         &self,
         request: &CodingCapabilityRequest<'_>,
     ) -> Result<Value, CodingCapabilityError> {
-        dispatch(request, &self.read_state, &self.edit_locks).await
+        dispatch(request, &self.edit_locks).await
     }
 }
 
 async fn dispatch(
     request: &CodingCapabilityRequest<'_>,
-    read_state: &SharedCodingReadState,
     edit_locks: &SharedCodingEditLocks,
 ) -> Result<Value, CodingCapabilityError> {
     match request.kind {
-        CodingCapabilityKind::ReadFile => file::read_file(request, read_state).await,
-        CodingCapabilityKind::WriteFile => file::write_file(request, read_state, edit_locks).await,
+        CodingCapabilityKind::ReadFile => file::read_file(request).await,
+        CodingCapabilityKind::WriteFile => file::write_file(request, edit_locks).await,
         CodingCapabilityKind::ListDir => file::list_dir(request).await,
         CodingCapabilityKind::Glob => glob_tool::glob(request).await,
         CodingCapabilityKind::Grep => grep_tool::grep(request).await,
-        CodingCapabilityKind::ApplyPatch => {
-            file::apply_patch(request, read_state, edit_locks).await
-        }
+        CodingCapabilityKind::ApplyPatch => file::apply_patch(request, edit_locks).await,
     }
 }
 

--- a/crates/ironclaw_first_party_extensions/src/coding/state.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/state.rs
@@ -1,16 +1,12 @@
 use std::{
-    collections::HashMap,
     hash::{DefaultHasher, Hash, Hasher},
     sync::Arc,
 };
 
-use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
-use super::{CodingCapabilityError, CodingCapabilityRequest};
+use super::CodingCapabilityRequest;
 
-use super::operation_error;
-
-pub(crate) type SharedCodingReadState = Arc<RwLock<CodingReadState>>;
 pub(crate) type SharedCodingEditLocks = Arc<CodingEditLocks>;
 
 /// Striped per-path async locks that serialize the read+write critical
@@ -47,11 +43,6 @@ impl CodingEditLocks {
     }
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct CodingReadState {
-    entries: HashMap<(CodingReadScopeKey, String), CodingReadEntry>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) struct CodingReadScopeKey {
     tenant_id: String,
@@ -60,66 +51,6 @@ pub(super) struct CodingReadScopeKey {
     project_id: Option<String>,
     mission_id: Option<String>,
     thread_id: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-struct CodingReadEntry {
-    content_hash: String,
-    partial: bool,
-}
-
-impl CodingReadState {
-    pub(super) fn record_read(
-        &mut self,
-        scope: CodingReadScopeKey,
-        path: String,
-        content_hash: String,
-        partial: bool,
-    ) {
-        self.entries.insert(
-            (scope, path),
-            CodingReadEntry {
-                content_hash,
-                partial,
-            },
-        );
-    }
-
-    pub(super) fn check_before_edit(
-        &self,
-        scope: &CodingReadScopeKey,
-        path: &str,
-        current_content_hash: &str,
-    ) -> Result<(), CodingCapabilityError> {
-        let key = (scope.clone(), path.to_string());
-        let Some(entry) = self.entries.get(&key) else {
-            return Err(operation_error());
-        };
-        if entry.partial || entry.content_hash != current_content_hash {
-            return Err(operation_error());
-        }
-        Ok(())
-    }
-
-    pub(super) fn update_after_write(
-        &mut self,
-        scope: &CodingReadScopeKey,
-        path: &str,
-        content_hash: String,
-    ) {
-        let key = (scope.clone(), path.to_string());
-        self.entries.insert(
-            key,
-            CodingReadEntry {
-                content_hash,
-                partial: false,
-            },
-        );
-    }
-}
-
-pub(super) fn content_hash(bytes: &[u8]) -> String {
-    blake3::hash(bytes).to_hex().to_string()
 }
 
 pub(super) fn read_scope_key(request: &CodingCapabilityRequest<'_>) -> CodingReadScopeKey {

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -86,21 +86,7 @@ async fn builtin_first_party_package_declares_expected_capabilities() {
         vec![
             EffectKind::ReadFilesystem,
             EffectKind::WriteFilesystem,
-            EffectKind::DeleteFilesystem,
             EffectKind::Network
-        ]
-    );
-    let skill_remove = package
-        .capabilities
-        .iter()
-        .find(|descriptor| descriptor.id.as_str() == SKILL_REMOVE_CAPABILITY_ID)
-        .expect("skill_remove manifest");
-    assert_eq!(
-        skill_remove.effects,
-        vec![
-            EffectKind::ReadFilesystem,
-            EffectKind::WriteFilesystem,
-            EffectKind::DeleteFilesystem
         ]
     );
     let http = package
@@ -3263,10 +3249,9 @@ async fn builtin_coding_apply_patch_serializes_concurrent_edits_on_same_path() {
     let result_b = task_b.await.unwrap();
 
     // Serialization guarantee: the second patch reads the post-write file and
-    // its cached hash (taken before either write) no longer matches, so
-    // exactly one apply_patch must succeed. Without the per-path edit lock,
-    // both calls can pass `check_before_edit` concurrently and silently lose
-    // an update.
+    // no longer finds `old_string`, so exactly one apply_patch must succeed.
+    // Without the per-path edit lock, both calls can read the original file
+    // concurrently and silently lose an update.
     let outcomes = [result_a.is_ok(), result_b.is_ok()];
     assert_eq!(
         outcomes.iter().filter(|ok| **ok).count(),
@@ -3734,22 +3719,13 @@ async fn builtin_coding_read_rejects_non_file_paths() {
 }
 
 #[tokio::test]
-async fn builtin_apply_patch_matches_v1_exact_unique_and_replace_all_behavior() {
+async fn builtin_apply_patch_matches_exact_unique_and_replace_all_behavior() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(temp.path().join("code.rs"), "old\nold\nunique\n").unwrap();
 
     let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
     let runtime = runtime_with_filesystem(filesystem);
     let context = execution_context_with_mounts(all_builtin_capability_ids(), mounts);
-
-    invoke_with_context(
-        &runtime,
-        READ_FILE_CAPABILITY_ID,
-        json!({"path": "/workspace/code.rs"}),
-        context.clone(),
-    )
-    .await
-    .unwrap();
 
     let duplicate = invoke_with_context(
         &runtime,
@@ -3793,7 +3769,7 @@ async fn builtin_apply_patch_matches_v1_exact_unique_and_replace_all_behavior() 
 }
 
 #[tokio::test]
-async fn builtin_apply_patch_requires_full_fresh_read_like_v1() {
+async fn builtin_apply_patch_accepts_unique_match_without_prior_read() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(temp.path().join("code.rs"), "old\n").unwrap();
 
@@ -3801,33 +3777,20 @@ async fn builtin_apply_patch_requires_full_fresh_read_like_v1() {
     let runtime = runtime_with_filesystem(filesystem);
     let context = execution_context_with_mounts(all_builtin_capability_ids(), mounts);
 
-    let unread = invoke_with_context(
+    let patched = invoke_with_context(
         &runtime,
         APPLY_PATCH_CAPABILITY_ID,
         json!({"path": "/workspace/code.rs", "old_string": "old", "new_string": "new"}),
-        context.clone(),
-    )
-    .await
-    .unwrap_err();
-    assert_eq!(unread, RuntimeFailureKind::OperationFailed);
-
-    invoke_with_context(
-        &runtime,
-        READ_FILE_CAPABILITY_ID,
-        json!({"path": "/workspace/code.rs", "limit": 1}),
-        context.clone(),
+        context,
     )
     .await
     .unwrap();
-    let partial = invoke_with_context(
-        &runtime,
-        APPLY_PATCH_CAPABILITY_ID,
-        json!({"path": "/workspace/code.rs", "old_string": "old", "new_string": "new"}),
-        context.clone(),
-    )
-    .await
-    .unwrap_err();
-    assert_eq!(partial, RuntimeFailureKind::OperationFailed);
+
+    assert_eq!(patched["success"], json!(true));
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("code.rs")).unwrap(),
+        "new\n"
+    );
 }
 
 #[tokio::test]
@@ -3869,7 +3832,7 @@ async fn builtin_apply_patch_accepts_file_content_written_by_same_scope() {
 }
 
 #[tokio::test]
-async fn builtin_apply_patch_rejects_same_second_content_changes_after_read() {
+async fn builtin_apply_patch_rejects_when_old_string_is_no_longer_present() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(temp.path().join("code.rs"), "old\n").unwrap();
 
@@ -3877,17 +3840,9 @@ async fn builtin_apply_patch_rejects_same_second_content_changes_after_read() {
     let runtime = runtime_with_filesystem(filesystem);
     let context = execution_context_with_mounts(all_builtin_capability_ids(), mounts);
 
-    invoke_with_context(
-        &runtime,
-        READ_FILE_CAPABILITY_ID,
-        json!({"path": "/workspace/code.rs"}),
-        context.clone(),
-    )
-    .await
-    .unwrap();
-    std::fs::write(temp.path().join("code.rs"), "old\nchanged\n").unwrap();
+    std::fs::write(temp.path().join("code.rs"), "changed\n").unwrap();
 
-    let stale = invoke_with_context(
+    let missing = invoke_with_context(
         &runtime,
         APPLY_PATCH_CAPABILITY_ID,
         json!({"path": "/workspace/code.rs", "old_string": "old", "new_string": "new"}),
@@ -3895,7 +3850,7 @@ async fn builtin_apply_patch_rejects_same_second_content_changes_after_read() {
     )
     .await
     .unwrap_err();
-    assert_eq!(stale, RuntimeFailureKind::OperationFailed);
+    assert_eq!(missing, RuntimeFailureKind::OperationFailed);
 }
 
 #[tokio::test]
@@ -4667,7 +4622,6 @@ fn builtin_effects() -> Vec<EffectKind> {
         EffectKind::DispatchCapability,
         EffectKind::ReadFilesystem,
         EffectKind::WriteFilesystem,
-        EffectKind::DeleteFilesystem,
         EffectKind::Network,
         EffectKind::SpawnProcess,
         EffectKind::ExecuteCode,


### PR DESCRIPTION
## Summary

Follow-up to #4189. Removes the hidden in-memory read/write freshness prerequisite from Reborn `builtin.apply_patch` and makes the tool behave like direct search/replace: patch when `old_string` uniquely matches the current file, fail when it is missing or ambiguous.

## Why

The previous fix still depended on cross-invocation handler state. Production logs can still hit `OperationFailed` when that state is absent or scoped differently, even though the current file has a valid unique match. The model-visible Reborn tool description does not expose this hidden prerequisite, so the runtime behavior was brittle and surprising.

## Changes

- Delete `CodingReadState` and content-hash freshness bookkeeping.
- Keep per-path edit locks so concurrent patches on the same file serialize.
- Update tests to cover direct unique-match patching without a prior read.
- Keep failures for missing `old_string`, ambiguous matches, no-op replacements, and concurrent lost-update prevention.

## Validation

- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_apply_patch`
- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_coding_apply_patch_serializes_concurrent_edits_on_same_path`
- `cargo test -p ironclaw_first_party_extensions`