### PR TITLE
[codex] classify invalid tool input as model error

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/mapping.rs
+++ b/crates/ironclaw_agent_loop/src/executor/mapping.rs
@@ -155,6 +155,7 @@ pub(super) fn capability_error_class(kind: &CapabilityFailureKind) -> Capability
 
 pub(super) fn capability_failure_kind(kind: &CapabilityFailureKind) -> LoopFailureKind {
     match kind {
+        CapabilityFailureKind::InvalidInput => LoopFailureKind::ModelError,
         CapabilityFailureKind::Authorization | CapabilityFailureKind::PolicyDenied => {
             LoopFailureKind::PolicyDenied
         }
@@ -179,4 +180,33 @@ pub(super) fn honor_retry_alteration(
         });
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_capability_input_is_model_error_not_protocol_failure() {
+        assert_eq!(
+            capability_error_class(&CapabilityFailureKind::InvalidInput),
+            CapabilityErrorClass::InputInvalid
+        );
+        assert_eq!(
+            capability_failure_kind(&CapabilityFailureKind::InvalidInput),
+            LoopFailureKind::ModelError
+        );
+    }
+
+    #[test]
+    fn protocol_and_policy_failure_kinds_remain_distinct() {
+        assert_eq!(
+            capability_failure_kind(&CapabilityFailureKind::InvalidOutput),
+            LoopFailureKind::CapabilityProtocolError
+        );
+        assert_eq!(
+            capability_failure_kind(&CapabilityFailureKind::PolicyDenied),
+            LoopFailureKind::PolicyDenied
+        );
+    }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -389,9 +389,9 @@ fn model_retry_attempt_class(class: ModelErrorClass) -> Option<RecoveryAttemptCl
 fn capability_error_to_failure_kind(class: CapabilityErrorClass) -> LoopFailureKind {
     match class {
         CapabilityErrorClass::PolicyDenied => LoopFailureKind::PolicyDenied,
+        CapabilityErrorClass::InputInvalid => LoopFailureKind::ModelError,
         CapabilityErrorClass::Transient
         | CapabilityErrorClass::Permanent
-        | CapabilityErrorClass::InputInvalid
         | CapabilityErrorClass::OperationFailed
         | CapabilityErrorClass::Unavailable
         | CapabilityErrorClass::Internal => LoopFailureKind::CapabilityProtocolError,
@@ -742,7 +742,7 @@ mod tests {
         use super::super::{
             CapabilityErrorClass, CapabilityErrorSummary, DefaultRecoveryStrategy, ModelErrorClass,
             ModelErrorSummary, RecoveryOutcome, RecoveryStrategy, RetryAlteration, RetryScope,
-            SanitizedStrategySummary, backoff_for,
+            SanitizedStrategySummary, backoff_for, capability_error_to_failure_kind,
         };
         use crate::state::{LoopExecutionState, RecoveryAttemptClass, RecoveryStrategyState};
         use ironclaw_turns::LoopFailureKind;
@@ -895,6 +895,10 @@ mod tests {
                 }
                 other => panic!("expected ToolErrorResult, got {other:?}"),
             }
+            assert_eq!(
+                capability_error_to_failure_kind(CapabilityErrorClass::InputInvalid),
+                LoopFailureKind::ModelError
+            );
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary
- classify invalid capability input as a model error in loop failure bookkeeping
- keep invalid tool input as a model-visible tool error result, not a recovery/protocol failure
- pin recovery and executor mappings with focused tests

## Why
`InputEncode` maps to `InvalidInput`, which is caused by model-emitted tool arguments that do not match the capability contract. That should remain model-correctable instead of being bucketed as a capability protocol/recovery failure.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_agent_loop invalid`