### PR TITLE
ci(nearai-bench): scope id-token: write to the bench job

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -37,8 +37,6 @@ permissions:
   pull-requests: write  # gh pr view + gh pr comment + reactions on PR comments
   issues: write         # belt-and-suspenders; also covers parse-error comment
   contents: read
-  id-token: write       # the called workflow uses OIDC and must be
-                        # granted this or it fails to start.
 
 jobs:
   parse:
@@ -173,6 +171,9 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write       # the called workflow uses OIDC to assume an
+                            # AWS role for S3 persistence; without this it
+                            # fails to start.
     # Concurrency lives on the authorized job, not the workflow root —
     # otherwise an unauthorized commenter typing `/benchmark whatever`
     # would acquire the per-PR group and cancel an in-flight maintainer


### PR DESCRIPTION
Fixes the still-failing /benchmark on #3834 after #4220.

The bench job declares its own `permissions:` block, which overrides the workflow-level one entirely (jobs don't inherit when they declare their own). The workflow-level `id-token: write` I added in #4220 was a no-op for bench, and GitHub validates the called workflow's permission contract at registration → `startup_failure` on every issue_comment event, not just /benchmark ones.

Moving the grant onto the bench job itself. After merge, retry `/benchmark ironclaw-smoke` on #3834.