### PR TITLE
[codex] Make runtime HTTP egress async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4391,6 +4391,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "blake3",
+ "futures-util",
  "glob",
  "ironclaw_auth",
  "ironclaw_filesystem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5100,6 +5100,7 @@ name = "ironclaw_scripts"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures-util",
  "ironclaw_extensions",
  "ironclaw_host_api",
  "ironclaw_resources",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4596,6 +4596,7 @@ name = "ironclaw_mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures-util",
  "ironclaw_extensions",
  "ironclaw_host_api",
  "ironclaw_resources",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5098,6 +5098,7 @@ dependencies = [
 name = "ironclaw_scripts"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "ironclaw_extensions",
  "ironclaw_host_api",
  "ironclaw_resources",
@@ -7641,7 +7642,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.14",

--- a/crates/ironclaw_first_party_extensions/Cargo.toml
+++ b/crates/ironclaw_first_party_extensions/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 async-trait = "0.1"
 base64 = "0.22.1"
 blake3 = "1"
+futures-util = "0.3"
 glob = "0.3"
 ironclaw_auth = { path = "../ironclaw_auth" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -1,10 +1,12 @@
 use std::{
     collections::HashMap,
     io::{self, Write},
+    panic::AssertUnwindSafe,
     sync::Arc,
     time::Instant,
 };
 
+use futures_util::FutureExt as _;
 use ironclaw_auth::{
     CredentialAccountService, CredentialRecoveryKind, CredentialRecoveryProjection, ProviderScope,
 };
@@ -313,7 +315,14 @@ async fn execute_runtime_http(
     request: RuntimeHttpEgressRequest,
     egress: Arc<dyn RuntimeHttpEgress>,
 ) -> Result<ironclaw_host_api::RuntimeHttpEgressResponse, GsuiteDispatchError> {
-    egress.execute(request).await.map_err(map_egress_error)
+    AssertUnwindSafe(egress.execute(request))
+        .catch_unwind()
+        .await
+        .map_err(|_| {
+            tracing::error!("GSuite runtime HTTP egress future panicked");
+            GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
+        })?
+        .map_err(map_egress_error)
 }
 
 fn response_output(

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -313,10 +313,7 @@ async fn execute_runtime_http(
     request: RuntimeHttpEgressRequest,
     egress: Arc<dyn RuntimeHttpEgress>,
 ) -> Result<ironclaw_host_api::RuntimeHttpEgressResponse, GsuiteDispatchError> {
-    tokio::task::spawn_blocking(move || egress.execute(request))
-        .await
-        .map_err(|_| GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend))?
-        .map_err(map_egress_error)
+    egress.execute(request).await.map_err(map_egress_error)
 }
 
 fn response_output(

--- a/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
+++ b/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
@@ -922,6 +922,25 @@ async fn gsuite_handler_maps_runtime_egress_errors() {
 }
 
 #[tokio::test]
+async fn gsuite_handler_maps_panicking_runtime_egress_to_backend() {
+    let scope = scope();
+    let auth =
+        auth_with_google_account(&scope, vec![provider_scope(GOOGLE_GMAIL_SEND_SCOPE)]).await;
+    let egress = Arc::new(RecordingEgress::with_responses(Vec::new()));
+
+    let error = dispatch_error(
+        auth,
+        scope,
+        GMAIL_SEND_MESSAGE_CAPABILITY_ID,
+        json!({ "message": { "raw": "base64url-rfc822" } }),
+        egress,
+    )
+    .await;
+
+    assert_eq!(error.kind(), RuntimeDispatchErrorKind::Backend);
+}
+
+#[tokio::test]
 async fn gsuite_handler_fails_before_egress_when_google_account_is_missing_or_ambiguous() {
     let scope = scope();
     let auth = Arc::new(InMemoryAuthProductServices::new());

--- a/crates/ironclaw_first_party_extensions/tests/support/mod.rs
+++ b/crates/ironclaw_first_party_extensions/tests/support/mod.rs
@@ -111,8 +111,9 @@ impl RecordingEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -374,21 +374,23 @@ pub fn is_sensitive_runtime_response_header(name: &str) -> bool {
             .any(|marker| normalized.contains(marker))
 }
 
+#[async_trait::async_trait]
 pub trait RuntimeHttpEgress: Send + Sync {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>;
 }
 
+#[async_trait::async_trait]
 impl<T> RuntimeHttpEgress for std::sync::Arc<T>
 where
     T: RuntimeHttpEgress + ?Sized,
 {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-        self.as_ref().execute(request)
+        self.as_ref().execute(request).await
     }
 }

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -5,6 +5,7 @@
 //! policy/transport with scoped secret leases; runtime crates must not perform
 //! their own outbound HTTP, DNS, private-IP checks, or credential injection.
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -374,7 +375,7 @@ pub fn is_sensitive_runtime_response_header(name: &str) -> bool {
             .any(|marker| normalized.contains(marker))
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait RuntimeHttpEgress: Send + Sync {
     async fn execute(
         &self,
@@ -382,7 +383,7 @@ pub trait RuntimeHttpEgress: Send + Sync {
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>;
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl<T> RuntimeHttpEgress for std::sync::Arc<T>
 where
     T: RuntimeHttpEgress + ?Sized,

--- a/crates/ironclaw_host_runtime/src/egress/mod.rs
+++ b/crates/ironclaw_host_runtime/src/egress/mod.rs
@@ -153,18 +153,19 @@ impl<N, S> HostHttpEgressService<N, S> {
     }
 }
 
+#[async_trait::async_trait]
 impl<N, S> RuntimeHttpEgress for HostHttpEgressService<N, S>
 where
-    N: NetworkHttpEgress,
-    S: SecretStore,
+    N: NetworkHttpEgress + Send + Sync,
+    S: SecretStore + Send + Sync,
 {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         let scope = request.scope.clone();
         let capability_id = request.capability_id.clone();
-        let result = pipeline::execute(self, request);
+        let result = pipeline::execute(self, request).await;
         match result {
             Ok(response) => Ok(response),
             Err(error) => {

--- a/crates/ironclaw_host_runtime/src/egress/mod.rs
+++ b/crates/ironclaw_host_runtime/src/egress/mod.rs
@@ -2,6 +2,7 @@ mod credential;
 mod pipeline;
 mod sanitize;
 
+use async_trait::async_trait;
 use ironclaw_host_api::{
     CapabilityId, NetworkPolicy, ResourceScope, RuntimeHttpEgress, RuntimeHttpEgressError,
     RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
@@ -153,7 +154,7 @@ impl<N, S> HostHttpEgressService<N, S> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl<N, S> RuntimeHttpEgress for HostHttpEgressService<N, S>
 where
     N: NetworkHttpEgress + Send + Sync,

--- a/crates/ironclaw_host_runtime/src/egress/pipeline.rs
+++ b/crates/ironclaw_host_runtime/src/egress/pipeline.rs
@@ -11,13 +11,13 @@ use crate::http_body::{
     RuntimeHttpBodyStoreError,
 };
 
-pub(super) fn execute<N, S>(
+pub(super) async fn execute<N, S>(
     service: &HostHttpEgressService<N, S>,
     mut request: RuntimeHttpEgressRequest,
 ) -> Result<RuntimeHttpEgressResponse, PipelineError>
 where
-    N: NetworkHttpEgress,
-    S: SecretStore,
+    N: NetworkHttpEgress + Send + Sync,
+    S: SecretStore + Send + Sync,
 {
     let network_policy = service.network_policy_for_request(&mut request)?;
     service.validate_credential_sources_for_request(&request)?;
@@ -34,7 +34,7 @@ where
     )
     .map_err(PipelineError::pre_transport_keep_staged_secrets)?;
 
-    let response = dispatch_network(service, request, network_policy)?;
+    let response = dispatch_network(service, request, network_policy).await?;
     let credentials_injected = !redaction_values.is_empty();
     let (response, response_redacted) = super::sanitize::sanitize_runtime_response(
         response,
@@ -93,13 +93,13 @@ fn authorize_body_store<N, S>(
     Ok(save_body_to)
 }
 
-fn dispatch_network<N, S>(
+async fn dispatch_network<N, S>(
     service: &HostHttpEgressService<N, S>,
     request: RuntimeHttpEgressRequest,
     network_policy: NetworkPolicy,
 ) -> Result<ironclaw_network::NetworkHttpResponse, PipelineError>
 where
-    N: NetworkHttpEgress,
+    N: NetworkHttpEgress + Send + Sync,
 {
     service
         .network()
@@ -113,6 +113,7 @@ where
             response_body_limit: request.response_body_limit,
             timeout_ms: request.timeout_ms,
         })
+        .await
         .map_err(|error| {
             PipelineError::post_transport(runtime_network_error(
                 service.unsafe_raw_diagnostics_allowed(),

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -1,4 +1,7 @@
+use std::panic::AssertUnwindSafe;
+
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use futures_util::FutureExt as _;
 use ironclaw_extensions::{CapabilityManifest, ExtensionError};
 use ironclaw_host_api::{
     EffectKind, MountAlias, MountGrant, MountPermissions, MountView, NetworkMethod, NetworkPolicy,
@@ -199,12 +202,11 @@ pub(super) async fn dispatch(
         save_body_to,
         timeout_ms: Some(timeout_ms),
     };
-    let response = tokio::task::spawn_blocking(move || egress.execute(http_request))
+    let response = AssertUnwindSafe(egress.execute(http_request))
+        .catch_unwind()
         .await
-        .map_err(|error| {
-            if error.is_panic() {
-                tracing::error!("first-party HTTP egress worker panicked");
-            }
+        .map_err(|_| {
+            tracing::error!("first-party HTTP egress future panicked");
             FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
         })?
         .map_err(http_error)?;

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -1,7 +1,4 @@
-use std::panic::AssertUnwindSafe;
-
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
-use futures_util::FutureExt as _;
 use ironclaw_extensions::{CapabilityManifest, ExtensionError};
 use ironclaw_host_api::{
     EffectKind, MountAlias, MountGrant, MountPermissions, MountView, NetworkMethod, NetworkPolicy,
@@ -202,14 +199,13 @@ pub(super) async fn dispatch(
         save_body_to,
         timeout_ms: Some(timeout_ms),
     };
-    let response = AssertUnwindSafe(egress.execute(http_request))
-        .catch_unwind()
-        .await
-        .map_err(|_| {
-            tracing::error!("first-party HTTP egress future panicked");
-            FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
-        })?
-        .map_err(http_error)?;
+    let response = super::run_egress_catching_panic(
+        egress.execute(http_request),
+        "first-party HTTP egress future panicked",
+        || FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend),
+    )
+    .await?
+    .map_err(http_error)?;
     let mut output = Map::new();
     output.insert("status".to_string(), json!(response.status));
     output.insert("headers".to_string(), response_headers(response.headers));

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -15,9 +15,10 @@ mod skill_url_install;
 mod spawn_subagent;
 mod time;
 
-use std::{sync::Arc, time::Instant};
+use std::{future::Future, panic::AssertUnwindSafe, sync::Arc, time::Instant};
 
 use async_trait::async_trait;
+use futures_util::FutureExt as _;
 use ironclaw_extensions::{
     CapabilityManifest, CapabilityVisibility, ExtensionError, ExtensionManifest, ExtensionPackage,
     ExtensionRuntime, MANIFEST_SCHEMA_VERSION, ManifestSource,
@@ -28,7 +29,8 @@ use ironclaw_first_party_extensions::coding::{
 use ironclaw_host_api::{
     CapabilityId, CapabilityProfileSchemaRef, EffectKind, ExtensionId, HostApiError,
     PermissionMode, RequestedTrustClass, ResourceCeiling, ResourceEstimate, ResourceProfile,
-    ResourceUsage, RuntimeDispatchErrorKind, TrustClass, VirtualPath,
+    ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgressError, RuntimeHttpEgressResponse,
+    TrustClass, VirtualPath,
 };
 
 use crate::{
@@ -419,6 +421,21 @@ fn resource_profile() -> Option<ResourceProfile> {
 
 fn input_error() -> FirstPartyCapabilityError {
     FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode)
+}
+
+async fn run_egress_catching_panic<F, P>(
+    future: F,
+    panic_message: &'static str,
+    on_panic: P,
+) -> Result<Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>, FirstPartyCapabilityError>
+where
+    F: Future<Output = Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>>,
+    P: FnOnce() -> FirstPartyCapabilityError,
+{
+    AssertUnwindSafe(future).catch_unwind().await.map_err(|_| {
+        tracing::error!("{panic_message}");
+        on_panic()
+    })
 }
 
 fn operation_error() -> FirstPartyCapabilityError {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install.rs
@@ -1,6 +1,5 @@
-use std::{panic::AssertUnwindSafe, path::PathBuf};
+use std::path::PathBuf;
 
-use futures_util::FutureExt as _;
 use ironclaw_host_api::{
     NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern, ResourceUsage,
     RuntimeDispatchErrorKind, RuntimeHttpEgressError, RuntimeHttpEgressReasonCode,
@@ -124,15 +123,16 @@ pub(super) async fn fetch_url_response(
         save_body_to: None,
         timeout_ms: Some(SKILL_URL_FETCH_TIMEOUT_MS),
     };
-    let response = AssertUnwindSafe(egress.execute(http_request))
-        .catch_unwind()
-        .await
-        .map_err(|_| {
-            tracing::error!("skill URL HTTP egress future panicked");
+    let response = super::run_egress_catching_panic(
+        egress.execute(http_request),
+        "skill URL HTTP egress future panicked",
+        || {
             FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
                 .with_usage(usage.clone())
-        })?
-        .map_err(|error| skill_url_fetch_error(error, usage))?;
+        },
+    )
+    .await?
+    .map_err(|error| skill_url_fetch_error(error, usage))?;
     usage.network_egress_bytes = usage
         .network_egress_bytes
         .saturating_add(response.request_bytes);

--- a/crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install.rs
@@ -1,5 +1,6 @@
-use std::path::PathBuf;
+use std::{panic::AssertUnwindSafe, path::PathBuf};
 
+use futures_util::FutureExt as _;
 use ironclaw_host_api::{
     NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern, ResourceUsage,
     RuntimeDispatchErrorKind, RuntimeHttpEgressError, RuntimeHttpEgressReasonCode,
@@ -123,13 +124,13 @@ pub(super) async fn fetch_url_response(
         save_body_to: None,
         timeout_ms: Some(SKILL_URL_FETCH_TIMEOUT_MS),
     };
-    let response = tokio::task::spawn_blocking(move || egress.execute(http_request))
+    let response = AssertUnwindSafe(egress.execute(http_request))
+        .catch_unwind()
         .await
-        .map_err(|error| {
-            if error.is_panic() {
-                tracing::error!("skill URL fetch egress worker panicked");
-            }
+        .map_err(|_| {
+            tracing::error!("skill URL HTTP egress future panicked");
             FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
+                .with_usage(usage.clone())
         })?
         .map_err(|error| skill_url_fetch_error(error, usage))?;
     usage.network_egress_bytes = usage
@@ -195,4 +196,65 @@ fn skill_url_fetch_error(
         }
     };
     FirstPartyCapabilityError::new(kind).with_usage(usage.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use ironclaw_host_api::{
+        CapabilityId, InvocationId, ResourceScope, RuntimeHttpEgress, RuntimeHttpEgressResponse,
+        TenantId, UserId,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn fetch_url_response_maps_panicking_runtime_egress_to_backend_failure() {
+        let request = FirstPartyCapabilityRequest::request_for_test(
+            CapabilityId::new("builtin.skill_install").unwrap(),
+            sample_scope(),
+            json!({}),
+            Some(Arc::new(PanickingRuntimeHttpEgress)),
+        );
+        let url = validate_skill_url(
+            "https://raw.githubusercontent.com/Pika-Labs/Pika-Skills/main/fetched-helper/SKILL.md",
+        )
+        .unwrap();
+        let mut usage = ResourceUsage::default();
+
+        let error = fetch_url_response(&request, &url, &mut usage, Vec::new())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), RuntimeDispatchErrorKind::Backend);
+        assert_eq!(error.usage(), Some(&ResourceUsage::default()));
+    }
+
+    #[derive(Debug)]
+    struct PanickingRuntimeHttpEgress;
+
+    #[async_trait]
+    impl RuntimeHttpEgress for PanickingRuntimeHttpEgress {
+        async fn execute(
+            &self,
+            _request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+            panic!("skill URL runtime HTTP egress panic")
+        }
+    }
+
+    fn sample_scope() -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant1").unwrap(),
+            user_id: UserId::new("user1").unwrap(),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
 }

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -285,8 +285,9 @@ mod tests {
 
     struct NoopRuntimeHttpEgress;
 
+    #[async_trait::async_trait]
     impl ironclaw_host_api::RuntimeHttpEgress for NoopRuntimeHttpEgress {
-        fn execute(
+        async fn execute(
             &self,
             _request: ironclaw_host_api::RuntimeHttpEgressRequest,
         ) -> Result<

--- a/crates/ironclaw_host_runtime/src/invocation_services.rs
+++ b/crates/ironclaw_host_runtime/src/invocation_services.rs
@@ -285,7 +285,7 @@ mod tests {
 
     struct NoopRuntimeHttpEgress;
 
-    #[async_trait::async_trait]
+    #[async_trait]
     impl ironclaw_host_api::RuntimeHttpEgress for NoopRuntimeHttpEgress {
         async fn execute(
             &self,

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -35,8 +35,8 @@ use super::{
 use crate::CommandExecutionRequest;
 use crate::obligations::{NetworkObligationPolicyStore, RuntimeSecretInjectionStore};
 
-#[test]
-fn shared_extension_registry_returns_same_instance() {
+#[tokio::test]
+async fn shared_extension_registry_returns_same_instance() {
     let services = test_services();
     let left = services.shared_extension_registry();
     let right = services.shared_extension_registry();
@@ -44,15 +44,15 @@ fn shared_extension_registry_returns_same_instance() {
     assert_eq!(Arc::as_ptr(&left), Arc::as_ptr(&right)); // safety: test assertion only; verifies both accessors expose the same shared registry.
 }
 
-#[test]
-fn product_auth_provider_runtime_ports_returns_none_without_egress() {
+#[tokio::test]
+async fn product_auth_provider_runtime_ports_returns_none_without_egress() {
     let services = test_services();
 
     assert!(services.product_auth_provider_runtime_ports().is_none());
 }
 
-#[test]
-fn product_auth_provider_runtime_ports_returns_configured_egress_and_obligation_handler() {
+#[tokio::test]
+async fn product_auth_provider_runtime_ports_returns_configured_egress_and_obligation_handler() {
     let services = test_services()
         .with_secret_store(Arc::new(InMemorySecretStore::new()))
         .try_with_host_http_egress(RecordingNetwork::ok())
@@ -68,8 +68,8 @@ fn product_auth_provider_runtime_ports_returns_configured_egress_and_obligation_
     let _handler = ports.obligation_handler();
 }
 
-#[test]
-fn host_http_egress_borrows_staged_policy_for_repeated_invocation_requests() {
+#[tokio::test]
+async fn host_http_egress_borrows_staged_policy_for_repeated_invocation_requests() {
     let network = RecordingNetwork::ok();
     let recorded_requests = Arc::clone(&network.requests);
     let services = test_services()
@@ -89,9 +89,11 @@ fn host_http_egress_borrows_staged_policy_for_repeated_invocation_requests() {
             scope.clone(),
             capability_id.clone(),
         ))
+        .await
         .expect("first request should observe staged policy");
     egress
         .execute(request_without_credentials(scope, capability_id))
+        .await
         .expect("second request in same invocation should observe borrowed staged policy");
 
     let requests = recorded_requests.lock().unwrap();
@@ -100,8 +102,8 @@ fn host_http_egress_borrows_staged_policy_for_repeated_invocation_requests() {
     assert_eq!(requests[1].policy, staged_policy);
 }
 
-#[test]
-fn host_http_egress_helper_injects_staged_credentials_from_handoff_store() {
+#[tokio::test]
+async fn host_http_egress_helper_injects_staged_credentials_from_handoff_store() {
     let scope = sample_scope();
     let capability_id = sample_capability_id();
     let handle = SecretHandle::new("api-token").unwrap();
@@ -128,6 +130,7 @@ fn host_http_egress_helper_injects_staged_credentials_from_handoff_store() {
 
     egress
         .execute(request_with_staged_credential(scope, capability_id, handle))
+        .await
         .expect("StagedObligation should inject from handoff store");
 
     let requests = recorded_requests.lock().unwrap();
@@ -144,8 +147,8 @@ fn host_http_egress_helper_injects_staged_credentials_from_handoff_store() {
     );
 }
 
-#[test]
-fn host_http_egress_treats_expired_staged_secret_as_missing() {
+#[tokio::test]
+async fn host_http_egress_treats_expired_staged_secret_as_missing() {
     let scope = sample_scope();
     let capability_id = sample_capability_id();
     let handle = SecretHandle::new("api-token").unwrap();
@@ -176,6 +179,7 @@ fn host_http_egress_treats_expired_staged_secret_as_missing() {
 
     let error = egress
         .execute(request_with_staged_credential(scope, capability_id, handle))
+        .await
         .expect_err("expired staged secret should fail as missing");
 
     assert!(matches!(
@@ -186,8 +190,8 @@ fn host_http_egress_treats_expired_staged_secret_as_missing() {
     assert!(recorded_requests.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_verification_rejects_mismatched_handoff_stores() {
+#[tokio::test]
+async fn host_http_egress_verification_rejects_mismatched_handoff_stores() {
     let mismatched_network_policies = Arc::new(NetworkObligationPolicyStore::new());
     let mismatched_secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
     let egress = Arc::new(crate::HostHttpEgressService::production(
@@ -917,8 +921,9 @@ impl RecordingNetwork {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for RecordingNetwork {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -921,7 +921,7 @@ impl RecordingNetwork {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl NetworkHttpEgress for RecordingNetwork {
     async fn execute(
         &self,

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -2583,6 +2583,21 @@ async fn builtin_http_maps_runtime_egress_errors_by_source() {
 }
 
 #[tokio::test]
+async fn builtin_http_maps_panicking_runtime_egress_to_backend_failure() {
+    let runtime = runtime_with_http_egress(Arc::new(PanickingRuntimeHttpEgress));
+    let error = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({"url": "https://api.example.test/v1/items"}),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::Backend);
+}
+
+#[tokio::test]
 async fn builtin_http_rejects_sensitive_headers_through_host_validator() {
     let transport = RecordingTransport::ok(NetworkHttpResponse {
         status: 200,
@@ -2675,7 +2690,7 @@ async fn builtin_http_returns_redirects_without_following_private_location() {
 }
 
 #[tokio::test]
-async fn builtin_http_runs_blocking_egress_off_tokio_worker() {
+async fn builtin_http_awaits_async_egress_without_blocking_tokio_worker() {
     let egress = Arc::new(SleepingRuntimeHttpEgress {
         delay: Duration::from_millis(100),
         body: Vec::new(),
@@ -2690,7 +2705,7 @@ async fn builtin_http_runs_blocking_egress_off_tokio_worker() {
     tokio::pin!(invocation);
 
     tokio::select! {
-        _ = &mut invocation => panic!("HTTP dispatch blocked the tokio worker"),
+        _ = &mut invocation => panic!("HTTP dispatch should remain pending while async egress sleeps"),
         _ = tokio::time::sleep(Duration::from_millis(20)) => {}
     }
 
@@ -4418,8 +4433,9 @@ impl RecordingRuntimeHttpEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -4455,12 +4471,13 @@ struct SleepingRuntimeHttpEgress {
     body: Vec<u8>,
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for SleepingRuntimeHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-        thread::sleep(self.delay);
+        tokio::time::sleep(self.delay).await;
         let body = if self.body.is_empty() {
             b"ok".to_vec()
         } else {
@@ -4479,6 +4496,19 @@ impl RuntimeHttpEgress for SleepingRuntimeHttpEgress {
 }
 
 #[derive(Debug, Clone)]
+struct PanickingRuntimeHttpEgress;
+
+#[async_trait::async_trait]
+impl RuntimeHttpEgress for PanickingRuntimeHttpEgress {
+    async fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        panic!("runtime HTTP egress panic")
+    }
+}
+
+#[derive(Debug, Clone)]
 struct RecordingTransport {
     response: Result<NetworkHttpResponse, NetworkHttpError>,
     requests: Arc<std::sync::Mutex<Vec<NetworkTransportRequest>>>,
@@ -4493,8 +4523,9 @@ impl RecordingTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpTransport for RecordingTransport {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkTransportRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -326,8 +326,8 @@ async fn first_party_handler_rejects_non_string_url_input() {
     }
 }
 
-#[test]
-fn http_error_kind_maps_all_reason_codes() {
+#[tokio::test]
+async fn http_error_kind_maps_all_reason_codes() {
     let cases = [
         (
             RuntimeHttpEgressReasonCode::CredentialUnavailable,
@@ -759,6 +759,7 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
                 save_body_to: None,
                 timeout_ms: Some(1000),
             })
+            .await
             .map_err(|error| {
                 FirstPartyCapabilityError::new(http_error_kind(error.reason_code()))
             })?;
@@ -970,8 +971,9 @@ struct FailingRuntimeHttpEgress {
 
 struct UnreachableRuntimeHttpEgress;
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for FailingRuntimeHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         _request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -979,8 +981,9 @@ impl RuntimeHttpEgress for FailingRuntimeHttpEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for UnreachableRuntimeHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         _request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -988,8 +991,9 @@ impl RuntimeHttpEgress for UnreachableRuntimeHttpEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for RecordingNetworkHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {

--- a/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/github_wasm_runtime_contract.rs
@@ -197,8 +197,8 @@ async fn host_runtime_services_missing_github_runtime_secret_blocks_on_auth() {
     );
 }
 
-#[test]
-fn bundled_github_wasm_executes_search_get_and_comment_operations() {
+#[tokio::test]
+async fn bundled_github_wasm_executes_search_get_and_comment_operations() {
     let search_http = Arc::new(RecordingWasmHostHttp::ok(WasmHttpResponse {
         status: 200,
         headers_json: "{}".to_string(),
@@ -273,8 +273,8 @@ fn bundled_github_wasm_executes_search_get_and_comment_operations() {
     );
 }
 
-#[test]
-fn bundled_github_wasm_sanitizes_host_http_and_api_failures() {
+#[tokio::test]
+async fn bundled_github_wasm_sanitizes_host_http_and_api_failures() {
     let cases = [
         (
             RecordingWasmHostHttp::err(WasmHostError::Unavailable(
@@ -336,8 +336,8 @@ fn bundled_github_wasm_sanitizes_host_http_and_api_failures() {
     }
 }
 
-#[test]
-fn bundled_github_wasm_leaves_success_json_for_host_output_decode() {
+#[tokio::test]
+async fn bundled_github_wasm_leaves_success_json_for_host_output_decode() {
     let execution = execute_bundled_github_wasm(
         "github.search_issues",
         json!({"query": "repo:nearai/ironclaw is:issue", "limit": 1}),
@@ -371,8 +371,9 @@ impl RecordingNetworkHttpEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for RecordingNetworkHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -100,8 +100,8 @@ use serde_json::json;
 use wit_component::{ComponentEncoder, StringEncoding, embed_component_metadata};
 use wit_parser::Resolve;
 
-#[test]
-fn production_wiring_validation_rejects_missing_components_and_local_only_defaults() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_missing_components_and_local_only_defaults() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -223,8 +223,8 @@ fn production_wiring_validation_rejects_missing_components_and_local_only_defaul
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_local_only_runtime_policy() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_local_only_runtime_policy() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -248,8 +248,8 @@ fn production_wiring_validation_rejects_local_only_runtime_policy() {
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_each_local_only_runtime_policy_field() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_each_local_only_runtime_policy_field() {
     let mut host_workspace = hosted_dev_runtime_policy();
     host_workspace.filesystem_backend = FilesystemBackendKind::HostWorkspace;
     assert_local_only_runtime_policy_rejected(host_workspace, "host_workspace_filesystem");
@@ -275,8 +275,8 @@ fn production_wiring_validation_rejects_each_local_only_runtime_policy_field() {
     assert_local_only_runtime_policy_rejected(inherited_secrets, "local_secret_environment");
 }
 
-#[test]
-fn production_wiring_validation_accepts_production_safe_runtime_policy_shape() {
+#[tokio::test]
+async fn production_wiring_validation_accepts_production_safe_runtime_policy_shape() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -300,8 +300,8 @@ fn production_wiring_validation_accepts_production_safe_runtime_policy_shape() {
     );
 }
 
-#[test]
-fn production_wiring_validation_accepts_persistent_resource_governor_component() {
+#[tokio::test]
+async fn production_wiring_validation_accepts_persistent_resource_governor_component() {
     let dir = tempfile::tempdir().unwrap();
     let governor = Arc::new(PersistentResourceGovernor::new(
         JsonFileResourceGovernorStore::new(dir.path().join("resource-governor.json")),
@@ -464,8 +464,8 @@ async fn with_filesystem_resource_governor_closes_process_reservations_on_cancel
     ));
 }
 
-#[test]
-fn production_wiring_validation_classifies_combined_store_as_run_state_and_approvals() {
+#[tokio::test]
+async fn production_wiring_validation_classifies_combined_store_as_run_state_and_approvals() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -512,8 +512,8 @@ fn production_wiring_validation_classifies_combined_store_as_run_state_and_appro
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -739,8 +739,8 @@ async fn production_turn_coordinator_requires_explicit_run_profile_resolver() {
     ));
 }
 
-#[test]
-fn production_wiring_validation_rejects_noop_turn_wake_notifier() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_noop_turn_wake_notifier() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -763,8 +763,8 @@ fn production_wiring_validation_rejects_noop_turn_wake_notifier() {
     );
 }
 
-#[test]
-fn production_wiring_validation_accepts_configured_turn_wake_notifier() {
+#[tokio::test]
+async fn production_wiring_validation_accepts_configured_turn_wake_notifier() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -918,8 +918,8 @@ async fn production_event_store_config_installs_verified_event_and_audit_sinks()
     );
 }
 
-#[test]
-fn production_wiring_validation_uses_configured_runtime_requirements() {
+#[tokio::test]
+async fn production_wiring_validation_uses_configured_runtime_requirements() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -966,8 +966,8 @@ fn production_wiring_validation_uses_configured_runtime_requirements() {
     );
 }
 
-#[test]
-fn production_wiring_validation_sees_underlying_in_memory_durable_logs() {
+#[tokio::test]
+async fn production_wiring_validation_sees_underlying_in_memory_durable_logs() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -999,8 +999,8 @@ fn production_wiring_validation_sees_underlying_in_memory_durable_logs() {
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_direct_durable_sink_wrappers_as_unverified() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_direct_durable_sink_wrappers_as_unverified() {
     let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
     let audit_log: Arc<dyn DurableAuditLog> = Arc::new(InMemoryDurableAuditLog::new());
     let services = HostRuntimeServices::new(
@@ -1034,8 +1034,8 @@ fn production_wiring_validation_rejects_direct_durable_sink_wrappers_as_unverifi
     );
 }
 
-#[test]
-fn production_wiring_validation_accepts_verified_host_http_egress_shape() {
+#[tokio::test]
+async fn production_wiring_validation_accepts_verified_host_http_egress_shape() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -1061,8 +1061,8 @@ fn production_wiring_validation_accepts_verified_host_http_egress_shape() {
     );
 }
 
-#[test]
-fn host_http_egress_helper_requires_graph_secret_store() {
+#[tokio::test]
+async fn host_http_egress_helper_requires_graph_secret_store() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -1083,8 +1083,8 @@ fn host_http_egress_helper_requires_graph_secret_store() {
     ));
 }
 
-#[test]
-fn production_wiring_validation_requires_credential_broker_when_configured() {
+#[tokio::test]
+async fn production_wiring_validation_requires_credential_broker_when_configured() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -1114,8 +1114,8 @@ fn production_wiring_validation_requires_credential_broker_when_configured() {
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_local_only_credential_broker() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_local_only_credential_broker() {
     let broker = Arc::new(InMemoryCredentialBroker::new());
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -1147,8 +1147,8 @@ fn production_wiring_validation_rejects_local_only_credential_broker() {
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -1174,8 +1174,8 @@ fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
     );
 }
 
-#[test]
-fn production_wiring_validation_tracks_process_port_for_builtin_shell() {
+#[tokio::test]
+async fn production_wiring_validation_tracks_process_port_for_builtin_shell() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_builtin_first_party_package()),
         Arc::new(LocalFilesystem::new()),
@@ -1222,8 +1222,8 @@ fn production_wiring_validation_tracks_process_port_for_builtin_shell() {
     );
 }
 
-#[test]
-fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_builtin_shell() {
+#[tokio::test]
+async fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_builtin_shell() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_builtin_first_party_package()),
         Arc::new(LocalFilesystem::new()),
@@ -1308,8 +1308,8 @@ fn production_wiring_validation_tracks_tenant_sandbox_process_port_for_builtin_s
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_empty_verified_wasm_credentials() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_empty_verified_wasm_credentials() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -1337,8 +1337,8 @@ fn production_wiring_validation_rejects_empty_verified_wasm_credentials() {
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_wasm_credentials_added_after_adapter() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_wasm_credentials_added_after_adapter() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -1368,8 +1368,8 @@ fn production_wiring_validation_rejects_wasm_credentials_added_after_adapter() {
     );
 }
 
-#[test]
-fn production_wiring_validation_rejects_wasm_credentials_replaced_after_adapter() {
+#[tokio::test]
+async fn production_wiring_validation_rejects_wasm_credentials_replaced_after_adapter() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -4605,8 +4605,8 @@ async fn host_runtime_services_denies_wasm_http_when_shared_egress_has_no_policy
     );
 }
 
-#[test]
-fn host_runtime_services_wasm_input_encode_releases_prepared_reservation() {
+#[tokio::test]
+async fn host_runtime_services_wasm_input_encode_releases_prepared_reservation() {
     let services = std::fs::read_to_string(
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/services.rs"),
     )
@@ -6066,8 +6066,9 @@ impl RecordingNetworkHttpEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for RecordingNetworkHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
@@ -6143,8 +6144,9 @@ impl RecordingRuntimeHttpEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -168,8 +168,9 @@ impl RecordingNetwork {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for RecordingNetwork {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
@@ -251,6 +252,7 @@ impl CapabilityDispatcher for ObligationAwareDispatcher {
                 save_body_to: None,
                 timeout_ms: None,
             })
+            .await
             .map_err(|_| DispatchError::Wasm {
                 kind: RuntimeDispatchErrorKind::NetworkDenied,
             })?;

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -601,24 +601,27 @@ async fn reborn_e2e_gate_host_http_consumes_staged_policy_and_secret_once() {
 
     let response = service
         .execute(request.clone())
+        .await
         .expect("host HTTP egress should use staged Reborn policy and secret material");
     assert_eq!(response.status, 200);
-    let recorded = network_recorder.lock().unwrap();
-    assert_eq!(recorded.len(), 1);
-    assert_eq!(recorded[0].policy, staged_policy);
-    assert_eq!(
-        recorded[0]
-            .headers
-            .iter()
-            .find(|(name, _)| name == "authorization"),
-        Some(&(
-            "authorization".to_string(),
-            "Bearer sk-reborn-e2e-staged-secret".to_string()
-        ))
-    );
-    drop(recorded);
+    {
+        let recorded = network_recorder.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].policy, staged_policy);
+        assert_eq!(
+            recorded[0]
+                .headers
+                .iter()
+                .find(|(name, _)| name == "authorization"),
+            Some(&(
+                "authorization".to_string(),
+                "Bearer sk-reborn-e2e-staged-secret".to_string()
+            ))
+        );
+    }
     let replay = service
         .execute(request)
+        .await
         .expect_err("consumed staged secret must not be reusable");
     assert!(matches!(replay, RuntimeHttpEgressError::Credential { .. }));
     assert_eq!(
@@ -811,8 +814,9 @@ impl RecordingNetwork {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for RecordingNetwork {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -36,8 +36,8 @@ use std::{
 };
 use tempfile::tempdir;
 
-#[test]
-fn host_http_egress_consumes_staged_obligation_secret_once() {
+#[tokio::test]
+async fn host_http_egress_consumes_staged_obligation_secret_once() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -90,24 +90,27 @@ fn host_http_egress_consumes_staged_obligation_secret_once() {
 
     service
         .execute(request.clone())
+        .await
         .expect("staged secret should be injected through host egress");
 
-    let requests = network_recorder.lock().unwrap();
-    assert_eq!(requests.len(), 1);
-    assert_eq!(
-        requests[0]
-            .headers
-            .iter()
-            .find(|(name, _)| name == "authorization"),
-        Some(&(
-            "authorization".to_string(),
-            "Bearer sk-staged-secret".to_string()
-        ))
-    );
-    drop(requests);
+    {
+        let requests = network_recorder.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]
+                .headers
+                .iter()
+                .find(|(name, _)| name == "authorization"),
+            Some(&(
+                "authorization".to_string(),
+                "Bearer sk-staged-secret".to_string()
+            ))
+        );
+    }
 
     let error = service
         .execute(request)
+        .await
         .expect_err("staged secret must not be reusable");
     assert!(matches!(
         error,
@@ -193,6 +196,7 @@ async fn host_http_egress_consumes_secret_staged_by_builtin_obligation_handler()
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("host egress should consume material staged by the obligation handler");
 
     let requests = network_recorder.lock().unwrap();
@@ -209,8 +213,8 @@ async fn host_http_egress_consumes_secret_staged_by_builtin_obligation_handler()
     );
 }
 
-#[test]
-fn host_http_egress_reuses_staged_secret_for_multiple_targets_in_one_request() {
+#[tokio::test]
+async fn host_http_egress_reuses_staged_secret_for_multiple_targets_in_one_request() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -283,6 +287,7 @@ fn host_http_egress_reuses_staged_secret_for_multiple_targets_in_one_request() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("same staged handle should be reusable within a single request plan");
 
     let requests = network_recorder.lock().unwrap();
@@ -304,8 +309,8 @@ fn host_http_egress_reuses_staged_secret_for_multiple_targets_in_one_request() {
     drop(requests);
 }
 
-#[test]
-fn host_http_egress_restores_staged_secret_when_later_injection_target_fails() {
+#[tokio::test]
+async fn host_http_egress_restores_staged_secret_when_later_injection_target_fails() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -368,6 +373,7 @@ fn host_http_egress_restores_staged_secret_when_later_injection_target_fails() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("later injection target failure should fail before dispatch");
 
     assert!(matches!(
@@ -403,6 +409,7 @@ fn host_http_egress_restores_staged_secret_when_later_injection_target_fails() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("staged secret should be restored after target-application failure");
 
     let requests = network_recorder.lock().unwrap();
@@ -419,8 +426,8 @@ fn host_http_egress_restores_staged_secret_when_later_injection_target_fails() {
     );
 }
 
-#[test]
-fn host_http_egress_rejects_invalid_path_placeholder_before_transport() {
+#[tokio::test]
+async fn host_http_egress_rejects_invalid_path_placeholder_before_transport() {
     for (placeholder, url) in [
         ("", "https://api.example.test/v1/__credential__/run"),
         (
@@ -489,6 +496,7 @@ fn host_http_egress_rejects_invalid_path_placeholder_before_transport() {
                 save_body_to: None,
                 timeout_ms: None,
             })
+            .await
             .expect_err("invalid path placeholder must fail before network dispatch");
 
         assert!(matches!(
@@ -502,8 +510,8 @@ fn host_http_egress_rejects_invalid_path_placeholder_before_transport() {
     }
 }
 
-#[test]
-fn host_http_egress_rejects_path_placeholder_value_breaking_chars_before_transport() {
+#[tokio::test]
+async fn host_http_egress_rejects_path_placeholder_value_breaking_chars_before_transport() {
     for material in [
         "",
         ".",
@@ -520,6 +528,7 @@ fn host_http_egress_rejects_path_placeholder_value_breaking_chars_before_transpo
             "__credential__",
             material,
         )
+        .await
         .expect_err("invalid path placeholder credential value must fail before network dispatch");
 
         assert!(matches!(
@@ -534,13 +543,14 @@ fn host_http_egress_rejects_path_placeholder_value_breaking_chars_before_transpo
     }
 }
 
-#[test]
-fn host_http_egress_requires_https_for_path_placeholder_before_transport() {
+#[tokio::test]
+async fn host_http_egress_requires_https_for_path_placeholder_before_transport() {
     let (error, network_recorder) = execute_path_placeholder_egress(
         "http://api.example.test/v1/__credential__/run",
         "__credential__",
         "sk-staged-secret",
     )
+    .await
     .expect_err("path placeholder credential injection must require HTTPS");
 
     assert!(matches!(
@@ -551,13 +561,14 @@ fn host_http_egress_requires_https_for_path_placeholder_before_transport() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_rejects_multiple_path_placeholder_occurrences_before_transport() {
+#[tokio::test]
+async fn host_http_egress_rejects_multiple_path_placeholder_occurrences_before_transport() {
     let (error, network_recorder) = execute_path_placeholder_egress(
         "https://api.example.test/__credential__/v1/__credential__/run",
         "__credential__",
         "sk-staged-secret",
     )
+    .await
     .expect_err("path placeholder credential injection must have one target segment");
 
     assert!(matches!(
@@ -568,13 +579,14 @@ fn host_http_egress_rejects_multiple_path_placeholder_occurrences_before_transpo
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_preserves_existing_path_encoding_when_rewriting_placeholder() {
+#[tokio::test]
+async fn host_http_egress_preserves_existing_path_encoding_when_rewriting_placeholder() {
     let (_response, network_recorder) = execute_path_placeholder_egress(
         "https://api.example.test/v1/foo%20bar/__credential__/run%2Ftail",
         "__credential__",
         "sk-staged-secret",
     )
+    .await
     .expect("path placeholder rewrite should preserve existing encoded segments");
 
     let requests = network_recorder.lock().unwrap();
@@ -585,8 +597,8 @@ fn host_http_egress_preserves_existing_path_encoding_when_rewriting_placeholder(
     );
 }
 
-#[test]
-fn host_http_egress_rejects_path_placeholder_target_url_errors_before_transport() {
+#[tokio::test]
+async fn host_http_egress_rejects_path_placeholder_target_url_errors_before_transport() {
     for (url, expected_reason) in [
         ("not a url", "credential injection target URL is invalid"),
         (
@@ -595,9 +607,11 @@ fn host_http_egress_rejects_path_placeholder_target_url_errors_before_transport(
         ),
     ] {
         let (error, network_recorder) =
-            execute_path_placeholder_egress(url, "__credential__", "sk-staged-secret").expect_err(
-                "invalid path placeholder target URL must fail before network dispatch",
-            );
+            execute_path_placeholder_egress(url, "__credential__", "sk-staged-secret")
+                .await
+                .expect_err(
+                    "invalid path placeholder target URL must fail before network dispatch",
+                );
 
         assert!(matches!(
             error,
@@ -611,8 +625,8 @@ fn host_http_egress_rejects_path_placeholder_target_url_errors_before_transport(
     }
 }
 
-#[test]
-fn host_http_egress_fails_closed_when_required_staged_secret_is_missing() {
+#[tokio::test]
+async fn host_http_egress_fails_closed_when_required_staged_secret_is_missing() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -655,6 +669,7 @@ fn host_http_egress_fails_closed_when_required_staged_secret_is_missing() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("missing staged material must fail before network dispatch");
 
     assert!(matches!(
@@ -664,8 +679,8 @@ fn host_http_egress_fails_closed_when_required_staged_secret_is_missing() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_does_not_take_staged_secret_from_other_capability() {
+#[tokio::test]
+async fn host_http_egress_does_not_take_staged_secret_from_other_capability() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -717,6 +732,7 @@ fn host_http_egress_does_not_take_staged_secret_from_other_capability() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("staged material for a different capability must not authorize egress");
 
     assert!(matches!(
@@ -726,8 +742,8 @@ fn host_http_egress_does_not_take_staged_secret_from_other_capability() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_does_not_take_staged_secret_for_other_handle() {
+#[tokio::test]
+async fn host_http_egress_does_not_take_staged_secret_for_other_handle() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -779,6 +795,7 @@ fn host_http_egress_does_not_take_staged_secret_for_other_handle() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("staged material for a different handle must not authorize egress");
 
     assert!(matches!(
@@ -788,8 +805,8 @@ fn host_http_egress_does_not_take_staged_secret_for_other_handle() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_removes_staged_secret_before_network_errors() {
+#[tokio::test]
+async fn host_http_egress_removes_staged_secret_before_network_errors() {
     let network = RecordingNetwork::err(NetworkHttpError::Transport {
         reason: "upstream rejected sk-staged-secret".to_string(),
         request_bytes: 12,
@@ -835,6 +852,7 @@ fn host_http_egress_removes_staged_secret_before_network_errors() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("network error should be sanitized after staged injection is consumed");
 
     assert!(matches!(
@@ -845,8 +863,8 @@ fn host_http_egress_removes_staged_secret_before_network_errors() {
     assert_eq!(network_recorder.lock().unwrap().len(), 1);
 }
 
-#[test]
-fn host_http_egress_skips_optional_missing_staged_secret() {
+#[tokio::test]
+async fn host_http_egress_skips_optional_missing_staged_secret() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -889,6 +907,7 @@ fn host_http_egress_skips_optional_missing_staged_secret() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("optional missing staged material should not block egress");
 
     assert_eq!(response.status, 200);
@@ -903,8 +922,8 @@ fn host_http_egress_skips_optional_missing_staged_secret() {
     );
 }
 
-#[test]
-fn host_http_egress_does_not_take_staged_secret_from_other_scope() {
+#[tokio::test]
+async fn host_http_egress_does_not_take_staged_secret_from_other_scope() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -956,6 +975,7 @@ fn host_http_egress_does_not_take_staged_secret_from_other_scope() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("staged material for a different scope must not authorize egress");
 
     assert!(matches!(
@@ -965,8 +985,8 @@ fn host_http_egress_does_not_take_staged_secret_from_other_scope() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_rejects_header_injection_prefix_control_chars() {
+#[tokio::test]
+async fn host_http_egress_rejects_header_injection_prefix_control_chars() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1011,6 +1031,7 @@ fn host_http_egress_rejects_header_injection_prefix_control_chars() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("header injection prefixes with control characters must be rejected");
 
     assert!(matches!(
@@ -1021,8 +1042,8 @@ fn host_http_egress_rejects_header_injection_prefix_control_chars() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_rejects_header_injection_value_control_chars() {
+#[tokio::test]
+async fn host_http_egress_rejects_header_injection_value_control_chars() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1073,6 +1094,7 @@ fn host_http_egress_rejects_header_injection_value_control_chars() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("header injection values with control characters must be rejected");
 
     assert_eq!(
@@ -1083,8 +1105,8 @@ fn host_http_egress_rejects_header_injection_value_control_chars() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_injects_staged_credentials_and_redacts_errors() {
+#[tokio::test]
+async fn host_http_egress_injects_staged_credentials_and_redacts_errors() {
     let network = RecordingNetwork::err(NetworkHttpError::Transport {
         reason: "upstream rejected token sk-test-secret".to_string(),
         request_bytes: 12,
@@ -1124,6 +1146,7 @@ fn host_http_egress_injects_staged_credentials_and_redacts_errors() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("network error should be sanitized");
 
     let rendered = error.to_string();
@@ -1144,8 +1167,8 @@ fn host_http_egress_injects_staged_credentials_and_redacts_errors() {
     );
 }
 
-#[test]
-fn host_http_egress_requires_available_required_credentials_before_network() {
+#[tokio::test]
+async fn host_http_egress_requires_available_required_credentials_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1188,6 +1211,7 @@ fn host_http_egress_requires_available_required_credentials_before_network() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("missing required credentials should fail before network dispatch");
 
     assert!(matches!(
@@ -1197,8 +1221,8 @@ fn host_http_egress_requires_available_required_credentials_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_required_credential_still_fails_after_optional_negative_cache() {
+#[tokio::test]
+async fn host_http_egress_required_credential_still_fails_after_optional_negative_cache() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1255,6 +1279,7 @@ fn host_http_egress_required_credential_still_fails_after_optional_negative_cach
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("required reuse of a negatively cached credential must fail closed");
 
     assert_eq!(
@@ -1264,8 +1289,8 @@ fn host_http_egress_required_credential_still_fails_after_optional_negative_cach
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_injects_and_redacts_url_encoded_query_credentials() {
+#[tokio::test]
+async fn host_http_egress_injects_and_redacts_url_encoded_query_credentials() {
     let network = UrlEchoNetwork::new();
     let network_recorder = network.requests.clone();
     let scope = sample_scope();
@@ -1306,6 +1331,7 @@ fn host_http_egress_injects_and_redacts_url_encoded_query_credentials() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("network error should be sanitized");
 
     let rendered = error.to_string();
@@ -1320,8 +1346,8 @@ fn host_http_egress_injects_and_redacts_url_encoded_query_credentials() {
     );
 }
 
-#[test]
-fn host_http_egress_redacts_path_placeholder_credentials_from_response() {
+#[tokio::test]
+async fn host_http_egress_redacts_path_placeholder_credentials_from_response() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 302,
         headers: vec![(
@@ -1372,6 +1398,7 @@ fn host_http_egress_redacts_path_placeholder_credentials_from_response() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("path placeholder credential response echoes should be redacted");
 
     assert_eq!(response.status, 302);
@@ -1396,8 +1423,8 @@ fn host_http_egress_redacts_path_placeholder_credentials_from_response() {
     );
 }
 
-#[test]
-fn host_http_egress_redacts_path_placeholder_credentials_from_network_errors() {
+#[tokio::test]
+async fn host_http_egress_redacts_path_placeholder_credentials_from_network_errors() {
     let network = UrlEchoNetwork::new();
     let network_recorder = network.requests.clone();
     let scope = sample_scope();
@@ -1436,6 +1463,7 @@ fn host_http_egress_redacts_path_placeholder_credentials_from_network_errors() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("network errors after path placeholder injection should be sanitized");
 
     let rendered = error.to_string();
@@ -1450,8 +1478,8 @@ fn host_http_egress_redacts_path_placeholder_credentials_from_network_errors() {
     );
 }
 
-#[test]
-fn host_http_egress_forwards_timeout_to_network() {
+#[tokio::test]
+async fn host_http_egress_forwards_timeout_to_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1480,6 +1508,7 @@ fn host_http_egress_forwards_timeout_to_network() {
             save_body_to: None,
             timeout_ms: Some(250),
         })
+        .await
         .expect("network response should be returned");
 
     let requests = network_recorder.lock().unwrap();
@@ -1487,8 +1516,8 @@ fn host_http_egress_forwards_timeout_to_network() {
     assert_eq!(requests[0].timeout_ms, Some(250));
 }
 
-#[test]
-fn host_http_egress_with_reqwest_transport_returns_redirect_without_following() {
+#[tokio::test]
+async fn host_http_egress_with_reqwest_transport_returns_redirect_without_following() {
     let (url, server) = single_response_server(
         "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:9/followed\r\nContent-Length: 0\r\n\r\n",
     );
@@ -1511,6 +1540,7 @@ fn host_http_egress_with_reqwest_transport_returns_redirect_without_following() 
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("redirect responses should be returned to the caller, not followed");
     server.join().unwrap();
 
@@ -1525,8 +1555,8 @@ fn host_http_egress_with_reqwest_transport_returns_redirect_without_following() 
     );
 }
 
-#[test]
-fn host_http_egress_preserves_request_and_response_byte_accounting() {
+#[tokio::test]
+async fn host_http_egress_preserves_request_and_response_byte_accounting() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1555,6 +1585,7 @@ fn host_http_egress_preserves_request_and_response_byte_accounting() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("network response should be returned");
 
     assert_eq!(response.request_bytes, 5);
@@ -1565,8 +1596,8 @@ fn host_http_egress_preserves_request_and_response_byte_accounting() {
     assert_eq!(requests[0].response_body_limit, Some(4096));
 }
 
-#[test]
-fn host_http_egress_without_policy_store_fails_closed_before_transport() {
+#[tokio::test]
+async fn host_http_egress_without_policy_store_fails_closed_before_transport() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1595,6 +1626,7 @@ fn host_http_egress_without_policy_store_fails_closed_before_transport() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("runtime HTTP egress must not trust caller-supplied network policy without a staged-policy store");
 
     assert!(matches!(
@@ -1608,8 +1640,8 @@ fn host_http_egress_without_policy_store_fails_closed_before_transport() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_borrows_staged_network_policy_before_transport() {
+#[tokio::test]
+async fn host_http_egress_borrows_staged_network_policy_before_transport() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1643,6 +1675,7 @@ fn host_http_egress_borrows_staged_network_policy_before_transport() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("staged network policy should authorize host-mediated HTTP");
 
     let requests = network_recorder.lock().unwrap();
@@ -1651,8 +1684,8 @@ fn host_http_egress_borrows_staged_network_policy_before_transport() {
     drop(requests);
 }
 
-#[test]
-fn production_host_http_egress_rejects_direct_secret_store_lease_before_transport() {
+#[tokio::test]
+async fn production_host_http_egress_rejects_direct_secret_store_lease_before_transport() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1700,6 +1733,7 @@ fn production_host_http_egress_rejects_direct_secret_store_lease_before_transpor
             save_body_to: None,
             timeout_ms: Some(1000),
         })
+        .await
         .expect_err("production egress must require staged secret obligations");
 
     assert!(matches!(
@@ -1710,8 +1744,9 @@ fn production_host_http_egress_rejects_direct_secret_store_lease_before_transpor
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn production_host_http_egress_discards_staged_policy_when_direct_secret_store_lease_is_rejected() {
+#[tokio::test]
+async fn production_host_http_egress_discards_staged_policy_when_direct_secret_store_lease_is_rejected()
+ {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1753,6 +1788,7 @@ fn production_host_http_egress_discards_staged_policy_when_direct_secret_store_l
             save_body_to: None,
             timeout_ms: Some(1000),
         })
+        .await
         .expect_err("rejected direct lease should discard staged policy");
     assert!(matches!(error, RuntimeHttpEgressError::Credential { .. }));
 
@@ -1771,6 +1807,7 @@ fn production_host_http_egress_discards_staged_policy_when_direct_secret_store_l
             save_body_to: None,
             timeout_ms: Some(1000),
         })
+        .await
         .expect_err("discarded staged policy must not authorize retry");
 
     assert!(matches!(
@@ -1784,8 +1821,9 @@ fn production_host_http_egress_discards_staged_policy_when_direct_secret_store_l
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn production_host_http_egress_rejects_cross_capability_staged_credentials_before_transport() {
+#[tokio::test]
+async fn production_host_http_egress_rejects_cross_capability_staged_credentials_before_transport()
+{
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1837,6 +1875,7 @@ fn production_host_http_egress_rejects_cross_capability_staged_credentials_befor
             save_body_to: None,
             timeout_ms: Some(1000),
         })
+        .await
         .expect_err("cross-capability staged credentials must be rejected");
 
     assert!(matches!(
@@ -1847,8 +1886,8 @@ fn production_host_http_egress_rejects_cross_capability_staged_credentials_befor
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn wasm_http_adapter_borrows_real_host_staged_network_policy() {
+#[tokio::test]
+async fn wasm_http_adapter_borrows_real_host_staged_network_policy() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -1893,8 +1932,8 @@ fn wasm_http_adapter_borrows_real_host_staged_network_policy() {
     drop(requests);
 }
 
-#[test]
-fn script_http_adapter_borrows_real_host_staged_network_policy() {
+#[tokio::test]
+async fn script_http_adapter_borrows_real_host_staged_network_policy() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 202,
         headers: vec![],
@@ -1927,6 +1966,7 @@ fn script_http_adapter_borrows_real_host_staged_network_policy() {
             response_body_limit: Some(4096),
             timeout_ms: Some(1000),
         })
+        .await
         .expect("script adapter should reach host egress using staged policy");
 
     assert_eq!(response.status, 202);
@@ -1939,8 +1979,8 @@ fn script_http_adapter_borrows_real_host_staged_network_policy() {
     drop(requests);
 }
 
-#[test]
-fn mcp_http_adapter_borrows_real_host_staged_network_policy() {
+#[tokio::test]
+async fn mcp_http_adapter_borrows_real_host_staged_network_policy() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 203,
         headers: vec![],
@@ -1973,6 +2013,7 @@ fn mcp_http_adapter_borrows_real_host_staged_network_policy() {
             response_body_limit: Some(4096),
             timeout_ms: Some(1000),
         })
+        .await
         .expect("MCP adapter should reach host egress using staged policy");
 
     assert_eq!(response.status, 203);
@@ -2187,8 +2228,8 @@ async fn mcp_http_client_cannot_use_direct_secret_store_lease_with_production_eg
     }));
 }
 
-#[test]
-fn first_party_http_egress_cannot_use_direct_secret_store_lease_with_production_egress() {
+#[tokio::test]
+async fn first_party_http_egress_cannot_use_direct_secret_store_lease_with_production_egress() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2229,6 +2270,7 @@ fn first_party_http_egress_cannot_use_direct_secret_store_lease_with_production_
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("production first-party egress must require staged credentials");
 
     assert!(matches!(
@@ -2239,8 +2281,8 @@ fn first_party_http_egress_cannot_use_direct_secret_store_lease_with_production_
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_fails_closed_without_staged_network_policy() {
+#[tokio::test]
+async fn host_http_egress_fails_closed_without_staged_network_policy() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2270,6 +2312,7 @@ fn host_http_egress_fails_closed_without_staged_network_policy() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("missing staged network policy should fail before transport");
 
     assert!(matches!(
@@ -2283,8 +2326,8 @@ fn host_http_egress_fails_closed_without_staged_network_policy() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_does_not_use_cross_scope_or_cross_capability_policy() {
+#[tokio::test]
+async fn host_http_egress_does_not_use_cross_scope_or_cross_capability_policy() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2321,6 +2364,7 @@ fn host_http_egress_does_not_use_cross_scope_or_cross_capability_policy() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("cross-scope or cross-capability staged policies must not authorize egress");
 
     assert!(matches!(
@@ -2334,8 +2378,8 @@ fn host_http_egress_does_not_use_cross_scope_or_cross_capability_policy() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_consumes_staged_policy_when_dispatch_fails_before_transport() {
+#[tokio::test]
+async fn host_http_egress_consumes_staged_policy_when_dispatch_fails_before_transport() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2376,14 +2420,15 @@ fn host_http_egress_consumes_staged_policy_when_dispatch_fails_before_transport(
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("credential failure should not leave reusable network policy state");
 
     assert!(matches!(error, RuntimeHttpEgressError::Credential { .. }));
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_consumes_staged_policy_when_request_validation_fails() {
+#[tokio::test]
+async fn host_http_egress_consumes_staged_policy_when_request_validation_fails() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2419,14 +2464,15 @@ fn host_http_egress_consumes_staged_policy_when_request_validation_fails() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("request validation failure should not leave reusable policy state");
 
     assert!(matches!(error, RuntimeHttpEgressError::Request { .. }));
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_redacts_injected_credentials_from_runtime_visible_response() {
+#[tokio::test]
+async fn host_http_egress_redacts_injected_credentials_from_runtime_visible_response() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![
@@ -2476,6 +2522,7 @@ fn host_http_egress_redacts_injected_credentials_from_runtime_visible_response()
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("sanitized response should be returned");
 
     assert!(response.redaction_applied);
@@ -2486,8 +2533,8 @@ fn host_http_egress_redacts_injected_credentials_from_runtime_visible_response()
     assert_eq!(response.body, b"upstream echoed [REDACTED]".to_vec());
 }
 
-#[test]
-fn host_http_egress_redacts_lowercase_percent_encoded_secret_echoes() {
+#[tokio::test]
+async fn host_http_egress_redacts_lowercase_percent_encoded_secret_echoes() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![(
@@ -2539,6 +2586,7 @@ fn host_http_egress_redacts_lowercase_percent_encoded_secret_echoes() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("lowercase percent-encoded echoed credentials should be redacted");
 
     assert!(response.redaction_applied);
@@ -2549,8 +2597,8 @@ fn host_http_egress_redacts_lowercase_percent_encoded_secret_echoes() {
     assert_eq!(response.body, b"upstream echoed [REDACTED]".to_vec());
 }
 
-#[test]
-fn host_http_egress_saves_sanitized_response_body_to_store() {
+#[tokio::test]
+async fn host_http_egress_saves_sanitized_response_body_to_store() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![("content-type".to_string(), "text/plain".to_string())],
@@ -2580,6 +2628,7 @@ fn host_http_egress_saves_sanitized_response_body_to_store() {
             save_body_to: Some(target.clone()),
             timeout_ms: None,
         })
+        .await
         .expect("response body should be saved");
 
     assert_eq!(response.body, Vec::<u8>::new());
@@ -2601,8 +2650,8 @@ fn host_http_egress_saves_sanitized_response_body_to_store() {
     assert_eq!(writes[0].body, b"large patch body".to_vec());
 }
 
-#[test]
-fn host_http_egress_saves_response_body_to_scoped_filesystem_store() {
+#[tokio::test]
+async fn host_http_egress_saves_response_body_to_scoped_filesystem_store() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![("content-type".to_string(), "text/plain".to_string())],
@@ -2642,6 +2691,7 @@ fn host_http_egress_saves_response_body_to_scoped_filesystem_store() {
             save_body_to: Some(target.clone()),
             timeout_ms: None,
         })
+        .await
         .expect("response body should be saved through the scoped filesystem");
 
     assert_eq!(response.body, Vec::<u8>::new());
@@ -2703,6 +2753,7 @@ async fn host_http_egress_saves_response_body_to_scoped_filesystem_store_from_to
             save_body_to: Some(target),
             timeout_ms: None,
         })
+        .await
         .expect("response body should be saved without nested Tokio runtime panic");
 
     assert_eq!(
@@ -2719,8 +2770,8 @@ async fn host_http_egress_saves_response_body_to_scoped_filesystem_store_from_to
     assert_eq!(saved, b"tokio filesystem body".to_vec());
 }
 
-#[test]
-fn host_http_egress_rejects_save_when_target_mount_view_is_read_only() {
+#[tokio::test]
+async fn host_http_egress_rejects_save_when_target_mount_view_is_read_only() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![("content-type".to_string(), "text/plain".to_string())],
@@ -2770,14 +2821,15 @@ fn host_http_egress_rejects_save_when_target_mount_view_is_read_only() {
             save_body_to: Some(target.clone()),
             timeout_ms: None,
         })
+        .await
         .expect_err("read-only target mount should deny saving before network");
 
     assert_eq!(error.stable_runtime_reason(), "request_denied");
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_save_target_requires_configured_body_store_before_network() {
+#[tokio::test]
+async fn host_http_egress_save_target_requires_configured_body_store_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2806,14 +2858,15 @@ fn host_http_egress_save_target_requires_configured_body_store_before_network() 
             save_body_to: Some(save_target("/workspace/pr.diff")),
             timeout_ms: None,
         })
+        .await
         .expect_err("missing body store should fail closed");
 
     assert!(matches!(error, RuntimeHttpEgressError::Request { .. }));
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_save_target_requires_write_authorization_before_network() {
+#[tokio::test]
+async fn host_http_egress_save_target_requires_write_authorization_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2846,6 +2899,7 @@ fn host_http_egress_save_target_requires_write_authorization_before_network() {
             save_body_to: Some(save_target("/workspace/pr.diff")),
             timeout_ms: None,
         })
+        .await
         .expect_err("unauthorized save target should fail closed");
 
     match error {
@@ -2863,8 +2917,8 @@ fn host_http_egress_save_target_requires_write_authorization_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_rejects_save_when_body_store_is_unavailable() {
+#[tokio::test]
+async fn host_http_egress_rejects_save_when_body_store_is_unavailable() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2894,6 +2948,7 @@ fn host_http_egress_rejects_save_when_body_store_is_unavailable() {
             save_body_to: Some(save_target("/workspace/pr.diff")),
             timeout_ms: None,
         })
+        .await
         .expect_err("unavailable body store should fail closed");
 
     match error {
@@ -2911,8 +2966,8 @@ fn host_http_egress_rejects_save_when_body_store_is_unavailable() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_discards_staged_secret_on_pre_injection_error() {
+#[tokio::test]
+async fn host_http_egress_discards_staged_secret_on_pre_injection_error() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -2964,6 +3019,7 @@ fn host_http_egress_discards_staged_secret_on_pre_injection_error() {
             save_body_to: Some(save_target("/workspace/pr.diff")),
             timeout_ms: None,
         })
+        .await
         .expect_err("pre-injection body-store failure should fail closed");
 
     stage_policy_sync(&services, &scope, &capability_id, sample_policy());
@@ -2992,6 +3048,7 @@ fn host_http_egress_discards_staged_secret_on_pre_injection_error() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("pre-injection failure should discard staged secrets");
 
     assert!(matches!(
@@ -3002,8 +3059,8 @@ fn host_http_egress_discards_staged_secret_on_pre_injection_error() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_fails_closed_when_body_store_write_fails() {
+#[tokio::test]
+async fn host_http_egress_fails_closed_when_body_store_write_fails() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![("content-type".to_string(), "text/plain".to_string())],
@@ -3032,6 +3089,7 @@ fn host_http_egress_fails_closed_when_body_store_write_fails() {
             save_body_to: Some(save_target("/workspace/pr.diff")),
             timeout_ms: None,
         })
+        .await
         .expect_err("body store write failure should fail closed");
 
     match error {
@@ -3049,8 +3107,8 @@ fn host_http_egress_fails_closed_when_body_store_write_fails() {
     assert!(store.writes().is_empty());
 }
 
-#[test]
-fn host_http_egress_fails_closed_when_real_scoped_filesystem_write_fails() {
+#[tokio::test]
+async fn host_http_egress_fails_closed_when_real_scoped_filesystem_write_fails() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![("content-type".to_string(), "text/plain".to_string())],
@@ -3097,6 +3155,7 @@ fn host_http_egress_fails_closed_when_real_scoped_filesystem_write_fails() {
             save_body_to: Some(target),
             timeout_ms: None,
         })
+        .await
         .expect_err("real scoped filesystem write failure should fail closed");
 
     match error {
@@ -3117,8 +3176,8 @@ fn host_http_egress_fails_closed_when_real_scoped_filesystem_write_fails() {
     );
 }
 
-#[test]
-fn host_http_egress_saves_redacted_response_body() {
+#[tokio::test]
+async fn host_http_egress_saves_redacted_response_body() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3163,6 +3222,7 @@ fn host_http_egress_saves_redacted_response_body() {
             save_body_to: Some(save_target("/workspace/redacted.txt")),
             timeout_ms: None,
         })
+        .await
         .expect("sanitized response body should be saved");
 
     assert!(response.redaction_applied);
@@ -3172,8 +3232,8 @@ fn host_http_egress_saves_redacted_response_body() {
     assert_eq!(writes[0].body, b"upstream echoed [REDACTED]".to_vec());
 }
 
-#[test]
-fn host_http_egress_strips_all_sensitive_response_headers() {
+#[tokio::test]
+async fn host_http_egress_strips_all_sensitive_response_headers() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![
@@ -3220,6 +3280,7 @@ fn host_http_egress_strips_all_sensitive_response_headers() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect("sensitive response headers should be stripped before runtime visibility");
 
     assert!(response.redaction_applied);
@@ -3229,8 +3290,8 @@ fn host_http_egress_strips_all_sensitive_response_headers() {
     );
 }
 
-#[test]
-fn host_http_egress_blocks_credential_shaped_response_body() {
+#[tokio::test]
+async fn host_http_egress_blocks_credential_shaped_response_body() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3258,6 +3319,7 @@ fn host_http_egress_blocks_credential_shaped_response_body() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("credential-shaped response bodies should not reach runtimes");
 
     assert!(matches!(
@@ -3270,8 +3332,8 @@ fn host_http_egress_blocks_credential_shaped_response_body() {
     assert_eq!(error.response_bytes(), 43);
 }
 
-#[test]
-fn host_http_egress_blocks_percent_encoded_credential_path_before_network() {
+#[tokio::test]
+async fn host_http_egress_blocks_percent_encoded_credential_path_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3301,6 +3363,7 @@ fn host_http_egress_blocks_percent_encoded_credential_path_before_network() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("percent-encoded credential-shaped path should fail before network dispatch");
 
     assert!(matches!(
@@ -3311,8 +3374,8 @@ fn host_http_egress_blocks_percent_encoded_credential_path_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_blocks_credential_shaped_runtime_request_before_network() {
+#[tokio::test]
+async fn host_http_egress_blocks_credential_shaped_runtime_request_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3341,6 +3404,7 @@ fn host_http_egress_blocks_credential_shaped_runtime_request_before_network() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("credential-shaped runtime requests should fail before network dispatch");
 
     assert!(matches!(
@@ -3352,8 +3416,8 @@ fn host_http_egress_blocks_credential_shaped_runtime_request_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_blocks_runtime_supplied_sensitive_headers_before_network() {
+#[tokio::test]
+async fn host_http_egress_blocks_runtime_supplied_sensitive_headers_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3385,6 +3449,7 @@ fn host_http_egress_blocks_runtime_supplied_sensitive_headers_before_network() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("runtime-supplied sensitive headers should fail before network dispatch");
 
     assert!(matches!(
@@ -3395,8 +3460,8 @@ fn host_http_egress_blocks_runtime_supplied_sensitive_headers_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_blocks_leaky_response_header_values() {
+#[tokio::test]
+async fn host_http_egress_blocks_leaky_response_header_values() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![(
@@ -3427,6 +3492,7 @@ fn host_http_egress_blocks_leaky_response_header_values() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("leaky response headers should fail closed");
 
     assert!(matches!(
@@ -3436,8 +3502,8 @@ fn host_http_egress_blocks_leaky_response_header_values() {
     ));
 }
 
-#[test]
-fn host_http_egress_blocks_runtime_supplied_credential_query_before_network() {
+#[tokio::test]
+async fn host_http_egress_blocks_runtime_supplied_credential_query_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3466,6 +3532,7 @@ fn host_http_egress_blocks_runtime_supplied_credential_query_before_network() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("runtime-supplied credential query params should fail before network dispatch");
 
     assert!(matches!(
@@ -3476,8 +3543,8 @@ fn host_http_egress_blocks_runtime_supplied_credential_query_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_blocks_percent_encoded_credential_values_before_network() {
+#[tokio::test]
+async fn host_http_egress_blocks_percent_encoded_credential_values_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3506,6 +3573,7 @@ fn host_http_egress_blocks_percent_encoded_credential_values_before_network() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("percent-encoded credential values should fail before network dispatch");
 
     assert!(matches!(
@@ -3516,8 +3584,8 @@ fn host_http_egress_blocks_percent_encoded_credential_values_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_blocks_runtime_supplied_auth_like_headers_before_network() {
+#[tokio::test]
+async fn host_http_egress_blocks_runtime_supplied_auth_like_headers_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -3546,6 +3614,7 @@ fn host_http_egress_blocks_runtime_supplied_auth_like_headers_before_network() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("runtime-supplied auth-like headers should fail before network dispatch");
 
     assert!(matches!(
@@ -3556,8 +3625,8 @@ fn host_http_egress_blocks_runtime_supplied_auth_like_headers_before_network() {
     assert!(network_recorder.lock().unwrap().is_empty());
 }
 
-#[test]
-fn host_http_egress_maps_network_errors_to_stable_runtime_reasons() {
+#[tokio::test]
+async fn host_http_egress_maps_network_errors_to_stable_runtime_reasons() {
     let network = RecordingNetwork::err(NetworkHttpError::Transport {
         reason: "connection failed for https://api.example.test/path?token=raw-secret".to_string(),
         request_bytes: 12,
@@ -3580,6 +3649,7 @@ fn host_http_egress_maps_network_errors_to_stable_runtime_reasons() {
             save_body_to: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("network errors should surface as stable sanitized variants");
 
     assert!(matches!(
@@ -3689,8 +3759,9 @@ impl UrlEchoNetwork {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for UrlEchoNetwork {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
@@ -3711,8 +3782,9 @@ impl JsonRpcMcpNetwork {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for JsonRpcMcpNetwork {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
@@ -3784,8 +3856,9 @@ impl RecordingNetwork {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpEgress for RecordingNetwork {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
@@ -3800,7 +3873,7 @@ type PathPlaceholderEgressResult = Result<
     (RuntimeHttpEgressError, RecordedRequests),
 >;
 
-fn execute_path_placeholder_egress(
+async fn execute_path_placeholder_egress(
     url: &str,
     placeholder: &str,
     material: &str,
@@ -3847,6 +3920,7 @@ fn execute_path_placeholder_egress(
     });
 
     response
+        .await
         .map(|response| (response, network_recorder.clone()))
         .map_err(|error| (error, network_recorder))
 }
@@ -3879,8 +3953,9 @@ struct RequestPolicyStagingEgress {
     inner: Arc<dyn RuntimeHttpEgress>,
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RequestPolicyStagingEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -3890,7 +3965,7 @@ impl RuntimeHttpEgress for RequestPolicyStagingEgress {
             &request.capability_id,
             request.network_policy.clone(),
         );
-        self.inner.execute(request)
+        self.inner.execute(request).await
     }
 }
 

--- a/crates/ironclaw_mcp/Cargo.toml
+++ b/crates/ironclaw_mcp/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+futures-util = "0.3"
 ironclaw_extensions = { path = "../ironclaw_extensions" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_resources = { path = "../ironclaw_resources" }

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -165,7 +165,7 @@ where
         Self { egress }
     }
 
-    pub fn request(
+    pub async fn request(
         &self,
         request: McpHostHttpRequest,
     ) -> Result<McpHostHttpResponse, McpHostHttpError> {
@@ -184,6 +184,7 @@ where
                 save_body_to: None,
                 timeout_ms: request.timeout_ms,
             })
+            .await
             .map_err(mcp_http_error)
     }
 }
@@ -194,32 +195,37 @@ fn mcp_http_error(error: RuntimeHttpEgressError) -> McpHostHttpError {
     }
 }
 
+#[async_trait]
 pub trait McpHostHttp: Send + Sync {
-    fn request(&self, request: McpHostHttpRequest)
-    -> Result<McpHostHttpResponse, McpHostHttpError>;
+    async fn request(
+        &self,
+        request: McpHostHttpRequest,
+    ) -> Result<McpHostHttpResponse, McpHostHttpError>;
 }
 
+#[async_trait]
 impl<E> McpHostHttp for McpRuntimeHttpAdapter<E>
 where
-    E: RuntimeHttpEgress,
+    E: RuntimeHttpEgress + Send + Sync,
 {
-    fn request(
+    async fn request(
         &self,
         request: McpHostHttpRequest,
     ) -> Result<McpHostHttpResponse, McpHostHttpError> {
-        McpRuntimeHttpAdapter::request(self, request)
+        McpRuntimeHttpAdapter::request(self, request).await
     }
 }
 
+#[async_trait]
 impl<T> McpHostHttp for Arc<T>
 where
-    T: McpHostHttp + ?Sized,
+    T: McpHostHttp + ?Sized + Send + Sync,
 {
-    fn request(
+    async fn request(
         &self,
         request: McpHostHttpRequest,
     ) -> Result<McpHostHttpResponse, McpHostHttpError> {
-        self.as_ref().request(request)
+        self.as_ref().request(request).await
     }
 }
 
@@ -365,7 +371,7 @@ where
         self.state.next_id.fetch_add(1, Ordering::SeqCst)
     }
 
-    fn send_json_rpc(
+    async fn send_json_rpc(
         &self,
         request: &McpClientRequest,
         session_key: &McpHostHttpSessionKey,
@@ -414,6 +420,7 @@ where
                 response_body_limit,
                 timeout_ms: plan.timeout_ms,
             })
+            .await
             .map_err(mcp_client_http_error)?;
 
         let usage = ResourceUsage {
@@ -540,37 +547,43 @@ where
         self.preflight_tools_call_credentials(&request, tool_call_params.clone())?;
 
         let mut usage = ResourceUsage::default();
-        let initialize = self.send_json_rpc(
-            &request,
-            &session_key,
-            Some(self.next_request_id()),
-            McpJsonRpcMethod::Initialize,
-            Some(json_rpc_initialize_params()),
-        )?;
+        let initialize = self
+            .send_json_rpc(
+                &request,
+                &session_key,
+                Some(self.next_request_id()),
+                McpJsonRpcMethod::Initialize,
+                Some(json_rpc_initialize_params()),
+            )
+            .await?;
         accumulate_usage(&mut usage, initialize.usage);
         if initialize.response.error {
             return Err(response_error());
         }
 
-        let initialized = self.send_json_rpc(
-            &request,
-            &session_key,
-            None,
-            McpJsonRpcMethod::InitializedNotification,
-            None,
-        )?;
+        let initialized = self
+            .send_json_rpc(
+                &request,
+                &session_key,
+                None,
+                McpJsonRpcMethod::InitializedNotification,
+                None,
+            )
+            .await?;
         accumulate_usage(&mut usage, initialized.usage);
         if initialized.response.error {
             return Err(response_error());
         }
 
-        let call = self.send_json_rpc(
-            &request,
-            &session_key,
-            Some(self.next_request_id()),
-            McpJsonRpcMethod::ToolsCall,
-            Some(tool_call_params),
-        )?;
+        let call = self
+            .send_json_rpc(
+                &request,
+                &session_key,
+                Some(self.next_request_id()),
+                McpJsonRpcMethod::ToolsCall,
+                Some(tool_call_params),
+            )
+            .await?;
         accumulate_usage(&mut usage, call.usage);
         if call.response.error {
             return Err(response_error());

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -7,6 +7,7 @@
 
 use std::{
     collections::HashMap,
+    panic::AssertUnwindSafe,
     sync::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
@@ -14,6 +15,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use futures_util::FutureExt as _;
 use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, ResourceEstimate, ResourceReservation,
@@ -169,23 +171,26 @@ where
         &self,
         request: McpHostHttpRequest,
     ) -> Result<McpHostHttpResponse, McpHostHttpError> {
-        self.egress
-            .execute(RuntimeHttpEgressRequest {
-                runtime: RuntimeKind::Mcp,
-                scope: request.scope,
-                capability_id: request.capability_id,
-                method: request.method,
-                url: request.url,
-                headers: request.headers,
-                body: request.body,
-                network_policy: request.network_policy,
-                credential_injections: request.credential_injections,
-                response_body_limit: request.response_body_limit,
-                save_body_to: None,
-                timeout_ms: request.timeout_ms,
-            })
-            .await
-            .map_err(mcp_http_error)
+        AssertUnwindSafe(self.egress.execute(RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::Mcp,
+            scope: request.scope,
+            capability_id: request.capability_id,
+            method: request.method,
+            url: request.url,
+            headers: request.headers,
+            body: request.body,
+            network_policy: request.network_policy,
+            credential_injections: request.credential_injections,
+            response_body_limit: request.response_body_limit,
+            save_body_to: None,
+            timeout_ms: request.timeout_ms,
+        }))
+        .catch_unwind()
+        .await
+        .map_err(|_| McpHostHttpError::Egress {
+            reason: "runtime_http_egress_panicked".to_string(),
+        })?
+        .map_err(mcp_http_error)
     }
 }
 

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -136,6 +136,30 @@ async fn mcp_host_http_adapter_returns_sanitized_shared_egress_errors() {
 }
 
 #[tokio::test]
+async fn mcp_host_http_adapter_maps_panicking_runtime_egress_to_sanitized_error() {
+    let adapter = McpRuntimeHttpAdapter::new(Arc::new(PanickingRuntimeEgress));
+
+    let error = adapter
+        .request(McpHostHttpRequest {
+            scope: sample_scope(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            method: NetworkMethod::Get,
+            url: "https://mcp.example.test/mcp".to_string(),
+            headers: vec![],
+            body: vec![],
+            network_policy: mcp_http_policy(),
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            timeout_ms: Some(1000),
+        })
+        .await
+        .expect_err("runtime egress panics should be contained at the MCP host boundary");
+
+    let rendered = error.to_string();
+    assert!(rendered.contains("runtime_http_egress_panicked"));
+}
+
+#[tokio::test]
 async fn concrete_mcp_http_client_routes_json_rpc_through_shared_egress() {
     let scope = sample_scope();
     let plan = host_http_plan();
@@ -678,7 +702,7 @@ async fn mcp_runtime_denies_budget_before_adapter_call() {
         .set_limit(
             account.clone(),
             ResourceLimits {
-                max_concurrency_slots: Some(0),
+                max_output_bytes: Some(1),
                 ..ResourceLimits::default()
             },
         )
@@ -692,7 +716,7 @@ async fn mcp_runtime_denies_budget_before_adapter_call() {
                 capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
                 scope,
                 estimate: ResourceEstimate {
-                    concurrency_slots: Some(1),
+                    output_bytes: Some(10_000),
                     ..ResourceEstimate::default()
                 },
                 resource_reservation: None,
@@ -1412,6 +1436,19 @@ impl RuntimeHttpEgress for SecretEchoRuntimeEgress {
     }
 }
 
+#[derive(Debug)]
+struct PanickingRuntimeEgress;
+
+#[async_trait]
+impl RuntimeHttpEgress for PanickingRuntimeEgress {
+    async fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        panic!("runtime HTTP egress should not unwind through MCP host");
+    }
+}
+
 struct ReleaseFailingGovernor {
     inner: InMemoryResourceGovernor,
 }
@@ -1566,7 +1603,13 @@ transport = "stdio"
 command = "github-mcp"
 args = ["--stdio"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "github-mcp.search"
 description = "Search GitHub"
 effects = ["network", "dispatch_capability"]
@@ -1589,7 +1632,13 @@ runner = "sandboxed_process"
 command = "script-echo"
 args = ["--json"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "script.echo"
 description = "Echo text"
 effects = ["dispatch_capability"]

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -109,8 +109,8 @@ async fn mcp_runtime_requires_host_mediated_egress_for_http_transports() {
     assert!(client.requests.lock().unwrap().is_empty());
 }
 
-#[test]
-fn mcp_host_http_adapter_returns_sanitized_shared_egress_errors() {
+#[tokio::test]
+async fn mcp_host_http_adapter_returns_sanitized_shared_egress_errors() {
     let adapter = McpRuntimeHttpAdapter::new(Arc::new(SecretEchoRuntimeEgress));
 
     let error = adapter
@@ -126,6 +126,7 @@ fn mcp_host_http_adapter_returns_sanitized_shared_egress_errors() {
             response_body_limit: Some(4096),
             timeout_ms: Some(1000),
         })
+        .await
         .expect_err("MCP HTTP adapter errors should be sanitized before runtime visibility");
 
     let rendered = error.to_string();
@@ -1032,8 +1033,9 @@ impl RecordingRuntimeEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -1216,8 +1218,9 @@ impl ScopedSessionRuntimeEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for ScopedSessionRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -1258,8 +1261,9 @@ impl RuntimeHttpEgress for ScopedSessionRuntimeEgress {
 #[derive(Debug)]
 struct InvalidSessionRuntimeEgress;
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for InvalidSessionRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -1282,8 +1286,9 @@ impl RuntimeHttpEgress for InvalidSessionRuntimeEgress {
 #[derive(Debug)]
 struct MissingIdRuntimeEgress;
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for MissingIdRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -1335,8 +1340,9 @@ impl ErrorSessionRuntimeEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for ErrorSessionRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -1392,8 +1398,9 @@ impl RuntimeHttpEgress for ErrorSessionRuntimeEgress {
 #[derive(Debug)]
 struct SecretEchoRuntimeEgress;
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for SecretEchoRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         _request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {

--- a/crates/ironclaw_network/Cargo.toml
+++ b/crates/ironclaw_network/Cargo.toml
@@ -8,9 +8,10 @@ publish = false
 async-trait = "0.1"
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 percent-encoding = "2"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
 thiserror = "2"
+tokio = { version = "1", features = ["rt"] }
 url = "2"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "time"] }

--- a/crates/ironclaw_network/src/egress.rs
+++ b/crates/ironclaw_network/src/egress.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use ironclaw_host_api::NetworkMethod;
 
 use crate::{
@@ -9,13 +10,17 @@ use crate::{
     url_target::network_target_for_http_url,
 };
 
+#[async_trait]
 pub trait NetworkHttpEgress: Send + Sync {
-    fn execute(&self, request: NetworkHttpRequest)
-    -> Result<NetworkHttpResponse, NetworkHttpError>;
+    async fn execute(
+        &self,
+        request: NetworkHttpRequest,
+    ) -> Result<NetworkHttpResponse, NetworkHttpError>;
 }
 
+#[async_trait]
 pub trait NetworkHttpTransport: Send + Sync {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkTransportRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError>;
@@ -49,12 +54,13 @@ impl<T, R> PolicyNetworkHttpEgress<T, R> {
     }
 }
 
+#[async_trait]
 impl<T, R> NetworkHttpEgress for PolicyNetworkHttpEgress<T, R>
 where
-    T: NetworkHttpTransport,
-    R: NetworkResolver,
+    T: NetworkHttpTransport + Send + Sync,
+    R: NetworkResolver + Clone + Send + Sync + 'static,
 {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
@@ -78,12 +84,17 @@ where
                 request_bytes: estimated_request_bytes,
                 response_bytes: 0,
             })?;
-        let resolved_ips = resolve_public_ips(
-            &target,
-            &request.policy,
-            &self.resolver,
-            estimated_request_bytes,
-        )?;
+        let resolver = self.resolver.clone();
+        let policy = request.policy.clone();
+        let resolved_ips = tokio::task::spawn_blocking(move || {
+            resolve_public_ips(&target, &policy, &resolver, estimated_request_bytes)
+        })
+        .await
+        .map_err(|error| NetworkHttpError::Transport {
+            reason: format!("network resolver worker failed: {error}"),
+            request_bytes: estimated_request_bytes,
+            response_bytes: 0,
+        })??;
         let transport_request = NetworkTransportRequest {
             method: permit.method,
             url: request.url,
@@ -93,7 +104,7 @@ where
             response_body_limit: request.response_body_limit,
             timeout_ms: request.timeout_ms,
         };
-        self.transport.execute(transport_request)
+        self.transport.execute(transport_request).await
     }
 }
 

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -1,11 +1,11 @@
 use std::{
     collections::HashMap,
-    io::Read,
     net::SocketAddr,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
+use async_trait::async_trait;
 use ironclaw_host_api::NetworkMethod;
 
 use crate::{
@@ -22,7 +22,7 @@ const MAX_REQWEST_CLIENT_CACHE_ENTRIES: usize = 128;
 #[derive(Clone)]
 pub struct ReqwestNetworkTransport {
     timeout: Duration,
-    client_cache: Arc<Mutex<HashMap<ReqwestClientKey, reqwest::blocking::Client>>>,
+    client_cache: Arc<Mutex<HashMap<ReqwestClientKey, reqwest::Client>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -55,33 +55,33 @@ impl ReqwestNetworkTransport {
         }
     }
 
-    fn client_for(
+    async fn client_for(
         &self,
         key: ReqwestClientKey,
         request_bytes: u64,
-    ) -> Result<reqwest::blocking::Client, NetworkHttpError> {
-        if let Some(client) = self
-            .client_cache
-            .lock()
-            .map_err(|_| NetworkHttpError::Transport {
-                reason: "reqwest client cache lock poisoned".to_string(),
+    ) -> Result<reqwest::Client, NetworkHttpError> {
+        {
+            let cache = self
+                .client_cache
+                .lock()
+                .map_err(|_| NetworkHttpError::Transport {
+                    reason: "reqwest client cache lock poisoned".to_string(),
+                    request_bytes,
+                    response_bytes: 0,
+                })?;
+            if let Some(client) = cache.get(&key).cloned() {
+                return Ok(client);
+            }
+        }
+
+        let build_key = key.clone();
+        let client = tokio::task::spawn_blocking(move || build_reqwest_client(&build_key))
+            .await
+            .map_err(|error| NetworkHttpError::Transport {
+                reason: format!("reqwest client builder task failed: {error}"),
                 request_bytes,
                 response_bytes: 0,
             })?
-            .get(&key)
-            .cloned()
-        {
-            return Ok(client);
-        }
-
-        let mut builder = reqwest::blocking::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .timeout(key.timeout);
-        if !key.resolved_addrs.is_empty() {
-            builder = builder.resolve_to_addrs(&key.host, &key.resolved_addrs);
-        }
-        let client = builder
-            .build()
             .map_err(|error| NetworkHttpError::Transport {
                 reason: reqwest_error_diagnostic(&error),
                 request_bytes,
@@ -103,8 +103,19 @@ impl ReqwestNetworkTransport {
     }
 }
 
+fn build_reqwest_client(key: &ReqwestClientKey) -> Result<reqwest::Client, reqwest::Error> {
+    let mut builder = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(key.timeout);
+    if !key.resolved_addrs.is_empty() {
+        builder = builder.resolve_to_addrs(&key.host, &key.resolved_addrs);
+    }
+    builder.build()
+}
+
+#[async_trait]
 impl NetworkHttpTransport for ReqwestNetworkTransport {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkTransportRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
@@ -137,15 +148,17 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
             .copied()
             .map(|resolved_ip| SocketAddr::new(resolved_ip, port))
             .collect::<Vec<_>>();
-        let client = self.client_for(
-            ReqwestClientKey {
-                host,
-                port,
-                resolved_addrs,
-                timeout: effective_request_timeout(request.timeout_ms, self.timeout),
-            },
-            request_bytes,
-        )?;
+        let client = self
+            .client_for(
+                ReqwestClientKey {
+                    host,
+                    port,
+                    resolved_addrs,
+                    timeout: effective_request_timeout(request.timeout_ms, self.timeout),
+                },
+                request_bytes,
+            )
+            .await?;
 
         let mut req = client
             .request(reqwest_method(request.method), url)
@@ -153,11 +166,14 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
         for (name, value) in request.headers {
             req = req.header(name, value);
         }
-        let response = req.send().map_err(|error| NetworkHttpError::Transport {
-            reason: reqwest_error_diagnostic(&error),
-            request_bytes,
-            response_bytes: 0,
-        })?;
+        let mut response = req
+            .send()
+            .await
+            .map_err(|error| NetworkHttpError::Transport {
+                reason: reqwest_error_diagnostic(&error),
+                request_bytes,
+                response_bytes: 0,
+            })?;
         let status = response.status().as_u16();
         let headers = response
             .headers()
@@ -166,23 +182,38 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
             .collect::<Vec<_>>();
         let limit = effective_response_body_limit(request.response_body_limit);
         let mut body = Vec::new();
-        let mut reader = response.take(limit.saturating_add(1));
-        reader
-            .read_to_end(&mut body)
-            .map_err(|error| NetworkHttpError::Transport {
-                reason: error.to_string(),
-                request_bytes,
-                response_bytes: body.len() as u64,
-            })?;
-        let response_bytes = body.len() as u64;
-        if response_bytes > limit {
-            return Err(NetworkHttpError::ResponseBodyLimit {
-                limit,
-                request_bytes,
-                response_bytes,
-            });
+        while let Some(chunk) =
+            response
+                .chunk()
+                .await
+                .map_err(|error| NetworkHttpError::Transport {
+                    reason: error.to_string(),
+                    request_bytes,
+                    response_bytes: body.len() as u64,
+                })?
+        {
+            let current_len = body.len() as u64;
+            let remaining = limit.saturating_sub(current_len);
+            if chunk.len() as u64 > remaining {
+                let take = remaining.saturating_add(1) as usize;
+                body.extend_from_slice(&chunk[..take.min(chunk.len())]);
+                return Err(NetworkHttpError::ResponseBodyLimit {
+                    limit,
+                    request_bytes,
+                    response_bytes: body.len() as u64,
+                });
+            }
+            body.extend_from_slice(&chunk);
+            let response_bytes = body.len() as u64;
+            if response_bytes > limit {
+                return Err(NetworkHttpError::ResponseBodyLimit {
+                    limit,
+                    request_bytes,
+                    response_bytes,
+                });
+            }
         }
-
+        let response_bytes = body.len() as u64;
         Ok(NetworkHttpResponse {
             status,
             headers,
@@ -265,8 +296,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn reqwest_transport_caches_clients_by_resolution_key() {
+    #[tokio::test]
+    async fn reqwest_transport_caches_clients_by_resolution_key() {
         let transport = ReqwestNetworkTransport::new(Duration::from_secs(1));
         let key = ReqwestClientKey {
             host: "api.example.test".to_string(),
@@ -278,8 +309,8 @@ mod tests {
             timeout: Duration::from_secs(1),
         };
 
-        let _ = transport.client_for(key.clone(), 0).unwrap();
-        let _ = transport.client_for(key, 0).unwrap();
+        let _ = transport.client_for(key.clone(), 0).await.unwrap();
+        let _ = transport.client_for(key, 0).await.unwrap();
 
         assert_eq!(transport.client_cache.lock().unwrap().len(), 1);
     }

--- a/crates/ironclaw_network/tests/network_http_egress_contract.rs
+++ b/crates/ironclaw_network/tests/network_http_egress_contract.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpListener};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ironclaw_host_api::{
     InvocationId, NetworkMethod, NetworkPolicy, NetworkTargetPattern, ResourceScope, TenantId,
@@ -13,8 +13,8 @@ use ironclaw_network::{
     NetworkUsage, PolicyNetworkHttpEgress, ReqwestNetworkTransport,
 };
 
-#[test]
-fn http_egress_authorizes_default_https_port_and_pins_resolved_ip() {
+#[tokio::test]
+async fn http_egress_authorizes_default_https_port_and_pins_resolved_ip() {
     let resolved_ips = vec![
         IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)),
         IpAddr::V4(Ipv4Addr::new(93, 184, 216, 35)),
@@ -46,6 +46,7 @@ fn http_egress_authorizes_default_https_port_and_pins_resolved_ip() {
             response_body_limit: Some(1024),
             timeout_ms: None,
         })
+        .await
         .expect("default HTTPS port should satisfy a 443 policy");
 
     assert_eq!(response.usage.response_bytes, 2);
@@ -55,8 +56,8 @@ fn http_egress_authorizes_default_https_port_and_pins_resolved_ip() {
     assert_eq!(requests[0].response_body_limit, Some(1024));
 }
 
-#[test]
-fn http_egress_forwards_timeout_to_transport() {
+#[tokio::test]
+async fn http_egress_forwards_timeout_to_transport() {
     let transport = RecordingTransport::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -84,6 +85,7 @@ fn http_egress_forwards_timeout_to_transport() {
             response_body_limit: Some(1024),
             timeout_ms: Some(250),
         })
+        .await
         .expect("network response should be returned");
 
     let requests = requests.lock().unwrap();
@@ -91,8 +93,8 @@ fn http_egress_forwards_timeout_to_transport() {
     assert_eq!(requests[0].timeout_ms, Some(250));
 }
 
-#[test]
-fn http_egress_denies_private_resolved_host_before_transport() {
+#[tokio::test]
+async fn http_egress_denies_private_resolved_host_before_transport() {
     let transport = RecordingTransport::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -116,6 +118,7 @@ fn http_egress_denies_private_resolved_host_before_transport() {
             response_body_limit: Some(1024),
             timeout_ms: None,
         })
+        .await
         .expect_err("private resolved targets should fail closed");
 
     assert!(error.to_string().contains("private"));
@@ -123,8 +126,8 @@ fn http_egress_denies_private_resolved_host_before_transport() {
     assert!(requests.lock().unwrap().is_empty());
 }
 
-#[test]
-fn http_egress_counts_url_and_headers_in_policy_egress_estimate_before_transport() {
+#[tokio::test]
+async fn http_egress_counts_url_and_headers_in_policy_egress_estimate_before_transport() {
     let transport = RecordingTransport::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -148,6 +151,7 @@ fn http_egress_counts_url_and_headers_in_policy_egress_estimate_before_transport
             response_body_limit: Some(1024),
             timeout_ms: None,
         })
+        .await
         .expect_err("URL and headers must count toward egress policy estimates");
 
     assert!(matches!(error, NetworkHttpError::PolicyDenied { .. }));
@@ -155,8 +159,29 @@ fn http_egress_counts_url_and_headers_in_policy_egress_estimate_before_transport
     assert!(requests.lock().unwrap().is_empty());
 }
 
-#[test]
-fn http_egress_rejects_caller_provided_host_header_before_transport() {
+#[tokio::test]
+async fn http_egress_maps_panicking_resolver_to_transport_error() {
+    let transport = RecordingTransport::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: b"ok".to_vec(),
+        usage: NetworkUsage::default(),
+    });
+    let requests = transport.requests.clone();
+    let egress = PolicyNetworkHttpEgress::new_with_resolver(transport, PanickingResolver);
+
+    let error = egress
+        .execute(sample_request("https://api.example.test/v1"))
+        .await
+        .expect_err("resolver panic should map to a transport error");
+
+    assert!(matches!(error, NetworkHttpError::Transport { .. }));
+    assert!(error.to_string().contains("network resolver worker failed"));
+    assert!(requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn http_egress_rejects_caller_provided_host_header_before_transport() {
     let transport = RecordingTransport::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -180,6 +205,7 @@ fn http_egress_rejects_caller_provided_host_header_before_transport() {
             response_body_limit: Some(1024),
             timeout_ms: None,
         })
+        .await
         .expect_err("caller-provided Host should not be forwarded after URL policy validation");
 
     assert!(matches!(error, NetworkHttpError::PolicyDenied { .. }));
@@ -188,8 +214,8 @@ fn http_egress_rejects_caller_provided_host_header_before_transport() {
     assert!(requests.lock().unwrap().is_empty());
 }
 
-#[test]
-fn http_egress_rejects_userinfo_url_before_transport() {
+#[tokio::test]
+async fn http_egress_rejects_userinfo_url_before_transport() {
     let transport = RecordingTransport::ok(NetworkHttpResponse {
         status: 200,
         headers: vec![],
@@ -213,6 +239,7 @@ fn http_egress_rejects_userinfo_url_before_transport() {
             response_body_limit: Some(1024),
             timeout_ms: None,
         })
+        .await
         .expect_err("userinfo credentials in URLs must fail before policy/DNS/transport");
 
     assert!(matches!(error, NetworkHttpError::InvalidUrl { .. }));
@@ -220,8 +247,8 @@ fn http_egress_rejects_userinfo_url_before_transport() {
     assert!(requests.lock().unwrap().is_empty());
 }
 
-#[test]
-fn reqwest_transport_does_not_follow_redirects() {
+#[tokio::test]
+async fn reqwest_transport_does_not_follow_redirects() {
     let (url, server) = single_response_server(
         "HTTP/1.1 302 Found\r\nLocation: http://example.invalid/\r\nContent-Length: 0\r\n\r\n",
     );
@@ -238,6 +265,7 @@ fn reqwest_transport_does_not_follow_redirects() {
             response_body_limit: Some(1024),
             timeout_ms: None,
         })
+        .await
         .expect("redirect responses should be returned, not followed");
     server.join().unwrap();
 
@@ -246,8 +274,8 @@ fn reqwest_transport_does_not_follow_redirects() {
     assert_eq!(response.usage.response_bytes, 0);
 }
 
-#[test]
-fn reqwest_transport_uses_all_resolved_addresses_for_connection_fallback() {
+#[tokio::test]
+async fn reqwest_transport_uses_all_resolved_addresses_for_connection_fallback() {
     let (url, server) = single_response_server_for_host(
         "fallback.example.test",
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
@@ -267,6 +295,7 @@ fn reqwest_transport_uses_all_resolved_addresses_for_connection_fallback() {
             response_body_limit: Some(1024),
             timeout_ms: None,
         })
+        .await
         .expect("transport should allow connector fallback across resolved addresses");
     server.join().unwrap();
 
@@ -274,8 +303,8 @@ fn reqwest_transport_uses_all_resolved_addresses_for_connection_fallback() {
     assert_eq!(response.body, b"ok");
 }
 
-#[test]
-fn reqwest_transport_enforces_streaming_response_limit_separately_from_request_bytes() {
+#[tokio::test]
+async fn reqwest_transport_enforces_streaming_response_limit_separately_from_request_bytes() {
     let (url, server) =
         single_response_server("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nabcdef");
     let egress = PolicyNetworkHttpEgress::new(ReqwestNetworkTransport::new(Duration::from_secs(2)));
@@ -291,6 +320,7 @@ fn reqwest_transport_enforces_streaming_response_limit_separately_from_request_b
             response_body_limit: Some(5),
             timeout_ms: None,
         })
+        .await
         .expect_err("response body limit should stop reads after the limit");
     server.join().unwrap();
 
@@ -299,8 +329,8 @@ fn reqwest_transport_enforces_streaming_response_limit_separately_from_request_b
     assert_eq!(error.response_bytes(), 6);
 }
 
-#[test]
-fn reqwest_transport_clamps_oversized_explicit_response_limit_to_safe_default() {
+#[tokio::test]
+async fn reqwest_transport_clamps_oversized_explicit_response_limit_to_safe_default() {
     let body_len = DEFAULT_RESPONSE_BODY_LIMIT + 1;
     let (url, server) = sized_response_server(body_len);
     let transport = ReqwestNetworkTransport::new(Duration::from_secs(2));
@@ -315,6 +345,7 @@ fn reqwest_transport_clamps_oversized_explicit_response_limit_to_safe_default() 
             response_body_limit: Some(DEFAULT_RESPONSE_BODY_LIMIT + 1024),
             timeout_ms: None,
         })
+        .await
         .expect_err("oversized explicit response limits should still be clamped");
     server.join().unwrap();
 
@@ -328,8 +359,8 @@ fn reqwest_transport_clamps_oversized_explicit_response_limit_to_safe_default() 
     assert_eq!(error.response_bytes(), DEFAULT_RESPONSE_BODY_LIMIT + 1);
 }
 
-#[test]
-fn reqwest_transport_clamps_unspecified_response_limit_to_safe_default() {
+#[tokio::test]
+async fn reqwest_transport_clamps_unspecified_response_limit_to_safe_default() {
     let body_len = DEFAULT_RESPONSE_BODY_LIMIT + 1;
     let (url, server) = sized_response_server(body_len);
     let transport = ReqwestNetworkTransport::new(Duration::from_secs(2));
@@ -344,6 +375,7 @@ fn reqwest_transport_clamps_unspecified_response_limit_to_safe_default() {
             response_body_limit: None,
             timeout_ms: None,
         })
+        .await
         .expect_err("unspecified response limits should still be bounded");
     server.join().unwrap();
 
@@ -355,6 +387,30 @@ fn reqwest_transport_clamps_unspecified_response_limit_to_safe_default() {
         }
     ));
     assert_eq!(error.response_bytes(), DEFAULT_RESPONSE_BODY_LIMIT + 1);
+}
+
+#[tokio::test]
+async fn http_egress_concurrent_requests_do_not_serialize_on_transport() {
+    let transport = DelayedTransport::new(Duration::from_millis(100));
+    let egress = PolicyNetworkHttpEgress::new_with_resolver(
+        transport,
+        StaticResolver::new(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))]),
+    );
+
+    let started = Instant::now();
+    let (left, middle, right) = tokio::join!(
+        egress.execute(sample_request("https://api.example.test/v1/left")),
+        egress.execute(sample_request("https://api.example.test/v1/middle")),
+        egress.execute(sample_request("https://api.example.test/v1/right")),
+    );
+
+    left.expect("left request should complete");
+    middle.expect("middle request should complete");
+    right.expect("right request should complete");
+    assert!(
+        started.elapsed() < Duration::from_millis(250),
+        "concurrent async egress calls should overlap instead of serializing"
+    );
 }
 
 #[derive(Clone)]
@@ -372,13 +428,45 @@ impl RecordingTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpTransport for RecordingTransport {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkTransportRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
         self.requests.lock().unwrap().push(request);
         self.response.clone()
+    }
+}
+
+#[derive(Clone)]
+struct DelayedTransport {
+    delay: Duration,
+}
+
+impl DelayedTransport {
+    fn new(delay: Duration) -> Self {
+        Self { delay }
+    }
+}
+
+#[async_trait::async_trait]
+impl NetworkHttpTransport for DelayedTransport {
+    async fn execute(
+        &self,
+        _request: NetworkTransportRequest,
+    ) -> Result<NetworkHttpResponse, NetworkHttpError> {
+        tokio::time::sleep(self.delay).await;
+        Ok(NetworkHttpResponse {
+            status: 200,
+            headers: vec![],
+            body: b"ok".to_vec(),
+            usage: NetworkUsage {
+                request_bytes: 0,
+                response_bytes: 2,
+                resolved_ip: None,
+            },
+        })
     }
 }
 
@@ -396,6 +484,28 @@ impl StaticResolver {
 impl NetworkResolver for StaticResolver {
     fn resolve_ips(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, NetworkHttpError> {
         Ok(self.ips.clone())
+    }
+}
+
+#[derive(Clone)]
+struct PanickingResolver;
+
+impl NetworkResolver for PanickingResolver {
+    fn resolve_ips(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, NetworkHttpError> {
+        panic!("resolver panic")
+    }
+}
+
+fn sample_request(url: &str) -> NetworkHttpRequest {
+    NetworkHttpRequest {
+        scope: sample_scope(),
+        method: NetworkMethod::Get,
+        url: url.to_string(),
+        headers: vec![],
+        body: vec![],
+        policy: policy("api.example.test", Some(443), true, None),
+        response_body_limit: Some(1024),
+        timeout_ms: None,
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/google_oauth/client.rs
+++ b/crates/ironclaw_reborn_composition/src/google_oauth/client.rs
@@ -148,7 +148,6 @@ impl AuthProviderClient for GoogleProviderClient {
             .authorize_google_token_exchange(&callback_scope, &self.capability_id, &network_policy)
             .await?;
 
-        let egress = Arc::clone(&self.egress);
         let egress_request = RuntimeHttpEgressRequest {
             runtime: self.runtime,
             scope: callback_scope.clone(),
@@ -172,10 +171,11 @@ impl AuthProviderClient for GoogleProviderClient {
         // Production host egress requires the policy staged above for this
         // scope/capability. The request-carried policy is only a legacy/test
         // fallback and must not be treated as authority on the production path.
-        let response = tokio::task::spawn_blocking(move || egress.execute(egress_request))
+        let response = self
+            .egress
+            .execute(egress_request)
             .await
             .map_err(|_| AuthProductError::BackendUnavailable)?;
-        let response = response.map_err(|_| AuthProductError::BackendUnavailable)?;
 
         if !(200..300).contains(&response.status) {
             return Err(AuthProductError::TokenExchangeFailed);
@@ -232,7 +232,6 @@ impl AuthProviderClient for GoogleProviderClient {
             .authorize_google_token_exchange(&refresh_scope, &self.capability_id, &network_policy)
             .await?;
 
-        let egress = Arc::clone(&self.egress);
         let egress_request = RuntimeHttpEgressRequest {
             runtime: self.runtime,
             scope: refresh_scope.clone(),
@@ -256,10 +255,11 @@ impl AuthProviderClient for GoogleProviderClient {
         // Production host egress requires the policy staged above for this
         // scope/capability. The request-carried policy is only a legacy/test
         // fallback and must not be treated as authority on the production path.
-        let response = tokio::task::spawn_blocking(move || egress.execute(egress_request))
+        let response = self
+            .egress
+            .execute(egress_request)
             .await
             .map_err(|_| AuthProductError::BackendUnavailable)?;
-        let response = response.map_err(|_| AuthProductError::BackendUnavailable)?;
 
         if !(200..300).contains(&response.status) {
             return Err(map_refresh_error(response.status));

--- a/crates/ironclaw_reborn_composition/src/google_oauth/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/google_oauth/mod.rs
@@ -1394,8 +1394,9 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl RuntimeHttpEgress for RecordingEgress {
-        fn execute(
+        async fn execute(
             &self,
             request: RuntimeHttpEgressRequest,
         ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -1432,8 +1433,9 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl NetworkHttpEgress for RecordingNetwork {
-        fn execute(
+        async fn execute(
             &self,
             request: NetworkHttpRequest,
         ) -> Result<NetworkHttpResponse, NetworkHttpError> {

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -32,8 +32,9 @@ impl RecordingEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -115,8 +116,8 @@ async fn auth_with_google_account(scope: &ResourceScope) -> Arc<InMemoryAuthProd
     auth
 }
 
-#[test]
-fn bundled_gsuite_input_schemas_reject_reviewed_shape_regressions() {
+#[tokio::test]
+async fn bundled_gsuite_input_schemas_reject_reviewed_shape_regressions() {
     let create_event = asset_schema("google-calendar/create_event.input.v1.json");
     let create_event_properties = create_event["properties"].as_object().unwrap();
     assert!(create_event_properties.contains_key("calendar_id"));
@@ -142,8 +143,8 @@ fn bundled_gsuite_input_schemas_reject_reviewed_shape_regressions() {
     );
 }
 
-#[test]
-fn bundled_gsuite_packages_are_host_bundled_but_not_registered_by_default() {
+#[tokio::test]
+async fn bundled_gsuite_packages_are_host_bundled_but_not_registered_by_default() {
     let packages = bundled_gsuite_extension_packages().unwrap();
 
     assert_eq!(packages.len(), 2);
@@ -167,8 +168,8 @@ fn bundled_gsuite_packages_are_host_bundled_but_not_registered_by_default() {
     assert_eq!(capability_count, 15);
 }
 
-#[test]
-fn bundled_gsuite_asset_manifests_match_package_specs() {
+#[tokio::test]
+async fn bundled_gsuite_asset_manifests_match_package_specs() {
     for spec in gsuite_package_specs() {
         let manifest = asset_manifest(spec.extension_id);
 

--- a/crates/ironclaw_scripts/Cargo.toml
+++ b/crates/ironclaw_scripts/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 ironclaw_extensions = { path = "../ironclaw_extensions" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_resources = { path = "../ironclaw_resources" }
+futures-util = "0.3"
 serde_json = "1"
 thiserror = "2"
 

--- a/crates/ironclaw_scripts/Cargo.toml
+++ b/crates/ironclaw_scripts/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]
+async-trait = "0.1"
 rust_decimal_macros = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_scripts/src/lib.rs
+++ b/crates/ironclaw_scripts/src/lib.rs
@@ -187,7 +187,7 @@ where
         Self { egress }
     }
 
-    pub fn request(
+    pub async fn request(
         &self,
         request: ScriptHostHttpRequest,
     ) -> Result<ScriptHostHttpResponse, ScriptHostHttpError> {
@@ -206,6 +206,7 @@ where
                 save_body_to: None,
                 timeout_ms: request.timeout_ms,
             })
+            .await
             .map_err(script_http_error)
     }
 }

--- a/crates/ironclaw_scripts/src/lib.rs
+++ b/crates/ironclaw_scripts/src/lib.rs
@@ -7,11 +7,13 @@
 
 use std::{
     io::{Read, Write},
+    panic::AssertUnwindSafe,
     process::{Command, Stdio},
     thread,
     time::{Duration, Instant},
 };
 
+use futures_util::FutureExt as _;
 use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, MountView, ResourceEstimate, ResourceReservation,
@@ -191,23 +193,26 @@ where
         &self,
         request: ScriptHostHttpRequest,
     ) -> Result<ScriptHostHttpResponse, ScriptHostHttpError> {
-        self.egress
-            .execute(RuntimeHttpEgressRequest {
-                runtime: RuntimeKind::Script,
-                scope: request.scope,
-                capability_id: request.capability_id,
-                method: request.method,
-                url: request.url,
-                headers: request.headers,
-                body: request.body,
-                network_policy: request.network_policy,
-                credential_injections: request.credential_injections,
-                response_body_limit: request.response_body_limit,
-                save_body_to: None,
-                timeout_ms: request.timeout_ms,
-            })
-            .await
-            .map_err(script_http_error)
+        AssertUnwindSafe(self.egress.execute(RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::Script,
+            scope: request.scope,
+            capability_id: request.capability_id,
+            method: request.method,
+            url: request.url,
+            headers: request.headers,
+            body: request.body,
+            network_policy: request.network_policy,
+            credential_injections: request.credential_injections,
+            response_body_limit: request.response_body_limit,
+            save_body_to: None,
+            timeout_ms: request.timeout_ms,
+        }))
+        .catch_unwind()
+        .await
+        .map_err(|_| ScriptHostHttpError::Egress {
+            reason: "runtime_http_egress_panicked".to_string(),
+        })?
+        .map_err(script_http_error)
     }
 }
 

--- a/crates/ironclaw_scripts/tests/script_http_adapter_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_http_adapter_contract.rs
@@ -139,6 +139,30 @@ async fn script_host_http_adapter_returns_sanitized_shared_egress_errors() {
     assert!(!rendered.contains("network request denied by policy"));
 }
 
+#[tokio::test]
+async fn script_host_http_adapter_maps_panicking_runtime_egress_to_sanitized_error() {
+    let adapter = ScriptRuntimeHttpAdapter::new(Arc::new(PanickingRuntimeEgress));
+
+    let error = adapter
+        .request(ScriptHostHttpRequest {
+            scope: sample_scope(),
+            capability_id: sample_capability_id(),
+            method: NetworkMethod::Get,
+            url: "https://script-api.example.test/run".to_string(),
+            headers: vec![],
+            body: vec![],
+            network_policy: sample_policy(),
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            timeout_ms: None,
+        })
+        .await
+        .expect_err("runtime egress panics should be contained at the script host boundary");
+
+    let rendered = error.to_string();
+    assert!(rendered.contains("runtime_http_egress_panicked"));
+}
+
 #[derive(Clone)]
 struct RecordingRuntimeEgress {
     response: Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>,
@@ -169,6 +193,19 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         self.requests.lock().unwrap().push(request);
         self.response.clone()
+    }
+}
+
+#[derive(Clone)]
+struct PanickingRuntimeEgress;
+
+#[async_trait::async_trait]
+impl RuntimeHttpEgress for PanickingRuntimeEgress {
+    async fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        panic!("runtime HTTP egress should not unwind through script host");
     }
 }
 

--- a/crates/ironclaw_scripts/tests/script_http_adapter_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_http_adapter_contract.rs
@@ -8,8 +8,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_scripts::{ScriptHostHttpRequest, ScriptRuntimeHttpAdapter};
 
-#[test]
-fn script_host_http_adapter_uses_shared_runtime_egress() {
+#[tokio::test]
+async fn script_host_http_adapter_uses_shared_runtime_egress() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 201,
         headers: vec![("content-type".to_string(), "application/json".to_string())],
@@ -35,6 +35,7 @@ fn script_host_http_adapter_uses_shared_runtime_egress() {
             response_body_limit: Some(4096),
             timeout_ms: None,
         })
+        .await
         .expect("script host-mediated HTTP should succeed");
 
     assert_eq!(response.status, 201);
@@ -53,8 +54,8 @@ fn script_host_http_adapter_uses_shared_runtime_egress() {
     assert_eq!(requests[0].response_body_limit, Some(4096));
 }
 
-#[test]
-fn script_host_http_adapter_forwards_host_supplied_policy_credentials_timeout_and_limits() {
+#[tokio::test]
+async fn script_host_http_adapter_forwards_host_supplied_policy_credentials_timeout_and_limits() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 204,
         headers: vec![],
@@ -92,6 +93,7 @@ fn script_host_http_adapter_forwards_host_supplied_policy_credentials_timeout_an
             response_body_limit: Some(512),
             timeout_ms: Some(2_500),
         })
+        .await
         .expect("script host-mediated HTTP should succeed");
 
     let requests = egress.requests.lock().unwrap();
@@ -105,8 +107,8 @@ fn script_host_http_adapter_forwards_host_supplied_policy_credentials_timeout_an
     assert_eq!(requests[0].timeout_ms, Some(2_500));
 }
 
-#[test]
-fn script_host_http_adapter_returns_sanitized_shared_egress_errors() {
+#[tokio::test]
+async fn script_host_http_adapter_returns_sanitized_shared_egress_errors() {
     let adapter = ScriptRuntimeHttpAdapter::new(Arc::new(RecordingRuntimeEgress::err(
         RuntimeHttpEgressError::Network {
             reason: "network request denied by policy for sk-test-secret".to_string(),
@@ -128,6 +130,7 @@ fn script_host_http_adapter_returns_sanitized_shared_egress_errors() {
             response_body_limit: Some(4096),
             timeout_ms: None,
         })
+        .await
         .expect_err("network denial should surface as a sanitized adapter error");
 
     let rendered = error.to_string();
@@ -158,8 +161,9 @@ impl RecordingRuntimeEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {

--- a/crates/ironclaw_scripts/tests/script_runner_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_runner_contract.rs
@@ -504,7 +504,13 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/echo.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "echo.say"
 description = "Echo text"
 effects = ["dispatch_capability"]

--- a/crates/ironclaw_wasm/Cargo.toml
+++ b/crates/ironclaw_wasm/Cargo.toml
@@ -9,6 +9,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_wasm_limiter = { path = "../ironclaw_wasm_limiter" }
 serde_json = "1"
 thiserror = "2"
+tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 wasmtime = { version = "44.0.2", features = ["component-model"] }
 wasmtime-wasi = "44.0.2"
@@ -21,7 +22,7 @@ ironclaw_extensions = { path = "../ironclaw_extensions" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_resources = { path = "../ironclaw_resources" }
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 wat = "1.245.1"
 wit-component = "0.245.1"
 wit-parser = "0.245.1"

--- a/crates/ironclaw_wasm/src/host.rs
+++ b/crates/ironclaw_wasm/src/host.rs
@@ -1,11 +1,16 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    future::Future,
+    sync::{Arc, LazyLock, Mutex, mpsc},
+};
 
 use ironclaw_host_api::{
     CapabilityId, NetworkMethod, NetworkPolicy, ResourceScope, RuntimeCredentialInjection,
     RuntimeCredentialSource, RuntimeCredentialTarget, RuntimeHttpEgress, RuntimeHttpEgressError,
-    RuntimeHttpEgressRequest, RuntimeKind, SecretHandle, is_sensitive_runtime_response_header,
+    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind, SecretHandle,
+    is_sensitive_runtime_response_header,
 };
 use serde_json::{Map, Value};
+use tokio::runtime::{Handle, RuntimeFlavor};
 
 use crate::WasmHostError;
 
@@ -299,7 +304,7 @@ where
 
 impl<E> WasmHostHttp for WasmRuntimeHttpAdapter<E>
 where
-    E: RuntimeHttpEgress,
+    E: RuntimeHttpEgress + Clone + Send + Sync + 'static,
 {
     fn request(&self, request: WasmHttpRequest) -> Result<WasmHttpResponse, WasmHostError> {
         let method = match wasm_network_method(&request.method) {
@@ -334,23 +339,27 @@ where
                 }
             };
 
-        let response = self
-            .egress
-            .execute(RuntimeHttpEgressRequest {
-                runtime: RuntimeKind::Wasm,
-                scope: self.scope.clone(),
-                capability_id: self.capability_id.clone(),
-                method,
-                url: request.url,
-                headers,
-                body,
-                network_policy: self.network_policy.clone(),
-                credential_injections,
-                response_body_limit: self.response_body_limit,
-                save_body_to: None,
-                timeout_ms: request.timeout_ms,
-            })
-            .map_err(wasm_http_error)?;
+        let egress = self.egress.clone();
+        let egress_request = RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::Wasm,
+            scope: self.scope.clone(),
+            capability_id: self.capability_id.clone(),
+            method,
+            url: request.url,
+            headers,
+            body,
+            network_policy: self.network_policy.clone(),
+            credential_injections,
+            response_body_limit: self.response_body_limit,
+            save_body_to: None,
+            timeout_ms: request.timeout_ms,
+        };
+        let response = block_on_runtime_http_egress(async move {
+            egress
+                .execute(egress_request)
+                .await
+                .map_err(wasm_http_error)
+        })?;
 
         Ok(WasmHttpResponse {
             status: response.status,
@@ -358,6 +367,59 @@ where
             body: response.body,
         })
     }
+}
+
+fn block_on_runtime_http_egress<F>(future: F) -> Result<RuntimeHttpEgressResponse, WasmHostError>
+where
+    F: Future<Output = Result<RuntimeHttpEgressResponse, WasmHostError>> + Send + 'static,
+{
+    match Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| handle.block_on(future))
+        }
+        Ok(_) => run_runtime_http_egress_on_worker(future),
+        Err(_) => run_runtime_http_egress_future(future),
+    }
+}
+
+fn run_runtime_http_egress_on_worker<F>(
+    future: F,
+) -> Result<RuntimeHttpEgressResponse, WasmHostError>
+where
+    F: Future<Output = Result<RuntimeHttpEgressResponse, WasmHostError>> + Send + 'static,
+{
+    static WASM_HTTP_EGRESS_RUNTIME: LazyLock<Result<tokio::runtime::Runtime, WasmHostError>> =
+        LazyLock::new(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .thread_name("wasm-http-egress")
+                .enable_all()
+                .build()
+                .map_err(|error| {
+                    WasmHostError::Failed(format!("WASM HTTP runtime unavailable: {error}"))
+                })
+        });
+    let runtime = WASM_HTTP_EGRESS_RUNTIME
+        .as_ref()
+        .map_err(|error| error.clone())?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    runtime.spawn(async move {
+        let _ = sender.send(future.await);
+    });
+    receiver
+        .recv()
+        .map_err(|_| WasmHostError::Failed("WASM HTTP runtime worker stopped".to_string()))?
+}
+
+fn run_runtime_http_egress_future<F>(future: F) -> Result<RuntimeHttpEgressResponse, WasmHostError>
+where
+    F: Future<Output = Result<RuntimeHttpEgressResponse, WasmHostError>>,
+{
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| WasmHostError::Failed(format!("WASM HTTP runtime unavailable: {error}")))?
+        .block_on(future)
 }
 
 fn wasm_network_method(method: &str) -> Result<NetworkMethod, WasmHostError> {

--- a/crates/ironclaw_wasm/src/host.rs
+++ b/crates/ironclaw_wasm/src/host.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::{Arc, LazyLock, Mutex, mpsc},
 };
 
@@ -387,7 +388,10 @@ where
 {
     match Handle::try_current() {
         Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
-            tokio::task::block_in_place(|| handle.block_on(future))
+            catch_unwind(AssertUnwindSafe(|| {
+                tokio::task::block_in_place(|| handle.block_on(future))
+            }))
+            .map_err(|_| runtime_http_egress_panicked())?
         }
         Ok(_) => run_runtime_http_egress_on_worker(future),
         Err(_) => run_runtime_http_egress_future(future),
@@ -419,7 +423,13 @@ where
     let runtime = WASM_HTTP_EGRESS_RUNTIME
         .as_ref()
         .map_err(|error| error.clone())?;
-    runtime.block_on(future)
+    catch_unwind(AssertUnwindSafe(|| runtime.block_on(future)))
+        .map_err(|_| runtime_http_egress_panicked())?
+}
+
+fn runtime_http_egress_panicked() -> WasmHostError {
+    tracing::error!("WASM runtime HTTP egress future panicked");
+    WasmHostError::Failed("runtime_http_egress_panicked".to_string())
 }
 
 fn wasm_network_method(method: &str) -> Result<NetworkMethod, WasmHostError> {

--- a/crates/ironclaw_wasm/src/host.rs
+++ b/crates/ironclaw_wasm/src/host.rs
@@ -14,6 +14,18 @@ use tokio::runtime::{Handle, RuntimeFlavor};
 
 use crate::WasmHostError;
 
+static WASM_HTTP_EGRESS_RUNTIME: LazyLock<Result<tokio::runtime::Runtime, WasmHostError>> =
+    LazyLock::new(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("wasm-http-egress")
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                WasmHostError::Failed(format!("WASM HTTP runtime unavailable: {error}"))
+            })
+    });
+
 /// HTTP request shape exposed through the WIT `host.http-request` import.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WasmHttpRequest {
@@ -388,17 +400,6 @@ fn run_runtime_http_egress_on_worker<F>(
 where
     F: Future<Output = Result<RuntimeHttpEgressResponse, WasmHostError>> + Send + 'static,
 {
-    static WASM_HTTP_EGRESS_RUNTIME: LazyLock<Result<tokio::runtime::Runtime, WasmHostError>> =
-        LazyLock::new(|| {
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(1)
-                .thread_name("wasm-http-egress")
-                .enable_all()
-                .build()
-                .map_err(|error| {
-                    WasmHostError::Failed(format!("WASM HTTP runtime unavailable: {error}"))
-                })
-        });
     let runtime = WASM_HTTP_EGRESS_RUNTIME
         .as_ref()
         .map_err(|error| error.clone())?;
@@ -415,11 +416,10 @@ fn run_runtime_http_egress_future<F>(future: F) -> Result<RuntimeHttpEgressRespo
 where
     F: Future<Output = Result<RuntimeHttpEgressResponse, WasmHostError>>,
 {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| WasmHostError::Failed(format!("WASM HTTP runtime unavailable: {error}")))?
-        .block_on(future)
+    let runtime = WASM_HTTP_EGRESS_RUNTIME
+        .as_ref()
+        .map_err(|error| error.clone())?;
+    runtime.block_on(future)
 }
 
 fn wasm_network_method(method: &str) -> Result<NetworkMethod, WasmHostError> {

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -27,7 +27,7 @@ use serde_json::{Value, json};
 use wit_component::{ComponentEncoder, StringEncoding, embed_component_metadata};
 use wit_parser::Resolve;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_loads_component_from_root_filesystem_and_uses_fresh_instances() {
     let component = tool_component(COUNTER_TOOL_WAT);
     let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/counter.wasm", &component).await;
@@ -81,7 +81,7 @@ async fn wasm_lane_loads_component_from_root_filesystem_and_uses_fresh_instances
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_guest_trap_releases_reservation_and_preserves_dispatch_failure() {
     let component = tool_component(TRAP_TOOL_WAT);
     let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/trap.wasm", &component).await;
@@ -123,7 +123,7 @@ async fn wasm_lane_guest_trap_releases_reservation_and_preserves_dispatch_failur
     assert_eq!(recorded[2].error_kind.as_deref(), Some("guest"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_execution_failure_reconciles_preserved_usage_from_runtime() {
     let component = tool_component(&trap_after_http_wat());
     let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/http-trap.wasm", &component).await;
@@ -197,7 +197,7 @@ async fn wasm_lane_execution_failure_reconciles_preserved_usage_from_runtime() {
     assert_eq!(recorded[2].error_kind.as_deref(), Some("guest"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_missing_module_file_returns_sanitized_filesystem_error() {
     let fs = mounted_empty_extension_root();
     let registry = Arc::new(registry_with_package(WASM_MANIFEST));
@@ -243,7 +243,7 @@ async fn wasm_lane_missing_module_file_returns_sanitized_filesystem_error() {
     assert_eq!(recorded[2].error_kind.as_deref(), Some("filesystem_denied"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_malformed_module_returns_sanitized_manifest_error() {
     let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/counter.wasm", b"not wasm").await;
     let registry = Arc::new(registry_with_package(WASM_MANIFEST));
@@ -287,7 +287,7 @@ async fn wasm_lane_malformed_module_returns_sanitized_manifest_error() {
     assert_eq!(recorded[2].error_kind.as_deref(), Some("manifest"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_invalid_output_json_returns_sanitized_output_error() {
     let invalid_output_wat = COUNTER_TOOL_WAT
         .replace(
@@ -345,7 +345,7 @@ async fn wasm_lane_invalid_output_json_returns_sanitized_output_error() {
     assert_eq!(recorded[2].error_kind.as_deref(), Some("output_decode"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_rejects_unsupported_import_through_dispatcher_without_reservation_leak() {
     let raw_unsupported_import = wat::parse_str(UNSUPPORTED_IMPORT_MODULE_WAT).unwrap();
     let fs =
@@ -396,7 +396,7 @@ async fn wasm_lane_rejects_unsupported_import_through_dispatcher_without_reserva
     assert!(!serialized_events.contains("UNSUPPORTED_IMPORT_SENTINEL_3067"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_enforces_memory_growth_budget_through_dispatcher() {
     let memory_growth = COUNTER_TOOL_WAT.replace(
         "global.get $count\n    i32.const 1\n    i32.add",
@@ -455,7 +455,7 @@ async fn wasm_lane_enforces_memory_growth_budget_through_dispatcher() {
     assert!(!serialized_events.contains("MEMORY_BOUND_SENTINEL_3067"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_lane_caps_overdue_host_import_at_dispatch_execution_deadline() {
     let component = tool_component(&trap_after_http_wat());
     let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/http-trap.wasm", &component).await;
@@ -546,8 +546,9 @@ impl RecordingRuntimeEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
@@ -571,8 +572,9 @@ impl SlowRuntimeEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for SlowRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {

--- a/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
+++ b/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
@@ -13,8 +13,8 @@ use ironclaw_wasm::{
 };
 use serde_json::{Value, json};
 
-#[test]
-fn wasm_runtime_http_adapter_uses_shared_runtime_egress() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_uses_shared_runtime_egress() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 201,
         headers: vec![("content-type".to_string(), "application/json".to_string())],
@@ -73,8 +73,40 @@ fn wasm_runtime_http_adapter_uses_shared_runtime_egress() {
     assert_eq!(requests[0].timeout_ms, Some(1234));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_strips_sensitive_response_headers() {
+#[tokio::test]
+async fn wasm_runtime_http_adapter_works_inside_current_thread_runtime() {
+    let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
+        status: 204,
+        headers: Vec::new(),
+        body: Vec::new(),
+        saved_body: None,
+        request_bytes: 0,
+        response_bytes: 0,
+        redaction_applied: false,
+    });
+    let adapter = WasmRuntimeHttpAdapter::new(
+        Arc::new(egress.clone()),
+        sample_scope(),
+        sample_capability_id(),
+        sample_policy(),
+    );
+
+    let response = adapter
+        .request(WasmHttpRequest {
+            method: "GET".to_string(),
+            url: "https://wasm-api.example.test/current-thread".to_string(),
+            headers_json: "{}".to_string(),
+            body: None,
+            timeout_ms: None,
+        })
+        .expect("current-thread runtimes should use the worker bridge without panicking");
+
+    assert_eq!(response.status, 204);
+    assert_eq!(egress.requests.lock().unwrap().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_strips_sensitive_response_headers() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![
@@ -139,8 +171,8 @@ fn wasm_runtime_http_adapter_strips_sensitive_response_headers() {
     assert!(!response.headers_json.contains("x-credential"));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_combines_duplicate_response_headers() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_combines_duplicate_response_headers() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![
@@ -187,8 +219,8 @@ fn wasm_runtime_http_adapter_combines_duplicate_response_headers() {
     );
 }
 
-#[test]
-fn wasm_runtime_http_adapter_resolves_credentials_per_request_destination() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_resolves_credentials_per_request_destination() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![],
@@ -225,8 +257,8 @@ fn wasm_runtime_http_adapter_resolves_credentials_per_request_destination() {
     assert_eq!(requests[0].credential_injections, vec![injection]);
 }
 
-#[test]
-fn wasm_runtime_http_adapter_does_not_reuse_credentials_for_other_destinations() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_does_not_reuse_credentials_for_other_destinations() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![],
@@ -262,8 +294,8 @@ fn wasm_runtime_http_adapter_does_not_reuse_credentials_for_other_destinations()
     assert!(requests[0].credential_injections.is_empty());
 }
 
-#[test]
-fn wasm_runtime_http_adapter_can_build_staged_obligation_credentials() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_can_build_staged_obligation_credentials() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![],
@@ -317,8 +349,8 @@ fn wasm_runtime_http_adapter_can_build_staged_obligation_credentials() {
     );
 }
 
-#[test]
-fn wasm_runtime_http_adapter_rejects_invalid_guest_headers_before_egress() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_rejects_invalid_guest_headers_before_egress() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![],
@@ -349,8 +381,8 @@ fn wasm_runtime_http_adapter_rejects_invalid_guest_headers_before_egress() {
     assert!(egress.requests.lock().unwrap().is_empty());
 }
 
-#[test]
-fn wasm_runtime_http_adapter_redacts_credential_errors_before_guest_visibility() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_redacts_credential_errors_before_guest_visibility() {
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(RecordingRuntimeEgress::err(
             RuntimeHttpEgressError::Credential {
@@ -379,8 +411,8 @@ fn wasm_runtime_http_adapter_redacts_credential_errors_before_guest_visibility()
     assert!(!rendered.contains("sk-test-secret"));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_redacts_shared_request_error_reasons() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_redacts_shared_request_error_reasons() {
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(RecordingRuntimeEgress::err(
             RuntimeHttpEgressError::Request {
@@ -411,8 +443,8 @@ fn wasm_runtime_http_adapter_redacts_shared_request_error_reasons() {
     assert!(!rendered.contains("sk-test-secret"));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_redacts_shared_network_denial_reasons() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_redacts_shared_network_denial_reasons() {
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(RecordingRuntimeEgress::err(
             RuntimeHttpEgressError::Network {
@@ -443,8 +475,8 @@ fn wasm_runtime_http_adapter_redacts_shared_network_denial_reasons() {
     assert!(!rendered.contains("sk-test-secret"));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_marks_post_send_shared_egress_errors_for_accounting() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_marks_post_send_shared_egress_errors_for_accounting() {
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(RecordingRuntimeEgress::err(
             RuntimeHttpEgressError::Response {
@@ -476,8 +508,8 @@ fn wasm_runtime_http_adapter_marks_post_send_shared_egress_errors_for_accounting
     assert!(!rendered.contains("sk-test-secret"));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_marks_zero_body_response_failures_after_send() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_marks_zero_body_response_failures_after_send() {
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(RecordingRuntimeEgress::err(
             RuntimeHttpEgressError::Network {
@@ -509,8 +541,8 @@ fn wasm_runtime_http_adapter_marks_zero_body_response_failures_after_send() {
     assert!(!rendered.contains("sk-test-secret"));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_redacts_credential_provider_errors() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_redacts_credential_provider_errors() {
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
             status: 200,
@@ -544,8 +576,8 @@ fn wasm_runtime_http_adapter_redacts_credential_provider_errors() {
     assert!(!rendered.contains("sk-test-secret"));
 }
 
-#[test]
-fn wasm_runtime_http_adapter_discards_staged_policy_on_pre_egress_request_failure() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_discards_staged_policy_on_pre_egress_request_failure() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![],
@@ -581,8 +613,8 @@ fn wasm_runtime_http_adapter_discards_staged_policy_on_pre_egress_request_failur
     assert_eq!(discarder.discards(), vec![(scope, capability_id)]);
 }
 
-#[test]
-fn wasm_runtime_http_adapter_discards_staged_policy_on_credential_provider_failure() {
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_discards_staged_policy_on_credential_provider_failure() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
         status: 200,
         headers: vec![],
@@ -641,8 +673,9 @@ impl RecordingRuntimeEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingRuntimeEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {

--- a/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
+++ b/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
@@ -574,6 +574,31 @@ async fn wasm_runtime_http_adapter_marks_zero_body_response_failures_after_send(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn wasm_runtime_http_adapter_maps_panicking_runtime_egress_to_failed_error() {
+    let adapter = WasmRuntimeHttpAdapter::new(
+        Arc::new(PanickingRuntimeEgress),
+        sample_scope(),
+        sample_capability_id(),
+        sample_policy(),
+    );
+
+    let error = adapter
+        .request(WasmHttpRequest {
+            method: "GET".to_string(),
+            url: "https://wasm-api.example.test/run".to_string(),
+            headers_json: "{}".to_string(),
+            body: None,
+            timeout_ms: Some(1000),
+        })
+        .expect_err("runtime egress panics should be contained at the WASM host boundary");
+
+    assert!(matches!(
+        error,
+        WasmHostError::Failed(reason) if reason == "runtime_http_egress_panicked"
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn wasm_runtime_http_adapter_redacts_credential_provider_errors() {
     let adapter = WasmRuntimeHttpAdapter::new(
         Arc::new(RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
@@ -713,6 +738,19 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         self.requests.lock().unwrap().push(request);
         self.response.clone()
+    }
+}
+
+#[derive(Clone)]
+struct PanickingRuntimeEgress;
+
+#[async_trait::async_trait]
+impl RuntimeHttpEgress for PanickingRuntimeEgress {
+    async fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        panic!("runtime HTTP egress should not unwind through WASM host");
     }
 }
 

--- a/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
+++ b/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
@@ -105,6 +105,38 @@ async fn wasm_runtime_http_adapter_works_inside_current_thread_runtime() {
     assert_eq!(egress.requests.lock().unwrap().len(), 1);
 }
 
+#[test]
+fn wasm_runtime_http_adapter_reuses_worker_runtime_without_active_tokio_runtime() {
+    let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {
+        status: 204,
+        headers: Vec::new(),
+        body: Vec::new(),
+        saved_body: None,
+        request_bytes: 0,
+        response_bytes: 0,
+        redaction_applied: false,
+    });
+    let adapter = WasmRuntimeHttpAdapter::new(
+        Arc::new(egress.clone()),
+        sample_scope(),
+        sample_capability_id(),
+        sample_policy(),
+    );
+
+    let response = adapter
+        .request(WasmHttpRequest {
+            method: "GET".to_string(),
+            url: "https://wasm-api.example.test/no-runtime".to_string(),
+            headers_json: "{}".to_string(),
+            body: None,
+            timeout_ms: None,
+        })
+        .expect("sync callers should use the shared WASM HTTP runtime");
+
+    assert_eq!(response.status, 204);
+    assert_eq!(egress.requests.lock().unwrap().len(), 1);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn wasm_runtime_http_adapter_strips_sensitive_response_headers() {
     let egress = RecordingRuntimeEgress::ok(RuntimeHttpEgressResponse {

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -1901,8 +1901,9 @@ impl RecordingRuntimeHttpEgress {
     }
 }
 
+#[async_trait::async_trait]
 impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
-    fn execute(
+    async fn execute(
         &self,
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {

--- a/tests/support/reborn/network.rs
+++ b/tests/support/reborn/network.rs
@@ -72,8 +72,9 @@ impl Default for RecordingNetworkHttpTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl NetworkHttpTransport for RecordingNetworkHttpTransport {
-    fn execute(
+    async fn execute(
         &self,
         request: NetworkTransportRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -870,8 +870,8 @@ mod reborn_support_tests {
         assert_eq!(replay.arguments, serde_json::json!({"q": "near"}));
     }
 
-    #[test]
-    fn recording_network_transport_records_request_and_returns_scripted_response() {
+    #[tokio::test]
+    async fn recording_network_transport_records_request_and_returns_scripted_response() {
         let transport = RecordingNetworkHttpTransport::new();
         transport.push_response(NetworkHttpResponse {
             status: 200,
@@ -890,6 +890,7 @@ mod reborn_support_tests {
                 response_body_limit: Some(1024),
                 timeout_ms: Some(50),
             })
+            .await
             .expect("scripted response");
 
         assert_eq!(response.status, 200);
@@ -917,12 +918,13 @@ mod reborn_support_tests {
                 response_body_limit: None,
                 timeout_ms: None,
             })
+            .await
             .expect_err("scripted error");
         assert!(matches!(error, NetworkHttpError::Transport { .. }));
     }
 
-    #[test]
-    fn network_transport_mixed_results() {
+    #[tokio::test]
+    async fn network_transport_mixed_results() {
         let transport = RecordingNetworkHttpTransport::new();
         transport.push_response(NetworkHttpResponse {
             status: 200,
@@ -942,29 +944,43 @@ mod reborn_support_tests {
             usage: NetworkUsage::default(),
         });
 
-        assert_eq!(execute_recorded_get(&transport).expect("first").status, 200);
-        assert!(execute_recorded_get(&transport).is_err());
-        assert_eq!(execute_recorded_get(&transport).expect("third").status, 202);
+        assert_eq!(
+            execute_recorded_get(&transport)
+                .await
+                .expect("first")
+                .status,
+            200
+        );
+        assert!(execute_recorded_get(&transport).await.is_err());
+        assert_eq!(
+            execute_recorded_get(&transport)
+                .await
+                .expect("third")
+                .status,
+            202
+        );
         assert_eq!(transport.requests().len(), 3);
     }
 
-    #[test]
-    fn recording_network_transport_sanitizes_sensitive_request_data() {
+    #[tokio::test]
+    async fn recording_network_transport_sanitizes_sensitive_request_data() {
         let transport = RecordingNetworkHttpTransport::new();
-        let _ = transport.execute(NetworkTransportRequest {
-            method: NetworkMethod::Get,
-            url: "https://api.example.test/v1?token=secret&ok=1".to_string(),
-            headers: vec![
-                ("authorization".to_string(), "Bearer secret".to_string()),
-                ("x-api-key".to_string(), "secret-key".to_string()),
-                ("x-token-type".to_string(), "Bearer".to_string()),
-                ("x-secret-hash-algorithm".to_string(), "sha256".to_string()),
-            ],
-            body: b"secret body".to_vec(),
-            resolved_ips: vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))],
-            response_body_limit: None,
-            timeout_ms: None,
-        });
+        let _ = transport
+            .execute(NetworkTransportRequest {
+                method: NetworkMethod::Get,
+                url: "https://api.example.test/v1?token=secret&ok=1".to_string(),
+                headers: vec![
+                    ("authorization".to_string(), "Bearer secret".to_string()),
+                    ("x-api-key".to_string(), "secret-key".to_string()),
+                    ("x-token-type".to_string(), "Bearer".to_string()),
+                    ("x-secret-hash-algorithm".to_string(), "sha256".to_string()),
+                ],
+                body: b"secret body".to_vec(),
+                resolved_ips: vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))],
+                response_body_limit: None,
+                timeout_ms: None,
+            })
+            .await;
 
         let request = transport.requests().pop().expect("recorded request");
         assert_eq!(request.url, "https://api.example.test/v1?<redacted>");
@@ -981,11 +997,13 @@ mod reborn_support_tests {
         assert_ne!(request.body_sha256, "secret body");
     }
 
-    #[test]
-    fn recording_network_transport_errors_on_unexpected_request() {
+    #[tokio::test]
+    async fn recording_network_transport_errors_on_unexpected_request() {
         let transport = RecordingNetworkHttpTransport::new();
 
-        let error = execute_recorded_get(&transport).expect_err("unexpected request should fail");
+        let error = execute_recorded_get(&transport)
+            .await
+            .expect_err("unexpected request should fail");
 
         assert!(
             matches!(&error, NetworkHttpError::Transport { reason, .. } if reason.contains("unexpected HTTP request")),
@@ -994,8 +1012,8 @@ mod reborn_support_tests {
         assert_eq!(transport.requests().len(), 1);
     }
 
-    #[test]
-    fn policy_network_egress_blocks_private_ip_before_transport() {
+    #[tokio::test]
+    async fn policy_network_egress_blocks_private_ip_before_transport() {
         let transport = RecordingNetworkHttpTransport::new();
         let _default_policy_egress = transport.policy_egress();
         let egress = PolicyNetworkHttpEgress::new_with_resolver(
@@ -1014,6 +1032,7 @@ mod reborn_support_tests {
                 response_body_limit: Some(1024),
                 timeout_ms: None,
             })
+            .await
             .expect_err("private IP should be denied before transport");
 
         assert!(matches!(error, NetworkHttpError::PolicyDenied { .. }));
@@ -2070,18 +2089,20 @@ mod reborn_support_tests {
         }
     }
 
-    fn execute_recorded_get(
+    async fn execute_recorded_get(
         transport: &RecordingNetworkHttpTransport,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
-        transport.execute(NetworkTransportRequest {
-            method: NetworkMethod::Get,
-            url: "https://api.example.test/v1".to_string(),
-            headers: vec![],
-            body: Vec::new(),
-            resolved_ips: vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))],
-            response_body_limit: None,
-            timeout_ms: None,
-        })
+        transport
+            .execute(NetworkTransportRequest {
+                method: NetworkMethod::Get,
+                url: "https://api.example.test/v1".to_string(),
+                headers: vec![],
+                body: Vec::new(),
+                resolved_ips: vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))],
+                response_body_limit: None,
+                timeout_ms: None,
+            })
+            .await
     }
 
     fn tool_result_message(


### PR DESCRIPTION
## Summary

Fixes #4206.

- Convert runtime HTTP egress contracts and transports to async end-to-end.
- Replace blocking reqwest transport usage with async reqwest and keep DNS/client setup on bounded blocking paths.
- Remove production caller `spawn_blocking` wrappers from Google OAuth, GSuite, MCP/scripts, and first-party HTTP paths.
- Preserve policy authorization, credential injection, redaction, response body limits, and save-body behavior.
- Add concurrency and regression coverage for async dispatch, resolver panic mapping, response body hard caps, panic translation, and WASM current-thread runtime bridging.

## Validation

- `cargo test -p ironclaw_network http_egress_concurrent_requests_do_not_serialize_on_transport -- --nocapture`
- `cargo test -p ironclaw_network http_egress_maps_panicking_resolver_to_transport_error -- --nocapture`
- `cargo test -p ironclaw_network reqwest_transport_enforces_streaming_response_limit_separately_from_request_bytes -- --nocapture`
- `cargo test -p ironclaw_wasm wasm_runtime_http_adapter_works_inside_current_thread_runtime -- --nocapture`
- `cargo test -p ironclaw_host_runtime builtin_http_awaits_async_egress_without_blocking_tokio_worker --test first_party_builtin_tools -- --nocapture`
- `cargo test -p ironclaw_host_runtime builtin_http_maps_panicking_runtime_egress_to_backend_failure --test first_party_builtin_tools -- --nocapture`
- `cargo test -p ironclaw_host_runtime fetch_url_response_maps_panicking_runtime_egress_to_backend_failure --lib -- --nocapture`
- `cargo test -p ironclaw_network --tests --no-run`
- `cargo test -p ironclaw_host_runtime --tests --no-run`
- `cargo test -p ironclaw_wasm --tests --no-run`
- `cargo clippy -p ironclaw_network -p ironclaw_host_api -p ironclaw_host_runtime -p ironclaw_first_party_extensions -p ironclaw_reborn_composition -p ironclaw_mcp -p ironclaw_wasm -p ironclaw_scripts --all-targets -- -D warnings`
- `cargo test --tests --no-run`

## Review

Ran two local `code-review` passes with `gpt-5.4-mini` subagents. The second pass found and this branch fixes the concrete runtime-flavor and response-limit issues. Remaining feedback was broad file-size cleanup for existing large modules and was left out of scope.
