### PR TITLE
Refine trigger loop and delivery resolution specs

### DIFF
--- a/docs/superpowers/specs/2026-05-21-trigger-loop-design.md
+++ b/docs/superpowers/specs/2026-05-21-trigger-loop-design.md
@@ -17,6 +17,14 @@ workflow from something other than a live human message. V1 delivers
 mail." Webhook and message-regex triggers are planned fast-follow work and the
 architecture must not preclude them.
 
+**P0 implementation goal:** ship cron-backed scheduled trigger events first. P0
+proves that a stored schedule can fire, enter the Reborn inbound/turn pipeline
+as a synthetic inbound message, run in a new dedicated thread, and persist the
+resulting thread. Fixed interval and one-shot schedules may share the same
+schedule-provider implementation if they are cheap, but cron scheduled events
+are the first acceptance target. Webhook, message-regex, and system-event
+sources are not P0.
+
 A trigger fire is treated as exactly what it is: a **synthetic inbound
 message**. Instead of building a parallel execution engine, a fire fans into
 the Reborn inbound pipeline (`InboundTurnService → TurnCoordinator →
@@ -36,7 +44,9 @@ cron is an external transport.
 
 ### In V1
 
-- Schedule trigger source: cron expression, fixed interval, one-shot timestamp.
+- Schedule trigger source: cron expression first; fixed interval and one-shot
+  timestamp may ride along in the same provider if they do not expand the P0
+  surface.
 - `trigger_create` / `trigger_list` / `trigger_remove` capabilities, invoked
   through the Reborn capability/dispatch surface.
 - Typed `TriggerRepository` with PostgreSQL + libSQL parity.
@@ -50,10 +60,11 @@ cron is an external transport.
 
 ### Acceptance criterion
 
-Cron triggers only. Webhook and regex sources are explicitly **not** acceptance
-criteria for V1. If Reborn outbound is not ready at implementation time,
-delivery (§6) drops to fast-follow and V1 acceptance is: a trigger fires on
-schedule, runs a turn in a new dedicated thread, and the thread persists.
+P0/V1 acceptance is cron-triggered events only. Webhook and regex sources are
+explicitly **not** acceptance criteria for V1. If Reborn outbound is not ready
+at implementation time, delivery (§6) drops to fast-follow and V1 acceptance is:
+a cron trigger fires on schedule, runs a turn in a new dedicated thread, and the
+thread persists.
 
 ### Deferred (fast-follow — architecture must leave room, no implementation in V1)
 

--- a/docs/superpowers/specs/2026-05-29-channel-communication-delivery-resolution.md
+++ b/docs/superpowers/specs/2026-05-29-channel-communication-delivery-resolution.md
@@ -35,23 +35,36 @@ This design keeps three concepts separate:
 | Outbound policy and validation | `ironclaw_outbound` | Owns notification policy state, `ReplyTargetBindingRef` validation, delivery attempts, sanitized failure records. |
 | Product transport rendering | product adapters / channels | Web UI, Telegram, etc. render/send after outbound policy authorizes a target. |
 
+Current implementation caveat: `ironclaw_outbound` is presently a policy and
+delivery-attempt preflight boundary, not the concrete sender. P0 delivery
+resolution applies only to Reborn product-adapter outbound paths such as
+`ProductAdapter::render_outbound` and adapter-declared outbound capabilities.
+Legacy channel/helper send paths are out of scope for this design until they are
+ported behind the Reborn product-adapter outbound boundary. Slack has not yet
+been ported to Reborn in this branch, so Slack-specific requested outbound is
+not a P0 acceptance criterion.
+
 ## 3. Proposed Layer
 
-Add a communication resolution step inside the outbound policy boundary between
-run events and outbound delivery. This is a **policy resolver**, not a general
-rules engine: it selects candidate delivery targets from already-canonical run
-events and preferences, then hands those candidates to existing outbound
-validation.
+Add `ironclaw_outbound::OutboundResolutionEngine` inside the outbound policy
+boundary. Every Reborn product-adapter outbound decision enters this engine
+before transport rendering. P0 is a **small deterministic rule engine**, not a
+user-authored or general-purpose rules platform: it applies an ordered set of
+host-owned policy rules to already-canonical run events, explicit outbound
+requests, and preferences, then hands the selected candidate to existing
+outbound validation.
 
 ```text
 Run event
   FinalReplyReady | ProgressUpdate | ApprovalNeeded | AuthRequired | RunBlocked
         |
         v
-ironclaw_outbound::CommunicationPolicyResolver
-  input: CommunicationResolutionRequest
+ironclaw_outbound::OutboundResolutionEngine
+  entrypoints:
+    resolve_requested_outbound(RequestedOutboundResolutionRequest)
+    resolve_run_notification(RunNotificationResolutionRequest)
   reads: tenant/user communication preferences
-  applies: source-route and user-default delivery policy
+  applies: ordered P0 communication rules
         |
         v
 CommunicationDeliveryCandidate
@@ -68,39 +81,102 @@ ironclaw_outbound::OutboundPolicyService
 Product outbound adapter / transport
 ```
 
-`ironclaw_outbound` owns this resolver because the existing Reborn event /
+`ironclaw_outbound` owns this engine because the existing Reborn event /
 projection contract already assigns outbound notification policy state,
 reply-target validation, delivery attempts, and sanitized failure records to
-that crate. The resolver must not live in `ironclaw_triggers`,
+that crate. The resolution engine must not live in `ironclaw_triggers`,
 `ironclaw_conversations`, or `ironclaw_approvals`. Reborn composition wires the
-resolver and store dependencies, but does not own the policy semantics.
+engine and store dependencies, but does not own the policy semantics.
 
-The resolver is read-only with respect to ingress and authority. It must not
-mutate `ProductInboundEnvelope`, `ExternalConversationRef`, inbound dedupe state,
-`AcceptedMessageRef`, `SourceBindingRef`, `ReplyTargetBindingRef`, pending-gate
-records, auth-flow records, approval records, leases, or turn submission
-behavior.
+The resolution engine is read-only with respect to ingress and authority. It
+must not mutate `ProductInboundEnvelope`, `ExternalConversationRef`, inbound
+dedupe state, `AcceptedMessageRef`, `SourceBindingRef`,
+`ReplyTargetBindingRef`, pending-gate records, auth-flow records, approval
+records, leases, or turn submission behavior.
 
-## 4. Resolver Input
+The engine is not a replacement for `ThreadNotificationPolicy` or
+`OutboundPolicyService`. `ThreadNotificationPolicy` remains the existing
+thread-scoped policy model for configured push targets and may be extended when
+the current target-kind model is insufficient. `OutboundResolutionEngine` is the
+decision layer above that policy model: it decides which candidate should be
+attempted for a particular outbound intent, then delegates validation and
+delivery-attempt recording to `OutboundPolicyService`.
 
-The resolver needs enough context to distinguish live chat from triggered jobs,
-text from voice, and final replies from approvals. Use one explicit request type
-with a tagged context enum rather than independently optional fields:
+The engine exposes typed entrypoints instead of one catch-all request:
+
+- `resolve_requested_outbound` handles explicit product-adapter send intent and
+  requires a requested target.
+- `resolve_run_notification` handles run-lifecycle notifications and receives
+  only the canonical origin facts needed for policy resolution.
+
+Both entrypoints return `CommunicationDeliveryCandidate`, and every candidate
+must pass through `OutboundPolicyService::prepare_delivery_attempt` before any
+product adapter renders or sends externally.
+
+### P0 Rule Engine
+
+P0 rule order is locked:
+
+1. **Explicit requested outbound wins.** When a Reborn product-adapter
+   capability path is explicitly trying to send a product message to a requested
+   outbound target — for example "send a test message on Telegram" through the
+   Telegram v2 adapter — communication resolution follows that requested
+   target. The target is still only a candidate and must pass outbound
+   validation before any transport sends.
+2. **Live inbound loops reply to their source route.** When the run descends
+   from a real inbound product/channel message, final replies prefer the same
+   source route's `reply_target_binding_ref`.
+3. **Triggered loops use preferred outbound.** When the run descends from a
+   trigger and has no live source route, final replies prefer the creator
+   user's configured outbound target.
+
+If the selected target is unavailable, unauthorized, unbound, or lacks required
+capabilities, P0 fails closed: outbound records a sanitized delivery failure and
+does not silently fall back to another channel. A future policy version may add
+an explicit `FallbackToDefault` rule, but that fallback must be modeled as an
+ordered policy rule with tests and must still revalidate the fallback target.
+
+## 4. Resolution Inputs
+
+The engine needs enough context to distinguish requested outbound from
+run-lifecycle notification, live chat from triggered jobs, text from voice, and
+final replies from approval/auth prompts. Use typed request shapes rather than a
+single broad tagged enum.
+
+### Requested Outbound Request
 
 ```rust
-CommunicationResolutionRequest {
+RequestedOutboundResolutionRequest {
     scope: TurnScope,
     actor: TurnActor,
-    event_kind: CommunicationEventKind,
+    requested: RequestedOutboundContext,
     modality: CommunicationModality,
-    context: CommunicationContext,
 }
 ```
 
-### Event Kind
+Requested outbound is command intent: the caller is asking to send a product
+message to a specific target. This request is invalid without a requested target.
+
+### Run Notification Request
 
 ```rust
-enum CommunicationEventKind {
+RunNotificationResolutionRequest {
+    scope: TurnScope,
+    actor: TurnActor,
+    event_kind: RunNotificationEventKind,
+    modality: CommunicationModality,
+    origin: RunNotificationOrigin,
+}
+```
+
+Run notification is lifecycle policy: the run emitted a final reply, progress
+update, approval/auth prompt, blocked state, or delivery-status update, and the
+engine decides where notification should be attempted.
+
+### Run Notification Event Kind
+
+```rust
+enum RunNotificationEventKind {
     FinalReplyReady,
     ProgressUpdate,
     ApprovalNeeded,
@@ -110,20 +186,17 @@ enum CommunicationEventKind {
 }
 ```
 
-### Context
+### Run Notification Origin
 
 ```rust
-enum CommunicationContext {
-    LiveUserMessage {
+enum RunNotificationOrigin {
+    LiveSourceRoute {
         source_route: SourceRouteContext,
     },
-    TriggeredJob {
+    Triggered {
         trigger: TriggerCommunicationContext,
     },
-    WebhookTrigger {
-        trigger: TriggerCommunicationContext,
-    },
-    MessageRegexTrigger {
+    TriggeredFromSourceRoute {
         trigger: TriggerCommunicationContext,
         source_route: SourceRouteContext,
     },
@@ -133,15 +206,40 @@ enum CommunicationContext {
 }
 ```
 
-This shape is a contract invariant: live user messages require source-route
-context; trigger-origin events require trigger context; message-regex triggers
-carry both because they are caused by a real product message but execute a
-stored trigger rule. Callers must not pass an under-specified request.
+This shape is a contract invariant: requested outbound uses
+`RequestedOutboundResolutionRequest` and requires an explicit requested target;
+live user-message notifications require source-route context; trigger-origin
+notifications require trigger context; future message-regex trigger
+notifications can normalize to `TriggeredFromSourceRoute` because they are
+caused by a real product message but execute a stored trigger rule. Callers must
+not pass an under-specified request.
 
 The request intentionally does not carry `PendingGate`, pending auth IDs,
 approval request IDs, credential names, OAuth callback data, or raw product
 payloads. Those identifiers stay with their owning auth, approval, gateway, or
 product-workflow paths.
+
+### Requested Outbound Context
+
+Use only when a capability/tool path is explicitly asking to send a message to a
+specific outbound target:
+
+```rust
+RequestedOutboundContext {
+    requested_target: ReplyTargetBindingRef,
+    requested_kind: RequestedOutboundKind,
+}
+
+enum RequestedOutboundKind {
+    ProductMessage,
+    DeliveryStatus,
+}
+```
+
+`requested_target` is a candidate, not send authority. It must still pass
+`ironclaw_outbound` validation before transport send. This context must not
+carry raw message payloads, credentials, channel tokens, OAuth state, or backend
+error details.
 
 ### Modality
 
@@ -201,6 +299,7 @@ CommunicationPreference {
     final_replies_target: Option<ReplyTargetBindingRef>,
     progress_target: Option<ReplyTargetBindingRef>,
     approval_prompt_target: Option<ReplyTargetBindingRef>,
+    auth_prompt_target: Option<ReplyTargetBindingRef>,
     default_modality: Option<CommunicationModality>,
     updated_at,
     updated_by,
@@ -212,10 +311,19 @@ grant of send authority. The stored `ReplyTargetBindingRef` values are
 candidates that must be revalidated at send time. `updated_by` records the user
 or tenant admin that last changed the preference.
 
+`CommunicationPreference` is not a replacement for the existing
+`ThreadNotificationPolicy`. Preferences are user-level defaults used by
+`OutboundResolutionEngine` when a run has no live source route or explicit
+requested target. `ThreadNotificationPolicy` remains the thread-scoped policy
+shape for configured push targets. Implementation may either derive direct
+candidates from preferences for P0, or lower preferences into a
+`ThreadNotificationPolicy` for a concrete thread when durable thread policy is
+needed; either path must still revalidate through `OutboundPolicyService`.
+
 Trigger records do not carry delivery configuration in the first trigger slice.
 Triggered jobs use the creator user's `final_replies_target` by default. A
 future per-trigger override may be added only as an override consumed by the
-outbound resolver:
+outbound resolution engine:
 
 ```rust
 enum TriggerDeliveryOverride {
@@ -238,9 +346,27 @@ Rules:
 
 ## 6. Resolution Rules
 
+Resolution is an ordered rule engine. The first matching rule yields a single
+candidate; validation and send preparation happen afterward through
+`OutboundPolicyService`.
+
+### Explicit Requested Outbound
+
+`resolve_requested_outbound` honors the requested target:
+
+```text
+RequestedOutbound:
+  requested.requested_target
+```
+
+If validation rejects the requested target, P0 fails closed and records a
+sanitized delivery failure. It does not fall back to source-route or user-default
+delivery. A future `FallbackToDefault` rule may be added as an explicit policy
+extension.
+
 ### Live User Message
 
-For `CommunicationContext::LiveUserMessage`, prefer replying to the source route
+For `RunNotificationOrigin::LiveSourceRoute`, prefer replying to the source route
 when the source route has a reply target:
 
 ```text
@@ -258,12 +384,13 @@ ApprovalNeeded:
 
 AuthRequired:
   source_route.reply_target_binding_ref if target supports auth prompts
+  else preference.auth_prompt_target if target supports auth prompts
   else normal auth-flow path only
 ```
 
 ### Triggered Job
 
-For `CommunicationContext::TriggeredJob`, there is no live origin conversation
+For `RunNotificationOrigin::Triggered`, there is no live origin conversation
 to reply to:
 
 ```text
@@ -279,26 +406,28 @@ ApprovalNeeded:
   else record ApprovalBlocked / RunBlocked through normal run-state/event path
 
 AuthRequired:
-  preference.approval_prompt_target only if target supports auth prompts
+  preference.auth_prompt_target only if target supports auth prompts
   else record auth-required state through normal auth-flow path
 ```
 
 ### Webhook Trigger
 
-Webhook trigger delivery follows triggered-job rules unless the trigger
-definition eventually carries an explicit delivery override. The webhook request
-itself must not be treated as a trusted reply destination.
+Webhook trigger delivery normalizes to `RunNotificationOrigin::Triggered` and
+follows triggered-job rules unless the trigger definition eventually carries an
+explicit delivery override. The webhook request itself must not be treated as a
+trusted reply destination.
 
 ### Message Regex Trigger
 
 Message-regex triggers observe an already-normalized inbound product message.
-They may default to the originating conversation only if a future trigger
-delivery override says so and the source route's reply target revalidates.
+They normalize to `RunNotificationOrigin::TriggeredFromSourceRoute`. They may
+default to the originating conversation only if a future trigger delivery
+override says so and the source route's reply target revalidates.
 
 ## 7. Target Capabilities
 
-The resolver must not hard-code product-specific behavior such as "Web UI
-supports approval cards" or "Telegram does not support gate prompts." Target
+The resolution engine must not hard-code product-specific behavior such as "Web
+UI supports approval cards" or "Telegram does not support gate prompts." Target
 capability knowledge belongs at the product-adapter / outbound validation
 boundary.
 
@@ -314,7 +443,7 @@ DeliveryTargetCapabilities {
 
 `ReplyTargetBindingValidator` or a sibling outbound capability port returns the
 capabilities for the candidate `ReplyTargetBindingRef` after validating that the
-target still belongs to the requested tenant/user/scope. The resolver may use
+target still belongs to the requested tenant/user/scope. The engine may use
 capabilities to suppress unsupported push kinds, but it must not infer support
 from channel names.
 
@@ -344,14 +473,14 @@ CapabilityHost returns RequireApproval
   -> ApprovalRequestStore saves Pending request
   -> RunState marks BlockedApproval
   -> EventStream publishes approval_needed
-  -> ironclaw_outbound::CommunicationPolicyResolver may notify approval_prompt_target
+  -> ironclaw_outbound::OutboundResolutionEngine may notify approval_prompt_target
   -> Product adapter renders GatePrompt if validated capabilities allow it
   -> Product inbound receives ApprovalResolution
   -> ApprovalResolver handles approve/deny
   -> CapabilityHost resumes exact invocation using fingerprinted lease
 ```
 
-The communication resolver may choose where to notify the user, but it does not
+The outbound resolution engine may choose where to notify the user, but it does not
 approve, deny, mint leases, or resume runtime work.
 
 Security rules:
@@ -368,14 +497,14 @@ Security rules:
   supported approval surface before the invocation resumes.
 - Product examples: current Telegram v2 drops `GatePrompt` / `AuthPrompt`, while
   Web UI can surface approval state through the normal pending-gate/run-history
-  path. These examples document current product behavior; the resolver consumes
+  path. These examples document current product behavior; the engine consumes
   validated capabilities, not product names.
 
 ## 9. Auth Prompt Delivery
 
 Auth prompt delivery and auth flow resolution are different contracts.
 Auth-required state remains owned by the auth flow / auth interaction path. The
-communication resolver may select where an already-created, redacted
+outbound resolution engine may select where an already-created, redacted
 `AuthPrompt` notification should be attempted, but it must not create, complete,
 cancel, replay, or retry auth flows.
 
@@ -388,7 +517,7 @@ Security rules:
 
 - Auth callback handling, credential exchange, token storage, and secret
   material stay outside communication delivery resolution.
-- The resolver must not accept credential names, OAuth state, callback payloads,
+- The engine must not accept credential names, OAuth state, callback payloads,
   pending-auth IDs, or pending-gate records as inputs.
 - If the validated target capabilities do not include auth prompts, do not
   emulate auth with normal chat text.
@@ -396,7 +525,7 @@ Security rules:
   is notify-only; credential exchange and resume still happen through a supported
   auth surface.
 - Product examples such as Web UI surfacing auth state and Telegram v2 dropping
-  `AuthPrompt` are adapter behavior. The resolver consumes validated
+  `AuthPrompt` are adapter behavior. The engine consumes validated
   capabilities, not product names.
 
 ## 10. Outbound Validation and Failure Semantics
@@ -412,8 +541,10 @@ CommunicationDeliveryCandidate
 
 If reply-target authorization is revoked or the target is unbound, outbound
 records a sanitized `authorization_revoked` delivery failure and returns no
-sendable target. The resolver must not silently fall back to another channel
-after revocation. Users can change their defaults explicitly.
+sendable target. The engine must not silently fall back to another channel
+after revocation. Users can change their defaults explicitly. Future fallback
+behavior, if added, must be an explicit ordered rule rather than an implicit
+error handler.
 
 Delivery failure records are support/audit metadata. They do not mutate
 canonical transcript state and do not mark the run failed.
@@ -424,7 +555,7 @@ Communication delivery resolution must not change inbound acceptance, replay, or
 resume semantics.
 
 - Inbound user-message binding stays in product workflow and
-  `ironclaw_conversations`. The resolver consumes canonical scope, actor, and
+  `ironclaw_conversations`. The engine consumes canonical scope, actor, and
   route context after inbound acceptance; it does not parse product payloads or
   submit turns.
 - Approval and auth resume stay in their existing gateway / bridge / control
@@ -432,7 +563,7 @@ resume semantics.
   cannot approve, deny, provide credentials, clear pending gates, or resume
   runtime work.
 - Product outbound payload shapes and adapter behavior stay unchanged. The
-  resolver selects a target candidate; product adapters still render
+  engine selects a target candidate; product adapters still render
   `FinalReply`, `Progress`, `GatePrompt`, `AuthPrompt`, projection updates, and
   unsupported-payload deferrals according to their existing capabilities.
 - Delivery failures remain delivery metadata only. They do not mutate canonical
@@ -448,6 +579,8 @@ resume semantics.
 - Do not use tenant/user defaults as proof that a target is still authorized.
 - Do not infer delivery, approval, or auth capabilities from channel names.
 - Revalidate `ReplyTargetBindingRef` before every external push.
+- Do not silently fallback from an explicit requested outbound target to another
+  channel in P0.
 - Keep ingress, execution, and outbound delivery identities separate.
 - Keep preference lookup scoped by tenant and user. Cross-tenant lookup must
   fail as unknown, not as unauthorized-with-details.
@@ -467,12 +600,26 @@ User sends text in Web UI
   -> Web UI renders final reply
 ```
 
+### Explicit Product-Adapter Test Message
+
+```text
+Agent/tool asks to send a test Telegram message through the Reborn product adapter
+  -> resolve_requested_outbound carries requested Telegram target
+  -> engine selects requested target
+  -> outbound revalidates
+  -> Telegram adapter renders/sends only if authorized
+```
+
+If the Telegram binding was revoked, outbound records `authorization_revoked`
+and does not silently send the test message to Web UI or another product. Slack
+follows this rule only after a Reborn Slack product adapter exists.
+
 ### Cron Trigger With Telegram Default
 
 ```text
-Trigger fires with CommunicationContext::TriggeredJob
+Trigger fires with RunNotificationOrigin::Triggered
   -> FinalReplyReady
-  -> outbound resolver uses user's final_replies_target = Telegram reply target
+  -> engine uses user's final_replies_target = Telegram reply target
   -> outbound revalidates
   -> Telegram adapter renders FinalReply
 ```
@@ -485,7 +632,7 @@ does not send or auto-fallback to Web UI.
 ```text
 Triggered run hits approval-gated tool
   -> ApprovalNeeded / BlockedApproval
-  -> outbound resolver checks approval_prompt_target capabilities
+  -> engine checks approval_prompt_target capabilities
   -> Web UI target can surface gate prompt when validator reports gate_prompts
   -> Telegram target is skipped until its validated capabilities include gate_prompts
   -> ApprovalResolver remains the only approve/deny authority
@@ -496,7 +643,7 @@ Triggered run hits approval-gated tool
 ```text
 Auth flow records auth-required state
   -> EventStream publishes auth_required
-  -> outbound resolver checks auth prompt target capabilities
+  -> engine checks auth_prompt_target capabilities
   -> Product adapter may render AuthPrompt if validated capabilities allow it
   -> Auth interaction service remains the only auth completion authority
 ```


### PR DESCRIPTION
## Summary
- clarify trigger loop P0 acceptance around cron-backed scheduled events
- refine delivery resolution as an outbound-owned resolution engine with typed entrypoints
- lock fail-closed target validation and separate ingress/execution/delivery authority

## Tests
- Not run; docs-only changes