### PR TITLE
[codex] Port NEAR AI MCP to Reborn extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4892,6 +4892,7 @@ dependencies = [
  "ironclaw_host_runtime",
  "ironclaw_llm",
  "ironclaw_loop_support",
+ "ironclaw_mcp",
  "ironclaw_network",
  "ironclaw_outbound",
  "ironclaw_processes",

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -336,6 +336,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 | Tool-level streaming | ✅ | ❌ | |
 | Z.AI tool_stream | ✅ | ❌ | Real-time tool call streaming |
 | Plugin tools | ✅ | ✅ | WASM tools |
+| NEAR AI MCP extension | ✅ | 🚧 | Host-bundled Reborn MCP extension exposes `nearai.search` via host-mediated HTTP and `llm_nearai_api_key`; dynamic MCP tool discovery remains pending |
 | Tool policies (allow/deny) | ✅ | ✅ | |
 | Exec approvals (`/approve`) | ✅ | ✅ | TUI approval overlay |
 | Tool inventory cache | ✅ | ❌ | Coalesced effective-tool inventory cache with channel-registry invalidation |

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -336,7 +336,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 | Tool-level streaming | ✅ | ❌ | |
 | Z.AI tool_stream | ✅ | ❌ | Real-time tool call streaming |
 | Plugin tools | ✅ | ✅ | WASM tools |
-| NEAR AI MCP extension | ✅ | 🚧 | Host-bundled Reborn MCP extension exposes `nearai.search` via host-mediated HTTP and `llm_nearai_api_key`; dynamic MCP tool discovery remains pending |
+| NEAR AI MCP extension | ✅ | 🚧 | Host-bundled Reborn MCP extension exposes `nearai.search` via host-mediated HTTP and `llm_nearai_api_key`; this is a static NEAR adapter, while the generic product-auth-to-MCP staged credential bridge remains tracked by #4176 and dynamic MCP tool discovery remains pending |
 | Tool policies (allow/deny) | ✅ | ✅ | |
 | Exec approvals (`/approve`) | ✅ | ✅ | TUI approval overlay |
 | Tool inventory cache | ✅ | ❌ | Coalesced effective-tool inventory cache with channel-registry invalidation |

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/manifest.toml
@@ -1,0 +1,25 @@
+schema_version = "reborn.extension_manifest.v2"
+id = "nearai"
+name = "NEAR AI"
+version = "0.1.0"
+description = "NEAR AI MCP tools for web search and hosted agent capabilities."
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "https://private.near.ai/mcp"
+
+[[capabilities]]
+id = "nearai.search"
+description = "Search through the NEAR AI MCP server."
+effects = ["dispatch_capability", "network", "use_secret"]
+runtime_credentials = [
+  { handle = "llm_nearai_api_key", audience = { scheme = "https", host_pattern = "*.near.ai" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/nearai/search.input.v1.json"
+output_schema_ref = "schemas/nearai/search.output.v1.json"
+prompt_doc_ref = "prompts/nearai/search.md"
+required_host_ports = ["host.runtime.http_egress"]

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/manifest.toml
@@ -3,7 +3,7 @@ id = "nearai"
 name = "NEAR AI"
 version = "0.1.0"
 description = "NEAR AI MCP tools for web search and hosted agent capabilities."
-trust = "third_party"
+trust = "first_party_requested"
 
 [runtime]
 kind = "mcp"
@@ -17,7 +17,7 @@ effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
   { handle = "llm_nearai_api_key", audience = { scheme = "https", host_pattern = "*.near.ai" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
-default_permission = "allow"
+default_permission = "ask"
 visibility = "model"
 input_schema_ref = "schemas/nearai/search.input.v1.json"
 output_schema_ref = "schemas/nearai/search.output.v1.json"

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/prompts/nearai/search.md
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/prompts/nearai/search.md
@@ -1,0 +1,1 @@
+Use for current web or hosted NEAR AI MCP search. Provide a concise `query`; pass through extra NEAR AI MCP-supported arguments only when the user asks for them.

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/prompts/nearai/search.md
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/prompts/nearai/search.md
@@ -1,1 +1,1 @@
-Use for current web or hosted NEAR AI MCP search. Provide a concise `query`; pass through extra NEAR AI MCP-supported arguments only when the user asks for them.
+Use for current web or hosted NEAR AI MCP search. Provide a concise `query`.

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.input.v1.json
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.input.v1.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "query": {
       "type": "string",
       "minLength": 1,
+      "maxLength": 2048,
       "description": "Search query to send to NEAR AI MCP."
     }
   },

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.input.v1.json
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.input.v1.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "query": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Search query to send to NEAR AI MCP."
+    }
+  },
+  "required": ["query"]
+}

--- a/crates/ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.output.v1.json
+++ b/crates/ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.output.v1.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "description": "Raw MCP tools/call result returned by the NEAR AI MCP server."
+}

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -84,6 +84,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime" }
 ironclaw_llm = { path = "../ironclaw_llm", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support" }
+ironclaw_mcp = { path = "../ironclaw_mcp" }
 ironclaw_network = { path = "../ironclaw_network" }
 ironclaw_outbound = { path = "../ironclaw_outbound" }
 ironclaw_processes = { path = "../ironclaw_processes" }

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -953,7 +953,7 @@ mod tests {
         let manifest_toml = nearai_mcp_manifest_toml_for_endpoint(&endpoint).unwrap();
         let manifest: Value = toml::from_str(&manifest_toml).unwrap();
 
-        assert_eq!(manifest["trust"].as_str(), Some("third_party"));
+        assert_eq!(manifest["trust"].as_str(), Some("first_party_requested"));
         assert_eq!(
             manifest["runtime"]["url"].as_str(),
             Some("https://10.0.0.12:8443/%22%0Atrust=%22system/mcp")

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -159,6 +159,9 @@ fn web_access_package() -> Result<AvailableExtensionPackage, ProductWorkflowErro
         "Web Access",
         WEB_ACCESS_MANIFEST,
         web_access_assets(),
+    )
+}
+
 fn nearai_mcp_package() -> Result<AvailableExtensionPackage, ProductWorkflowError> {
     let manifest = nearai_mcp_manifest_toml()?;
     bundled_extension_package("nearai", "NEAR AI", &manifest, nearai_mcp_assets(&manifest))
@@ -185,16 +188,13 @@ pub(crate) fn gmail_manifest_digest() -> String {
     sha256_digest_token(GMAIL_MANIFEST.as_bytes())
 }
 
-<<<<<<< HEAD
 pub(crate) fn web_access_manifest_digest() -> String {
     sha256_digest_token(WEB_ACCESS_MANIFEST.as_bytes())
-pub(crate) fn nearai_mcp_manifest_toml() -> String {
-    NEARAI_MCP_MANIFEST.replace("https://private.near.ai/mcp", &nearai_mcp_url_from_env())
-=======
+}
+
 pub(crate) fn nearai_mcp_manifest_toml() -> Result<String, ProductWorkflowError> {
     let endpoint = nearai_mcp_endpoint_from_env().map_err(map_binding_error)?;
     nearai_mcp_manifest_toml_for_endpoint(&endpoint)
->>>>>>> a274bf73c (Address NEAR AI MCP review feedback)
 }
 
 fn nearai_mcp_manifest_toml_for_endpoint(
@@ -388,6 +388,11 @@ fn web_access_assets() -> Vec<AvailableExtensionAsset> {
             "prompts/web-access/get_content.md",
             include_bytes!(
                 "../../ironclaw_first_party_extensions/assets/web-access/prompts/web-access/get_content.md"
+            ),
+        ),
+    ]
+}
+
 fn nearai_mcp_assets(manifest: &str) -> Vec<AvailableExtensionAsset> {
     vec![
         bytes_asset("manifest.toml", manifest.as_bytes()),
@@ -908,8 +913,7 @@ mod tests {
     fn bundled_first_party_manifest_asset_refs_are_packaged() {
         let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
 
-        for extension_id in ["web-access", "google-calendar", "gmail"] {
-        for extension_id in ["nearai", "google-calendar", "gmail"] {
+        for extension_id in ["web-access", "nearai", "google-calendar", "gmail"] {
             let package_ref =
                 LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id).unwrap();
             let package = catalog.resolve(&package_ref).unwrap();

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -8,6 +8,9 @@ use ironclaw_product_workflow::{
     LifecycleExtensionSource, LifecycleExtensionSummary, LifecyclePackageKind, LifecyclePackageRef,
     ProductWorkflowError,
 };
+use toml::Value;
+
+use crate::nearai_mcp::{NearAiMcpEndpoint, nearai_mcp_endpoint_from_env};
 
 const GITHUB_MANIFEST: &str =
     include_str!("../../ironclaw_first_party_extensions/assets/github/manifest.toml");
@@ -157,13 +160,8 @@ fn web_access_package() -> Result<AvailableExtensionPackage, ProductWorkflowErro
         WEB_ACCESS_MANIFEST,
         web_access_assets(),
 fn nearai_mcp_package() -> Result<AvailableExtensionPackage, ProductWorkflowError> {
-    let manifest = nearai_mcp_manifest_toml();
-    bundled_extension_package(
-        "nearai",
-        "NEAR AI MCP",
-        &manifest,
-        nearai_mcp_assets(&manifest),
-    )
+    let manifest = nearai_mcp_manifest_toml()?;
+    bundled_extension_package("nearai", "NEAR AI", &manifest, nearai_mcp_assets(&manifest))
 }
 
 fn google_calendar_package() -> Result<AvailableExtensionPackage, ProductWorkflowError> {
@@ -187,21 +185,67 @@ pub(crate) fn gmail_manifest_digest() -> String {
     sha256_digest_token(GMAIL_MANIFEST.as_bytes())
 }
 
+<<<<<<< HEAD
 pub(crate) fn web_access_manifest_digest() -> String {
     sha256_digest_token(WEB_ACCESS_MANIFEST.as_bytes())
 pub(crate) fn nearai_mcp_manifest_toml() -> String {
     NEARAI_MCP_MANIFEST.replace("https://private.near.ai/mcp", &nearai_mcp_url_from_env())
+=======
+pub(crate) fn nearai_mcp_manifest_toml() -> Result<String, ProductWorkflowError> {
+    let endpoint = nearai_mcp_endpoint_from_env().map_err(map_binding_error)?;
+    nearai_mcp_manifest_toml_for_endpoint(&endpoint)
+>>>>>>> a274bf73c (Address NEAR AI MCP review feedback)
 }
 
-fn nearai_mcp_url_from_env() -> String {
-    let configured_base = std::env::var("NEARAI_BASE_URL")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
-    let base = configured_base.unwrap_or_else(|| "https://private.near.ai".to_string());
-    let base = base.trim_end_matches('/');
-    let base = base.strip_suffix("/v1").unwrap_or(base);
-    format!("{base}/mcp")
+fn nearai_mcp_manifest_toml_for_endpoint(
+    endpoint: &NearAiMcpEndpoint,
+) -> Result<String, ProductWorkflowError> {
+    let mut manifest = toml::from_str::<Value>(NEARAI_MCP_MANIFEST).map_err(|error| {
+        map_binding_error(format!("bundled NEAR AI manifest TOML is invalid: {error}"))
+    })?;
+    let runtime = manifest
+        .get_mut("runtime")
+        .and_then(Value::as_table_mut)
+        .ok_or_else(|| map_binding_error("bundled NEAR AI manifest lacks runtime table"))?;
+    runtime.insert("url".to_string(), Value::String(endpoint.url.clone()));
+
+    let capabilities = manifest
+        .get_mut("capabilities")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| map_binding_error("bundled NEAR AI manifest lacks capabilities array"))?;
+    let search = capabilities
+        .first_mut()
+        .and_then(Value::as_table_mut)
+        .ok_or_else(|| map_binding_error("bundled NEAR AI manifest lacks search capability"))?;
+    let runtime_credentials = search
+        .get_mut("runtime_credentials")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| map_binding_error("bundled NEAR AI manifest lacks runtime credentials"))?;
+    let credential = runtime_credentials
+        .first_mut()
+        .and_then(Value::as_table_mut)
+        .ok_or_else(|| map_binding_error("bundled NEAR AI manifest lacks runtime credential"))?;
+    let audience = credential
+        .get_mut("audience")
+        .and_then(Value::as_table_mut)
+        .ok_or_else(|| {
+            map_binding_error("bundled NEAR AI manifest lacks runtime credential audience")
+        })?;
+    audience.insert(
+        "host_pattern".to_string(),
+        Value::String(endpoint.host_pattern.clone()),
+    );
+    if let Some(port) = endpoint.port {
+        audience.insert("port".to_string(), Value::Integer(i64::from(port)));
+    } else {
+        audience.remove("port");
+    }
+
+    toml::to_string(&manifest).map_err(|error| {
+        map_binding_error(format!(
+            "bundled NEAR AI manifest TOML render failed: {error}"
+        ))
+    })
 }
 
 fn bundled_extension_package(
@@ -845,6 +889,7 @@ mod tests {
     use ironclaw_host_api::{EffectKind, HostPortCatalog};
 
     use super::*;
+    use crate::nearai_mcp::nearai_mcp_endpoint_from_base;
 
     #[test]
     fn visible_capability_ids_excludes_write_effects() {
@@ -897,6 +942,31 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn nearai_manifest_renderer_uses_validated_endpoint_fields() {
+        let endpoint =
+            nearai_mcp_endpoint_from_base(Some("https://10.0.0.12:8443/%22%0Atrust=%22system"))
+                .unwrap();
+
+        let manifest_toml = nearai_mcp_manifest_toml_for_endpoint(&endpoint).unwrap();
+        let manifest: Value = toml::from_str(&manifest_toml).unwrap();
+
+        assert_eq!(manifest["trust"].as_str(), Some("third_party"));
+        assert_eq!(
+            manifest["runtime"]["url"].as_str(),
+            Some("https://10.0.0.12:8443/%22%0Atrust=%22system/mcp")
+        );
+        assert_eq!(
+            manifest["capabilities"][0]["runtime_credentials"][0]["audience"]["host_pattern"]
+                .as_str(),
+            Some("10.0.0.12")
+        );
+        assert_eq!(
+            manifest["capabilities"][0]["runtime_credentials"][0]["audience"]["port"].as_integer(),
+            Some(8443)
+        );
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -19,6 +19,8 @@ const GMAIL_MANIFEST: &str =
     include_str!("../../ironclaw_first_party_extensions/assets/gmail/manifest.toml");
 const WEB_ACCESS_MANIFEST: &str =
     include_str!("../../ironclaw_first_party_extensions/assets/web-access/manifest.toml");
+const NEARAI_MCP_MANIFEST: &str =
+    include_str!("../../ironclaw_first_party_extensions/assets/nearai-mcp/manifest.toml");
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct AvailableExtensionAsset {
@@ -70,6 +72,7 @@ impl AvailableExtensionCatalog {
         Ok(Self::from_packages(vec![
             github_package()?,
             web_access_package()?,
+            nearai_mcp_package()?,
             google_calendar_package()?,
             gmail_package()?,
         ]))
@@ -153,6 +156,13 @@ fn web_access_package() -> Result<AvailableExtensionPackage, ProductWorkflowErro
         "Web Access",
         WEB_ACCESS_MANIFEST,
         web_access_assets(),
+fn nearai_mcp_package() -> Result<AvailableExtensionPackage, ProductWorkflowError> {
+    let manifest = nearai_mcp_manifest_toml();
+    bundled_extension_package(
+        "nearai",
+        "NEAR AI MCP",
+        &manifest,
+        nearai_mcp_assets(&manifest),
     )
 }
 
@@ -179,6 +189,19 @@ pub(crate) fn gmail_manifest_digest() -> String {
 
 pub(crate) fn web_access_manifest_digest() -> String {
     sha256_digest_token(WEB_ACCESS_MANIFEST.as_bytes())
+pub(crate) fn nearai_mcp_manifest_toml() -> String {
+    NEARAI_MCP_MANIFEST.replace("https://private.near.ai/mcp", &nearai_mcp_url_from_env())
+}
+
+fn nearai_mcp_url_from_env() -> String {
+    let configured_base = std::env::var("NEARAI_BASE_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let base = configured_base.unwrap_or_else(|| "https://private.near.ai".to_string());
+    let base = base.trim_end_matches('/');
+    let base = base.strip_suffix("/v1").unwrap_or(base);
+    format!("{base}/mcp")
 }
 
 fn bundled_extension_package(
@@ -321,6 +344,25 @@ fn web_access_assets() -> Vec<AvailableExtensionAsset> {
             "prompts/web-access/get_content.md",
             include_bytes!(
                 "../../ironclaw_first_party_extensions/assets/web-access/prompts/web-access/get_content.md"
+fn nearai_mcp_assets(manifest: &str) -> Vec<AvailableExtensionAsset> {
+    vec![
+        bytes_asset("manifest.toml", manifest.as_bytes()),
+        bytes_asset(
+            "schemas/nearai/search.input.v1.json",
+            include_bytes!(
+                "../../ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.input.v1.json"
+            ),
+        ),
+        bytes_asset(
+            "schemas/nearai/search.output.v1.json",
+            include_bytes!(
+                "../../ironclaw_first_party_extensions/assets/nearai-mcp/schemas/nearai/search.output.v1.json"
+            ),
+        ),
+        bytes_asset(
+            "prompts/nearai/search.md",
+            include_bytes!(
+                "../../ironclaw_first_party_extensions/assets/nearai-mcp/prompts/nearai/search.md"
             ),
         ),
     ]
@@ -822,6 +864,7 @@ mod tests {
         let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
 
         for extension_id in ["web-access", "google-calendar", "gmail"] {
+        for extension_id in ["nearai", "google-calendar", "gmail"] {
             let package_ref =
                 LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id).unwrap();
             let package = catalog.resolve(&package_ref).unwrap();

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -237,10 +237,15 @@ where
         tracing::debug!("skipping NEAR AI MCP runtime because host runtime HTTP egress is absent");
         return Ok(services);
     };
-    let endpoint =
-        nearai_mcp_endpoint_from_env().map_err(|reason| RebornBuildError::InvalidConfig {
-            reason: format!("NEAR AI MCP endpoint config is invalid: {reason}"),
-        })?;
+    let endpoint = match nearai_mcp_endpoint_from_env() {
+        Ok(endpoint) => endpoint,
+        Err(reason) => {
+            tracing::debug!(
+                "skipping NEAR AI MCP runtime: {reason} (this only affects the optional NEAR AI MCP extension)"
+            );
+            return Ok(services);
+        }
+    };
     Ok(services.with_mcp_runtime(nearai_mcp_runtime(
         runtime_ports.runtime_http_egress(),
         endpoint,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -98,8 +98,12 @@ use crate::{
         extend_builtin_first_party_package, insert_handlers as insert_extension_lifecycle_handlers,
     },
     gsuite::register_bundled_gsuite_first_party_handlers,
+<<<<<<< HEAD
     web_access::register_bundled_web_access_first_party_handlers,
     nearai_mcp::nearai_mcp_runtime,
+=======
+    nearai_mcp::{nearai_mcp_endpoint_from_env, nearai_mcp_runtime},
+>>>>>>> a274bf73c (Address NEAR AI MCP review feedback)
 };
 
 #[cfg(feature = "libsql")]
@@ -229,12 +233,18 @@ where
     S: ironclaw_processes::ProcessStore + 'static,
     R: ironclaw_processes::ProcessResultStore + 'static,
 {
-    let runtime_ports = services
-        .product_auth_provider_runtime_ports()
-        .ok_or_else(|| RebornBuildError::InvalidConfig {
-            reason: "NEAR AI MCP runtime requires host runtime HTTP egress".to_string(),
+    let Some(runtime_ports) = services.product_auth_provider_runtime_ports() else {
+        tracing::debug!("skipping NEAR AI MCP runtime because host runtime HTTP egress is absent");
+        return Ok(services);
+    };
+    let endpoint =
+        nearai_mcp_endpoint_from_env().map_err(|reason| RebornBuildError::InvalidConfig {
+            reason: format!("NEAR AI MCP endpoint config is invalid: {reason}"),
         })?;
-    Ok(services.with_mcp_runtime(nearai_mcp_runtime(runtime_ports.runtime_http_egress())))
+    Ok(services.with_mcp_runtime(nearai_mcp_runtime(
+        runtime_ports.runtime_http_egress(),
+        endpoint,
+    )))
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1992,8 +2002,24 @@ mod tests {
         );
         assert_eq!(
             search.runtime_credentials[0].audience.host_pattern,
-            "*.near.ai"
+            "private.near.ai"
         );
+    }
+
+    #[test]
+    fn attach_nearai_mcp_runtime_skips_services_without_runtime_http_egress() {
+        let services = HostRuntimeServices::new(
+            Arc::new(ExtensionRegistry::new()),
+            Arc::new(LocalFilesystem::new()),
+            Arc::new(InMemoryResourceGovernor::new()),
+            Arc::new(GrantAuthorizer::new()),
+            ProcessServices::in_memory(),
+            CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        );
+
+        let services = attach_nearai_mcp_runtime(services).expect("attach is optional");
+
+        assert!(services.product_auth_provider_runtime_ports().is_none());
     }
 
     #[cfg(feature = "libsql")]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -98,12 +98,8 @@ use crate::{
         extend_builtin_first_party_package, insert_handlers as insert_extension_lifecycle_handlers,
     },
     gsuite::register_bundled_gsuite_first_party_handlers,
-<<<<<<< HEAD
-    web_access::register_bundled_web_access_first_party_handlers,
-    nearai_mcp::nearai_mcp_runtime,
-=======
     nearai_mcp::{nearai_mcp_endpoint_from_env, nearai_mcp_runtime},
->>>>>>> a274bf73c (Address NEAR AI MCP review feedback)
+    web_access::register_bundled_web_access_first_party_handlers,
 };
 
 #[cfg(feature = "libsql")]
@@ -1203,6 +1199,8 @@ fn gsuite_allowed_effects() -> Vec<EffectKind> {
 
 fn web_access_allowed_effects() -> Vec<EffectKind> {
     vec![EffectKind::DispatchCapability, EffectKind::Network]
+}
+
 #[cfg(test)]
 fn nearai_allowed_effects() -> Vec<EffectKind> {
     vec![
@@ -1929,10 +1927,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let services = build_reborn_services(RebornBuildInput::local_dev(
             "local-dev-web-access-owner",
-    async fn local_dev_nearai_mcp_installs_and_activates_model_visible_capability() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let services = build_reborn_services(RebornBuildInput::local_dev(
-            "local-dev-nearai-mcp-owner",
             dir.path().join("local-dev"),
         ))
         .await
@@ -1977,6 +1971,22 @@ mod tests {
         };
         assert_eq!(failure.capability_id.as_str(), "web-access.search");
         assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+    }
+
+    #[tokio::test]
+    async fn local_dev_nearai_mcp_installs_and_activates_model_visible_capability() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let services = build_reborn_services(RebornBuildInput::local_dev(
+            "local-dev-nearai-mcp-owner",
+            dir.path().join("local-dev"),
+        ))
+        .await
+        .expect("local-dev services build");
+        let local_runtime = services.local_runtime.as_ref().expect("local runtime");
+        let extension_management = local_runtime
+            .extension_management
+            .as_ref()
+            .expect("extension management");
         let nearai_ref =
             LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").expect("valid ref");
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -99,6 +99,7 @@ use crate::{
     },
     gsuite::register_bundled_gsuite_first_party_handlers,
     web_access::register_bundled_web_access_first_party_handlers,
+    nearai_mcp::nearai_mcp_runtime,
 };
 
 #[cfg(feature = "libsql")]
@@ -217,6 +218,23 @@ where
         .ok_or_else(|| RebornBuildError::InvalidConfig {
             reason: "Google OAuth provider backend requires host runtime HTTP egress".to_string(),
         })
+}
+
+fn attach_nearai_mcp_runtime<F, G, S, R>(
+    services: HostRuntimeServices<F, G, S, R>,
+) -> Result<HostRuntimeServices<F, G, S, R>, RebornBuildError>
+where
+    F: ironclaw_filesystem::RootFilesystem + 'static,
+    G: ironclaw_resources::ResourceGovernor + 'static,
+    S: ironclaw_processes::ProcessStore + 'static,
+    R: ironclaw_processes::ProcessResultStore + 'static,
+{
+    let runtime_ports = services
+        .product_auth_provider_runtime_ports()
+        .ok_or_else(|| RebornBuildError::InvalidConfig {
+            reason: "NEAR AI MCP runtime requires host runtime HTTP egress".to_string(),
+        })?;
+    Ok(services.with_mcp_runtime(nearai_mcp_runtime(runtime_ports.runtime_http_egress())))
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -477,6 +495,7 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     .with_approval_requests(Arc::clone(&store_graph.approval_requests))
     .with_capability_leases(Arc::clone(&store_graph.capability_leases))
     .with_turn_state_and_transition_port(Arc::clone(&store_graph.turn_state));
+    services = attach_nearai_mcp_runtime(services)?;
     let local_dev_process_port = local_dev_process_port_for_policy(
         &runtime_policy,
         &workspace_root,
@@ -1169,6 +1188,13 @@ fn gsuite_allowed_effects() -> Vec<EffectKind> {
 
 fn web_access_allowed_effects() -> Vec<EffectKind> {
     vec![EffectKind::DispatchCapability, EffectKind::Network]
+#[cfg(test)]
+fn nearai_allowed_effects() -> Vec<EffectKind> {
+    vec![
+        EffectKind::DispatchCapability,
+        EffectKind::Network,
+        EffectKind::UseSecret,
+    ]
 }
 
 async fn build_production_shaped(
@@ -1621,6 +1647,7 @@ where
     .with_filesystem_turn_state_store(stores.scoped_filesystem)
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
+    let services = attach_nearai_mcp_runtime(services)?;
     let google_provider_client = google_oauth_config
         .map(|config| {
             let runtime_ports = require_product_auth_runtime_ports(&services)?;
@@ -1887,6 +1914,10 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let services = build_reborn_services(RebornBuildInput::local_dev(
             "local-dev-web-access-owner",
+    async fn local_dev_nearai_mcp_installs_and_activates_model_visible_capability() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let services = build_reborn_services(RebornBuildInput::local_dev(
+            "local-dev-nearai-mcp-owner",
             dir.path().join("local-dev"),
         ))
         .await
@@ -1931,6 +1962,38 @@ mod tests {
         };
         assert_eq!(failure.capability_id.as_str(), "web-access.search");
         assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+        let nearai_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, "nearai").expect("valid ref");
+
+        extension_management
+            .install(nearai_ref.clone())
+            .await
+            .expect("install NEAR AI MCP");
+        extension_management
+            .activate(nearai_ref)
+            .await
+            .expect("activate NEAR AI MCP");
+
+        let capabilities = extension_management
+            .active_model_visible_capabilities()
+            .await
+            .expect("active capabilities");
+        let search = capabilities
+            .iter()
+            .find(|capability| capability.id.as_str() == "nearai.search")
+            .expect("nearai.search active");
+
+        assert_eq!(search.provider.as_str(), "nearai");
+        assert_eq!(search.effects, nearai_allowed_effects());
+        assert_eq!(search.runtime_credentials.len(), 1);
+        assert_eq!(
+            search.runtime_credentials[0].handle,
+            SecretHandle::new("llm_nearai_api_key").unwrap()
+        );
+        assert_eq!(
+            search.runtime_credentials[0].audience.host_pattern,
+            "*.near.ai"
+        );
     }
 
     #[cfg(feature = "libsql")]

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -39,6 +39,7 @@ mod llm_catalog;
 mod local_dev_capability_policy;
 mod local_dev_mounts;
 mod local_runtime_profile;
+mod nearai_mcp;
 #[cfg(feature = "webui-v2-beta")]
 mod product_auth_serve;
 mod product_live_adapters;

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use ironclaw_host_api::{
+    CapabilityId, NetworkPolicy, NetworkScheme, NetworkTargetPattern, RuntimeCredentialInjection,
+    RuntimeCredentialSource, RuntimeCredentialTarget, RuntimeHttpEgress, SecretHandle,
+};
+use ironclaw_mcp::{
+    McpExecutor, McpHostHttpClient, McpHostHttpEgressPlan, McpHostHttpEgressPlanRequest,
+    McpHostHttpEgressPlanner, McpRuntime, McpRuntimeConfig, McpRuntimeHttpAdapter,
+};
+
+const NEARAI_EXTENSION_ID: &str = "nearai";
+const NEARAI_API_KEY_SECRET_HANDLE: &str = "llm_nearai_api_key";
+const NEARAI_MCP_TIMEOUT_MS: u32 = 60_000;
+const NEARAI_MCP_RESPONSE_BODY_LIMIT: u64 = 2 * 1024 * 1024;
+const NEARAI_MCP_NETWORK_EGRESS_LIMIT: u64 = 2 * 1024 * 1024;
+
+pub(crate) fn nearai_mcp_runtime(
+    runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+) -> Arc<impl McpExecutor> {
+    let http = McpRuntimeHttpAdapter::new(runtime_http_egress);
+    let client = McpHostHttpClient::new(http, NearAiMcpEgressPlanner);
+    Arc::new(McpRuntime::new(McpRuntimeConfig::default(), client))
+}
+
+#[derive(Debug, Clone)]
+struct NearAiMcpEgressPlanner;
+
+impl McpHostHttpEgressPlanner for NearAiMcpEgressPlanner {
+    fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan {
+        if request.provider.as_str() != NEARAI_EXTENSION_ID || !nearai_mcp_url_allowed(request.url)
+        {
+            return McpHostHttpEgressPlan::default();
+        }
+        McpHostHttpEgressPlan {
+            network_policy: nearai_network_policy(),
+            credential_injections: vec![nearai_api_key_injection(request.capability_id)],
+            response_body_limit: Some(NEARAI_MCP_RESPONSE_BODY_LIMIT),
+            timeout_ms: Some(NEARAI_MCP_TIMEOUT_MS),
+        }
+    }
+}
+
+fn nearai_mcp_url_allowed(url: &str) -> bool {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|url| {
+            (url.scheme() == "https")
+                .then(|| url.host_str().map(|host| host.to_ascii_lowercase()))?
+        })
+        .is_some_and(|host| host == "near.ai" || host.ends_with(".near.ai"))
+}
+
+fn nearai_network_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "*.near.ai".to_string(),
+            port: None,
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(NEARAI_MCP_NETWORK_EGRESS_LIMIT),
+    }
+}
+
+fn nearai_api_key_injection(capability_id: &CapabilityId) -> RuntimeCredentialInjection {
+    RuntimeCredentialInjection {
+        handle: nearai_api_key_handle(),
+        source: RuntimeCredentialSource::StagedObligation {
+            capability_id: capability_id.clone(),
+        },
+        target: RuntimeCredentialTarget::Header {
+            name: "authorization".to_string(),
+            prefix: Some("Bearer ".to_string()),
+        },
+        required: true,
+    }
+}
+
+fn nearai_api_key_handle() -> SecretHandle {
+    SecretHandle::new(NEARAI_API_KEY_SECRET_HANDLE).expect("valid NEAR AI secret handle")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
+
+    #[test]
+    fn planner_allows_only_nearai_https_targets() {
+        let planner = NearAiMcpEgressPlanner;
+        let provider = ironclaw_host_api::ExtensionId::new("nearai").unwrap();
+        let capability_id = CapabilityId::new("nearai.search").unwrap();
+        let scope = scope();
+        let allowed_url = "https://cloud-api.near.ai/mcp";
+        let denied_url = "https://attacker.example/mcp";
+        let allowed = McpHostHttpEgressPlanRequest {
+            provider: &provider,
+            capability_id: &capability_id,
+            scope: &scope,
+            transport: "http",
+            method: ironclaw_host_api::NetworkMethod::Post,
+            url: allowed_url,
+            headers: &[],
+            body: &[],
+        };
+        let denied = McpHostHttpEgressPlanRequest {
+            url: denied_url,
+            ..allowed
+        };
+
+        assert_eq!(
+            planner.plan(allowed).network_policy.allowed_targets,
+            nearai_network_policy().allowed_targets
+        );
+        assert!(
+            planner
+                .plan(denied)
+                .network_policy
+                .allowed_targets
+                .is_empty()
+        );
+    }
+
+    fn scope() -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant-a").unwrap(),
+            user_id: UserId::new("user-a").unwrap(),
+            agent_id: Some(AgentId::new("agent-a").unwrap()),
+            project_id: Some(ProjectId::new("project-a").unwrap()),
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{net::IpAddr, sync::Arc};
 
 use ironclaw_host_api::{
     CapabilityId, NetworkPolicy, NetworkScheme, NetworkTargetPattern, RuntimeCredentialInjection,
@@ -15,57 +15,130 @@ const NEARAI_MCP_TIMEOUT_MS: u32 = 60_000;
 const NEARAI_MCP_RESPONSE_BODY_LIMIT: u64 = 2 * 1024 * 1024;
 const NEARAI_MCP_NETWORK_EGRESS_LIMIT: u64 = 2 * 1024 * 1024;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NearAiMcpEndpoint {
+    pub(crate) url: String,
+    pub(crate) host_pattern: String,
+    pub(crate) port: Option<u16>,
+    deny_private_ip_ranges: bool,
+}
+
+pub(crate) fn nearai_mcp_endpoint_from_env() -> Result<NearAiMcpEndpoint, String> {
+    let configured_base = std::env::var("NEARAI_BASE_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    nearai_mcp_endpoint_from_base(configured_base.as_deref())
+}
+
+pub(crate) fn nearai_mcp_endpoint_from_base(
+    configured_base: Option<&str>,
+) -> Result<NearAiMcpEndpoint, String> {
+    let base = configured_base.unwrap_or("https://private.near.ai");
+    let mut url = url::Url::parse(base)
+        .map_err(|error| format!("NEARAI_BASE_URL must be an absolute URL: {error}"))?;
+    if url.scheme() != "https" {
+        return Err("NEARAI_BASE_URL must use https".to_string());
+    }
+    if url.username() != "" || url.password().is_some() {
+        return Err("NEARAI_BASE_URL must not include userinfo".to_string());
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err("NEARAI_BASE_URL must not include query or fragment components".to_string());
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "NEARAI_BASE_URL must include a host".to_string())?
+        .to_ascii_lowercase();
+    let ip = host.parse::<IpAddr>().ok();
+    if ip.is_some_and(is_forbidden_endpoint_ip) {
+        return Err("NEARAI_BASE_URL host is not allowed".to_string());
+    }
+    if matches!(ip, Some(IpAddr::V6(_))) {
+        return Err("NEARAI_BASE_URL IPv6 hosts are not supported yet".to_string());
+    }
+
+    let mut path = url.path().trim_end_matches('/').to_string();
+    if path.eq_ignore_ascii_case("/v1") {
+        path = String::new();
+    }
+    if path.is_empty() {
+        url.set_path("/mcp");
+    } else if !path.eq_ignore_ascii_case("/mcp") {
+        url.set_path(&format!("{path}/mcp"));
+    } else {
+        url.set_path("/mcp");
+    }
+
+    Ok(NearAiMcpEndpoint {
+        url: url.to_string(),
+        host_pattern: host,
+        port: url.port(),
+        deny_private_ip_ranges: !ip.is_some_and(is_private_or_loopback_ip),
+    })
+}
+
 pub(crate) fn nearai_mcp_runtime(
     runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+    endpoint: NearAiMcpEndpoint,
 ) -> Arc<impl McpExecutor> {
     let http = McpRuntimeHttpAdapter::new(runtime_http_egress);
-    let client = McpHostHttpClient::new(http, NearAiMcpEgressPlanner);
+    let client = McpHostHttpClient::new(http, NearAiMcpEgressPlanner { endpoint });
     Arc::new(McpRuntime::new(McpRuntimeConfig::default(), client))
 }
 
 #[derive(Debug, Clone)]
-struct NearAiMcpEgressPlanner;
+struct NearAiMcpEgressPlanner {
+    endpoint: NearAiMcpEndpoint,
+}
 
 impl McpHostHttpEgressPlanner for NearAiMcpEgressPlanner {
     fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan {
-        if request.provider.as_str() != NEARAI_EXTENSION_ID || !nearai_mcp_url_allowed(request.url)
+        if request.provider.as_str() != NEARAI_EXTENSION_ID
+            || !nearai_mcp_url_allowed(request.url, &self.endpoint)
         {
             return McpHostHttpEgressPlan::default();
         }
+        let Some(credential_injection) = nearai_api_key_injection(request.capability_id) else {
+            return McpHostHttpEgressPlan::default();
+        };
         McpHostHttpEgressPlan {
-            network_policy: nearai_network_policy(),
-            credential_injections: vec![nearai_api_key_injection(request.capability_id)],
+            network_policy: nearai_network_policy(&self.endpoint),
+            credential_injections: vec![credential_injection],
             response_body_limit: Some(NEARAI_MCP_RESPONSE_BODY_LIMIT),
             timeout_ms: Some(NEARAI_MCP_TIMEOUT_MS),
         }
     }
 }
 
-fn nearai_mcp_url_allowed(url: &str) -> bool {
+fn nearai_mcp_url_allowed(url: &str, endpoint: &NearAiMcpEndpoint) -> bool {
     url::Url::parse(url)
         .ok()
         .and_then(|url| {
-            (url.scheme() == "https")
-                .then(|| url.host_str().map(|host| host.to_ascii_lowercase()))?
+            if url.scheme() != "https" || url.port() != endpoint.port {
+                return None;
+            }
+            url.host_str().map(|host| host.to_ascii_lowercase())
         })
-        .is_some_and(|host| host == "near.ai" || host.ends_with(".near.ai"))
+        .is_some_and(|host| host == endpoint.host_pattern)
 }
 
-fn nearai_network_policy() -> NetworkPolicy {
+fn nearai_network_policy(endpoint: &NearAiMcpEndpoint) -> NetworkPolicy {
     NetworkPolicy {
         allowed_targets: vec![NetworkTargetPattern {
             scheme: Some(NetworkScheme::Https),
-            host_pattern: "*.near.ai".to_string(),
-            port: None,
+            host_pattern: endpoint.host_pattern.clone(),
+            port: endpoint.port,
         }],
-        deny_private_ip_ranges: true,
+        deny_private_ip_ranges: endpoint.deny_private_ip_ranges,
         max_egress_bytes: Some(NEARAI_MCP_NETWORK_EGRESS_LIMIT),
     }
 }
 
-fn nearai_api_key_injection(capability_id: &CapabilityId) -> RuntimeCredentialInjection {
-    RuntimeCredentialInjection {
-        handle: nearai_api_key_handle(),
+fn nearai_api_key_injection(capability_id: &CapabilityId) -> Option<RuntimeCredentialInjection> {
+    Some(RuntimeCredentialInjection {
+        handle: nearai_api_key_handle()?,
         source: RuntimeCredentialSource::StagedObligation {
             capability_id: capability_id.clone(),
         },
@@ -74,11 +147,41 @@ fn nearai_api_key_injection(capability_id: &CapabilityId) -> RuntimeCredentialIn
             prefix: Some("Bearer ".to_string()),
         },
         required: true,
+    })
+}
+
+fn nearai_api_key_handle() -> Option<SecretHandle> {
+    SecretHandle::new(NEARAI_API_KEY_SECRET_HANDLE).ok()
+}
+
+fn is_private_or_loopback_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_private() || ip.is_loopback(),
+        IpAddr::V6(ip) => ip.is_loopback() || ip.is_unique_local(),
     }
 }
 
-fn nearai_api_key_handle() -> SecretHandle {
-    SecretHandle::new(NEARAI_API_KEY_SECRET_HANDLE).expect("valid NEAR AI secret handle")
+fn is_forbidden_endpoint_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_link_local()
+                || ip.is_broadcast()
+                || ip.is_documentation()
+                || ip.is_multicast()
+                || ip.octets()[0] == 0
+        }
+        IpAddr::V6(ip) => {
+            ip.is_unspecified()
+                || ip.is_unicast_link_local()
+                || ip.is_multicast()
+                || is_documentation_v6(ip)
+        }
+    }
+}
+
+fn is_documentation_v6(ip: std::net::Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x2001 && segments[1] == 0x0db8
 }
 
 #[cfg(test)]
@@ -88,11 +191,14 @@ mod tests {
 
     #[test]
     fn planner_allows_only_nearai_https_targets() {
-        let planner = NearAiMcpEgressPlanner;
+        let endpoint = nearai_mcp_endpoint_from_base(None).unwrap();
+        let planner = NearAiMcpEgressPlanner {
+            endpoint: endpoint.clone(),
+        };
         let provider = ironclaw_host_api::ExtensionId::new("nearai").unwrap();
         let capability_id = CapabilityId::new("nearai.search").unwrap();
         let scope = scope();
-        let allowed_url = "https://cloud-api.near.ai/mcp";
+        let allowed_url = "https://private.near.ai/mcp";
         let denied_url = "https://attacker.example/mcp";
         let allowed = McpHostHttpEgressPlanRequest {
             provider: &provider,
@@ -111,11 +217,85 @@ mod tests {
 
         assert_eq!(
             planner.plan(allowed).network_policy.allowed_targets,
-            nearai_network_policy().allowed_targets
+            nearai_network_policy(&endpoint).allowed_targets
         );
         assert!(
             planner
                 .plan(denied)
+                .network_policy
+                .allowed_targets
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn endpoint_validation_normalizes_custom_https_base() {
+        let endpoint = nearai_mcp_endpoint_from_base(Some("https://search.example.test/v1/"))
+            .expect("custom endpoint");
+
+        assert_eq!(endpoint.url, "https://search.example.test/mcp");
+        assert_eq!(endpoint.host_pattern, "search.example.test");
+        assert_eq!(endpoint.port, None);
+        assert!(endpoint.deny_private_ip_ranges);
+    }
+
+    #[test]
+    fn endpoint_validation_rejects_http_and_forbidden_ips() {
+        assert!(nearai_mcp_endpoint_from_base(Some("http://search.example.test")).is_err());
+        assert!(nearai_mcp_endpoint_from_base(Some("https://169.254.169.254")).is_err());
+        assert!(nearai_mcp_endpoint_from_base(Some("https://224.0.0.1")).is_err());
+    }
+
+    #[test]
+    fn endpoint_validation_allows_private_loopback_https_targets() {
+        let private =
+            nearai_mcp_endpoint_from_base(Some("https://10.0.0.12:8443")).expect("private IP");
+        let loopback =
+            nearai_mcp_endpoint_from_base(Some("https://127.0.0.1")).expect("loopback IP");
+
+        assert_eq!(private.host_pattern, "10.0.0.12");
+        assert_eq!(private.port, Some(8443));
+        assert!(!private.deny_private_ip_ranges);
+        assert!(!loopback.deny_private_ip_ranges);
+    }
+
+    #[test]
+    fn planner_rejects_wrong_provider_and_http_scheme() {
+        let endpoint = nearai_mcp_endpoint_from_base(Some("https://search.example.test"))
+            .expect("custom endpoint");
+        let planner = NearAiMcpEgressPlanner { endpoint };
+        let nearai_provider = ironclaw_host_api::ExtensionId::new("nearai").unwrap();
+        let other_provider = ironclaw_host_api::ExtensionId::new("other").unwrap();
+        let capability_id = CapabilityId::new("nearai.search").unwrap();
+        let scope = scope();
+        let allowed = McpHostHttpEgressPlanRequest {
+            provider: &nearai_provider,
+            capability_id: &capability_id,
+            scope: &scope,
+            transport: "http",
+            method: ironclaw_host_api::NetworkMethod::Post,
+            url: "https://search.example.test/mcp",
+            headers: &[],
+            body: &[],
+        };
+
+        assert_eq!(planner.plan(allowed).credential_injections.len(), 1);
+        assert!(
+            planner
+                .plan(McpHostHttpEgressPlanRequest {
+                    provider: &other_provider,
+                    ..allowed
+                })
+                .network_policy
+                .allowed_targets
+                .is_empty()
+        );
+        assert!(
+            planner
+                .plan(McpHostHttpEgressPlanRequest {
+                    url: "http://search.example.test/mcp",
+                    ..allowed
+                })
                 .network_policy
                 .allowed_targets
                 .is_empty()

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -95,6 +95,9 @@ struct NearAiMcpEgressPlanner {
 
 impl McpHostHttpEgressPlanner for NearAiMcpEgressPlanner {
     fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan {
+        // This is a narrow NEAR AI MCP adapter. Do not grow this into the
+        // generic product-auth-to-MCP planner; nearai/ironclaw#4176 owns that
+        // bridge, including account selection and typed AuthRequired recovery.
         if request.provider.as_str() != NEARAI_EXTENSION_ID
             || !nearai_mcp_url_allowed(request.url, &self.endpoint)
         {

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -315,6 +315,64 @@ mod tests {
         );
     }
 
+    #[test]
+    fn planner_denies_nearai_url_for_wrong_provider() {
+        let endpoint = nearai_mcp_endpoint_from_base(None).unwrap();
+        let planner = NearAiMcpEgressPlanner {
+            endpoint: endpoint.clone(),
+        };
+        let other_provider = ironclaw_host_api::ExtensionId::new("not-nearai").unwrap();
+        let capability_id = CapabilityId::new("nearai.search").unwrap();
+        let scope = scope();
+        let request = McpHostHttpEgressPlanRequest {
+            provider: &other_provider,
+            capability_id: &capability_id,
+            scope: &scope,
+            transport: "http",
+            method: ironclaw_host_api::NetworkMethod::Post,
+            url: "https://private.near.ai/mcp",
+            headers: &[],
+            body: &[],
+        };
+        assert!(
+            planner
+                .plan(request)
+                .network_policy
+                .allowed_targets
+                .is_empty(),
+            "wrong provider must produce empty plan"
+        );
+    }
+
+    #[test]
+    fn planner_denies_http_nearai_url() {
+        let endpoint = nearai_mcp_endpoint_from_base(None).unwrap();
+        let planner = NearAiMcpEgressPlanner {
+            endpoint: endpoint.clone(),
+        };
+        let provider = ironclaw_host_api::ExtensionId::new("nearai").unwrap();
+        let capability_id = CapabilityId::new("nearai.search").unwrap();
+        let scope = scope();
+        let request = McpHostHttpEgressPlanRequest {
+            provider: &provider,
+            capability_id: &capability_id,
+            scope: &scope,
+            transport: "http",
+            method: ironclaw_host_api::NetworkMethod::Post,
+            url: "http://private.near.ai/mcp",
+            headers: &[],
+            body: &[],
+        };
+        assert!(
+            planner
+                .plan(request)
+                .network_policy
+                .allowed_targets
+                .is_empty(),
+            "http scheme must produce empty plan"
+        );
+    }
+
     fn scope() -> ResourceScope {
         ResourceScope {
             tenant_id: TenantId::new("tenant-a").unwrap(),

--- a/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/nearai_mcp.rs
@@ -107,7 +107,14 @@ impl McpHostHttpEgressPlanner for NearAiMcpEgressPlanner {
             return McpHostHttpEgressPlan::default();
         };
         McpHostHttpEgressPlan {
-            network_policy: nearai_network_policy(&self.endpoint),
+            // Mirror the staged ApplyNetworkPolicy grant's deny_private_ip_ranges
+            // default. The bundled manifest's network policy always denies private
+            // IPs, so the planner must not accept endpoint-derived policies that
+            // permit them — dispatch would reject the request anyway.
+            network_policy: nearai_network_policy(
+                &self.endpoint,
+                /*deny_private_ip_ranges=*/ true,
+            ),
             credential_injections: vec![credential_injection],
             response_body_limit: Some(NEARAI_MCP_RESPONSE_BODY_LIMIT),
             timeout_ms: Some(NEARAI_MCP_TIMEOUT_MS),
@@ -127,14 +134,17 @@ fn nearai_mcp_url_allowed(url: &str, endpoint: &NearAiMcpEndpoint) -> bool {
         .is_some_and(|host| host == endpoint.host_pattern)
 }
 
-fn nearai_network_policy(endpoint: &NearAiMcpEndpoint) -> NetworkPolicy {
+fn nearai_network_policy(
+    endpoint: &NearAiMcpEndpoint,
+    deny_private_ip_ranges: bool,
+) -> NetworkPolicy {
     NetworkPolicy {
         allowed_targets: vec![NetworkTargetPattern {
             scheme: Some(NetworkScheme::Https),
             host_pattern: endpoint.host_pattern.clone(),
             port: endpoint.port,
         }],
-        deny_private_ip_ranges: endpoint.deny_private_ip_ranges,
+        deny_private_ip_ranges,
         max_egress_bytes: Some(NEARAI_MCP_NETWORK_EGRESS_LIMIT),
     }
 }
@@ -220,7 +230,7 @@ mod tests {
 
         assert_eq!(
             planner.plan(allowed).network_policy.allowed_targets,
-            nearai_network_policy(&endpoint).allowed_targets
+            nearai_network_policy(&endpoint, endpoint.deny_private_ip_ranges).allowed_targets
         );
         assert!(
             planner


### PR DESCRIPTION
## Summary
- Add NEAR AI as a host-bundled Reborn MCP extension with a model-visible `nearai.search` capability.
- Wire the MCP runtime through host-mediated HTTP egress and staged runtime credentials for `llm_nearai_api_key`.
- Package the extension manifest, schemas, and prompt assets alongside the existing first-party extension catalog.

## Notes
- Secrets are not read from environment variables. The API key flows through the host secret broker/store via the manifest `runtime_credentials` declaration and staged obligation injection.
- `NEARAI_BASE_URL` remains only as an optional endpoint override for non-secret routing.
- Dynamic MCP tool discovery remains tracked as pending in `FEATURE_PARITY.md`.

## Validation
- `cargo test -p ironclaw_reborn_composition nearai --lib`
- `cargo test -p ironclaw_reborn_composition bundled_first_party_manifest_asset_refs_are_packaged --lib`
- `cargo fmt --check`
- `git diff --check`