### PR TITLE
fix(reborn): Treat invalid model tool output as recoverable

### DIFF
--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -1521,6 +1521,10 @@ fn sanitized_reasoning_deltas(reasoning: Option<String>) -> Vec<String> {
 #[serde(rename_all = "snake_case")]
 pub enum HostManagedModelErrorKind {
     InvalidRequest,
+    /// Provider/model output was structurally invalid for the active loop
+    /// contract. This is model-side bad output, not caller misuse of the host
+    /// model port.
+    InvalidOutput,
     PolicyDenied,
     ConfigurationError,
     BudgetExceeded,
@@ -1816,6 +1820,7 @@ fn model_gateway_error(error: HostManagedModelError) -> AgentLoopHostError {
 fn model_error_kind(kind: HostManagedModelErrorKind) -> AgentLoopHostErrorKind {
     match kind {
         HostManagedModelErrorKind::InvalidRequest => AgentLoopHostErrorKind::InvalidInvocation,
+        HostManagedModelErrorKind::InvalidOutput => AgentLoopHostErrorKind::Unavailable,
         HostManagedModelErrorKind::PolicyDenied => AgentLoopHostErrorKind::PolicyDenied,
         HostManagedModelErrorKind::ConfigurationError => AgentLoopHostErrorKind::Unavailable,
         HostManagedModelErrorKind::BudgetExceeded => AgentLoopHostErrorKind::BudgetExceeded,
@@ -1830,6 +1835,7 @@ fn model_error_kind(kind: HostManagedModelErrorKind) -> AgentLoopHostErrorKind {
 fn safe_model_summary(kind: HostManagedModelErrorKind) -> &'static str {
     match kind {
         HostManagedModelErrorKind::InvalidRequest => "model request is invalid",
+        HostManagedModelErrorKind::InvalidOutput => "model output is invalid",
         HostManagedModelErrorKind::PolicyDenied => "model profile is not permitted",
         HostManagedModelErrorKind::ConfigurationError => "model route configuration is invalid",
         HostManagedModelErrorKind::BudgetExceeded => "model request exceeded its budget",

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -954,6 +954,42 @@ async fn model_port_limits_provider_tool_definitions_to_model_visible_capability
 }
 
 #[tokio::test]
+async fn model_port_maps_invalid_model_output_to_recoverable_model_error() {
+    let fixture = ThreadFixture::new().await;
+    let messages = user_model_messages(&fixture);
+    issue_prompt_grant(&fixture.run_context, &messages);
+
+    let gateway = Arc::new(RecordingGateway::model_error(
+        HostManagedModelErrorKind::InvalidOutput,
+        "model returned a tool call outside the advertised capability surface",
+    ));
+    let model_port = ThreadBackedLoopModelPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway.clone(),
+        16,
+    );
+
+    let error = model_port
+        .stream_model(LoopModelRequest {
+            messages,
+            surface_version: None,
+            model_preference: None,
+            capability_view: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::Unavailable);
+    assert_eq!(
+        error.safe_summary,
+        "model returned a tool call outside the advertised capability surface"
+    );
+    assert_eq!(gateway.calls.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn model_port_preserves_capability_info_for_filtered_capability_view() {
     let fixture = ThreadFixture::new().await;
     let messages = user_model_messages(&fixture);
@@ -3837,6 +3873,14 @@ impl RecordingGateway {
                 HostManagedModelErrorKind::PolicyDenied,
                 safe_summary,
             )),
+        }
+    }
+
+    fn model_error(kind: HostManagedModelErrorKind, safe_summary: &str) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            tool_definition_calls: Mutex::new(Vec::new()),
+            response: Err(HostManagedModelError::safe(kind, safe_summary)),
         }
     }
 

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -850,7 +850,7 @@ async fn tool_response_to_host(
             .any(|tool_call| !advertised_tool_names.contains(&tool_call.name))
         {
             return Err(HostManagedModelError::safe(
-                HostManagedModelErrorKind::InvalidRequest,
+                HostManagedModelErrorKind::InvalidOutput,
                 "model returned a tool call outside the advertised capability surface",
             ));
         }
@@ -912,7 +912,7 @@ async fn tool_response_to_host(
             "model response was blocked by provider policy",
         )),
         FinishReason::ToolUse => Err(HostManagedModelError::safe(
-            HostManagedModelErrorKind::InvalidRequest,
+            HostManagedModelErrorKind::InvalidOutput,
             "model returned tool-use finish without tool calls",
         )),
         FinishReason::Unknown => Err(HostManagedModelError::safe(
@@ -984,7 +984,7 @@ fn response_to_host_reply(
             "model response was blocked by provider policy",
         )),
         FinishReason::ToolUse => Err(HostManagedModelError::safe(
-            HostManagedModelErrorKind::InvalidRequest,
+            HostManagedModelErrorKind::InvalidOutput,
             "model returned unsupported tool calls for a text-only loop",
         )),
         FinishReason::Unknown => Err(HostManagedModelError::safe(

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -413,7 +413,7 @@ async fn gateway_rejects_unknown_provider_tool_call_before_registration() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidRequest);
+    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
     assert!(capabilities.registered.lock().unwrap().is_empty());
 }
 
@@ -1155,7 +1155,7 @@ async fn gateway_rejects_tool_use_provider_responses() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidRequest);
+    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
 }
 
 #[tokio::test]
@@ -1174,7 +1174,7 @@ async fn gateway_rejects_tool_use_without_tool_calls_on_capability_path() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidRequest);
+    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
     assert!(capabilities.registered.lock().unwrap().is_empty());
 }
 

--- a/tests/support/reborn/model_replay.rs
+++ b/tests/support/reborn/model_replay.rs
@@ -454,7 +454,7 @@ async fn provider_tool_calls_response(
 
 fn capability_host_error(error: AgentLoopHostError) -> HostManagedModelError {
     HostManagedModelError::safe(
-        HostManagedModelErrorKind::InvalidRequest,
+        HostManagedModelErrorKind::InvalidOutput,
         format!("capability trace replay failed: {}", error.safe_summary),
     )
 }

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -587,7 +587,7 @@ mod reborn_support_tests {
             .await
             .expect_err("unadvertised scripted capability should fail");
 
-        assert_eq!(error.kind, HostManagedModelErrorKind::InvalidRequest);
+        assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
         assert!(
             error
                 .safe_summary


### PR DESCRIPTION
## Summary
- add a model-gateway InvalidOutput error kind for malformed provider/model output
- map InvalidOutput to a recoverable model error instead of host InvalidInvocation
- update Reborn gateway and trace replay tests for hallucinated/unadvertised tool calls
- add caller-level coverage through ThreadBackedLoopModelPort

## Validation
- cargo fmt
- git diff --check
- cargo test -p ironclaw_loop_support --test thread_loop_support_contract model_port_maps_invalid_model_output_to_recoverable_model_error -- --nocapture
- cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway gateway_rejects_tool_use -- --nocapture
- cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway gateway_rejects_unknown_provider_tool_call_before_registration -- --nocapture

## Not run
- cargo test --test support_unit_tests trace_replay_rejects_scripted_capability_not_advertised_by_surface -- --nocapture failed during root crate compilation because the local disk is full: No space left on device writing Cargo incremental query cache.