### PR TITLE
Allow extension search without query

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -149,9 +149,8 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
         "schemas/builtin/extension_search.input.v1.json" => json!({
             "type": "object",
             "properties": {
-                "query": { "type": "string", "description": "Search query for locally available Reborn extensions" }
+                "query": { "type": "string", "description": "Optional search query for locally available Reborn extensions. Omit to list all extensions." }
             },
-            "required": ["query"],
             "additionalProperties": false
         }),
         "schemas/builtin/extension_install.input.v1.json"

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
@@ -118,6 +118,7 @@ struct ExtensionLifecycleToolHandler {
 
 #[derive(Debug, Deserialize)]
 struct SearchInput {
+    #[serde(default)]
     query: String,
 }
 
@@ -246,8 +247,9 @@ mod tests {
         let search = descriptor_for(&surface, EXTENSION_SEARCH_CAPABILITY_ID);
         assert_eq!(search.default_permission, PermissionMode::Allow);
         assert_eq!(
-            search.parameters_schema["required"],
-            serde_json::json!(["query"])
+            search.parameters_schema.get("required"),
+            None,
+            "extension_search query should be optional so models can list all extensions"
         );
 
         let install = descriptor_for(&surface, EXTENSION_INSTALL_CAPABILITY_ID);
@@ -337,7 +339,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_dev_extension_lifecycle_tool_rejects_malformed_and_unknown_inputs() {
+    async fn local_dev_extension_lifecycle_tool_lists_all_and_rejects_malformed_inputs() {
         let dir = tempfile::tempdir().expect("tempdir");
         let services = build_reborn_services(RebornBuildInput::local_dev(
             "extension-tools-invalid-owner",
@@ -347,14 +349,17 @@ mod tests {
         .expect("local-dev services build");
         let runtime = services.host_runtime.expect("host runtime composed");
 
-        assert_eq!(
-            invoke_json(
-                runtime.as_ref(),
-                EXTENSION_SEARCH_CAPABILITY_ID,
-                serde_json::json!({})
-            )
-            .await,
-            Err(RuntimeFailureKind::InvalidInput)
+        let list_all = invoke_json(
+            runtime.as_ref(),
+            EXTENSION_SEARCH_CAPABILITY_ID,
+            serde_json::json!({}),
+        )
+        .await
+        .expect("search without a query should list all extensions");
+        assert_eq!(list_all["payload"]["kind"], "extension_search");
+        assert!(
+            list_all["payload"]["count"].as_u64().unwrap_or_default() > 0,
+            "list-all extension search should return the bundled local-dev packages"
         );
         assert_eq!(
             invoke_json(


### PR DESCRIPTION
## Summary
- Make model-visible `builtin.extension_search` accept omitted `query` as list-all, matching Reborn CLI behavior
- Update the built-in JSON schema so providers no longer require `query`
- Cover empty-query search through the local-dev host runtime lifecycle tests

## Tests
- `cargo test -p ironclaw_reborn_composition extension_lifecycle_capabilities -- --nocapture`
- `cargo test -p ironclaw_host_runtime visible_surface_resolves_builtin_first_party_input_schema_refs -- --nocapture`