### PR TITLE
feat(reborn): product-facing auth HTTP surfaces — manual-token, recovery, refresh, cleanup (#4201)

### DIFF
--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -82,10 +82,11 @@ Inbound order (outer → inner → handler):
    `BodyLimitPolicy` from `ironclaw_webui_v2::webui_v2_routes()` and,
    when present, product-auth route descriptors at composition time and
    enforces it before auth runs (so an oversized payload never spends a
-   bearer-validation step). Today: `create_thread` and product-auth
-   OAuth start 16 KiB, `send_message` 1 MiB, `cancel_run` and
-   `resolve_gate` 4 KiB, `get_timeline`, `stream_events`, and
-   product-auth OAuth callback `NoBody`.
+   bearer-validation step). Today: `create_thread`, product-auth OAuth
+   start, manual-token setup/secret-submit, accounts list/select/recovery/
+   refresh, and lifecycle cleanup — all 16 KiB; `send_message` 1 MiB;
+   `cancel_run` and `resolve_gate` 4 KiB; `get_timeline`,
+   `stream_events`, and product-auth OAuth callback `NoBody`.
    `BodyLimitPolicy` is an exhaustive `match`, so a new variant added
    upstream fails the build rather than silently disabling
    enforcement.

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -6,8 +6,10 @@ use ironclaw_auth::{
     AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId,
     AuthFlowKind, AuthFlowManager, AuthFlowRecord, AuthFlowRecordSource, AuthFlowStatus,
     AuthInteractionId, AuthInteractionService, AuthProductError, AuthProductScope,
-    AuthProviderClient, AuthProviderId, CredentialAccountId, CredentialAccountLabel,
-    CredentialAccountService, CredentialAccountStatus, CredentialAccountUpdateBinding,
+    AuthProviderClient, AuthProviderId, CredentialAccountChoiceRequest, CredentialAccountId,
+    CredentialAccountLabel, CredentialAccountListPage, CredentialAccountListRequest,
+    CredentialAccountProjection, CredentialAccountService, CredentialAccountStatus,
+    CredentialAccountUpdateBinding, CredentialRecoveryProjection, CredentialRecoveryRequest,
     CredentialRefreshReport, CredentialRefreshRequest, CredentialSetupService,
     InMemoryAuthProductServices, ManualTokenSetupRequest, NewAuthFlow, OAuthAuthorizationUrl,
     OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
@@ -552,6 +554,51 @@ impl RebornProductAuthServices {
     ) -> Result<CredentialRefreshReport, RebornCredentialLifecycleError> {
         self.credential_account_service
             .refresh_account(request)
+            .await
+            .map_err(RebornCredentialLifecycleError::from)
+    }
+
+    /// List redacted credential account projections through the injected
+    /// account port.
+    ///
+    /// Routes/CLIs/extensions enter here so they never bypass the account
+    /// port's grant filtering, status redaction, or extension-scoped
+    /// visibility rules.
+    pub async fn list_credential_accounts(
+        &self,
+        request: CredentialAccountListRequest,
+    ) -> Result<CredentialAccountListPage, RebornCredentialLifecycleError> {
+        self.credential_account_service
+            .list_accounts(request)
+            .await
+            .map_err(RebornCredentialLifecycleError::from)
+    }
+
+    /// Select a single configured credential account through the injected
+    /// account port.
+    ///
+    /// The selection is validated by the underlying port; this facade does
+    /// not reconstruct selection authority locally.
+    pub async fn select_credential_account(
+        &self,
+        request: CredentialAccountChoiceRequest,
+    ) -> Result<CredentialAccountProjection, RebornCredentialLifecycleError> {
+        self.credential_account_service
+            .select_configured_account(request)
+            .await
+            .map_err(RebornCredentialLifecycleError::from)
+    }
+
+    /// Project the stable credential recovery state for a provider through
+    /// the injected account port. The projection drives WebUI/CLI/API
+    /// recovery, refresh, and reauthorize prompts without exposing backend
+    /// errors or secret handles.
+    pub async fn project_credential_recovery(
+        &self,
+        request: CredentialRecoveryRequest,
+    ) -> Result<CredentialRecoveryProjection, RebornCredentialLifecycleError> {
+        self.credential_account_service
+            .project_credential_recovery(request)
             .await
             .map_err(RebornCredentialLifecycleError::from)
     }

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -22,9 +22,13 @@ use chrono::{Duration as ChronoDuration, Utc};
 use ironclaw_auth::{
     AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowStatus, AuthGateRef, AuthInteractionId,
     AuthProductError, AuthProductScope, AuthProviderId, AuthSessionId, AuthSurface,
-    AuthorizationCodeHash, CredentialAccountId, CredentialAccountLabel, CredentialAccountStatus,
+    AuthorizationCodeHash, CredentialAccountChoiceRequest, CredentialAccountId,
+    CredentialAccountLabel, CredentialAccountListPage, CredentialAccountListRequest,
+    CredentialAccountProjection, CredentialAccountStatus, CredentialRecoveryProjection,
+    CredentialRecoveryRequest, CredentialRefreshReport, CredentialRefreshRequest,
     OAuthAuthorizationCode, OAuthAuthorizationUrl, OAuthProviderCallbackRequest, OpaqueStateHash,
-    PkceVerifierHash, PkceVerifierSecret, ProviderScope, Timestamp, TurnRunRef,
+    PkceVerifierHash, PkceVerifierSecret, ProviderScope, SecretCleanupAction, SecretCleanupReport,
+    SecretCleanupRequest, Timestamp, TurnRunRef,
 };
 use ironclaw_host_api::NetworkMethod;
 use ironclaw_host_api::ingress::{
@@ -33,7 +37,7 @@ use ironclaw_host_api::ingress::{
     RateLimitPolicy, RateLimitScope, StreamingMode, WebSocketOriginPolicy,
 };
 use ironclaw_host_api::{
-    AgentId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
+    AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
 };
 use ironclaw_product_workflow::WebUiAuthenticatedCaller;
 use lru::LruCache;
@@ -52,10 +56,25 @@ use crate::{
 pub(crate) const OAUTH_START_PATH: &str = "/api/reborn/product-auth/oauth/start";
 pub(crate) const OAUTH_CALLBACK_PATH: &str = "/api/reborn/product-auth/oauth/callback/{flow_id}";
 pub(crate) const MANUAL_TOKEN_SUBMIT_PATH: &str = "/api/reborn/product-auth/manual-token/submit";
+pub(crate) const MANUAL_TOKEN_SETUP_PATH: &str = "/api/reborn/product-auth/manual-token/setup";
+pub(crate) const MANUAL_TOKEN_SECRET_SUBMIT_PATH: &str =
+    "/api/reborn/product-auth/manual-token/secret-submit";
+pub(crate) const ACCOUNTS_LIST_PATH: &str = "/api/reborn/product-auth/accounts/list";
+pub(crate) const ACCOUNTS_SELECT_PATH: &str = "/api/reborn/product-auth/accounts/select";
+pub(crate) const ACCOUNTS_RECOVERY_PATH: &str = "/api/reborn/product-auth/accounts/recovery";
+pub(crate) const ACCOUNTS_REFRESH_PATH: &str = "/api/reborn/product-auth/accounts/refresh";
+pub(crate) const LIFECYCLE_CLEANUP_PATH: &str = "/api/reborn/product-auth/lifecycle/cleanup";
 
 const OAUTH_START_ROUTE_ID: &str = "product_auth.oauth.start";
 const OAUTH_CALLBACK_ROUTE_ID: &str = "product_auth.oauth.callback";
 const MANUAL_TOKEN_SUBMIT_ROUTE_ID: &str = "product_auth.manual_token.submit";
+const MANUAL_TOKEN_SETUP_ROUTE_ID: &str = "product_auth.manual_token.setup";
+const MANUAL_TOKEN_SECRET_SUBMIT_ROUTE_ID: &str = "product_auth.manual_token.secret_submit";
+const ACCOUNTS_LIST_ROUTE_ID: &str = "product_auth.accounts.list";
+const ACCOUNTS_SELECT_ROUTE_ID: &str = "product_auth.accounts.select";
+const ACCOUNTS_RECOVERY_ROUTE_ID: &str = "product_auth.accounts.recovery";
+const ACCOUNTS_REFRESH_ROUTE_ID: &str = "product_auth.accounts.refresh";
+const LIFECYCLE_CLEANUP_ROUTE_ID: &str = "product_auth.lifecycle.cleanup";
 const OAUTH_PKCE_VERIFIER_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(1024) {
     Some(value) => value,
     // SAFETY: 1024 is a non-zero literal cache cap.
@@ -209,11 +228,29 @@ pub(crate) struct ProductAuthRouteMount {
     pub(crate) descriptors: Vec<IngressRouteDescriptor>,
 }
 
+// ToolDispatcher exemption (issue #4201): product-auth HTTP is a host-owned
+// auth/secret-ingress boundary. Its mutations enter `RebornProductAuthServices`
+// directly because credential setup, secure secret-submit, recovery, refresh,
+// and lifecycle cleanup are not in-turn tool calls and must not surface raw
+// secrets through the model-visible tool-dispatch path. The "everything goes
+// through tools" invariant in `docs/reborn/contracts/auth-product.md` therefore
+// explicitly exempts this surface; routes still derive scope from
+// authenticated caller context and emit only redacted projections.
 pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductAuthRouteMount {
     ProductAuthRouteMount {
         protected: Router::new()
             .route(OAUTH_START_PATH, post(oauth_start_handler))
             .route(MANUAL_TOKEN_SUBMIT_PATH, post(manual_token_submit_handler))
+            .route(MANUAL_TOKEN_SETUP_PATH, post(manual_token_setup_handler))
+            .route(
+                MANUAL_TOKEN_SECRET_SUBMIT_PATH,
+                post(manual_token_secret_submit_handler),
+            )
+            .route(ACCOUNTS_LIST_PATH, post(accounts_list_handler))
+            .route(ACCOUNTS_SELECT_PATH, post(accounts_select_handler))
+            .route(ACCOUNTS_RECOVERY_PATH, post(accounts_recovery_handler))
+            .route(ACCOUNTS_REFRESH_PATH, post(accounts_refresh_handler))
+            .route(LIFECYCLE_CLEANUP_PATH, post(lifecycle_cleanup_handler))
             .with_state(state.clone()),
         public: Router::new()
             .route(OAUTH_CALLBACK_PATH, get(oauth_callback_handler))
@@ -240,6 +277,48 @@ pub(crate) fn product_auth_route_descriptors() -> Vec<IngressRouteDescriptor> {
             MANUAL_TOKEN_SUBMIT_ROUTE_ID,
             NetworkMethod::Post,
             MANUAL_TOKEN_SUBMIT_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            MANUAL_TOKEN_SETUP_ROUTE_ID,
+            NetworkMethod::Post,
+            MANUAL_TOKEN_SETUP_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            MANUAL_TOKEN_SECRET_SUBMIT_ROUTE_ID,
+            NetworkMethod::Post,
+            MANUAL_TOKEN_SECRET_SUBMIT_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_LIST_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_LIST_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_SELECT_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_SELECT_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_RECOVERY_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_RECOVERY_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_REFRESH_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_REFRESH_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            LIFECYCLE_CLEANUP_ROUTE_ID,
+            NetworkMethod::Post,
+            LIFECYCLE_CLEANUP_PATH,
             protected_mutation_policy(),
         ),
     ]
@@ -343,6 +422,117 @@ pub(crate) struct ManualTokenSubmitResponse {
     pub(crate) credential_ref: CredentialAccountId,
     pub(crate) status: CredentialAccountStatus,
     pub(crate) continuation: AuthContinuationRef,
+}
+
+#[derive(Deserialize)]
+struct ManualTokenSetupHttpRequest {
+    provider: String,
+    account_label: String,
+    #[serde(default)]
+    run_id: Option<String>,
+    #[serde(default)]
+    gate_ref: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ManualTokenSetupResponse {
+    pub(crate) interaction_id: AuthInteractionId,
+    pub(crate) provider: AuthProviderId,
+    pub(crate) label: CredentialAccountLabel,
+    pub(crate) expires_at: Timestamp,
+    /// Invocation scope used to mint this interaction. The browser carries it
+    /// back on the secret-submit call so the host can re-derive the same
+    /// `AuthProductScope` and let the interaction service match the pending
+    /// scope without trusting browser-supplied scope identifiers.
+    pub(crate) invocation_id: InvocationId,
+}
+
+#[derive(Deserialize)]
+struct ManualTokenSecretSubmitHttpRequest {
+    interaction_id: String,
+    token: UnvalidatedRawSecretValue,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsListHttpRequest {
+    provider: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsSelectHttpRequest {
+    provider: String,
+    account_id: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsRecoveryHttpRequest {
+    provider: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsRefreshHttpRequest {
+    provider: String,
+    account_id: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LifecycleCleanupHttpRequest {
+    extension_id: String,
+    action: SecretCleanupAction,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -638,6 +828,310 @@ async fn abandon_manual_token_after_submit_failure(
     }
 }
 
+async fn manual_token_setup_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<ManualTokenSetupHttpRequest>,
+) -> Result<Json<ManualTokenSetupResponse>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let invocation_id = scope.resource.invocation_id;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let label = CredentialAccountLabel::new(request.account_label)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let continuation =
+        manual_token_continuation(request.run_id.as_deref(), request.gate_ref.as_deref())?;
+    let expires_at = Utc::now() + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS);
+
+    let challenge = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .request_manual_token_setup(RebornManualTokenSetupRequest::new(
+                scope,
+                provider,
+                label,
+                continuation,
+                expires_at,
+            )),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(ManualTokenSetupResponse {
+        interaction_id: challenge.interaction_id,
+        provider: challenge.provider,
+        label: challenge.label,
+        expires_at: challenge.expires_at,
+        invocation_id,
+    }))
+}
+
+async fn manual_token_secret_submit_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<ManualTokenSecretSubmitHttpRequest>,
+) -> Result<Json<ManualTokenSubmitResponse>, ProductAuthRouteFailure> {
+    // Secret-submit is the secure out-of-band entry point: the raw token is
+    // read straight off the dedicated body, never echoed back, and never
+    // surfaced in model transcript or tool arguments. Only the redacted
+    // submit projection is returned.
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let interaction_id = parse_interaction_id(&request.interaction_id)?;
+    let token = request
+        .token
+        .into_validated()
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+
+    let submitted = match tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .submit_manual_token(RebornManualTokenSubmitRequest::new(
+                scope.clone(),
+                interaction_id,
+                token.into_secret(),
+            )),
+    )
+    .await
+    {
+        Ok(Ok(submitted)) => submitted,
+        Ok(Err(error)) => {
+            abandon_manual_token_after_submit_failure(&state, &scope, interaction_id, error.code)
+                .await;
+            return Err(ProductAuthRouteFailure::from(error));
+        }
+        Err(_) => {
+            abandon_manual_token_after_submit_failure(
+                &state,
+                &scope,
+                interaction_id,
+                AuthErrorCode::BackendUnavailable,
+            )
+            .await;
+            return Err(ProductAuthRouteFailure::backend_timeout());
+        }
+    };
+
+    Ok(Json(ManualTokenSubmitResponse {
+        credential_ref: submitted.account_id,
+        status: submitted.status,
+        continuation: submitted.continuation,
+    }))
+}
+
+async fn accounts_list_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsListHttpRequest>,
+) -> Result<Json<CredentialAccountListPage>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+
+    let mut list_request = CredentialAccountListRequest::new(scope, provider);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        list_request = list_request.for_extension(parse_extension_id(extension_id)?);
+    }
+    if let Some(cursor) = request.cursor.as_deref() {
+        list_request = list_request.with_cursor(parse_credential_account_id(cursor)?);
+    }
+    if let Some(limit) = request.limit {
+        list_request = list_request.with_limit(limit);
+    }
+    list_request
+        .validate()
+        .map_err(ProductAuthRouteFailure::from)?;
+
+    let page = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state.product_auth.list_credential_accounts(list_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(page))
+}
+
+async fn accounts_select_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsSelectHttpRequest>,
+) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let account_id = parse_credential_account_id(&request.account_id)?;
+
+    let mut choice_request = CredentialAccountChoiceRequest::new(scope, provider, account_id);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        choice_request = choice_request.for_extension(parse_extension_id(extension_id)?);
+    }
+
+    let projection = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state.product_auth.select_credential_account(choice_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(projection))
+}
+
+async fn accounts_recovery_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsRecoveryHttpRequest>,
+) -> Result<Json<CredentialRecoveryProjection>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+
+    let mut recovery_request = CredentialRecoveryRequest::new(scope, provider);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        recovery_request = recovery_request.for_extension(parse_extension_id(extension_id)?);
+    }
+
+    let projection = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .project_credential_recovery(recovery_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(projection))
+}
+
+async fn accounts_refresh_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsRefreshHttpRequest>,
+) -> Result<Json<CredentialRefreshReport>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let account_id = parse_credential_account_id(&request.account_id)?;
+
+    let mut refresh_request = CredentialRefreshRequest::new(scope, provider, account_id);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        refresh_request = refresh_request.for_extension(parse_extension_id(extension_id)?);
+    }
+
+    let report = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .refresh_credential_account(refresh_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(report))
+}
+
+async fn lifecycle_cleanup_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<LifecycleCleanupHttpRequest>,
+) -> Result<Json<SecretCleanupReport>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let extension_id = parse_extension_id(&request.extension_id)?;
+
+    let cleanup_request = SecretCleanupRequest {
+        scope,
+        extension_id,
+        action: request.action,
+    };
+
+    let report = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .cleanup_credentials_for_lifecycle(cleanup_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(report))
+}
+
+fn manual_token_continuation(
+    run_id: Option<&str>,
+    gate_ref: Option<&str>,
+) -> Result<AuthContinuationRef, ProductAuthRouteFailure> {
+    match (run_id, gate_ref) {
+        (Some(run_id), Some(gate_ref)) => Ok(AuthContinuationRef::TurnGateResume {
+            turn_run_ref: TurnRunRef::new(run_id.to_string())
+                .map_err(|_| ProductAuthRouteFailure::invalid_request())?,
+            gate_ref: AuthGateRef::new(gate_ref.to_string())
+                .map_err(|_| ProductAuthRouteFailure::invalid_request())?,
+        }),
+        (None, None) => Ok(AuthContinuationRef::SetupOnly),
+        // run_id without gate_ref (or vice versa) is rejected so we never
+        // resume the wrong gate or fabricate a partial turn-resume.
+        _ => Err(ProductAuthRouteFailure::invalid_request()),
+    }
+}
+
+fn parse_interaction_id(value: &str) -> Result<AuthInteractionId, ProductAuthRouteFailure> {
+    let parsed = Uuid::parse_str(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    Ok(AuthInteractionId::from_uuid(parsed))
+}
+
+fn parse_credential_account_id(
+    value: &str,
+) -> Result<CredentialAccountId, ProductAuthRouteFailure> {
+    let parsed = Uuid::parse_str(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    Ok(CredentialAccountId::from_uuid(parsed))
+}
+
+fn parse_extension_id(value: &str) -> Result<ExtensionId, ProductAuthRouteFailure> {
+    ExtensionId::new(value.to_string()).map_err(|_| ProductAuthRouteFailure::invalid_request())
+}
+
 async fn oauth_callback_handler(
     State(state): State<ProductAuthRouteState>,
     Path(flow_id): Path<String>,
@@ -781,6 +1275,15 @@ fn scope_from_authenticated_caller_parts(
     thread_id: Option<&String>,
     session_id: Option<&String>,
 ) -> Result<AuthProductScope, ProductAuthRouteFailure> {
+    scope_from_authenticated_caller_parts_with_invocation(caller, thread_id, session_id, None)
+}
+
+fn scope_from_authenticated_caller_parts_with_invocation(
+    caller: &WebUiAuthenticatedCaller,
+    thread_id: Option<&String>,
+    session_id: Option<&String>,
+    invocation_id: Option<&str>,
+) -> Result<AuthProductScope, ProductAuthRouteFailure> {
     let thread_id = thread_id
         .map(|value| {
             ThreadId::new(value.clone()).map_err(|_| ProductAuthRouteFailure::invalid_request())
@@ -792,6 +1295,17 @@ fn scope_from_authenticated_caller_parts(
                 .map_err(|_| ProductAuthRouteFailure::invalid_request())
         })
         .transpose()?;
+    // invocation_id, when supplied by the caller, must be a valid existing
+    // identifier (round-tripped from a prior start/setup response). Otherwise
+    // we mint a fresh one — the OAuth start/callback pattern from #4031 uses
+    // the same shape: the host owns the canonical id and the browser carries
+    // it forward across follow-up calls.
+    let invocation_id = match invocation_id {
+        Some(value) => {
+            InvocationId::parse(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?
+        }
+        None => InvocationId::new(),
+    };
 
     let mut scope = AuthProductScope::new(
         ResourceScope {
@@ -801,7 +1315,7 @@ fn scope_from_authenticated_caller_parts(
             project_id: caller.project_id.clone(),
             mission_id: None,
             thread_id,
-            invocation_id: InvocationId::new(),
+            invocation_id,
         },
         AuthSurface::Callback,
     );

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -4,6 +4,10 @@
 //! composition, one-way hashing of callback material, and sanitized response
 //! rendering. It deliberately delegates durable flow state, provider exchange,
 //! credential mutation, and continuation dispatch to [`RebornProductAuthServices`].
+//
+// arch-exempt: large_file, product-auth HTTP surface (9 mutation routes + OAuth
+// callback + helpers) has no smaller home until a dedicated product_auth_serve/
+// submodule split is tracked, plan #4201-decomp
 
 use std::{
     num::{NonZeroU32, NonZeroU64, NonZeroUsize},
@@ -49,8 +53,8 @@ use uuid::Uuid;
 use crate::auth::RebornOAuthStartFlowRequest;
 use crate::{
     RebornAuthProductError, RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest,
-    RebornOAuthCallbackError, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
-    RebornOAuthCallbackResponse, RebornProductAuthServices,
+    RebornManualTokenSubmitResponse, RebornOAuthCallbackError, RebornOAuthCallbackOutcome,
+    RebornOAuthCallbackRequest, RebornOAuthCallbackResponse, RebornProductAuthServices,
 };
 
 pub(crate) const OAUTH_START_PATH: &str = "/api/reborn/product-auth/oauth/start";
@@ -232,8 +236,8 @@ pub(crate) struct ProductAuthRouteMount {
 // mutations enter `RebornProductAuthServices` directly; they are not in-turn
 // tool calls and must not surface raw secrets through the model-visible
 // tool-dispatch path. Contract: `docs/reborn/contracts/auth-product.md`.
+// dispatch-exempt: host-owned auth/secret ingress, not in-turn tool dispatch
 pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductAuthRouteMount {
-    // dispatch-exempt: host-owned auth/secret ingress, not in-turn tool dispatch
     ProductAuthRouteMount {
         protected: Router::new()
             .route(OAUTH_START_PATH, post(oauth_start_handler))
@@ -398,9 +402,12 @@ pub(crate) struct ManualTokenSubmitResponse {
 ///
 /// `invocation_id` is round-tripped from a prior start/setup response so the
 /// host can re-derive the same `AuthProductScope` across follow-up calls
-/// (mirroring the OAuth start/callback pattern). All three fields are
-/// optional: routes default to a fresh scope when the browser has no prior
-/// invocation to carry forward.
+/// (mirroring the OAuth start/callback pattern). Routes that are follow-ups to
+/// an established interaction — `secret-submit`, `accounts/list`,
+/// `accounts/select`, `accounts/recovery`, and `accounts/refresh` — require
+/// `invocation_id` via [`scope_from_authenticated_caller_parts_requiring_invocation`].
+/// Setup-phase routes (`manual-token/setup`, OAuth start) accept a fresh scope
+/// when the field is absent.
 #[derive(Default, Deserialize)]
 struct ScopeFields {
     #[serde(default)]
@@ -624,7 +631,14 @@ async fn oauth_start_handler(
         return Err(ProductAuthRouteFailure::invalid_request());
     }
 
-    let scope = scope_from_authenticated_caller(&caller, &request)?;
+    let scope = scope_from_authenticated_caller_parts(
+        &caller,
+        &ScopeFields {
+            session_id: request.session_id.clone(),
+            thread_id: request.thread_id.clone(),
+            invocation_id: None,
+        },
+    )?;
     let provider = AuthProviderId::new(request.provider).map_err(|_| {
         ProductAuthRouteFailure::new(StatusCode::BAD_REQUEST, AuthErrorCode::InvalidRequest)
     })?;
@@ -711,40 +725,15 @@ async fn manual_token_submit_handler(
         ),
     ))
     .await?;
-    let submitted = match tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state
-            .product_auth
-            .submit_manual_token(RebornManualTokenSubmitRequest::new(
-                scope.clone(),
-                challenge.interaction_id,
-                token.into_secret(),
-            )),
+    // submit_manual_token uses inline timeout (not run_with_backend_timeout) because
+    // it needs to call abandon_manual_token on failure — see submit_manual_token_with_abandon.
+    let submitted = submit_manual_token_with_abandon(
+        &state,
+        &scope,
+        challenge.interaction_id,
+        token.into_secret(),
     )
-    .await
-    {
-        Ok(Ok(submitted)) => submitted,
-        Ok(Err(error)) => {
-            abandon_manual_token_after_submit_failure(
-                &state,
-                &scope,
-                challenge.interaction_id,
-                error.code,
-            )
-            .await;
-            return Err(ProductAuthRouteFailure::from(error));
-        }
-        Err(_) => {
-            abandon_manual_token_after_submit_failure(
-                &state,
-                &scope,
-                challenge.interaction_id,
-                AuthErrorCode::BackendUnavailable,
-            )
-            .await;
-            return Err(ProductAuthRouteFailure::backend_timeout());
-        }
-    };
+    .await?;
 
     Ok(Json(ManualTokenSubmitResponse {
         credential_ref: submitted.account_id,
@@ -769,18 +758,66 @@ async fn abandon_manual_token_after_submit_failure(
     {
         Ok(Ok(_)) => {}
         Ok(Err(cleanup_error)) => {
-            tracing::debug!(
+            tracing::warn!(
                 error_code = ?submit_error_code,
                 cleanup_error_code = ?cleanup_error.code,
-                "manual-token submit failed and interaction cleanup failed"
+                "manual-token submit failed and interaction cleanup failed — interaction may be orphaned until TTL"
             );
         }
         Err(_) => {
-            tracing::debug!(
+            tracing::warn!(
                 error_code = ?submit_error_code,
                 cleanup_error_code = ?AuthErrorCode::BackendUnavailable,
-                "manual-token submit failed and interaction cleanup timed out"
+                "manual-token submit failed and interaction cleanup timed out — interaction may be orphaned until TTL"
             );
+        }
+    }
+}
+
+/// Submit a manual token and, on any failure, abandon the pending interaction
+/// before returning the error so the interaction slot is released promptly.
+///
+/// Uses a dedicated `tokio::time::timeout` instead of `run_with_backend_timeout`
+/// because it needs access to `scope` and `interaction_id` for the cleanup call
+/// — the generic timeout helper returns early on failure without them.
+///
+/// Note: cumulative per-request timeout is up to 2× `PRODUCT_AUTH_BACKEND_TIMEOUT`
+/// (submit + abandon). Detaching the abandon via `tokio::spawn` is deferred until
+/// the existing caller-level test for synchronous abandon can be updated
+/// (#4201-decomp).
+async fn submit_manual_token_with_abandon(
+    state: &ProductAuthRouteState,
+    scope: &AuthProductScope,
+    interaction_id: AuthInteractionId,
+    secret: SecretString,
+) -> Result<RebornManualTokenSubmitResponse, ProductAuthRouteFailure> {
+    match tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .submit_manual_token(RebornManualTokenSubmitRequest::new(
+                scope.clone(),
+                interaction_id,
+                secret,
+            )),
+    )
+    .await
+    {
+        Ok(Ok(submitted)) => Ok(submitted),
+        Ok(Err(error)) => {
+            let code = error.code;
+            abandon_manual_token_after_submit_failure(state, scope, interaction_id, code).await;
+            Err(ProductAuthRouteFailure::from(error))
+        }
+        Err(_) => {
+            abandon_manual_token_after_submit_failure(
+                state,
+                scope,
+                interaction_id,
+                AuthErrorCode::BackendUnavailable,
+            )
+            .await;
+            Err(ProductAuthRouteFailure::backend_timeout())
         }
     }
 }
@@ -828,40 +865,26 @@ async fn manual_token_secret_submit_handler(
     let scope =
         scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let interaction_id = parse_interaction_id(&request.interaction_id)?;
-    let token = request
-        .token
-        .into_validated()
-        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
-
-    let submitted = match tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state
-            .product_auth
-            .submit_manual_token(RebornManualTokenSubmitRequest::new(
-                scope.clone(),
-                interaction_id,
-                token.into_secret(),
-            )),
-    )
-    .await
-    {
-        Ok(Ok(submitted)) => submitted,
-        Ok(Err(error)) => {
-            abandon_manual_token_after_submit_failure(&state, &scope, interaction_id, error.code)
-                .await;
-            return Err(ProductAuthRouteFailure::from(error));
-        }
+    // If token validation fails, the interaction created by the prior setup call
+    // would be orphaned until TTL. Abandon it synchronously so the slot is
+    // released promptly even though the client receives an invalid_request.
+    let token = match request.token.into_validated() {
+        Ok(t) => t,
         Err(_) => {
             abandon_manual_token_after_submit_failure(
                 &state,
                 &scope,
                 interaction_id,
-                AuthErrorCode::BackendUnavailable,
+                AuthErrorCode::InvalidRequest,
             )
             .await;
-            return Err(ProductAuthRouteFailure::backend_timeout());
+            return Err(ProductAuthRouteFailure::invalid_request());
         }
     };
+
+    let submitted =
+        submit_manual_token_with_abandon(&state, &scope, interaction_id, token.into_secret())
+            .await?;
 
     Ok(Json(ManualTokenSubmitResponse {
         credential_ref: submitted.account_id,
@@ -907,7 +930,10 @@ async fn accounts_select_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsSelectRequest>,
 ) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
+    // invocation_id is required to match the scope used for the preceding
+    // accounts/list call so that select binds the choice to the same context.
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     let account_id = parse_credential_account_id(&request.account_id)?;
@@ -929,7 +955,10 @@ async fn accounts_recovery_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsRecoveryRequest>,
 ) -> Result<Json<CredentialRecoveryProjection>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
+    // invocation_id is required to keep recovery/refresh on the same scope as
+    // the preceding list/select calls.
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
@@ -953,7 +982,10 @@ async fn accounts_refresh_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsRefreshRequest>,
 ) -> Result<Json<CredentialRefreshReport>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
+    // invocation_id is required to match the scope used for list/select so the
+    // refresh target resolves in the same interaction context.
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     let account_id = parse_credential_account_id(&request.account_id)?;
@@ -1041,10 +1073,10 @@ fn parse_optional_extension(
 /// project both the elapsed-timeout failure and any returned auth error onto
 /// the route's sanitized failure shape.
 ///
-/// Every protected product-auth route enters `RebornProductAuthServices` the
-/// same way; centralising the timeout/error wiring stops each handler from
-/// having to re-derive the same four lines and keeps the failure projection
-/// identical across routes.
+/// Every protected product-auth route except the two manual-token submit
+/// handlers uses this helper. Those handlers use a raw `tokio::time::timeout`
+/// instead because they need to call `abandon_manual_token_after_submit_failure`
+/// on error — see [`submit_manual_token_with_abandon`].
 async fn run_with_backend_timeout<T, F>(future: F) -> Result<T, ProductAuthRouteFailure>
 where
     F: std::future::Future<Output = Result<T, RebornAuthProductError>>,
@@ -1183,20 +1215,6 @@ fn should_forget_pkce_verifier(code: AuthErrorCode) -> bool {
     )
 }
 
-fn scope_from_authenticated_caller(
-    caller: &WebUiAuthenticatedCaller,
-    request: &OAuthStartRequest,
-) -> Result<AuthProductScope, ProductAuthRouteFailure> {
-    scope_from_authenticated_caller_parts(
-        caller,
-        &ScopeFields {
-            session_id: request.session_id.clone(),
-            thread_id: request.thread_id.clone(),
-            invocation_id: None,
-        },
-    )
-}
-
 /// Derive an `AuthProductScope` from the authenticated caller plus the
 /// caller-supplied scope fields shared by every product-auth route body.
 ///
@@ -1250,9 +1268,11 @@ fn scope_from_authenticated_caller_parts(
 }
 
 /// Like [`scope_from_authenticated_caller_parts`] but returns `invalid_request`
-/// when `invocation_id` is absent. Use for follow-up routes where the browser
-/// MUST carry back the id minted by a prior setup/start response so the host
-/// can re-derive the matching scope without minting a fresh, unmatched one.
+/// when `invocation_id` is absent. Used by all follow-up routes
+/// (`secret-submit`, `accounts/list`, `accounts/select`, `accounts/recovery`,
+/// `accounts/refresh`) where the browser MUST carry back the id minted by a
+/// prior setup/start response so the host re-derives the same scope across the
+/// interaction lifecycle.
 fn scope_from_authenticated_caller_parts_requiring_invocation(
     caller: &WebUiAuthenticatedCaller,
     fields: &ScopeFields,

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -228,15 +228,12 @@ pub(crate) struct ProductAuthRouteMount {
     pub(crate) descriptors: Vec<IngressRouteDescriptor>,
 }
 
-// ToolDispatcher exemption (issue #4201): product-auth HTTP is a host-owned
-// auth/secret-ingress boundary. Its mutations enter `RebornProductAuthServices`
-// directly because credential setup, secure secret-submit, recovery, refresh,
-// and lifecycle cleanup are not in-turn tool calls and must not surface raw
-// secrets through the model-visible tool-dispatch path. The "everything goes
-// through tools" invariant in `docs/reborn/contracts/auth-product.md` therefore
-// explicitly exempts this surface; routes still derive scope from
-// authenticated caller context and emit only redacted projections.
+// Product-auth HTTP is a host-owned auth/secret-ingress boundary. Its
+// mutations enter `RebornProductAuthServices` directly; they are not in-turn
+// tool calls and must not surface raw secrets through the model-visible
+// tool-dispatch path. Contract: `docs/reborn/contracts/auth-product.md`.
 pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductAuthRouteMount {
+    // dispatch-exempt: host-owned auth/secret ingress, not in-turn tool dispatch
     ProductAuthRouteMount {
         protected: Router::new()
             .route(OAUTH_START_PATH, post(oauth_start_handler))
@@ -415,7 +412,7 @@ struct ScopeFields {
 }
 
 #[derive(Deserialize)]
-struct ManualTokenSetupHttpRequest {
+struct ManualTokenSetupRequest {
     provider: String,
     account_label: String,
     #[serde(default)]
@@ -440,7 +437,7 @@ pub(crate) struct ManualTokenSetupResponse {
 }
 
 #[derive(Deserialize)]
-struct ManualTokenSecretSubmitHttpRequest {
+struct ManualTokenSecretSubmitRequest {
     interaction_id: String,
     token: UnvalidatedRawSecretValue,
     #[serde(flatten)]
@@ -448,7 +445,7 @@ struct ManualTokenSecretSubmitHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsListHttpRequest {
+struct AccountsListRequest {
     provider: String,
     #[serde(default)]
     requester_extension: Option<String>,
@@ -461,7 +458,7 @@ struct AccountsListHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsSelectHttpRequest {
+struct AccountsSelectRequest {
     provider: String,
     account_id: String,
     #[serde(default)]
@@ -471,7 +468,7 @@ struct AccountsSelectHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsRecoveryHttpRequest {
+struct AccountsRecoveryRequest {
     provider: String,
     #[serde(default)]
     requester_extension: Option<String>,
@@ -480,7 +477,7 @@ struct AccountsRecoveryHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsRefreshHttpRequest {
+struct AccountsRefreshRequest {
     provider: String,
     account_id: String,
     #[serde(default)]
@@ -490,7 +487,7 @@ struct AccountsRefreshHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct LifecycleCleanupHttpRequest {
+struct LifecycleCleanupRequest {
     extension_id: String,
     action: SecretCleanupAction,
     #[serde(flatten)]
@@ -791,7 +788,7 @@ async fn abandon_manual_token_after_submit_failure(
 async fn manual_token_setup_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<ManualTokenSetupHttpRequest>,
+    Json(request): Json<ManualTokenSetupRequest>,
 ) -> Result<Json<ManualTokenSetupResponse>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let invocation_id = scope.resource.invocation_id;
@@ -820,13 +817,16 @@ async fn manual_token_setup_handler(
 async fn manual_token_secret_submit_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<ManualTokenSecretSubmitHttpRequest>,
+    Json(request): Json<ManualTokenSecretSubmitRequest>,
 ) -> Result<Json<ManualTokenSubmitResponse>, ProductAuthRouteFailure> {
     // Secret-submit is the secure out-of-band entry point: the raw token is
     // read straight off the dedicated body, never echoed back, and never
     // surfaced in model transcript or tool arguments. Only the redacted
     // submit projection is returned.
-    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
+    // invocation_id is required: it must be the id returned by setup so the
+    // interaction service can match the pending scope.
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let interaction_id = parse_interaction_id(&request.interaction_id)?;
     let token = request
         .token
@@ -873,9 +873,12 @@ async fn manual_token_secret_submit_handler(
 async fn accounts_list_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsListHttpRequest>,
+    Json(request): Json<AccountsListRequest>,
 ) -> Result<Json<CredentialAccountListPage>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
+    // invocation_id is required so the list is scoped to the caller's current
+    // interaction context; omitting it would silently yield an empty page.
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
@@ -902,7 +905,7 @@ async fn accounts_list_handler(
 async fn accounts_select_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsSelectHttpRequest>,
+    Json(request): Json<AccountsSelectRequest>,
 ) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
@@ -924,7 +927,7 @@ async fn accounts_select_handler(
 async fn accounts_recovery_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsRecoveryHttpRequest>,
+    Json(request): Json<AccountsRecoveryRequest>,
 ) -> Result<Json<CredentialRecoveryProjection>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
@@ -948,7 +951,7 @@ async fn accounts_recovery_handler(
 async fn accounts_refresh_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsRefreshHttpRequest>,
+    Json(request): Json<AccountsRefreshRequest>,
 ) -> Result<Json<CredentialRefreshReport>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
@@ -973,7 +976,7 @@ async fn accounts_refresh_handler(
 async fn lifecycle_cleanup_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<LifecycleCleanupHttpRequest>,
+    Json(request): Json<LifecycleCleanupRequest>,
 ) -> Result<Json<SecretCleanupReport>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let extension_id = parse_extension_id(&request.extension_id)?;
@@ -1244,6 +1247,20 @@ fn scope_from_authenticated_caller_parts(
         scope = scope.with_session_id(session_id);
     }
     Ok(scope)
+}
+
+/// Like [`scope_from_authenticated_caller_parts`] but returns `invalid_request`
+/// when `invocation_id` is absent. Use for follow-up routes where the browser
+/// MUST carry back the id minted by a prior setup/start response so the host
+/// can re-derive the matching scope without minting a fresh, unmatched one.
+fn scope_from_authenticated_caller_parts_requiring_invocation(
+    caller: &WebUiAuthenticatedCaller,
+    fields: &ScopeFields,
+) -> Result<AuthProductScope, ProductAuthRouteFailure> {
+    if fields.invocation_id.is_none() {
+        return Err(ProductAuthRouteFailure::invalid_request());
+    }
+    scope_from_authenticated_caller_parts(caller, fields)
 }
 
 fn scope_from_callback_query(

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -48,9 +48,9 @@ use uuid::Uuid;
 
 use crate::auth::RebornOAuthStartFlowRequest;
 use crate::{
-    RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest, RebornOAuthCallbackError,
-    RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest, RebornOAuthCallbackResponse,
-    RebornProductAuthServices,
+    RebornAuthProductError, RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest,
+    RebornOAuthCallbackError, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
+    RebornOAuthCallbackResponse, RebornProductAuthServices,
 };
 
 pub(crate) const OAUTH_START_PATH: &str = "/api/reborn/product-auth/oauth/start";
@@ -704,21 +704,16 @@ async fn manual_token_submit_handler(
     };
     let expires_at = Utc::now() + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS);
 
-    let challenge = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state
-            .product_auth
-            .request_manual_token_setup(RebornManualTokenSetupRequest::new(
-                scope.clone(),
-                provider,
-                label,
-                continuation,
-                expires_at,
-            )),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let challenge = run_with_backend_timeout(state.product_auth.request_manual_token_setup(
+        RebornManualTokenSetupRequest::new(
+            scope.clone(),
+            provider,
+            label,
+            continuation,
+            expires_at,
+        ),
+    ))
+    .await?;
     let submitted = match tokio::time::timeout(
         PRODUCT_AUTH_BACKEND_TIMEOUT,
         state
@@ -808,21 +803,10 @@ async fn manual_token_setup_handler(
         manual_token_continuation(request.run_id.as_deref(), request.gate_ref.as_deref())?;
     let expires_at = Utc::now() + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS);
 
-    let challenge = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state
-            .product_auth
-            .request_manual_token_setup(RebornManualTokenSetupRequest::new(
-                scope,
-                provider,
-                label,
-                continuation,
-                expires_at,
-            )),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let challenge = run_with_backend_timeout(state.product_auth.request_manual_token_setup(
+        RebornManualTokenSetupRequest::new(scope, provider, label, continuation, expires_at),
+    ))
+    .await?;
 
     Ok(Json(ManualTokenSetupResponse {
         interaction_id: challenge.interaction_id,
@@ -896,8 +880,8 @@ async fn accounts_list_handler(
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
     let mut list_request = CredentialAccountListRequest::new(scope, provider);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        list_request = list_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        list_request = list_request.for_extension(extension_id);
     }
     if let Some(cursor) = request.cursor.as_deref() {
         list_request = list_request.with_cursor(parse_credential_account_id(cursor)?);
@@ -909,13 +893,8 @@ async fn accounts_list_handler(
         .validate()
         .map_err(ProductAuthRouteFailure::from)?;
 
-    let page = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state.product_auth.list_credential_accounts(list_request),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let page =
+        run_with_backend_timeout(state.product_auth.list_credential_accounts(list_request)).await?;
 
     Ok(Json(page))
 }
@@ -931,17 +910,13 @@ async fn accounts_select_handler(
     let account_id = parse_credential_account_id(&request.account_id)?;
 
     let mut choice_request = CredentialAccountChoiceRequest::new(scope, provider, account_id);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        choice_request = choice_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        choice_request = choice_request.for_extension(extension_id);
     }
 
-    let projection = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state.product_auth.select_credential_account(choice_request),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let projection =
+        run_with_backend_timeout(state.product_auth.select_credential_account(choice_request))
+            .await?;
 
     Ok(Json(projection))
 }
@@ -956,19 +931,16 @@ async fn accounts_recovery_handler(
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
     let mut recovery_request = CredentialRecoveryRequest::new(scope, provider);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        recovery_request = recovery_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        recovery_request = recovery_request.for_extension(extension_id);
     }
 
-    let projection = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
+    let projection = run_with_backend_timeout(
         state
             .product_auth
             .project_credential_recovery(recovery_request),
     )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    .await?;
 
     Ok(Json(projection))
 }
@@ -984,19 +956,16 @@ async fn accounts_refresh_handler(
     let account_id = parse_credential_account_id(&request.account_id)?;
 
     let mut refresh_request = CredentialRefreshRequest::new(scope, provider, account_id);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        refresh_request = refresh_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        refresh_request = refresh_request.for_extension(extension_id);
     }
 
-    let report = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
+    let report = run_with_backend_timeout(
         state
             .product_auth
             .refresh_credential_account(refresh_request),
     )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    .await?;
 
     Ok(Json(report))
 }
@@ -1015,15 +984,12 @@ async fn lifecycle_cleanup_handler(
         action: request.action,
     };
 
-    let report = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
+    let report = run_with_backend_timeout(
         state
             .product_auth
             .cleanup_credentials_for_lifecycle(cleanup_request),
     )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    .await?;
 
     Ok(Json(report))
 }
@@ -1060,6 +1026,31 @@ fn parse_credential_account_id(
 
 fn parse_extension_id(value: &str) -> Result<ExtensionId, ProductAuthRouteFailure> {
     ExtensionId::new(value.to_string()).map_err(|_| ProductAuthRouteFailure::invalid_request())
+}
+
+fn parse_optional_extension(
+    value: Option<&str>,
+) -> Result<Option<ExtensionId>, ProductAuthRouteFailure> {
+    value.map(parse_extension_id).transpose()
+}
+
+/// Await a product-auth backend call under the shared backend timeout and
+/// project both the elapsed-timeout failure and any returned auth error onto
+/// the route's sanitized failure shape.
+///
+/// Every protected product-auth route enters `RebornProductAuthServices` the
+/// same way; centralising the timeout/error wiring stops each handler from
+/// having to re-derive the same four lines and keeps the failure projection
+/// identical across routes.
+async fn run_with_backend_timeout<T, F>(future: F) -> Result<T, ProductAuthRouteFailure>
+where
+    F: std::future::Future<Output = Result<T, RebornAuthProductError>>,
+{
+    match tokio::time::timeout(PRODUCT_AUTH_BACKEND_TIMEOUT, future).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(ProductAuthRouteFailure::from(error)),
+        Err(_) => Err(ProductAuthRouteFailure::backend_timeout()),
+    }
 }
 
 async fn oauth_callback_handler(

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -260,68 +260,41 @@ pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductA
 }
 
 pub(crate) fn product_auth_route_descriptors() -> Vec<IngressRouteDescriptor> {
-    vec![
-        descriptor(
-            OAUTH_START_ROUTE_ID,
-            NetworkMethod::Post,
-            OAUTH_START_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            OAUTH_CALLBACK_ROUTE_ID,
-            NetworkMethod::Get,
-            OAUTH_CALLBACK_PATH,
-            callback_policy(),
-        ),
-        descriptor(
-            MANUAL_TOKEN_SUBMIT_ROUTE_ID,
-            NetworkMethod::Post,
-            MANUAL_TOKEN_SUBMIT_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            MANUAL_TOKEN_SETUP_ROUTE_ID,
-            NetworkMethod::Post,
-            MANUAL_TOKEN_SETUP_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
+    // All protected mutations share the same LocalGateway + Bearer + per-caller
+    // policy. Listing them as a table keeps the policy choice next to the path
+    // and stops descriptor blocks from drifting per-route.
+    const PROTECTED_MUTATIONS: &[(&str, &str)] = &[
+        (OAUTH_START_ROUTE_ID, OAUTH_START_PATH),
+        (MANUAL_TOKEN_SUBMIT_ROUTE_ID, MANUAL_TOKEN_SUBMIT_PATH),
+        (MANUAL_TOKEN_SETUP_ROUTE_ID, MANUAL_TOKEN_SETUP_PATH),
+        (
             MANUAL_TOKEN_SECRET_SUBMIT_ROUTE_ID,
-            NetworkMethod::Post,
             MANUAL_TOKEN_SECRET_SUBMIT_PATH,
-            protected_mutation_policy(),
         ),
-        descriptor(
-            ACCOUNTS_LIST_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_LIST_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            ACCOUNTS_SELECT_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_SELECT_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            ACCOUNTS_RECOVERY_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_RECOVERY_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            ACCOUNTS_REFRESH_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_REFRESH_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            LIFECYCLE_CLEANUP_ROUTE_ID,
-            NetworkMethod::Post,
-            LIFECYCLE_CLEANUP_PATH,
-            protected_mutation_policy(),
-        ),
-    ]
+        (ACCOUNTS_LIST_ROUTE_ID, ACCOUNTS_LIST_PATH),
+        (ACCOUNTS_SELECT_ROUTE_ID, ACCOUNTS_SELECT_PATH),
+        (ACCOUNTS_RECOVERY_ROUTE_ID, ACCOUNTS_RECOVERY_PATH),
+        (ACCOUNTS_REFRESH_ROUTE_ID, ACCOUNTS_REFRESH_PATH),
+        (LIFECYCLE_CLEANUP_ROUTE_ID, LIFECYCLE_CLEANUP_PATH),
+    ];
+    let mut descriptors: Vec<IngressRouteDescriptor> = PROTECTED_MUTATIONS
+        .iter()
+        .map(|(route_id, path)| {
+            descriptor(
+                route_id,
+                NetworkMethod::Post,
+                path,
+                protected_mutation_policy(),
+            )
+        })
+        .collect();
+    descriptors.push(descriptor(
+        OAUTH_CALLBACK_ROUTE_ID,
+        NetworkMethod::Get,
+        OAUTH_CALLBACK_PATH,
+        callback_policy(),
+    ));
+    descriptors
 }
 
 fn descriptor(
@@ -424,6 +397,23 @@ pub(crate) struct ManualTokenSubmitResponse {
     pub(crate) continuation: AuthContinuationRef,
 }
 
+/// Caller-supplied scope fields shared by every product-auth route body.
+///
+/// `invocation_id` is round-tripped from a prior start/setup response so the
+/// host can re-derive the same `AuthProductScope` across follow-up calls
+/// (mirroring the OAuth start/callback pattern). All three fields are
+/// optional: routes default to a fresh scope when the browser has no prior
+/// invocation to carry forward.
+#[derive(Default, Deserialize)]
+struct ScopeFields {
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
 #[derive(Deserialize)]
 struct ManualTokenSetupHttpRequest {
     provider: String,
@@ -432,12 +422,8 @@ struct ManualTokenSetupHttpRequest {
     run_id: Option<String>,
     #[serde(default)]
     gate_ref: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -457,12 +443,8 @@ pub(crate) struct ManualTokenSetupResponse {
 struct ManualTokenSecretSubmitHttpRequest {
     interaction_id: String,
     token: UnvalidatedRawSecretValue,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -474,12 +456,8 @@ struct AccountsListHttpRequest {
     cursor: Option<String>,
     #[serde(default)]
     limit: Option<usize>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -488,12 +466,8 @@ struct AccountsSelectHttpRequest {
     account_id: String,
     #[serde(default)]
     requester_extension: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -501,12 +475,8 @@ struct AccountsRecoveryHttpRequest {
     provider: String,
     #[serde(default)]
     requester_extension: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -515,24 +485,16 @@ struct AccountsRefreshHttpRequest {
     account_id: String,
     #[serde(default)]
     requester_extension: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
 struct LifecycleCleanupHttpRequest {
     extension_id: String,
     action: SecretCleanupAction,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -717,8 +679,11 @@ async fn manual_token_submit_handler(
 ) -> Result<Json<ManualTokenSubmitResponse>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(
         &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
+        &ScopeFields {
+            session_id: request.session_id.clone(),
+            thread_id: request.thread_id.clone(),
+            invocation_id: None,
+        },
     )?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
@@ -833,12 +798,7 @@ async fn manual_token_setup_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<ManualTokenSetupHttpRequest>,
 ) -> Result<Json<ManualTokenSetupResponse>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let invocation_id = scope.resource.invocation_id;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
@@ -882,12 +842,7 @@ async fn manual_token_secret_submit_handler(
     // read straight off the dedicated body, never echoed back, and never
     // surfaced in model transcript or tool arguments. Only the redacted
     // submit projection is returned.
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let interaction_id = parse_interaction_id(&request.interaction_id)?;
     let token = request
         .token
@@ -936,12 +891,7 @@ async fn accounts_list_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsListHttpRequest>,
 ) -> Result<Json<CredentialAccountListPage>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
@@ -975,12 +925,7 @@ async fn accounts_select_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsSelectHttpRequest>,
 ) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     let account_id = parse_credential_account_id(&request.account_id)?;
@@ -1006,12 +951,7 @@ async fn accounts_recovery_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsRecoveryHttpRequest>,
 ) -> Result<Json<CredentialRecoveryProjection>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
@@ -1038,12 +978,7 @@ async fn accounts_refresh_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsRefreshHttpRequest>,
 ) -> Result<Json<CredentialRefreshReport>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     let account_id = parse_credential_account_id(&request.account_id)?;
@@ -1071,12 +1006,7 @@ async fn lifecycle_cleanup_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<LifecycleCleanupHttpRequest>,
 ) -> Result<Json<SecretCleanupReport>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let extension_id = parse_extension_id(&request.extension_id)?;
 
     let cleanup_request = SecretCleanupRequest {
@@ -1265,42 +1195,42 @@ fn scope_from_authenticated_caller(
 ) -> Result<AuthProductScope, ProductAuthRouteFailure> {
     scope_from_authenticated_caller_parts(
         caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
+        &ScopeFields {
+            session_id: request.session_id.clone(),
+            thread_id: request.thread_id.clone(),
+            invocation_id: None,
+        },
     )
 }
 
+/// Derive an `AuthProductScope` from the authenticated caller plus the
+/// caller-supplied scope fields shared by every product-auth route body.
+///
+/// `invocation_id`, when supplied, must parse as an existing identifier
+/// (round-tripped from a prior start/setup response). Otherwise we mint a
+/// fresh one — mirroring the OAuth start/callback pattern from #4031 so the
+/// host owns the canonical id and the browser carries it forward across
+/// follow-up calls.
 fn scope_from_authenticated_caller_parts(
     caller: &WebUiAuthenticatedCaller,
-    thread_id: Option<&String>,
-    session_id: Option<&String>,
+    fields: &ScopeFields,
 ) -> Result<AuthProductScope, ProductAuthRouteFailure> {
-    scope_from_authenticated_caller_parts_with_invocation(caller, thread_id, session_id, None)
-}
-
-fn scope_from_authenticated_caller_parts_with_invocation(
-    caller: &WebUiAuthenticatedCaller,
-    thread_id: Option<&String>,
-    session_id: Option<&String>,
-    invocation_id: Option<&str>,
-) -> Result<AuthProductScope, ProductAuthRouteFailure> {
-    let thread_id = thread_id
+    let thread_id = fields
+        .thread_id
+        .as_deref()
         .map(|value| {
-            ThreadId::new(value.clone()).map_err(|_| ProductAuthRouteFailure::invalid_request())
+            ThreadId::new(value.to_string()).map_err(|_| ProductAuthRouteFailure::invalid_request())
         })
         .transpose()?;
-    let session_id = session_id
+    let session_id = fields
+        .session_id
+        .as_deref()
         .map(|value| {
-            AuthSessionId::new(value.clone())
+            AuthSessionId::new(value.to_string())
                 .map_err(|_| ProductAuthRouteFailure::invalid_request())
         })
         .transpose()?;
-    // invocation_id, when supplied by the caller, must be a valid existing
-    // identifier (round-tripped from a prior start/setup response). Otherwise
-    // we mint a fresh one — the OAuth start/callback pattern from #4031 uses
-    // the same shape: the host owns the canonical id and the browser carries
-    // it forward across follow-up calls.
-    let invocation_id = match invocation_id {
+    let invocation_id = match fields.invocation_id.as_deref() {
         Some(value) => {
             InvocationId::parse(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?
         }

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
@@ -1,0 +1,542 @@
+//! Caller-level tests for issue #4201: product-facing HTTP surfaces for
+//! manual-token setup/secret-submit, credential account list/select/recovery,
+//! refresh, and lifecycle cleanup.
+//!
+//! These tests drive the HTTP routes end-to-end through `webui_v2_app` so the
+//! caller path (auth layer + body limit + rate limit + handler +
+//! `RebornProductAuthServices`) is exercised, not just the facade helpers.
+
+#![cfg(feature = "webui-v2-beta")]
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::body::{Body, to_bytes};
+use axum::http::{HeaderValue, Method, Request, StatusCode, header};
+use ironclaw_auth::{
+    AuthContinuationEvent, AuthProductError, AuthProductScope, AuthSurface, CredentialAccountLabel,
+    CredentialAccountStatus, CredentialOwnership, InMemoryAuthProductServices,
+    NewCredentialAccount,
+};
+use ironclaw_auth::{AuthProviderId, CredentialAccountService};
+use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
+use ironclaw_product_workflow::{
+    ExtensionName, RebornCancelRunResponse, RebornCreateThreadResponse, RebornGetRunStateRequest,
+    RebornGetRunStateResponse, RebornListThreadsResponse, RebornResolveGateResponse,
+    RebornServicesApi, RebornServicesError, RebornServicesErrorCode, RebornServicesErrorKind,
+    RebornSetupExtensionResponse, RebornStreamEventsRequest, RebornStreamEventsResponse,
+    RebornSubmitTurnResponse, RebornTimelineRequest, RebornTimelineResponse,
+    WebUiAuthenticatedCaller, WebUiCancelRunRequest, WebUiCreateThreadRequest,
+    WebUiListThreadsRequest, WebUiResolveGateRequest, WebUiSendMessageRequest,
+    WebUiSetupExtensionRequest,
+};
+use ironclaw_reborn_composition::{
+    RebornAuthContinuationDispatcher, RebornProductAuthServices, RebornReadiness,
+    RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig, webui_v2_app,
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+const TENANT: &str = "tenant-4201";
+const USER: &str = "user-4201";
+const AGENT: &str = "agent-4201";
+const PROJECT: &str = "project-4201";
+const VALID_TOKEN: &str = "valid-bearer-token-4201";
+
+struct OnlyValidToken;
+
+#[async_trait]
+impl WebuiAuthenticator for OnlyValidToken {
+    async fn authenticate(&self, token: &str) -> Option<UserId> {
+        (token == VALID_TOKEN).then(|| UserId::new(USER).expect("user id"))
+    }
+}
+
+#[derive(Default)]
+struct NoopAuthDispatcher {
+    events: Mutex<Vec<AuthContinuationEvent>>,
+}
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for NoopAuthDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        self.events.lock().expect("auth events lock").push(event);
+        Ok(())
+    }
+}
+
+struct UnusedServices;
+
+#[async_trait]
+impl RebornServicesApi for UnusedServices {
+    async fn create_thread(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiCreateThreadRequest,
+    ) -> Result<RebornCreateThreadResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn submit_turn(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiSendMessageRequest,
+    ) -> Result<RebornSubmitTurnResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn get_timeline(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornTimelineRequest,
+    ) -> Result<RebornTimelineResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn stream_events(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornStreamEventsRequest,
+    ) -> Result<RebornStreamEventsResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn get_run_state(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornGetRunStateRequest,
+    ) -> Result<RebornGetRunStateResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn cancel_run(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiCancelRunRequest,
+    ) -> Result<RebornCancelRunResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn resolve_gate(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiResolveGateRequest,
+    ) -> Result<RebornResolveGateResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn list_threads(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiListThreadsRequest,
+    ) -> Result<RebornListThreadsResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn setup_extension(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _extension_name: ExtensionName,
+        _request: WebUiSetupExtensionRequest,
+    ) -> Result<RebornSetupExtensionResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+}
+
+fn unused_service_error() -> RebornServicesError {
+    RebornServicesError {
+        code: RebornServicesErrorCode::Internal,
+        kind: RebornServicesErrorKind::Internal,
+        status_code: 500,
+        retryable: false,
+        field: None,
+        validation_code: None,
+    }
+}
+
+struct AppFixture {
+    app: axum::Router,
+    shared: Arc<InMemoryAuthProductServices>,
+}
+
+fn build_fixture() -> AppFixture {
+    let shared = Arc::new(InMemoryAuthProductServices::new());
+    let product_auth = Arc::new(RebornProductAuthServices::from_shared(
+        shared.clone(),
+        Arc::new(NoopAuthDispatcher::default()),
+    ));
+    let bundle = RebornWebuiBundle {
+        api: Arc::new(UnusedServices),
+        product_auth: Some(product_auth),
+        readiness: RebornReadiness::disabled(),
+    };
+    let config = WebuiServeConfig::new(
+        TenantId::new(TENANT).expect("tenant"),
+        Arc::new(OnlyValidToken),
+        vec![HeaderValue::from_static("http://localhost:1234")],
+    )
+    .with_default_agent_id(AgentId::new(AGENT).expect("agent"))
+    .with_default_project_id(ProjectId::new(PROJECT).expect("project"));
+    let app = webui_v2_app(bundle, config).expect("webui v2 app");
+    AppFixture { app, shared }
+}
+
+fn caller_scope_with_invocation(invocation_id: InvocationId) -> AuthProductScope {
+    AuthProductScope::new(
+        ResourceScope {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            user_id: UserId::new(USER).expect("user"),
+            agent_id: Some(AgentId::new(AGENT).expect("agent")),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            mission_id: None,
+            thread_id: None,
+            invocation_id,
+        },
+        AuthSurface::Callback,
+    )
+}
+
+async fn seed_configured_account(
+    shared: &InMemoryAuthProductServices,
+    invocation_id: InvocationId,
+    provider: &str,
+    label: &str,
+) -> ironclaw_auth::CredentialAccountId {
+    let account = shared
+        .create_account(NewCredentialAccount {
+            scope: caller_scope_with_invocation(invocation_id),
+            provider: AuthProviderId::new(provider.to_string()).expect("provider"),
+            label: CredentialAccountLabel::new(label.to_string()).expect("label"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: None,
+            refresh_secret: None,
+            scopes: Vec::new(),
+        })
+        .await
+        .expect("seeded account");
+    account.id
+}
+
+async fn read_body_string(response: axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+async fn post_authenticated(
+    app: &axum::Router,
+    uri: &str,
+    body: Value,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(uri)
+                .header(header::AUTHORIZATION, format!("Bearer {VALID_TOKEN}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot")
+}
+
+async fn post_unauthenticated(
+    app: &axum::Router,
+    uri: &str,
+    body: Value,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(uri)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot")
+}
+
+const PATHS: &[&str] = &[
+    "/api/reborn/product-auth/manual-token/setup",
+    "/api/reborn/product-auth/manual-token/secret-submit",
+    "/api/reborn/product-auth/accounts/list",
+    "/api/reborn/product-auth/accounts/select",
+    "/api/reborn/product-auth/accounts/recovery",
+    "/api/reborn/product-auth/accounts/refresh",
+    "/api/reborn/product-auth/lifecycle/cleanup",
+];
+
+#[tokio::test]
+async fn product_auth_new_routes_require_bearer_auth() {
+    let fixture = build_fixture();
+    for path in PATHS {
+        let response = post_unauthenticated(&fixture.app, path, json!({})).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{path} must require bearer auth"
+        );
+    }
+}
+
+#[tokio::test]
+async fn manual_token_setup_then_secret_submit_returns_redacted_projection() {
+    let fixture = build_fixture();
+    let raw_token = "ghp_routing_through_4201_secret";
+
+    let setup_response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/setup",
+        json!({
+            "provider": "github",
+            "account_label": "work github 4201",
+            "run_id": "22222222-2222-2222-2222-222222222222",
+            "gate_ref": "gate:auth-github-4201",
+            "thread_id": "thread-auth-4201"
+        }),
+    )
+    .await;
+    assert_eq!(setup_response.status(), StatusCode::OK);
+    let setup_body = read_body_string(setup_response).await;
+    let setup_json: Value = serde_json::from_str(&setup_body).expect("setup json");
+    let interaction_id = setup_json["interaction_id"]
+        .as_str()
+        .expect("interaction id")
+        .to_string();
+    let invocation_id = setup_json["invocation_id"]
+        .as_str()
+        .expect("invocation id from setup response")
+        .to_string();
+    assert_eq!(setup_json["provider"].as_str(), Some("github"));
+    assert_eq!(setup_json["label"].as_str(), Some("work github 4201"));
+
+    let submit_response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/secret-submit",
+        json!({
+            "interaction_id": interaction_id,
+            "token": raw_token,
+            "thread_id": "thread-auth-4201",
+            "invocation_id": invocation_id
+        }),
+    )
+    .await;
+    assert_eq!(submit_response.status(), StatusCode::OK);
+    let submit_body = read_body_string(submit_response).await;
+    assert!(
+        !submit_body.contains(raw_token),
+        "secret-submit response must not echo raw token: {submit_body}"
+    );
+    assert!(
+        !submit_body.contains("interaction_id"),
+        "secret-submit response must not echo interaction_id: {submit_body}"
+    );
+    let submit_json: Value = serde_json::from_str(&submit_body).expect("submit json");
+    assert!(submit_json["credential_ref"].as_str().is_some());
+    assert_eq!(submit_json["status"].as_str(), Some("configured"));
+    assert_eq!(
+        submit_json["continuation"]["type"].as_str(),
+        Some("turn_gate_resume")
+    );
+    assert_eq!(
+        submit_json["continuation"]["gate_ref"].as_str(),
+        Some("gate:auth-github-4201")
+    );
+}
+
+#[tokio::test]
+async fn manual_token_setup_rejects_partial_continuation_inputs() {
+    let fixture = build_fixture();
+    let invalid_bodies = [
+        json!({
+            "provider": "github",
+            "account_label": "label-only-run",
+            "run_id": "22222222-2222-2222-2222-222222222222"
+        }),
+        json!({
+            "provider": "github",
+            "account_label": "label-only-gate",
+            "gate_ref": "gate:auth-github"
+        }),
+    ];
+    for body in invalid_bodies {
+        let response = post_authenticated(
+            &fixture.app,
+            "/api/reborn/product-auth/manual-token/setup",
+            body,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = read_body_string(response).await;
+        assert!(body.contains("\"code\":\"invalid_request\""));
+    }
+}
+
+#[tokio::test]
+async fn manual_token_secret_submit_invalid_interaction_is_sanitized() {
+    let fixture = build_fixture();
+    let raw_token = "ghp_invalid_interaction_secret";
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/secret-submit",
+        json!({
+            "interaction_id": "not-a-uuid",
+            "token": raw_token
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+    assert!(!body.contains(raw_token));
+}
+
+#[tokio::test]
+async fn accounts_list_returns_only_seeded_provider_accounts() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let github_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+    let _slack_id =
+        seed_configured_account(&fixture.shared, invocation_id, "slack", "work slack").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/list",
+        json!({
+            "provider": "github",
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("list json");
+    let accounts = json["accounts"].as_array().expect("accounts array");
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(
+        accounts[0]["id"].as_str(),
+        Some(github_id.to_string().as_str())
+    );
+    assert_eq!(accounts[0]["provider"].as_str(), Some("github"));
+    assert_eq!(accounts[0]["status"].as_str(), Some("configured"));
+    // Redacted projection must never carry secret handle names.
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn accounts_list_invalid_limit_is_sanitized() {
+    let fixture = build_fixture();
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/list",
+        json!({ "provider": "github", "limit": 0 }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}
+
+#[tokio::test]
+async fn accounts_select_returns_redacted_projection() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/select",
+        json!({
+            "provider": "github",
+            "account_id": account_id.to_string(),
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("select json");
+    assert_eq!(json["id"].as_str(), Some(account_id.to_string().as_str()));
+    assert_eq!(json["status"].as_str(), Some("configured"));
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn accounts_recovery_projects_setup_required_when_no_account_exists() {
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/recovery",
+        json!({ "provider": "github" }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("recovery json");
+    assert_eq!(json["provider"].as_str(), Some("github"));
+    assert_eq!(json["kind"].as_str(), Some("setup_required"));
+    assert_eq!(json["reason"].as_str(), Some("no_account"));
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn lifecycle_cleanup_redacts_report_and_reaches_service() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    // Seed an unrelated account so cleanup has scope to walk but no extension owns it.
+    let _account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/lifecycle/cleanup",
+        json!({
+            "extension_id": "ext-no-grant-4201",
+            "action": "deactivate",
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("cleanup json");
+    // No matching extension grant: report must be empty but well-formed.
+    assert_eq!(
+        json,
+        json!({}),
+        "cleanup report must omit empty arrays via skip_serializing_if"
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_cleanup_rejects_invalid_extension_id() {
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/lifecycle/cleanup",
+        json!({ "extension_id": "", "action": "deactivate" }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
@@ -540,3 +540,159 @@ async fn lifecycle_cleanup_rejects_invalid_extension_id() {
     let body = read_body_string(response).await;
     assert!(body.contains("\"code\":\"invalid_request\""));
 }
+
+#[tokio::test]
+async fn accounts_refresh_returns_report_for_seeded_account() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "refresh-test").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/refresh",
+        json!({
+            "provider": "github",
+            "account_id": account_id.to_string(),
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("refresh json");
+    assert_eq!(
+        json["account"]["id"].as_str(),
+        Some(account_id.to_string().as_str())
+    );
+    assert!(json["recovery"].is_object(), "recovery must be present");
+    assert!(json["refreshed"].is_boolean(), "refreshed must be present");
+    // Redacted projection must never carry secret handle names.
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn manual_token_secret_submit_requires_invocation_id() {
+    // Omitting invocation_id means the host cannot re-derive the setup scope;
+    // the route must reject with invalid_request rather than minting a fresh
+    // invocation that will never match the pending interaction.
+    let fixture = build_fixture();
+    let raw_token = "ghp_should_not_be_echoed_invocation_required";
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/secret-submit",
+        json!({
+            "interaction_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "token": raw_token
+            // invocation_id intentionally absent
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+    assert!(
+        !body.contains(raw_token),
+        "raw token must not be echoed: {body}"
+    );
+}
+
+#[tokio::test]
+async fn accounts_list_requires_invocation_id() {
+    // Omitting invocation_id would cause a fresh scope to be minted, silently
+    // returning an empty page instead of scoped results.
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/list",
+        json!({ "provider": "github" /* invocation_id absent */ }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}
+
+#[tokio::test]
+async fn new_routes_reject_malformed_invocation_id() {
+    // All new routes that accept invocation_id must return 400 on a non-UUID
+    // value so audit tooling can confirm the validation path is live.
+    let fixture = build_fixture();
+    let cases: &[(&str, Value)] = &[
+        (
+            "/api/reborn/product-auth/manual-token/secret-submit",
+            json!({
+                "interaction_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "token": "tok",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/list",
+            json!({ "provider": "github", "invocation_id": "not-a-uuid" }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/select",
+            json!({
+                "provider": "github",
+                "account_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/recovery",
+            json!({ "provider": "github", "invocation_id": "not-a-uuid" }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/refresh",
+            json!({
+                "provider": "github",
+                "account_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+        (
+            "/api/reborn/product-auth/lifecycle/cleanup",
+            json!({
+                "extension_id": "ext-test",
+                "action": "deactivate",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+    ];
+    for (path, body) in cases {
+        let response = post_authenticated(&fixture.app, path, body.clone()).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "{path} must reject malformed invocation_id"
+        );
+        let body_str = read_body_string(response).await;
+        assert!(
+            body_str.contains("\"code\":\"invalid_request\""),
+            "{path} must return invalid_request for malformed invocation_id: {body_str}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn accounts_select_rejects_malformed_account_id() {
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/select",
+        json!({
+            "provider": "github",
+            "account_id": "not-a-uuid",
+            "invocation_id": InvocationId::new().to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
@@ -18,7 +18,7 @@ use ironclaw_auth::{
     CredentialAccountStatus, CredentialOwnership, InMemoryAuthProductServices,
     NewCredentialAccount,
 };
-use ironclaw_auth::{AuthProviderId, CredentialAccountService};
+use ironclaw_auth::{AuthProviderId, CredentialAccountId, CredentialAccountService};
 use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
 use ironclaw_product_workflow::{
     ExtensionName, RebornCancelRunResponse, RebornCreateThreadResponse, RebornGetRunStateRequest,
@@ -480,11 +480,12 @@ async fn accounts_select_returns_redacted_projection() {
 #[tokio::test]
 async fn accounts_recovery_projects_setup_required_when_no_account_exists() {
     let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
 
     let response = post_authenticated(
         &fixture.app,
         "/api/reborn/product-auth/accounts/recovery",
-        json!({ "provider": "github" }),
+        json!({ "provider": "github", "invocation_id": invocation_id.to_string() }),
     )
     .await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -695,4 +696,259 @@ async fn accounts_select_rejects_malformed_account_id() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let body = read_body_string(response).await;
     assert!(body.contains("\"code\":\"invalid_request\""));
+}
+
+// --- finding t1: body-limit enforcement ---
+
+#[tokio::test]
+async fn new_product_auth_routes_enforce_body_limit() {
+    // PROTECTED_MUTATION policy sets BodyLimitPolicy::Limited{16 KiB}.
+    // Any route receiving a body that exceeds this cap must be rejected
+    // with 413 before auth or the handler runs.
+    let fixture = build_fixture();
+    // Construct a JSON payload that exceeds 16 KiB.
+    let padding = "x".repeat(16 * 1024 + 1);
+    let oversized_body = format!("{{\"provider\":\"github\",\"padding\":\"{padding}\"}}");
+    assert!(oversized_body.len() > 16 * 1024);
+
+    let response = fixture
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/reborn/product-auth/manual-token/setup")
+                .header(header::AUTHORIZATION, format!("Bearer {VALID_TOKEN}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(oversized_body))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "oversized body must be rejected before the handler"
+    );
+    let body = read_body_string(response).await;
+    assert!(
+        body.contains("body limit"),
+        "413 body should reference the body limit, got: {body}"
+    );
+}
+
+// --- finding t2: rate-limit enforcement ---
+
+#[tokio::test]
+async fn new_product_auth_routes_enforce_per_caller_rate_limit() {
+    // PROTECTED_MUTATION declares RateLimitPolicy::Limited{PerCaller, 20 req/60s}.
+    // Send 20 requests from the same bearer token and confirm the 21st returns 429.
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let body = json!({
+        "provider": "github",
+        "invocation_id": invocation_id.to_string()
+    })
+    .to_string();
+
+    let make_request = || {
+        Request::builder()
+            .method(Method::POST)
+            .uri("/api/reborn/product-auth/accounts/recovery")
+            .header(header::AUTHORIZATION, format!("Bearer {VALID_TOKEN}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.clone()))
+            .expect("request")
+    };
+
+    for i in 0..20 {
+        let response = fixture
+            .app
+            .clone()
+            .oneshot(make_request())
+            .await
+            .expect("oneshot");
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "request {i} should be within the per-caller rate-limit budget"
+        );
+    }
+
+    let response = fixture
+        .app
+        .clone()
+        .oneshot(make_request())
+        .await
+        .expect("oneshot");
+    assert_eq!(
+        response.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "21st request must exceed the per-caller rate-limit window"
+    );
+    let body_str = read_body_string(response).await;
+    assert!(
+        body_str.contains("Rate limit exceeded") || body_str.contains("rate limit"),
+        "429 body should explain the limit, got: {body_str}"
+    );
+}
+
+// --- finding t3: accounts_refresh error path ---
+
+#[tokio::test]
+async fn accounts_refresh_returns_error_for_unknown_account_id() {
+    // Refreshing a syntactically valid but unseeded account_id must return
+    // a sanitized error (not 500, no secret-handle leakage).
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let unknown_id = CredentialAccountId::from_uuid(uuid::Uuid::new_v4());
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/refresh",
+        json!({
+            "provider": "github",
+            "account_id": unknown_id.to_string(),
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    // Backend returns CredentialMissing which projects to 409 CONFLICT.
+    assert_eq!(
+        response.status(),
+        StatusCode::CONFLICT,
+        "unknown account_id must produce a sanitized error, not 500"
+    );
+    let body = read_body_string(response).await;
+    assert!(!body.contains("access_secret"), "no secret leakage: {body}");
+    assert!(
+        !body.contains("refresh_secret"),
+        "no secret leakage: {body}"
+    );
+}
+
+// --- finding t4: accounts_recovery existing-account projection ---
+
+#[tokio::test]
+async fn accounts_recovery_projects_configured_for_existing_account() {
+    // With a seeded Configured account the recovery projection must not be
+    // setup_required; it should project a non-empty configured or selection
+    // state, and the response must never carry secret handles.
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let _account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/recovery",
+        json!({
+            "provider": "github",
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("recovery json");
+    assert_ne!(
+        json["kind"].as_str(),
+        Some("setup_required"),
+        "seeded account must not project setup_required: {body}"
+    );
+    assert!(!body.contains("access_secret"), "no secret leakage: {body}");
+    assert!(
+        !body.contains("refresh_secret"),
+        "no secret leakage: {body}"
+    );
+}
+
+// --- finding t5: manual_token_setup validation error paths ---
+
+#[tokio::test]
+async fn manual_token_setup_rejects_empty_provider_and_label() {
+    let fixture = build_fixture();
+    let cases = [
+        // empty provider
+        json!({ "provider": "", "account_label": "my-account" }),
+        // empty account_label
+        json!({ "provider": "github", "account_label": "" }),
+    ];
+    for body in cases {
+        let response = post_authenticated(
+            &fixture.app,
+            "/api/reborn/product-auth/manual-token/setup",
+            body,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body_str = read_body_string(response).await;
+        assert!(
+            body_str.contains("\"code\":\"invalid_request\""),
+            "empty provider/label must return invalid_request, got: {body_str}"
+        );
+    }
+}
+
+// --- finding t6: accounts_refresh malformed account_id ---
+
+#[tokio::test]
+async fn accounts_refresh_rejects_malformed_account_id() {
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/refresh",
+        json!({
+            "provider": "github",
+            "account_id": "not-a-uuid",
+            "invocation_id": InvocationId::new().to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}
+
+// --- finding b1 regression: select/recovery/refresh require invocation_id ---
+
+#[tokio::test]
+async fn follow_up_routes_require_invocation_id() {
+    // accounts/select, accounts/recovery, and accounts/refresh are follow-up
+    // routes and must reject requests that omit invocation_id (same as
+    // accounts/list and secret-submit) so all five routes share the same scope
+    // derivation contract.
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+
+    let cases: &[(&str, Value)] = &[
+        (
+            "/api/reborn/product-auth/accounts/select",
+            json!({ "provider": "github", "account_id": account_id.to_string() /* no invocation_id */ }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/recovery",
+            json!({ "provider": "github" /* no invocation_id */ }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/refresh",
+            json!({ "provider": "github", "account_id": account_id.to_string() /* no invocation_id */ }),
+        ),
+    ];
+    for (path, body) in cases {
+        let response = post_authenticated(&fixture.app, path, body.clone()).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "{path} must reject missing invocation_id"
+        );
+        let body_str = read_body_string(response).await;
+        assert!(
+            body_str.contains("\"code\":\"invalid_request\""),
+            "{path}: expected invalid_request, got: {body_str}"
+        );
+    }
 }

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -430,6 +430,52 @@ pretending cleanup succeeded.
 
 ---
 
+## Product Facing HTTP Surfaces (#4201)
+
+The Reborn composition mounts host-owned HTTP routes that enter
+`RebornProductAuthServices` (see
+`crates/ironclaw_reborn_composition/src/product_auth_serve.rs`). All mutation
+routes share the same `LocalGateway` + `BearerToken` + per-caller body and
+rate-limit posture as the original `oauth/start` route and derive
+`AuthProductScope` from the authenticated caller, never from caller-supplied
+tenant/user fields.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/reborn/product-auth/oauth/start` | Open an OAuth setup flow; returns redacted authorization URL + invocation scope. |
+| `GET`  | `/api/reborn/product-auth/oauth/callback/{flow_id}` | Public OAuth callback; validates scope/state hash before any product effect. |
+| `POST` | `/api/reborn/product-auth/manual-token/submit` | One-shot manual-token setup + secret-submit (legacy WebUI shape, compatibility). |
+| `POST` | `/api/reborn/product-auth/manual-token/setup` | Mint a manual-token interaction challenge; returns `interaction_id` + `invocation_id`. |
+| `POST` | `/api/reborn/product-auth/manual-token/secret-submit` | Submit the raw token for an existing `interaction_id`; model transcript, tool arguments, logs, and durable events only ever see the redacted `credential_submitted` / `auth_failed` projection. |
+| `POST` | `/api/reborn/product-auth/accounts/list` | List redacted credential account projections for a provider. |
+| `POST` | `/api/reborn/product-auth/accounts/select` | Select a single configured account by id; returns its redacted projection. |
+| `POST` | `/api/reborn/product-auth/accounts/recovery` | Project the stable recovery state for a provider (configured / setup_required / reauthorize_required / account_selection_required). |
+| `POST` | `/api/reborn/product-auth/accounts/refresh` | Refresh / reauthorize an account; returns `CredentialRefreshReport` + projected recovery state. |
+| `POST` | `/api/reborn/product-auth/lifecycle/cleanup` | Apply ownership-aware deactivate/uninstall cleanup for an extension; returns a redacted `SecretCleanupReport`. |
+
+Rules:
+
+- `secret-submit` is the only product-facing entry point for raw manual-token
+  material. The raw token never enters tool arguments, model transcript,
+  durable chat history, projections, debug output, or errors; only redacted
+  `credential_submitted` / `auth_failed` projections cross the boundary.
+- Manual-token setup and secret-submit are linked by `interaction_id` plus an
+  `invocation_id` round-tripped through the browser, matching the OAuth
+  start/callback pattern.
+- All routes project only adapter-safe DTOs (`CredentialAccountProjection`,
+  `CredentialAccountListPage`, `CredentialRecoveryProjection`,
+  `CredentialRefreshReport`, `SecretCleanupReport`). Raw secret handles,
+  backend error strings, and host paths must not be projected.
+- These routes are an explicit exemption from the "everything goes through
+  tools" `ToolDispatcher::dispatch()` invariant. Product-auth HTTP is a
+  host-owned auth/secret-ingress boundary: credential setup, secure
+  secret-submit, recovery, refresh, and lifecycle cleanup are not in-turn
+  tool calls and must not surface raw secrets through the model-visible tool
+  dispatch path. Routes still derive scope from authenticated caller context
+  and enter `RebornProductAuthServices`.
+
+---
+
 ## V1 Behavior Inventory
 
 | Product behavior | V1 evidence path | Reborn owner | First-slice status |


### PR DESCRIPTION
Closes #4201.

Mounts the remaining product-facing auth HTTP routes through `RebornProductAuthServices`, completing the WebUI/CLI/API surface left open after #4175 (durable ports) and #4176 (consumer wiring). Browser/CLI callers can now drive manual-token onboarding, account list/select/recovery, refresh/reauthorize, and deactivate/uninstall cleanup over the wire without reaching into route-local stores or v1 auth fallbacks.

## Routes

All protected routes share the same `LocalGateway` + `BearerToken` + per-caller body/rate-limit posture as the existing `oauth/start` route, and derive `AuthProductScope` from the authenticated caller (never from caller-supplied tenant/user fields).

| Method | Path | Purpose |
| --- | --- | --- |
| `POST` | `/api/reborn/product-auth/manual-token/setup` | Mint a manual-token interaction challenge; returns `interaction_id` + `invocation_id`. |
| `POST` | `/api/reborn/product-auth/manual-token/secret-submit` | Submit the raw token for an existing `interaction_id`; only redacted `credential_submitted` / `auth_failed` projection is model-visible. |
| `POST` | `/api/reborn/product-auth/accounts/list` | List redacted credential account projections for a provider. |
| `POST` | `/api/reborn/product-auth/accounts/select` | Select a single configured account by id; returns its redacted projection. |
| `POST` | `/api/reborn/product-auth/accounts/recovery` | Project the stable recovery state (configured / setup_required / reauthorize_required / account_selection_required). |
| `POST` | `/api/reborn/product-auth/accounts/refresh` | Refresh / reauthorize an account; returns `CredentialRefreshReport` + projected recovery state. |
| `POST` | `/api/reborn/product-auth/lifecycle/cleanup` | Apply ownership-aware deactivate/uninstall cleanup for an extension; returns a redacted `SecretCleanupReport`. |

The legacy one-shot `manual-token/submit` route is preserved for the existing WebUI compatibility surface.

## Design notes

- **secret-submit is the only product-facing entry for raw manual-token material.** The raw token never appears in tool arguments, model transcript, durable chat history, projections, debug output, or errors. Only the redacted `ManualTokenSubmitResponse` (`credential_ref` + `status` + `continuation`) crosses the boundary.
- **invocation_id round-trip.** Manual-token setup returns the host-minted `invocation_id`; the browser carries it forward on `secret-submit`, matching the OAuth start/callback pattern in #4031 so the interaction service can validate scope without trusting browser-supplied scope identifiers. Account routes and lifecycle cleanup accept an optional `invocation_id` for the same reason.
- **Adapter-safe DTOs only.** Routes project `CredentialAccountProjection`, `CredentialAccountListPage`, `CredentialRecoveryProjection`, `CredentialRefreshReport`, `SecretCleanupReport` — no raw secret handles, backend error strings, or host paths.
- **ToolDispatcher exemption documented inline + in the contract doc.** Product-auth HTTP is a host-owned auth/secret-ingress boundary: credential setup, secure secret-submit, recovery, refresh, and lifecycle cleanup are not in-turn tool calls and must not surface raw secrets through the model-visible tool-dispatch path. Routes still derive scope from authenticated caller context and enter `RebornProductAuthServices`.
- **Facade wrappers added on `RebornProductAuthServices`** for `list_credential_accounts`, `select_credential_account`, and `project_credential_recovery` so route handlers don't bypass the credential account port.

## Test coverage

`crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs` drives the full caller path (auth layer + body limit + rate limit + handler + `RebornProductAuthServices`):

- `product_auth_new_routes_require_bearer_auth` — every new route returns 401 without a bearer token.
- `manual_token_setup_then_secret_submit_returns_redacted_projection` — happy-path setup → secret-submit; asserts raw token does not appear in either response body, asserts `credential_ref` / `status` / `continuation` are projected.
- `manual_token_setup_rejects_partial_continuation_inputs` — `run_id` without `gate_ref` (or vice versa) is `invalid_request`.
- `manual_token_secret_submit_invalid_interaction_is_sanitized` — non-UUID `interaction_id` is `invalid_request` with no raw-token echo.
- `accounts_list_returns_only_seeded_provider_accounts` — list is filtered by provider; no secret handles in projection.
- `accounts_list_invalid_limit_is_sanitized` — `limit: 0` is `invalid_request`.
- `accounts_select_returns_redacted_projection` — select returns the redacted projection for a seeded account.
- `accounts_recovery_projects_setup_required_when_no_account_exists` — recovery returns `setup_required` / `no_account` with no secret material.
- `lifecycle_cleanup_redacts_report_and_reaches_service` — cleanup returns redacted empty report when no extension owns/grants any account.
- `lifecycle_cleanup_rejects_invalid_extension_id` — empty `extension_id` is `invalid_request`.

The existing one-shot `manual-token/submit` tests still pass (24 in `webui_v2_product_auth.rs`).

## Checks

- `cargo fmt -- --check` clean.
- `cargo clippy --workspace --all-features --tests` clean.
- `cargo test -p ironclaw_reborn_composition --features webui-v2-beta --tests` — all 4201, 24 existing product-auth, and 294 lib tests pass.

## Out of scope

- Durable production port impls: #4175.
- First-party / WASM / MCP runtime consumer wiring: #4176.
- WebUI JS client wiring to the new endpoints (existing `api.js` keeps the legacy one-shot `manual-token/submit` shape).

## Refs

- Closes #4201
- Related: #4175, #4176, #4031, #4112, #3289
- Contract: `docs/reborn/contracts/auth-product.md` (updated in this PR)
