### PR TITLE
[codex] Verify auth gate blocked exits

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/checkpoint.rs
+++ b/crates/ironclaw_agent_loop/src/executor/checkpoint.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
-use ironclaw_turns::run_profile::{
-    LoopCheckpointRequest, LoopProgressEvent, StageCheckpointPayloadRequest,
+use ironclaw_turns::{
+    LoopGateRef,
+    run_profile::{LoopCheckpointRequest, LoopProgressEvent, StageCheckpointPayloadRequest},
 };
 
 use crate::state::{CheckpointKind, LoopExecutionState};
@@ -27,8 +28,37 @@ impl CheckpointStage {
     pub(super) async fn write(
         &self,
         ctx: StageContext<'_>,
+        state: LoopExecutionState,
+        kind: CheckpointKind,
+    ) -> Result<CheckpointWrite, AgentLoopExecutorError> {
+        self.write_with_gate_ref(ctx, state, kind, None).await
+    }
+
+    /// Variant of [`write`] for `BeforeBlock` checkpoints. Stores the
+    /// triggering gate ref in the checkpoint record so that
+    /// `verify_blocked_evidence` can cross-check gate identity and reject
+    /// a rogue driver that reuses a legitimate checkpoint from a different gate.
+    pub(super) async fn write_before_block(
+        &self,
+        ctx: StageContext<'_>,
+        state: LoopExecutionState,
+        gate_ref: &LoopGateRef,
+    ) -> Result<CheckpointWrite, AgentLoopExecutorError> {
+        self.write_with_gate_ref(
+            ctx,
+            state,
+            CheckpointKind::BeforeBlock,
+            Some(gate_ref.clone()),
+        )
+        .await
+    }
+
+    async fn write_with_gate_ref(
+        &self,
+        ctx: StageContext<'_>,
         mut state: LoopExecutionState,
         kind: CheckpointKind,
+        gate_ref: Option<LoopGateRef>,
     ) -> Result<CheckpointWrite, AgentLoopExecutorError> {
         state.last_checkpoint = Some(crate::state::CheckpointMarker {
             kind,
@@ -51,6 +81,7 @@ impl CheckpointStage {
             .checkpoint(LoopCheckpointRequest {
                 kind: host_kind,
                 state_ref: state_ref.clone(),
+                gate_ref,
             })
             .await
             .map_err(|_| AgentLoopExecutorError::CheckpointFailed { stage: kind })?;

--- a/crates/ironclaw_agent_loop/src/executor/gates.rs
+++ b/crates/ironclaw_agent_loop/src/executor/gates.rs
@@ -70,7 +70,7 @@ impl ExecutorStage<GateInput> for GateStage {
                     )
                     .await;
                 let checked = CheckpointStage
-                    .write(ctx, state, CheckpointKind::BeforeBlock)
+                    .write_before_block(ctx, state, &gate_ref)
                     .await?;
                 Ok(BatchStep::Exit(LoopExit::Blocked(LoopBlocked {
                     kind: blocked_kind(kind),
@@ -158,7 +158,7 @@ impl ExecutorStage<AwaitDependentRunGateInput> for AwaitDependentRunGateStage {
                     )
                     .await;
                 let checked = CheckpointStage
-                    .write(ctx, state, CheckpointKind::BeforeBlock)
+                    .write_before_block(ctx, state, &gate_ref)
                     .await?;
                 Ok(BatchStep::Exit(LoopExit::Blocked(LoopBlocked {
                     kind: blocked_kind(GateKind::AwaitDependentRun),

--- a/crates/ironclaw_hooks/src/middleware/checkpoint_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/checkpoint_port.rs
@@ -167,6 +167,7 @@ mod tests {
         LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeModel,
             state_ref: LoopCheckpointStateRef::new("checkpoint:test-0001").expect("ok"),
+            gate_ref: None,
         }
     }
 

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -2265,6 +2265,7 @@ mod tests {
             .checkpoint(LoopCheckpointRequest {
                 kind: LoopCheckpointKind::BeforeSideEffect,
                 state_ref,
+                gate_ref: None,
             })
             .await
             .expect("write checkpoint metadata");
@@ -2302,6 +2303,7 @@ mod tests {
             .checkpoint(LoopCheckpointRequest {
                 kind: LoopCheckpointKind::BeforeModel,
                 state_ref,
+                gate_ref: None,
             })
             .await
             .expect("write checkpoint metadata");
@@ -2337,6 +2339,7 @@ mod tests {
             .checkpoint(LoopCheckpointRequest {
                 kind: LoopCheckpointKind::BeforeModel,
                 state_ref,
+                gate_ref: None,
             })
             .await
             .expect("write checkpoint metadata");
@@ -2393,6 +2396,7 @@ mod tests {
                 schema_id: expected_schema_id.clone(),
                 schema_version: expected_schema_version,
                 kind: LoopCheckpointKind::BeforeBlock,
+                gate_ref: None,
             })
             .await
             .expect("write checkpoint metadata");

--- a/crates/ironclaw_reborn/src/loop_driver_host/port_adapters.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host/port_adapters.rs
@@ -145,6 +145,7 @@ impl LoopCheckpointPort for HostManagedLoopCheckpointPort {
                 schema_id: self.run_context.checkpoint_schema_id.clone(),
                 schema_version: self.run_context.checkpoint_schema_version,
                 kind: request.kind,
+                gate_ref: request.gate_ref,
             })
             .await
             .map_err(turn_error_to_host_error)?;

--- a/crates/ironclaw_reborn/src/loop_driver_host/tests.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host/tests.rs
@@ -67,6 +67,7 @@ async fn checkpoint_port_load_payload_roundtrips_staged_payload() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeSideEffect,
             state_ref,
+            gate_ref: None,
         })
         .await
         .expect("write checkpoint metadata");
@@ -104,6 +105,7 @@ async fn checkpoint_port_load_payload_rejects_schema_mismatch() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeModel,
             state_ref,
+            gate_ref: None,
         })
         .await
         .expect("write checkpoint metadata");
@@ -139,6 +141,7 @@ async fn checkpoint_port_load_payload_rejects_schema_version_mismatch() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeModel,
             state_ref,
+            gate_ref: None,
         })
         .await
         .expect("write checkpoint metadata");
@@ -194,6 +197,7 @@ async fn checkpoint_port_load_payload_missing_state_record_is_unavailable() {
             schema_id: expected_schema_id.clone(),
             schema_version: expected_schema_version,
             kind: LoopCheckpointKind::BeforeBlock,
+            gate_ref: None,
         })
         .await
         .expect("write checkpoint metadata");

--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -283,6 +283,11 @@ where
                 // applier persist that state.
                 return Ok(false);
             }
+            // `LoopBlockedKind` is `#[non_exhaustive]` in a sibling crate, so
+            // the compiler requires a wildcard arm. Any unknown variant is
+            // intentionally failed closed: we have no evidence model for it
+            // yet, and treating it as unverified prevents a new variant from
+            // silently routing through the Auth carve-out.
             _ => return Ok(false),
         }
 
@@ -299,8 +304,13 @@ where
             return Ok(false);
         };
 
+        // Bind gate identity: the checkpoint must have been created for the
+        // exact same gate that the blocked exit reports. This prevents a rogue
+        // driver from reusing a legitimate BeforeBlock checkpoint (e.g. from
+        // an Approval or Resource gate in the same run) as Auth evidence.
         Ok(checkpoint.kind == LoopCheckpointKind::BeforeBlock
-            && checkpoint.state_ref == request.blocked.state_ref)
+            && checkpoint.state_ref == request.blocked.state_ref
+            && checkpoint.gate_ref.as_ref() == Some(&request.blocked.gate_ref))
     }
 
     async fn verify_failure_evidence(

--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -12,8 +12,9 @@ use ironclaw_threads::{
     ThreadMessageId, ThreadMessageRecord, ThreadScope, ToolResultReferenceEnvelope,
 };
 use ironclaw_turns::{
-    GetRunStateRequest, LoopCheckpointKind, LoopMessageRef, LoopResultRef, TurnError, TurnId,
-    TurnRunId, TurnScope, TurnStateStore, TurnStatus,
+    GetLoopCheckpointRequest, GetRunStateRequest, LoopBlockedKind, LoopCheckpointKind,
+    LoopMessageRef, LoopResultRef, TurnError, TurnId, TurnRunId, TurnScope, TurnStateStore,
+    TurnStatus,
 };
 
 pub use ironclaw_turns::loop_exit::{
@@ -267,13 +268,39 @@ where
 
     async fn verify_blocked_evidence(
         &self,
-        _request: BlockedEvidenceRequest<'_>,
+        request: BlockedEvidenceRequest<'_>,
     ) -> Result<bool, TurnError> {
-        // A BeforeBlock checkpoint alone is not sufficient: #3424 requires a
-        // durable pending gate/process ref. The current text-only adapter has
-        // no gate/process outcome store, so it must fail closed without doing
-        // unrelated checkpoint I/O.
-        Ok(false)
+        match request.blocked.kind {
+            LoopBlockedKind::Auth => {}
+            LoopBlockedKind::Approval
+            | LoopBlockedKind::Resource
+            | LoopBlockedKind::AwaitDependentRun => {
+                // A BeforeBlock checkpoint alone is not sufficient for approval,
+                // resource, or dependent-run gates: #3424 requires a durable
+                // pending gate/process ref for those block types. Auth gates use
+                // the blocked turn state itself as the product-visible pending ref,
+                // so verifying the pre-block checkpoint is enough to let the
+                // applier persist that state.
+                return Ok(false);
+            }
+            _ => return Ok(false),
+        }
+
+        let Some(checkpoint) = self
+            .loop_checkpoint_store
+            .get_loop_checkpoint(GetLoopCheckpointRequest {
+                scope: request.scope.clone(),
+                turn_id: request.turn_id,
+                run_id: request.run_id,
+                checkpoint_id: request.blocked.checkpoint_id,
+            })
+            .await?
+        else {
+            return Ok(false);
+        };
+
+        Ok(checkpoint.kind == LoopCheckpointKind::BeforeBlock
+            && checkpoint.state_ref == request.blocked.state_ref)
     }
 
     async fn verify_failure_evidence(

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -8,8 +8,8 @@ use ironclaw_threads::{
 };
 use ironclaw_turns::{
     LoopBlockedKind, LoopCheckpointKind, LoopCompleted, LoopCompletionKind, LoopExit, LoopFailed,
-    LoopFailureKind, LoopMessageRef, LoopResultRef, TurnCheckpointId, TurnError, TurnId, TurnRunId,
-    TurnScope, TurnStateStore, TurnStatus,
+    LoopFailureKind, LoopGateRef, LoopMessageRef, LoopResultRef, TurnCheckpointId, TurnError,
+    TurnId, TurnRunId, TurnScope, TurnStateStore, TurnStatus,
 };
 
 use super::{
@@ -154,11 +154,13 @@ async fn auth_blocked_exit_with_durable_checkpoint_maps_to_blocked_auth() {
     let checkpoint_id = TurnCheckpointId::new();
     let state_ref = ironclaw_turns::LoopCheckpointStateRef::new("checkpoint:auth-blocked-state")
         .expect("valid state ref");
-    let checkpoint = loop_checkpoint_record(
+    let gate_ref = LoopGateRef::new("gate:test").expect("valid gate ref");
+    let checkpoint = loop_checkpoint_record_with_gate(
         &claimed,
         checkpoint_id,
         state_ref.clone(),
         LoopCheckpointKind::BeforeBlock,
+        Some(gate_ref),
     );
     let transition = Arc::new(RecordingTransitionPort::new());
     let evidence = Arc::new(text_checkpoint_evidence(Arc::new(
@@ -907,11 +909,13 @@ async fn thread_checkpoint_evidence_verifies_auth_blocked_checkpoint() {
     let checkpoint_id = TurnCheckpointId::new();
     let state_ref = ironclaw_turns::LoopCheckpointStateRef::new("checkpoint:auth-blocked-state")
         .expect("valid state ref");
-    let checkpoint = loop_checkpoint_record(
+    let gate_ref = LoopGateRef::new("gate:test").expect("valid gate ref");
+    let checkpoint = loop_checkpoint_record_with_gate(
         &claimed,
         checkpoint_id,
         state_ref.clone(),
         LoopCheckpointKind::BeforeBlock,
+        Some(gate_ref),
     );
     let evidence = text_checkpoint_evidence(Arc::new(StaticLoopCheckpointStore::new(checkpoint)));
     let exit = blocked_exit_with_checkpoint(LoopBlockedKind::Auth, checkpoint_id, state_ref);
@@ -929,6 +933,45 @@ async fn thread_checkpoint_evidence_verifies_auth_blocked_checkpoint() {
         .expect("auth blocked evidence should verify through checkpoint lookup");
 
     assert!(verified);
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_rejects_auth_blocked_checkpoint_gate_mismatch() {
+    // A checkpoint from a different gate (e.g. an Approval block) must not
+    // validate as Auth evidence even when the state_ref matches.
+    let claimed = claimed_run();
+    let checkpoint_id = TurnCheckpointId::new();
+    let state_ref = ironclaw_turns::LoopCheckpointStateRef::new("checkpoint:auth-blocked-state")
+        .expect("valid state ref");
+    // Checkpoint carries a *different* gate_ref (e.g. from an Approval block).
+    let checkpoint_gate = LoopGateRef::new("gate:approval").expect("valid gate ref");
+    let checkpoint = loop_checkpoint_record_with_gate(
+        &claimed,
+        checkpoint_id,
+        state_ref.clone(),
+        LoopCheckpointKind::BeforeBlock,
+        Some(checkpoint_gate),
+    );
+    let evidence = text_checkpoint_evidence(Arc::new(StaticLoopCheckpointStore::new(checkpoint)));
+    // Blocked exit claims Auth but reuses the Approval-gate checkpoint id.
+    let exit = blocked_exit_with_checkpoint(LoopBlockedKind::Auth, checkpoint_id, state_ref);
+    let LoopExit::Blocked(blocked) = &exit else {
+        unreachable!("blocked helper returns blocked exit")
+    };
+    let verified = evidence
+        .verify_blocked_evidence(BlockedEvidenceRequest {
+            scope: &claimed.state.scope,
+            turn_id: claimed.state.turn_id,
+            run_id: claimed.state.run_id,
+            blocked,
+        })
+        .await
+        .expect("gate mismatch should be a closed evidence miss, not an error");
+
+    assert!(
+        !verified,
+        "cross-gate checkpoint reuse must not verify as Auth"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -149,6 +149,35 @@ async fn blocked_exit_requires_before_block_checkpoint() {
 }
 
 #[tokio::test]
+async fn auth_blocked_exit_with_durable_checkpoint_maps_to_blocked_auth() {
+    let claimed = claimed_run();
+    let checkpoint_id = TurnCheckpointId::new();
+    let state_ref = ironclaw_turns::LoopCheckpointStateRef::new("checkpoint:auth-blocked-state")
+        .expect("valid state ref");
+    let checkpoint = loop_checkpoint_record(
+        &claimed,
+        checkpoint_id,
+        state_ref.clone(),
+        LoopCheckpointKind::BeforeBlock,
+    );
+    let transition = Arc::new(RecordingTransitionPort::new());
+    let evidence = Arc::new(text_checkpoint_evidence(Arc::new(
+        StaticLoopCheckpointStore::new(checkpoint),
+    )));
+    let applier = Arc::new(LoopExitApplier::new(transition.clone(), evidence));
+    let exit = blocked_exit_with_checkpoint(LoopBlockedKind::Auth, checkpoint_id, state_ref);
+
+    let state = applier.apply(&claimed, exit).await.expect("applied");
+
+    assert_eq!(state.status, TurnStatus::BlockedAuth);
+    assert_eq!(
+        state.gate_ref.as_ref().map(|gate_ref| gate_ref.as_str()),
+        Some("gate:test")
+    );
+    assert_eq!(transition.apply_count(), 1);
+}
+
+#[tokio::test]
 async fn cancelled_exit_requires_observed_cancel_input() {
     let fixture =
         Fixture::new(InMemoryLoopExitEvidencePort::new().with_final_checkpoint_verified(true));
@@ -868,6 +897,70 @@ async fn thread_checkpoint_evidence_does_not_read_checkpoint_for_blocked_claims(
         })
         .await
         .expect("blocked evidence should fail closed without checkpoint I/O");
+
+    assert!(!verified);
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_verifies_auth_blocked_checkpoint() {
+    let claimed = claimed_run();
+    let checkpoint_id = TurnCheckpointId::new();
+    let state_ref = ironclaw_turns::LoopCheckpointStateRef::new("checkpoint:auth-blocked-state")
+        .expect("valid state ref");
+    let checkpoint = loop_checkpoint_record(
+        &claimed,
+        checkpoint_id,
+        state_ref.clone(),
+        LoopCheckpointKind::BeforeBlock,
+    );
+    let evidence = text_checkpoint_evidence(Arc::new(StaticLoopCheckpointStore::new(checkpoint)));
+    let exit = blocked_exit_with_checkpoint(LoopBlockedKind::Auth, checkpoint_id, state_ref);
+    let LoopExit::Blocked(blocked) = &exit else {
+        unreachable!("blocked helper returns blocked exit")
+    };
+    let verified = evidence
+        .verify_blocked_evidence(BlockedEvidenceRequest {
+            scope: &claimed.state.scope,
+            turn_id: claimed.state.turn_id,
+            run_id: claimed.state.run_id,
+            blocked,
+        })
+        .await
+        .expect("auth blocked evidence should verify through checkpoint lookup");
+
+    assert!(verified);
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_rejects_auth_blocked_checkpoint_state_mismatch() {
+    let claimed = claimed_run();
+    let checkpoint_id = TurnCheckpointId::new();
+    let checkpoint = loop_checkpoint_record(
+        &claimed,
+        checkpoint_id,
+        ironclaw_turns::LoopCheckpointStateRef::new("checkpoint:other-state")
+            .expect("valid state ref"),
+        LoopCheckpointKind::BeforeBlock,
+    );
+    let evidence = text_checkpoint_evidence(Arc::new(StaticLoopCheckpointStore::new(checkpoint)));
+    let exit = blocked_exit_with_checkpoint(
+        LoopBlockedKind::Auth,
+        checkpoint_id,
+        ironclaw_turns::LoopCheckpointStateRef::new("checkpoint:auth-blocked-state")
+            .expect("valid state ref"),
+    );
+    let LoopExit::Blocked(blocked) = &exit else {
+        unreachable!("blocked helper returns blocked exit")
+    };
+    let verified = evidence
+        .verify_blocked_evidence(BlockedEvidenceRequest {
+            scope: &claimed.state.scope,
+            turn_id: claimed.state.turn_id,
+            run_id: claimed.state.run_id,
+            blocked,
+        })
+        .await
+        .expect("state mismatch should be a closed evidence miss");
 
     assert!(!verified);
 }

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/support.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/support.rs
@@ -8,7 +8,7 @@ use ironclaw_threads::{
 };
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
-    GetLoopCheckpointRequest, GetRunStateRequest, LoopBlocked, LoopBlockedKind,
+    GetLoopCheckpointRequest, GetRunStateRequest, LoopBlocked, LoopBlockedKind, LoopCheckpointKind,
     LoopCheckpointRecord, LoopCheckpointStateRef, LoopCheckpointStore, LoopCompleted,
     LoopCompletionKind, LoopExit, LoopExitId, LoopGateRef, LoopMessageRef, LoopResultRef,
     PutLoopCheckpointRequest, ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse,
@@ -122,6 +122,45 @@ impl LoopCheckpointStore for PanicLoopCheckpointStore {
     }
 }
 
+pub(super) struct StaticLoopCheckpointStore {
+    record: Option<LoopCheckpointRecord>,
+}
+
+impl StaticLoopCheckpointStore {
+    pub(super) fn new(record: LoopCheckpointRecord) -> Self {
+        Self {
+            record: Some(record),
+        }
+    }
+}
+
+#[async_trait]
+impl LoopCheckpointStore for StaticLoopCheckpointStore {
+    async fn put_loop_checkpoint(
+        &self,
+        _request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        panic!("put_loop_checkpoint should not be called by evidence tests")
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        Ok(self.record.as_ref().and_then(|record| {
+            if record.scope == request.scope
+                && record.turn_id == request.turn_id
+                && record.run_id == request.run_id
+                && record.checkpoint_id == request.checkpoint_id
+            {
+                Some(record.clone())
+            } else {
+                None
+            }
+        }))
+    }
+}
+
 pub(super) fn test_exit_id() -> LoopExitId {
     LoopExitId::new("exit:test").expect("valid")
 }
@@ -141,13 +180,44 @@ pub(super) fn completed_exit(
 }
 
 pub(super) fn blocked_exit(kind: LoopBlockedKind) -> LoopExit {
+    blocked_exit_with_checkpoint(
+        kind,
+        TurnCheckpointId::new(),
+        LoopCheckpointStateRef::new("checkpoint:blocked-state").expect("valid"),
+    )
+}
+
+pub(super) fn blocked_exit_with_checkpoint(
+    kind: LoopBlockedKind,
+    checkpoint_id: TurnCheckpointId,
+    state_ref: LoopCheckpointStateRef,
+) -> LoopExit {
     LoopExit::Blocked(LoopBlocked {
         kind,
         gate_ref: LoopGateRef::new("gate:test").expect("valid"),
-        checkpoint_id: TurnCheckpointId::new(),
-        state_ref: LoopCheckpointStateRef::new("checkpoint:blocked-state").expect("valid"),
+        checkpoint_id,
+        state_ref,
         exit_id: test_exit_id(),
     })
+}
+
+pub(super) fn loop_checkpoint_record(
+    claimed: &ClaimedTurnRun,
+    checkpoint_id: TurnCheckpointId,
+    state_ref: LoopCheckpointStateRef,
+    kind: LoopCheckpointKind,
+) -> LoopCheckpointRecord {
+    LoopCheckpointRecord {
+        checkpoint_id,
+        scope: claimed.state.scope.clone(),
+        turn_id: claimed.state.turn_id,
+        run_id: claimed.state.run_id,
+        state_ref,
+        schema_id: claimed.resolved_run_profile.checkpoint_schema_id.clone(),
+        schema_version: claimed.resolved_run_profile.checkpoint_schema_version,
+        kind,
+        created_at: chrono::Utc::now(),
+    }
 }
 
 pub(super) struct Fixture {

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/support.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/support.rs
@@ -207,6 +207,16 @@ pub(super) fn loop_checkpoint_record(
     state_ref: LoopCheckpointStateRef,
     kind: LoopCheckpointKind,
 ) -> LoopCheckpointRecord {
+    loop_checkpoint_record_with_gate(claimed, checkpoint_id, state_ref, kind, None)
+}
+
+pub(super) fn loop_checkpoint_record_with_gate(
+    claimed: &ClaimedTurnRun,
+    checkpoint_id: TurnCheckpointId,
+    state_ref: LoopCheckpointStateRef,
+    kind: LoopCheckpointKind,
+    gate_ref: Option<LoopGateRef>,
+) -> LoopCheckpointRecord {
     LoopCheckpointRecord {
         checkpoint_id,
         scope: claimed.state.scope.clone(),
@@ -216,6 +226,7 @@ pub(super) fn loop_checkpoint_record(
         schema_id: claimed.resolved_run_profile.checkpoint_schema_id.clone(),
         schema_version: claimed.resolved_run_profile.checkpoint_schema_version,
         kind,
+        gate_ref,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -3327,6 +3327,7 @@ async fn observer_hook_fires_after_checkpoint_through_factory() {
     host.checkpoint(LoopCheckpointRequest {
         kind: LoopCheckpointKind::BeforeModel,
         state_ref: state_record.state_ref,
+        gate_ref: None,
     })
     .await
     .expect("checkpoint write succeeds through the wrapped checkpoint port");

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -233,6 +233,7 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeModel,
             state_ref: checkpoint_state.state_ref.clone(),
+            gate_ref: None,
         })
         .await
         .unwrap();
@@ -1905,6 +1906,7 @@ async fn text_only_host_e2e_keeps_persisted_model_route_through_full_flow() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeModel,
             state_ref: checkpoint_state.state_ref.clone(),
+            gate_ref: None,
         })
         .await
         .unwrap();
@@ -2990,6 +2992,7 @@ async fn text_only_host_e2e_flow_persists_checkpoint_mapping_in_turn_state_store
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeBlock,
             state_ref: checkpoint_state.state_ref.clone(),
+            gate_ref: None,
         })
         .await
         .unwrap();
@@ -3621,6 +3624,7 @@ async fn text_only_host_checkpoint_port_persists_ref_without_public_payload() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeSideEffect,
             state_ref: checkpoint_state.state_ref.clone(),
+            gate_ref: None,
         })
         .await
         .unwrap();
@@ -3684,6 +3688,7 @@ async fn text_only_host_checkpoint_port_rejects_foreign_state_ref() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeModel,
             state_ref: foreign_state.state_ref,
+            gate_ref: None,
         })
         .await
         .unwrap_err();
@@ -3703,6 +3708,7 @@ async fn text_only_host_checkpoint_port_rejects_kind_mismatch() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeSideEffect,
             state_ref: state.state_ref,
+            gate_ref: None,
         })
         .await
         .unwrap_err();
@@ -3729,6 +3735,7 @@ async fn text_only_host_checkpoint_port_maps_store_failures_to_unavailable() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeBlock,
             state_ref: state.state_ref,
+            gate_ref: None,
         })
         .await
         .unwrap_err();
@@ -3764,6 +3771,7 @@ async fn text_only_host_stage_checkpoint_payload_returns_ref_usable_by_checkpoin
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeSideEffect,
             state_ref: state_ref.clone(),
+            gate_ref: None,
         })
         .await
         .expect("checkpoint should accept the staged state_ref");

--- a/crates/ironclaw_turns/src/checkpoint_state.rs
+++ b/crates/ironclaw_turns/src/checkpoint_state.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    CheckpointSchemaId, LoopCheckpointKind, LoopCheckpointStateRef, RunProfileVersion,
+    CheckpointSchemaId, LoopCheckpointKind, LoopCheckpointStateRef, LoopGateRef, RunProfileVersion,
     TurnCheckpointId, TurnError, TurnId, TurnRunId, TurnScope, TurnTimestamp,
 };
 
@@ -170,6 +170,11 @@ pub struct LoopCheckpointRecord {
     pub schema_id: CheckpointSchemaId,
     pub schema_version: RunProfileVersion,
     pub kind: LoopCheckpointKind,
+    /// Gate that triggered this checkpoint. `None` for checkpoint kinds other
+    /// than `BeforeBlock` and for legacy records persisted before this field
+    /// was added.
+    #[serde(default)]
+    pub gate_ref: Option<LoopGateRef>,
     pub created_at: TurnTimestamp,
 }
 
@@ -182,6 +187,8 @@ pub struct PutLoopCheckpointRequest {
     pub schema_id: CheckpointSchemaId,
     pub schema_version: RunProfileVersion,
     pub kind: LoopCheckpointKind,
+    /// Gate identity for `BeforeBlock` checkpoints; `None` for other kinds.
+    pub gate_ref: Option<LoopGateRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -279,6 +286,7 @@ impl LoopCheckpointStore for InMemoryLoopCheckpointStore {
             schema_id: request.schema_id,
             schema_version: request.schema_version,
             kind: request.kind,
+            gate_ref: request.gate_ref,
             created_at: Utc::now(),
         };
         let mut records = self.records.lock().map_err(|_| TurnError::Unavailable {

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -410,6 +410,7 @@ impl LoopCheckpointStore for InMemoryTurnStateStore {
             schema_id: request.schema_id,
             schema_version: request.schema_version,
             kind: request.kind,
+            gate_ref: request.gate_ref,
             created_at: Utc::now(),
         };
         let mut inner = self.lock_inner()?;

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -1708,6 +1708,11 @@ pub trait LoopTranscriptPort: Send + Sync {
 pub struct LoopCheckpointRequest {
     pub kind: LoopCheckpointKind,
     pub state_ref: LoopCheckpointStateRef,
+    /// Gate identity for `BeforeBlock` checkpoints; `None` for other kinds.
+    /// Defaults to `None` for backward-compatible deserialization of older
+    /// records that predate this field.
+    #[serde(default)]
+    pub gate_ref: Option<crate::ids::LoopGateRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -2118,6 +2118,7 @@ impl AgentLoopDriver for CapabilityDriver {
             .checkpoint(LoopCheckpointRequest {
                 kind: LoopCheckpointKind::BeforeBlock,
                 state_ref: state_ref.clone(),
+                gate_ref: None,
             })
             .await
             .map_err(driver_error)?;

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -74,6 +74,7 @@ async fn loop_checkpoint_store_maps_checkpoint_ids_to_staged_state_refs() {
             schema_id: state_record.schema_id.clone(),
             schema_version: state_record.schema_version,
             kind: state_record.kind,
+            gate_ref: None,
         })
         .await
         .unwrap();
@@ -118,6 +119,7 @@ async fn loop_checkpoint_store_handles_parallel_puts() {
                     schema_id: state_record.schema_id,
                     schema_version: state_record.schema_version,
                     kind: state_record.kind,
+                    gate_ref: None,
                 })
                 .await
                 .unwrap_or_else(|error| panic!("{suffix} checkpoint put failed: {error}"))
@@ -169,6 +171,7 @@ async fn turn_state_loop_checkpoint_store_survives_persistence_snapshot() {
             schema_id: state_record.schema_id.clone(),
             schema_version: state_record.schema_version,
             kind: state_record.kind,
+            gate_ref: None,
         })
         .await
         .unwrap();
@@ -212,6 +215,7 @@ async fn turn_state_loop_checkpoint_store_rejects_cross_scope_after_snapshot_rel
             schema_id: state_record.schema_id,
             schema_version: state_record.schema_version,
             kind: state_record.kind,
+            gate_ref: None,
         })
         .await
         .unwrap();
@@ -251,6 +255,7 @@ async fn loop_checkpoint_store_rejects_cross_run_checkpoint_id() {
             schema_id: state_record.schema_id,
             schema_version: state_record.schema_version,
             kind: state_record.kind,
+            gate_ref: None,
         })
         .await
         .unwrap();

--- a/crates/ironclaw_turns/tests/loop_checkpoint_store_contract.rs
+++ b/crates/ironclaw_turns/tests/loop_checkpoint_store_contract.rs
@@ -30,6 +30,7 @@ fn put_request(scope: TurnScope, turn_id: TurnId, run_id: TurnRunId) -> PutLoopC
         schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
         schema_version: RunProfileVersion::new(1),
         kind: LoopCheckpointKind::BeforeModel,
+        gate_ref: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- verify Reborn auth blocked exits against a durable same-run BeforeBlock checkpoint
- allow validated auth blocked exits to persist as BlockedAuth instead of falling into RecoveryRequired
- keep approval/resource/dependent-run blocked evidence fail-closed until their pending gate/process evidence exists

## Tests
- cargo fmt --all
- cargo test -p ironclaw_reborn loop_exit_applier
- cargo test -p ironclaw_reborn
- git diff --check

Base is now reborn-integration; this PR no longer depends on #4231.