### PR TITLE
[codex] Project skill activations to WebUI

### DIFF
--- a/crates/ironclaw_event_streams/src/types.rs
+++ b/crates/ironclaw_event_streams/src/types.rs
@@ -178,6 +178,12 @@ pub enum ThreadLiveProjectionItem {
         phase: ThreadLiveWorkSummaryPhase,
         body: String,
     },
+    SkillActivation {
+        id: String,
+        run_id: TurnRunId,
+        skill_names: Vec<String>,
+        feedback: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_first_party_extension_ports/src/activation.rs
+++ b/crates/ironclaw_first_party_extension_ports/src/activation.rs
@@ -344,19 +344,19 @@ where
                     },
                 );
         }
-        if !plan.selection.activations.is_empty() || !plan.selection.feedback.is_empty() {
-            if let Some(observer) = self
-                .activation_observer
-                .lock()
-                .map_err(|_| SkillActivationSelectionError::Internal)?
-                .clone()
-            {
-                observer.observe_skill_activation(SkillActivationObservedEvent {
-                    run_context: run_context.clone(),
-                    activations: plan.selection.activations.clone(),
-                    feedback: plan.selection.feedback.clone(),
-                });
-            }
+        let has_activation_event =
+            !plan.selection.activations.is_empty() || !plan.selection.feedback.is_empty();
+        let activation_observer = self
+            .activation_observer
+            .lock()
+            .map_err(|_| SkillActivationSelectionError::Internal)?
+            .clone();
+        if let (true, Some(observer)) = (has_activation_event, activation_observer) {
+            observer.observe_skill_activation(SkillActivationObservedEvent {
+                run_context: run_context.clone(),
+                activations: plan.selection.activations.clone(),
+                feedback: plan.selection.feedback.clone(),
+            });
         }
         if plan.selection.activations.is_empty() {
             return Ok(Vec::new());

--- a/crates/ironclaw_first_party_extension_ports/src/activation.rs
+++ b/crates/ironclaw_first_party_extension_ports/src/activation.rs
@@ -82,6 +82,17 @@ pub struct SkillActivationSelection {
     pub feedback: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillActivationObservedEvent {
+    pub run_context: LoopRunContext,
+    pub activations: Vec<SkillActivationRequest>,
+    pub feedback: Vec<String>,
+}
+
+pub trait SkillActivationObserver: std::fmt::Debug + Send + Sync {
+    fn observe_skill_activation(&self, event: SkillActivationObservedEvent);
+}
+
 /// Fully resolved activation output for one user message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkillActivationPlan {
@@ -169,6 +180,7 @@ where
     bundle_source: Arc<S>,
     config: SkillActivationSelectorConfig,
     setup_marker_source: Option<Arc<dyn SetupMarkerSource>>,
+    activation_observer: Mutex<Option<Arc<dyn SkillActivationObserver>>>,
     messages_by_run: Mutex<HashMap<SkillActivationMessageKey, SkillActivationMessage>>,
     activation_cache: Mutex<HashMap<ActivationCandidateCacheKey, CachedActivationCandidate>>,
     plans_by_run: Mutex<HashMap<(TurnScope, TurnRunId), CapturedSkillActivationPlan>>,
@@ -193,6 +205,7 @@ where
             bundle_source,
             config,
             setup_marker_source: None,
+            activation_observer: Mutex::new(None),
             messages_by_run: Mutex::new(HashMap::new()),
             activation_cache: Mutex::new(HashMap::new()),
             plans_by_run: Mutex::new(HashMap::new()),
@@ -247,6 +260,17 @@ where
 
     pub(crate) fn bundle_source(&self) -> Arc<S> {
         Arc::clone(&self.bundle_source)
+    }
+
+    pub fn set_activation_observer(
+        &self,
+        observer: Arc<dyn SkillActivationObserver>,
+    ) -> Result<(), SkillActivationSelectionError> {
+        *self
+            .activation_observer
+            .lock()
+            .map_err(|_| SkillActivationSelectionError::Internal)? = Some(observer);
+        Ok(())
     }
 
     pub(crate) fn take_activation_plan_for_run(
@@ -319,6 +343,20 @@ where
                         run_context: run_context.clone(),
                     },
                 );
+        }
+        if !plan.selection.activations.is_empty() || !plan.selection.feedback.is_empty() {
+            if let Some(observer) = self
+                .activation_observer
+                .lock()
+                .map_err(|_| SkillActivationSelectionError::Internal)?
+                .clone()
+            {
+                observer.observe_skill_activation(SkillActivationObservedEvent {
+                    run_context: run_context.clone(),
+                    activations: plan.selection.activations.clone(),
+                    feedback: plan.selection.feedback.clone(),
+                });
+            }
         }
         if plan.selection.activations.is_empty() {
             return Ok(Vec::new());

--- a/crates/ironclaw_first_party_extension_ports/src/lib.rs
+++ b/crates/ironclaw_first_party_extension_ports/src/lib.rs
@@ -14,7 +14,8 @@ mod skills;
 
 pub use activation::{
     DEFAULT_MAX_ACTIVE_SKILLS, DEFAULT_MAX_SKILL_CONTEXT_TOKENS, SelectableSkillContextSource,
-    SkillActivationMode, SkillActivationPlan, SkillActivationRequest, SkillActivationSelection,
+    SkillActivationMode, SkillActivationObservedEvent, SkillActivationObserver,
+    SkillActivationPlan, SkillActivationRequest, SkillActivationSelection,
     SkillActivationSelectionError, SkillActivationSelectorConfig,
 };
 pub use assets::{SkillBundleAsset, SkillBundleAssetReadError, SkillBundleAssetReader};

--- a/crates/ironclaw_product_adapters/src/lib.rs
+++ b/crates/ironclaw_product_adapters/src/lib.rs
@@ -54,8 +54,9 @@ pub use outbound::{
     CAPABILITY_DISPLAY_RESULT_REF_MAX_BYTES, CAPABILITY_DISPLAY_SUMMARY_MAX_BYTES,
     CapabilityActivityStatusView, CapabilityActivityView, CapabilityActivityViewInput,
     CapabilityDisplayPreviewView, CapabilityDisplayPreviewViewInput, FinalReplyView,
-    GatePromptView, ProductOutboundEnvelope, ProductOutboundPayload, ProductOutboundTarget,
-    ProductProjectionItem, ProductProjectionState, ProductRenderOutcome,
+    GatePromptView, PROJECTION_SKILL_ACTIVATION_MAX_ITEMS, PROJECTION_SKILL_FEEDBACK_MAX_BYTES,
+    PROJECTION_SKILL_NAME_MAX_BYTES, ProductOutboundEnvelope, ProductOutboundPayload,
+    ProductOutboundTarget, ProductProjectionItem, ProductProjectionState, ProductRenderOutcome,
     ProductSynchronousResponse, ProductWorkSummaryPhase, ProgressKind, ProgressUpdateView,
     ProjectionCursor,
 };

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -17,9 +17,12 @@ const PROJECTION_THREAD_ID_MAX_BYTES: usize = 512;
 const PROJECTION_ITEM_ID_MAX_BYTES: usize = 512;
 const PROJECTION_TEXT_MAX_BYTES: usize = 128 * 1024;
 const PROJECTION_WORK_SUMMARY_MAX_BYTES: usize = 1024;
-const PROJECTION_SKILL_NAME_MAX_BYTES: usize = 128;
-const PROJECTION_SKILL_FEEDBACK_MAX_BYTES: usize = 1024;
-const PROJECTION_SKILL_ACTIVATION_MAX_ITEMS: usize = 16;
+/// Maximum byte length for a projected skill activation name.
+pub const PROJECTION_SKILL_NAME_MAX_BYTES: usize = 128;
+/// Maximum byte length for a projected skill activation feedback note.
+pub const PROJECTION_SKILL_FEEDBACK_MAX_BYTES: usize = 1024;
+/// Maximum number of skill activation names or feedback notes per projection item.
+pub const PROJECTION_SKILL_ACTIVATION_MAX_ITEMS: usize = 16;
 const CAPABILITY_ACTIVITY_ERROR_KIND_MAX_BYTES: usize = 64;
 const CAPABILITY_ACTIVITY_ERROR_KIND_SEGMENT_MAX_BYTES: usize = 24;
 const CAPABILITY_ACTIVITY_UNCLASSIFIED_ERROR_KIND: &str = "Unclassified";

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -17,6 +17,9 @@ const PROJECTION_THREAD_ID_MAX_BYTES: usize = 512;
 const PROJECTION_ITEM_ID_MAX_BYTES: usize = 512;
 const PROJECTION_TEXT_MAX_BYTES: usize = 128 * 1024;
 const PROJECTION_WORK_SUMMARY_MAX_BYTES: usize = 1024;
+const PROJECTION_SKILL_NAME_MAX_BYTES: usize = 128;
+const PROJECTION_SKILL_FEEDBACK_MAX_BYTES: usize = 1024;
+const PROJECTION_SKILL_ACTIVATION_MAX_ITEMS: usize = 16;
 const CAPABILITY_ACTIVITY_ERROR_KIND_MAX_BYTES: usize = 64;
 const CAPABILITY_ACTIVITY_ERROR_KIND_SEGMENT_MAX_BYTES: usize = 24;
 const CAPABILITY_ACTIVITY_UNCLASSIFIED_ERROR_KIND: &str = "Unclassified";
@@ -562,6 +565,12 @@ pub enum ProductProjectionItem {
         gate_ref: String,
         headline: String,
     },
+    SkillActivation {
+        id: String,
+        run_id: TurnRunId,
+        skill_names: Vec<String>,
+        feedback: Vec<String>,
+    },
 }
 
 impl ProductProjectionItem {
@@ -595,6 +604,41 @@ impl ProductProjectionItem {
                     headline,
                     PROJECTION_TEXT_MAX_BYTES,
                 )
+            }
+            Self::SkillActivation {
+                id,
+                skill_names,
+                feedback,
+                ..
+            } => {
+                validate_bounded_text("projection_item_id", id, PROJECTION_ITEM_ID_MAX_BYTES)?;
+                if skill_names.len() > PROJECTION_SKILL_ACTIVATION_MAX_ITEMS {
+                    return Err(invalid(
+                        "projection_skill_names",
+                        "too many activated skills",
+                    ));
+                }
+                if feedback.len() > PROJECTION_SKILL_ACTIVATION_MAX_ITEMS {
+                    return Err(invalid(
+                        "projection_skill_feedback",
+                        "too many skill activation feedback entries",
+                    ));
+                }
+                for skill_name in skill_names {
+                    validate_bounded_text(
+                        "projection_skill_name",
+                        skill_name,
+                        PROJECTION_SKILL_NAME_MAX_BYTES,
+                    )?;
+                }
+                for note in feedback {
+                    validate_bounded_text(
+                        "projection_skill_feedback",
+                        note,
+                        PROJECTION_SKILL_FEEDBACK_MAX_BYTES,
+                    )?;
+                }
+                Ok(())
             }
         }
     }
@@ -630,6 +674,12 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
                 gate_ref: String,
                 headline: String,
             },
+            SkillActivation {
+                id: String,
+                run_id: TurnRunId,
+                skill_names: Vec<String>,
+                feedback: Vec<String>,
+            },
         }
         let value = match Wire::deserialize(deserializer)? {
             Wire::Text { id, body } => ProductProjectionItem::Text { id, body },
@@ -649,6 +699,17 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
                 ProductProjectionItem::RunStatus { run_id, status }
             }
             Wire::Gate { gate_ref, headline } => ProductProjectionItem::Gate { gate_ref, headline },
+            Wire::SkillActivation {
+                id,
+                run_id,
+                skill_names,
+                feedback,
+            } => ProductProjectionItem::SkillActivation {
+                id,
+                run_id,
+                skill_names,
+                feedback,
+            },
         };
         value.validate().map_err(serde::de::Error::custom)?;
         Ok(value)
@@ -843,6 +904,29 @@ mod tests {
         assert_eq!(value["items"][0]["work_summary"]["phase"], "planning");
         let decoded: ProductProjectionState =
             serde_json::from_value(value).expect("deserialize work summary projection");
+        assert_eq!(decoded, state);
+    }
+
+    #[test]
+    fn projection_state_round_trips_skill_activation_item() {
+        let run_id = TurnRunId::new();
+        let state = ProductProjectionState::new(
+            "thread-1",
+            vec![ProductProjectionItem::SkillActivation {
+                id: "skill-activation:run:1".to_string(),
+                run_id,
+                skill_names: vec!["code-review".to_string()],
+                feedback: vec!["code-review: force-activated via explicit mention".to_string()],
+            }],
+        )
+        .expect("valid skill activation projection");
+        let value = serde_json::to_value(&state).expect("serialize");
+        assert_eq!(
+            value["items"][0]["skill_activation"]["skill_names"][0],
+            "code-review"
+        );
+        let decoded: ProductProjectionState =
+            serde_json::from_value(value).expect("deserialize skill activation projection");
         assert_eq!(decoded, state);
     }
 

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -14,19 +14,19 @@ use ironclaw_event_streams::{
     InMemoryProjectionUpdateSource, NoExposureProjectionRedactionValidator,
     ProjectionStreamError as EventProjectionStreamError, ProjectionStreamItem,
     ProjectionSubscribeRequest, ProjectionSubscription as EventProjectionSubscription,
-    ProjectionTarget, ProjectionViewClass, SubscriberCapabilities, ThreadLiveProjectionItem,
-    ThreadLiveProjectionUpdate, ThreadLiveWorkSummaryPhase,
+    ProjectionTarget, ProjectionViewClass, SubscriberCapabilities, ThreadLiveProjectionUpdate,
 };
 use ironclaw_events::{DurableEventLog, EventCursor, EventStreamKey, ReadScope};
+use ironclaw_first_party_extension_ports::SkillActivationObserver;
 use ironclaw_host_api::UserId;
 use ironclaw_outbound::InMemoryOutboundStateStore;
 use ironclaw_product_adapters::{
     AdapterInstallationId, CapabilityActivityStatusView, CapabilityActivityView,
     CapabilityActivityViewInput, ExternalActorRef, ExternalConversationRef, ProductAdapterError,
     ProductAdapterId, ProductOutboundEnvelope, ProductOutboundPayload, ProductOutboundTarget,
-    ProductProjectionItem, ProductProjectionState, ProductWorkSummaryPhase,
-    ProductWorkflowRejectionKind, ProjectionCursor as ProductProjectionCursor, ProjectionStream,
-    ProjectionSubscriptionRequest, RedactedString,
+    ProductProjectionItem, ProductProjectionState, ProductWorkflowRejectionKind,
+    ProjectionCursor as ProductProjectionCursor, ProjectionStream, ProjectionSubscriptionRequest,
+    RedactedString,
 };
 use ironclaw_turns::{
     ReplyTargetBindingRef, TurnActor, TurnCoordinator, TurnEventProjectionCursor,
@@ -38,7 +38,10 @@ mod live_progress;
 mod runtime_replay;
 mod turn_events;
 use display_preview::{CapabilityDisplayPreviewSource, NoopCapabilityDisplayPreviewSource};
-use live_progress::LiveProgressMilestoneSink;
+use live_progress::{
+    LiveProgressMilestoneSink, LiveProjectionPublisher, LiveSkillActivationObserver,
+    product_items_for_live_update,
+};
 use runtime_replay::{
     RuntimePayloadCandidate, replay_payload_candidates, snapshot_payload_candidates,
 };
@@ -89,16 +92,29 @@ impl RebornProjectionServices {
         })
     }
 
-    pub(crate) fn with_live_progress_milestone_sink(
+    pub(crate) fn with_live_progress_milestone_sink_for_publisher(
         &self,
         inner: Arc<dyn LoopHostMilestoneSink>,
-        actor_user_id: UserId,
+        publisher: Arc<LiveProjectionPublisher>,
     ) -> Arc<dyn LoopHostMilestoneSink> {
-        Arc::new(LiveProgressMilestoneSink::new(
-            inner,
+        Arc::new(LiveProgressMilestoneSink::new(inner, publisher))
+    }
+
+    pub(crate) fn live_projection_publisher(
+        &self,
+        actor_user_id: UserId,
+    ) -> Arc<LiveProjectionPublisher> {
+        Arc::new(LiveProjectionPublisher::new(
             Arc::clone(&self.live_updates),
             actor_user_id,
         ))
+    }
+
+    pub(crate) fn skill_activation_observer(
+        &self,
+        publisher: Arc<LiveProjectionPublisher>,
+    ) -> Arc<dyn SkillActivationObserver> {
+        Arc::new(LiveSkillActivationObserver::new(publisher))
     }
 }
 
@@ -538,27 +554,7 @@ fn live_update_payloads(
             reason: "runtime delivery offset exceeds runtime item payload count".to_string(),
         });
     }
-    let items = update
-        .items
-        .iter()
-        .map(|item| match item {
-            ThreadLiveProjectionItem::Thinking { id, body } => ProductProjectionItem::Thinking {
-                id: id.clone(),
-                body: body.clone(),
-            },
-            ThreadLiveProjectionItem::WorkSummary {
-                id,
-                run_id,
-                phase,
-                body,
-            } => ProductProjectionItem::WorkSummary {
-                id: id.clone(),
-                run_id: *run_id,
-                phase: live_work_summary_phase_to_product_phase(*phase),
-                body: body.clone(),
-            },
-        })
-        .collect::<Vec<_>>();
+    let items = product_items_for_live_update(update);
     if items.is_empty() {
         return Ok(None);
     }
@@ -570,17 +566,6 @@ fn live_update_payloads(
         total: 1,
         already_delivered: 0,
     }))
-}
-
-fn live_work_summary_phase_to_product_phase(
-    phase: ThreadLiveWorkSummaryPhase,
-) -> ProductWorkSummaryPhase {
-    match phase {
-        ThreadLiveWorkSummaryPhase::Planning => ProductWorkSummaryPhase::Planning,
-        ThreadLiveWorkSummaryPhase::Waiting => ProductWorkSummaryPhase::Waiting,
-        ThreadLiveWorkSummaryPhase::Retrying => ProductWorkSummaryPhase::Retrying,
-        ThreadLiveWorkSummaryPhase::Context => ProductWorkSummaryPhase::Context,
-    }
 }
 
 async fn snapshot_payloads(

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -12,9 +12,11 @@ use ironclaw_event_streams::{
     ThreadLiveProjectionUpdate, ThreadLiveWorkSummaryPhase,
 };
 use ironclaw_events::{EventCursor, EventStreamKey, ReadScope};
+use ironclaw_first_party_extension_ports::{SkillActivationObservedEvent, SkillActivationObserver};
 use ironclaw_host_api::UserId;
+use ironclaw_product_adapters::{ProductProjectionItem, ProductWorkSummaryPhase};
 use ironclaw_turns::{
-    TurnRunId,
+    TurnRunId, TurnScope,
     run_profile::{
         AgentLoopHostError, LoopDriverNoteKind, LoopHostMilestone, LoopHostMilestoneKind,
         LoopHostMilestoneSink, LoopSafeSummary, sanitize_model_visible_text,
@@ -30,19 +32,50 @@ const LIVE_PROGRESS_CURSOR_BASE: u64 = 1 << 62;
 
 pub(super) struct LiveProgressMilestoneSink {
     inner: Arc<dyn LoopHostMilestoneSink>,
+    publisher: Arc<LiveProjectionPublisher>,
+}
+
+#[derive(Debug)]
+pub(super) struct LiveSkillActivationObserver {
+    publisher: Arc<LiveProjectionPublisher>,
+}
+
+pub(crate) struct LiveProjectionPublisher {
     update_source: Arc<InMemoryProjectionUpdateSource>,
     actor_user_id: UserId,
     next_sequence: AtomicU64,
 }
 
+impl std::fmt::Debug for LiveProjectionPublisher {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LiveProjectionPublisher")
+            .field("actor_user_id", &self.actor_user_id)
+            .finish_non_exhaustive()
+    }
+}
+
 impl LiveProgressMilestoneSink {
     pub(super) fn new(
         inner: Arc<dyn LoopHostMilestoneSink>,
+        publisher: Arc<LiveProjectionPublisher>,
+    ) -> Self {
+        Self { inner, publisher }
+    }
+}
+
+impl LiveSkillActivationObserver {
+    pub(super) fn new(publisher: Arc<LiveProjectionPublisher>) -> Self {
+        Self { publisher }
+    }
+}
+
+impl LiveProjectionPublisher {
+    pub(super) fn new(
         update_source: Arc<InMemoryProjectionUpdateSource>,
         actor_user_id: UserId,
     ) -> Self {
         Self {
-            inner,
             update_source,
             actor_user_id,
             next_sequence: AtomicU64::new(0),
@@ -53,19 +86,14 @@ impl LiveProgressMilestoneSink {
         self.next_sequence.fetch_add(1, Ordering::Relaxed) + 1
     }
 
-    fn publish_live_item(
-        &self,
-        milestone: &LoopHostMilestone,
-        sequence: u64,
-        item: ThreadLiveProjectionItem,
-    ) {
+    fn publish_live_item(&self, scope: &TurnScope, sequence: u64, item: ThreadLiveProjectionItem) {
         let cursor = EventProjectionCursor::for_scope(
-            self.projection_scope(milestone),
+            self.projection_scope(scope),
             EventCursor::new(LIVE_PROGRESS_CURSOR_BASE.saturating_add(sequence)),
         );
         let update = ThreadLiveProjectionUpdate {
             cursor,
-            thread_id: milestone.scope.thread_id.clone(),
+            thread_id: scope.thread_id.clone(),
             items: vec![item],
         };
         if let Err(error) = self
@@ -74,12 +102,77 @@ impl LiveProgressMilestoneSink {
         {
             tracing::debug!(
                 error = %error,
-                run_id = %milestone.run_id,
                 "failed to publish live progress projection"
             );
         }
     }
 
+    fn projection_scope(&self, scope: &TurnScope) -> EventProjectionScope {
+        EventProjectionScope {
+            stream: EventStreamKey::new(
+                scope.tenant_id.clone(),
+                self.actor_user_id.clone(),
+                scope.agent_id.clone(),
+            ),
+            read_scope: ReadScope {
+                project_id: scope.project_id.clone(),
+                mission_id: None,
+                thread_id: Some(scope.thread_id.clone()),
+                process_id: None,
+            },
+        }
+    }
+}
+
+pub(super) fn product_items_for_live_update(
+    update: &ThreadLiveProjectionUpdate,
+) -> Vec<ProductProjectionItem> {
+    update
+        .items
+        .iter()
+        .map(|item| match item {
+            ThreadLiveProjectionItem::Thinking { id, body } => ProductProjectionItem::Thinking {
+                id: id.clone(),
+                body: body.clone(),
+            },
+            ThreadLiveProjectionItem::WorkSummary {
+                id,
+                run_id,
+                phase,
+                body,
+            } => ProductProjectionItem::WorkSummary {
+                id: id.clone(),
+                run_id: *run_id,
+                phase: live_work_summary_phase_to_product_phase(*phase),
+                body: body.clone(),
+            },
+            ThreadLiveProjectionItem::SkillActivation {
+                id,
+                run_id,
+                skill_names,
+                feedback,
+            } => ProductProjectionItem::SkillActivation {
+                id: id.clone(),
+                run_id: *run_id,
+                skill_names: skill_names.clone(),
+                feedback: feedback.clone(),
+            },
+        })
+        .collect()
+}
+
+fn live_work_summary_phase_to_product_phase(
+    phase: ThreadLiveWorkSummaryPhase,
+) -> ProductWorkSummaryPhase {
+    match phase {
+        ThreadLiveWorkSummaryPhase::Planning => ProductWorkSummaryPhase::Planning,
+        ThreadLiveWorkSummaryPhase::Waiting => ProductWorkSummaryPhase::Waiting,
+        ThreadLiveWorkSummaryPhase::Retrying => ProductWorkSummaryPhase::Retrying,
+        ThreadLiveWorkSummaryPhase::Context => ProductWorkSummaryPhase::Context,
+    }
+}
+
+impl LiveProgressMilestoneSink {
     fn publish_reasoning_delta(&self, milestone: &LoopHostMilestone, safe_delta: &str) {
         // The delta is already model-visible sanitized upstream. Re-sanitize at
         // the product projection boundary so this publish path has its own
@@ -88,9 +181,9 @@ impl LiveProgressMilestoneSink {
         if safe_delta.is_empty() {
             return;
         }
-        let sequence = self.next_live_sequence();
-        self.publish_live_item(
-            milestone,
+        let sequence = self.publisher.next_live_sequence();
+        self.publisher.publish_live_item(
+            &milestone.scope,
             sequence,
             ThreadLiveProjectionItem::Thinking {
                 id: thinking_id(milestone.run_id, sequence),
@@ -120,9 +213,9 @@ impl LiveProgressMilestoneSink {
                 return;
             }
         };
-        let sequence = self.next_live_sequence();
-        self.publish_live_item(
-            milestone,
+        let sequence = self.publisher.next_live_sequence();
+        self.publisher.publish_live_item(
+            &milestone.scope,
             sequence,
             ThreadLiveProjectionItem::WorkSummary {
                 id: work_summary_id(milestone.run_id, sequence),
@@ -132,21 +225,40 @@ impl LiveProgressMilestoneSink {
             },
         );
     }
+}
 
-    fn projection_scope(&self, milestone: &LoopHostMilestone) -> EventProjectionScope {
-        EventProjectionScope {
-            stream: EventStreamKey::new(
-                milestone.scope.tenant_id.clone(),
-                self.actor_user_id.clone(),
-                milestone.scope.agent_id.clone(),
-            ),
-            read_scope: ReadScope {
-                project_id: milestone.scope.project_id.clone(),
-                mission_id: None,
-                thread_id: Some(milestone.scope.thread_id.clone()),
-                process_id: None,
-            },
+impl SkillActivationObserver for LiveSkillActivationObserver {
+    fn observe_skill_activation(&self, event: SkillActivationObservedEvent) {
+        let skill_names = event
+            .activations
+            .iter()
+            .map(|activation| {
+                sanitize_model_visible_text(&activation.name)
+                    .trim()
+                    .to_string()
+            })
+            .filter(|name| !name.is_empty())
+            .collect::<Vec<_>>();
+        let feedback = event
+            .feedback
+            .iter()
+            .map(|note| sanitize_model_visible_text(note).trim().to_string())
+            .filter(|note| !note.is_empty())
+            .collect::<Vec<_>>();
+        if skill_names.is_empty() && feedback.is_empty() {
+            return;
         }
+        let sequence = self.publisher.next_live_sequence();
+        self.publisher.publish_live_item(
+            &event.run_context.scope,
+            sequence,
+            ThreadLiveProjectionItem::SkillActivation {
+                id: skill_activation_id(event.run_context.run_id, sequence),
+                run_id: event.run_context.run_id,
+                skill_names,
+                feedback,
+            },
+        );
     }
 }
 
@@ -176,6 +288,10 @@ fn thinking_id(run_id: TurnRunId, sequence: u64) -> String {
 
 fn work_summary_id(run_id: TurnRunId, sequence: u64) -> String {
     format!("work-summary:{run_id}:{sequence}")
+}
+
+fn skill_activation_id(run_id: TurnRunId, sequence: u64) -> String {
+    format!("skill-activation:{run_id}:{sequence}")
 }
 
 fn driver_note_kind_to_live_work_summary_phase(

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -14,7 +14,10 @@ use ironclaw_event_streams::{
 use ironclaw_events::{EventCursor, EventStreamKey, ReadScope};
 use ironclaw_first_party_extension_ports::{SkillActivationObservedEvent, SkillActivationObserver};
 use ironclaw_host_api::UserId;
-use ironclaw_product_adapters::{ProductProjectionItem, ProductWorkSummaryPhase};
+use ironclaw_product_adapters::{
+    PROJECTION_SKILL_ACTIVATION_MAX_ITEMS, PROJECTION_SKILL_FEEDBACK_MAX_BYTES,
+    PROJECTION_SKILL_NAME_MAX_BYTES, ProductProjectionItem, ProductWorkSummaryPhase,
+};
 use ironclaw_turns::{
     TurnRunId, TurnScope,
     run_profile::{
@@ -233,17 +236,22 @@ impl SkillActivationObserver for LiveSkillActivationObserver {
             .activations
             .iter()
             .map(|activation| {
-                sanitize_model_visible_text(&activation.name)
-                    .trim()
-                    .to_string()
+                sanitize_bounded_model_visible_text(
+                    &activation.name,
+                    PROJECTION_SKILL_NAME_MAX_BYTES,
+                )
             })
             .filter(|name| !name.is_empty())
+            .take(PROJECTION_SKILL_ACTIVATION_MAX_ITEMS)
             .collect::<Vec<_>>();
         let feedback = event
             .feedback
             .iter()
-            .map(|note| sanitize_model_visible_text(note).trim().to_string())
+            .map(|note| {
+                sanitize_bounded_model_visible_text(note, PROJECTION_SKILL_FEEDBACK_MAX_BYTES)
+            })
             .filter(|note| !note.is_empty())
+            .take(PROJECTION_SKILL_ACTIVATION_MAX_ITEMS)
             .collect::<Vec<_>>();
         if skill_names.is_empty() && feedback.is_empty() {
             return;
@@ -292,6 +300,19 @@ fn work_summary_id(run_id: TurnRunId, sequence: u64) -> String {
 
 fn skill_activation_id(run_id: TurnRunId, sequence: u64) -> String {
     format!("skill-activation:{run_id}:{sequence}")
+}
+
+fn sanitize_bounded_model_visible_text(value: &str, max_bytes: usize) -> String {
+    let sanitized = sanitize_model_visible_text(value);
+    let trimmed = sanitized.trim();
+    if trimmed.len() <= max_bytes {
+        return trimmed.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !trimmed.is_char_boundary(end) {
+        end -= 1;
+    }
+    trimmed[..end].trim_end().to_string()
 }
 
 fn driver_note_kind_to_live_work_summary_phase(

--- a/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
@@ -1,9 +1,14 @@
 use super::*;
+use ironclaw_first_party_extension_ports::{
+    SkillActivationMode, SkillActivationObservedEvent, SkillActivationRequest,
+};
+use ironclaw_product_adapters::ProductWorkSummaryPhase;
 use ironclaw_turns::{
     TurnId,
     run_profile::{
-        CapabilityInputRef, InMemoryLoopHostMilestoneSink, LoopDriverId, LoopDriverNoteKind,
-        LoopHostMilestone, LoopHostMilestoneKind, LoopSafeSummary,
+        CapabilityInputRef, InMemoryLoopHostMilestoneSink, InMemoryRunProfileResolver,
+        LoopDriverId, LoopDriverNoteKind, LoopHostMilestone, LoopHostMilestoneKind, LoopRunContext,
+        LoopSafeSummary, RunProfileResolutionRequest, RunProfileResolver,
     },
 };
 
@@ -402,9 +407,9 @@ async fn webui_event_stream_drains_live_reasoning_projection_from_update_source(
         event_log,
         ReplyTargetBindingRef::new("webui-thinking-reply").unwrap(),
     );
-    let sink = services.with_live_progress_milestone_sink(
+    let sink = services.with_live_progress_milestone_sink_for_publisher(
         Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        user_id.clone(),
+        services.live_projection_publisher(user_id.clone()),
     );
     let scope = TurnScope::new(
         tenant_id.clone(),
@@ -449,6 +454,78 @@ async fn webui_event_stream_drains_live_reasoning_projection_from_update_source(
 }
 
 #[tokio::test]
+async fn webui_event_stream_drains_skill_activation_projection_from_observer() {
+    let tenant_id = TenantId::new("webui-skill-activation-tenant").unwrap();
+    let user_id = UserId::new("webui-skill-activation-user").unwrap();
+    let agent_id = AgentId::new("webui-skill-activation-agent").unwrap();
+    let thread_id = ThreadId::new("webui-skill-activation-thread").unwrap();
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-skill-activation-reply").unwrap(),
+    );
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let run_id = TurnRunId::new();
+    let observer =
+        services.skill_activation_observer(services.live_projection_publisher(user_id.clone()));
+
+    observer.observe_skill_activation(SkillActivationObservedEvent {
+        run_context: LoopRunContext::new(
+            scope.clone(),
+            TurnId::new(),
+            run_id,
+            InMemoryRunProfileResolver::default()
+                .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+                .await
+                .unwrap(),
+        ),
+        activations: vec![SkillActivationRequest {
+            name: "code-review".to_string(),
+            source: None,
+            bundle_id: None,
+            mode: SkillActivationMode::ExplicitMention,
+        }],
+        feedback: vec!["code-review: force-activated via explicit mention".to_string()],
+    });
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event.payload(),
+            ProductOutboundPayload::ProjectionUpdate { state }
+                if state.thread_id == thread_id.to_string()
+                    && state.items.iter().any(|item| matches!(
+                        item,
+                        ProductProjectionItem::SkillActivation {
+                            run_id: observed_run_id,
+                            skill_names,
+                            feedback,
+                            ..
+                        } if *observed_run_id == run_id
+                            && skill_names == &vec!["code-review".to_string()]
+                            && feedback == &vec![
+                                "code-review: force-activated via explicit mention".to_string()
+                            ]
+                    ))
+        )
+    }));
+}
+
+#[tokio::test]
 async fn webui_event_stream_drains_work_summary_projection_from_driver_note() {
     let tenant_id = TenantId::new("webui-work-summary-tenant").unwrap();
     let user_id = UserId::new("webui-work-summary-user").unwrap();
@@ -459,9 +536,9 @@ async fn webui_event_stream_drains_work_summary_projection_from_driver_note() {
         event_log,
         ReplyTargetBindingRef::new("webui-work-summary-reply").unwrap(),
     );
-    let sink = services.with_live_progress_milestone_sink(
+    let sink = services.with_live_progress_milestone_sink_for_publisher(
         Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        user_id.clone(),
+        services.live_projection_publisher(user_id.clone()),
     );
     let scope = TurnScope::new(
         tenant_id.clone(),
@@ -523,9 +600,9 @@ async fn webui_event_stream_maps_subscription_terminated_work_summary_to_context
         event_log,
         ReplyTargetBindingRef::new("webui-terminated-summary-reply").unwrap(),
     );
-    let sink = services.with_live_progress_milestone_sink(
+    let sink = services.with_live_progress_milestone_sink_for_publisher(
         Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        user_id.clone(),
+        services.live_projection_publisher(user_id.clone()),
     );
     let scope = TurnScope::new(
         tenant_id.clone(),
@@ -587,9 +664,9 @@ async fn webui_event_stream_skips_empty_work_summary_body() {
         event_log,
         ReplyTargetBindingRef::new("webui-empty-summary-reply").unwrap(),
     );
-    let sink = services.with_live_progress_milestone_sink(
+    let sink = services.with_live_progress_milestone_sink_for_publisher(
         Arc::new(InMemoryLoopHostMilestoneSink::default()),
-        user_id.clone(),
+        services.live_projection_publisher(user_id.clone()),
     );
     let scope = TurnScope::new(
         tenant_id.clone(),

--- a/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
@@ -2,7 +2,10 @@ use super::*;
 use ironclaw_first_party_extension_ports::{
     SkillActivationMode, SkillActivationObservedEvent, SkillActivationRequest,
 };
-use ironclaw_product_adapters::ProductWorkSummaryPhase;
+use ironclaw_product_adapters::{
+    PROJECTION_SKILL_ACTIVATION_MAX_ITEMS, PROJECTION_SKILL_FEEDBACK_MAX_BYTES,
+    PROJECTION_SKILL_NAME_MAX_BYTES, ProductWorkSummaryPhase,
+};
 use ironclaw_turns::{
     TurnId,
     run_profile::{
@@ -523,6 +526,91 @@ async fn webui_event_stream_drains_skill_activation_projection_from_observer() {
                     ))
         )
     }));
+}
+
+#[tokio::test]
+async fn webui_event_stream_bounds_skill_activation_projection_from_observer() {
+    let tenant_id = TenantId::new("webui-skill-bounds-tenant").unwrap();
+    let user_id = UserId::new("webui-skill-bounds-user").unwrap();
+    let agent_id = AgentId::new("webui-skill-bounds-agent").unwrap();
+    let thread_id = ThreadId::new("webui-skill-bounds-thread").unwrap();
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-skill-bounds-reply").unwrap(),
+    );
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let run_id = TurnRunId::new();
+    let observer =
+        services.skill_activation_observer(services.live_projection_publisher(user_id.clone()));
+    let mut activations = (0..=PROJECTION_SKILL_ACTIVATION_MAX_ITEMS)
+        .map(|index| SkillActivationRequest {
+            name: format!("skill-{index}"),
+            source: None,
+            bundle_id: None,
+            mode: SkillActivationMode::ExplicitMention,
+        })
+        .collect::<Vec<_>>();
+    activations[0].name = format!("skill-{}", "🚀".repeat(80));
+    let mut feedback = (0..=PROJECTION_SKILL_ACTIVATION_MAX_ITEMS)
+        .map(|index| format!("feedback-{index}"))
+        .collect::<Vec<_>>();
+    feedback[0] = format!("feedback-{}", "🚀".repeat(300));
+
+    observer.observe_skill_activation(SkillActivationObservedEvent {
+        run_context: LoopRunContext::new(
+            scope.clone(),
+            TurnId::new(),
+            run_id,
+            InMemoryRunProfileResolver::default()
+                .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+                .await
+                .unwrap(),
+        ),
+        activations,
+        feedback,
+    });
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    let item = events
+        .iter()
+        .find_map(|event| match event.payload() {
+            ProductOutboundPayload::ProjectionUpdate { state } => {
+                state.items.iter().find_map(|item| match item {
+                    ProductProjectionItem::SkillActivation {
+                        skill_names,
+                        feedback,
+                        ..
+                    } => Some((skill_names, feedback)),
+                    _ => None,
+                })
+            }
+            _ => None,
+        })
+        .expect("skill activation projection update");
+
+    assert_eq!(item.0.len(), PROJECTION_SKILL_ACTIVATION_MAX_ITEMS);
+    assert_eq!(item.1.len(), PROJECTION_SKILL_ACTIVATION_MAX_ITEMS);
+    assert!(item.0[0].len() <= PROJECTION_SKILL_NAME_MAX_BYTES);
+    assert!(item.1[0].len() <= PROJECTION_SKILL_FEEDBACK_MAX_BYTES);
+    assert!(item.0[0].is_char_boundary(item.0[0].len()));
+    assert!(item.1[0].is_char_boundary(item.1[0].len()));
+    assert!(!item.0.iter().any(|name| name == "skill-16"));
+    assert!(!item.1.iter().any(|note| note == "feedback-16"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -990,8 +990,20 @@ pub async fn build_reborn_runtime(
         Arc::clone(&event_log),
         validated_identity.reply_target_binding_ref.clone(),
     );
-    let milestone_sink = projection_services
-        .with_live_progress_milestone_sink(durable_milestone_sink, actor_user_id.clone());
+    let live_projection_publisher =
+        projection_services.live_projection_publisher(actor_user_id.clone());
+    if let Some(skill_activation_source) = &skill_activation_source {
+        skill_activation_source
+            .set_activation_observer(
+                projection_services
+                    .skill_activation_observer(Arc::clone(&live_projection_publisher)),
+            )
+            .map_err(|error| RebornRuntimeError::SkillExecution(error.to_string()))?;
+    }
+    let milestone_sink = projection_services.with_live_progress_milestone_sink_for_publisher(
+        durable_milestone_sink,
+        live_projection_publisher,
+    );
     let local_dev_capability_policy = Arc::new(local_dev_capability_policy().map_err(|error| {
         tracing::error!(%error, "local-dev capability policy is invalid");
         RebornRuntimeError::InvalidArgument {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -307,6 +307,33 @@ function applyProjectionItems({
         setIsProcessing(false);
       }
     }
+
+    if (item.skill_activation) {
+      const {
+        id,
+        skill_names: skillNames = [],
+        feedback = [],
+      } = item.skill_activation;
+      if (skillNames.length || feedback.length) {
+        const messageId = `skill-${id || skillNames.join("-") || "activation"}`;
+        const content = [
+          skillNames.length ? `Skill activated: ${skillNames.join(", ")}` : "",
+          ...feedback,
+        ].filter(Boolean).join("\n");
+        setMessages((prev) => {
+          if (prev.some((m) => m.id === messageId)) return prev;
+          return [
+            ...prev,
+            {
+              id: messageId,
+              role: "system",
+              content,
+              timestamp: new Date().toISOString(),
+            },
+          ];
+        });
+      }
+    }
   }
   if (latestRunIdRef && activeRunId) {
     latestRunIdRef.current = activeRunId;


### PR DESCRIPTION
## Summary

- adds a live projection item for skill activation events
- observes first-party Reborn skill selection and publishes activated skill names plus selector feedback to WebUI projection updates
- teaches WebUI v2 chat event handling to render skill activation projection updates

## Why

Reborn already selects and injects skills during prompt construction, but the WebUI projection stream had no way to observe that selection. This adds a bounded product-safe projection shape so the browser can show when a skill activates.

## Validation

- `cargo check -p ironclaw_reborn_composition -p ironclaw_product_adapters -p ironclaw_event_streams -p ironclaw_first_party_extension_ports`
- `cargo test -p ironclaw_product_adapters --lib projection_state_round_trips_skill_activation_item`
- `cargo test -p ironclaw_reborn_composition webui_event_stream_drains_skill_activation_projection_from_observer`
- `cargo test -p ironclaw_reborn_composition skill_execution_adapter_prepares_filesystem_bundles_end_to_end`
- `cargo fmt --check`

Note: a broader `cargo test -p ironclaw_product_adapters ...` run hit existing feature-gated integration tests that require `test-support`; the new product projection test was rerun through `--lib`.
