### PR TITLE
[codex] tighten builtin HTTP input diagnostics

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -487,6 +487,10 @@ fn log_raw_http_input_error_for_local_diagnostics(
     validation_stage: &'static str,
     error: FirstPartyCapabilityError,
 ) -> FirstPartyCapabilityError {
+    tracing::debug!(
+        validation_stage,
+        "first-party HTTP tool input validation failed"
+    );
     if crate::unsafe_raw_http_diagnostics_enabled(unsafe_raw_diagnostics_allowed) {
         tracing::warn!(
             validation_stage,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -212,9 +212,30 @@ fn http_schema(require_save_to: bool) -> Value {
             "description": "HTTP method. Defaults to get."
         },
         "headers": {
-            "description": "HTTP headers as an object or array of {name,value} entries"
+            "description": "HTTP headers as an object or array of {name,value} entries",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "value": { "type": "string" }
+                        },
+                        "required": ["name", "value"],
+                        "additionalProperties": false
+                    }
+                }
+            ]
         },
-        "body": { "description": "String or JSON request body" },
+        "body": {
+            "description": "String or JSON request body",
+            "type": ["string", "object", "array", "number", "boolean", "null"]
+        },
         "body_base64": { "type": "string", "description": "Base64-encoded request body" },
         "response_body_limit": {
             "type": "integer",

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -22,10 +22,11 @@ use ironclaw_filesystem::{
 };
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
-    CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime,
-    MAX_HOT_PROMPT_BYTES, MAX_HOT_SCHEMA_BYTES, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
-    RuntimeFailureKind, SurfaceKind, VisibleCapabilityAccess, VisibleCapabilityRequest,
-    VisibleCapabilitySurface, builtin_first_party_package, publish_hot_capability_catalog,
+    CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HTTP_CAPABILITY_ID,
+    HostRuntime, MAX_HOT_PROMPT_BYTES, MAX_HOT_SCHEMA_BYTES, RuntimeCapabilityOutcome,
+    RuntimeCapabilityRequest, RuntimeFailureKind, SurfaceKind, VisibleCapabilityAccess,
+    VisibleCapabilityRequest, VisibleCapabilitySurface, builtin_first_party_package,
+    publish_hot_capability_catalog,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -541,6 +542,44 @@ async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
     assert_schema_has_property(&surface, "builtin.skill_install", "content");
     assert_schema_has_property(&surface, "builtin.skill_install", "url");
     assert_schema_has_property(&surface, "builtin.skill_install", "name");
+
+    let http_schema = &surface
+        .capabilities
+        .iter()
+        .find(|capability| capability.descriptor.id == capability_id(HTTP_CAPABILITY_ID))
+        .expect("builtin.http should be visible")
+        .descriptor
+        .parameters_schema;
+    assert!(
+        http_schema.get("not").is_none(),
+        "builtin.http should not use top-level `not`; provider schema shaping flattens it"
+    );
+    let http_validator = jsonschema::validator_for(http_schema).expect("http schema is valid");
+    http_validator
+        .validate(&json!({
+            "method": "post",
+            "url": "https://api.example.test/v1/items",
+            "headers": {
+                "content-type": "application/json"
+            },
+            "body": {"ok": true}
+        }))
+        .expect("http schema should accept valid JSON request bodies");
+    for input in [
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": {"x-request-id": 123}
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": [{"name": "x-request-id"}]
+        }),
+    ] {
+        assert!(
+            http_validator.validate(&input).is_err(),
+            "http schema should reject handler-invalid header input: {input}"
+        );
+    }
 
     let skill_install_schema = &surface
         .capabilities


### PR DESCRIPTION
## Summary
- add safe validation-stage debug logging for builtin HTTP InputEncode failures
- tighten builtin HTTP parameter schema for headers and body shapes
- cover the builtin HTTP schema in the visible surface contract without using provider-hostile top-level `not`

## Root cause
`builtin.http` could fail inside the first-party handler with `InputEncode` after policy and authorization succeeded, while the model-visible schema still allowed some handler-invalid shapes. The logs also did not expose which safe validation stage failed.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_host_runtime visible_surface_resolves_builtin_first_party_input_schema_refs`
- `cargo test -p ironclaw_host_runtime builtin_http`