### PR TITLE
fix(reborn): lock auth read model wiring

### DIFF
--- a/crates/ironclaw_product_workflow/CLAUDE.md
+++ b/crates/ironclaw_product_workflow/CLAUDE.md
@@ -82,6 +82,10 @@ WebUI gate resolution routing should use current run-state first: a
 enters `AuthInteractionService`, and generic fallback is only for non-typed
 blocked gates or legacy/replay shapes. Do not let generic WebUI gate handling
 resume/cancel auth-blocked runs.
+Typed auth/approval interaction services intentionally re-read run-state through
+`blocked_gate_state` immediately before resume/cancel side effects. Treat that
+second read as a freshness/TOCTOU guard unless a future coordinator returns a
+sealed gate grant that can safely replace it.
 
 WebUI-facing facade methods must bind browser thread ids through
 `SessionThreadService` using a `ThreadScope` derived from the authenticated

--- a/crates/ironclaw_product_workflow/src/gate_state.rs
+++ b/crates/ironclaw_product_workflow/src/gate_state.rs
@@ -18,6 +18,10 @@ pub(crate) enum BlockedGateStateError {
 }
 
 /// Checks the parked run by actor first, then matches status and gate.
+///
+/// Callers that already read run-state for facade routing should still use
+/// this before mutating typed gate state: the second read is a freshness /
+/// TOCTOU guard immediately before resume/cancel side effects.
 pub(crate) async fn blocked_gate_state(
     turn_coordinator: &dyn TurnCoordinator,
     scope: &TurnScope,

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -1011,6 +1011,10 @@ impl RebornServices {
         if state.actor.as_ref() != Some(actor) {
             return Err(participant_denied());
         }
+        // This read only selects the WebUI route. The typed auth/approval
+        // services intentionally re-read run-state through `blocked_gate_state`
+        // before mutating auth/approval records or resuming/cancelling a run,
+        // so stale facade classification cannot authorize a side effect.
         GateResolutionRoute::from_run_state(
             state.status,
             state.gate_ref.as_ref(),

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -34,6 +34,13 @@
   pre-authorizing the existing scoped account. Do not route raw token values
   through chat commands, model-visible messages, serializable DTOs,
   projections, or route-local pending maps.
+- `RebornProductAuthServices::flow_record_source` is an optional WebUI/local-dev
+  read-projection port, not a required product-auth capability. Local-dev
+  in-memory composition wires it so pending auth gates can be rendered from
+  blocked turn state plus auth-flow records. If a supplied product-auth bundle
+  omits it, runtime composition must expose the WebUI auth interaction surface
+  as explicitly unavailable; do not fabricate a route-local or unscoped pending
+  auth read model.
 - Blocked run-state approval/auth gate rendering and resume belongs to #3094;
   keep this crate's #3811 auth seam reusable by that layer without implementing
   a second gate-resolution path.

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -348,6 +348,13 @@ pub struct RebornProductAuthServices {
     provider_client: Arc<dyn AuthProviderClient>,
     cleanup_service: Arc<dyn SecretCleanupService>,
     continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
+    /// Optional read projection for WebUI/local-dev auth interactions.
+    ///
+    /// `RebornProductAuthServices` may still support OAuth callbacks,
+    /// manual-token setup, credential refresh, and continuation dispatch
+    /// without this port. When absent, runtime composition must expose the
+    /// WebUI pending-auth interaction surface as explicitly unavailable
+    /// instead of silently fabricating an unscoped read model.
     flow_record_source: Option<Arc<dyn AuthFlowRecordSource>>,
 }
 
@@ -453,6 +460,11 @@ impl RebornProductAuthServices {
         self.flow_manager.clone()
     }
 
+    /// Auth-flow read projection used only by product/WebUI interaction views.
+    ///
+    /// `None` is an intentional unsupported mode for bundles that can perform
+    /// product-auth side effects but do not provide a scoped pending-auth
+    /// projection. Callers must map it to a stable unavailable surface.
     pub(crate) fn flow_record_source(&self) -> Option<Arc<dyn AuthFlowRecordSource>> {
         self.flow_record_source.clone()
     }
@@ -495,6 +507,8 @@ impl RebornProductAuthServices {
         self
     }
 
+    /// Enable WebUI/local-dev auth interaction read models from a scoped
+    /// auth-flow projection source.
     pub(crate) fn with_flow_record_source(mut self, source: Arc<dyn AuthFlowRecordSource>) -> Self {
         self.flow_record_source = Some(source);
         self

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -86,10 +86,16 @@ use crate::factory::{LocalDevRootFilesystem, LocalDevTurnStateStore};
 use crate::local_dev_capability_policy::local_dev_capability_policy;
 use crate::projection::{RebornProjectionServices, build_reborn_projection_services};
 use crate::runtime_input::{PollSettings, RebornRuntimeIdentity, RebornRuntimeInput};
-use crate::{RebornBuildError, RebornCompositionProfile, RebornServices, build_reborn_services};
+use crate::{
+    RebornBuildError, RebornCompositionProfile, RebornProductAuthServices, RebornServices,
+    build_reborn_services,
+};
 
 mod approval;
 mod auth_interaction;
+#[cfg(test)]
+#[path = "runtime/tests/auth_interaction.rs"]
+mod auth_interaction_tests;
 #[cfg(test)]
 #[path = "runtime/tests/default_system_prompt.rs"]
 mod default_system_prompt_tests;
@@ -1109,23 +1115,11 @@ pub async fn build_reborn_runtime(
             approval_resolver,
             Arc::clone(&planned_turn_coordinator),
         ));
-    let auth_interaction_service: Arc<dyn AuthInteractionService> =
-        if let Some(product_auth) = services.product_auth.as_ref() {
-            if let Some(flow_records) = product_auth.flow_record_source() {
-                Arc::new(DefaultAuthInteractionService::new(
-                    Arc::new(auth_interaction::LocalDevAuthInteractionReadModel::new(
-                        Arc::clone(&turn_state_store),
-                        flow_records,
-                    )),
-                    product_auth.flow_manager(),
-                    Arc::clone(&planned_turn_coordinator),
-                ))
-            } else {
-                Arc::new(auth_interaction::UnavailableAuthInteractionService)
-            }
-        } else {
-            Arc::new(auth_interaction::UnavailableAuthInteractionService)
-        };
+    let auth_interaction_service = build_webui_auth_interaction_service(
+        services.product_auth.as_deref(),
+        Arc::clone(&turn_state_store),
+        Arc::clone(&planned_turn_coordinator),
+    );
     let turn_event_source: Arc<dyn TurnEventProjectionSource> = turn_state_store.clone();
     let projection_services = projection_services
         .with_turn_events(turn_event_source, Arc::clone(&planned_turn_coordinator))
@@ -1164,6 +1158,32 @@ pub async fn build_reborn_runtime(
         skill_activation_source,
         skill_execution_adapter,
     })
+}
+
+fn build_webui_auth_interaction_service(
+    product_auth: Option<&RebornProductAuthServices>,
+    turn_state_store: Arc<LocalDevTurnStateStore>,
+    turn_coordinator: Arc<dyn TurnCoordinator>,
+) -> Arc<dyn AuthInteractionService> {
+    // `AuthFlowRecordSource` is optional on the product-auth bundle because
+    // production may supply a durable read projection that is not the flow
+    // manager itself. Local-dev can render pending WebUI auth interactions only
+    // when the bundle explicitly exposes this scoped projection; otherwise the
+    // WebUI surface fails closed with a stable unavailable error.
+    let Some(product_auth) = product_auth else {
+        return Arc::new(auth_interaction::UnavailableAuthInteractionService);
+    };
+    let Some(flow_records) = product_auth.flow_record_source() else {
+        return Arc::new(auth_interaction::UnavailableAuthInteractionService);
+    };
+    Arc::new(DefaultAuthInteractionService::new(
+        Arc::new(auth_interaction::LocalDevAuthInteractionReadModel::new(
+            turn_state_store,
+            flow_records,
+        )),
+        product_auth.flow_manager(),
+        turn_coordinator,
+    ))
 }
 
 const LOOP_RUN_CAPABILITY_ID: &str = "loop.run";

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/auth_interaction.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/auth_interaction.rs
@@ -1,0 +1,324 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_auth::{
+    AuthChallenge, AuthContinuationRef, AuthFlowKind, AuthGateRef, AuthProductScope,
+    AuthProviderId, AuthSessionId, AuthSurface, InMemoryAuthProductServices, NewAuthFlow,
+    OAuthAuthorizationUrl, OpaqueStateHash, PkceVerifierHash, TurnRunRef,
+};
+use ironclaw_host_api::runtime_policy::{
+    ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
+    NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+};
+use ironclaw_host_api::{InvocationId, ResourceScope};
+use ironclaw_loop_support::{
+    HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
+    HostManagedModelResponse,
+};
+use ironclaw_product_workflow::{
+    AuthInteractionRejectionKind, ListPendingAuthInteractionsRequest, ProductWorkflowError,
+};
+use ironclaw_turns::runner::{BlockRunRequest, ClaimRunRequest, TurnRunTransitionPort};
+use ironclaw_turns::{
+    AcceptedMessageRef, AllowAllTurnAdmissionPolicy, BlockedReason, GateRef, IdempotencyKey,
+    InMemoryRunProfileResolver, LoopCheckpointStateRef, ReplyTargetBindingRef, RunProfileRequest,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCheckpointId,
+    TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope, TurnStateStore,
+};
+
+use crate::input::RebornBuildInput;
+use crate::runtime_input::{RebornRuntimeIdentity, RebornRuntimeInput, TurnRunnerSettings};
+use crate::{RebornProductAuthServicePorts, RebornRuntimeProcessBinding};
+
+use super::{RebornRuntime, build_reborn_runtime};
+
+#[derive(Debug)]
+struct UnusedModelGateway;
+
+#[async_trait]
+impl HostManagedModelGateway for UnusedModelGateway {
+    async fn stream_model(
+        &self,
+        _request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        Ok(HostManagedModelResponse::assistant_reply(
+            "unused auth interaction test reply".to_string(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn local_dev_runtime_auth_interactions_use_flow_record_source() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let runtime = build_runtime(
+        "auth-read-model-present",
+        root.path().join("local-dev"),
+        None,
+    )
+    .await
+    .expect("runtime builds");
+    let conversation = runtime.new_conversation().await.expect("conversation");
+    let scope = TurnScope::new(
+        runtime.thread_scope.tenant_id.clone(),
+        Some(runtime.thread_scope.agent_id.clone()),
+        runtime.thread_scope.project_id.clone(),
+        conversation.0,
+    );
+    let actor = TurnActor::new(runtime.actor_user_id.clone());
+    let gate_ref = GateRef::new("gate:runtime-auth-read-model").expect("gate");
+    let run_id = submit_and_block_auth_run(&runtime, scope.clone(), actor.clone(), &gate_ref).await;
+    create_auth_flow(&runtime, &scope, &actor, run_id, &gate_ref).await;
+
+    let pending = runtime
+        .webui_auth_interaction_service()
+        .list_pending(ListPendingAuthInteractionsRequest {
+            scope: scope.clone(),
+            actor: actor.clone(),
+        })
+        .await
+        .expect("pending auth interactions");
+
+    assert_eq!(pending.auth_interactions.len(), 1);
+    let view = &pending.auth_interactions[0];
+    assert_eq!(view.scope.tenant_id, scope.tenant_id);
+    assert_eq!(view.scope.user_id, actor.user_id);
+    assert_eq!(view.scope.thread_id, scope.thread_id);
+    assert_eq!(view.run_id, run_id);
+    assert_eq!(view.auth_request_ref, gate_ref);
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}
+
+#[tokio::test]
+async fn local_dev_runtime_auth_interactions_are_unavailable_without_flow_record_source() {
+    let auth = Arc::new(InMemoryAuthProductServices::new());
+    let ports = RebornProductAuthServicePorts::from_shared(auth);
+    let root = tempfile::tempdir().expect("tempdir");
+    let runtime = build_runtime(
+        "auth-read-model-absent",
+        root.path().join("local-dev"),
+        Some(ports),
+    )
+    .await
+    .expect("runtime builds");
+    assert!(
+        runtime
+            .services
+            .product_auth
+            .as_ref()
+            .expect("product auth")
+            .flow_record_source()
+            .is_none(),
+        "custom product-auth ports intentionally do not imply a WebUI read projection"
+    );
+    let conversation = runtime.new_conversation().await.expect("conversation");
+    let scope = TurnScope::new(
+        runtime.thread_scope.tenant_id.clone(),
+        Some(runtime.thread_scope.agent_id.clone()),
+        runtime.thread_scope.project_id.clone(),
+        conversation.0,
+    );
+
+    let error = runtime
+        .webui_auth_interaction_service()
+        .list_pending(ListPendingAuthInteractionsRequest {
+            scope,
+            actor: TurnActor::new(runtime.actor_user_id.clone()),
+        })
+        .await
+        .expect_err("auth interaction read model is unavailable");
+
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::FlowUnavailable
+        }
+    ));
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}
+
+async fn build_runtime(
+    owner: &str,
+    storage_root: PathBuf,
+    product_auth_ports: Option<RebornProductAuthServicePorts>,
+) -> Result<RebornRuntime, super::RebornRuntimeError> {
+    let mut services = RebornBuildInput::local_dev(owner, storage_root)
+        .with_runtime_policy(local_dev_runtime_policy())
+        .with_runtime_process_binding(RebornRuntimeProcessBinding::None);
+    if let Some(ports) = product_auth_ports {
+        services = services.with_product_auth_ports(ports);
+    }
+    build_reborn_runtime(
+        RebornRuntimeInput::from_services(services)
+            .with_identity(RebornRuntimeIdentity {
+                tenant_id: format!("{owner}-tenant"),
+                agent_id: format!("{owner}-agent"),
+                source_binding_id: format!("{owner}-source"),
+                reply_target_binding_id: format!("{owner}-reply"),
+            })
+            .with_runner_settings(TurnRunnerSettings {
+                heartbeat_interval: Duration::from_secs(60),
+                poll_interval: Duration::from_secs(60),
+            })
+            .with_model_gateway_override(Arc::new(UnusedModelGateway)),
+    )
+    .await
+}
+
+async fn submit_and_block_auth_run(
+    runtime: &RebornRuntime,
+    scope: TurnScope,
+    actor: TurnActor,
+    gate_ref: &GateRef,
+) -> TurnRunId {
+    let local_runtime = runtime
+        .services
+        .local_runtime
+        .as_ref()
+        .expect("local runtime");
+    let admission = AllowAllTurnAdmissionPolicy;
+    let profiles = InMemoryRunProfileResolver::default();
+    let submit = local_runtime
+        .turn_state
+        .submit_turn(
+            SubmitTurnRequest {
+                scope: scope.clone(),
+                actor,
+                accepted_message_ref: AcceptedMessageRef::new("message-runtime-auth-read-model")
+                    .expect("message ref"),
+                source_binding_ref: SourceBindingRef::new("source-runtime-auth-read-model")
+                    .expect("source ref"),
+                reply_target_binding_ref: ReplyTargetBindingRef::new(
+                    "reply-runtime-auth-read-model",
+                )
+                .expect("reply ref"),
+                requested_run_profile: Some(RunProfileRequest::new("default").expect("profile")),
+                idempotency_key: IdempotencyKey::new("submit-runtime-auth-read-model")
+                    .expect("idempotency key"),
+                received_at: Utc::now(),
+                requested_run_id: None,
+                parent_run_id: None,
+                subagent_depth: 0,
+                spawn_tree_root_run_id: None,
+            },
+            &admission,
+            &profiles,
+        )
+        .await
+        .expect("submit turn through local-dev turn state");
+    let SubmitTurnResponse::Accepted { run_id, .. } = submit;
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    local_runtime
+        .turn_state
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope),
+        })
+        .await
+        .expect("claim run")
+        .expect("queued run exists");
+    local_runtime
+        .turn_state
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref: LoopCheckpointStateRef::new("checkpoint:runtime-auth-read-model")
+                .expect("checkpoint ref"),
+            reason: BlockedReason::Auth {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .expect("block auth run");
+    run_id
+}
+
+async fn create_auth_flow(
+    runtime: &RebornRuntime,
+    scope: &TurnScope,
+    actor: &TurnActor,
+    run_id: TurnRunId,
+    gate_ref: &GateRef,
+) {
+    runtime
+        .services
+        .product_auth
+        .as_ref()
+        .expect("product auth")
+        .flow_manager()
+        .create_flow(NewAuthFlow {
+            scope: auth_scope_for_turn(scope, actor),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: AuthProviderId::new("github").expect("provider"),
+            challenge: AuthChallenge::OAuthUrl {
+                authorization_url: OAuthAuthorizationUrl::new("https://provider.example/oauth")
+                    .expect("authorization url"),
+                expires_at: Utc::now() + chrono::Duration::minutes(5),
+            },
+            continuation: AuthContinuationRef::TurnGateResume {
+                turn_run_ref: TurnRunRef::new(run_id.to_string()).expect("turn run ref"),
+                gate_ref: AuthGateRef::new(gate_ref.as_str()).expect("auth gate ref"),
+            },
+            update_binding: None,
+            opaque_state_hash: Some(state_hash()),
+            pkce_verifier_hash: Some(pkce_hash()),
+            expires_at: Utc::now() + chrono::Duration::minutes(5),
+        })
+        .await
+        .expect("auth flow");
+}
+
+fn auth_scope_for_turn(scope: &TurnScope, actor: &TurnActor) -> AuthProductScope {
+    AuthProductScope::new(
+        ResourceScope {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: actor.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            mission_id: None,
+            thread_id: Some(scope.thread_id.clone()),
+            invocation_id: InvocationId::new(),
+        },
+        AuthSurface::Web,
+    )
+    .with_session_id(AuthSessionId::new("session-runtime-auth-read-model").expect("session id"))
+}
+
+fn state_hash() -> OpaqueStateHash {
+    OpaqueStateHash::new(fake_digest("state-hash")).expect("state hash")
+}
+
+fn pkce_hash() -> PkceVerifierHash {
+    PkceVerifierHash::new(fake_digest("pkce-hash")).expect("pkce hash")
+}
+
+fn fake_digest(value: &str) -> String {
+    format!(
+        "{:064x}",
+        value.bytes().fold(0_u64, |hash, byte| {
+            hash.wrapping_mul(31).wrapping_add(u64::from(byte))
+        })
+    )
+}
+
+fn local_dev_runtime_policy() -> EffectiveRuntimePolicy {
+    EffectiveRuntimePolicy {
+        deployment: DeploymentMode::LocalSingleUser,
+        requested_profile: RuntimeProfile::LocalDev,
+        resolved_profile: RuntimeProfile::LocalDev,
+        filesystem_backend: FilesystemBackendKind::HostWorkspace,
+        process_backend: ProcessBackendKind::LocalHost,
+        network_mode: NetworkMode::DirectLogged,
+        secret_mode: SecretMode::ScrubbedEnv,
+        approval_policy: ApprovalPolicy::AskDestructive,
+        audit_mode: AuditMode::LocalMinimal,
+    }
+}


### PR DESCRIPTION
## Summary

- Clarified the optional `AuthFlowRecordSource` contract for Reborn product-auth bundles.
- Kept WebUI auth interaction wiring fail-closed when no scoped auth-flow read projection is available.
- Added local-dev runtime-level coverage for pending auth gates with and without the flow-record source.
- Documented why typed auth/approval gate resolution intentionally re-reads run-state before side effects.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Closes #4205

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_composition auth_interaction --locked`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; runtime/factory behavior is covered by tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo clippy -p ironclaw_reborn_composition --all-targets --all-features -- -D warnings`
- `git diff --check`

## Security Impact

Yes. This tightens the WebUI auth interaction boundary by making absent scoped auth-flow read projections fail closed instead of allowing ambiguous local read-model wiring. It also documents the typed gate re-read as a freshness/TOCTOU guard before resume/cancel side effects. No new network calls, secrets access, file access, tool execution, or sandbox policy changes.

## Database Impact

None.

## Blast Radius

Limited to Reborn product-auth runtime composition, WebUI auth interaction read-model wiring, and product-workflow gate-state documentation/comments. The local-dev runtime continues to use the in-memory auth flow source; custom product-auth bundles without that read projection now have explicit runtime-level test coverage for the unavailable path.

## Rollback Plan

Revert this PR to restore the previous inline auth interaction wiring and remove the added runtime-level contract tests/docs.

## Review Follow-Through

Reviewer judgment requested on whether keeping `flow_record_source` optional is the right long-term contract for production bundles that may provide a different durable auth interaction projection.

---

**Review track**: C
