### PR TITLE
ci(nearai-bench): track @main instead of pinning to a SHA

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -178,10 +178,12 @@ jobs:
     concurrency:
       group: nearai-bench-${{ github.event.issue.number }}
       cancel-in-progress: true
-    # Pinned to a reviewed commit on nearai/benchmarks main — mutable @main
-    # + secrets: inherit was the supply-chain hole. Bump this SHA in a
-    # deliberate PR when nearai/benchmarks ships a new reusable workflow.
-    uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@67effacd8c8a7f6f43b422e30a1810822b9d6d5f
+    # Tracks nearai/benchmarks main. Renderer / workflow changes there
+    # take effect on the next /benchmark without needing a deliberate
+    # SHA bump here. Both repos are under the same org with the same
+    # write-access set, so the supply-chain delta vs. a pinned SHA is
+    # small enough to trade for not stalling out every renderer change.
+    uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@main
     with:
       ironclaw-rev: ${{ needs.parse.outputs.head_sha }}
       pr-repo: ${{ github.repository }}


### PR DESCRIPTION
Drops the reviewed-SHA pin on \`bench-pr-reusable.yml\` and tracks \`@main\` directly.

## Why

The previous pin (\`67effacd\`) was 4+ PRs behind nearai/benchmarks main, which meant every renderer or workflow improvement there required a fresh ironclaw PR to take effect. The canary on #3834 hit two of those: missing viewer URLs in the PR comment, plus a 422 reaction error that had been fixed weeks ago. Future renderer changes would just keep stalling out on bumps.

## Trade-off

The pin existed for supply-chain hardening — \`secrets: inherit\` would forward \`OPENROUTER_API_KEY\` into whatever \`bench-pr-reusable.yml\` shipped, so a malicious commit on benchmarks main could exfiltrate that key. With \`@main\`, that's now the trust boundary.

Acceptable here because:
- Both repos are under the same org with the same write-access set
- The forwarded secret is the only sensitive surface (we already declare minimum permissions and the called workflow can only downgrade them)
- We were going to keep bumping the pin to main anyway — the pin was theatre at this point

## Test plan

After merge, re-comment \`/benchmark ironclaw-smoke\` on #3834 — expect per-task \`<details>\` blocks with \`step-by-step viewer\` links, a footer \`[browse run]\` link, and no 422 on the reaction step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)