### PR TITLE
ci(nearai-bench): grant id-token: write so @main resolves

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -37,6 +37,8 @@ permissions:
   pull-requests: write  # gh pr view + gh pr comment + reactions on PR comments
   issues: write         # belt-and-suspenders; also covers parse-error comment
   contents: read
+  id-token: write       # the called workflow uses OIDC and must be
+                        # granted this or it fails to start.
 
 jobs:
   parse:


### PR DESCRIPTION
Fixes startup_failure on every \`/benchmark\` after #4217.

## Root cause

\`nearai/benchmarks\`'s \`bench-pr-reusable.yml\` declares \`id-token: write\` at the workflow level (added in nearai/benchmarks#42 for OIDC → AWS to persist run traces to S3). When a reusable workflow declares a permission, the caller has to grant at least that, or GitHub rejects the run before any job starts — \`startup_failure\` with no logs.

The previous SHA pin (\`67effacd\`) predates #42, so the called workflow didn't ask for \`id-token\` and this caller happened to work. #4217 bumped to \`@main\`, which now resolves to a SHA where \`id-token: write\` is declared — and every \`/benchmark\` immediately fails to start.

## Canary
[Run 26609449327](https://github.com/nearai/ironclaw/actions/runs/26609449327) on PR #3834, triggered right after #4217 merged.

## Test plan
After merge, re-comment \`/benchmark ironclaw-smoke\` on #3834. Should start cleanly, run for ~5 min, post the result comment with viewer-URL links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)