### PR TITLE
Wire Reborn auth consumers through staged credentials

### DIFF
--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -248,42 +248,31 @@ mod tests {
     }
 
     #[test]
-    fn from_dispatch_auth_required_preserves_required_secrets() {
-        let secrets = vec![
-            SecretHandle::new("google-access-token").unwrap(),
-            SecretHandle::new("google-refresh-token").unwrap(),
+    fn from_dispatch_auth_required_round_trips_required_secrets() {
+        let cases: &[&[&str]] = &[
+            &[],
+            &["google-access-token"],
+            &["google-access-token", "google-refresh-token"],
         ];
-        let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
-            capability: cap(),
-            required_secrets: secrets.clone(),
-        });
-        match err {
-            CapabilityInvocationError::AuthorizationRequiresAuth {
-                capability,
-                required_secrets,
-            } => {
-                assert_eq!(capability, cap());
-                assert_eq!(required_secrets, secrets);
+        for handles in cases {
+            let secrets: Vec<SecretHandle> = handles
+                .iter()
+                .map(|h| SecretHandle::new(*h).unwrap())
+                .collect();
+            let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
+                capability: cap(),
+                required_secrets: secrets.clone(),
+            });
+            match err {
+                CapabilityInvocationError::AuthorizationRequiresAuth {
+                    capability,
+                    required_secrets,
+                } => {
+                    assert_eq!(capability, cap(), "handles: {handles:?}");
+                    assert_eq!(required_secrets, secrets, "handles: {handles:?}");
+                }
+                other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
             }
-            other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn from_dispatch_auth_required_preserves_empty_required_secrets() {
-        let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
-            capability: cap(),
-            required_secrets: Vec::new(),
-        });
-        match err {
-            CapabilityInvocationError::AuthorizationRequiresAuth {
-                capability,
-                required_secrets,
-            } => {
-                assert_eq!(capability, cap());
-                assert!(required_secrets.is_empty());
-            }
-            other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
         }
     }
 }

--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -135,7 +135,7 @@ fn dispatch_error_kind(error: &DispatchError) -> DispatchFailureKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironclaw_host_api::{ExtensionId, RuntimeDispatchErrorKind, RuntimeKind};
+    use ironclaw_host_api::{ExtensionId, RuntimeDispatchErrorKind, RuntimeKind, SecretHandle};
 
     fn cap() -> CapabilityId {
         CapabilityId::new("test.cap").unwrap()
@@ -244,6 +244,46 @@ mod tests {
                 )
             }
             other => panic!("expected Dispatch variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_dispatch_auth_required_preserves_required_secrets() {
+        let secrets = vec![
+            SecretHandle::new("google-access-token").unwrap(),
+            SecretHandle::new("google-refresh-token").unwrap(),
+        ];
+        let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
+            capability: cap(),
+            required_secrets: secrets.clone(),
+        });
+        match err {
+            CapabilityInvocationError::AuthorizationRequiresAuth {
+                capability,
+                required_secrets,
+            } => {
+                assert_eq!(capability, cap());
+                assert_eq!(required_secrets, secrets);
+            }
+            other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_dispatch_auth_required_preserves_empty_required_secrets() {
+        let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
+            capability: cap(),
+            required_secrets: Vec::new(),
+        });
+        match err {
+            CapabilityInvocationError::AuthorizationRequiresAuth {
+                capability,
+                required_secrets,
+            } => {
+                assert_eq!(capability, cap());
+                assert!(required_secrets.is_empty());
+            }
+            other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
         }
     }
 }

--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -109,8 +109,13 @@ impl From<ProcessError> for CapabilityInvocationError {
 
 impl From<DispatchError> for CapabilityInvocationError {
     fn from(error: DispatchError) -> Self {
-        Self::Dispatch {
-            kind: dispatch_error_kind(&error),
+        match error {
+            DispatchError::AuthRequired { capability } => {
+                Self::AuthorizationRequiresAuth { capability }
+            }
+            other => Self::Dispatch {
+                kind: dispatch_error_kind(&other),
+            },
         }
     }
 }

--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -1,6 +1,7 @@
 use ironclaw_authorization::CapabilityLeaseError;
 use ironclaw_host_api::{
     CapabilityId, DenyReason, DispatchError, DispatchFailureKind, HostApiError, Obligation,
+    SecretHandle,
 };
 use ironclaw_processes::ProcessError;
 
@@ -38,7 +39,10 @@ pub enum CapabilityInvocationError {
     #[error("capability {capability} invocation requires approval")]
     AuthorizationRequiresApproval { capability: CapabilityId },
     #[error("capability {capability} invocation requires authentication")]
-    AuthorizationRequiresAuth { capability: CapabilityId },
+    AuthorizationRequiresAuth {
+        capability: CapabilityId,
+        required_secrets: Vec<SecretHandle>,
+    },
     #[error("capability {capability} invocation fingerprint failed: {source}")]
     InvocationFingerprint {
         capability: CapabilityId,
@@ -110,9 +114,13 @@ impl From<ProcessError> for CapabilityInvocationError {
 impl From<DispatchError> for CapabilityInvocationError {
     fn from(error: DispatchError) -> Self {
         match error {
-            DispatchError::AuthRequired { capability } => {
-                Self::AuthorizationRequiresAuth { capability }
-            }
+            DispatchError::AuthRequired {
+                capability,
+                required_secrets,
+            } => Self::AuthorizationRequiresAuth {
+                capability,
+                required_secrets,
+            },
             other => Self::Dispatch {
                 kind: dispatch_error_kind(&other),
             },

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -470,8 +470,15 @@ where
                     &obligation_outcome,
                 )
                 .await;
-                fail_run_if_configured(self.run_state, &scope, invocation_id, "Dispatch").await;
-                return Err(CapabilityInvocationError::from(error));
+                let invocation_error = CapabilityInvocationError::from(error);
+                apply_run_state_transition_if_configured(
+                    self.run_state,
+                    &scope,
+                    invocation_id,
+                    &invocation_error,
+                )
+                .await;
+                return Err(invocation_error);
             }
         };
 
@@ -807,8 +814,14 @@ where
                     &obligation_outcome,
                 )
                 .await;
-                fail_run_if_configured(Some(run_state), &scope, invocation_id, "Dispatch").await;
                 let invocation_error = CapabilityInvocationError::from(error);
+                apply_run_state_transition_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    &invocation_error,
+                )
+                .await;
                 if let Err(revoke_error) = capability_leases
                     .revoke(&scope, claimed_lease.grant.id)
                     .await

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -1640,6 +1640,12 @@ fn prepare_obligation_error_to_invocation(
             }
         }
         CapabilityObligationError::AuthRequired => {
+            // silent-ok: CapabilityObligationError::AuthRequired is a unit variant
+            // (see ironclaw_capabilities::obligations) and the obligation handler
+            // does not surface which staged secret was missing. The runtime auth
+            // gate accepts an empty `required_secrets` list and falls back to the
+            // generic re-auth prompt; the dispatch-side conversion in error.rs
+            // forwards the real list when DispatchError::AuthRequired is raised.
             CapabilityInvocationError::AuthorizationRequiresAuth {
                 capability: capability_id.clone(),
                 required_secrets: Vec::new(),

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -1642,6 +1642,7 @@ fn prepare_obligation_error_to_invocation(
         CapabilityObligationError::AuthRequired => {
             CapabilityInvocationError::AuthorizationRequiresAuth {
                 capability: capability_id.clone(),
+                required_secrets: Vec::new(),
             }
         }
         CapabilityObligationError::Failed { kind } => CapabilityInvocationError::ObligationFailed {

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -1640,12 +1640,12 @@ fn prepare_obligation_error_to_invocation(
             }
         }
         CapabilityObligationError::AuthRequired => {
-            // silent-ok: CapabilityObligationError::AuthRequired is a unit variant
-            // (see ironclaw_capabilities::obligations) and the obligation handler
-            // does not surface which staged secret was missing. The runtime auth
-            // gate accepts an empty `required_secrets` list and falls back to the
-            // generic re-auth prompt; the dispatch-side conversion in error.rs
-            // forwards the real list when DispatchError::AuthRequired is raised.
+            // CapabilityObligationError::AuthRequired is a unit variant (no secret
+            // handle list).  The obligation handler does not surface which staged
+            // secret was missing, so required_secrets is left empty here.  The
+            // runtime auth gate accepts an empty list and falls back to the generic
+            // re-auth prompt; the dispatch-side conversion in error.rs forwards the
+            // real list when DispatchError::AuthRequired is raised instead.
             CapabilityInvocationError::AuthorizationRequiresAuth {
                 capability: capability_id.clone(),
                 required_secrets: Vec::new(),

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
@@ -51,8 +51,7 @@ async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
     let dispatcher = AuthRequiredDispatcher;
     let run_state = InMemoryRunStateStore::new();
     let authorizer = PlainAllowAuthorizer;
-    let host = CapabilityHost::new(&registry, &dispatcher, &authorizer)
-        .with_run_state(&run_state);
+    let host = CapabilityHost::new(&registry, &dispatcher, &authorizer).with_run_state(&run_state);
     let context = execution_context(CapabilitySet::default());
     let scope = context.resource_scope.clone();
     let invocation_id = context.invocation_id;
@@ -69,7 +68,10 @@ async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
         .unwrap_err();
 
     assert!(
-        matches!(err, CapabilityInvocationError::AuthorizationRequiresAuth { .. }),
+        matches!(
+            err,
+            CapabilityInvocationError::AuthorizationRequiresAuth { .. }
+        ),
         "expected AuthorizationRequiresAuth, got {err:?}"
     );
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
+use ironclaw_authorization::*;
 use ironclaw_capabilities::*;
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
+use ironclaw_trust::TrustDecision;
 use serde_json::json;
 
 mod support;
@@ -38,6 +40,44 @@ async fn capability_host_blocks_auth_when_obligation_requires_secret_recovery() 
     assert!(!dispatcher.has_request());
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::BlockedAuth);
+    assert_eq!(run.error_kind.as_deref(), Some("AuthRequired"));
+}
+
+#[tokio::test]
+async fn capability_host_blocks_auth_when_dispatch_returns_auth_required() {
+    // P1 regression: dispatch-path DispatchError::AuthRequired must transition
+    // the run to BlockedAuth, not Failed, so auth-resume can pick it up.
+    let registry = registry_with_echo_capability();
+    let dispatcher = AuthRequiredDispatcher;
+    let run_state = InMemoryRunStateStore::new();
+    let authorizer = PlainAllowAuthorizer;
+    let host = CapabilityHost::new(&registry, &dispatcher, &authorizer)
+        .with_run_state(&run_state);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+
+    let err = host
+        .invoke_json(CapabilityInvocationRequest {
+            context,
+            capability_id: capability_id(),
+            estimate: ResourceEstimate::default(),
+            input: json!({"message": "dispatch auth required"}),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, CapabilityInvocationError::AuthorizationRequiresAuth { .. }),
+        "expected AuthorizationRequiresAuth, got {err:?}"
+    );
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(
+        run.status,
+        RunStatus::BlockedAuth,
+        "dispatch AuthRequired must set BlockedAuth, not Failed"
+    );
     assert_eq!(run.error_kind.as_deref(), Some("AuthRequired"));
 }
 
@@ -120,5 +160,39 @@ impl CapabilityObligationHandler for PostDispatchAuthRequiredObligationHandler {
         _request: CapabilityObligationCompletionRequest<'_>,
     ) -> Result<CapabilityDispatchResult, CapabilityObligationError> {
         Err(CapabilityObligationError::AuthRequired)
+    }
+}
+
+/// An authorizer that allows dispatch with no obligations, used to let dispatch
+/// reach the dispatcher so `DispatchError::AuthRequired` can be tested.
+struct PlainAllowAuthorizer;
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for PlainAllowAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        _context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+        _trust_decision: &TrustDecision,
+    ) -> Decision {
+        Decision::Allow {
+            obligations: Obligations::empty(),
+        }
+    }
+}
+
+struct AuthRequiredDispatcher;
+
+#[async_trait]
+impl CapabilityDispatcher for AuthRequiredDispatcher {
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        Err(DispatchError::AuthRequired {
+            capability: request.capability_id,
+            required_secrets: vec![],
+        })
     }
 }

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -459,6 +459,7 @@ fn dispatch_error_kind(error: &DispatchError) -> &'static str {
         DispatchError::RuntimeMismatch { .. } => "runtime_mismatch",
         DispatchError::MissingRuntimeBackend { .. } => "missing_runtime_backend",
         DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime",
+        DispatchError::AuthRequired { .. } => "auth_required",
         DispatchError::Mcp { kind }
         | DispatchError::Script { kind }
         | DispatchError::Wasm { kind }

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -361,7 +361,7 @@ where
             capability_id,
             provider,
             runtime,
-            dispatch_error_kind(error),
+            error.event_kind(),
         ))
         .await
     }
@@ -452,17 +452,5 @@ where
     }
 }
 
-fn dispatch_error_kind(error: &DispatchError) -> &'static str {
-    match error {
-        DispatchError::UnknownCapability { .. } => "unknown_capability",
-        DispatchError::UnknownProvider { .. } => "unknown_provider",
-        DispatchError::RuntimeMismatch { .. } => "runtime_mismatch",
-        DispatchError::MissingRuntimeBackend { .. } => "missing_runtime_backend",
-        DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime",
-        DispatchError::AuthRequired { .. } => "auth_required",
-        DispatchError::Mcp { kind }
-        | DispatchError::Script { kind }
-        | DispatchError::Wasm { kind }
-        | DispatchError::FirstParty { kind } => kind.event_kind(),
-    }
-}
+// Removed: dispatch_error_kind was a local copy of DispatchError::event_kind() from ironclaw_host_api.
+// Call error.event_kind() directly instead.

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -55,16 +55,14 @@ pub struct GsuiteExecutor {
 }
 
 impl GsuiteExecutor {
-    pub fn new(accounts: Arc<dyn CredentialAccountService>) -> Self {
+    pub fn new(
+        accounts: Arc<dyn CredentialAccountService>,
+        credential_stager: Arc<dyn GsuiteCredentialStager>,
+    ) -> Self {
         Self {
             resolver: Arc::new(GoogleCredentialResolver::new(accounts)),
-            credential_stager: Arc::new(NoopGsuiteCredentialStager),
+            credential_stager,
         }
-    }
-
-    pub fn with_credential_stager(mut self, stager: Arc<dyn GsuiteCredentialStager>) -> Self {
-        self.credential_stager = stager;
-        self
     }
 
     pub async fn dispatch(
@@ -171,7 +169,7 @@ impl GsuiteExecutor {
                 access_secret: &access_secret,
             })
             .await
-            .map_err(map_stage_error)
+            .map_err(|error| map_stage_error(error, access_secret))
     }
 }
 
@@ -191,11 +189,20 @@ pub struct GsuiteDispatchResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GsuiteCredentialDispatchReason {
     Recovery(CredentialRecoveryProjection),
-    MissingScopes { missing_scopes: Vec<ProviderScope> },
+    MissingScopes {
+        missing_scopes: Vec<ProviderScope>,
+    },
     MissingAccessSecret,
-    AuthRequired,
+    AuthRequired {
+        required_secrets: Vec<ironclaw_host_api::SecretHandle>,
+    },
     BackendAuth,
     HostApi,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GsuiteAuthRequirement {
+    pub required_secrets: Vec<ironclaw_host_api::SecretHandle>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -237,16 +244,25 @@ impl GsuiteDispatchError {
         self.usage.as_ref()
     }
 
+    pub fn auth_requirement(&self) -> Option<GsuiteAuthRequirement> {
+        match self.reason.as_ref()? {
+            GsuiteCredentialDispatchReason::Recovery(_)
+            | GsuiteCredentialDispatchReason::MissingScopes { .. }
+            | GsuiteCredentialDispatchReason::MissingAccessSecret => {
+                Some(GsuiteAuthRequirement::default())
+            }
+            GsuiteCredentialDispatchReason::AuthRequired { required_secrets } => {
+                Some(GsuiteAuthRequirement {
+                    required_secrets: required_secrets.clone(),
+                })
+            }
+            GsuiteCredentialDispatchReason::BackendAuth
+            | GsuiteCredentialDispatchReason::HostApi => None,
+        }
+    }
+
     pub fn is_auth_required(&self) -> bool {
-        matches!(
-            self.reason,
-            Some(
-                GsuiteCredentialDispatchReason::Recovery(_)
-                    | GsuiteCredentialDispatchReason::MissingScopes { .. }
-                    | GsuiteCredentialDispatchReason::MissingAccessSecret
-                    | GsuiteCredentialDispatchReason::AuthRequired
-            )
-        )
+        self.auth_requirement().is_some()
     }
 }
 
@@ -269,19 +285,6 @@ pub trait GsuiteCredentialStager: Send + Sync {
         &self,
         request: GsuiteCredentialStageRequest<'_>,
     ) -> Result<(), GsuiteCredentialStageError>;
-}
-
-#[derive(Debug, Default)]
-pub struct NoopGsuiteCredentialStager;
-
-#[async_trait]
-impl GsuiteCredentialStager for NoopGsuiteCredentialStager {
-    async fn stage(
-        &self,
-        _request: GsuiteCredentialStageRequest<'_>,
-    ) -> Result<(), GsuiteCredentialStageError> {
-        Ok(())
-    }
 }
 
 enum CapabilityExecution {
@@ -778,12 +781,17 @@ fn map_credential_error(error: GoogleCredentialError) -> GsuiteDispatchError {
     }
 }
 
-fn map_stage_error(error: GsuiteCredentialStageError) -> GsuiteDispatchError {
+fn map_stage_error(
+    error: GsuiteCredentialStageError,
+    required_secret: ironclaw_host_api::SecretHandle,
+) -> GsuiteDispatchError {
     match error {
-        GsuiteCredentialStageError::AuthRequired => {
-            GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
-                .with_reason(GsuiteCredentialDispatchReason::AuthRequired)
-        }
+        GsuiteCredentialStageError::AuthRequired => GsuiteDispatchError::new(
+            RuntimeDispatchErrorKind::Client,
+        )
+        .with_reason(GsuiteCredentialDispatchReason::AuthRequired {
+            required_secrets: vec![required_secret],
+        }),
         GsuiteCredentialStageError::Backend => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
                 .with_reason(GsuiteCredentialDispatchReason::HostApi)

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -243,10 +243,21 @@ impl GsuiteDispatchError {
     /// `BackendAuth` and `HostApi` return `None`; all other reasons return `Some`.
     /// `AuthRequired` forwards its explicit handle list; the remaining auth reasons
     /// return an empty `Vec` (the caller reads [`Self::reason`] for richer context).
+    /// `Recovery(Configured)` returns `None` because it signals a backend infrastructure
+    /// failure — prompting the user to re-authenticate would be incorrect.
     pub fn auth_requirement(&self) -> Option<Vec<ironclaw_host_api::SecretHandle>> {
         match self.reason.as_ref()? {
-            GsuiteCredentialDispatchReason::Recovery(_)
-            | GsuiteCredentialDispatchReason::MissingScopes { .. }
+            GsuiteCredentialDispatchReason::Recovery(recovery) => {
+                match recovery.kind() {
+                    // Backend infrastructure failure: do not trigger the auth gate.
+                    CredentialRecoveryKind::Configured => None,
+                    // User-actionable recovery: trigger auth gate with no specific handle.
+                    CredentialRecoveryKind::SetupRequired
+                    | CredentialRecoveryKind::ReauthorizeRequired
+                    | CredentialRecoveryKind::AccountSelectionRequired => Some(Vec::new()),
+                }
+            }
+            GsuiteCredentialDispatchReason::MissingScopes { .. }
             | GsuiteCredentialDispatchReason::MissingAccessSecret => Some(Vec::new()),
             GsuiteCredentialDispatchReason::AuthRequired { required_secrets } => {
                 Some(required_secrets.clone())
@@ -789,7 +800,7 @@ fn map_stage_error(
         }),
         GsuiteCredentialStageError::Backend => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
-                .with_reason(GsuiteCredentialDispatchReason::HostApi)
+                .with_reason(GsuiteCredentialDispatchReason::BackendAuth)
         }
     }
 }
@@ -1355,6 +1366,41 @@ mod tests {
         assert_eq!(merged.len(), 3);
         assert_eq!(merged[0]["name"], "new");
         assert_eq!(merged[2]["email"], "carol@example.com");
+    }
+
+    #[test]
+    fn merge_attendees_with_empty_existing_list() {
+        let merged = merge_attendees(
+            vec![],
+            vec![serde_json::json!({"email": "alice@example.com"})],
+        );
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0]["email"], "alice@example.com");
+    }
+
+    #[test]
+    fn merge_attendees_appends_addition_without_email_field() {
+        // An addition object that has no "email" key cannot be deduped and is
+        // appended unconditionally.
+        let merged = merge_attendees(
+            vec![serde_json::json!({"email": "alice@example.com"})],
+            vec![
+                serde_json::json!({"displayName": "Bob"}), // no email
+                serde_json::json!({"email": "carol@example.com"}),
+            ],
+        );
+        assert_eq!(merged.len(), 3, "got {merged:?}");
+        // Ordering: existing first, then no-email addition, then carol.
+        assert_eq!(merged[0]["email"], "alice@example.com");
+        assert_eq!(merged[1]["displayName"], "Bob");
+        assert_eq!(merged[2]["email"], "carol@example.com");
+    }
+
+    #[test]
+    fn merge_attendees_with_no_additions() {
+        let existing = vec![serde_json::json!({"email": "alice@example.com"})];
+        let merged = merge_attendees(existing.clone(), vec![]);
+        assert_eq!(merged, existing);
     }
 
     #[test]

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -82,11 +82,17 @@ impl GsuiteExecutor {
             .resolve(request.scope, &extension, &scopes)
             .await
             .map_err(map_credential_error)?;
+        // Stage after parsing so a parse failure doesn't leave a staged credential
+        // behind in the injection store.
+        let execution = capability_execution(capability, request.input)?;
         self.stage_credential(&request, credential.access_secret.clone())
             .await?;
-        let execution = capability_execution(capability, request.input)?;
         let (response, network_egress_bytes) = match execution
-            .execute(&request, credential.access_secret)
+            .execute(
+                &request,
+                credential.access_secret,
+                self.credential_stager.as_ref(),
+            )
             .await?
         {
             CapabilityExecutionOutcome::Response {
@@ -109,12 +115,18 @@ impl GsuiteExecutor {
                     .map_err(|error| {
                         add_network_usage(map_credential_error(error), network_egress_bytes)
                     })?;
+                // Parse before staging for the same reason as the primary path:
+                // a parse failure should not leave a credential staged.
+                let retry_execution = capability_execution(capability, request.input)?;
                 self.stage_credential(&request, refreshed.access_secret.clone())
                     .await
                     .map_err(|error| add_network_usage(error, network_egress_bytes))?;
-                let retry_execution = capability_execution(capability, request.input)?;
                 match retry_execution
-                    .execute(&request, refreshed.access_secret)
+                    .execute(
+                        &request,
+                        refreshed.access_secret,
+                        self.credential_stager.as_ref(),
+                    )
                     .await
                     .map_err(|error| add_network_usage(error, network_egress_bytes))?
                 {
@@ -317,6 +329,7 @@ impl CapabilityExecution {
         self,
         request: &GsuiteDispatchRequest<'_>,
         access_secret: ironclaw_host_api::SecretHandle,
+        stager: &dyn GsuiteCredentialStager,
     ) -> Result<CapabilityExecutionOutcome, GsuiteDispatchError> {
         match self {
             Self::Single { method, url, body } => {
@@ -328,7 +341,9 @@ impl CapabilityExecution {
                 let network_egress_bytes = response.request_bytes;
                 Ok(response_outcome(response, network_egress_bytes))
             }
-            Self::AddAttendees(input) => execute_add_attendees(request, access_secret, input).await,
+            Self::AddAttendees(input) => {
+                execute_add_attendees(request, access_secret, stager, input).await
+            }
         }
     }
 }
@@ -336,6 +351,7 @@ impl CapabilityExecution {
 async fn execute_add_attendees(
     request: &GsuiteDispatchRequest<'_>,
     access_secret: ironclaw_host_api::SecretHandle,
+    stager: &dyn GsuiteCredentialStager,
     input: CalendarAddAttendeesInput,
 ) -> Result<CapabilityExecutionOutcome, GsuiteDispatchError> {
     let url = input.event_path.url();
@@ -364,6 +380,22 @@ async fn execute_add_attendees(
         .cloned()
         .unwrap_or_default();
     let attendees = merge_attendees(existing, input.attendees);
+    // Re-stage before the PATCH: the staged-obligation store is one-shot,
+    // so the GET egress consumed the first injection. Stage again so the
+    // PATCH egress has its credential available.
+    stager
+        .stage(GsuiteCredentialStageRequest {
+            scope: request.scope,
+            capability_id: request.capability_id,
+            access_secret: &access_secret,
+        })
+        .await
+        .map_err(|error| {
+            add_network_usage(
+                map_stage_error(error, access_secret.clone()),
+                network_egress_bytes,
+            )
+        })?;
     let mut patch = runtime_request(
         request,
         access_secret,

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -242,6 +242,24 @@ impl GsuiteDispatchError {
         self.usage.as_ref()
     }
 
+    /// Project the credential dispatch reason onto a [`GsuiteAuthRequirement`]
+    /// for the host runtime auth gate.
+    ///
+    /// `GsuiteAuthRequirement` is intentionally narrow: it only carries the
+    /// `required_secrets` list the runtime needs to prompt re-auth. Richer
+    /// recovery context (provider, selected/candidate accounts, recovery
+    /// reason) is exposed separately via [`Self::reason`]; the host runtime
+    /// reads `reason()` for telemetry and surfacing user-facing recovery state,
+    /// while the auth gate only needs the secret list. That is why:
+    ///
+    /// * `Recovery(_)`, `MissingScopes { .. }`, and `MissingAccessSecret`
+    ///   return `Some(GsuiteAuthRequirement::default())` — they are auth
+    ///   required, but the specific staged secrets are unknown at this layer;
+    ///   the projection survives via `reason()`.
+    /// * `AuthRequired { required_secrets }` forwards the explicit list so the
+    ///   gate can name the missing handles.
+    /// * `BackendAuth` and `HostApi` are infrastructure failures, not
+    ///   user-actionable, and return `None`.
     pub fn auth_requirement(&self) -> Option<GsuiteAuthRequirement> {
         match self.reason.as_ref()? {
             GsuiteCredentialDispatchReason::Recovery(_)
@@ -1126,6 +1144,76 @@ mod tests {
             configured_recovery.kind(),
             RuntimeDispatchErrorKind::Backend
         );
+    }
+
+    #[test]
+    fn auth_requirement_classifies_each_credential_dispatch_reason() {
+        // Recovery -> Some(default): projection is preserved via reason(),
+        // not via the requirement struct (see auth_requirement doc-comment).
+        let recovery = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client).with_reason(
+            GsuiteCredentialDispatchReason::Recovery(
+                ironclaw_auth::CredentialRecoveryProjection::setup_required(
+                    ironclaw_auth::AuthProviderId::new("google").unwrap(),
+                    ironclaw_auth::CredentialRecoveryReason::NoAccount,
+                    Vec::new(),
+                ),
+            ),
+        );
+        assert_eq!(
+            recovery.auth_requirement(),
+            Some(GsuiteAuthRequirement::default())
+        );
+        assert!(recovery.is_auth_required());
+        assert!(recovery.reason().is_some());
+
+        // MissingScopes -> Some(default).
+        let scope =
+            ProviderScope::new("https://www.googleapis.com/auth/gmail.modify").expect("scope");
+        let missing_scopes = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
+            .with_reason(GsuiteCredentialDispatchReason::MissingScopes {
+                missing_scopes: vec![scope],
+            });
+        assert_eq!(
+            missing_scopes.auth_requirement(),
+            Some(GsuiteAuthRequirement::default())
+        );
+
+        // MissingAccessSecret -> Some(default).
+        let missing_access = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
+            .with_reason(GsuiteCredentialDispatchReason::MissingAccessSecret);
+        assert_eq!(
+            missing_access.auth_requirement(),
+            Some(GsuiteAuthRequirement::default())
+        );
+
+        // AuthRequired { required_secrets } -> Some with secrets forwarded.
+        let handle = ironclaw_host_api::SecretHandle::new("google-access-token").unwrap();
+        let auth_required = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client).with_reason(
+            GsuiteCredentialDispatchReason::AuthRequired {
+                required_secrets: vec![handle.clone()],
+            },
+        );
+        assert_eq!(
+            auth_required.auth_requirement(),
+            Some(GsuiteAuthRequirement {
+                required_secrets: vec![handle],
+            })
+        );
+
+        // BackendAuth -> None (infra failure, not user-actionable).
+        let backend_auth = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
+            .with_reason(GsuiteCredentialDispatchReason::BackendAuth);
+        assert_eq!(backend_auth.auth_requirement(), None);
+        assert!(!backend_auth.is_auth_required());
+
+        // HostApi -> None.
+        let host_api = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
+            .with_reason(GsuiteCredentialDispatchReason::HostApi);
+        assert_eq!(host_api.auth_requirement(), None);
+
+        // No reason at all -> None.
+        let no_reason = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client);
+        assert_eq!(no_reason.auth_requirement(), None);
     }
 
     #[test]

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -186,7 +186,7 @@ pub struct GsuiteDispatchResult {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GsuiteCredentialDispatchReason {
-    Recovery(CredentialRecoveryProjection),
+    Recovery(Box<CredentialRecoveryProjection>),
     MissingScopes {
         missing_scopes: Vec<ProviderScope>,
     },
@@ -766,7 +766,7 @@ fn map_credential_error(error: GoogleCredentialError) -> GsuiteDispatchError {
     match error {
         GoogleCredentialError::Recovery(recovery) => {
             GsuiteDispatchError::new(map_recovery_kind(&recovery))
-                .with_reason(GsuiteCredentialDispatchReason::Recovery(recovery))
+                .with_reason(GsuiteCredentialDispatchReason::Recovery(Box::new(recovery)))
         }
         GoogleCredentialError::MissingScopes { missing_scopes } => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
@@ -1156,7 +1156,9 @@ mod tests {
             },
         );
         let configured_recovery = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
-            .with_reason(GsuiteCredentialDispatchReason::Recovery(configured_proj));
+            .with_reason(GsuiteCredentialDispatchReason::Recovery(Box::new(
+                configured_proj,
+            )));
         assert_eq!(
             configured_recovery.auth_requirement(),
             None,
@@ -1167,13 +1169,13 @@ mod tests {
         // Recovery(SetupRequired) -> Some(empty): user-actionable, triggers auth gate.
         // Richer projection is preserved via reason() per the doc-comment contract.
         let recovery = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client).with_reason(
-            GsuiteCredentialDispatchReason::Recovery(
+            GsuiteCredentialDispatchReason::Recovery(Box::new(
                 ironclaw_auth::CredentialRecoveryProjection::setup_required(
                     ironclaw_auth::AuthProviderId::new("google").unwrap(),
                     ironclaw_auth::CredentialRecoveryReason::NoAccount,
                     Vec::new(),
                 ),
-            ),
+            )),
         );
         assert_eq!(recovery.auth_requirement(), Some(Vec::new()));
         assert!(recovery.is_auth_required());

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -6,6 +6,7 @@ use std::{
     time::Instant,
 };
 
+use async_trait::async_trait;
 use futures_util::FutureExt as _;
 use ironclaw_auth::{
     CredentialAccountService, CredentialRecoveryKind, CredentialRecoveryProjection, ProviderScope,
@@ -50,13 +51,20 @@ const GMAIL_API_BASE: &str = "https://gmail.googleapis.com/gmail/v1";
 #[derive(Clone)]
 pub struct GsuiteExecutor {
     resolver: Arc<GoogleCredentialResolver>,
+    credential_stager: Arc<dyn GsuiteCredentialStager>,
 }
 
 impl GsuiteExecutor {
     pub fn new(accounts: Arc<dyn CredentialAccountService>) -> Self {
         Self {
             resolver: Arc::new(GoogleCredentialResolver::new(accounts)),
+            credential_stager: Arc::new(NoopGsuiteCredentialStager),
         }
+    }
+
+    pub fn with_credential_stager(mut self, stager: Arc<dyn GsuiteCredentialStager>) -> Self {
+        self.credential_stager = stager;
+        self
     }
 
     pub async fn dispatch(
@@ -76,6 +84,8 @@ impl GsuiteExecutor {
             .resolve(request.scope, &extension, &scopes)
             .await
             .map_err(map_credential_error)?;
+        self.stage_credential(&request, &extension, credential.access_secret.clone())
+            .await?;
         let execution = capability_execution(capability, request.input)?;
         let (response, network_egress_bytes) = match execution
             .execute(&request, credential.access_secret)
@@ -101,6 +111,9 @@ impl GsuiteExecutor {
                     .map_err(|error| {
                         add_network_usage(map_credential_error(error), network_egress_bytes)
                     })?;
+                self.stage_credential(&request, &extension, refreshed.access_secret.clone())
+                    .await
+                    .map_err(|error| add_network_usage(error, network_egress_bytes))?;
                 let retry_execution = capability_execution(capability, request.input)?;
                 match retry_execution
                     .execute(&request, refreshed.access_secret)
@@ -143,6 +156,23 @@ impl GsuiteExecutor {
             },
         })
     }
+
+    async fn stage_credential(
+        &self,
+        request: &GsuiteDispatchRequest<'_>,
+        extension_id: &ExtensionId,
+        access_secret: ironclaw_host_api::SecretHandle,
+    ) -> Result<(), GsuiteDispatchError> {
+        self.credential_stager
+            .stage(GsuiteCredentialStageRequest {
+                scope: request.scope,
+                capability_id: request.capability_id,
+                extension_id,
+                access_secret: &access_secret,
+            })
+            .await
+            .map_err(map_stage_error)
+    }
 }
 
 pub struct GsuiteDispatchRequest<'a> {
@@ -160,8 +190,10 @@ pub struct GsuiteDispatchResult {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GsuiteCredentialDispatchReason {
+    Recovery(CredentialRecoveryProjection),
     MissingScopes { missing_scopes: Vec<ProviderScope> },
     MissingAccessSecret,
+    AuthRequired,
     BackendAuth,
     HostApi,
 }
@@ -203,6 +235,52 @@ impl GsuiteDispatchError {
 
     pub fn usage(&self) -> Option<&ResourceUsage> {
         self.usage.as_ref()
+    }
+
+    pub fn is_auth_required(&self) -> bool {
+        matches!(
+            self.reason,
+            Some(
+                GsuiteCredentialDispatchReason::Recovery(_)
+                    | GsuiteCredentialDispatchReason::MissingScopes { .. }
+                    | GsuiteCredentialDispatchReason::MissingAccessSecret
+                    | GsuiteCredentialDispatchReason::AuthRequired
+            )
+        )
+    }
+}
+
+pub struct GsuiteCredentialStageRequest<'a> {
+    pub scope: &'a ResourceScope,
+    pub capability_id: &'a CapabilityId,
+    pub extension_id: &'a ExtensionId,
+    pub access_secret: &'a ironclaw_host_api::SecretHandle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GsuiteCredentialStageError {
+    AuthRequired,
+    Backend,
+}
+
+#[async_trait]
+pub trait GsuiteCredentialStager: Send + Sync {
+    async fn stage(
+        &self,
+        request: GsuiteCredentialStageRequest<'_>,
+    ) -> Result<(), GsuiteCredentialStageError>;
+}
+
+#[derive(Debug, Default)]
+pub struct NoopGsuiteCredentialStager;
+
+#[async_trait]
+impl GsuiteCredentialStager for NoopGsuiteCredentialStager {
+    async fn stage(
+        &self,
+        _request: GsuiteCredentialStageRequest<'_>,
+    ) -> Result<(), GsuiteCredentialStageError> {
+        Ok(())
     }
 }
 
@@ -679,6 +757,7 @@ fn map_credential_error(error: GoogleCredentialError) -> GsuiteDispatchError {
     match error {
         GoogleCredentialError::Recovery(recovery) => {
             GsuiteDispatchError::new(map_recovery_kind(&recovery))
+                .with_reason(GsuiteCredentialDispatchReason::Recovery(recovery))
         }
         GoogleCredentialError::MissingScopes { missing_scopes } => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
@@ -693,6 +772,19 @@ fn map_credential_error(error: GoogleCredentialError) -> GsuiteDispatchError {
                 .with_reason(GsuiteCredentialDispatchReason::BackendAuth)
         }
         GoogleCredentialError::HostApi(_) => {
+            GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
+                .with_reason(GsuiteCredentialDispatchReason::HostApi)
+        }
+    }
+}
+
+fn map_stage_error(error: GsuiteCredentialStageError) -> GsuiteDispatchError {
+    match error {
+        GsuiteCredentialStageError::AuthRequired => {
+            GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
+                .with_reason(GsuiteCredentialDispatchReason::AuthRequired)
+        }
+        GsuiteCredentialStageError::Backend => {
             GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
                 .with_reason(GsuiteCredentialDispatchReason::HostApi)
         }

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -1139,8 +1139,33 @@ mod tests {
 
     #[test]
     fn auth_requirement_classifies_each_credential_dispatch_reason() {
-        // Recovery -> Some(default): projection is preserved via reason(),
-        // not via the requirement struct (see auth_requirement doc-comment).
+        // Recovery(Configured) -> None: backend infra failure, must NOT trigger the
+        // auth gate even though it carries a Recovery reason.  This is the S1 fix—
+        // the old catch-all Recovery(_) arm incorrectly returned Some(vec![]) here.
+        let configured_proj = ironclaw_auth::CredentialRecoveryProjection::configured(
+            ironclaw_auth::AuthProviderId::new("google").unwrap(),
+            ironclaw_auth::CredentialAccountProjection {
+                id: ironclaw_auth::CredentialAccountId::new(),
+                provider: ironclaw_auth::AuthProviderId::new("google").unwrap(),
+                label: ironclaw_auth::CredentialAccountLabel::new("Google").unwrap(),
+                status: ironclaw_auth::CredentialAccountStatus::Configured,
+                ownership: ironclaw_auth::CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                secret_handle_count: 1,
+            },
+        );
+        let configured_recovery = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)
+            .with_reason(GsuiteCredentialDispatchReason::Recovery(configured_proj));
+        assert_eq!(
+            configured_recovery.auth_requirement(),
+            None,
+            "Recovery(Configured) is a backend infra failure — must not trigger the auth gate"
+        );
+        assert!(!configured_recovery.is_auth_required());
+
+        // Recovery(SetupRequired) -> Some(empty): user-actionable, triggers auth gate.
+        // Richer projection is preserved via reason() per the doc-comment contract.
         let recovery = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client).with_reason(
             GsuiteCredentialDispatchReason::Recovery(
                 ironclaw_auth::CredentialRecoveryProjection::setup_required(

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -82,7 +82,7 @@ impl GsuiteExecutor {
             .resolve(request.scope, &extension, &scopes)
             .await
             .map_err(map_credential_error)?;
-        self.stage_credential(&request, &extension, credential.access_secret.clone())
+        self.stage_credential(&request, credential.access_secret.clone())
             .await?;
         let execution = capability_execution(capability, request.input)?;
         let (response, network_egress_bytes) = match execution
@@ -109,7 +109,7 @@ impl GsuiteExecutor {
                     .map_err(|error| {
                         add_network_usage(map_credential_error(error), network_egress_bytes)
                     })?;
-                self.stage_credential(&request, &extension, refreshed.access_secret.clone())
+                self.stage_credential(&request, refreshed.access_secret.clone())
                     .await
                     .map_err(|error| add_network_usage(error, network_egress_bytes))?;
                 let retry_execution = capability_execution(capability, request.input)?;
@@ -158,14 +158,12 @@ impl GsuiteExecutor {
     async fn stage_credential(
         &self,
         request: &GsuiteDispatchRequest<'_>,
-        extension_id: &ExtensionId,
         access_secret: ironclaw_host_api::SecretHandle,
     ) -> Result<(), GsuiteDispatchError> {
         self.credential_stager
             .stage(GsuiteCredentialStageRequest {
                 scope: request.scope,
                 capability_id: request.capability_id,
-                extension_id,
                 access_secret: &access_secret,
             })
             .await
@@ -269,7 +267,6 @@ impl GsuiteDispatchError {
 pub struct GsuiteCredentialStageRequest<'a> {
     pub scope: &'a ResourceScope,
     pub capability_id: &'a CapabilityId,
-    pub extension_id: &'a ExtensionId,
     pub access_secret: &'a ironclaw_host_api::SecretHandle,
 }
 

--- a/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/handlers.rs
@@ -198,11 +198,6 @@ pub enum GsuiteCredentialDispatchReason {
     HostApi,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct GsuiteAuthRequirement {
-    pub required_secrets: Vec<ironclaw_host_api::SecretHandle>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("GSuite capability dispatch failed: {kind}")]
 pub struct GsuiteDispatchError {
@@ -242,35 +237,19 @@ impl GsuiteDispatchError {
         self.usage.as_ref()
     }
 
-    /// Project the credential dispatch reason onto a [`GsuiteAuthRequirement`]
-    /// for the host runtime auth gate.
+    /// Returns the secret handles the runtime auth gate must prompt for, or `None`
+    /// if the error is an infrastructure failure rather than a user-actionable auth condition.
     ///
-    /// `GsuiteAuthRequirement` is intentionally narrow: it only carries the
-    /// `required_secrets` list the runtime needs to prompt re-auth. Richer
-    /// recovery context (provider, selected/candidate accounts, recovery
-    /// reason) is exposed separately via [`Self::reason`]; the host runtime
-    /// reads `reason()` for telemetry and surfacing user-facing recovery state,
-    /// while the auth gate only needs the secret list. That is why:
-    ///
-    /// * `Recovery(_)`, `MissingScopes { .. }`, and `MissingAccessSecret`
-    ///   return `Some(GsuiteAuthRequirement::default())` — they are auth
-    ///   required, but the specific staged secrets are unknown at this layer;
-    ///   the projection survives via `reason()`.
-    /// * `AuthRequired { required_secrets }` forwards the explicit list so the
-    ///   gate can name the missing handles.
-    /// * `BackendAuth` and `HostApi` are infrastructure failures, not
-    ///   user-actionable, and return `None`.
-    pub fn auth_requirement(&self) -> Option<GsuiteAuthRequirement> {
+    /// `BackendAuth` and `HostApi` return `None`; all other reasons return `Some`.
+    /// `AuthRequired` forwards its explicit handle list; the remaining auth reasons
+    /// return an empty `Vec` (the caller reads [`Self::reason`] for richer context).
+    pub fn auth_requirement(&self) -> Option<Vec<ironclaw_host_api::SecretHandle>> {
         match self.reason.as_ref()? {
             GsuiteCredentialDispatchReason::Recovery(_)
             | GsuiteCredentialDispatchReason::MissingScopes { .. }
-            | GsuiteCredentialDispatchReason::MissingAccessSecret => {
-                Some(GsuiteAuthRequirement::default())
-            }
+            | GsuiteCredentialDispatchReason::MissingAccessSecret => Some(Vec::new()),
             GsuiteCredentialDispatchReason::AuthRequired { required_secrets } => {
-                Some(GsuiteAuthRequirement {
-                    required_secrets: required_secrets.clone(),
-                })
+                Some(required_secrets.clone())
             }
             GsuiteCredentialDispatchReason::BackendAuth
             | GsuiteCredentialDispatchReason::HostApi => None,
@@ -288,11 +267,12 @@ pub struct GsuiteCredentialStageRequest<'a> {
     pub access_secret: &'a ironclaw_host_api::SecretHandle,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GsuiteCredentialStageError {
-    AuthRequired,
-    Backend,
-}
+/// Alias for [`ironclaw_host_api::CredentialStageError`].
+///
+/// The shared type lives in `ironclaw_host_api` so that both the GSuite staging
+/// trait and the host-runtime staging layer use the same type without a
+/// cross-crate conversion step.
+pub type GsuiteCredentialStageError = ironclaw_host_api::CredentialStageError;
 
 #[async_trait]
 pub trait GsuiteCredentialStager: Send + Sync {
@@ -1159,32 +1139,23 @@ mod tests {
                 ),
             ),
         );
-        assert_eq!(
-            recovery.auth_requirement(),
-            Some(GsuiteAuthRequirement::default())
-        );
+        assert_eq!(recovery.auth_requirement(), Some(Vec::new()));
         assert!(recovery.is_auth_required());
         assert!(recovery.reason().is_some());
 
-        // MissingScopes -> Some(default).
+        // MissingScopes -> Some(empty): richer projection lives in reason().
         let scope =
             ProviderScope::new("https://www.googleapis.com/auth/gmail.modify").expect("scope");
         let missing_scopes = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
             .with_reason(GsuiteCredentialDispatchReason::MissingScopes {
                 missing_scopes: vec![scope],
             });
-        assert_eq!(
-            missing_scopes.auth_requirement(),
-            Some(GsuiteAuthRequirement::default())
-        );
+        assert_eq!(missing_scopes.auth_requirement(), Some(Vec::new()));
 
-        // MissingAccessSecret -> Some(default).
+        // MissingAccessSecret -> Some(empty).
         let missing_access = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
             .with_reason(GsuiteCredentialDispatchReason::MissingAccessSecret);
-        assert_eq!(
-            missing_access.auth_requirement(),
-            Some(GsuiteAuthRequirement::default())
-        );
+        assert_eq!(missing_access.auth_requirement(), Some(Vec::new()));
 
         // AuthRequired { required_secrets } -> Some with secrets forwarded.
         let handle = ironclaw_host_api::SecretHandle::new("google-access-token").unwrap();
@@ -1193,12 +1164,7 @@ mod tests {
                 required_secrets: vec![handle.clone()],
             },
         );
-        assert_eq!(
-            auth_required.auth_requirement(),
-            Some(GsuiteAuthRequirement {
-                required_secrets: vec![handle],
-            })
-        );
+        assert_eq!(auth_required.auth_requirement(), Some(vec![handle]));
 
         // BackendAuth -> None (infra failure, not user-actionable).
         let backend_auth = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Backend)

--- a/crates/ironclaw_first_party_extensions/src/gsuite/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/mod.rs
@@ -14,9 +14,9 @@ pub use handlers::{
     CALENDAR_UPDATE_EVENT_CAPABILITY_ID, GMAIL_CREATE_DRAFT_CAPABILITY_ID,
     GMAIL_GET_MESSAGE_CAPABILITY_ID, GMAIL_LIST_MESSAGES_CAPABILITY_ID,
     GMAIL_REPLY_TO_MESSAGE_CAPABILITY_ID, GMAIL_SEND_MESSAGE_CAPABILITY_ID,
-    GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GsuiteAuthRequirement, GsuiteCredentialDispatchReason,
-    GsuiteCredentialStageError, GsuiteCredentialStageRequest, GsuiteCredentialStager,
-    GsuiteDispatchError, GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor,
+    GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GsuiteCredentialDispatchReason, GsuiteCredentialStageError,
+    GsuiteCredentialStageRequest, GsuiteCredentialStager, GsuiteDispatchError,
+    GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor,
 };
 pub use manifest::{
     CALENDAR_EXTENSION_ID, GMAIL_EXTENSION_ID, GSUITE_OUTPUT_BYTES_LIMIT,

--- a/crates/ironclaw_first_party_extensions/src/gsuite/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/mod.rs
@@ -14,9 +14,9 @@ pub use handlers::{
     CALENDAR_UPDATE_EVENT_CAPABILITY_ID, GMAIL_CREATE_DRAFT_CAPABILITY_ID,
     GMAIL_GET_MESSAGE_CAPABILITY_ID, GMAIL_LIST_MESSAGES_CAPABILITY_ID,
     GMAIL_REPLY_TO_MESSAGE_CAPABILITY_ID, GMAIL_SEND_MESSAGE_CAPABILITY_ID,
-    GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GsuiteCredentialDispatchReason, GsuiteCredentialStageError,
-    GsuiteCredentialStageRequest, GsuiteCredentialStager, GsuiteDispatchError,
-    GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor, NoopGsuiteCredentialStager,
+    GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GsuiteAuthRequirement, GsuiteCredentialDispatchReason,
+    GsuiteCredentialStageError, GsuiteCredentialStageRequest, GsuiteCredentialStager,
+    GsuiteDispatchError, GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor,
 };
 pub use manifest::{
     CALENDAR_EXTENSION_ID, GMAIL_EXTENSION_ID, GSUITE_OUTPUT_BYTES_LIMIT,

--- a/crates/ironclaw_first_party_extensions/src/gsuite/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/mod.rs
@@ -14,8 +14,9 @@ pub use handlers::{
     CALENDAR_UPDATE_EVENT_CAPABILITY_ID, GMAIL_CREATE_DRAFT_CAPABILITY_ID,
     GMAIL_GET_MESSAGE_CAPABILITY_ID, GMAIL_LIST_MESSAGES_CAPABILITY_ID,
     GMAIL_REPLY_TO_MESSAGE_CAPABILITY_ID, GMAIL_SEND_MESSAGE_CAPABILITY_ID,
-    GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GsuiteCredentialDispatchReason, GsuiteDispatchError,
-    GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor,
+    GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GsuiteCredentialDispatchReason, GsuiteCredentialStageError,
+    GsuiteCredentialStageRequest, GsuiteCredentialStager, GsuiteDispatchError,
+    GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor, NoopGsuiteCredentialStager,
 };
 pub use manifest::{
     CALENDAR_EXTENSION_ID, GMAIL_EXTENSION_ID, GSUITE_OUTPUT_BYTES_LIMIT,

--- a/crates/ironclaw_first_party_extensions/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/src/lib.rs
@@ -20,11 +20,11 @@ pub use gsuite::{
     GMAIL_LIST_MESSAGES_CAPABILITY_ID, GMAIL_REPLY_TO_MESSAGE_CAPABILITY_ID,
     GMAIL_SEND_MESSAGE_CAPABILITY_ID, GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GSUITE_OUTPUT_BYTES_LIMIT,
     GSUITE_REQUEST_BODY_LIMIT, GSUITE_RESPONSE_BODY_LIMIT, GSUITE_TIMEOUT_MS, GoogleCredential,
-    GoogleCredentialError, GoogleCredentialResolver, GsuiteCapabilityOperation,
-    GsuiteCapabilitySpec, GsuiteCredentialDispatchReason, GsuiteCredentialStageError,
-    GsuiteCredentialStageRequest, GsuiteCredentialStager, GsuiteDispatchError,
-    GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor, GsuitePackageSpec,
-    NoopGsuiteCredentialStager, calendar_package_spec, find_gsuite_capability, gmail_package_spec,
+    GoogleCredentialError, GoogleCredentialResolver, GsuiteAuthRequirement,
+    GsuiteCapabilityOperation, GsuiteCapabilitySpec, GsuiteCredentialDispatchReason,
+    GsuiteCredentialStageError, GsuiteCredentialStageRequest, GsuiteCredentialStager,
+    GsuiteDispatchError, GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor,
+    GsuitePackageSpec, calendar_package_spec, find_gsuite_capability, gmail_package_spec,
     google_api_network_policy, google_provider_id, gsuite_package_specs, gsuite_resource_profile,
 };
 pub use web_access::{

--- a/crates/ironclaw_first_party_extensions/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/src/lib.rs
@@ -20,12 +20,12 @@ pub use gsuite::{
     GMAIL_LIST_MESSAGES_CAPABILITY_ID, GMAIL_REPLY_TO_MESSAGE_CAPABILITY_ID,
     GMAIL_SEND_MESSAGE_CAPABILITY_ID, GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GSUITE_OUTPUT_BYTES_LIMIT,
     GSUITE_REQUEST_BODY_LIMIT, GSUITE_RESPONSE_BODY_LIMIT, GSUITE_TIMEOUT_MS, GoogleCredential,
-    GoogleCredentialError, GoogleCredentialResolver, GsuiteAuthRequirement,
-    GsuiteCapabilityOperation, GsuiteCapabilitySpec, GsuiteCredentialDispatchReason,
-    GsuiteCredentialStageError, GsuiteCredentialStageRequest, GsuiteCredentialStager,
-    GsuiteDispatchError, GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor,
-    GsuitePackageSpec, calendar_package_spec, find_gsuite_capability, gmail_package_spec,
-    google_api_network_policy, google_provider_id, gsuite_package_specs, gsuite_resource_profile,
+    GoogleCredentialError, GoogleCredentialResolver, GsuiteCapabilityOperation,
+    GsuiteCapabilitySpec, GsuiteCredentialDispatchReason, GsuiteCredentialStageError,
+    GsuiteCredentialStageRequest, GsuiteCredentialStager, GsuiteDispatchError,
+    GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor, GsuitePackageSpec,
+    calendar_package_spec, find_gsuite_capability, gmail_package_spec, google_api_network_policy,
+    google_provider_id, gsuite_package_specs, gsuite_resource_profile,
 };
 pub use web_access::{
     EXA_MCP_HOST, NETWORK_EGRESS_LIMIT, WEB_ACCESS_EXTENSION_ID, WEB_GET_CONTENT_CAPABILITY_ID,

--- a/crates/ironclaw_first_party_extensions/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/src/lib.rs
@@ -21,10 +21,11 @@ pub use gsuite::{
     GMAIL_SEND_MESSAGE_CAPABILITY_ID, GMAIL_TRASH_MESSAGE_CAPABILITY_ID, GSUITE_OUTPUT_BYTES_LIMIT,
     GSUITE_REQUEST_BODY_LIMIT, GSUITE_RESPONSE_BODY_LIMIT, GSUITE_TIMEOUT_MS, GoogleCredential,
     GoogleCredentialError, GoogleCredentialResolver, GsuiteCapabilityOperation,
-    GsuiteCapabilitySpec, GsuiteCredentialDispatchReason, GsuiteDispatchError,
+    GsuiteCapabilitySpec, GsuiteCredentialDispatchReason, GsuiteCredentialStageError,
+    GsuiteCredentialStageRequest, GsuiteCredentialStager, GsuiteDispatchError,
     GsuiteDispatchRequest, GsuiteDispatchResult, GsuiteExecutor, GsuitePackageSpec,
-    calendar_package_spec, find_gsuite_capability, gmail_package_spec, google_api_network_policy,
-    google_provider_id, gsuite_package_specs, gsuite_resource_profile,
+    NoopGsuiteCredentialStager, calendar_package_spec, find_gsuite_capability, gmail_package_spec,
+    google_api_network_policy, google_provider_id, gsuite_package_specs, gsuite_resource_profile,
 };
 pub use web_access::{
     EXA_MCP_HOST, NETWORK_EGRESS_LIMIT, WEB_ACCESS_EXTENSION_ID, WEB_GET_CONTENT_CAPABILITY_ID,

--- a/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
+++ b/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
@@ -236,7 +236,7 @@ async fn gsuite_handler_refresh_retries_with_the_same_account_after_account_sele
     ]));
     let capability_id = capability_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
 
-    let output = GsuiteExecutor::new(auth.clone())
+    let output = GsuiteExecutor::new(auth.clone(), noop_credential_stager())
         .dispatch(GsuiteDispatchRequest {
             capability_id: &capability_id,
             scope: &scope,
@@ -351,7 +351,7 @@ async fn gsuite_handler_errors_when_refresh_retry_is_still_auth_expired() {
     ]));
     let capability_id = capability_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
 
-    let error = GsuiteExecutor::new(auth)
+    let error = GsuiteExecutor::new(auth, noop_credential_stager())
         .dispatch(GsuiteDispatchRequest {
             capability_id: &capability_id,
             scope: &scope,
@@ -576,7 +576,7 @@ async fn gsuite_handler_uses_selected_credential_handle_for_runtime_egress() {
     let scope = scope();
     let auth =
         auth_with_google_account(&scope, vec![provider_scope(GOOGLE_GMAIL_SEND_SCOPE)]).await;
-    let executor = GsuiteExecutor::new(auth);
+    let executor = GsuiteExecutor::new(auth, noop_credential_stager());
     let capability_id = capability_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
     let egress = Arc::new(RecordingEgress::permissive_success());
 
@@ -613,7 +613,7 @@ async fn gsuite_handler_applies_google_api_network_policy() {
     let scope = scope();
     let auth =
         auth_with_google_account(&scope, vec![provider_scope(GOOGLE_GMAIL_SEND_SCOPE)]).await;
-    let executor = GsuiteExecutor::new(auth);
+    let executor = GsuiteExecutor::new(auth, noop_credential_stager());
     let capability_id = capability_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
     let egress = Arc::new(RecordingEgress::permissive_success());
 
@@ -649,7 +649,7 @@ async fn gsuite_handler_fails_before_egress_when_scope_is_missing() {
     let scope = scope();
     let auth =
         auth_with_google_account(&scope, vec![provider_scope(GOOGLE_GMAIL_SEND_SCOPE)]).await;
-    let executor = GsuiteExecutor::new(auth);
+    let executor = GsuiteExecutor::new(auth, noop_credential_stager());
     let capability_id = capability_id(GMAIL_TRASH_MESSAGE_CAPABILITY_ID);
     let egress = Arc::new(RecordingEgress::permissive_success());
 
@@ -1291,7 +1291,7 @@ async fn add_attendees_refreshes_expired_get_and_retries_patch() {
         RecordingEgress::json_with_request_bytes(json!({"id":"evt-1","updated":true}), 211),
     ]));
 
-    let result = GsuiteExecutor::new(auth)
+    let result = GsuiteExecutor::new(auth, noop_credential_stager())
         .dispatch(GsuiteDispatchRequest {
             capability_id: &capability_id,
             scope: &scope,
@@ -1345,7 +1345,7 @@ async fn add_attendees_reports_both_google_api_requests() {
         vec![provider_scope(ironclaw_auth::GOOGLE_CALENDAR_EVENTS_SCOPE)],
     )
     .await;
-    let executor = GsuiteExecutor::new(auth);
+    let executor = GsuiteExecutor::new(auth, noop_credential_stager());
     let capability_id = capability_id(CALENDAR_ADD_ATTENDEES_CAPABILITY_ID);
     let egress = Arc::new(RecordingEgress::with_responses(vec![
         RecordingEgress::json_with_request_bytes(
@@ -1381,7 +1381,7 @@ async fn add_attendees_reports_failed_initial_get_network_usage() {
         vec![provider_scope(ironclaw_auth::GOOGLE_CALENDAR_EVENTS_SCOPE)],
     )
     .await;
-    let executor = GsuiteExecutor::new(auth);
+    let executor = GsuiteExecutor::new(auth, noop_credential_stager());
     let capability_id = capability_id(CALENDAR_ADD_ATTENDEES_CAPABILITY_ID);
     let egress = Arc::new(RecordingEgress::with_errors(vec![
         RuntimeHttpEgressError::Network {

--- a/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
+++ b/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
@@ -373,6 +373,65 @@ async fn gsuite_handler_errors_when_refresh_retry_is_still_auth_expired() {
     );
 }
 
+#[tokio::test]
+async fn gsuite_handler_stage_credential_failure_on_refresh_retry_returns_auth_required() {
+    // stage_credential is called twice: once after initial resolve (line 87 in handlers.rs)
+    // and once after the 401-triggered token refresh (line 112).  This test verifies the
+    // second call's failure (CredentialStageError::AuthRequired) is correctly projected
+    // to GsuiteDispatchError::auth_requirement() -> Some([handle]).
+    let scope = scope();
+    let auth = Arc::new(InMemoryAuthProductServices::new());
+    let access_handle = SecretHandle::new("google-access-token").unwrap();
+    ironclaw_auth::CredentialAccountService::create_account(
+        auth.as_ref(),
+        NewCredentialAccount {
+            scope: auth_scope(&scope),
+            provider: google_provider_id().unwrap(),
+            label: CredentialAccountLabel::new("work google").unwrap(),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(access_handle.clone()),
+            refresh_secret: Some(SecretHandle::new("google-refresh-token").unwrap()),
+            scopes: vec![provider_scope(GOOGLE_GMAIL_SEND_SCOPE)],
+        },
+    )
+    .await
+    .unwrap();
+    // Egress: 401 on first call triggers refresh; second call succeeds at egress level
+    // but the post-refresh stager fails with AuthRequired before egress is reached.
+    let egress = Arc::new(RecordingEgress::with_responses(vec![
+        RecordingEgress::json_status(
+            401,
+            json!({"error":{"status":"UNAUTHENTICATED","message":"expired"}}),
+        ),
+        // second egress response is never consumed — stager fails first
+    ]));
+
+    let error = dispatch_error_with_stager(
+        auth,
+        scope,
+        GMAIL_SEND_MESSAGE_CAPABILITY_ID,
+        json!({ "message": { "raw": "base64url-rfc822" } }),
+        egress.clone(),
+        FailOnNthCallStager::fail_on_second_call(),
+    )
+    .await;
+
+    // stage_credential failure on the refresh path must surface as auth_required.
+    assert!(
+        error.is_auth_required(),
+        "post-refresh staging failure must produce auth_required; got: {error:?}"
+    );
+    // Only one egress request was made (the 401-triggering initial request).
+    assert_eq!(
+        egress.requests().len(),
+        1,
+        "exactly one egress request must have been made before stage_credential failure"
+    );
+}
+
 struct AccountSwitchingAuthService {
     state: Mutex<AccountSwitchingAuthState>,
 }

--- a/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
+++ b/crates/ironclaw_first_party_extensions/tests/gsuite_core.rs
@@ -1471,3 +1471,62 @@ async fn add_attendees_reports_failed_initial_get_network_usage() {
         Some(101)
     );
 }
+
+#[tokio::test]
+async fn add_attendees_restages_credential_before_patch() {
+    // P2 regression: the staged-obligation store is one-shot.
+    // execute_add_attendees makes GET then PATCH; without restaging, the PATCH
+    // fires with no credential. We use FailOnNthCallStager to verify the second
+    // staging call happens — if it doesn't happen, the dispatch succeeds instead
+    // of returning AuthRequired.
+    let scope = scope();
+    let auth = auth_with_google_account(
+        &scope,
+        vec![provider_scope(ironclaw_auth::GOOGLE_CALENDAR_EVENTS_SCOPE)],
+    )
+    .await;
+    let capability_id = capability_id(CALENDAR_ADD_ATTENDEES_CAPABILITY_ID);
+    let egress = Arc::new(RecordingEgress::with_responses(vec![
+        RecordingEgress::json_with_request_bytes(
+            json!({
+                "attendees": [{"email": "existing@example.com"}],
+                "etag": "test-etag"
+            }),
+            50,
+        ),
+        // PATCH response — would succeed, but stager fails before we get here
+        RecordingEgress::json_with_request_bytes(json!({"id": "evt-1", "updated": true}), 80),
+    ]));
+
+    // Stager succeeds on first call (for GET), fails AuthRequired on second call (for PATCH).
+    // Without the P2 fix, the second staging call never happens and dispatch succeeds.
+    let error = GsuiteExecutor::new(auth, FailOnNthCallStager::fail_on_second_call())
+        .dispatch(GsuiteDispatchRequest {
+            capability_id: &capability_id,
+            scope: &scope,
+            input: &json!({
+                "calendar_id": "primary",
+                "event_id": "evt-1",
+                "attendees": [{"email": "new@example.com"}]
+            }),
+            runtime_http_egress: egress.clone(),
+        })
+        .await
+        .expect_err("second staging should fail with AuthRequired before PATCH fires");
+
+    assert!(
+        error.is_auth_required(),
+        "stager auth-required on PATCH restage must surface as AuthRequired; got {error:?}"
+    );
+    // Only the GET fired; PATCH was blocked by staging failure
+    assert_eq!(
+        egress.requests().len(),
+        1,
+        "PATCH must not fire after staging failure; egress count should be 1 (GET only)"
+    );
+    assert_eq!(
+        error.usage().map(|u| u.network_egress_bytes),
+        Some(50),
+        "GET network bytes must be reported even when PATCH staging fails"
+    );
+}

--- a/crates/ironclaw_first_party_extensions/tests/support/mod.rs
+++ b/crates/ironclaw_first_party_extensions/tests/support/mod.rs
@@ -5,11 +5,13 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use async_trait::async_trait;
 use ironclaw_auth::{
     AuthProductScope, AuthSurface, CredentialAccountLabel, CredentialAccountStatus,
     CredentialOwnership, InMemoryAuthProductServices, NewCredentialAccount, ProviderScope,
 };
 use ironclaw_first_party_extensions::{
+    GsuiteCredentialStageError, GsuiteCredentialStageRequest, GsuiteCredentialStager,
     GsuiteDispatchError, GsuiteDispatchRequest, GsuiteExecutor, google_provider_id,
 };
 use ironclaw_host_api::{
@@ -17,6 +19,23 @@ use ironclaw_host_api::{
     RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, SecretHandle, UserId,
 };
 use serde_json::json;
+
+#[derive(Debug, Default)]
+pub(crate) struct NoopCredentialStager;
+
+#[async_trait]
+impl GsuiteCredentialStager for NoopCredentialStager {
+    async fn stage(
+        &self,
+        _request: GsuiteCredentialStageRequest<'_>,
+    ) -> Result<(), GsuiteCredentialStageError> {
+        Ok(())
+    }
+}
+
+pub(crate) fn noop_credential_stager() -> Arc<dyn GsuiteCredentialStager> {
+    Arc::new(NoopCredentialStager)
+}
 
 pub(crate) struct RecordingEgress {
     requests: Mutex<Vec<RuntimeHttpEgressRequest>>,
@@ -228,7 +247,7 @@ pub(crate) async fn dispatch_ok(
     input: serde_json::Value,
     egress: Arc<RecordingEgress>,
 ) -> serde_json::Value {
-    let executor = GsuiteExecutor::new(auth);
+    let executor = GsuiteExecutor::new(auth, noop_credential_stager());
     let capability_id = capability_id(capability);
     executor
         .dispatch(GsuiteDispatchRequest {
@@ -249,7 +268,7 @@ pub(crate) async fn dispatch_error(
     input: serde_json::Value,
     egress: Arc<RecordingEgress>,
 ) -> GsuiteDispatchError {
-    let executor = GsuiteExecutor::new(auth);
+    let executor = GsuiteExecutor::new(auth, noop_credential_stager());
     let capability_id = capability_id(capability);
     executor
         .dispatch(GsuiteDispatchRequest {

--- a/crates/ironclaw_first_party_extensions/tests/support/mod.rs
+++ b/crates/ironclaw_first_party_extensions/tests/support/mod.rs
@@ -280,3 +280,57 @@ pub(crate) async fn dispatch_error(
         .await
         .unwrap_err()
 }
+
+/// A stager that succeeds on the first N-1 calls and fails with AuthRequired on the Nth call.
+pub(crate) struct FailOnNthCallStager {
+    calls: std::sync::atomic::AtomicUsize,
+    fail_on: usize,
+}
+
+impl FailOnNthCallStager {
+    pub(crate) fn fail_on_second_call() -> Arc<dyn GsuiteCredentialStager> {
+        Arc::new(Self {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            fail_on: 2,
+        })
+    }
+}
+
+#[async_trait]
+impl GsuiteCredentialStager for FailOnNthCallStager {
+    async fn stage(
+        &self,
+        _request: GsuiteCredentialStageRequest<'_>,
+    ) -> Result<(), GsuiteCredentialStageError> {
+        let n = self
+            .calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        if n >= self.fail_on {
+            Err(GsuiteCredentialStageError::AuthRequired)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub(crate) async fn dispatch_error_with_stager(
+    auth: Arc<InMemoryAuthProductServices>,
+    scope: ResourceScope,
+    capability: &str,
+    input: serde_json::Value,
+    egress: Arc<RecordingEgress>,
+    stager: Arc<dyn GsuiteCredentialStager>,
+) -> GsuiteDispatchError {
+    let executor = GsuiteExecutor::new(auth, stager);
+    let capability_id = capability_id(capability);
+    executor
+        .dispatch(GsuiteDispatchRequest {
+            capability_id: &capability_id,
+            scope: &scope,
+            input: &input,
+            runtime_http_egress: egress,
+        })
+        .await
+        .unwrap_err()
+}

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -4,6 +4,8 @@
 //! normalized runtime result. Concrete dispatcher/runtime crates implement the
 //! behavior; caller-facing workflow crates depend only on this neutral port.
 
+use std::fmt;
+
 use async_trait::async_trait;
 use serde_json::Value;
 use thiserror::Error;
@@ -158,7 +160,7 @@ impl std::fmt::Display for DispatchFailureKind {
 }
 
 /// Runtime dispatch failures surfaced through the neutral host API port.
-#[derive(Debug, Error)]
+#[derive(Error)]
 pub enum DispatchError {
     #[error("unknown capability {capability}")]
     UnknownCapability { capability: CapabilityId },
@@ -184,6 +186,11 @@ pub enum DispatchError {
         capability: CapabilityId,
         runtime: RuntimeKind,
     },
+    /// Authentication is required to dispatch this capability.
+    ///
+    /// `required_secrets` names the credentials the caller must stage.  The
+    /// field is intentionally absent from the `Debug` output to avoid leaking
+    /// secret-handle identifiers into logs.
     #[error("capability {capability} dispatch requires authentication")]
     AuthRequired {
         capability: CapabilityId,
@@ -197,6 +204,64 @@ pub enum DispatchError {
     Wasm { kind: RuntimeDispatchErrorKind },
     #[error("first-party dispatch failed: {kind}")]
     FirstParty { kind: RuntimeDispatchErrorKind },
+}
+
+impl fmt::Debug for DispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownCapability { capability } => f
+                .debug_struct("UnknownCapability")
+                .field("capability", capability)
+                .finish(),
+            Self::UnknownProvider {
+                capability,
+                provider,
+            } => f
+                .debug_struct("UnknownProvider")
+                .field("capability", capability)
+                .field("provider", provider)
+                .finish(),
+            Self::RuntimeMismatch {
+                capability,
+                descriptor_runtime,
+                package_runtime,
+            } => f
+                .debug_struct("RuntimeMismatch")
+                .field("capability", capability)
+                .field("descriptor_runtime", descriptor_runtime)
+                .field("package_runtime", package_runtime)
+                .finish(),
+            Self::MissingRuntimeBackend { runtime } => f
+                .debug_struct("MissingRuntimeBackend")
+                .field("runtime", runtime)
+                .finish(),
+            Self::UnsupportedRuntime {
+                capability,
+                runtime,
+            } => f
+                .debug_struct("UnsupportedRuntime")
+                .field("capability", capability)
+                .field("runtime", runtime)
+                .finish(),
+            // `required_secrets` handle names are omitted from Debug output to
+            // prevent leaking secret identifiers into logs and error chains.
+            Self::AuthRequired {
+                capability,
+                required_secrets,
+            } => f
+                .debug_struct("AuthRequired")
+                .field("capability", capability)
+                .field(
+                    "required_secrets",
+                    &format!("[{} handle(s) redacted]", required_secrets.len()),
+                )
+                .finish(),
+            Self::Mcp { kind } => f.debug_struct("Mcp").field("kind", kind).finish(),
+            Self::Script { kind } => f.debug_struct("Script").field("kind", kind).finish(),
+            Self::Wasm { kind } => f.debug_struct("Wasm").field("kind", kind).finish(),
+            Self::FirstParty { kind } => f.debug_struct("FirstParty").field("kind", kind).finish(),
+        }
+    }
 }
 
 /// Stable two-variant error for staged credential operations.

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::{
     CapabilityId, ExtensionId, MountView, ResourceEstimate, ResourceReceipt, ResourceReservation,
-    ResourceScope, ResourceUsage, RuntimeKind,
+    ResourceScope, ResourceUsage, RuntimeKind, SecretHandle,
 };
 
 /// Request for one already-authorized declared capability dispatch.
@@ -185,7 +185,10 @@ pub enum DispatchError {
         runtime: RuntimeKind,
     },
     #[error("capability {capability} dispatch requires authentication")]
-    AuthRequired { capability: CapabilityId },
+    AuthRequired {
+        capability: CapabilityId,
+        required_secrets: Vec<SecretHandle>,
+    },
     #[error("MCP dispatch failed: {kind}")]
     Mcp { kind: RuntimeDispatchErrorKind },
     #[error("script dispatch failed: {kind}")]

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -199,6 +199,19 @@ pub enum DispatchError {
     FirstParty { kind: RuntimeDispatchErrorKind },
 }
 
+/// Stable two-variant error for staged credential operations.
+///
+/// Both the host-runtime staging layer (`ProductAuthCredentialStageError`) and the
+/// per-extension staging traits (e.g. `GsuiteCredentialStageError`) map 1:1 to this
+/// type so that no mechanical conversion glue is needed across crate boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialStageError {
+    /// Credential is missing, expired, or revoked — user must re-authenticate.
+    AuthRequired,
+    /// Internal staging failure not attributable to the user's credentials.
+    Backend,
+}
+
 impl DispatchError {
     pub const fn failure_kind(&self) -> DispatchFailureKind {
         match self {
@@ -212,6 +225,25 @@ impl DispatchError {
             | Self::Script { kind }
             | Self::Wasm { kind }
             | Self::FirstParty { kind } => DispatchFailureKind::Runtime(*kind),
+        }
+    }
+
+    /// Stable event-token string for the error, suitable for telemetry and structured logging.
+    ///
+    /// This is the single canonical source for dispatch error event tokens; crates should
+    /// call this method rather than maintaining a parallel local `match` over `DispatchError`.
+    pub fn event_kind(&self) -> &'static str {
+        match self {
+            Self::UnknownCapability { .. } => "unknown_capability",
+            Self::UnknownProvider { .. } => "unknown_provider",
+            Self::RuntimeMismatch { .. } => "runtime_mismatch",
+            Self::MissingRuntimeBackend { .. } => "missing_runtime_backend",
+            Self::UnsupportedRuntime { .. } => "unsupported_runtime",
+            Self::AuthRequired { .. } => "auth_required",
+            Self::Mcp { kind }
+            | Self::Script { kind }
+            | Self::Wasm { kind }
+            | Self::FirstParty { kind } => kind.event_kind(),
         }
     }
 }

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -133,6 +133,7 @@ pub enum DispatchFailureKind {
     RuntimeMismatch,
     MissingRuntimeBackend,
     UnsupportedRuntime,
+    AuthRequired,
     Runtime(RuntimeDispatchErrorKind),
 }
 
@@ -144,6 +145,7 @@ impl DispatchFailureKind {
             Self::RuntimeMismatch => "RuntimeMismatch",
             Self::MissingRuntimeBackend => "MissingRuntimeBackend",
             Self::UnsupportedRuntime => "UnsupportedRuntime",
+            Self::AuthRequired => "AuthRequired",
             Self::Runtime(kind) => kind.as_str(),
         }
     }
@@ -182,6 +184,8 @@ pub enum DispatchError {
         capability: CapabilityId,
         runtime: RuntimeKind,
     },
+    #[error("capability {capability} dispatch requires authentication")]
+    AuthRequired { capability: CapabilityId },
     #[error("MCP dispatch failed: {kind}")]
     Mcp { kind: RuntimeDispatchErrorKind },
     #[error("script dispatch failed: {kind}")]
@@ -200,6 +204,7 @@ impl DispatchError {
             Self::RuntimeMismatch { .. } => DispatchFailureKind::RuntimeMismatch,
             Self::MissingRuntimeBackend { .. } => DispatchFailureKind::MissingRuntimeBackend,
             Self::UnsupportedRuntime { .. } => DispatchFailureKind::UnsupportedRuntime,
+            Self::AuthRequired { .. } => DispatchFailureKind::AuthRequired,
             Self::Mcp { kind }
             | Self::Script { kind }
             | Self::Wasm { kind }

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1689,3 +1689,29 @@ fn sample_network_policy() -> NetworkPolicy {
         max_egress_bytes: Some(1024 * 1024),
     }
 }
+
+#[test]
+fn dispatch_error_event_kind_pins_auth_required_token() {
+    // "auth_required" is a stable observability token used in tracing and metrics.
+    // Regressions (typos, missing match arms) must be caught here.
+    let cap = || CapabilityId::new("test.cap").unwrap();
+    let handle = SecretHandle::new("google-access-token").unwrap();
+
+    assert_eq!(
+        DispatchError::AuthRequired {
+            capability: cap(),
+            required_secrets: vec![handle],
+        }
+        .event_kind(),
+        "auth_required"
+    );
+    // Empty required_secrets must produce the same token.
+    assert_eq!(
+        DispatchError::AuthRequired {
+            capability: cap(),
+            required_secrets: Vec::new(),
+        }
+        .event_kind(),
+        "auth_required"
+    );
+}

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1715,3 +1715,31 @@ fn dispatch_error_event_kind_pins_auth_required_token() {
         "auth_required"
     );
 }
+
+#[test]
+fn dispatch_error_auth_required_debug_redacts_required_secrets() {
+    let handle = SecretHandle::new("google-access-token").unwrap();
+    let error = DispatchError::AuthRequired {
+        capability: CapabilityId::new("test.cap").unwrap(),
+        required_secrets: vec![handle],
+    };
+    let debug = format!("{error:?}");
+    assert!(
+        !debug.contains("google-access-token"),
+        "handle name must not appear in Debug output; got: {debug}"
+    );
+    assert!(
+        debug.contains("1 handle(s) redacted"),
+        "redaction count must appear in Debug output; got: {debug}"
+    );
+    // Empty list variant.
+    let empty = DispatchError::AuthRequired {
+        capability: CapabilityId::new("test.cap").unwrap(),
+        required_secrets: Vec::new(),
+    };
+    let debug_empty = format!("{empty:?}");
+    assert!(
+        debug_empty.contains("0 handle(s) redacted"),
+        "zero redaction count must appear; got: {debug_empty}"
+    );
+}

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -280,6 +280,24 @@ fn dispatch_errors_preserve_typed_failure_kind() {
         .failure_kind(),
         DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)
     );
+    let required_secrets = vec![SecretHandle::new("google-access-token").unwrap()];
+    assert_eq!(
+        DispatchError::AuthRequired {
+            capability: CapabilityId::new("test.cap").unwrap(),
+            required_secrets: required_secrets.clone(),
+        }
+        .failure_kind(),
+        DispatchFailureKind::AuthRequired
+    );
+    // Empty required_secrets must classify the same way.
+    assert_eq!(
+        DispatchError::AuthRequired {
+            capability: CapabilityId::new("test.cap").unwrap(),
+            required_secrets: Vec::new(),
+        }
+        .failure_kind(),
+        DispatchFailureKind::AuthRequired
+    );
 }
 
 #[test]
@@ -324,6 +342,11 @@ fn dispatch_failure_kind_display_preserves_stable_literals() {
     assert_eq!(
         DispatchFailureKind::UnsupportedRuntime.as_str(),
         "UnsupportedRuntime"
+    );
+    assert_eq!(DispatchFailureKind::AuthRequired.as_str(), "AuthRequired");
+    assert_eq!(
+        DispatchFailureKind::AuthRequired.to_string(),
+        "AuthRequired"
     );
     assert_eq!(
         DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::NetworkDenied).as_str(),

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -103,11 +103,24 @@ impl FirstPartyCapabilityResult {
 pub struct FirstPartyCapabilityError {
     kind: RuntimeDispatchErrorKind,
     usage: Option<ResourceUsage>,
+    auth_required: bool,
 }
 
 impl FirstPartyCapabilityError {
     pub fn new(kind: RuntimeDispatchErrorKind) -> Self {
-        Self { kind, usage: None }
+        Self {
+            kind,
+            usage: None,
+            auth_required: false,
+        }
+    }
+
+    pub fn auth_required() -> Self {
+        Self {
+            kind: RuntimeDispatchErrorKind::Client,
+            usage: None,
+            auth_required: true,
+        }
     }
 
     pub fn with_usage(mut self, usage: ResourceUsage) -> Self {
@@ -121,6 +134,10 @@ impl FirstPartyCapabilityError {
 
     pub fn usage(&self) -> Option<&ResourceUsage> {
         self.usage.as_ref()
+    }
+
+    pub fn is_auth_required(&self) -> bool {
+        self.auth_required
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use async_trait::async_trait;
 use ironclaw_host_api::{
     CapabilityId, MountView, ResourceEstimate, ResourceScope, ResourceUsage,
-    RuntimeDispatchErrorKind,
+    RuntimeDispatchErrorKind, SecretHandle,
 };
 use serde_json::Value;
 
@@ -103,7 +103,12 @@ impl FirstPartyCapabilityResult {
 pub struct FirstPartyCapabilityError {
     kind: RuntimeDispatchErrorKind,
     usage: Option<ResourceUsage>,
-    auth_required: bool,
+    auth: Option<FirstPartyAuthRequirement>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FirstPartyAuthRequirement {
+    pub required_secrets: Vec<SecretHandle>,
 }
 
 impl FirstPartyCapabilityError {
@@ -111,15 +116,19 @@ impl FirstPartyCapabilityError {
         Self {
             kind,
             usage: None,
-            auth_required: false,
+            auth: None,
         }
     }
 
     pub fn auth_required() -> Self {
+        Self::auth_required_with(FirstPartyAuthRequirement::default())
+    }
+
+    pub fn auth_required_with(auth: FirstPartyAuthRequirement) -> Self {
         Self {
             kind: RuntimeDispatchErrorKind::Client,
             usage: None,
-            auth_required: true,
+            auth: Some(auth),
         }
     }
 
@@ -136,8 +145,12 @@ impl FirstPartyCapabilityError {
         self.usage.as_ref()
     }
 
+    pub fn auth_requirement(&self) -> Option<&FirstPartyAuthRequirement> {
+        self.auth.as_ref()
+    }
+
     pub fn is_auth_required(&self) -> bool {
-        self.auth_required
+        self.auth.is_some()
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -238,3 +238,63 @@ impl FirstPartyCapabilityRegistry {
         self.handlers.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{ResourceUsage, SecretHandle};
+
+    #[test]
+    fn first_party_capability_error_kind_returns_none_for_auth_required() {
+        // kind() must return None for both auth_required() and auth_required_with().
+        assert_eq!(FirstPartyCapabilityError::auth_required().kind(), None);
+        let handle = SecretHandle::new("google-access-token").unwrap();
+        assert_eq!(
+            FirstPartyCapabilityError::auth_required_with(vec![handle.clone()]).kind(),
+            None
+        );
+        assert!(FirstPartyCapabilityError::auth_required().is_auth_required());
+    }
+
+    #[test]
+    fn first_party_capability_error_with_usage_preserves_required_secrets() {
+        let handle = SecretHandle::new("google-access-token").unwrap();
+        let usage = ResourceUsage {
+            network_egress_bytes: 42,
+            ..ResourceUsage::default()
+        };
+        let error = FirstPartyCapabilityError::auth_required_with(vec![handle.clone()])
+            .with_usage(usage.clone());
+
+        assert!(error.is_auth_required());
+        assert_eq!(
+            error.kind(),
+            None,
+            "kind() must remain None for AuthRequired after with_usage"
+        );
+        assert_eq!(
+            error.required_secrets(),
+            Some(&vec![handle]),
+            "required_secrets must survive with_usage"
+        );
+        assert_eq!(
+            error.usage().map(|u| u.network_egress_bytes),
+            Some(42),
+            "usage must be set"
+        );
+    }
+
+    #[test]
+    fn first_party_capability_error_with_usage_on_dispatch_variant() {
+        use ironclaw_host_api::RuntimeDispatchErrorKind;
+        let error = FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend).with_usage(
+            ResourceUsage {
+                network_egress_bytes: 10,
+                ..ResourceUsage::default()
+            },
+        );
+        assert_eq!(error.kind(), Some(RuntimeDispatchErrorKind::Backend));
+        assert_eq!(error.required_secrets(), None);
+        assert!(!error.is_auth_required());
+    }
+}

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -98,59 +98,92 @@ impl FirstPartyCapabilityResult {
 }
 
 /// Stable redacted first-party handler failure.
+///
+/// Two distinct outcomes are modelled as enum variants rather than optional
+/// fields so that the compiler enforces exhaustive handling and the `Display`
+/// impl produces a meaningful message for both paths.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("first-party capability dispatch failed: {kind}")]
-pub struct FirstPartyCapabilityError {
-    kind: RuntimeDispatchErrorKind,
-    usage: Option<ResourceUsage>,
-    auth: Option<FirstPartyAuthRequirement>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct FirstPartyAuthRequirement {
-    pub required_secrets: Vec<SecretHandle>,
+pub enum FirstPartyCapabilityError {
+    /// Runtime dispatch failed for a non-auth reason.
+    #[error("first-party capability dispatch failed: {kind}")]
+    Dispatch {
+        kind: RuntimeDispatchErrorKind,
+        usage: Option<ResourceUsage>,
+    },
+    /// Dispatch was blocked because a staged credential is missing or expired.
+    #[error("first-party capability requires authentication")]
+    AuthRequired {
+        /// Specific secret handles the runtime auth gate must prompt for.
+        /// May be empty when the obligation layer does not know which handle failed.
+        required_secrets: Vec<SecretHandle>,
+        usage: Option<ResourceUsage>,
+    },
 }
 
 impl FirstPartyCapabilityError {
+    /// Construct a dispatch failure with no auth context.
     pub fn new(kind: RuntimeDispatchErrorKind) -> Self {
-        Self {
-            kind,
-            usage: None,
-            auth: None,
-        }
+        Self::Dispatch { kind, usage: None }
     }
 
+    /// Construct an auth-required failure with no specific secret handles.
     pub fn auth_required() -> Self {
-        Self::auth_required_with(FirstPartyAuthRequirement::default())
-    }
-
-    pub fn auth_required_with(auth: FirstPartyAuthRequirement) -> Self {
-        Self {
-            kind: RuntimeDispatchErrorKind::Client,
+        Self::AuthRequired {
+            required_secrets: Vec::new(),
             usage: None,
-            auth: Some(auth),
         }
     }
 
-    pub fn with_usage(mut self, usage: ResourceUsage) -> Self {
-        self.usage = Some(usage);
-        self
+    /// Construct an auth-required failure naming the handles to re-authorize.
+    pub fn auth_required_with(required_secrets: Vec<SecretHandle>) -> Self {
+        Self::AuthRequired {
+            required_secrets,
+            usage: None,
+        }
     }
 
-    pub fn kind(&self) -> RuntimeDispatchErrorKind {
-        self.kind
+    /// Attach resource usage. Builder-style for use in handler return expressions.
+    pub fn with_usage(self, usage: ResourceUsage) -> Self {
+        match self {
+            Self::Dispatch { kind, .. } => Self::Dispatch {
+                kind,
+                usage: Some(usage),
+            },
+            Self::AuthRequired {
+                required_secrets, ..
+            } => Self::AuthRequired {
+                required_secrets,
+                usage: Some(usage),
+            },
+        }
+    }
+
+    /// Runtime dispatch error kind. Returns `None` for `AuthRequired` variants.
+    pub fn kind(&self) -> Option<RuntimeDispatchErrorKind> {
+        match self {
+            Self::Dispatch { kind, .. } => Some(*kind),
+            Self::AuthRequired { .. } => None,
+        }
     }
 
     pub fn usage(&self) -> Option<&ResourceUsage> {
-        self.usage.as_ref()
+        match self {
+            Self::Dispatch { usage, .. } | Self::AuthRequired { usage, .. } => usage.as_ref(),
+        }
     }
 
-    pub fn auth_requirement(&self) -> Option<&FirstPartyAuthRequirement> {
-        self.auth.as_ref()
+    /// Secret handles required for re-authentication, if this is an auth failure.
+    pub fn required_secrets(&self) -> Option<&Vec<SecretHandle>> {
+        match self {
+            Self::AuthRequired {
+                required_secrets, ..
+            } => Some(required_secrets),
+            Self::Dispatch { .. } => None,
+        }
     }
 
     pub fn is_auth_required(&self) -> bool {
-        self.auth.is_some()
+        matches!(self, Self::AuthRequired { .. })
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/skill_url_install.rs
@@ -229,7 +229,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(error.kind(), RuntimeDispatchErrorKind::Backend);
+        assert_eq!(error.kind(), Some(RuntimeDispatchErrorKind::Backend));
         assert_eq!(error.usage(), Some(&ResourceUsage::default()));
     }
 

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -66,8 +66,8 @@ pub use extension_contracts::{
     discover_extensions_with_default_host_api_contracts_and_catalog,
 };
 pub use first_party::{
-    FirstPartyAuthRequirement, FirstPartyCapabilityError, FirstPartyCapabilityHandler,
-    FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
+    FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
 };
 pub use first_party_tools::{
     APPLY_PATCH_CAPABILITY_ID, BUILTIN_FIRST_PARTY_PROVIDER, BuiltinFirstPartyTools,

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -66,8 +66,8 @@ pub use extension_contracts::{
     discover_extensions_with_default_host_api_contracts_and_catalog,
 };
 pub use first_party::{
-    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
-    FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+    FirstPartyAuthRequirement, FirstPartyCapabilityError, FirstPartyCapabilityHandler,
+    FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
 };
 pub use first_party_tools::{
     APPLY_PATCH_CAPABILITY_ID, BUILTIN_FIRST_PARTY_PROVIDER, BuiltinFirstPartyTools,
@@ -99,9 +99,10 @@ pub use sandbox_process::{
     RebornScopedSandboxCommandTransport,
 };
 pub use services::{
-    HostRuntimeServices, ProductAuthProviderRuntimePorts, ProductionEventStoreWiringError,
-    ProductionWiringComponent, ProductionWiringConfig, ProductionWiringIssue,
-    ProductionWiringIssueKind, ProductionWiringReport, RegisteredRuntimeHealth,
+    HostRuntimeServices, ProductAuthCredentialStageError, ProductAuthProviderRuntimePorts,
+    ProductionEventStoreWiringError, ProductionWiringComponent, ProductionWiringConfig,
+    ProductionWiringIssue, ProductionWiringIssueKind, ProductionWiringReport,
+    RegisteredRuntimeHealth,
 };
 pub use surface::{CapabilitySurfacePolicy, VisibleCapability, VisibleCapabilityAccess};
 pub use turn_scheduler::{

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -1656,6 +1656,10 @@ output_schema_ref = "schemas/test.output.json"
             dispatch_kind_to_failure(DispatchFailureKind::RuntimeMismatch),
             RuntimeFailureKind::Backend
         );
+        assert_eq!(
+            dispatch_kind_to_failure(DispatchFailureKind::AuthRequired),
+            RuntimeFailureKind::Authorization
+        );
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -25,7 +25,7 @@ use ironclaw_capabilities::{
 use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry, SharedExtensionRegistry};
 use ironclaw_host_api::{
     ApprovalRequestId, CapabilityDispatcher, CapabilityId, DispatchFailureKind, InvocationId,
-    PackageSource, ResourceScope, RuntimeDispatchErrorKind, RuntimeKind,
+    PackageSource, ResourceScope, RuntimeDispatchErrorKind, RuntimeKind, SecretHandle,
     runtime_policy::EffectiveRuntimePolicy,
 };
 use ironclaw_process_sandbox::{
@@ -527,9 +527,10 @@ impl HostRuntime for DefaultHostRuntime {
                     "capability resume failed"
                 );
                 match error {
-                    CapabilityInvocationError::AuthorizationRequiresAuth { capability } => {
-                        Ok(auth_required_outcome(capability))
-                    }
+                    CapabilityInvocationError::AuthorizationRequiresAuth {
+                        capability,
+                        required_secrets,
+                    } => Ok(auth_required_outcome(capability, required_secrets)),
                     other => Ok(RuntimeCapabilityOutcome::Failed(failure_from(
                         other,
                         capability_id,
@@ -983,9 +984,10 @@ impl DefaultHostRuntime {
                     }
                 }
             }
-            CapabilityInvocationError::AuthorizationRequiresAuth { capability } => {
-                Ok(auth_required_outcome(capability))
-            }
+            CapabilityInvocationError::AuthorizationRequiresAuth {
+                capability,
+                required_secrets,
+            } => Ok(auth_required_outcome(capability, required_secrets)),
             other => Ok(RuntimeCapabilityOutcome::Failed(failure_from(
                 other,
                 capability_id,
@@ -1256,12 +1258,15 @@ fn completed_outcome_from(
     }
 }
 
-fn auth_required_outcome(capability_id: CapabilityId) -> RuntimeCapabilityOutcome {
+fn auth_required_outcome(
+    capability_id: CapabilityId,
+    required_secrets: Vec<SecretHandle>,
+) -> RuntimeCapabilityOutcome {
     RuntimeCapabilityOutcome::AuthRequired(RuntimeAuthGate {
         gate_id: RuntimeGateId::new(),
         capability_id,
         reason: RuntimeBlockedReason::AuthRequired,
-        required_secrets: Vec::new(),
+        required_secrets,
     })
 }
 

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -1396,6 +1396,7 @@ fn dispatch_kind_to_failure(kind: DispatchFailureKind) -> RuntimeFailureKind {
         DispatchFailureKind::MissingRuntimeBackend | DispatchFailureKind::UnsupportedRuntime => {
             RuntimeFailureKind::MissingRuntime
         }
+        DispatchFailureKind::AuthRequired => RuntimeFailureKind::Authorization,
         DispatchFailureKind::RuntimeMismatch => RuntimeFailureKind::Backend,
         DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExtensionRuntimeMismatch) => {
             RuntimeFailureKind::MissingRuntime

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -622,10 +622,19 @@ impl HostRuntime for DefaultHostRuntime {
                     idempotency_key = idempotency_key.as_deref().unwrap_or(""),
                     "capability spawn resume failed"
                 );
-                Ok(RuntimeCapabilityOutcome::Failed(failure_from(
-                    error,
-                    capability_id,
-                )))
+                // Mirror resume_capability: AuthorizationRequiresAuth must return
+                // AuthRequired, not Failed. Without this arm a spawned capability
+                // that needs re-auth after an approval resume silently fails.
+                match error {
+                    CapabilityInvocationError::AuthorizationRequiresAuth {
+                        capability,
+                        required_secrets,
+                    } => Ok(auth_required_outcome(capability, required_secrets)),
+                    other => Ok(RuntimeCapabilityOutcome::Failed(failure_from(
+                        other,
+                        capability_id,
+                    ))),
+                }
             }
         }
     }
@@ -1389,67 +1398,66 @@ pub(crate) fn failure_kind_from(error: &CapabilityInvocationError) -> RuntimeFai
         CapabilityInvocationError::Lease(_)
         | CapabilityInvocationError::RunState(_)
         | CapabilityInvocationError::Process(_) => RuntimeFailureKind::Backend,
-        CapabilityInvocationError::Dispatch { kind } => dispatch_kind_to_failure(*kind),
+        CapabilityInvocationError::Dispatch { kind } => RuntimeFailureKind::from(*kind),
     }
 }
 
-fn dispatch_kind_to_failure(kind: DispatchFailureKind) -> RuntimeFailureKind {
-    match kind {
-        DispatchFailureKind::UnknownCapability | DispatchFailureKind::UnknownProvider => {
-            RuntimeFailureKind::InvalidOutput
-        }
-        DispatchFailureKind::MissingRuntimeBackend | DispatchFailureKind::UnsupportedRuntime => {
-            RuntimeFailureKind::MissingRuntime
-        }
-        DispatchFailureKind::AuthRequired => RuntimeFailureKind::Authorization,
-        DispatchFailureKind::RuntimeMismatch => RuntimeFailureKind::Backend,
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExtensionRuntimeMismatch) => {
-            RuntimeFailureKind::MissingRuntime
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Memory)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Resource) => {
-            RuntimeFailureKind::Resource
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::NetworkDenied) => {
-            RuntimeFailureKind::Network
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::PolicyDenied) => {
-            RuntimeFailureKind::PolicyDenied
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OutputTooLarge) => {
-            RuntimeFailureKind::OutputTooLarge
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::FilesystemDenied) => {
-            RuntimeFailureKind::Authorization
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::SecretDenied) => {
-            RuntimeFailureKind::Authorization
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExitFailure) => {
-            RuntimeFailureKind::Process
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InputEncode) => {
-            RuntimeFailureKind::InvalidInput
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OutputDecode)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InvalidResult) => {
-            RuntimeFailureKind::InvalidOutput
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OperationFailed) => {
-            RuntimeFailureKind::OperationFailed
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Client)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Executor)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Manifest)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::MethodMissing)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UndeclaredCapability)
-        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UnsupportedRunner) => {
-            RuntimeFailureKind::Backend
-        }
-        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Unknown) => {
-            RuntimeFailureKind::Unknown
+impl From<DispatchFailureKind> for RuntimeFailureKind {
+    fn from(kind: DispatchFailureKind) -> Self {
+        match kind {
+            DispatchFailureKind::UnknownCapability | DispatchFailureKind::UnknownProvider => {
+                RuntimeFailureKind::InvalidOutput
+            }
+            DispatchFailureKind::MissingRuntimeBackend
+            | DispatchFailureKind::UnsupportedRuntime => RuntimeFailureKind::MissingRuntime,
+            DispatchFailureKind::AuthRequired => RuntimeFailureKind::Authorization,
+            DispatchFailureKind::RuntimeMismatch => RuntimeFailureKind::Backend,
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExtensionRuntimeMismatch) => {
+                RuntimeFailureKind::MissingRuntime
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Memory)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Resource) => {
+                RuntimeFailureKind::Resource
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::NetworkDenied) => {
+                RuntimeFailureKind::Network
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::PolicyDenied) => {
+                RuntimeFailureKind::PolicyDenied
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OutputTooLarge) => {
+                RuntimeFailureKind::OutputTooLarge
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::FilesystemDenied) => {
+                RuntimeFailureKind::Authorization
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::SecretDenied) => {
+                RuntimeFailureKind::Authorization
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExitFailure) => {
+                RuntimeFailureKind::Process
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InputEncode) => {
+                RuntimeFailureKind::InvalidInput
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OutputDecode)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InvalidResult) => {
+                RuntimeFailureKind::InvalidOutput
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OperationFailed) => {
+                RuntimeFailureKind::OperationFailed
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Client)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Executor)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Manifest)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::MethodMissing)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UndeclaredCapability)
+            | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UnsupportedRunner) => {
+                RuntimeFailureKind::Backend
+            }
+            DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Unknown) => Self::Unknown,
         }
     }
 }
@@ -1626,7 +1634,7 @@ output_schema_ref = "schemas/test.output.json"
         ];
         for (variant, expected) in cases {
             let kind = DispatchFailureKind::Runtime(*variant);
-            let actual = dispatch_kind_to_failure(kind);
+            let actual = RuntimeFailureKind::from(kind);
             assert_eq!(
                 actual, *expected,
                 "dispatch kind {kind:?} should map to {expected:?}, got {actual:?}"
@@ -1636,30 +1644,35 @@ output_schema_ref = "schemas/test.output.json"
 
     #[test]
     fn dispatch_kind_to_failure_pins_dispatch_error_top_level_kinds() {
-        assert_eq!(
-            dispatch_kind_to_failure(DispatchFailureKind::UnknownCapability),
-            RuntimeFailureKind::InvalidOutput
-        );
-        assert_eq!(
-            dispatch_kind_to_failure(DispatchFailureKind::UnknownProvider),
-            RuntimeFailureKind::InvalidOutput
-        );
-        assert_eq!(
-            dispatch_kind_to_failure(DispatchFailureKind::MissingRuntimeBackend),
-            RuntimeFailureKind::MissingRuntime
-        );
-        assert_eq!(
-            dispatch_kind_to_failure(DispatchFailureKind::UnsupportedRuntime),
-            RuntimeFailureKind::MissingRuntime
-        );
-        assert_eq!(
-            dispatch_kind_to_failure(DispatchFailureKind::RuntimeMismatch),
-            RuntimeFailureKind::Backend
-        );
-        assert_eq!(
-            dispatch_kind_to_failure(DispatchFailureKind::AuthRequired),
-            RuntimeFailureKind::Authorization
-        );
+        let cases: &[(DispatchFailureKind, RuntimeFailureKind)] = &[
+            (
+                DispatchFailureKind::UnknownCapability,
+                RuntimeFailureKind::InvalidOutput,
+            ),
+            (
+                DispatchFailureKind::UnknownProvider,
+                RuntimeFailureKind::InvalidOutput,
+            ),
+            (
+                DispatchFailureKind::MissingRuntimeBackend,
+                RuntimeFailureKind::MissingRuntime,
+            ),
+            (
+                DispatchFailureKind::UnsupportedRuntime,
+                RuntimeFailureKind::MissingRuntime,
+            ),
+            (
+                DispatchFailureKind::RuntimeMismatch,
+                RuntimeFailureKind::Backend,
+            ),
+            (
+                DispatchFailureKind::AuthRequired,
+                RuntimeFailureKind::Authorization,
+            ),
+        ];
+        for (kind, expected) in cases {
+            assert_eq!(RuntimeFailureKind::from(*kind), *expected, "kind {kind:?}");
+        }
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -216,15 +216,21 @@ impl ProductAuthProviderRuntimePorts {
             .secret_store
             .consume(scope, lease.id)
             .await
-            .map_err(|_| ProductAuthCredentialStageError::Backend)?;
+            .map_err(stage_secret_error)?;
         self.secret_injection_store
             .insert(scope, capability_id, handle, secret)
             .map_err(|_| ProductAuthCredentialStageError::Backend)
     }
 }
 
+/// Classify a [`SecretStoreError`] for the host staging surface.
+///
+/// Unknown / expired / revoked secrets are all user-actionable re-auth
+/// conditions: they map to [`ProductAuthCredentialStageError::AuthRequired`]
+/// so the runtime auth gate fires instead of surfacing a generic backend
+/// failure. Anything else is a true backend defect.
 fn stage_secret_error(error: SecretStoreError) -> ProductAuthCredentialStageError {
-    if error.is_unknown_secret() {
+    if error.is_unknown_secret() || error.is_expired() || error.is_revoked() {
         ProductAuthCredentialStageError::AuthRequired
     } else {
         ProductAuthCredentialStageError::Backend

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -58,7 +58,7 @@ use ironclaw_run_state::{
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
 use ironclaw_secrets::{
     CredentialAccountStore, CredentialSessionStore, InMemoryCredentialBroker, InMemorySecretStore,
-    SecretStore,
+    SecretStore, SecretStoreError,
 };
 use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
 use ironclaw_turns::{
@@ -207,20 +207,11 @@ impl ProductAuthProviderRuntimePorts {
         capability_id: &CapabilityId,
         handle: &SecretHandle,
     ) -> Result<(), ProductAuthCredentialStageError> {
-        let exists = self
-            .secret_store
-            .metadata(scope, handle)
-            .await
-            .map_err(|_| ProductAuthCredentialStageError::Backend)?
-            .is_some();
-        if !exists {
-            return Err(ProductAuthCredentialStageError::AuthRequired);
-        }
         let lease = self
             .secret_store
             .lease_once(scope, handle)
             .await
-            .map_err(|_| ProductAuthCredentialStageError::Backend)?;
+            .map_err(stage_secret_error)?;
         let secret = self
             .secret_store
             .consume(scope, lease.id)
@@ -229,6 +220,14 @@ impl ProductAuthProviderRuntimePorts {
         self.secret_injection_store
             .insert(scope, capability_id, handle, secret)
             .map_err(|_| ProductAuthCredentialStageError::Backend)
+    }
+}
+
+fn stage_secret_error(error: SecretStoreError) -> ProductAuthCredentialStageError {
+    if error.is_unknown_secret() {
+        ProductAuthCredentialStageError::AuthRequired
+    } else {
+        ProductAuthCredentialStageError::Backend
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -31,7 +31,7 @@ use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
     CapabilityDispatcher, CapabilityId, DispatchError, ResourceReservationId, ResourceScope,
-    ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeKind,
+    ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeKind, SecretHandle,
     runtime_policy::{
         DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind, NetworkMode,
         ProcessBackendKind, RuntimeProfile, SecretMode,
@@ -161,23 +161,35 @@ where
 
 /// Canonical host-runtime ports used by product-auth provider adapters.
 ///
-/// This intentionally exposes only the already-composed egress and obligation
-/// handler. Product/auth adapters must not receive the mutable handoff stores
-/// that back those ports.
+/// This intentionally exposes only the already-composed egress, obligation
+/// handler, and scoped one-shot secret staging operation. Product/auth adapters
+/// must not receive the mutable handoff stores that back those ports.
 #[derive(Clone)]
 pub struct ProductAuthProviderRuntimePorts {
     runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
     obligation_handler: Arc<dyn CapabilityObligationHandler>,
+    secret_store: Arc<dyn SecretStore>,
+    secret_injection_store: Arc<RuntimeSecretInjectionStore>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProductAuthCredentialStageError {
+    AuthRequired,
+    Backend,
 }
 
 impl ProductAuthProviderRuntimePorts {
     fn new(
         runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
         obligation_handler: Arc<dyn CapabilityObligationHandler>,
+        secret_store: Arc<dyn SecretStore>,
+        secret_injection_store: Arc<RuntimeSecretInjectionStore>,
     ) -> Self {
         Self {
             runtime_http_egress,
             obligation_handler,
+            secret_store,
+            secret_injection_store,
         }
     }
 
@@ -187,6 +199,36 @@ impl ProductAuthProviderRuntimePorts {
 
     pub fn obligation_handler(&self) -> Arc<dyn CapabilityObligationHandler> {
         Arc::clone(&self.obligation_handler)
+    }
+
+    pub async fn stage_secret_once(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) -> Result<(), ProductAuthCredentialStageError> {
+        let exists = self
+            .secret_store
+            .metadata(scope, handle)
+            .await
+            .map_err(|_| ProductAuthCredentialStageError::Backend)?
+            .is_some();
+        if !exists {
+            return Err(ProductAuthCredentialStageError::AuthRequired);
+        }
+        let lease = self
+            .secret_store
+            .lease_once(scope, handle)
+            .await
+            .map_err(|_| ProductAuthCredentialStageError::Backend)?;
+        let secret = self
+            .secret_store
+            .consume(scope, lease.id)
+            .await
+            .map_err(|_| ProductAuthCredentialStageError::Backend)?;
+        self.secret_injection_store
+            .insert(scope, capability_id, handle, secret)
+            .map_err(|_| ProductAuthCredentialStageError::Backend)
     }
 }
 
@@ -364,9 +406,12 @@ where
     /// product-auth provider adapters.
     pub fn product_auth_provider_runtime_ports(&self) -> Option<ProductAuthProviderRuntimePorts> {
         let runtime_http_egress = runtime_http_egress(&self.runtime_http_egress)?;
+        let secret_store = self.secret_store.clone()?;
         Some(ProductAuthProviderRuntimePorts::new(
             runtime_http_egress,
             Arc::new(self.builtin_obligation_handler()),
+            secret_store,
+            Arc::clone(&self.secret_injection_store),
         ))
     }
 

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -172,11 +172,11 @@ pub struct ProductAuthProviderRuntimePorts {
     secret_injection_store: Arc<RuntimeSecretInjectionStore>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProductAuthCredentialStageError {
-    AuthRequired,
-    Backend,
-}
+/// Alias for [`ironclaw_host_api::CredentialStageError`].
+///
+/// The shared type lives in `ironclaw_host_api` so that per-extension staging
+/// traits can use it without a dependency on `ironclaw_host_runtime`.
+pub type ProductAuthCredentialStageError = ironclaw_host_api::CredentialStageError;
 
 impl ProductAuthProviderRuntimePorts {
     fn new(
@@ -229,7 +229,9 @@ impl ProductAuthProviderRuntimePorts {
 /// conditions: they map to [`ProductAuthCredentialStageError::AuthRequired`]
 /// so the runtime auth gate fires instead of surfacing a generic backend
 /// failure. Anything else is a true backend defect.
-fn stage_secret_error(error: SecretStoreError) -> ProductAuthCredentialStageError {
+///
+/// `pub(crate)` for testing; not part of the public API.
+pub(crate) fn stage_secret_error(error: SecretStoreError) -> ProductAuthCredentialStageError {
     if error.is_unknown_secret() || error.is_expired() || error.is_revoked() {
         ProductAuthCredentialStageError::AuthRequired
     } else {

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -230,9 +230,18 @@ impl ProductAuthProviderRuntimePorts {
 /// so the runtime auth gate fires instead of surfacing a generic backend
 /// failure. Anything else is a true backend defect.
 ///
-/// `pub(crate)` for testing; not part of the public API.
+/// `pub(crate)` so it can be unit-tested directly; used in production by
+/// [`ProductAuthProviderRuntimePorts::stage_secret_once`]. Not part of the public API.
 pub(crate) fn stage_secret_error(error: SecretStoreError) -> ProductAuthCredentialStageError {
-    if error.is_unknown_secret() || error.is_expired() || error.is_revoked() {
+    // Unknown / expired / revoked / consumed / unknown-lease are all user-actionable
+    // re-auth conditions: the credential is missing or no longer valid.  Anything
+    // else is a true backend defect.
+    if error.is_unknown_secret()
+        || error.is_unknown_lease()
+        || error.is_expired()
+        || error.is_revoked()
+        || error.is_consumed()
+    {
         ProductAuthCredentialStageError::AuthRequired
     } else {
         ProductAuthCredentialStageError::Backend

--- a/crates/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/ironclaw_host_runtime/src/services/process_executor.rs
@@ -80,7 +80,7 @@ impl ProcessExecutor for RuntimeDispatchProcessExecutor {
                 input: request.input,
             })
             .await
-            .map_err(|error| ProcessExecutionError::new(dispatch_error_kind(&error)))?;
+            .map_err(|error| ProcessExecutionError::new(error.event_kind()))?;
         if request.cancellation.is_cancelled() {
             return Err(ProcessExecutionError::new("cancelled"));
         }
@@ -90,20 +90,8 @@ impl ProcessExecutor for RuntimeDispatchProcessExecutor {
     }
 }
 
-fn dispatch_error_kind(error: &DispatchError) -> &'static str {
-    match error {
-        DispatchError::UnknownCapability { .. } => "unknown_capability",
-        DispatchError::UnknownProvider { .. } => "unknown_provider",
-        DispatchError::RuntimeMismatch { .. } => "runtime_mismatch",
-        DispatchError::MissingRuntimeBackend { .. } => "missing_runtime_backend",
-        DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime",
-        DispatchError::AuthRequired { .. } => "auth_required",
-        DispatchError::Mcp { kind }
-        | DispatchError::Script { kind }
-        | DispatchError::Wasm { kind }
-        | DispatchError::FirstParty { kind } => kind.event_kind(),
-    }
-}
+// Removed: dispatch_error_kind was a local copy of DispatchError::event_kind() from ironclaw_host_api.
+// Call error.event_kind() directly instead.
 
 #[cfg(test)]
 mod tests {
@@ -361,7 +349,7 @@ mod tests {
         ];
 
         for (error, expected) in cases {
-            assert_eq!(dispatch_error_kind(&error), expected);
+            assert_eq!(error.event_kind(), expected);
         }
     }
 

--- a/crates/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/ironclaw_host_runtime/src/services/process_executor.rs
@@ -97,6 +97,7 @@ fn dispatch_error_kind(error: &DispatchError) -> &'static str {
         DispatchError::RuntimeMismatch { .. } => "runtime_mismatch",
         DispatchError::MissingRuntimeBackend { .. } => "missing_runtime_backend",
         DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime",
+        DispatchError::AuthRequired { .. } => "auth_required",
         DispatchError::Mcp { kind }
         | DispatchError::Script { kind }
         | DispatchError::Wasm { kind }

--- a/crates/ironclaw_host_runtime/src/services/process_executor.rs
+++ b/crates/ironclaw_host_runtime/src/services/process_executor.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ironclaw_host_api::{
-    CapabilityDispatchRequest, CapabilityDispatcher, DispatchError, RuntimeKind,
-};
+use ironclaw_host_api::{CapabilityDispatchRequest, CapabilityDispatcher, RuntimeKind};
 use ironclaw_processes::{
     ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult, ProcessExecutor,
 };
@@ -99,8 +97,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use ironclaw_host_api::{
-        AgentId, CapabilityDispatchResult, CapabilityId, ExtensionId, InvocationId, MountView,
-        ProcessId, ProjectId, ReservationStatus, ResourceEstimate, ResourceReceipt,
+        AgentId, CapabilityDispatchResult, CapabilityId, DispatchError, ExtensionId, InvocationId,
+        MountView, ProcessId, ProjectId, ReservationStatus, ResourceEstimate, ResourceReceipt,
         ResourceReservationId, ResourceScope, ResourceUsage, RuntimeDispatchErrorKind, TenantId,
         ThreadId, UserId,
     };

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -320,9 +320,10 @@ where
                     reservation.id,
                     error.usage(),
                 )?;
-                if error.is_auth_required() {
+                if let Some(auth) = error.auth_requirement() {
                     return Err(DispatchError::AuthRequired {
                         capability: request.capability_id.clone(),
+                        required_secrets: auth.required_secrets.clone(),
                     });
                 }
                 return Err(DispatchError::FirstParty { kind: error.kind() });

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -316,11 +316,18 @@ where
                     is_auth_required = error.is_auth_required(),
                     "first-party runtime adapter handler failed"
                 );
-                account_or_release_failed_first_party_execution(
+                if let Err(acct_err) = account_or_release_failed_first_party_execution(
                     request.governor,
                     reservation.id,
                     error.usage(),
-                )?;
+                ) {
+                    tracing::warn!(
+                        reservation_id = %reservation.id,
+                        error = ?acct_err,
+                        "first-party resource accounting failed on handler error; \
+                         returning original handler error"
+                    );
+                }
                 return match error {
                     FirstPartyCapabilityError::AuthRequired {
                         required_secrets, ..
@@ -352,6 +359,7 @@ where
                     reservation_id = %reservation.id,
                     "first-party runtime adapter output serialization failed"
                 );
+                release_first_party_reservation(request.governor, reservation.id);
                 DispatchError::FirstParty {
                     kind: RuntimeDispatchErrorKind::OutputDecode,
                 }

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -18,6 +18,7 @@ use super::{
     WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WitToolHost, WitToolRequest,
     WitToolRuntime, WitToolRuntimeConfig, plan_capability, runtime_http_egress,
 };
+use crate::FirstPartyCapabilityError;
 
 pub(super) struct ServiceResolvedRuntimeAdapter<T> {
     inner: Arc<T>,
@@ -312,7 +313,7 @@ where
             Ok(Err(error)) => {
                 tracing::debug!(
                     reservation_id = %reservation.id,
-                    error_kind = %error.kind(),
+                    is_auth_required = error.is_auth_required(),
                     "first-party runtime adapter handler failed"
                 );
                 account_or_release_failed_first_party_execution(
@@ -320,13 +321,17 @@ where
                     reservation.id,
                     error.usage(),
                 )?;
-                if let Some(auth) = error.auth_requirement() {
-                    return Err(DispatchError::AuthRequired {
+                return match error {
+                    FirstPartyCapabilityError::AuthRequired {
+                        required_secrets, ..
+                    } => Err(DispatchError::AuthRequired {
                         capability: request.capability_id.clone(),
-                        required_secrets: auth.required_secrets.clone(),
-                    });
-                }
-                return Err(DispatchError::FirstParty { kind: error.kind() });
+                        required_secrets,
+                    }),
+                    FirstPartyCapabilityError::Dispatch { kind, .. } => {
+                        Err(DispatchError::FirstParty { kind })
+                    }
+                };
             }
             Err(_) => {
                 tracing::debug!(

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -320,6 +320,11 @@ where
                     reservation.id,
                     error.usage(),
                 )?;
+                if error.is_auth_required() {
+                    return Err(DispatchError::AuthRequired {
+                        capability: request.capability_id.clone(),
+                    });
+                }
                 return Err(DispatchError::FirstParty { kind: error.kind() });
             }
             Err(_) => {

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -21,7 +21,10 @@ use ironclaw_processes::{InMemoryProcessResultStore, InMemoryProcessStore, Proce
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceTally,
 };
-use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
+use ironclaw_secrets::{
+    InMemorySecretStore, SecretLease, SecretLeaseId, SecretLeaseStatus, SecretMaterial,
+    SecretMetadata, SecretStore, SecretStoreError,
+};
 use serde_json::{Value, json};
 
 use super::{
@@ -964,4 +967,186 @@ impl NetworkHttpEgress for RecordingNetwork {
             },
         })
     }
+}
+
+/// Stage at which the failing store should inject `error`.
+#[derive(Debug, Clone, Copy)]
+enum FailingStage {
+    Lease,
+    Consume,
+}
+
+/// Test double that injects a chosen `SecretStoreError` at a chosen stage.
+struct FailingSecretStore {
+    stage: FailingStage,
+    error: Mutex<Option<SecretStoreError>>,
+}
+
+impl FailingSecretStore {
+    fn new(stage: FailingStage, error: SecretStoreError) -> Self {
+        Self {
+            stage,
+            error: Mutex::new(Some(error)),
+        }
+    }
+
+    fn take_error(&self) -> SecretStoreError {
+        self.error
+            .lock()
+            .unwrap()
+            .take()
+            .expect("FailingSecretStore error already consumed")
+    }
+}
+
+#[async_trait]
+impl SecretStore for FailingSecretStore {
+    async fn put(
+        &self,
+        _scope: ResourceScope,
+        _handle: SecretHandle,
+        _material: SecretMaterial,
+    ) -> Result<SecretMetadata, SecretStoreError> {
+        Err(SecretStoreError::StoreUnavailable {
+            reason: "failing test store does not support put".to_string(),
+        })
+    }
+
+    async fn metadata(
+        &self,
+        _scope: &ResourceScope,
+        _handle: &SecretHandle,
+    ) -> Result<Option<SecretMetadata>, SecretStoreError> {
+        Ok(None)
+    }
+
+    async fn delete(
+        &self,
+        _scope: &ResourceScope,
+        _handle: &SecretHandle,
+    ) -> Result<bool, SecretStoreError> {
+        Ok(false)
+    }
+
+    async fn lease_once(
+        &self,
+        scope: &ResourceScope,
+        _handle: &SecretHandle,
+    ) -> Result<SecretLease, SecretStoreError> {
+        match self.stage {
+            FailingStage::Lease => Err(self.take_error()),
+            FailingStage::Consume => Ok(SecretLease {
+                id: SecretLeaseId::default(),
+                scope: scope.clone(),
+                handle: SecretHandle::new("failing-handle").unwrap(),
+                status: SecretLeaseStatus::Active,
+            }),
+        }
+    }
+
+    async fn consume(
+        &self,
+        _scope: &ResourceScope,
+        _lease_id: SecretLeaseId,
+    ) -> Result<SecretMaterial, SecretStoreError> {
+        match self.stage {
+            FailingStage::Consume => Err(self.take_error()),
+            FailingStage::Lease => Err(SecretStoreError::StoreUnavailable {
+                reason: "unexpected consume after failing lease".to_string(),
+            }),
+        }
+    }
+
+    async fn revoke(
+        &self,
+        _scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretLease, SecretStoreError> {
+        Err(SecretStoreError::UnknownLease {
+            scope: Box::new(sample_scope()),
+            lease_id,
+        })
+    }
+
+    async fn leases_for_scope(
+        &self,
+        _scope: &ResourceScope,
+    ) -> Result<Vec<SecretLease>, SecretStoreError> {
+        Ok(Vec::new())
+    }
+}
+
+async fn stage_secret_once_with_store<S: SecretStore + 'static>(
+    store: S,
+) -> Result<(), crate::ProductAuthCredentialStageError> {
+    let services = test_services()
+        .with_secret_store(Arc::new(store))
+        .try_with_host_http_egress(RecordingNetwork::ok())
+        .expect("host HTTP egress should wire");
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    let handle = SecretHandle::new("never-staged").unwrap();
+    let ports = services
+        .product_auth_provider_runtime_ports()
+        .expect("runtime ports should be configured");
+    ports
+        .stage_secret_once(&scope, &capability_id, &handle)
+        .await
+}
+
+#[tokio::test]
+async fn stage_secret_once_returns_auth_required_for_unknown_handle() {
+    let scope = sample_scope();
+    let store = FailingSecretStore::new(
+        FailingStage::Lease,
+        SecretStoreError::UnknownSecret {
+            scope: Box::new(scope.clone()),
+            handle: SecretHandle::new("never-staged").unwrap(),
+        },
+    );
+    let err = stage_secret_once_with_store(store).await.unwrap_err();
+    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
+}
+
+#[tokio::test]
+async fn stage_secret_once_returns_auth_required_for_expired_secret() {
+    let store = FailingSecretStore::new(FailingStage::Lease, SecretStoreError::SecretExpired);
+    let err = stage_secret_once_with_store(store).await.unwrap_err();
+    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
+}
+
+#[tokio::test]
+async fn stage_secret_once_returns_auth_required_for_revoked_lease_on_consume() {
+    let store = FailingSecretStore::new(
+        FailingStage::Consume,
+        SecretStoreError::LeaseRevoked {
+            lease_id: SecretLeaseId::default(),
+        },
+    );
+    let err = stage_secret_once_with_store(store).await.unwrap_err();
+    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
+}
+
+#[tokio::test]
+async fn stage_secret_once_returns_auth_required_for_expired_lease_on_consume() {
+    let store = FailingSecretStore::new(
+        FailingStage::Consume,
+        SecretStoreError::LeaseExpired {
+            lease_id: SecretLeaseId::default(),
+        },
+    );
+    let err = stage_secret_once_with_store(store).await.unwrap_err();
+    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
+}
+
+#[tokio::test]
+async fn stage_secret_once_returns_backend_on_secret_store_failure() {
+    let store = FailingSecretStore::new(
+        FailingStage::Lease,
+        SecretStoreError::BackendMisconfigured {
+            reason: "vault offline".to_string(),
+        },
+    );
+    let err = stage_secret_once_with_store(store).await.unwrap_err();
+    assert_eq!(err, crate::ProductAuthCredentialStageError::Backend);
 }

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -645,6 +645,55 @@ async fn first_party_adapter_releases_reservation_when_planner_denies() {
     );
 }
 
+#[tokio::test]
+async fn first_party_adapter_maps_handler_auth_required_to_dispatch_auth_required() {
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
+    let registry = Arc::new(FirstPartyCapabilityRegistry::new().with_handler(
+        descriptor.id.clone(),
+        Arc::new(AuthRequiredFirstPartyHandler),
+    ));
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            None,
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(DispatchError::AuthRequired { capability }) if capability == descriptor.id
+    ));
+}
+
 fn test_services() -> HostRuntimeServices<
     LocalFilesystem,
     InMemoryResourceGovernor,
@@ -778,6 +827,18 @@ impl crate::FirstPartyCapabilityHandler for PanicFirstPartyHandler {
         _request: crate::FirstPartyCapabilityRequest,
     ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
         panic!("service-resolution denial should happen before handler dispatch")
+    }
+}
+
+struct AuthRequiredFirstPartyHandler;
+
+#[async_trait]
+impl crate::FirstPartyCapabilityHandler for AuthRequiredFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        _request: crate::FirstPartyCapabilityRequest,
+    ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
+        Err(crate::FirstPartyCapabilityError::auth_required())
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -22,8 +22,7 @@ use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceTally,
 };
 use ironclaw_secrets::{
-    InMemorySecretStore, SecretLease, SecretLeaseId, SecretLeaseStatus, SecretMaterial,
-    SecretMetadata, SecretStore, SecretStoreError,
+    InMemorySecretStore, SecretLeaseId, SecretMaterial, SecretStore, SecretStoreError,
 };
 use serde_json::{Value, json};
 
@@ -969,184 +968,54 @@ impl NetworkHttpEgress for RecordingNetwork {
     }
 }
 
-/// Stage at which the failing store should inject `error`.
-#[derive(Debug, Clone, Copy)]
-enum FailingStage {
-    Lease,
-    Consume,
-}
+/// `stage_secret_error` maps `SecretStoreError` variants to `ProductAuthCredentialStageError`.
+///
+/// These are synchronous unit tests of a pure function — no store, no async.
+#[test]
+fn stage_secret_error_maps_auth_and_backend_variants() {
+    use crate::services::stage_secret_error;
+    use ironclaw_host_api::CredentialStageError::{AuthRequired, Backend};
 
-/// Test double that injects a chosen `SecretStoreError` at a chosen stage.
-struct FailingSecretStore {
-    stage: FailingStage,
-    error: Mutex<Option<SecretStoreError>>,
-}
-
-impl FailingSecretStore {
-    fn new(stage: FailingStage, error: SecretStoreError) -> Self {
-        Self {
-            stage,
-            error: Mutex::new(Some(error)),
-        }
-    }
-
-    fn take_error(&self) -> SecretStoreError {
-        self.error
-            .lock()
-            .unwrap()
-            .take()
-            .expect("FailingSecretStore error already consumed")
-    }
-}
-
-#[async_trait]
-impl SecretStore for FailingSecretStore {
-    async fn put(
-        &self,
-        _scope: ResourceScope,
-        _handle: SecretHandle,
-        _material: SecretMaterial,
-    ) -> Result<SecretMetadata, SecretStoreError> {
-        Err(SecretStoreError::StoreUnavailable {
-            reason: "failing test store does not support put".to_string(),
-        })
-    }
-
-    async fn metadata(
-        &self,
-        _scope: &ResourceScope,
-        _handle: &SecretHandle,
-    ) -> Result<Option<SecretMetadata>, SecretStoreError> {
-        Ok(None)
-    }
-
-    async fn delete(
-        &self,
-        _scope: &ResourceScope,
-        _handle: &SecretHandle,
-    ) -> Result<bool, SecretStoreError> {
-        Ok(false)
-    }
-
-    async fn lease_once(
-        &self,
-        scope: &ResourceScope,
-        _handle: &SecretHandle,
-    ) -> Result<SecretLease, SecretStoreError> {
-        match self.stage {
-            FailingStage::Lease => Err(self.take_error()),
-            FailingStage::Consume => Ok(SecretLease {
-                id: SecretLeaseId::default(),
-                scope: scope.clone(),
-                handle: SecretHandle::new("failing-handle").unwrap(),
-                status: SecretLeaseStatus::Active,
-            }),
-        }
-    }
-
-    async fn consume(
-        &self,
-        _scope: &ResourceScope,
-        _lease_id: SecretLeaseId,
-    ) -> Result<SecretMaterial, SecretStoreError> {
-        match self.stage {
-            FailingStage::Consume => Err(self.take_error()),
-            FailingStage::Lease => Err(SecretStoreError::StoreUnavailable {
-                reason: "unexpected consume after failing lease".to_string(),
-            }),
-        }
-    }
-
-    async fn revoke(
-        &self,
-        _scope: &ResourceScope,
-        lease_id: SecretLeaseId,
-    ) -> Result<SecretLease, SecretStoreError> {
-        Err(SecretStoreError::UnknownLease {
-            scope: Box::new(sample_scope()),
-            lease_id,
-        })
-    }
-
-    async fn leases_for_scope(
-        &self,
-        _scope: &ResourceScope,
-    ) -> Result<Vec<SecretLease>, SecretStoreError> {
-        Ok(Vec::new())
-    }
-}
-
-async fn stage_secret_once_with_store<S: SecretStore + 'static>(
-    store: S,
-) -> Result<(), crate::ProductAuthCredentialStageError> {
-    let services = test_services()
-        .with_secret_store(Arc::new(store))
-        .try_with_host_http_egress(RecordingNetwork::ok())
-        .expect("host HTTP egress should wire");
     let scope = sample_scope();
-    let capability_id = sample_capability_id();
-    let handle = SecretHandle::new("never-staged").unwrap();
-    let ports = services
-        .product_auth_provider_runtime_ports()
-        .expect("runtime ports should be configured");
-    ports
-        .stage_secret_once(&scope, &capability_id, &handle)
-        .await
-}
-
-#[tokio::test]
-async fn stage_secret_once_returns_auth_required_for_unknown_handle() {
-    let scope = sample_scope();
-    let store = FailingSecretStore::new(
-        FailingStage::Lease,
-        SecretStoreError::UnknownSecret {
-            scope: Box::new(scope.clone()),
-            handle: SecretHandle::new("never-staged").unwrap(),
-        },
-    );
-    let err = stage_secret_once_with_store(store).await.unwrap_err();
-    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
-}
-
-#[tokio::test]
-async fn stage_secret_once_returns_auth_required_for_expired_secret() {
-    let store = FailingSecretStore::new(FailingStage::Lease, SecretStoreError::SecretExpired);
-    let err = stage_secret_once_with_store(store).await.unwrap_err();
-    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
-}
-
-#[tokio::test]
-async fn stage_secret_once_returns_auth_required_for_revoked_lease_on_consume() {
-    let store = FailingSecretStore::new(
-        FailingStage::Consume,
-        SecretStoreError::LeaseRevoked {
-            lease_id: SecretLeaseId::default(),
-        },
-    );
-    let err = stage_secret_once_with_store(store).await.unwrap_err();
-    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
-}
-
-#[tokio::test]
-async fn stage_secret_once_returns_auth_required_for_expired_lease_on_consume() {
-    let store = FailingSecretStore::new(
-        FailingStage::Consume,
-        SecretStoreError::LeaseExpired {
-            lease_id: SecretLeaseId::default(),
-        },
-    );
-    let err = stage_secret_once_with_store(store).await.unwrap_err();
-    assert_eq!(err, crate::ProductAuthCredentialStageError::AuthRequired);
-}
-
-#[tokio::test]
-async fn stage_secret_once_returns_backend_on_secret_store_failure() {
-    let store = FailingSecretStore::new(
-        FailingStage::Lease,
-        SecretStoreError::BackendMisconfigured {
-            reason: "vault offline".to_string(),
-        },
-    );
-    let err = stage_secret_once_with_store(store).await.unwrap_err();
-    assert_eq!(err, crate::ProductAuthCredentialStageError::Backend);
+    let cases: &[(SecretStoreError, crate::ProductAuthCredentialStageError)] = &[
+        (
+            SecretStoreError::UnknownSecret {
+                scope: Box::new(scope.clone()),
+                handle: SecretHandle::new("h").unwrap(),
+            },
+            AuthRequired,
+        ),
+        (SecretStoreError::SecretExpired, AuthRequired),
+        (
+            SecretStoreError::LeaseRevoked {
+                lease_id: SecretLeaseId::default(),
+            },
+            AuthRequired,
+        ),
+        (
+            SecretStoreError::LeaseExpired {
+                lease_id: SecretLeaseId::default(),
+            },
+            AuthRequired,
+        ),
+        (
+            SecretStoreError::BackendMisconfigured {
+                reason: "vault offline".to_string(),
+            },
+            Backend,
+        ),
+        (
+            SecretStoreError::StoreUnavailable {
+                reason: "down".to_string(),
+            },
+            Backend,
+        ),
+    ];
+    for (error, expected) in cases {
+        assert_eq!(
+            stage_secret_error(error.clone()),
+            *expected,
+            "error: {error:?}"
+        );
+    }
 }

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -21,7 +21,7 @@ use ironclaw_processes::{InMemoryProcessResultStore, InMemoryProcessStore, Proce
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceTally,
 };
-use ironclaw_secrets::{InMemorySecretStore, SecretMaterial};
+use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
 use serde_json::{Value, json};
 
 use super::{
@@ -34,6 +34,8 @@ use super::{
 };
 use crate::CommandExecutionRequest;
 use crate::obligations::{NetworkObligationPolicyStore, RuntimeSecretInjectionStore};
+
+mod first_party_runtime_adapter;
 
 #[tokio::test]
 async fn shared_extension_registry_returns_same_instance() {
@@ -53,10 +55,22 @@ async fn product_auth_provider_runtime_ports_returns_none_without_egress() {
 
 #[tokio::test]
 async fn product_auth_provider_runtime_ports_returns_configured_egress_and_obligation_handler() {
+    let secret_store = Arc::new(InMemorySecretStore::new());
     let services = test_services()
-        .with_secret_store(Arc::new(InMemorySecretStore::new()))
+        .with_secret_store(Arc::clone(&secret_store))
         .try_with_host_http_egress(RecordingNetwork::ok())
         .expect("host HTTP egress should wire with graph secret store");
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    let handle = SecretHandle::new("product-auth-secret").unwrap();
+    secret_store
+        .put(
+            scope.clone(),
+            handle.clone(),
+            SecretMaterial::from("product-auth-material"),
+        )
+        .await
+        .expect("test secret should store");
 
     let ports = services
         .product_auth_provider_runtime_ports()
@@ -66,6 +80,17 @@ async fn product_auth_provider_runtime_ports_returns_configured_egress_and_oblig
         &configured_egress(&services)
     ));
     let _handler = ports.obligation_handler();
+    ports
+        .stage_secret_once(&scope, &capability_id, &handle)
+        .await
+        .expect("runtime ports should stage product auth secret");
+    assert!(
+        services
+            .secret_injection_store
+            .take(&scope, &capability_id, &handle)
+            .expect("staged secret should be readable for assertion")
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -645,55 +670,6 @@ async fn first_party_adapter_releases_reservation_when_planner_denies() {
     );
 }
 
-#[tokio::test]
-async fn first_party_adapter_maps_handler_auth_required_to_dispatch_auth_required() {
-    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
-    let registry = Arc::new(FirstPartyCapabilityRegistry::new().with_handler(
-        descriptor.id.clone(),
-        Arc::new(AuthRequiredFirstPartyHandler),
-    ));
-    let adapter = FirstPartyRuntimeAdapter::from_registry(
-        registry,
-        Arc::new(LocalInvocationServicesResolver::new(
-            Arc::new(LocalFilesystem::new()),
-            None,
-            Arc::new(LocalHostProcessPort::new()),
-            None,
-        )),
-    );
-    let filesystem = LocalFilesystem::new();
-    let governor = InMemoryResourceGovernor::new();
-    let scope = sample_scope();
-    let package = test_package(WASM_MANIFEST, "test-wasm");
-    let policy = policy_with(
-        FilesystemBackendKind::HostWorkspace,
-        ProcessBackendKind::LocalHost,
-        NetworkMode::DirectLogged,
-        SecretMode::ScrubbedEnv,
-    );
-
-    let result = adapter
-        .dispatch_json(RuntimeAdapterRequest {
-            package: &package,
-            descriptor: &descriptor,
-            filesystem: &filesystem,
-            governor: &governor,
-            runtime_policy: &policy,
-            capability_id: &descriptor.id,
-            scope,
-            estimate: ResourceEstimate::default(),
-            mounts: None,
-            resource_reservation: None,
-            input: json!({}),
-        })
-        .await;
-
-    assert!(matches!(
-        result,
-        Err(DispatchError::AuthRequired { capability }) if capability == descriptor.id
-    ));
-}
-
 fn test_services() -> HostRuntimeServices<
     LocalFilesystem,
     InMemoryResourceGovernor,
@@ -827,18 +803,6 @@ impl crate::FirstPartyCapabilityHandler for PanicFirstPartyHandler {
         _request: crate::FirstPartyCapabilityRequest,
     ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
         panic!("service-resolution denial should happen before handler dispatch")
-    }
-}
-
-struct AuthRequiredFirstPartyHandler;
-
-#[async_trait]
-impl crate::FirstPartyCapabilityHandler for AuthRequiredFirstPartyHandler {
-    async fn dispatch(
-        &self,
-        _request: crate::FirstPartyCapabilityRequest,
-    ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
-        Err(crate::FirstPartyCapabilityError::auth_required())
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -998,6 +998,23 @@ fn stage_secret_error_maps_auth_and_backend_variants() {
             },
             AuthRequired,
         ),
+        // Consumed lease: one-shot lease already used by a concurrent call.
+        // stable_reason = "CredentialExpired" — user-actionable, must be AuthRequired.
+        (
+            SecretStoreError::LeaseConsumed {
+                lease_id: SecretLeaseId::default(),
+            },
+            AuthRequired,
+        ),
+        // Unknown lease: lease gone (expired/evicted between lease_once and consume).
+        // stable_reason = "MissingCredential" — user-actionable, must be AuthRequired.
+        (
+            SecretStoreError::UnknownLease {
+                scope: Box::new(scope.clone()),
+                lease_id: SecretLeaseId::default(),
+            },
+            AuthRequired,
+        ),
         (
             SecretStoreError::BackendMisconfigured {
                 reason: "vault offline".to_string(),
@@ -1018,4 +1035,50 @@ fn stage_secret_error_maps_auth_and_backend_variants() {
             "error: {error:?}"
         );
     }
+}
+
+// T6 — RegisteredRuntimeHealth
+#[tokio::test]
+async fn registered_runtime_health_empty_available_reports_all_required_as_missing() {
+    use crate::services::{RegisteredRuntimeHealth, RuntimeBackendHealth};
+    let health = RegisteredRuntimeHealth::new(vec![]);
+    let missing = health
+        .missing_runtime_backends(&[RuntimeKind::Wasm, RuntimeKind::Mcp])
+        .await
+        .expect("health check must succeed");
+    // Both kinds are missing; order is normalized by runtime_sort_key.
+    assert!(
+        missing.contains(&RuntimeKind::Wasm),
+        "Wasm must be missing; got {missing:?}"
+    );
+    assert!(
+        missing.contains(&RuntimeKind::Mcp),
+        "Mcp must be missing; got {missing:?}"
+    );
+    assert_eq!(missing.len(), 2);
+}
+
+#[tokio::test]
+async fn registered_runtime_health_deduplicates_duplicate_required_kinds() {
+    use crate::services::{RegisteredRuntimeHealth, RuntimeBackendHealth};
+    let health = RegisteredRuntimeHealth::new(vec![RuntimeKind::Wasm]);
+    let missing = health
+        .missing_runtime_backends(&[RuntimeKind::Mcp, RuntimeKind::Mcp, RuntimeKind::Wasm])
+        .await
+        .expect("health check must succeed");
+    assert_eq!(missing, vec![RuntimeKind::Mcp], "got {missing:?}");
+}
+
+#[tokio::test]
+async fn registered_runtime_health_returns_empty_when_all_required_available() {
+    use crate::services::{RegisteredRuntimeHealth, RuntimeBackendHealth};
+    let health = RegisteredRuntimeHealth::new(vec![RuntimeKind::Wasm, RuntimeKind::Mcp]);
+    let missing = health
+        .missing_runtime_backends(&[RuntimeKind::Wasm])
+        .await
+        .expect("health check must succeed");
+    assert!(
+        missing.is_empty(),
+        "expected no missing kinds; got {missing:?}"
+    );
 }

--- a/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ironclaw_host_api::{DispatchError, ResourceEstimate, RuntimeKind};
+use ironclaw_host_api::{
+    DispatchError, ResourceEstimate, RuntimeDispatchErrorKind, RuntimeKind, SecretHandle,
+};
 use serde_json::json;
 
 use super::*;
@@ -49,10 +51,188 @@ async fn first_party_adapter_maps_handler_auth_required_to_dispatch_auth_require
         })
         .await;
 
-    assert!(matches!(
-        result,
-        Err(DispatchError::AuthRequired { capability, .. }) if capability == descriptor.id
+    // required_secrets must be forwarded, not silently dropped.
+    match result {
+        Err(DispatchError::AuthRequired {
+            capability,
+            required_secrets,
+        }) => {
+            assert_eq!(capability, descriptor.id);
+            assert!(
+                required_secrets.is_empty(),
+                "auth_required() handler yields no required handles; got {required_secrets:?}"
+            );
+        }
+        other => panic!("expected AuthRequired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn first_party_adapter_releases_reservation_when_handler_returns_auth_required() {
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
+    let registry = Arc::new(FirstPartyCapabilityRegistry::new().with_handler(
+        descriptor.id.clone(),
+        Arc::new(AuthRequiredFirstPartyHandler),
     ));
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            None,
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    assert!(matches!(result, Err(DispatchError::AuthRequired { .. })));
+    assert_eq!(
+        governor.reserved_for(&tenant_account),
+        ResourceTally::default(),
+        "reservation must be released when handler returns AuthRequired"
+    );
+}
+
+#[tokio::test]
+async fn first_party_adapter_forwards_required_secrets_from_auth_required_handler() {
+    let handle = SecretHandle::new("google-access-token").unwrap();
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
+    let registry = Arc::new(FirstPartyCapabilityRegistry::new().with_handler(
+        descriptor.id.clone(),
+        Arc::new(AuthRequiredWithSecretsHandler {
+            handle: handle.clone(),
+        }),
+    ));
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            None,
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    match result {
+        Err(DispatchError::AuthRequired {
+            required_secrets, ..
+        }) => {
+            assert_eq!(required_secrets, vec![handle]);
+        }
+        other => panic!("expected AuthRequired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn first_party_adapter_maps_panicking_handler_to_backend() {
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
+    let registry = Arc::new(
+        FirstPartyCapabilityRegistry::new()
+            .with_handler(descriptor.id.clone(), Arc::new(PanicOnDispatchHandler)),
+    );
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            None,
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(DispatchError::FirstParty {
+                kind: RuntimeDispatchErrorKind::Backend
+            })
+        ),
+        "panicking handler must be contained as Backend, got {result:?}"
+    );
+    assert_eq!(
+        governor.reserved_for(&tenant_account),
+        ResourceTally::default(),
+        "reservation must be released when handler panics"
+    );
 }
 
 struct AuthRequiredFirstPartyHandler;
@@ -64,5 +244,33 @@ impl crate::FirstPartyCapabilityHandler for AuthRequiredFirstPartyHandler {
         _request: crate::FirstPartyCapabilityRequest,
     ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
         Err(crate::FirstPartyCapabilityError::auth_required())
+    }
+}
+
+struct AuthRequiredWithSecretsHandler {
+    handle: SecretHandle,
+}
+
+#[async_trait]
+impl crate::FirstPartyCapabilityHandler for AuthRequiredWithSecretsHandler {
+    async fn dispatch(
+        &self,
+        _request: crate::FirstPartyCapabilityRequest,
+    ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
+        Err(crate::FirstPartyCapabilityError::auth_required_with(vec![
+            self.handle.clone(),
+        ]))
+    }
+}
+
+struct PanicOnDispatchHandler;
+
+#[async_trait]
+impl crate::FirstPartyCapabilityHandler for PanicOnDispatchHandler {
+    async fn dispatch(
+        &self,
+        _request: crate::FirstPartyCapabilityRequest,
+    ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
+        panic!("handler panic must be contained at the adapter boundary")
     }
 }

--- a/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{DispatchError, ResourceEstimate, RuntimeKind};
+use serde_json::json;
+
+use super::*;
+
+#[tokio::test]
+async fn first_party_adapter_maps_handler_auth_required_to_dispatch_auth_required() {
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
+    let registry = Arc::new(FirstPartyCapabilityRegistry::new().with_handler(
+        descriptor.id.clone(),
+        Arc::new(AuthRequiredFirstPartyHandler),
+    ));
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            None,
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(DispatchError::AuthRequired { capability, .. }) if capability == descriptor.id
+    ));
+}
+
+struct AuthRequiredFirstPartyHandler;
+
+#[async_trait]
+impl crate::FirstPartyCapabilityHandler for AuthRequiredFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        _request: crate::FirstPartyCapabilityRequest,
+    ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
+        Err(crate::FirstPartyCapabilityError::auth_required())
+    }
+}

--- a/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -274,3 +274,144 @@ impl crate::FirstPartyCapabilityHandler for PanicOnDispatchHandler {
         panic!("handler panic must be contained at the adapter boundary")
     }
 }
+
+// Test double: reconcile always fails with UnknownReservation.
+// Used to verify the reconcile-failure path in FirstPartyRuntimeAdapter
+// releases the reservation and returns DispatchError::FirstParty { Resource }.
+struct ReconcileFailingGovernor {
+    inner: InMemoryResourceGovernor,
+}
+
+impl ReconcileFailingGovernor {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryResourceGovernor::new(),
+        }
+    }
+}
+
+impl ResourceGovernor for ReconcileFailingGovernor {
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ironclaw_resources::ResourceLimits,
+    ) -> Result<(), ironclaw_resources::ResourceError> {
+        self.inner.set_limit(account, limits)
+    }
+
+    fn reserve_with_outcome(
+        &self,
+        scope: ironclaw_host_api::ResourceScope,
+        estimate: ironclaw_host_api::ResourceEstimate,
+    ) -> Result<ironclaw_resources::ReservationOutcome, ironclaw_resources::ResourceError> {
+        self.inner.reserve_with_outcome(scope, estimate)
+    }
+
+    fn reserve_with_id_and_outcome(
+        &self,
+        scope: ironclaw_host_api::ResourceScope,
+        estimate: ironclaw_host_api::ResourceEstimate,
+        reservation_id: ironclaw_host_api::ResourceReservationId,
+    ) -> Result<ironclaw_resources::ReservationOutcome, ironclaw_resources::ResourceError> {
+        self.inner
+            .reserve_with_id_and_outcome(scope, estimate, reservation_id)
+    }
+
+    fn reconcile(
+        &self,
+        reservation_id: ironclaw_host_api::ResourceReservationId,
+        _actual: ironclaw_host_api::ResourceUsage,
+    ) -> Result<ironclaw_host_api::ResourceReceipt, ironclaw_resources::ResourceError> {
+        Err(ironclaw_resources::ResourceError::UnknownReservation { id: reservation_id })
+    }
+
+    fn release(
+        &self,
+        reservation_id: ironclaw_host_api::ResourceReservationId,
+    ) -> Result<ironclaw_host_api::ResourceReceipt, ironclaw_resources::ResourceError> {
+        self.inner.release(reservation_id)
+    }
+
+    fn account_snapshot(
+        &self,
+        account: &ResourceAccount,
+    ) -> Result<Option<ironclaw_resources::AccountSnapshot>, ironclaw_resources::ResourceError>
+    {
+        self.inner.account_snapshot(account)
+    }
+}
+
+#[tokio::test]
+async fn first_party_adapter_releases_reservation_when_reconcile_fails_after_success() {
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
+    let registry = Arc::new(
+        FirstPartyCapabilityRegistry::new()
+            .with_handler(descriptor.id.clone(), Arc::new(SucceedingFirstPartyHandler)),
+    );
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            None,
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = ReconcileFailingGovernor::new();
+    let scope = sample_scope();
+    let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(DispatchError::FirstParty {
+                kind: RuntimeDispatchErrorKind::Resource
+            })
+        ),
+        "reconcile failure must produce FirstParty{{Resource}}, got {result:?}"
+    );
+    assert_eq!(
+        governor.inner.reserved_for(&tenant_account),
+        ResourceTally::default(),
+        "reservation must be released after reconcile failure"
+    );
+}
+
+struct SucceedingFirstPartyHandler;
+
+#[async_trait]
+impl crate::FirstPartyCapabilityHandler for SucceedingFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        _request: crate::FirstPartyCapabilityRequest,
+    ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
+        Ok(crate::FirstPartyCapabilityResult {
+            output: serde_json::json!({"ok": true}),
+            usage: ironclaw_host_api::ResourceUsage::default(),
+        })
+    }
+}

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -264,8 +264,9 @@ pub struct McpHostHttpEgressPlanRequest<'a> {
 /// `plan` must be deterministic and side-effect-free. The concrete HTTP client
 /// plans the real `tools/call` body once before the MCP handshake, validates
 /// its credential sources, then threads that plan into the later `tools/call`
-/// transport send. Handshake requests are planned independently and remain
-/// credential-free.
+/// transport send. Planner-visible headers are stable policy headers only; the
+/// dynamic MCP session header is added by the protocol client after planning.
+/// Handshake requests are planned independently and remain credential-free.
 pub trait McpHostHttpEgressPlanner: Send + Sync {
     fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan;
 }
@@ -315,6 +316,7 @@ struct McpHostHttpSessionCleanup {
 }
 
 struct PlannedMcpJsonRpc {
+    policy_headers: Vec<(String, String)>,
     body: Vec<u8>,
     plan: McpHostHttpEgressPlan,
 }
@@ -390,7 +392,7 @@ where
         method: McpJsonRpcMethod,
         params: Option<Value>,
     ) -> Result<McpJsonRpcExchange, String> {
-        let planned = self.plan_json_rpc(request, session_key, id, method, params)?;
+        let planned = self.plan_json_rpc(request, id, method, params)?;
         self.send_planned_json_rpc(request, session_key, id, method, planned)
             .await
     }
@@ -398,23 +400,19 @@ where
     fn plan_json_rpc(
         &self,
         request: &McpClientRequest,
-        session_key: &McpHostHttpSessionKey,
         id: Option<u64>,
         method: McpJsonRpcMethod,
         params: Option<Value>,
     ) -> Result<PlannedMcpJsonRpc, String> {
         let url = request.url.as_deref().ok_or_else(request_denied)?;
         let body = encode_json_rpc_request(id, method.as_str(), params)?;
-        let mut headers = vec![
+        let policy_headers = vec![
             ("Content-Type".to_string(), "application/json".to_string()),
             (
                 "Accept".to_string(),
                 "application/json, text/event-stream".to_string(),
             ),
         ];
-        if let Some(session_id) = self.current_session_id(session_key)? {
-            headers.push(("Mcp-Session-Id".to_string(), session_id));
-        }
 
         let plan = self.planner.plan(McpHostHttpEgressPlanRequest {
             provider: &request.provider,
@@ -423,10 +421,14 @@ where
             transport: &request.transport,
             method: NetworkMethod::Post,
             url,
-            headers: &headers,
+            headers: &policy_headers,
             body: &body,
         });
-        Ok(PlannedMcpJsonRpc { body, plan })
+        Ok(PlannedMcpJsonRpc {
+            policy_headers,
+            body,
+            plan,
+        })
     }
 
     async fn send_planned_json_rpc(
@@ -438,13 +440,7 @@ where
         planned: PlannedMcpJsonRpc,
     ) -> Result<McpJsonRpcExchange, String> {
         let url = request.url.as_deref().ok_or_else(request_denied)?;
-        let mut headers = vec![
-            ("Content-Type".to_string(), "application/json".to_string()),
-            (
-                "Accept".to_string(),
-                "application/json, text/event-stream".to_string(),
-            ),
-        ];
+        let mut headers = planned.policy_headers;
         if let Some(session_id) = self.current_session_id(session_key)? {
             headers.push(("Mcp-Session-Id".to_string(), session_id));
         }
@@ -567,7 +563,6 @@ where
         let tool_call_id = self.next_request_id();
         let tool_call_plan = self.plan_json_rpc(
             &request,
-            &session_key,
             Some(tool_call_id),
             McpJsonRpcMethod::ToolsCall,
             Some(tool_call_params),

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -316,6 +316,9 @@ struct McpHostHttpSessionCleanup {
 }
 
 struct PlannedMcpJsonRpc {
+    id: Option<u64>,
+    method: McpJsonRpcMethod,
+    url: String,
     policy_headers: Vec<(String, String)>,
     body: Vec<u8>,
     plan: McpHostHttpEgressPlan,
@@ -393,7 +396,7 @@ where
         params: Option<Value>,
     ) -> Result<McpJsonRpcExchange, String> {
         let planned = self.plan_json_rpc(request, id, method, params)?;
-        self.send_planned_json_rpc(request, session_key, id, method, planned)
+        self.send_planned_json_rpc(request, session_key, planned)
             .await
     }
 
@@ -425,6 +428,9 @@ where
             body: &body,
         });
         Ok(PlannedMcpJsonRpc {
+            id,
+            method,
+            url: url.to_string(),
             policy_headers,
             body,
             plan,
@@ -435,11 +441,8 @@ where
         &self,
         request: &McpClientRequest,
         session_key: &McpHostHttpSessionKey,
-        id: Option<u64>,
-        method: McpJsonRpcMethod,
         planned: PlannedMcpJsonRpc,
     ) -> Result<McpJsonRpcExchange, String> {
-        let url = request.url.as_deref().ok_or_else(request_denied)?;
         let mut headers = planned.policy_headers;
         if let Some(session_id) = self.current_session_id(session_key)? {
             headers.push(("Mcp-Session-Id".to_string(), session_id));
@@ -449,15 +452,16 @@ where
             planned.plan.response_body_limit,
             request.max_output_bytes,
         );
-        let credential_injections =
-            method.credential_injections(planned.plan.credential_injections)?;
+        let credential_injections = planned
+            .method
+            .credential_injections(planned.plan.credential_injections)?;
         let response = self
             .http
             .request(McpHostHttpRequest {
                 scope: request.scope.clone(),
                 capability_id: request.capability_id.clone(),
                 method: NetworkMethod::Post,
-                url: url.to_string(),
+                url: planned.url,
                 headers,
                 body: planned.body,
                 network_policy: planned.plan.network_policy,
@@ -478,7 +482,7 @@ where
         }
         self.capture_session_id(session_key, &response)?;
 
-        if response.status == 202 && id.is_none() {
+        if response.status == 202 && planned.id.is_none() {
             return Ok(McpJsonRpcExchange {
                 response: McpJsonRpcResponse {
                     result: None,
@@ -489,7 +493,7 @@ where
         }
 
         Ok(McpJsonRpcExchange {
-            response: parse_mcp_response(&response, id)?,
+            response: parse_mcp_response(&response, planned.id)?,
             usage,
         })
     }
@@ -601,13 +605,7 @@ where
         }
 
         let call = self
-            .send_planned_json_rpc(
-                &request,
-                &session_key,
-                Some(tool_call_id),
-                McpJsonRpcMethod::ToolsCall,
-                tool_call_plan,
-            )
+            .send_planned_json_rpc(&request, &session_key, tool_call_plan)
             .await?;
         accumulate_usage(&mut usage, call.usage);
         if call.response.error {

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -571,9 +571,7 @@ where
             McpJsonRpcMethod::ToolsCall,
             Some(tool_call_params),
         )?;
-        McpJsonRpcMethod::ToolsCall
-            .credential_injections(tool_call_plan.plan.credential_injections.clone())
-            .map(|_| ())?;
+        validate_tools_call_credential_injections(&tool_call_plan.plan.credential_injections)?;
 
         let mut usage = ResourceUsage::default();
         let initialize = self
@@ -674,6 +672,23 @@ impl McpJsonRpcMethod {
             Self::Initialize | Self::InitializedNotification => Ok(Vec::new()),
         }
     }
+}
+
+/// Validate credential injections planned for a `tools/call` request without
+/// consuming the list, so the caller can reuse it in the actual send.
+///
+/// Returns `Err(denied)` if any injection uses a [`RuntimeCredentialSource::SecretStoreLease`],
+/// which is not permitted over the MCP `tools/call` boundary.
+fn validate_tools_call_credential_injections(
+    credential_injections: &[RuntimeCredentialInjection],
+) -> Result<(), String> {
+    if credential_injections
+        .iter()
+        .any(|injection| matches!(injection.source, RuntimeCredentialSource::SecretStoreLease))
+    {
+        return Err(request_denied());
+    }
+    Ok(())
 }
 
 fn mcp_client_http_error(error: McpHostHttpError) -> String {

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -262,9 +262,10 @@ pub struct McpHostHttpEgressPlanRequest<'a> {
 /// timeouts for the shared egress service.
 ///
 /// `plan` must be deterministic and side-effect-free. The concrete HTTP client
-/// calls it once before the MCP handshake to fail closed on disallowed
-/// `tools/call` credential plans, then again while building each JSON-RPC
-/// exchange so request headers and body bytes match the actual transport call.
+/// plans the real `tools/call` body once before the MCP handshake, validates
+/// its credential sources, then threads that plan into the later `tools/call`
+/// transport send. Handshake requests are planned independently and remain
+/// credential-free.
 pub trait McpHostHttpEgressPlanner: Send + Sync {
     fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan;
 }
@@ -311,6 +312,11 @@ struct McpHostHttpClientState {
 struct McpHostHttpSessionCleanup {
     state: Arc<McpHostHttpClientState>,
     session_key: McpHostHttpSessionKey,
+}
+
+struct PlannedMcpJsonRpc {
+    body: Vec<u8>,
+    plan: McpHostHttpEgressPlan,
 }
 
 impl McpHostHttpSessionCleanup {
@@ -384,6 +390,19 @@ where
         method: McpJsonRpcMethod,
         params: Option<Value>,
     ) -> Result<McpJsonRpcExchange, String> {
+        let planned = self.plan_json_rpc(request, session_key, id, method, params)?;
+        self.send_planned_json_rpc(request, session_key, id, method, planned)
+            .await
+    }
+
+    fn plan_json_rpc(
+        &self,
+        request: &McpClientRequest,
+        session_key: &McpHostHttpSessionKey,
+        id: Option<u64>,
+        method: McpJsonRpcMethod,
+        params: Option<Value>,
+    ) -> Result<PlannedMcpJsonRpc, String> {
         let url = request.url.as_deref().ok_or_else(request_denied)?;
         let body = encode_json_rpc_request(id, method.as_str(), params)?;
         let mut headers = vec![
@@ -407,10 +426,35 @@ where
             headers: &headers,
             body: &body,
         });
+        Ok(PlannedMcpJsonRpc { body, plan })
+    }
 
-        let response_body_limit =
-            effective_mcp_response_body_limit(plan.response_body_limit, request.max_output_bytes);
-        let credential_injections = method.credential_injections(plan.credential_injections)?;
+    async fn send_planned_json_rpc(
+        &self,
+        request: &McpClientRequest,
+        session_key: &McpHostHttpSessionKey,
+        id: Option<u64>,
+        method: McpJsonRpcMethod,
+        planned: PlannedMcpJsonRpc,
+    ) -> Result<McpJsonRpcExchange, String> {
+        let url = request.url.as_deref().ok_or_else(request_denied)?;
+        let mut headers = vec![
+            ("Content-Type".to_string(), "application/json".to_string()),
+            (
+                "Accept".to_string(),
+                "application/json, text/event-stream".to_string(),
+            ),
+        ];
+        if let Some(session_id) = self.current_session_id(session_key)? {
+            headers.push(("Mcp-Session-Id".to_string(), session_id));
+        }
+
+        let response_body_limit = effective_mcp_response_body_limit(
+            planned.plan.response_body_limit,
+            request.max_output_bytes,
+        );
+        let credential_injections =
+            method.credential_injections(planned.plan.credential_injections)?;
         let response = self
             .http
             .request(McpHostHttpRequest {
@@ -419,11 +463,11 @@ where
                 method: NetworkMethod::Post,
                 url: url.to_string(),
                 headers,
-                body,
-                network_policy: plan.network_policy,
+                body: planned.body,
+                network_policy: planned.plan.network_policy,
                 credential_injections,
                 response_body_limit,
-                timeout_ms: plan.timeout_ms,
+                timeout_ms: planned.plan.timeout_ms,
             })
             .await
             .map_err(mcp_client_http_error)?;
@@ -452,36 +496,6 @@ where
             response: parse_mcp_response(&response, id)?,
             usage,
         })
-    }
-
-    fn preflight_tools_call_credentials(
-        &self,
-        request: &McpClientRequest,
-        params: Value,
-    ) -> Result<(), String> {
-        let url = request.url.as_deref().ok_or_else(request_denied)?;
-        let body =
-            encode_json_rpc_request(Some(0), McpJsonRpcMethod::ToolsCall.as_str(), Some(params))?;
-        let headers = vec![
-            ("Content-Type".to_string(), "application/json".to_string()),
-            (
-                "Accept".to_string(),
-                "application/json, text/event-stream".to_string(),
-            ),
-        ];
-        let plan = self.planner.plan(McpHostHttpEgressPlanRequest {
-            provider: &request.provider,
-            capability_id: &request.capability_id,
-            scope: &request.scope,
-            transport: &request.transport,
-            method: NetworkMethod::Post,
-            url,
-            headers: &headers,
-            body: &body,
-        });
-        McpJsonRpcMethod::ToolsCall
-            .credential_injections(plan.credential_injections)
-            .map(|_| ())
     }
 
     fn current_session_id(
@@ -549,14 +563,25 @@ where
             "name": tool_name,
             "arguments": request.input.clone(),
         });
-        self.preflight_tools_call_credentials(&request, tool_call_params.clone())?;
+        let initialize_id = self.next_request_id();
+        let tool_call_id = self.next_request_id();
+        let tool_call_plan = self.plan_json_rpc(
+            &request,
+            &session_key,
+            Some(tool_call_id),
+            McpJsonRpcMethod::ToolsCall,
+            Some(tool_call_params),
+        )?;
+        McpJsonRpcMethod::ToolsCall
+            .credential_injections(tool_call_plan.plan.credential_injections.clone())
+            .map(|_| ())?;
 
         let mut usage = ResourceUsage::default();
         let initialize = self
             .send_json_rpc(
                 &request,
                 &session_key,
-                Some(self.next_request_id()),
+                Some(initialize_id),
                 McpJsonRpcMethod::Initialize,
                 Some(json_rpc_initialize_params()),
             )
@@ -581,12 +606,12 @@ where
         }
 
         let call = self
-            .send_json_rpc(
+            .send_planned_json_rpc(
                 &request,
                 &session_key,
-                Some(self.next_request_id()),
+                Some(tool_call_id),
                 McpJsonRpcMethod::ToolsCall,
-                Some(tool_call_params),
+                tool_call_plan,
             )
             .await?;
         accumulate_usage(&mut usage, call.usage);

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -307,6 +307,10 @@ pub struct McpHostHttpClient<H, P> {
 #[derive(Debug)]
 struct McpHostHttpClientState {
     next_id: AtomicU64,
+    // `std::sync::Mutex` is appropriate here: the lock is held only for O(1)
+    // HashMap operations (never across an `.await`), and the key includes
+    // `invocation_id` so concurrent dispatches from different invocations act
+    // on disjoint map entries with no real contention.
     session_ids: Mutex<HashMap<McpHostHttpSessionKey, String>>,
 }
 

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -256,13 +256,21 @@ async fn concrete_mcp_http_client_routes_json_rpc_through_shared_egress() {
     }));
 
     let planner_calls = planner.calls();
-    assert_eq!(planner_calls.len(), 4);
+    assert_eq!(planner_calls.len(), 3);
     assert!(planner_calls.iter().all(|call| call.scope == scope));
     assert!(
         planner_calls
             .iter()
             .all(|call| call.url == "https://mcp.example.test/mcp")
     );
+    assert_eq!(
+        planner_calls
+            .iter()
+            .map(|call| call.json_rpc_method.as_str())
+            .collect::<Vec<_>>(),
+        vec!["tools/call", "initialize", "notifications/initialized"]
+    );
+    assert_eq!(planner_calls[0].json_rpc_id, json_rpc_id(&requests[2].body));
 }
 
 #[tokio::test]
@@ -338,7 +346,7 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
             .all(|(name, _)| !name.eq_ignore_ascii_case("Mcp-Session-Id")),
         "failed preflight must not leave a stale session id for the next initialize"
     );
-    assert_eq!(planner.calls().len(), 5);
+    assert_eq!(planner.calls().len(), 4);
 }
 
 #[tokio::test]
@@ -1067,7 +1075,7 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
         self.requests.lock().unwrap().push(request.clone());
         match method.as_str() {
             "initialize" => Ok(runtime_json_response(
-                Some(1),
+                json_rpc_id(&request.body),
                 json!({
                     "protocolVersion": "2024-11-05",
                     "capabilities": {"tools": {"listChanged": false}},
@@ -1108,6 +1116,8 @@ struct RecordedPlanCall {
     scope: ResourceScope,
     method: NetworkMethod,
     url: String,
+    json_rpc_method: String,
+    json_rpc_id: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -1139,6 +1149,8 @@ impl McpHostHttpEgressPlanner for RecordingEgressPlanner {
             scope: request.scope.clone(),
             method: request.method,
             url: request.url.to_string(),
+            json_rpc_method: json_rpc_method(request.body),
+            json_rpc_id: json_rpc_id(request.body),
         });
         self.plan.lock().unwrap().clone()
     }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -97,7 +97,7 @@ use crate::{
     extension_lifecycle_capabilities::{
         extend_builtin_first_party_package, insert_handlers as insert_extension_lifecycle_handlers,
     },
-    gsuite::register_bundled_gsuite_first_party_handlers,
+    gsuite::{ObligationGsuiteCredentialStager, register_bundled_gsuite_first_party_handlers},
     nearai_mcp::{nearai_mcp_endpoint_from_env, nearai_mcp_runtime},
     web_access::register_bundled_web_access_first_party_handlers,
 };
@@ -519,10 +519,14 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         services = services.with_runtime_process_port(Arc::new(process_port));
     }
     services = apply_runtime_process_binding(services, runtime_process_binding);
+    let product_auth_runtime_ports = require_product_auth_runtime_ports(&services)?;
     let google_provider_client = google_oauth_config
         .map(|config| {
-            let runtime_ports = require_product_auth_runtime_ports(&services)?;
-            google_provider_client(config, Arc::clone(&secret_store), runtime_ports)
+            google_provider_client(
+                config,
+                Arc::clone(&secret_store),
+                product_auth_runtime_ports.clone(),
+            )
         })
         .transpose()?;
     let product_auth = match product_auth_ports {
@@ -542,6 +546,9 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     register_bundled_gsuite_first_party_handlers(
         &mut first_party_registry,
         product_auth.credential_account_service(),
+        Arc::new(ObligationGsuiteCredentialStager::new(
+            product_auth_runtime_ports.obligation_handler(),
+        )),
     )
     .map_err(|error| RebornBuildError::InvalidConfig {
         reason: format!("GSuite first-party handlers are invalid: {error}"),
@@ -1633,6 +1640,7 @@ where
         google_oauth_config,
     } = context;
     let secret_store: Arc<dyn SecretStore> = stores.secret_credentials.secret_store.clone();
+    let mut first_party_registry = builtin_first_party_registry()?;
     let services = HostRuntimeServices::new(
         Arc::new(builtin_extension_registry()?),
         Arc::clone(&stores.filesystem),
@@ -1643,7 +1651,6 @@ where
     )
     .with_trust_policy(production_wiring.trust_policy)
     .with_runtime_policy(production_wiring.runtime_policy)
-    .with_first_party_capabilities(Arc::new(builtin_first_party_registry()?))
     .with_capability_leases(stores.leases)
     .with_secret_store(stores.secret_credentials.secret_store)
     .with_credential_broker(stores.secret_credentials.credential_broker)
@@ -1660,11 +1667,11 @@ where
     .with_filesystem_turn_state_store(stores.scoped_filesystem)
     .with_run_profile_resolver(planned_run_profile_resolver()?)
     .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
+    let product_auth_runtime_ports = require_product_auth_runtime_ports(&services)?;
     let services = attach_nearai_mcp_runtime(services)?;
     let google_provider_client = google_oauth_config
         .map(|config| {
-            let runtime_ports = require_product_auth_runtime_ports(&services)?;
-            google_provider_client(config, secret_store, runtime_ports)
+            google_provider_client(config, secret_store, product_auth_runtime_ports.clone())
         })
         .transpose()?;
     let services = apply_production_runtime_process_binding(
@@ -1674,12 +1681,26 @@ where
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);
-    let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
-        Arc::new(services.host_runtime_for_production(&wiring_config)?);
     let product_auth = product_auth_ports.map(|ports| {
         compose_product_auth_services(ports, turn_coordinator.clone(), google_provider_client)
     });
     let product_auth_ready = product_auth.is_some();
+    if let Some(product_auth) = &product_auth {
+        register_bundled_gsuite_first_party_handlers(
+            &mut first_party_registry,
+            product_auth.credential_account_service(),
+            Arc::new(ObligationGsuiteCredentialStager::new(
+                product_auth_runtime_ports.obligation_handler(),
+            )),
+        )
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("GSuite first-party handlers are invalid: {error}"),
+        })?;
+    }
+    let services = services.with_first_party_capabilities(Arc::new(first_party_registry));
+
+    let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
+        Arc::new(services.host_runtime_for_production(&wiring_config)?);
 
     Ok(RebornServices {
         host_runtime: Some(host_runtime),

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -97,7 +97,9 @@ use crate::{
     extension_lifecycle_capabilities::{
         extend_builtin_first_party_package, insert_handlers as insert_extension_lifecycle_handlers,
     },
-    gsuite::{ObligationGsuiteCredentialStager, register_bundled_gsuite_first_party_handlers},
+    gsuite::{
+        ProductAuthRuntimeGsuiteCredentialStager, register_bundled_gsuite_first_party_handlers,
+    },
     nearai_mcp::{nearai_mcp_endpoint_from_env, nearai_mcp_runtime},
     web_access::register_bundled_web_access_first_party_handlers,
 };
@@ -546,8 +548,8 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     register_bundled_gsuite_first_party_handlers(
         &mut first_party_registry,
         product_auth.credential_account_service(),
-        Arc::new(ObligationGsuiteCredentialStager::new(
-            product_auth_runtime_ports.obligation_handler(),
+        Arc::new(ProductAuthRuntimeGsuiteCredentialStager::new(
+            product_auth_runtime_ports.clone(),
         )),
     )
     .map_err(|error| RebornBuildError::InvalidConfig {
@@ -1689,8 +1691,8 @@ where
         register_bundled_gsuite_first_party_handlers(
             &mut first_party_registry,
             product_auth.credential_account_service(),
-            Arc::new(ObligationGsuiteCredentialStager::new(
-                product_auth_runtime_ports.obligation_handler(),
+            Arc::new(ProductAuthRuntimeGsuiteCredentialStager::new(
+                product_auth_runtime_ports.clone(),
             )),
         )
         .map_err(|error| RebornBuildError::InvalidConfig {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1695,15 +1695,15 @@ where
             Arc::new(UnavailableAuthProviderClient),
         )
     });
-    let product_auth = Some(compose_product_auth_services(
+    let product_auth_services = compose_product_auth_services(
         product_auth_ports,
         turn_coordinator.clone(),
         google_provider_client,
-    ));
+    );
     let product_auth_ready = true;
     register_bundled_gsuite_first_party_handlers(
         &mut first_party_registry,
-        product_auth.as_ref().unwrap().credential_account_service(),
+        product_auth_services.credential_account_service(),
         Arc::new(ProductAuthRuntimeGsuiteCredentialStager::new(
             product_auth_runtime_ports.clone(),
         )),
@@ -1720,7 +1720,7 @@ where
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
         readiness: readiness_for(profile, true, true, product_auth_ready),
-        product_auth,
+        product_auth: Some(product_auth_services),
         local_runtime: None,
     })
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -218,7 +218,7 @@ where
     services
         .product_auth_provider_runtime_ports()
         .ok_or_else(|| RebornBuildError::InvalidConfig {
-            reason: "Google OAuth provider backend requires host runtime HTTP egress".to_string(),
+            reason: "product auth runtime ports unavailable; host runtime must be configured with HTTP egress and a secret store".to_string(),
         })
 }
 

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -2,17 +2,23 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_auth::CredentialAccountService;
+use ironclaw_capabilities::{
+    CapabilityObligationError, CapabilityObligationHandler, CapabilityObligationPhase,
+    CapabilityObligationRequest,
+};
 use ironclaw_extensions::{
     CapabilityManifest, CapabilityVisibility, ExtensionError, ExtensionManifest, ExtensionPackage,
     ExtensionRuntime, MANIFEST_SCHEMA_VERSION, ManifestSource,
 };
 use ironclaw_first_party_extensions::{
-    GsuiteCapabilitySpec, GsuiteDispatchError, GsuiteDispatchRequest, GsuiteExecutor,
-    GsuitePackageSpec, gsuite_package_specs, gsuite_resource_profile,
+    GsuiteCapabilitySpec, GsuiteCredentialStageError, GsuiteCredentialStageRequest,
+    GsuiteCredentialStager, GsuiteDispatchError, GsuiteDispatchRequest, GsuiteExecutor,
+    GsuitePackageSpec, NoopGsuiteCredentialStager, gsuite_package_specs, gsuite_resource_profile,
 };
 use ironclaw_host_api::{
-    CapabilityId, CapabilityProfileSchemaRef, ExtensionId, HostApiError, RequestedTrustClass,
-    TrustClass, VirtualPath,
+    CapabilityId, CapabilityProfileSchemaRef, CapabilitySet, CorrelationId, ExecutionContext,
+    ExtensionId, HostApiError, MountView, Obligation, RequestedTrustClass, ResourceEstimate,
+    ResourceScope, RuntimeKind, TrustClass, VirtualPath,
 };
 use ironclaw_host_runtime::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
@@ -39,17 +45,28 @@ pub fn bundled_gsuite_extension_packages() -> Result<Vec<ExtensionPackage>, Exte
 pub fn bundled_gsuite_first_party_handlers(
     accounts: Arc<dyn CredentialAccountService>,
 ) -> Result<FirstPartyCapabilityRegistry, HostApiError> {
+    bundled_gsuite_first_party_handlers_with_credential_stager(
+        accounts,
+        Arc::new(NoopGsuiteCredentialStager),
+    )
+}
+
+pub fn bundled_gsuite_first_party_handlers_with_credential_stager(
+    accounts: Arc<dyn CredentialAccountService>,
+    credential_stager: Arc<dyn GsuiteCredentialStager>,
+) -> Result<FirstPartyCapabilityRegistry, HostApiError> {
     let mut registry = FirstPartyCapabilityRegistry::new();
-    register_bundled_gsuite_first_party_handlers(&mut registry, accounts)?;
+    register_bundled_gsuite_first_party_handlers(&mut registry, accounts, credential_stager)?;
     Ok(registry)
 }
 
 pub(crate) fn register_bundled_gsuite_first_party_handlers(
     registry: &mut FirstPartyCapabilityRegistry,
     accounts: Arc<dyn CredentialAccountService>,
+    credential_stager: Arc<dyn GsuiteCredentialStager>,
 ) -> Result<(), HostApiError> {
     let handler = Arc::new(GsuiteFirstPartyHandler {
-        executor: GsuiteExecutor::new(accounts),
+        executor: GsuiteExecutor::new(accounts).with_credential_stager(credential_stager),
     });
     for package in gsuite_package_specs() {
         for capability in package.capabilities {
@@ -149,10 +166,86 @@ fn capability_manifest(
 }
 
 fn gsuite_error(error: GsuiteDispatchError) -> FirstPartyCapabilityError {
-    let mapped = FirstPartyCapabilityError::new(error.kind());
+    let mapped = if error.is_auth_required() {
+        FirstPartyCapabilityError::auth_required()
+    } else {
+        FirstPartyCapabilityError::new(error.kind())
+    };
     if let Some(usage) = error.usage().cloned() {
         mapped.with_usage(usage)
     } else {
         mapped
+    }
+}
+
+pub(crate) struct ObligationGsuiteCredentialStager {
+    obligation_handler: Arc<dyn CapabilityObligationHandler>,
+}
+
+impl ObligationGsuiteCredentialStager {
+    pub(crate) fn new(obligation_handler: Arc<dyn CapabilityObligationHandler>) -> Self {
+        Self { obligation_handler }
+    }
+}
+
+#[async_trait]
+impl GsuiteCredentialStager for ObligationGsuiteCredentialStager {
+    async fn stage(
+        &self,
+        request: GsuiteCredentialStageRequest<'_>,
+    ) -> Result<(), GsuiteCredentialStageError> {
+        let context = gsuite_staging_context(request.scope, request.extension_id.clone())?;
+        let obligation = Obligation::InjectSecretOnce {
+            handle: request.access_secret.clone(),
+        };
+        let obligations = [obligation];
+        let estimate = ResourceEstimate::default();
+        self.obligation_handler
+            .satisfy(CapabilityObligationRequest {
+                phase: CapabilityObligationPhase::Invoke,
+                context: &context,
+                capability_id: request.capability_id,
+                estimate: &estimate,
+                obligations: &obligations,
+            })
+            .await
+            .map_err(stage_obligation_error)
+    }
+}
+
+fn gsuite_staging_context(
+    scope: &ResourceScope,
+    extension_id: ExtensionId,
+) -> Result<ExecutionContext, GsuiteCredentialStageError> {
+    let mounts = MountView::new(Vec::new()).map_err(|_| GsuiteCredentialStageError::Backend)?;
+    let context = ExecutionContext {
+        invocation_id: scope.invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: scope.mission_id.clone(),
+        thread_id: scope.thread_id.clone(),
+        extension_id,
+        runtime: RuntimeKind::FirstParty,
+        trust: TrustClass::FirstParty,
+        grants: CapabilitySet::default(),
+        mounts,
+        resource_scope: scope.clone(),
+    };
+    context
+        .validate()
+        .map_err(|_| GsuiteCredentialStageError::Backend)?;
+    Ok(context)
+}
+
+fn stage_obligation_error(error: CapabilityObligationError) -> GsuiteCredentialStageError {
+    match error {
+        CapabilityObligationError::AuthRequired => GsuiteCredentialStageError::AuthRequired,
+        CapabilityObligationError::Unsupported { .. }
+        | CapabilityObligationError::Failed { .. } => GsuiteCredentialStageError::Backend,
     }
 }

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -151,6 +151,15 @@ fn capability_manifest(
     })
 }
 
+/// Convert a [`GsuiteDispatchError`] into the neutral [`FirstPartyCapabilityError`].
+///
+/// Recovery context carried by [`GsuiteCredentialDispatchReason::Recovery`] and
+/// [`GsuiteCredentialDispatchReason::MissingScopes`] (recovery kind, provider id,
+/// available accounts, missing OAuth scopes) is intentionally dropped here:
+/// [`FirstPartyCapabilityError`] has no recovery-payload field.  Upper services
+/// receive a generic `AuthRequired` gate.  To thread structured recovery hints
+/// through to the runtime, `FirstPartyCapabilityError::AuthRequired` must be
+/// extended with an opaque reason payload (tracked as a follow-up).
 fn gsuite_error(error: GsuiteDispatchError) -> FirstPartyCapabilityError {
     let usage = error.usage().cloned();
     let base = match error.auth_requirement() {

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -2,10 +2,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_auth::CredentialAccountService;
-use ironclaw_capabilities::{
-    CapabilityObligationError, CapabilityObligationHandler, CapabilityObligationPhase,
-    CapabilityObligationRequest,
-};
 use ironclaw_extensions::{
     CapabilityManifest, CapabilityVisibility, ExtensionError, ExtensionManifest, ExtensionPackage,
     ExtensionRuntime, MANIFEST_SCHEMA_VERSION, ManifestSource,
@@ -13,16 +9,16 @@ use ironclaw_extensions::{
 use ironclaw_first_party_extensions::{
     GsuiteCapabilitySpec, GsuiteCredentialStageError, GsuiteCredentialStageRequest,
     GsuiteCredentialStager, GsuiteDispatchError, GsuiteDispatchRequest, GsuiteExecutor,
-    GsuitePackageSpec, NoopGsuiteCredentialStager, gsuite_package_specs, gsuite_resource_profile,
+    GsuitePackageSpec, gsuite_package_specs, gsuite_resource_profile,
 };
 use ironclaw_host_api::{
-    CapabilityId, CapabilityProfileSchemaRef, CapabilitySet, CorrelationId, ExecutionContext,
-    ExtensionId, HostApiError, MountView, Obligation, RequestedTrustClass, ResourceEstimate,
-    ResourceScope, RuntimeKind, TrustClass, VirtualPath,
+    CapabilityId, CapabilityProfileSchemaRef, ExtensionId, HostApiError, RequestedTrustClass,
+    TrustClass, VirtualPath,
 };
 use ironclaw_host_runtime::{
-    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
-    FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+    FirstPartyAuthRequirement, FirstPartyCapabilityError, FirstPartyCapabilityHandler,
+    FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+    ProductAuthCredentialStageError, ProductAuthProviderRuntimePorts,
 };
 
 /// Host-bundled GSuite packages available to an install/activation surface.
@@ -44,15 +40,6 @@ pub fn bundled_gsuite_extension_packages() -> Result<Vec<ExtensionPackage>, Exte
 /// dispatch still requires active package descriptors.
 pub fn bundled_gsuite_first_party_handlers(
     accounts: Arc<dyn CredentialAccountService>,
-) -> Result<FirstPartyCapabilityRegistry, HostApiError> {
-    bundled_gsuite_first_party_handlers_with_credential_stager(
-        accounts,
-        Arc::new(NoopGsuiteCredentialStager),
-    )
-}
-
-pub fn bundled_gsuite_first_party_handlers_with_credential_stager(
-    accounts: Arc<dyn CredentialAccountService>,
     credential_stager: Arc<dyn GsuiteCredentialStager>,
 ) -> Result<FirstPartyCapabilityRegistry, HostApiError> {
     let mut registry = FirstPartyCapabilityRegistry::new();
@@ -66,7 +53,7 @@ pub(crate) fn register_bundled_gsuite_first_party_handlers(
     credential_stager: Arc<dyn GsuiteCredentialStager>,
 ) -> Result<(), HostApiError> {
     let handler = Arc::new(GsuiteFirstPartyHandler {
-        executor: GsuiteExecutor::new(accounts).with_credential_stager(credential_stager),
+        executor: GsuiteExecutor::new(accounts, credential_stager),
     });
     for package in gsuite_package_specs() {
         for capability in package.capabilities {
@@ -166,8 +153,10 @@ fn capability_manifest(
 }
 
 fn gsuite_error(error: GsuiteDispatchError) -> FirstPartyCapabilityError {
-    let mapped = if error.is_auth_required() {
-        FirstPartyCapabilityError::auth_required()
+    let mapped = if let Some(auth) = error.auth_requirement() {
+        FirstPartyCapabilityError::auth_required_with(FirstPartyAuthRequirement {
+            required_secrets: auth.required_secrets,
+        })
     } else {
         FirstPartyCapabilityError::new(error.kind())
     };
@@ -178,74 +167,34 @@ fn gsuite_error(error: GsuiteDispatchError) -> FirstPartyCapabilityError {
     }
 }
 
-pub(crate) struct ObligationGsuiteCredentialStager {
-    obligation_handler: Arc<dyn CapabilityObligationHandler>,
+pub(crate) struct ProductAuthRuntimeGsuiteCredentialStager {
+    runtime_ports: ProductAuthProviderRuntimePorts,
 }
 
-impl ObligationGsuiteCredentialStager {
-    pub(crate) fn new(obligation_handler: Arc<dyn CapabilityObligationHandler>) -> Self {
-        Self { obligation_handler }
+impl ProductAuthRuntimeGsuiteCredentialStager {
+    pub(crate) fn new(runtime_ports: ProductAuthProviderRuntimePorts) -> Self {
+        Self { runtime_ports }
     }
 }
 
 #[async_trait]
-impl GsuiteCredentialStager for ObligationGsuiteCredentialStager {
+impl GsuiteCredentialStager for ProductAuthRuntimeGsuiteCredentialStager {
     async fn stage(
         &self,
         request: GsuiteCredentialStageRequest<'_>,
     ) -> Result<(), GsuiteCredentialStageError> {
-        let context = gsuite_staging_context(request.scope, request.extension_id.clone())?;
-        let obligation = Obligation::InjectSecretOnce {
-            handle: request.access_secret.clone(),
-        };
-        let obligations = [obligation];
-        let estimate = ResourceEstimate::default();
-        self.obligation_handler
-            .satisfy(CapabilityObligationRequest {
-                phase: CapabilityObligationPhase::Invoke,
-                context: &context,
-                capability_id: request.capability_id,
-                estimate: &estimate,
-                obligations: &obligations,
-            })
+        self.runtime_ports
+            .stage_secret_once(request.scope, request.capability_id, request.access_secret)
             .await
-            .map_err(stage_obligation_error)
+            .map_err(stage_runtime_credential_error)
     }
 }
 
-fn gsuite_staging_context(
-    scope: &ResourceScope,
-    extension_id: ExtensionId,
-) -> Result<ExecutionContext, GsuiteCredentialStageError> {
-    let mounts = MountView::new(Vec::new()).map_err(|_| GsuiteCredentialStageError::Backend)?;
-    let context = ExecutionContext {
-        invocation_id: scope.invocation_id,
-        correlation_id: CorrelationId::new(),
-        process_id: None,
-        parent_process_id: None,
-        tenant_id: scope.tenant_id.clone(),
-        user_id: scope.user_id.clone(),
-        agent_id: scope.agent_id.clone(),
-        project_id: scope.project_id.clone(),
-        mission_id: scope.mission_id.clone(),
-        thread_id: scope.thread_id.clone(),
-        extension_id,
-        runtime: RuntimeKind::FirstParty,
-        trust: TrustClass::FirstParty,
-        grants: CapabilitySet::default(),
-        mounts,
-        resource_scope: scope.clone(),
-    };
-    context
-        .validate()
-        .map_err(|_| GsuiteCredentialStageError::Backend)?;
-    Ok(context)
-}
-
-fn stage_obligation_error(error: CapabilityObligationError) -> GsuiteCredentialStageError {
+fn stage_runtime_credential_error(
+    error: ProductAuthCredentialStageError,
+) -> GsuiteCredentialStageError {
     match error {
-        CapabilityObligationError::AuthRequired => GsuiteCredentialStageError::AuthRequired,
-        CapabilityObligationError::Unsupported { .. }
-        | CapabilityObligationError::Failed { .. } => GsuiteCredentialStageError::Backend,
+        ProductAuthCredentialStageError::AuthRequired => GsuiteCredentialStageError::AuthRequired,
+        ProductAuthCredentialStageError::Backend => GsuiteCredentialStageError::Backend,
     }
 }

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -16,9 +16,8 @@ use ironclaw_host_api::{
     TrustClass, VirtualPath,
 };
 use ironclaw_host_runtime::{
-    FirstPartyAuthRequirement, FirstPartyCapabilityError, FirstPartyCapabilityHandler,
-    FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
-    ProductAuthCredentialStageError, ProductAuthProviderRuntimePorts,
+    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
+    FirstPartyCapabilityRequest, FirstPartyCapabilityResult, ProductAuthProviderRuntimePorts,
 };
 
 /// Host-bundled GSuite packages available to an install/activation surface.
@@ -153,17 +152,14 @@ fn capability_manifest(
 }
 
 fn gsuite_error(error: GsuiteDispatchError) -> FirstPartyCapabilityError {
-    let mapped = if let Some(auth) = error.auth_requirement() {
-        FirstPartyCapabilityError::auth_required_with(FirstPartyAuthRequirement {
-            required_secrets: auth.required_secrets,
-        })
-    } else {
-        FirstPartyCapabilityError::new(error.kind())
+    let usage = error.usage().cloned();
+    let base = match error.auth_requirement() {
+        Some(required_secrets) => FirstPartyCapabilityError::auth_required_with(required_secrets),
+        None => FirstPartyCapabilityError::new(error.kind()),
     };
-    if let Some(usage) = error.usage().cloned() {
-        mapped.with_usage(usage)
-    } else {
-        mapped
+    match usage {
+        Some(u) => base.with_usage(u),
+        None => base,
     }
 }
 
@@ -183,18 +179,10 @@ impl GsuiteCredentialStager for ProductAuthRuntimeGsuiteCredentialStager {
         &self,
         request: GsuiteCredentialStageRequest<'_>,
     ) -> Result<(), GsuiteCredentialStageError> {
+        // Both GsuiteCredentialStageError and ProductAuthCredentialStageError are
+        // type aliases for ironclaw_host_api::CredentialStageError — no conversion needed.
         self.runtime_ports
             .stage_secret_once(request.scope, request.capability_id, request.access_secret)
             .await
-            .map_err(stage_runtime_credential_error)
-    }
-}
-
-fn stage_runtime_credential_error(
-    error: ProductAuthCredentialStageError,
-) -> GsuiteCredentialStageError {
-    match error {
-        ProductAuthCredentialStageError::AuthRequired => GsuiteCredentialStageError::AuthRequired,
-        ProductAuthCredentialStageError::Backend => GsuiteCredentialStageError::Backend,
     }
 }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -81,7 +81,10 @@ pub use extension_lifecycle_command::{
     execute_reborn_extension_lifecycle_command, render_reborn_extension_lifecycle_response,
 };
 pub use factory::{RebornServices, build_reborn_services};
-pub use gsuite::{bundled_gsuite_extension_packages, bundled_gsuite_first_party_handlers};
+pub use gsuite::{
+    bundled_gsuite_extension_packages, bundled_gsuite_first_party_handlers,
+    bundled_gsuite_first_party_handlers_with_credential_stager,
+};
 pub use input::{OAuthClientConfig, RebornBuildInput, RebornRuntimeProcessBinding};
 pub use ironclaw_product_workflow::{
     LifecycleExtensionSource, LifecycleExtensionSummary, LifecyclePhase, LifecycleProductPayload,

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -81,10 +81,7 @@ pub use extension_lifecycle_command::{
     execute_reborn_extension_lifecycle_command, render_reborn_extension_lifecycle_response,
 };
 pub use factory::{RebornServices, build_reborn_services};
-pub use gsuite::{
-    bundled_gsuite_extension_packages, bundled_gsuite_first_party_handlers,
-    bundled_gsuite_first_party_handlers_with_credential_stager,
-};
+pub use gsuite::{bundled_gsuite_extension_packages, bundled_gsuite_first_party_handlers};
 pub use input::{OAuthClientConfig, RebornBuildInput, RebornRuntimeProcessBinding};
 pub use ironclaw_product_workflow::{
     LifecycleExtensionSource, LifecycleExtensionSummary, LifecyclePhase, LifecycleProductPayload,

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -19,7 +19,6 @@ use ironclaw_host_api::{
 use ironclaw_host_runtime::FirstPartyCapabilityRequest;
 use ironclaw_reborn_composition::{
     bundled_gsuite_extension_packages, bundled_gsuite_first_party_handlers,
-    bundled_gsuite_first_party_handlers_with_credential_stager,
 };
 use serde_json::json;
 
@@ -266,7 +265,9 @@ async fn bundled_gsuite_asset_manifests_match_package_specs() {
 async fn bundled_gsuite_handlers_register_and_forward_runtime_egress() {
     let scope = scope();
     let auth = auth_with_google_account(&scope).await;
-    let registry = bundled_gsuite_first_party_handlers(auth).unwrap();
+    let registry =
+        bundled_gsuite_first_party_handlers(auth, Arc::new(RecordingCredentialStager::default()))
+            .unwrap();
     let capability_id = cap_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
     let egress = Arc::new(RecordingEgress::default());
     let egress_port: Arc<dyn RuntimeHttpEgress> = egress.clone();
@@ -297,7 +298,7 @@ async fn bundled_gsuite_handlers_stage_selected_account_secret_before_egress() {
     let scope = scope();
     let auth = auth_with_google_account(&scope).await;
     let stager = Arc::new(RecordingCredentialStager::default());
-    let registry = bundled_gsuite_first_party_handlers_with_credential_stager(
+    let registry = bundled_gsuite_first_party_handlers(
         auth,
         stager.clone() as Arc<dyn GsuiteCredentialStager>,
     )
@@ -335,11 +336,9 @@ async fn bundled_gsuite_handlers_project_staging_auth_failures_as_auth_required(
     let scope = scope();
     let auth = auth_with_google_account(&scope).await;
     let stager = Arc::new(RecordingCredentialStager::auth_required());
-    let registry = bundled_gsuite_first_party_handlers_with_credential_stager(
-        auth,
-        stager as Arc<dyn GsuiteCredentialStager>,
-    )
-    .unwrap();
+    let registry =
+        bundled_gsuite_first_party_handlers(auth, stager as Arc<dyn GsuiteCredentialStager>)
+            .unwrap();
     let capability_id = cap_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
     let egress = Arc::new(RecordingEgress::default());
     let egress_port: Arc<dyn RuntimeHttpEgress> = egress.clone();
@@ -355,7 +354,13 @@ async fn bundled_gsuite_handlers_project_staging_auth_failures_as_auth_required(
         .await
         .unwrap_err();
 
-    assert!(error.is_auth_required());
+    assert_eq!(
+        error
+            .auth_requirement()
+            .expect("staging auth failure should surface auth requirement")
+            .required_secrets,
+        vec![SecretHandle::new("google-access-token").unwrap()]
+    );
     assert!(egress.requests().is_empty());
 }
 
@@ -363,7 +368,9 @@ async fn bundled_gsuite_handlers_project_staging_auth_failures_as_auth_required(
 async fn bundled_gsuite_handlers_register_all_gsuite_capabilities() {
     let scope = scope();
     let auth = auth_with_google_account(&scope).await;
-    let registry = bundled_gsuite_first_party_handlers(auth).unwrap();
+    let registry =
+        bundled_gsuite_first_party_handlers(auth, Arc::new(RecordingCredentialStager::default()))
+            .unwrap();
     let expected_capability_ids = gsuite_package_specs()
         .iter()
         .flat_map(|package| {
@@ -386,7 +393,9 @@ async fn bundled_gsuite_handlers_register_all_gsuite_capabilities() {
 async fn bundled_gsuite_handler_fails_closed_without_runtime_egress() {
     let scope = scope();
     let auth = Arc::new(InMemoryAuthProductServices::new());
-    let registry = bundled_gsuite_first_party_handlers(auth).unwrap();
+    let registry =
+        bundled_gsuite_first_party_handlers(auth, Arc::new(RecordingCredentialStager::default()))
+            .unwrap();
     let capability_id = cap_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
     let handler = registry.get(&capability_id).expect("handler registered");
 

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -354,12 +354,15 @@ async fn bundled_gsuite_handlers_project_staging_auth_failures_as_auth_required(
         .await
         .unwrap_err();
 
+    assert!(
+        error.is_auth_required(),
+        "staging auth failure should be auth required"
+    );
     assert_eq!(
         error
-            .auth_requirement()
-            .expect("staging auth failure should surface auth requirement")
-            .required_secrets,
-        vec![SecretHandle::new("google-access-token").unwrap()]
+            .required_secrets()
+            .expect("staging auth failure should surface required secrets"),
+        &vec![SecretHandle::new("google-access-token").unwrap()]
     );
     assert!(egress.requests().is_empty());
 }
@@ -409,5 +412,5 @@ async fn bundled_gsuite_handler_fails_closed_without_runtime_egress() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.kind(), RuntimeDispatchErrorKind::NetworkDenied);
+    assert_eq!(error.kind(), Some(RuntimeDispatchErrorKind::NetworkDenied));
 }

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -7,17 +7,19 @@ use ironclaw_auth::{
 };
 use ironclaw_extensions::{ExtensionRuntime, ManifestSource};
 use ironclaw_first_party_extensions::{
-    CALENDAR_LIST_CALENDARS_CAPABILITY_ID, GMAIL_SEND_MESSAGE_CAPABILITY_ID, google_provider_id,
-    gsuite_package_specs,
+    CALENDAR_LIST_CALENDARS_CAPABILITY_ID, GMAIL_SEND_MESSAGE_CAPABILITY_ID,
+    GsuiteCredentialStageError, GsuiteCredentialStageRequest, GsuiteCredentialStager,
+    google_provider_id, gsuite_package_specs,
 };
 use ironclaw_host_api::{
-    CapabilityId, InvocationId, ResourceScope, RuntimeDispatchErrorKind, RuntimeHttpEgress,
-    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, SecretHandle,
-    TrustClass, UserId,
+    CapabilityId, InvocationId, ResourceScope, RuntimeCredentialSource, RuntimeDispatchErrorKind,
+    RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    SecretHandle, TrustClass, UserId,
 };
 use ironclaw_host_runtime::FirstPartyCapabilityRequest;
 use ironclaw_reborn_composition::{
     bundled_gsuite_extension_packages, bundled_gsuite_first_party_handlers,
+    bundled_gsuite_first_party_handlers_with_credential_stager,
 };
 use serde_json::json;
 
@@ -29,6 +31,43 @@ struct RecordingEgress {
 impl RecordingEgress {
     fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
         self.requests.lock().expect("egress lock").clone()
+    }
+}
+
+#[derive(Default)]
+struct RecordingCredentialStager {
+    staged: Mutex<Vec<SecretHandle>>,
+    fail_auth_required: bool,
+}
+
+impl RecordingCredentialStager {
+    fn auth_required() -> Self {
+        Self {
+            staged: Mutex::new(Vec::new()),
+            fail_auth_required: true,
+        }
+    }
+
+    fn staged(&self) -> Vec<SecretHandle> {
+        self.staged.lock().expect("stager lock").clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl GsuiteCredentialStager for RecordingCredentialStager {
+    async fn stage(
+        &self,
+        request: GsuiteCredentialStageRequest<'_>,
+    ) -> Result<(), GsuiteCredentialStageError> {
+        self.staged
+            .lock()
+            .expect("stager lock")
+            .push(request.access_secret.clone());
+        if self.fail_auth_required {
+            Err(GsuiteCredentialStageError::AuthRequired)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -251,6 +290,73 @@ async fn bundled_gsuite_handlers_register_and_forward_runtime_egress() {
     assert_eq!(requests[0].capability_id, capability_id);
     assert_eq!(requests[0].scope, scope);
     assert!(requests[0].url.ends_with("/users/me/messages/send"));
+}
+
+#[tokio::test]
+async fn bundled_gsuite_handlers_stage_selected_account_secret_before_egress() {
+    let scope = scope();
+    let auth = auth_with_google_account(&scope).await;
+    let stager = Arc::new(RecordingCredentialStager::default());
+    let registry = bundled_gsuite_first_party_handlers_with_credential_stager(
+        auth,
+        stager.clone() as Arc<dyn GsuiteCredentialStager>,
+    )
+    .unwrap();
+    let capability_id = cap_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
+    let egress = Arc::new(RecordingEgress::default());
+    let egress_port: Arc<dyn RuntimeHttpEgress> = egress.clone();
+    let handler = registry.get(&capability_id).expect("handler registered");
+
+    handler
+        .dispatch(FirstPartyCapabilityRequest::request_for_test(
+            capability_id,
+            scope,
+            json!({ "message": { "raw": "base64url-rfc822" } }),
+            Some(egress_port),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        stager.staged(),
+        vec![SecretHandle::new("google-access-token").unwrap()]
+    );
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 1);
+    assert!(matches!(
+        requests[0].credential_injections[0].source,
+        RuntimeCredentialSource::StagedObligation { ref capability_id }
+            if capability_id.as_str() == GMAIL_SEND_MESSAGE_CAPABILITY_ID
+    ));
+}
+
+#[tokio::test]
+async fn bundled_gsuite_handlers_project_staging_auth_failures_as_auth_required() {
+    let scope = scope();
+    let auth = auth_with_google_account(&scope).await;
+    let stager = Arc::new(RecordingCredentialStager::auth_required());
+    let registry = bundled_gsuite_first_party_handlers_with_credential_stager(
+        auth,
+        stager as Arc<dyn GsuiteCredentialStager>,
+    )
+    .unwrap();
+    let capability_id = cap_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
+    let egress = Arc::new(RecordingEgress::default());
+    let egress_port: Arc<dyn RuntimeHttpEgress> = egress.clone();
+    let handler = registry.get(&capability_id).expect("handler registered");
+
+    let error = handler
+        .dispatch(FirstPartyCapabilityRequest::request_for_test(
+            capability_id,
+            scope,
+            json!({ "message": { "raw": "base64url-rfc822" } }),
+            Some(egress_port),
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(error.is_auth_required());
+    assert!(egress.requests().is_empty());
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -414,3 +414,82 @@ async fn bundled_gsuite_handler_fails_closed_without_runtime_egress() {
 
     assert_eq!(error.kind(), Some(RuntimeDispatchErrorKind::NetworkDenied));
 }
+
+// ---------------------------------------------------------------------------
+// T5: gsuite_error integration — tests that staging errors are projected
+// correctly into FirstPartyCapabilityError through handler dispatch.
+// ---------------------------------------------------------------------------
+
+struct BackendStager;
+
+#[async_trait::async_trait]
+impl GsuiteCredentialStager for BackendStager {
+    async fn stage(
+        &self,
+        _request: GsuiteCredentialStageRequest<'_>,
+    ) -> Result<(), GsuiteCredentialStageError> {
+        Err(GsuiteCredentialStageError::Backend)
+    }
+}
+
+#[tokio::test]
+async fn bundled_gsuite_handler_projects_stage_auth_required_to_first_party_auth_required() {
+    let scope = scope();
+    let auth = auth_with_google_account(&scope).await;
+    let registry = bundled_gsuite_first_party_handlers(
+        auth,
+        Arc::new(RecordingCredentialStager::auth_required()),
+    )
+    .unwrap();
+    let capability_id = cap_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
+    let handler = registry.get(&capability_id).expect("handler registered");
+
+    let error = handler
+        .dispatch(FirstPartyCapabilityRequest::request_for_test(
+            capability_id,
+            scope,
+            json!({ "message": { "raw": "base64url-rfc822" } }),
+            Some(Arc::new(RecordingEgress::default()) as Arc<dyn RuntimeHttpEgress>),
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.is_auth_required(),
+        "stage AuthRequired must project to FirstPartyCapabilityError::AuthRequired; got {error:?}"
+    );
+    assert_eq!(
+        error.kind(),
+        None,
+        "AuthRequired variant must have no dispatch kind"
+    );
+}
+
+#[tokio::test]
+async fn bundled_gsuite_handler_projects_stage_backend_to_first_party_dispatch_backend() {
+    let scope = scope();
+    let auth = auth_with_google_account(&scope).await;
+    let registry = bundled_gsuite_first_party_handlers(auth, Arc::new(BackendStager)).unwrap();
+    let capability_id = cap_id(GMAIL_SEND_MESSAGE_CAPABILITY_ID);
+    let handler = registry.get(&capability_id).expect("handler registered");
+
+    let error = handler
+        .dispatch(FirstPartyCapabilityRequest::request_for_test(
+            capability_id,
+            scope,
+            json!({ "message": { "raw": "base64url-rfc822" } }),
+            Some(Arc::new(RecordingEgress::default()) as Arc<dyn RuntimeHttpEgress>),
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(
+        !error.is_auth_required(),
+        "stage Backend must NOT project to AuthRequired; got {error:?}"
+    );
+    assert_eq!(
+        error.kind(),
+        Some(RuntimeDispatchErrorKind::Backend),
+        "stage Backend must produce Dispatch {{ kind: Backend }}"
+    );
+}

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -246,6 +246,10 @@ secret material. Composition resolves this boundary as follows:
   composition maps that handle to an authorized configured GitHub account and
   stages that account's access secret for the declared `api.github.com`
   audience only.
+- GSuite first-party handlers receive an explicit credential stager backed by
+  host-runtime product-auth ports. Composition does not synthesize an
+  `ExecutionContext`; host runtime owns the scoped one-shot secret handoff into
+  `RuntimeCredentialSource::StagedObligation`.
 - MCP HTTP/SSE auth is modeled as server-scoped product-auth account
   selection. A host-owned MCP server entry supplies the provider/server auth
   requirement; composition selects the account before building a runtime egress

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -227,6 +227,46 @@ Rules:
   state. They must not expose raw provider error text, response bodies, host
   paths, access-token handles, refresh-token handles, or secret values.
 
+### Runtime Credential Consumers
+
+Product-auth accounts are the account-selection and recovery authority for
+runtime credential consumers; runtime lanes still consume only host-staged
+secret material. Composition resolves this boundary as follows:
+
+- GSuite first-party capabilities continue to choose a Google account
+  dynamically through `CredentialAccountService` because the selected access
+  secret is account-specific. Reborn composition stages that selected access
+  secret through the host-runtime `InjectSecretOnce` obligation handler before
+  first-party HTTP egress consumes the `StagedObligation`. GSuite should not
+  publish static `runtime_credentials` declarations until a manifest credential
+  handle can name a stable product-auth account binding without bypassing
+  account selection, refresh, or recovery.
+- GitHub first-party WASM starts as a manual-token product-auth provider. The
+  manifest handle `github_token` is the runtime credential declaration; host
+  composition maps that handle to an authorized configured GitHub account and
+  stages that account's access secret for the declared `api.github.com`
+  audience only.
+- MCP HTTP/SSE auth is modeled as server-scoped product-auth account
+  selection. A host-owned MCP server entry supplies the provider/server auth
+  requirement; composition selects the account before building a runtime egress
+  plan. MCP protocol code must not choose accounts.
+- When multiple authorized accounts match a GitHub extension or MCP server,
+  account selection returns `account_selection_required`. Consumers must not
+  pick the first account as a fallback.
+- Missing, expired, revoked, refresh-failed, inactive, unauthorized, or
+  ambiguous credentials project typed auth recovery (`setup_required`,
+  `reauthorize_required`, or `account_selection_required`) so product workflow
+  can surface `AuthRequired` and resume the blocked turn. Non-recoverable
+  backend failures return stable fail-closed errors.
+- Refresh-on-use is provider-specific behind
+  `CredentialAccountService::refresh_account` and provider clients. Runtime
+  egress and MCP/WASM/first-party consumers must not implement generic token
+  refresh or inspect provider token material.
+- Header and query-param credential targets are the preferred first production
+  targets. Path-placeholder targets are supported by host egress for
+  compatibility, but consumers should use them only when an upstream protocol
+  explicitly requires URL path placement.
+
 ---
 
 ## Manual Token Setup

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -73,9 +73,10 @@ MCP HTTP/SSE follows the same rule through `ironclaw_mcp::McpHostHttpClient`: th
 For MCP HTTP/SSE credentials, the host planner is called once for the real
 `tools/call` JSON-RPC body before the handshake. The client validates that plan
 up front, then reuses it when sending `tools/call`; the handshake requests are
-planned separately and strip credential injections. This keeps the planner
-idempotent and prevents staged secret handles from being recomputed from
-runtime-visible MCP input.
+planned separately and strip credential injections. Planner-visible headers are
+stable policy headers only; the protocol-owned `Mcp-Session-Id` header is added
+after planning. This keeps the planner idempotent and prevents staged secret
+handles from being recomputed from runtime-visible MCP input.
 
 Credential injection plans identify their material source. Production runtime tool egress for first-party/native, MCP, script, and WASM lanes must use `RuntimeCredentialSource::StagedObligation { capability_id }`, the `InjectSecretOnce` handoff path. `HostHttpEgressService` must be configured with the same `RuntimeSecretInjectionStore` as the obligation handler and must call `take(scope, capability_id, handle)` before runtime/network use. Missing required staged material fails before outbound transport, and successful or failed transport attempts cannot reuse the staged value because `take(...)` removes it first. `RuntimeCredentialSource::SecretStoreLease` is retained only for explicitly named legacy/test compatibility paths that are not backed by an already-satisfied authorization obligation; production egress rejects direct secret-store leases before transport. If one approved request plan injects the same source+handle into multiple targets, the egress service consumes the staged or leased material once and reuses it only within that request. Header, query-param, and path-placeholder credential targets are supported; request-body targets remain out of scope.
 

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -70,7 +70,20 @@ Raw HTTP diagnostic logging is intentionally double-gated: the unsafe `IRONCLAW_
 
 MCP HTTP/SSE follows the same rule through `ironclaw_mcp::McpHostHttpClient`: the host supplies an `McpRuntimeHttpAdapter<RuntimeHttpEgress>` and an egress planner for scoped network policy, credential injection handles, response body limits, and timeouts. Generic or direct-network MCP clients keep `uses_host_mediated_http_egress() == false`, so `McpRuntime` rejects HTTP/SSE manifests before any outbound attempt.
 
+For MCP HTTP/SSE credentials, the host planner is called once for the real
+`tools/call` JSON-RPC body before the handshake. The client validates that plan
+up front, then reuses it when sending `tools/call`; the handshake requests are
+planned separately and strip credential injections. This keeps the planner
+idempotent and prevents staged secret handles from being recomputed from
+runtime-visible MCP input.
+
 Credential injection plans identify their material source. Production runtime tool egress for first-party/native, MCP, script, and WASM lanes must use `RuntimeCredentialSource::StagedObligation { capability_id }`, the `InjectSecretOnce` handoff path. `HostHttpEgressService` must be configured with the same `RuntimeSecretInjectionStore` as the obligation handler and must call `take(scope, capability_id, handle)` before runtime/network use. Missing required staged material fails before outbound transport, and successful or failed transport attempts cannot reuse the staged value because `take(...)` removes it first. `RuntimeCredentialSource::SecretStoreLease` is retained only for explicitly named legacy/test compatibility paths that are not backed by an already-satisfied authorization obligation; production egress rejects direct secret-store leases before transport. If one approved request plan injects the same source+handle into multiple targets, the egress service consumes the staged or leased material once and reuses it only within that request. Header, query-param, and path-placeholder credential targets are supported; request-body targets remain out of scope.
+
+GSuite first-party handlers use the same staged-obligation path even though
+their credential handle is selected dynamically from product-auth account state
+instead of a static manifest `runtime_credentials` entry. Composition stages the
+selected Google access-secret handle through the host obligation handler before
+the first-party HTTP request is sent.
 
 Path-placeholder credential targets are higher risk than headers or query parameters because upstream access logs, CDN edge logs, reverse proxies, crash dumps, and `Referer` propagation routinely capture URL paths and rarely apply credential redaction to path segments. `HostHttpEgressService` therefore allows path-placeholder injection only for HTTPS URLs, requires the placeholder to appear exactly once as a full path segment, and accepts only non-empty unreserved path-segment credential values other than `.` or `..`. Capability owners should prefer header or query-param targets unless a documented upstream contract specifically requires path placement.
 

--- a/docs/reborn/contracts/mcp.md
+++ b/docs/reborn/contracts/mcp.md
@@ -150,7 +150,14 @@ Transport-specific policy is a host adapter responsibility:
 
 - stdio process spawning should reuse the mediated process/sandbox substrate where appropriate
 - HTTP/SSE transport must go through host network policy, not ambient network access
-- secret injection must be explicit and audited in a later auth/secrets slice
+- HTTP/SSE credential planning is host-owned. The MCP client plans the real
+  `tools/call` JSON-RPC body once before the handshake, rejects direct
+  `SecretStoreLease` sources before any transport request, and threads the
+  approved staged plan into the eventual `tools/call` send.
+- `initialize` and `notifications/initialized` remain credential-free even
+  when the host-planned `tools/call` carries staged credentials.
+- MCP protocol code consumes `RuntimeCredentialInjection` plans only; product
+  auth account selection belongs to composition, not to the MCP crate.
 
 ---
 

--- a/docs/reborn/contracts/mcp.md
+++ b/docs/reborn/contracts/mcp.md
@@ -154,6 +154,9 @@ Transport-specific policy is a host adapter responsibility:
   `tools/call` JSON-RPC body once before the handshake, rejects direct
   `SecretStoreLease` sources before any transport request, and threads the
   approved staged plan into the eventual `tools/call` send.
+- Planner-visible headers exclude the dynamic MCP session header. The protocol
+  client appends `Mcp-Session-Id` after planning when the server establishes a
+  session.
 - `initialize` and `notifications/initialized` remain credential-free even
   when the host-planned `tools/call` carries staged credentials.
 - MCP protocol code consumes `RuntimeCredentialInjection` plans only; product


### PR DESCRIPTION
## Summary

Refs #4176.

This PR wires the runtime credential consumer paths that depend on host-owned staged credentials:

- adds a composition-owned GSuite credential stager that resolves the selected Google product-auth account and satisfies `InjectSecretOnce` before first-party host HTTP egress consumes the `StagedObligation`;
- projects recoverable first-party credential failures through `DispatchError::AuthRequired` so the host runtime can return `RuntimeCapabilityOutcome::AuthRequired` instead of a generic failed runtime dispatch;
- fixes MCP HTTP/SSE credential planning to plan the real `tools/call` JSON-RPC body once before handshake and thread that validated plan into the eventual `tools/call` send;
- documents the open-question decisions for GSuite dynamic selection, GitHub manual-token-first modeling, server-scoped MCP account selection, recovery semantics, refresh ownership, and credential target scope.

## Open-question decisions

- GSuite stays dynamic through `CredentialAccountService`; static `runtime_credentials` are deferred until account bindings are stable.
- GitHub first-party WASM remains `github_token` manifest-driven with manual-token product-auth as the first account model; the existing staged host HTTP path is covered by `github_wasm_runtime_contract`.
- MCP auth selection is composition-owned and server-scoped; MCP protocol code only consumes host-planned staged credential injections.
- Multiple matching accounts return account-selection-required; missing/expired/revoked/refresh-failed credentials map to auth recovery/AuthRequired; backend failures fail closed.
- Refresh stays provider-specific behind `CredentialAccountService::refresh_account`.
- Header/query targets are preferred; path placeholders remain compatibility-only where an upstream protocol requires them.

## Tests

- `cargo test -p ironclaw_reborn_composition --test gsuite`
- `cargo test -p ironclaw_mcp`
- `cargo test -p ironclaw_host_runtime first_party_adapter_maps_handler_auth_required_to_dispatch_auth_required`
- `cargo test -p ironclaw_host_runtime --test github_wasm_runtime_contract`
- `cargo test -p ironclaw_first_party_extensions -p ironclaw_host_api -p ironclaw_capabilities`
- `git diff --check`
