### PR TITLE
docs(reborn): design — #4112 WebUI v2 auth E2E on top of #4245

### DIFF
--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -82,10 +82,11 @@ Inbound order (outer → inner → handler):
    `BodyLimitPolicy` from `ironclaw_webui_v2::webui_v2_routes()` and,
    when present, product-auth route descriptors at composition time and
    enforces it before auth runs (so an oversized payload never spends a
-   bearer-validation step). Today: `create_thread` and product-auth
-   OAuth start 16 KiB, `send_message` 1 MiB, `cancel_run` and
-   `resolve_gate` 4 KiB, `get_timeline`, `stream_events`, and
-   product-auth OAuth callback `NoBody`.
+   bearer-validation step). Today: `create_thread`, product-auth OAuth
+   start, manual-token setup/secret-submit, accounts list/select/recovery/
+   refresh, and lifecycle cleanup — all 16 KiB; `send_message` 1 MiB;
+   `cancel_run` and `resolve_gate` 4 KiB; `get_timeline`,
+   `stream_events`, and product-auth OAuth callback `NoBody`.
    `BodyLimitPolicy` is an exhaustive `match`, so a new variant added
    upstream fails the build rather than silently disabling
    enforcement.

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -6,8 +6,10 @@ use ironclaw_auth::{
     AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId,
     AuthFlowKind, AuthFlowManager, AuthFlowRecord, AuthFlowRecordSource, AuthFlowStatus,
     AuthInteractionId, AuthInteractionService, AuthProductError, AuthProductScope,
-    AuthProviderClient, AuthProviderId, CredentialAccountId, CredentialAccountLabel,
-    CredentialAccountService, CredentialAccountStatus, CredentialAccountUpdateBinding,
+    AuthProviderClient, AuthProviderId, CredentialAccountChoiceRequest, CredentialAccountId,
+    CredentialAccountLabel, CredentialAccountListPage, CredentialAccountListRequest,
+    CredentialAccountProjection, CredentialAccountService, CredentialAccountStatus,
+    CredentialAccountUpdateBinding, CredentialRecoveryProjection, CredentialRecoveryRequest,
     CredentialRefreshReport, CredentialRefreshRequest, CredentialSetupService,
     InMemoryAuthProductServices, ManualTokenSetupRequest, NewAuthFlow, OAuthAuthorizationUrl,
     OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
@@ -552,6 +554,51 @@ impl RebornProductAuthServices {
     ) -> Result<CredentialRefreshReport, RebornCredentialLifecycleError> {
         self.credential_account_service
             .refresh_account(request)
+            .await
+            .map_err(RebornCredentialLifecycleError::from)
+    }
+
+    /// List redacted credential account projections through the injected
+    /// account port.
+    ///
+    /// Routes/CLIs/extensions enter here so they never bypass the account
+    /// port's grant filtering, status redaction, or extension-scoped
+    /// visibility rules.
+    pub async fn list_credential_accounts(
+        &self,
+        request: CredentialAccountListRequest,
+    ) -> Result<CredentialAccountListPage, RebornCredentialLifecycleError> {
+        self.credential_account_service
+            .list_accounts(request)
+            .await
+            .map_err(RebornCredentialLifecycleError::from)
+    }
+
+    /// Select a single configured credential account through the injected
+    /// account port.
+    ///
+    /// The selection is validated by the underlying port; this facade does
+    /// not reconstruct selection authority locally.
+    pub async fn select_credential_account(
+        &self,
+        request: CredentialAccountChoiceRequest,
+    ) -> Result<CredentialAccountProjection, RebornCredentialLifecycleError> {
+        self.credential_account_service
+            .select_configured_account(request)
+            .await
+            .map_err(RebornCredentialLifecycleError::from)
+    }
+
+    /// Project the stable credential recovery state for a provider through
+    /// the injected account port. The projection drives WebUI/CLI/API
+    /// recovery, refresh, and reauthorize prompts without exposing backend
+    /// errors or secret handles.
+    pub async fn project_credential_recovery(
+        &self,
+        request: CredentialRecoveryRequest,
+    ) -> Result<CredentialRecoveryProjection, RebornCredentialLifecycleError> {
+        self.credential_account_service
+            .project_credential_recovery(request)
             .await
             .map_err(RebornCredentialLifecycleError::from)
     }

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -22,9 +22,13 @@ use chrono::{Duration as ChronoDuration, Utc};
 use ironclaw_auth::{
     AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowStatus, AuthGateRef, AuthInteractionId,
     AuthProductError, AuthProductScope, AuthProviderId, AuthSessionId, AuthSurface,
-    AuthorizationCodeHash, CredentialAccountId, CredentialAccountLabel, CredentialAccountStatus,
+    AuthorizationCodeHash, CredentialAccountChoiceRequest, CredentialAccountId,
+    CredentialAccountLabel, CredentialAccountListPage, CredentialAccountListRequest,
+    CredentialAccountProjection, CredentialAccountStatus, CredentialRecoveryProjection,
+    CredentialRecoveryRequest, CredentialRefreshReport, CredentialRefreshRequest,
     OAuthAuthorizationCode, OAuthAuthorizationUrl, OAuthProviderCallbackRequest, OpaqueStateHash,
-    PkceVerifierHash, PkceVerifierSecret, ProviderScope, Timestamp, TurnRunRef,
+    PkceVerifierHash, PkceVerifierSecret, ProviderScope, SecretCleanupAction, SecretCleanupReport,
+    SecretCleanupRequest, Timestamp, TurnRunRef,
 };
 use ironclaw_host_api::NetworkMethod;
 use ironclaw_host_api::ingress::{
@@ -33,7 +37,7 @@ use ironclaw_host_api::ingress::{
     RateLimitPolicy, RateLimitScope, StreamingMode, WebSocketOriginPolicy,
 };
 use ironclaw_host_api::{
-    AgentId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
+    AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
 };
 use ironclaw_product_workflow::WebUiAuthenticatedCaller;
 use lru::LruCache;
@@ -52,10 +56,25 @@ use crate::{
 pub(crate) const OAUTH_START_PATH: &str = "/api/reborn/product-auth/oauth/start";
 pub(crate) const OAUTH_CALLBACK_PATH: &str = "/api/reborn/product-auth/oauth/callback/{flow_id}";
 pub(crate) const MANUAL_TOKEN_SUBMIT_PATH: &str = "/api/reborn/product-auth/manual-token/submit";
+pub(crate) const MANUAL_TOKEN_SETUP_PATH: &str = "/api/reborn/product-auth/manual-token/setup";
+pub(crate) const MANUAL_TOKEN_SECRET_SUBMIT_PATH: &str =
+    "/api/reborn/product-auth/manual-token/secret-submit";
+pub(crate) const ACCOUNTS_LIST_PATH: &str = "/api/reborn/product-auth/accounts/list";
+pub(crate) const ACCOUNTS_SELECT_PATH: &str = "/api/reborn/product-auth/accounts/select";
+pub(crate) const ACCOUNTS_RECOVERY_PATH: &str = "/api/reborn/product-auth/accounts/recovery";
+pub(crate) const ACCOUNTS_REFRESH_PATH: &str = "/api/reborn/product-auth/accounts/refresh";
+pub(crate) const LIFECYCLE_CLEANUP_PATH: &str = "/api/reborn/product-auth/lifecycle/cleanup";
 
 const OAUTH_START_ROUTE_ID: &str = "product_auth.oauth.start";
 const OAUTH_CALLBACK_ROUTE_ID: &str = "product_auth.oauth.callback";
 const MANUAL_TOKEN_SUBMIT_ROUTE_ID: &str = "product_auth.manual_token.submit";
+const MANUAL_TOKEN_SETUP_ROUTE_ID: &str = "product_auth.manual_token.setup";
+const MANUAL_TOKEN_SECRET_SUBMIT_ROUTE_ID: &str = "product_auth.manual_token.secret_submit";
+const ACCOUNTS_LIST_ROUTE_ID: &str = "product_auth.accounts.list";
+const ACCOUNTS_SELECT_ROUTE_ID: &str = "product_auth.accounts.select";
+const ACCOUNTS_RECOVERY_ROUTE_ID: &str = "product_auth.accounts.recovery";
+const ACCOUNTS_REFRESH_ROUTE_ID: &str = "product_auth.accounts.refresh";
+const LIFECYCLE_CLEANUP_ROUTE_ID: &str = "product_auth.lifecycle.cleanup";
 const OAUTH_PKCE_VERIFIER_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(1024) {
     Some(value) => value,
     // SAFETY: 1024 is a non-zero literal cache cap.
@@ -209,11 +228,29 @@ pub(crate) struct ProductAuthRouteMount {
     pub(crate) descriptors: Vec<IngressRouteDescriptor>,
 }
 
+// ToolDispatcher exemption (issue #4201): product-auth HTTP is a host-owned
+// auth/secret-ingress boundary. Its mutations enter `RebornProductAuthServices`
+// directly because credential setup, secure secret-submit, recovery, refresh,
+// and lifecycle cleanup are not in-turn tool calls and must not surface raw
+// secrets through the model-visible tool-dispatch path. The "everything goes
+// through tools" invariant in `docs/reborn/contracts/auth-product.md` therefore
+// explicitly exempts this surface; routes still derive scope from
+// authenticated caller context and emit only redacted projections.
 pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductAuthRouteMount {
     ProductAuthRouteMount {
         protected: Router::new()
             .route(OAUTH_START_PATH, post(oauth_start_handler))
             .route(MANUAL_TOKEN_SUBMIT_PATH, post(manual_token_submit_handler))
+            .route(MANUAL_TOKEN_SETUP_PATH, post(manual_token_setup_handler))
+            .route(
+                MANUAL_TOKEN_SECRET_SUBMIT_PATH,
+                post(manual_token_secret_submit_handler),
+            )
+            .route(ACCOUNTS_LIST_PATH, post(accounts_list_handler))
+            .route(ACCOUNTS_SELECT_PATH, post(accounts_select_handler))
+            .route(ACCOUNTS_RECOVERY_PATH, post(accounts_recovery_handler))
+            .route(ACCOUNTS_REFRESH_PATH, post(accounts_refresh_handler))
+            .route(LIFECYCLE_CLEANUP_PATH, post(lifecycle_cleanup_handler))
             .with_state(state.clone()),
         public: Router::new()
             .route(OAUTH_CALLBACK_PATH, get(oauth_callback_handler))
@@ -240,6 +277,48 @@ pub(crate) fn product_auth_route_descriptors() -> Vec<IngressRouteDescriptor> {
             MANUAL_TOKEN_SUBMIT_ROUTE_ID,
             NetworkMethod::Post,
             MANUAL_TOKEN_SUBMIT_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            MANUAL_TOKEN_SETUP_ROUTE_ID,
+            NetworkMethod::Post,
+            MANUAL_TOKEN_SETUP_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            MANUAL_TOKEN_SECRET_SUBMIT_ROUTE_ID,
+            NetworkMethod::Post,
+            MANUAL_TOKEN_SECRET_SUBMIT_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_LIST_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_LIST_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_SELECT_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_SELECT_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_RECOVERY_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_RECOVERY_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            ACCOUNTS_REFRESH_ROUTE_ID,
+            NetworkMethod::Post,
+            ACCOUNTS_REFRESH_PATH,
+            protected_mutation_policy(),
+        ),
+        descriptor(
+            LIFECYCLE_CLEANUP_ROUTE_ID,
+            NetworkMethod::Post,
+            LIFECYCLE_CLEANUP_PATH,
             protected_mutation_policy(),
         ),
     ]
@@ -343,6 +422,117 @@ pub(crate) struct ManualTokenSubmitResponse {
     pub(crate) credential_ref: CredentialAccountId,
     pub(crate) status: CredentialAccountStatus,
     pub(crate) continuation: AuthContinuationRef,
+}
+
+#[derive(Deserialize)]
+struct ManualTokenSetupHttpRequest {
+    provider: String,
+    account_label: String,
+    #[serde(default)]
+    run_id: Option<String>,
+    #[serde(default)]
+    gate_ref: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ManualTokenSetupResponse {
+    pub(crate) interaction_id: AuthInteractionId,
+    pub(crate) provider: AuthProviderId,
+    pub(crate) label: CredentialAccountLabel,
+    pub(crate) expires_at: Timestamp,
+    /// Invocation scope used to mint this interaction. The browser carries it
+    /// back on the secret-submit call so the host can re-derive the same
+    /// `AuthProductScope` and let the interaction service match the pending
+    /// scope without trusting browser-supplied scope identifiers.
+    pub(crate) invocation_id: InvocationId,
+}
+
+#[derive(Deserialize)]
+struct ManualTokenSecretSubmitHttpRequest {
+    interaction_id: String,
+    token: UnvalidatedRawSecretValue,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsListHttpRequest {
+    provider: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsSelectHttpRequest {
+    provider: String,
+    account_id: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsRecoveryHttpRequest {
+    provider: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccountsRefreshHttpRequest {
+    provider: String,
+    account_id: String,
+    #[serde(default)]
+    requester_extension: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LifecycleCleanupHttpRequest {
+    extension_id: String,
+    action: SecretCleanupAction,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -638,6 +828,310 @@ async fn abandon_manual_token_after_submit_failure(
     }
 }
 
+async fn manual_token_setup_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<ManualTokenSetupHttpRequest>,
+) -> Result<Json<ManualTokenSetupResponse>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let invocation_id = scope.resource.invocation_id;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let label = CredentialAccountLabel::new(request.account_label)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let continuation =
+        manual_token_continuation(request.run_id.as_deref(), request.gate_ref.as_deref())?;
+    let expires_at = Utc::now() + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS);
+
+    let challenge = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .request_manual_token_setup(RebornManualTokenSetupRequest::new(
+                scope,
+                provider,
+                label,
+                continuation,
+                expires_at,
+            )),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(ManualTokenSetupResponse {
+        interaction_id: challenge.interaction_id,
+        provider: challenge.provider,
+        label: challenge.label,
+        expires_at: challenge.expires_at,
+        invocation_id,
+    }))
+}
+
+async fn manual_token_secret_submit_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<ManualTokenSecretSubmitHttpRequest>,
+) -> Result<Json<ManualTokenSubmitResponse>, ProductAuthRouteFailure> {
+    // Secret-submit is the secure out-of-band entry point: the raw token is
+    // read straight off the dedicated body, never echoed back, and never
+    // surfaced in model transcript or tool arguments. Only the redacted
+    // submit projection is returned.
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let interaction_id = parse_interaction_id(&request.interaction_id)?;
+    let token = request
+        .token
+        .into_validated()
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+
+    let submitted = match tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .submit_manual_token(RebornManualTokenSubmitRequest::new(
+                scope.clone(),
+                interaction_id,
+                token.into_secret(),
+            )),
+    )
+    .await
+    {
+        Ok(Ok(submitted)) => submitted,
+        Ok(Err(error)) => {
+            abandon_manual_token_after_submit_failure(&state, &scope, interaction_id, error.code)
+                .await;
+            return Err(ProductAuthRouteFailure::from(error));
+        }
+        Err(_) => {
+            abandon_manual_token_after_submit_failure(
+                &state,
+                &scope,
+                interaction_id,
+                AuthErrorCode::BackendUnavailable,
+            )
+            .await;
+            return Err(ProductAuthRouteFailure::backend_timeout());
+        }
+    };
+
+    Ok(Json(ManualTokenSubmitResponse {
+        credential_ref: submitted.account_id,
+        status: submitted.status,
+        continuation: submitted.continuation,
+    }))
+}
+
+async fn accounts_list_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsListHttpRequest>,
+) -> Result<Json<CredentialAccountListPage>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+
+    let mut list_request = CredentialAccountListRequest::new(scope, provider);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        list_request = list_request.for_extension(parse_extension_id(extension_id)?);
+    }
+    if let Some(cursor) = request.cursor.as_deref() {
+        list_request = list_request.with_cursor(parse_credential_account_id(cursor)?);
+    }
+    if let Some(limit) = request.limit {
+        list_request = list_request.with_limit(limit);
+    }
+    list_request
+        .validate()
+        .map_err(ProductAuthRouteFailure::from)?;
+
+    let page = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state.product_auth.list_credential_accounts(list_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(page))
+}
+
+async fn accounts_select_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsSelectHttpRequest>,
+) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let account_id = parse_credential_account_id(&request.account_id)?;
+
+    let mut choice_request = CredentialAccountChoiceRequest::new(scope, provider, account_id);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        choice_request = choice_request.for_extension(parse_extension_id(extension_id)?);
+    }
+
+    let projection = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state.product_auth.select_credential_account(choice_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(projection))
+}
+
+async fn accounts_recovery_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsRecoveryHttpRequest>,
+) -> Result<Json<CredentialRecoveryProjection>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+
+    let mut recovery_request = CredentialRecoveryRequest::new(scope, provider);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        recovery_request = recovery_request.for_extension(parse_extension_id(extension_id)?);
+    }
+
+    let projection = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .project_credential_recovery(recovery_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(projection))
+}
+
+async fn accounts_refresh_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<AccountsRefreshHttpRequest>,
+) -> Result<Json<CredentialRefreshReport>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let account_id = parse_credential_account_id(&request.account_id)?;
+
+    let mut refresh_request = CredentialRefreshRequest::new(scope, provider, account_id);
+    if let Some(extension_id) = request.requester_extension.as_deref() {
+        refresh_request = refresh_request.for_extension(parse_extension_id(extension_id)?);
+    }
+
+    let report = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .refresh_credential_account(refresh_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(report))
+}
+
+async fn lifecycle_cleanup_handler(
+    State(state): State<ProductAuthRouteState>,
+    Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Json(request): Json<LifecycleCleanupHttpRequest>,
+) -> Result<Json<SecretCleanupReport>, ProductAuthRouteFailure> {
+    let scope = scope_from_authenticated_caller_parts_with_invocation(
+        &caller,
+        request.thread_id.as_ref(),
+        request.session_id.as_ref(),
+        request.invocation_id.as_deref(),
+    )?;
+    let extension_id = parse_extension_id(&request.extension_id)?;
+
+    let cleanup_request = SecretCleanupRequest {
+        scope,
+        extension_id,
+        action: request.action,
+    };
+
+    let report = tokio::time::timeout(
+        PRODUCT_AUTH_BACKEND_TIMEOUT,
+        state
+            .product_auth
+            .cleanup_credentials_for_lifecycle(cleanup_request),
+    )
+    .await
+    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
+    .map_err(ProductAuthRouteFailure::from)?;
+
+    Ok(Json(report))
+}
+
+fn manual_token_continuation(
+    run_id: Option<&str>,
+    gate_ref: Option<&str>,
+) -> Result<AuthContinuationRef, ProductAuthRouteFailure> {
+    match (run_id, gate_ref) {
+        (Some(run_id), Some(gate_ref)) => Ok(AuthContinuationRef::TurnGateResume {
+            turn_run_ref: TurnRunRef::new(run_id.to_string())
+                .map_err(|_| ProductAuthRouteFailure::invalid_request())?,
+            gate_ref: AuthGateRef::new(gate_ref.to_string())
+                .map_err(|_| ProductAuthRouteFailure::invalid_request())?,
+        }),
+        (None, None) => Ok(AuthContinuationRef::SetupOnly),
+        // run_id without gate_ref (or vice versa) is rejected so we never
+        // resume the wrong gate or fabricate a partial turn-resume.
+        _ => Err(ProductAuthRouteFailure::invalid_request()),
+    }
+}
+
+fn parse_interaction_id(value: &str) -> Result<AuthInteractionId, ProductAuthRouteFailure> {
+    let parsed = Uuid::parse_str(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    Ok(AuthInteractionId::from_uuid(parsed))
+}
+
+fn parse_credential_account_id(
+    value: &str,
+) -> Result<CredentialAccountId, ProductAuthRouteFailure> {
+    let parsed = Uuid::parse_str(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    Ok(CredentialAccountId::from_uuid(parsed))
+}
+
+fn parse_extension_id(value: &str) -> Result<ExtensionId, ProductAuthRouteFailure> {
+    ExtensionId::new(value.to_string()).map_err(|_| ProductAuthRouteFailure::invalid_request())
+}
+
 async fn oauth_callback_handler(
     State(state): State<ProductAuthRouteState>,
     Path(flow_id): Path<String>,
@@ -781,6 +1275,15 @@ fn scope_from_authenticated_caller_parts(
     thread_id: Option<&String>,
     session_id: Option<&String>,
 ) -> Result<AuthProductScope, ProductAuthRouteFailure> {
+    scope_from_authenticated_caller_parts_with_invocation(caller, thread_id, session_id, None)
+}
+
+fn scope_from_authenticated_caller_parts_with_invocation(
+    caller: &WebUiAuthenticatedCaller,
+    thread_id: Option<&String>,
+    session_id: Option<&String>,
+    invocation_id: Option<&str>,
+) -> Result<AuthProductScope, ProductAuthRouteFailure> {
     let thread_id = thread_id
         .map(|value| {
             ThreadId::new(value.clone()).map_err(|_| ProductAuthRouteFailure::invalid_request())
@@ -792,6 +1295,17 @@ fn scope_from_authenticated_caller_parts(
                 .map_err(|_| ProductAuthRouteFailure::invalid_request())
         })
         .transpose()?;
+    // invocation_id, when supplied by the caller, must be a valid existing
+    // identifier (round-tripped from a prior start/setup response). Otherwise
+    // we mint a fresh one — the OAuth start/callback pattern from #4031 uses
+    // the same shape: the host owns the canonical id and the browser carries
+    // it forward across follow-up calls.
+    let invocation_id = match invocation_id {
+        Some(value) => {
+            InvocationId::parse(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?
+        }
+        None => InvocationId::new(),
+    };
 
     let mut scope = AuthProductScope::new(
         ResourceScope {
@@ -801,7 +1315,7 @@ fn scope_from_authenticated_caller_parts(
             project_id: caller.project_id.clone(),
             mission_id: None,
             thread_id,
-            invocation_id: InvocationId::new(),
+            invocation_id,
         },
         AuthSurface::Callback,
     );

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -228,15 +228,12 @@ pub(crate) struct ProductAuthRouteMount {
     pub(crate) descriptors: Vec<IngressRouteDescriptor>,
 }
 
-// ToolDispatcher exemption (issue #4201): product-auth HTTP is a host-owned
-// auth/secret-ingress boundary. Its mutations enter `RebornProductAuthServices`
-// directly because credential setup, secure secret-submit, recovery, refresh,
-// and lifecycle cleanup are not in-turn tool calls and must not surface raw
-// secrets through the model-visible tool-dispatch path. The "everything goes
-// through tools" invariant in `docs/reborn/contracts/auth-product.md` therefore
-// explicitly exempts this surface; routes still derive scope from
-// authenticated caller context and emit only redacted projections.
+// Product-auth HTTP is a host-owned auth/secret-ingress boundary. Its
+// mutations enter `RebornProductAuthServices` directly; they are not in-turn
+// tool calls and must not surface raw secrets through the model-visible
+// tool-dispatch path. Contract: `docs/reborn/contracts/auth-product.md`.
 pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductAuthRouteMount {
+    // dispatch-exempt: host-owned auth/secret ingress, not in-turn tool dispatch
     ProductAuthRouteMount {
         protected: Router::new()
             .route(OAUTH_START_PATH, post(oauth_start_handler))
@@ -415,7 +412,7 @@ struct ScopeFields {
 }
 
 #[derive(Deserialize)]
-struct ManualTokenSetupHttpRequest {
+struct ManualTokenSetupRequest {
     provider: String,
     account_label: String,
     #[serde(default)]
@@ -440,7 +437,7 @@ pub(crate) struct ManualTokenSetupResponse {
 }
 
 #[derive(Deserialize)]
-struct ManualTokenSecretSubmitHttpRequest {
+struct ManualTokenSecretSubmitRequest {
     interaction_id: String,
     token: UnvalidatedRawSecretValue,
     #[serde(flatten)]
@@ -448,7 +445,7 @@ struct ManualTokenSecretSubmitHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsListHttpRequest {
+struct AccountsListRequest {
     provider: String,
     #[serde(default)]
     requester_extension: Option<String>,
@@ -461,7 +458,7 @@ struct AccountsListHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsSelectHttpRequest {
+struct AccountsSelectRequest {
     provider: String,
     account_id: String,
     #[serde(default)]
@@ -471,7 +468,7 @@ struct AccountsSelectHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsRecoveryHttpRequest {
+struct AccountsRecoveryRequest {
     provider: String,
     #[serde(default)]
     requester_extension: Option<String>,
@@ -480,7 +477,7 @@ struct AccountsRecoveryHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct AccountsRefreshHttpRequest {
+struct AccountsRefreshRequest {
     provider: String,
     account_id: String,
     #[serde(default)]
@@ -490,7 +487,7 @@ struct AccountsRefreshHttpRequest {
 }
 
 #[derive(Deserialize)]
-struct LifecycleCleanupHttpRequest {
+struct LifecycleCleanupRequest {
     extension_id: String,
     action: SecretCleanupAction,
     #[serde(flatten)]
@@ -791,7 +788,7 @@ async fn abandon_manual_token_after_submit_failure(
 async fn manual_token_setup_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<ManualTokenSetupHttpRequest>,
+    Json(request): Json<ManualTokenSetupRequest>,
 ) -> Result<Json<ManualTokenSetupResponse>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let invocation_id = scope.resource.invocation_id;
@@ -820,13 +817,16 @@ async fn manual_token_setup_handler(
 async fn manual_token_secret_submit_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<ManualTokenSecretSubmitHttpRequest>,
+    Json(request): Json<ManualTokenSecretSubmitRequest>,
 ) -> Result<Json<ManualTokenSubmitResponse>, ProductAuthRouteFailure> {
     // Secret-submit is the secure out-of-band entry point: the raw token is
     // read straight off the dedicated body, never echoed back, and never
     // surfaced in model transcript or tool arguments. Only the redacted
     // submit projection is returned.
-    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
+    // invocation_id is required: it must be the id returned by setup so the
+    // interaction service can match the pending scope.
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let interaction_id = parse_interaction_id(&request.interaction_id)?;
     let token = request
         .token
@@ -873,9 +873,12 @@ async fn manual_token_secret_submit_handler(
 async fn accounts_list_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsListHttpRequest>,
+    Json(request): Json<AccountsListRequest>,
 ) -> Result<Json<CredentialAccountListPage>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
+    // invocation_id is required so the list is scoped to the caller's current
+    // interaction context; omitting it would silently yield an empty page.
+    let scope =
+        scope_from_authenticated_caller_parts_requiring_invocation(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
@@ -902,7 +905,7 @@ async fn accounts_list_handler(
 async fn accounts_select_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsSelectHttpRequest>,
+    Json(request): Json<AccountsSelectRequest>,
 ) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
@@ -924,7 +927,7 @@ async fn accounts_select_handler(
 async fn accounts_recovery_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsRecoveryHttpRequest>,
+    Json(request): Json<AccountsRecoveryRequest>,
 ) -> Result<Json<CredentialRecoveryProjection>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
@@ -948,7 +951,7 @@ async fn accounts_recovery_handler(
 async fn accounts_refresh_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<AccountsRefreshHttpRequest>,
+    Json(request): Json<AccountsRefreshRequest>,
 ) -> Result<Json<CredentialRefreshReport>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
@@ -973,7 +976,7 @@ async fn accounts_refresh_handler(
 async fn lifecycle_cleanup_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
-    Json(request): Json<LifecycleCleanupHttpRequest>,
+    Json(request): Json<LifecycleCleanupRequest>,
 ) -> Result<Json<SecretCleanupReport>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let extension_id = parse_extension_id(&request.extension_id)?;
@@ -1244,6 +1247,20 @@ fn scope_from_authenticated_caller_parts(
         scope = scope.with_session_id(session_id);
     }
     Ok(scope)
+}
+
+/// Like [`scope_from_authenticated_caller_parts`] but returns `invalid_request`
+/// when `invocation_id` is absent. Use for follow-up routes where the browser
+/// MUST carry back the id minted by a prior setup/start response so the host
+/// can re-derive the matching scope without minting a fresh, unmatched one.
+fn scope_from_authenticated_caller_parts_requiring_invocation(
+    caller: &WebUiAuthenticatedCaller,
+    fields: &ScopeFields,
+) -> Result<AuthProductScope, ProductAuthRouteFailure> {
+    if fields.invocation_id.is_none() {
+        return Err(ProductAuthRouteFailure::invalid_request());
+    }
+    scope_from_authenticated_caller_parts(caller, fields)
 }
 
 fn scope_from_callback_query(

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -48,9 +48,9 @@ use uuid::Uuid;
 
 use crate::auth::RebornOAuthStartFlowRequest;
 use crate::{
-    RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest, RebornOAuthCallbackError,
-    RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest, RebornOAuthCallbackResponse,
-    RebornProductAuthServices,
+    RebornAuthProductError, RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest,
+    RebornOAuthCallbackError, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,
+    RebornOAuthCallbackResponse, RebornProductAuthServices,
 };
 
 pub(crate) const OAUTH_START_PATH: &str = "/api/reborn/product-auth/oauth/start";
@@ -704,21 +704,16 @@ async fn manual_token_submit_handler(
     };
     let expires_at = Utc::now() + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS);
 
-    let challenge = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state
-            .product_auth
-            .request_manual_token_setup(RebornManualTokenSetupRequest::new(
-                scope.clone(),
-                provider,
-                label,
-                continuation,
-                expires_at,
-            )),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let challenge = run_with_backend_timeout(state.product_auth.request_manual_token_setup(
+        RebornManualTokenSetupRequest::new(
+            scope.clone(),
+            provider,
+            label,
+            continuation,
+            expires_at,
+        ),
+    ))
+    .await?;
     let submitted = match tokio::time::timeout(
         PRODUCT_AUTH_BACKEND_TIMEOUT,
         state
@@ -808,21 +803,10 @@ async fn manual_token_setup_handler(
         manual_token_continuation(request.run_id.as_deref(), request.gate_ref.as_deref())?;
     let expires_at = Utc::now() + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS);
 
-    let challenge = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state
-            .product_auth
-            .request_manual_token_setup(RebornManualTokenSetupRequest::new(
-                scope,
-                provider,
-                label,
-                continuation,
-                expires_at,
-            )),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let challenge = run_with_backend_timeout(state.product_auth.request_manual_token_setup(
+        RebornManualTokenSetupRequest::new(scope, provider, label, continuation, expires_at),
+    ))
+    .await?;
 
     Ok(Json(ManualTokenSetupResponse {
         interaction_id: challenge.interaction_id,
@@ -896,8 +880,8 @@ async fn accounts_list_handler(
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
     let mut list_request = CredentialAccountListRequest::new(scope, provider);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        list_request = list_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        list_request = list_request.for_extension(extension_id);
     }
     if let Some(cursor) = request.cursor.as_deref() {
         list_request = list_request.with_cursor(parse_credential_account_id(cursor)?);
@@ -909,13 +893,8 @@ async fn accounts_list_handler(
         .validate()
         .map_err(ProductAuthRouteFailure::from)?;
 
-    let page = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state.product_auth.list_credential_accounts(list_request),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let page =
+        run_with_backend_timeout(state.product_auth.list_credential_accounts(list_request)).await?;
 
     Ok(Json(page))
 }
@@ -931,17 +910,13 @@ async fn accounts_select_handler(
     let account_id = parse_credential_account_id(&request.account_id)?;
 
     let mut choice_request = CredentialAccountChoiceRequest::new(scope, provider, account_id);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        choice_request = choice_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        choice_request = choice_request.for_extension(extension_id);
     }
 
-    let projection = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
-        state.product_auth.select_credential_account(choice_request),
-    )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    let projection =
+        run_with_backend_timeout(state.product_auth.select_credential_account(choice_request))
+            .await?;
 
     Ok(Json(projection))
 }
@@ -956,19 +931,16 @@ async fn accounts_recovery_handler(
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
     let mut recovery_request = CredentialRecoveryRequest::new(scope, provider);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        recovery_request = recovery_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        recovery_request = recovery_request.for_extension(extension_id);
     }
 
-    let projection = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
+    let projection = run_with_backend_timeout(
         state
             .product_auth
             .project_credential_recovery(recovery_request),
     )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    .await?;
 
     Ok(Json(projection))
 }
@@ -984,19 +956,16 @@ async fn accounts_refresh_handler(
     let account_id = parse_credential_account_id(&request.account_id)?;
 
     let mut refresh_request = CredentialRefreshRequest::new(scope, provider, account_id);
-    if let Some(extension_id) = request.requester_extension.as_deref() {
-        refresh_request = refresh_request.for_extension(parse_extension_id(extension_id)?);
+    if let Some(extension_id) = parse_optional_extension(request.requester_extension.as_deref())? {
+        refresh_request = refresh_request.for_extension(extension_id);
     }
 
-    let report = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
+    let report = run_with_backend_timeout(
         state
             .product_auth
             .refresh_credential_account(refresh_request),
     )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    .await?;
 
     Ok(Json(report))
 }
@@ -1015,15 +984,12 @@ async fn lifecycle_cleanup_handler(
         action: request.action,
     };
 
-    let report = tokio::time::timeout(
-        PRODUCT_AUTH_BACKEND_TIMEOUT,
+    let report = run_with_backend_timeout(
         state
             .product_auth
             .cleanup_credentials_for_lifecycle(cleanup_request),
     )
-    .await
-    .map_err(|_| ProductAuthRouteFailure::backend_timeout())?
-    .map_err(ProductAuthRouteFailure::from)?;
+    .await?;
 
     Ok(Json(report))
 }
@@ -1060,6 +1026,31 @@ fn parse_credential_account_id(
 
 fn parse_extension_id(value: &str) -> Result<ExtensionId, ProductAuthRouteFailure> {
     ExtensionId::new(value.to_string()).map_err(|_| ProductAuthRouteFailure::invalid_request())
+}
+
+fn parse_optional_extension(
+    value: Option<&str>,
+) -> Result<Option<ExtensionId>, ProductAuthRouteFailure> {
+    value.map(parse_extension_id).transpose()
+}
+
+/// Await a product-auth backend call under the shared backend timeout and
+/// project both the elapsed-timeout failure and any returned auth error onto
+/// the route's sanitized failure shape.
+///
+/// Every protected product-auth route enters `RebornProductAuthServices` the
+/// same way; centralising the timeout/error wiring stops each handler from
+/// having to re-derive the same four lines and keeps the failure projection
+/// identical across routes.
+async fn run_with_backend_timeout<T, F>(future: F) -> Result<T, ProductAuthRouteFailure>
+where
+    F: std::future::Future<Output = Result<T, RebornAuthProductError>>,
+{
+    match tokio::time::timeout(PRODUCT_AUTH_BACKEND_TIMEOUT, future).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(ProductAuthRouteFailure::from(error)),
+        Err(_) => Err(ProductAuthRouteFailure::backend_timeout()),
+    }
 }
 
 async fn oauth_callback_handler(

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve.rs
@@ -260,68 +260,41 @@ pub(crate) fn product_auth_route_mount(state: ProductAuthRouteState) -> ProductA
 }
 
 pub(crate) fn product_auth_route_descriptors() -> Vec<IngressRouteDescriptor> {
-    vec![
-        descriptor(
-            OAUTH_START_ROUTE_ID,
-            NetworkMethod::Post,
-            OAUTH_START_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            OAUTH_CALLBACK_ROUTE_ID,
-            NetworkMethod::Get,
-            OAUTH_CALLBACK_PATH,
-            callback_policy(),
-        ),
-        descriptor(
-            MANUAL_TOKEN_SUBMIT_ROUTE_ID,
-            NetworkMethod::Post,
-            MANUAL_TOKEN_SUBMIT_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            MANUAL_TOKEN_SETUP_ROUTE_ID,
-            NetworkMethod::Post,
-            MANUAL_TOKEN_SETUP_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
+    // All protected mutations share the same LocalGateway + Bearer + per-caller
+    // policy. Listing them as a table keeps the policy choice next to the path
+    // and stops descriptor blocks from drifting per-route.
+    const PROTECTED_MUTATIONS: &[(&str, &str)] = &[
+        (OAUTH_START_ROUTE_ID, OAUTH_START_PATH),
+        (MANUAL_TOKEN_SUBMIT_ROUTE_ID, MANUAL_TOKEN_SUBMIT_PATH),
+        (MANUAL_TOKEN_SETUP_ROUTE_ID, MANUAL_TOKEN_SETUP_PATH),
+        (
             MANUAL_TOKEN_SECRET_SUBMIT_ROUTE_ID,
-            NetworkMethod::Post,
             MANUAL_TOKEN_SECRET_SUBMIT_PATH,
-            protected_mutation_policy(),
         ),
-        descriptor(
-            ACCOUNTS_LIST_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_LIST_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            ACCOUNTS_SELECT_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_SELECT_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            ACCOUNTS_RECOVERY_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_RECOVERY_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            ACCOUNTS_REFRESH_ROUTE_ID,
-            NetworkMethod::Post,
-            ACCOUNTS_REFRESH_PATH,
-            protected_mutation_policy(),
-        ),
-        descriptor(
-            LIFECYCLE_CLEANUP_ROUTE_ID,
-            NetworkMethod::Post,
-            LIFECYCLE_CLEANUP_PATH,
-            protected_mutation_policy(),
-        ),
-    ]
+        (ACCOUNTS_LIST_ROUTE_ID, ACCOUNTS_LIST_PATH),
+        (ACCOUNTS_SELECT_ROUTE_ID, ACCOUNTS_SELECT_PATH),
+        (ACCOUNTS_RECOVERY_ROUTE_ID, ACCOUNTS_RECOVERY_PATH),
+        (ACCOUNTS_REFRESH_ROUTE_ID, ACCOUNTS_REFRESH_PATH),
+        (LIFECYCLE_CLEANUP_ROUTE_ID, LIFECYCLE_CLEANUP_PATH),
+    ];
+    let mut descriptors: Vec<IngressRouteDescriptor> = PROTECTED_MUTATIONS
+        .iter()
+        .map(|(route_id, path)| {
+            descriptor(
+                route_id,
+                NetworkMethod::Post,
+                path,
+                protected_mutation_policy(),
+            )
+        })
+        .collect();
+    descriptors.push(descriptor(
+        OAUTH_CALLBACK_ROUTE_ID,
+        NetworkMethod::Get,
+        OAUTH_CALLBACK_PATH,
+        callback_policy(),
+    ));
+    descriptors
 }
 
 fn descriptor(
@@ -424,6 +397,23 @@ pub(crate) struct ManualTokenSubmitResponse {
     pub(crate) continuation: AuthContinuationRef,
 }
 
+/// Caller-supplied scope fields shared by every product-auth route body.
+///
+/// `invocation_id` is round-tripped from a prior start/setup response so the
+/// host can re-derive the same `AuthProductScope` across follow-up calls
+/// (mirroring the OAuth start/callback pattern). All three fields are
+/// optional: routes default to a fresh scope when the browser has no prior
+/// invocation to carry forward.
+#[derive(Default, Deserialize)]
+struct ScopeFields {
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    invocation_id: Option<String>,
+}
+
 #[derive(Deserialize)]
 struct ManualTokenSetupHttpRequest {
     provider: String,
@@ -432,12 +422,8 @@ struct ManualTokenSetupHttpRequest {
     run_id: Option<String>,
     #[serde(default)]
     gate_ref: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -457,12 +443,8 @@ pub(crate) struct ManualTokenSetupResponse {
 struct ManualTokenSecretSubmitHttpRequest {
     interaction_id: String,
     token: UnvalidatedRawSecretValue,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -474,12 +456,8 @@ struct AccountsListHttpRequest {
     cursor: Option<String>,
     #[serde(default)]
     limit: Option<usize>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -488,12 +466,8 @@ struct AccountsSelectHttpRequest {
     account_id: String,
     #[serde(default)]
     requester_extension: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -501,12 +475,8 @@ struct AccountsRecoveryHttpRequest {
     provider: String,
     #[serde(default)]
     requester_extension: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
@@ -515,24 +485,16 @@ struct AccountsRefreshHttpRequest {
     account_id: String,
     #[serde(default)]
     requester_extension: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Deserialize)]
 struct LifecycleCleanupHttpRequest {
     extension_id: String,
     action: SecretCleanupAction,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    invocation_id: Option<String>,
+    #[serde(flatten)]
+    scope: ScopeFields,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -717,8 +679,11 @@ async fn manual_token_submit_handler(
 ) -> Result<Json<ManualTokenSubmitResponse>, ProductAuthRouteFailure> {
     let scope = scope_from_authenticated_caller_parts(
         &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
+        &ScopeFields {
+            session_id: request.session_id.clone(),
+            thread_id: request.thread_id.clone(),
+            invocation_id: None,
+        },
     )?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
@@ -833,12 +798,7 @@ async fn manual_token_setup_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<ManualTokenSetupHttpRequest>,
 ) -> Result<Json<ManualTokenSetupResponse>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let invocation_id = scope.resource.invocation_id;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
@@ -882,12 +842,7 @@ async fn manual_token_secret_submit_handler(
     // read straight off the dedicated body, never echoed back, and never
     // surfaced in model transcript or tool arguments. Only the redacted
     // submit projection is returned.
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let interaction_id = parse_interaction_id(&request.interaction_id)?;
     let token = request
         .token
@@ -936,12 +891,7 @@ async fn accounts_list_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsListHttpRequest>,
 ) -> Result<Json<CredentialAccountListPage>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
@@ -975,12 +925,7 @@ async fn accounts_select_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsSelectHttpRequest>,
 ) -> Result<Json<CredentialAccountProjection>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     let account_id = parse_credential_account_id(&request.account_id)?;
@@ -1006,12 +951,7 @@ async fn accounts_recovery_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsRecoveryHttpRequest>,
 ) -> Result<Json<CredentialRecoveryProjection>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
 
@@ -1038,12 +978,7 @@ async fn accounts_refresh_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<AccountsRefreshHttpRequest>,
 ) -> Result<Json<CredentialRefreshReport>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let provider = AuthProviderId::new(request.provider)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     let account_id = parse_credential_account_id(&request.account_id)?;
@@ -1071,12 +1006,7 @@ async fn lifecycle_cleanup_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<LifecycleCleanupHttpRequest>,
 ) -> Result<Json<SecretCleanupReport>, ProductAuthRouteFailure> {
-    let scope = scope_from_authenticated_caller_parts_with_invocation(
-        &caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
-        request.invocation_id.as_deref(),
-    )?;
+    let scope = scope_from_authenticated_caller_parts(&caller, &request.scope)?;
     let extension_id = parse_extension_id(&request.extension_id)?;
 
     let cleanup_request = SecretCleanupRequest {
@@ -1265,42 +1195,42 @@ fn scope_from_authenticated_caller(
 ) -> Result<AuthProductScope, ProductAuthRouteFailure> {
     scope_from_authenticated_caller_parts(
         caller,
-        request.thread_id.as_ref(),
-        request.session_id.as_ref(),
+        &ScopeFields {
+            session_id: request.session_id.clone(),
+            thread_id: request.thread_id.clone(),
+            invocation_id: None,
+        },
     )
 }
 
+/// Derive an `AuthProductScope` from the authenticated caller plus the
+/// caller-supplied scope fields shared by every product-auth route body.
+///
+/// `invocation_id`, when supplied, must parse as an existing identifier
+/// (round-tripped from a prior start/setup response). Otherwise we mint a
+/// fresh one — mirroring the OAuth start/callback pattern from #4031 so the
+/// host owns the canonical id and the browser carries it forward across
+/// follow-up calls.
 fn scope_from_authenticated_caller_parts(
     caller: &WebUiAuthenticatedCaller,
-    thread_id: Option<&String>,
-    session_id: Option<&String>,
+    fields: &ScopeFields,
 ) -> Result<AuthProductScope, ProductAuthRouteFailure> {
-    scope_from_authenticated_caller_parts_with_invocation(caller, thread_id, session_id, None)
-}
-
-fn scope_from_authenticated_caller_parts_with_invocation(
-    caller: &WebUiAuthenticatedCaller,
-    thread_id: Option<&String>,
-    session_id: Option<&String>,
-    invocation_id: Option<&str>,
-) -> Result<AuthProductScope, ProductAuthRouteFailure> {
-    let thread_id = thread_id
+    let thread_id = fields
+        .thread_id
+        .as_deref()
         .map(|value| {
-            ThreadId::new(value.clone()).map_err(|_| ProductAuthRouteFailure::invalid_request())
+            ThreadId::new(value.to_string()).map_err(|_| ProductAuthRouteFailure::invalid_request())
         })
         .transpose()?;
-    let session_id = session_id
+    let session_id = fields
+        .session_id
+        .as_deref()
         .map(|value| {
-            AuthSessionId::new(value.clone())
+            AuthSessionId::new(value.to_string())
                 .map_err(|_| ProductAuthRouteFailure::invalid_request())
         })
         .transpose()?;
-    // invocation_id, when supplied by the caller, must be a valid existing
-    // identifier (round-tripped from a prior start/setup response). Otherwise
-    // we mint a fresh one — the OAuth start/callback pattern from #4031 uses
-    // the same shape: the host owns the canonical id and the browser carries
-    // it forward across follow-up calls.
-    let invocation_id = match invocation_id {
+    let invocation_id = match fields.invocation_id.as_deref() {
         Some(value) => {
             InvocationId::parse(value).map_err(|_| ProductAuthRouteFailure::invalid_request())?
         }

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
@@ -1,0 +1,542 @@
+//! Caller-level tests for issue #4201: product-facing HTTP surfaces for
+//! manual-token setup/secret-submit, credential account list/select/recovery,
+//! refresh, and lifecycle cleanup.
+//!
+//! These tests drive the HTTP routes end-to-end through `webui_v2_app` so the
+//! caller path (auth layer + body limit + rate limit + handler +
+//! `RebornProductAuthServices`) is exercised, not just the facade helpers.
+
+#![cfg(feature = "webui-v2-beta")]
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::body::{Body, to_bytes};
+use axum::http::{HeaderValue, Method, Request, StatusCode, header};
+use ironclaw_auth::{
+    AuthContinuationEvent, AuthProductError, AuthProductScope, AuthSurface, CredentialAccountLabel,
+    CredentialAccountStatus, CredentialOwnership, InMemoryAuthProductServices,
+    NewCredentialAccount,
+};
+use ironclaw_auth::{AuthProviderId, CredentialAccountService};
+use ironclaw_host_api::{AgentId, InvocationId, ProjectId, ResourceScope, TenantId, UserId};
+use ironclaw_product_workflow::{
+    ExtensionName, RebornCancelRunResponse, RebornCreateThreadResponse, RebornGetRunStateRequest,
+    RebornGetRunStateResponse, RebornListThreadsResponse, RebornResolveGateResponse,
+    RebornServicesApi, RebornServicesError, RebornServicesErrorCode, RebornServicesErrorKind,
+    RebornSetupExtensionResponse, RebornStreamEventsRequest, RebornStreamEventsResponse,
+    RebornSubmitTurnResponse, RebornTimelineRequest, RebornTimelineResponse,
+    WebUiAuthenticatedCaller, WebUiCancelRunRequest, WebUiCreateThreadRequest,
+    WebUiListThreadsRequest, WebUiResolveGateRequest, WebUiSendMessageRequest,
+    WebUiSetupExtensionRequest,
+};
+use ironclaw_reborn_composition::{
+    RebornAuthContinuationDispatcher, RebornProductAuthServices, RebornReadiness,
+    RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig, webui_v2_app,
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+const TENANT: &str = "tenant-4201";
+const USER: &str = "user-4201";
+const AGENT: &str = "agent-4201";
+const PROJECT: &str = "project-4201";
+const VALID_TOKEN: &str = "valid-bearer-token-4201";
+
+struct OnlyValidToken;
+
+#[async_trait]
+impl WebuiAuthenticator for OnlyValidToken {
+    async fn authenticate(&self, token: &str) -> Option<UserId> {
+        (token == VALID_TOKEN).then(|| UserId::new(USER).expect("user id"))
+    }
+}
+
+#[derive(Default)]
+struct NoopAuthDispatcher {
+    events: Mutex<Vec<AuthContinuationEvent>>,
+}
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for NoopAuthDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        self.events.lock().expect("auth events lock").push(event);
+        Ok(())
+    }
+}
+
+struct UnusedServices;
+
+#[async_trait]
+impl RebornServicesApi for UnusedServices {
+    async fn create_thread(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiCreateThreadRequest,
+    ) -> Result<RebornCreateThreadResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn submit_turn(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiSendMessageRequest,
+    ) -> Result<RebornSubmitTurnResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn get_timeline(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornTimelineRequest,
+    ) -> Result<RebornTimelineResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn stream_events(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornStreamEventsRequest,
+    ) -> Result<RebornStreamEventsResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn get_run_state(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: RebornGetRunStateRequest,
+    ) -> Result<RebornGetRunStateResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn cancel_run(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiCancelRunRequest,
+    ) -> Result<RebornCancelRunResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn resolve_gate(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiResolveGateRequest,
+    ) -> Result<RebornResolveGateResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn list_threads(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _request: WebUiListThreadsRequest,
+    ) -> Result<RebornListThreadsResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+
+    async fn setup_extension(
+        &self,
+        _caller: WebUiAuthenticatedCaller,
+        _extension_name: ExtensionName,
+        _request: WebUiSetupExtensionRequest,
+    ) -> Result<RebornSetupExtensionResponse, RebornServicesError> {
+        Err(unused_service_error())
+    }
+}
+
+fn unused_service_error() -> RebornServicesError {
+    RebornServicesError {
+        code: RebornServicesErrorCode::Internal,
+        kind: RebornServicesErrorKind::Internal,
+        status_code: 500,
+        retryable: false,
+        field: None,
+        validation_code: None,
+    }
+}
+
+struct AppFixture {
+    app: axum::Router,
+    shared: Arc<InMemoryAuthProductServices>,
+}
+
+fn build_fixture() -> AppFixture {
+    let shared = Arc::new(InMemoryAuthProductServices::new());
+    let product_auth = Arc::new(RebornProductAuthServices::from_shared(
+        shared.clone(),
+        Arc::new(NoopAuthDispatcher::default()),
+    ));
+    let bundle = RebornWebuiBundle {
+        api: Arc::new(UnusedServices),
+        product_auth: Some(product_auth),
+        readiness: RebornReadiness::disabled(),
+    };
+    let config = WebuiServeConfig::new(
+        TenantId::new(TENANT).expect("tenant"),
+        Arc::new(OnlyValidToken),
+        vec![HeaderValue::from_static("http://localhost:1234")],
+    )
+    .with_default_agent_id(AgentId::new(AGENT).expect("agent"))
+    .with_default_project_id(ProjectId::new(PROJECT).expect("project"));
+    let app = webui_v2_app(bundle, config).expect("webui v2 app");
+    AppFixture { app, shared }
+}
+
+fn caller_scope_with_invocation(invocation_id: InvocationId) -> AuthProductScope {
+    AuthProductScope::new(
+        ResourceScope {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            user_id: UserId::new(USER).expect("user"),
+            agent_id: Some(AgentId::new(AGENT).expect("agent")),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            mission_id: None,
+            thread_id: None,
+            invocation_id,
+        },
+        AuthSurface::Callback,
+    )
+}
+
+async fn seed_configured_account(
+    shared: &InMemoryAuthProductServices,
+    invocation_id: InvocationId,
+    provider: &str,
+    label: &str,
+) -> ironclaw_auth::CredentialAccountId {
+    let account = shared
+        .create_account(NewCredentialAccount {
+            scope: caller_scope_with_invocation(invocation_id),
+            provider: AuthProviderId::new(provider.to_string()).expect("provider"),
+            label: CredentialAccountLabel::new(label.to_string()).expect("label"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: None,
+            refresh_secret: None,
+            scopes: Vec::new(),
+        })
+        .await
+        .expect("seeded account");
+    account.id
+}
+
+async fn read_body_string(response: axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+async fn post_authenticated(
+    app: &axum::Router,
+    uri: &str,
+    body: Value,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(uri)
+                .header(header::AUTHORIZATION, format!("Bearer {VALID_TOKEN}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot")
+}
+
+async fn post_unauthenticated(
+    app: &axum::Router,
+    uri: &str,
+    body: Value,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(uri)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("oneshot")
+}
+
+const PATHS: &[&str] = &[
+    "/api/reborn/product-auth/manual-token/setup",
+    "/api/reborn/product-auth/manual-token/secret-submit",
+    "/api/reborn/product-auth/accounts/list",
+    "/api/reborn/product-auth/accounts/select",
+    "/api/reborn/product-auth/accounts/recovery",
+    "/api/reborn/product-auth/accounts/refresh",
+    "/api/reborn/product-auth/lifecycle/cleanup",
+];
+
+#[tokio::test]
+async fn product_auth_new_routes_require_bearer_auth() {
+    let fixture = build_fixture();
+    for path in PATHS {
+        let response = post_unauthenticated(&fixture.app, path, json!({})).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{path} must require bearer auth"
+        );
+    }
+}
+
+#[tokio::test]
+async fn manual_token_setup_then_secret_submit_returns_redacted_projection() {
+    let fixture = build_fixture();
+    let raw_token = "ghp_routing_through_4201_secret";
+
+    let setup_response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/setup",
+        json!({
+            "provider": "github",
+            "account_label": "work github 4201",
+            "run_id": "22222222-2222-2222-2222-222222222222",
+            "gate_ref": "gate:auth-github-4201",
+            "thread_id": "thread-auth-4201"
+        }),
+    )
+    .await;
+    assert_eq!(setup_response.status(), StatusCode::OK);
+    let setup_body = read_body_string(setup_response).await;
+    let setup_json: Value = serde_json::from_str(&setup_body).expect("setup json");
+    let interaction_id = setup_json["interaction_id"]
+        .as_str()
+        .expect("interaction id")
+        .to_string();
+    let invocation_id = setup_json["invocation_id"]
+        .as_str()
+        .expect("invocation id from setup response")
+        .to_string();
+    assert_eq!(setup_json["provider"].as_str(), Some("github"));
+    assert_eq!(setup_json["label"].as_str(), Some("work github 4201"));
+
+    let submit_response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/secret-submit",
+        json!({
+            "interaction_id": interaction_id,
+            "token": raw_token,
+            "thread_id": "thread-auth-4201",
+            "invocation_id": invocation_id
+        }),
+    )
+    .await;
+    assert_eq!(submit_response.status(), StatusCode::OK);
+    let submit_body = read_body_string(submit_response).await;
+    assert!(
+        !submit_body.contains(raw_token),
+        "secret-submit response must not echo raw token: {submit_body}"
+    );
+    assert!(
+        !submit_body.contains("interaction_id"),
+        "secret-submit response must not echo interaction_id: {submit_body}"
+    );
+    let submit_json: Value = serde_json::from_str(&submit_body).expect("submit json");
+    assert!(submit_json["credential_ref"].as_str().is_some());
+    assert_eq!(submit_json["status"].as_str(), Some("configured"));
+    assert_eq!(
+        submit_json["continuation"]["type"].as_str(),
+        Some("turn_gate_resume")
+    );
+    assert_eq!(
+        submit_json["continuation"]["gate_ref"].as_str(),
+        Some("gate:auth-github-4201")
+    );
+}
+
+#[tokio::test]
+async fn manual_token_setup_rejects_partial_continuation_inputs() {
+    let fixture = build_fixture();
+    let invalid_bodies = [
+        json!({
+            "provider": "github",
+            "account_label": "label-only-run",
+            "run_id": "22222222-2222-2222-2222-222222222222"
+        }),
+        json!({
+            "provider": "github",
+            "account_label": "label-only-gate",
+            "gate_ref": "gate:auth-github"
+        }),
+    ];
+    for body in invalid_bodies {
+        let response = post_authenticated(
+            &fixture.app,
+            "/api/reborn/product-auth/manual-token/setup",
+            body,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = read_body_string(response).await;
+        assert!(body.contains("\"code\":\"invalid_request\""));
+    }
+}
+
+#[tokio::test]
+async fn manual_token_secret_submit_invalid_interaction_is_sanitized() {
+    let fixture = build_fixture();
+    let raw_token = "ghp_invalid_interaction_secret";
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/secret-submit",
+        json!({
+            "interaction_id": "not-a-uuid",
+            "token": raw_token
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+    assert!(!body.contains(raw_token));
+}
+
+#[tokio::test]
+async fn accounts_list_returns_only_seeded_provider_accounts() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let github_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+    let _slack_id =
+        seed_configured_account(&fixture.shared, invocation_id, "slack", "work slack").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/list",
+        json!({
+            "provider": "github",
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("list json");
+    let accounts = json["accounts"].as_array().expect("accounts array");
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(
+        accounts[0]["id"].as_str(),
+        Some(github_id.to_string().as_str())
+    );
+    assert_eq!(accounts[0]["provider"].as_str(), Some("github"));
+    assert_eq!(accounts[0]["status"].as_str(), Some("configured"));
+    // Redacted projection must never carry secret handle names.
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn accounts_list_invalid_limit_is_sanitized() {
+    let fixture = build_fixture();
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/list",
+        json!({ "provider": "github", "limit": 0 }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}
+
+#[tokio::test]
+async fn accounts_select_returns_redacted_projection() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/select",
+        json!({
+            "provider": "github",
+            "account_id": account_id.to_string(),
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("select json");
+    assert_eq!(json["id"].as_str(), Some(account_id.to_string().as_str()));
+    assert_eq!(json["status"].as_str(), Some("configured"));
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn accounts_recovery_projects_setup_required_when_no_account_exists() {
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/recovery",
+        json!({ "provider": "github" }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("recovery json");
+    assert_eq!(json["provider"].as_str(), Some("github"));
+    assert_eq!(json["kind"].as_str(), Some("setup_required"));
+    assert_eq!(json["reason"].as_str(), Some("no_account"));
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn lifecycle_cleanup_redacts_report_and_reaches_service() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    // Seed an unrelated account so cleanup has scope to walk but no extension owns it.
+    let _account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "work github").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/lifecycle/cleanup",
+        json!({
+            "extension_id": "ext-no-grant-4201",
+            "action": "deactivate",
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("cleanup json");
+    // No matching extension grant: report must be empty but well-formed.
+    assert_eq!(
+        json,
+        json!({}),
+        "cleanup report must omit empty arrays via skip_serializing_if"
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_cleanup_rejects_invalid_extension_id() {
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/lifecycle/cleanup",
+        json!({ "extension_id": "", "action": "deactivate" }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
@@ -540,3 +540,159 @@ async fn lifecycle_cleanup_rejects_invalid_extension_id() {
     let body = read_body_string(response).await;
     assert!(body.contains("\"code\":\"invalid_request\""));
 }
+
+#[tokio::test]
+async fn accounts_refresh_returns_report_for_seeded_account() {
+    let fixture = build_fixture();
+    let invocation_id = InvocationId::new();
+    let account_id =
+        seed_configured_account(&fixture.shared, invocation_id, "github", "refresh-test").await;
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/refresh",
+        json!({
+            "provider": "github",
+            "account_id": account_id.to_string(),
+            "invocation_id": invocation_id.to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_body_string(response).await;
+    let json: Value = serde_json::from_str(&body).expect("refresh json");
+    assert_eq!(
+        json["account"]["id"].as_str(),
+        Some(account_id.to_string().as_str())
+    );
+    assert!(json["recovery"].is_object(), "recovery must be present");
+    assert!(json["refreshed"].is_boolean(), "refreshed must be present");
+    // Redacted projection must never carry secret handle names.
+    assert!(!body.contains("access_secret"));
+    assert!(!body.contains("refresh_secret"));
+}
+
+#[tokio::test]
+async fn manual_token_secret_submit_requires_invocation_id() {
+    // Omitting invocation_id means the host cannot re-derive the setup scope;
+    // the route must reject with invalid_request rather than minting a fresh
+    // invocation that will never match the pending interaction.
+    let fixture = build_fixture();
+    let raw_token = "ghp_should_not_be_echoed_invocation_required";
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/manual-token/secret-submit",
+        json!({
+            "interaction_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "token": raw_token
+            // invocation_id intentionally absent
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+    assert!(
+        !body.contains(raw_token),
+        "raw token must not be echoed: {body}"
+    );
+}
+
+#[tokio::test]
+async fn accounts_list_requires_invocation_id() {
+    // Omitting invocation_id would cause a fresh scope to be minted, silently
+    // returning an empty page instead of scoped results.
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/list",
+        json!({ "provider": "github" /* invocation_id absent */ }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}
+
+#[tokio::test]
+async fn new_routes_reject_malformed_invocation_id() {
+    // All new routes that accept invocation_id must return 400 on a non-UUID
+    // value so audit tooling can confirm the validation path is live.
+    let fixture = build_fixture();
+    let cases: &[(&str, Value)] = &[
+        (
+            "/api/reborn/product-auth/manual-token/secret-submit",
+            json!({
+                "interaction_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "token": "tok",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/list",
+            json!({ "provider": "github", "invocation_id": "not-a-uuid" }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/select",
+            json!({
+                "provider": "github",
+                "account_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/recovery",
+            json!({ "provider": "github", "invocation_id": "not-a-uuid" }),
+        ),
+        (
+            "/api/reborn/product-auth/accounts/refresh",
+            json!({
+                "provider": "github",
+                "account_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+        (
+            "/api/reborn/product-auth/lifecycle/cleanup",
+            json!({
+                "extension_id": "ext-test",
+                "action": "deactivate",
+                "invocation_id": "not-a-uuid"
+            }),
+        ),
+    ];
+    for (path, body) in cases {
+        let response = post_authenticated(&fixture.app, path, body.clone()).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "{path} must reject malformed invocation_id"
+        );
+        let body_str = read_body_string(response).await;
+        assert!(
+            body_str.contains("\"code\":\"invalid_request\""),
+            "{path} must return invalid_request for malformed invocation_id: {body_str}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn accounts_select_rejects_malformed_account_id() {
+    let fixture = build_fixture();
+
+    let response = post_authenticated(
+        &fixture.app,
+        "/api/reborn/product-auth/accounts/select",
+        json!({
+            "provider": "github",
+            "account_id": "not-a-uuid",
+            "invocation_id": InvocationId::new().to_string()
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = read_body_string(response).await;
+    assert!(body.contains("\"code\":\"invalid_request\""));
+}

--- a/docs/reborn/2026-05-30-4112-webui-v2-auth-e2e-implementation.md
+++ b/docs/reborn/2026-05-30-4112-webui-v2-auth-e2e-implementation.md
@@ -1,0 +1,431 @@
+# Reborn WebUI v2: GSuite OAuth + Notion MCP OAuth + GitHub PAT — Implementation Design
+
+**Issue:** [#4112](https://github.com/nearai/ironclaw/issues/4112)
+**Base branch:** `codex/issue-4201-product-auth-http` (PR [#4245](https://github.com/nearai/ironclaw/pull/4245))
+**Scope:** WebUI v2 surface + browser E2E proof for all three auth flows. Backend HTTP routes already mounted by #4245.
+**Status:** Design — not yet implemented. Revised after advisor pass to avoid wire-breaking changes and tighten MVP scope.
+
+---
+
+## 0. Repository state when this doc was written
+
+- Local clone: `/Users/firatsertgoz/Documents/ironclaw`, on branch `codex/issue-4201-product-auth-http` (last commit `3e41002f4`).
+- Working tree dirty from a prior unrelated session; stashed via `git stash -u` (msg: "WIP on codex/issue-3537-extension-v2-cutover"). Restore with `git stash pop` if needed.
+- No worktree was created. **Recommendation before implementation:** `git worktree add ../ironclaw-4112 codex/issue-4201-product-auth-http` so the main clone is not mutated.
+
+---
+
+## 1. Context recap
+
+### Backend (already done in #4245)
+
+Routes mounted in `crates/ironclaw_reborn_composition/src/product_auth_serve.rs:56-66, 238-252`:
+
+| Route | Purpose | Body fields (verified at `:354-503`) |
+|---|---|---|
+| `POST /api/reborn/product-auth/oauth/start` | Start OAuth flow | `{provider, authorization_url, opaque_state, pkce_verifier, expires_at, session_id?, thread_id?}` |
+| `GET /api/reborn/product-auth/oauth/callback/{flow_id}` | IDP callback | query: `code`, `state` |
+| `POST /api/reborn/product-auth/manual-token/submit` | **Single-shot gate-resume** path used by WebUI today | `{provider, account_label, token, run_id, gate_ref, session_id?, thread_id?}` |
+| `POST /api/reborn/product-auth/manual-token/setup` | Two-step flow: create pending interaction | `{provider, account_label, run_id?, gate_ref?, scope: {session_id?, thread_id?, invocation_id?}}` |
+| `POST /api/reborn/product-auth/manual-token/secret-submit` | Two-step flow: submit secret out-of-band | `{interaction_id, token, scope: ScopeFields}` |
+| `POST /api/reborn/product-auth/accounts/list` | List credential accounts | `{provider, requester_extension?, cursor?, limit?, scope}` |
+| `POST /api/reborn/product-auth/accounts/select` | Select account for current scope | `{provider, account_id, requester_extension?, scope}` |
+| `POST /api/reborn/product-auth/accounts/recovery` | Project recovery options for a stuck account | `{provider, requester_extension?, scope}` |
+| `POST /api/reborn/product-auth/accounts/refresh` | Refresh access token / probe health | `{provider, account_id, requester_extension?, scope}` |
+| `POST /api/reborn/product-auth/lifecycle/cleanup` | Disconnect / uninstall cleanup | `{extension_id, action, scope}` |
+
+**Important DTO observation (correction from prior draft):** `/manual-token/submit` is the gate-resume path WebUI already uses (`api.js:237-258` — verified). `/manual-token/setup` + `/secret-submit` are an alternate two-step path for callers that need an out-of-band secret ingress (e.g., a popup window or rich modal that does not have the `run_id`/`gate_ref` upfront). **WebUI's chat-flow manual-token path will continue using `/submit`**; the new two-step routes are not on the issue's critical path.
+
+### WebUI v2 today
+
+- **Crate:** `crates/ironclaw_webui_v2_static` (Rust-hosted static SPA, feature `webui-v2-beta`).
+- **Stack:** React 19 + HTM + react-router 7 + @tanstack/react-query + react-hook-form via esm.sh importmap; Tailwind v4 browser CDN. **No build step, no `package.json`** under `static/`.
+- **SSE consumer:** `static/js/pages/chat/hooks/useSSE.js:12-27` lists the named events, including `gate` and `auth_required`. Handlers in `useChatEvents.js:107-115`.
+- **Gate UI:**
+  - `components/auth-token-card.js` — manual-token password input. Pure presentational; calls `onSubmit(value)` prop. **HTTP wiring lives in `hooks/useChat.js:239-323 submitAuthToken`**, which posts to `/api/reborn/product-auth/manual-token/submit` via `api.js:237`.
+  - `components/approval-card.js` — Approve/Deny/Always modal.
+  - `lib/gates.js::gateFromEvent` normalizes `gate`/`auth_required` SSE prompts.
+- **Reads server fields it never receives.** `gates.js:9-32` reads `prompt.provider` and `prompt.account_label`, but the server's `AuthPromptView` (defined `crates/ironclaw_product_adapters/src/outbound.rs:539-545`) only carries `{turn_run_id, auth_request_ref, headline, body}`. So `provider` and `accountLabel` are perpetually `undefined`/`"github"` (fallback), and **there is no `auth_url` on the wire at all**.
+
+### Where `AuthChallenge` data actually lives
+
+Verified by direct repo read, not speculation:
+
+1. **Engine pause site** (`crates/ironclaw_engine/src/gate/mod.rs:44-67`): `ResumeKind::Authentication { credential_name, instructions, auth_url: Option<String> }`. So at the engine level, `auth_url` exists alongside the gate but is engine-internal — not surfaced through `TurnLifecycleEvent`.
+2. **Reborn flow store**: `crates/ironclaw_reborn_composition/src/auth.rs:806-823` — `start_setup_oauth_flow` persists `AuthChallenge::OAuthUrl` in `flow_manager` keyed by flow id.
+3. **Reborn interaction store**: `auth.rs:830-857` — `request_secret_input` returns the `ManualTokenRequired` challenge from `interaction_service`.
+4. **Projection layer** (`crates/ironclaw_reborn_composition/src/projection/turn_events.rs:140-185`): `blocked_prompt_payload` only inspects `TurnRunState.gate_ref` — never reaches into flow/interaction stores.
+5. **Event schema** (`crates/ironclaw_turns/src/events.rs:62-81`): `TurnLifecycleEvent` carries `blocked_gate: Option<TurnBlockedGateMetadata { gate_ref, gate_kind }>` — kind discriminator but no challenge body.
+
+### Gaps that 4112 must close
+
+1. **`AuthPromptView` carries no provider/auth_url** — WebUI cannot distinguish OAuth vs ManualToken, cannot render an OAuth URL button. **Primary gap.**
+2. **No OAuth-URL UI component** — `auth-oauth-card.js` does not exist.
+3. **No browser E2E for product-auth flows** — `pytest-playwright` is wired (`tests/e2e/conftest.py:1163-1232`) but no scenario uses it for product-auth.
+4. **No mock OAuth IDP fixture** — only inline aiohttp Bearer-mock in `tests/e2e/scenarios/test_skill_oauth_flow.py:38-104`.
+
+---
+
+## 2. Design (revised)
+
+### 2.1 Wire-shape changes (Rust) — **additive, non-breaking**
+
+#### Extend `AuthPromptView` with optional fields
+
+The struct derives `Deserialize`, so it must stay backward-compatible for any consumer that may persist or replay the event. **All new fields are `Option<…>` with `serde(default, skip_serializing_if = "Option::is_none")`** so existing serialized rows and v1 channels continue to round-trip.
+
+```rust
+// crates/ironclaw_product_adapters/src/outbound.rs:539
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthPromptView {
+    pub turn_run_id: TurnRunId,
+    pub auth_request_ref: String,
+    pub headline: String,
+    pub body: String,
+
+    // --- v2 additions, all optional & backwards-compatible ---
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub challenge_kind: Option<AuthPromptChallengeKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_label: Option<String>,
+    /// Opaque IDP authorization URL — already user-visible on v1 wire as
+    /// `AppEvent::OnboardingState.auth_url`. Present only for `OAuthUrl`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthPromptChallengeKind {
+    OAuthUrl,
+    ManualToken,
+    /// Catch-all for the remaining `AuthChallenge` variants we don't yet
+    /// surface in WebUI v2 chat flow. Renders as a fall-through manual-token
+    /// or a "see settings" hint.
+    Other,
+}
+```
+
+**Why optional, not `serde(flatten)` enum:** flattening a tagged enum into a struct that already has 4 mandatory fields and derives `Deserialize` is wire-breaking — any persisted event row without the tag field would fail to deserialize. Optional siblings are forward+backward compatible.
+
+**Redaction invariant:** only opaque IDP URLs ever flow through `authorization_url`. No PKCE verifier, no client secret, no auth code, no access/refresh token, no `interaction_id`.
+
+#### Source the challenge in `blocked_prompt_payload` — lookup-at-projection (Option B)
+
+`TurnLifecycleEvent` is a serialized event row; extending it for one consumer is high-blast-radius. Instead, add a single read-only lookup on the auth-side service that the projection layer already has DI access to:
+
+```rust
+// crates/ironclaw_reborn_composition/src/auth.rs (impl RebornProductAuthServices)
+pub async fn lookup_pending_challenge_for_gate(
+    &self,
+    scope: &AuthProductScope,
+    gate_ref: &GateRef,
+) -> Result<Option<AuthChallengeProjection>, AuthProductError> {
+    // Try flow_manager first (OAuth), then interaction_service (ManualToken).
+    // Return a *projected* (redacted) view, never the raw AuthChallenge enum.
+    ...
+}
+
+/// Projection-safe view. No raw secrets, no PKCE verifier, no opaque_state.
+pub struct AuthChallengeProjection {
+    pub kind: AuthPromptChallengeKind,
+    pub provider: String,
+    pub account_label: Option<String>,
+    pub authorization_url: Option<String>,
+    pub expires_at: Option<Timestamp>,
+}
+```
+
+Then `blocked_prompt_payload` (`projection/turn_events.rs:170-180`) optionally enriches `AuthPromptView` from the lookup. If the lookup returns `None` (e.g., the flow was already consumed), the prompt falls back to the original 4-field view — UI shows a generic auth card with the existing copy.
+
+**Trade-off accepted:** one extra read per BlockedAuth projection. Cost is negligible (in-memory store; ~1 µs).
+
+#### Contract doc
+
+Append a new section to `docs/reborn/contracts/auth-product.md`:
+- the 5 added optional fields, redaction invariant, and worked JSON examples for `OAuthUrl` and `ManualToken`;
+- explicit "v1 consumers may ignore all v2 fields" backward-compat statement.
+
+### 2.2 WebUI v2 changes (JS, no build) — **MVP only**
+
+#### Scope decision (MVP)
+
+Per issue 4112 acceptance, MVP renders **two** challenge variants in the chat flow:
+- **`oauth_url`** → new `auth-oauth-card.js` (GSuite + Notion).
+- **`manual_token`** → existing `auth-token-card.js`, unchanged HTTP wiring (`/manual-token/submit`). Only header copy is provider-aware once `provider`/`account_label` actually arrive on the wire.
+
+**Deferred to follow-up tickets** (out of scope for 4112):
+- `AccountSelectionRequired` UI card and `/accounts/select` wiring.
+- `ReauthorizeRequired` UI card and `/accounts/recovery` wiring.
+- `SetupRequired` UI card.
+- Account-management settings page (list/refresh/disconnect) for `/accounts/*` + `/lifecycle/cleanup`.
+- Two-step `/manual-token/setup` + `/secret-submit` (alternate ingress, not the chat-flow path).
+
+#### File map (MVP)
+```
+crates/ironclaw_webui_v2_static/static/js/
+├── lib/
+│   └── api.js                                  # +0 new helpers (existing submitManualToken stays)
+└── pages/chat/
+    ├── lib/
+    │   └── gates.js                            # read challenge_kind + authorization_url
+    ├── components/
+    │   ├── auth-token-card.js                  # tweak header to surface provider/account_label
+    │   └── auth-oauth-card.js                  # NEW — OAuthUrl UI
+    ├── hooks/
+    │   ├── useSSE.js                           # +"auth_completed" event name
+    │   ├── useChat.js                          # handle auth_completed → clear gate
+    │   └── useChatEvents.js                    # route auth_completed → clear pendingGate
+    └── chat.js                                 # dispatch by challengeKind
+```
+
+#### `gates.js` (small additive change)
+
+```js
+if (eventType === "auth_required") {
+  return {
+    kind: "auth_required",
+    challengeKind: prompt.challenge_kind || "manual_token", // fallback preserves today's UI
+    runId: prompt.turn_run_id,
+    gateRef: prompt.auth_request_ref,
+    provider: prompt.provider || "github",
+    accountLabel: prompt.account_label || "Manual token",
+    authorizationUrl: prompt.authorization_url, // undefined for manual_token
+    expiresAt: prompt.expires_at,
+    headline: prompt.headline,
+    body: prompt.body,
+  };
+}
+```
+
+#### `chat.js` dispatch (~5-line change at L116-126)
+
+```js
+${pendingGate?.kind === "auth_required"
+  ? (pendingGate.challengeKind === "oauth_url"
+      ? html`<${AuthOauthCard} gate=${pendingGate} onCancel=${onAuthCancel} />`
+      : html`<${AuthTokenCard} gate=${pendingGate} onSubmit=${submitAuthToken} onCancel=${onAuthCancel} />`)
+  : pendingGate?.kind === "gate"
+    ? html`<${ApprovalCard} gate=${pendingGate} ... />`
+    : null}
+```
+
+#### `auth-oauth-card.js` (new, ~80 LoC)
+
+```js
+import { html } from "htm/react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export function AuthOauthCard({ gate, onCancel }) {
+  const { t } = useTranslation();
+  const [opened, setOpened] = React.useState(false);
+
+  const openAuth = React.useCallback(() => {
+    // window.open is a user-gesture-allowed popup; OAuth callback is handled
+    // server-side by /api/reborn/product-auth/oauth/callback/{flow_id} which
+    // resumes the paused run. WebUI observes the resume via the next
+    // auth_completed (or turn-status) SSE frame and clears pendingGate.
+    window.open(gate.authorizationUrl, "_blank", "noopener,noreferrer");
+    setOpened(true);
+  }, [gate.authorizationUrl]);
+
+  return html`
+    <div className="auth-oauth-card">
+      <h3>${gate.headline || t("authGate.oauthHeadline", { provider: gate.provider })}</h3>
+      <p>${gate.body}</p>
+      <p className="muted">${t("authGate.accountLabel")}: ${gate.accountLabel}</p>
+      <button onClick=${openAuth} className="btn-primary">
+        ${opened ? t("authGate.reopenAuthorization") : t("authGate.openAuthorization")}
+      </button>
+      <button onClick=${onCancel} className="btn-secondary">${t("authGate.cancel")}</button>
+      ${gate.expiresAt && html`<p className="muted">${t("authGate.expiresAt")}: ${new Date(gate.expiresAt).toLocaleString()}</p>`}
+    </div>
+  `;
+}
+```
+
+No fetch, no secret handling, no popup-tracking complexity. The OAuth callback completes server-side; WebUI just waits.
+
+#### Closing the OAuth card
+
+Two options, picked by evidence rather than speculation:
+
+- **Option α (preferred if available):** existing SSE projection already emits `projection_update` with run status flipping `BlockedAuth → Running` when the callback resumes. If `useChatEvents.js` already clears `pendingGate` on that transition, **no new event needed**. Spike before P1 locks in: run `test_skill_oauth_flow.py` against the v2 wire to confirm.
+- **Option β (fallback):** add `ProductOutboundPayload::AuthCompleted { turn_run_id, auth_request_ref }`, emitted from `blocked_prompt_payload` on the status flip, and a matching `auth_completed` SSE event name added to `useSSE.js::V2_EVENT_NAMES`.
+
+**Decision rule:** if option α works, ship α (zero new wire surface). Only add β if the OAuth card otherwise stays mounted after the resume.
+
+### 2.3 Approval gate after auth
+
+Already wired (`approval-card.js`, `engine_v2_gate_integration.rs`). Once auth completes and the tool runs, the engine raises a separate `gate` SSE event for any tool with `requires_approval = true`. **No new code.** E2E test asserts this.
+
+---
+
+## 3. Browser E2E — three scenarios
+
+All under `tests/e2e/scenarios/`, using `pytest-playwright`. Browser fixture already in `conftest.py:1163-1232`.
+
+### 3.1 New shared fixtures (`tests/e2e/fixtures/`)
+
+```python
+# mock_oauth_idp.py — aiohttp server with /authorize + /token endpoints.
+#   Validates PKCE (S256), opaque state, emits a 302 to the callback URL
+#   carrying ?code=&state=. /token issues a fake access_token + refresh_token.
+#   Supports a "fail PKCE" mode for negative tests.
+@pytest.fixture(scope="module")
+async def mock_oauth_idp() -> AsyncIterator[str]: ...
+
+# mock_bearer_api.py — extracted from test_skill_oauth_flow.py::_start_mock_api.
+@pytest.fixture(scope="module")
+async def mock_bearer_api() -> AsyncIterator[str]: ...
+
+# mock_notion_mcp.py — minimal MCP server (initialize / tools/list / tools/call)
+#   that proxies auth_required upstream and requires Bearer on tool calls.
+@pytest.fixture(scope="module")
+async def mock_notion_mcp() -> AsyncIterator[str]: ...
+
+# ironclaw_v2 binary fixture — spawn with feature webui-v2-beta, env-override
+# provider endpoints to the mock IDP/API URLs, wait for WebUI port to bind.
+@pytest.fixture
+async def ironclaw_v2(tmp_path, mock_llm, mock_oauth_idp, mock_bearer_api) -> AsyncIterator[V2Handle]: ...
+```
+
+### 3.2 `test_v2_github_pat_flow.py` (P-first — simplest, no OAuth machinery)
+
+```
+1. Open WebUI v2 (page.goto).
+2. Send message that triggers GitHub tool ("list issues on owner/repo").
+3. Expect AuthTokenCard rendered: provider="github", accountLabel surfaced, password input visible.
+4. Type ghp_fake_xyz, submit. Capture POST body via page.on("request"):
+   assert URL == "/api/reborn/product-auth/manual-token/submit"
+   assert body.token == "ghp_fake_xyz".
+5. After submit, capture all SSE frames and DOM snapshots; scan against
+   leak_detector::GITHUB_PAT_REGEX (line 1190). Assert zero matches.
+6. Mock GitHub API receives "list issues" with Bearer header.
+7. Send message triggering a *write* ("create issue"). ApprovalCard renders.
+   Click Approve. Mock API receives POST /repos/.../issues.
+   Send another, click Deny. Mock API receives nothing.
+```
+
+### 3.3 `test_v2_gsuite_oauth_flow.py`
+
+```
+1. Open WebUI v2, send Gmail-requiring message.
+2. Expect AuthOauthCard rendered: provider="google", authorization_url set.
+3. Click "Open authorization page" — capture window.open call via
+   context.expect_page() (Playwright multi-page API).
+4. In the popup page, follow the IDP authorize → callback redirect.
+5. In the original page, assert OAuth card unmounts within timeout
+   (poll: pendingGate clears, projection flips to Running).
+6. Mock Gmail API receives Bearer.
+7. Leak scan: scan SSE frames, DOM, localStorage. Assert no access_token,
+   refresh_token, pkce_verifier, raw state.
+8. Multi-user isolation: spawn a second incognito context as a different
+   user. Send same message. Assert that user gets its own AuthOauthCard
+   (independent flow_id, independent challenge).
+```
+
+### 3.4 `test_v2_notion_mcp_oauth_flow.py`
+
+Same skeleton as GSuite, with `mock_notion_mcp` as the capability target. The MCP transport injects the Bearer header into `tools/call` after OAuth completes; mock asserts the header arrived. Tool routing reference: `crates/ironclaw_reborn_composition/src/nearai_mcp.rs:100`.
+
+---
+
+## 4. Phased implementation plan
+
+| Phase | LoC est. | Files | Verification |
+|---|---|---|---|
+| **P0 Spike — OAuth card teardown** | 0 | run existing v2 wire against a mock callback | Decide α vs β for closing the card |
+| **P1 Wire** | ~150 Rust | `outbound.rs`, `auth.rs` (`lookup_pending_challenge_for_gate`), `projection/turn_events.rs`, `tests/webui_v2_product_auth_4201.rs`, `docs/.../auth-product.md` | New Rust test: `AuthPromptView` round-trips with and without v2 fields. Integration test: BlockedAuth projection enriches when challenge present. |
+| **P2 UI dispatch + OAuth card** | ~150 JS | `gates.js`, `chat.js`, `auth-oauth-card.js`, (optional `useSSE.js`, `useChat.js`, `useChatEvents.js` for β) | Manual smoke against a stub backend; existing manual-token flow still green. |
+| **P3 Shared E2E fixtures** | ~400 Python | `tests/e2e/fixtures/mock_oauth_idp.py`, `mock_bearer_api.py`, `mock_notion_mcp.py`, `conftest.py` wiring | Each fixture self-test asserts /authorize + /token shapes. |
+| **P4 GitHub PAT E2E** | ~250 Python | `tests/e2e/scenarios/test_v2_github_pat_flow.py` | `pytest tests/e2e/scenarios/test_v2_github_pat_flow.py` green |
+| **P5 GSuite OAuth E2E** | ~300 Python | `tests/e2e/scenarios/test_v2_gsuite_oauth_flow.py` | green |
+| **P6 Notion MCP OAuth E2E** | ~350 Python | `tests/e2e/scenarios/test_v2_notion_mcp_oauth_flow.py` | green |
+
+**Total MVP:** ~150 Rust + ~150 JS + ~1300 Python ≈ **1600 LoC**.
+
+**PR slicing:**
+- **PR A** = P1 (wire). Backward compatible; merges with green CI even before WebUI changes.
+- **PR B** = P2 (WebUI). Depends on A.
+- **PR C** = P3 + P4 (fixtures + GitHub PAT E2E). First end-to-end proof.
+- **PR D** = P5 + P6 (GSuite + Notion E2E).
+
+**Parallelizable:** P3 can start in parallel with P1/P2.
+
+---
+
+## 5. Verification checklist (from issue 4112 acceptance)
+
+- [ ] User can start and complete GSuite OAuth, Notion MCP OAuth, and GitHub PAT auth from WebUI v2 without manual API calls → P2 + P4/P5/P6.
+- [ ] All three flows use the Reborn-native product-auth routes from #4031 → asserted in E2E by `page.on("request")` URL captures.
+- [ ] Each E2E drives the browser/WebUI path, not only `RebornProductAuthServices` helpers → Playwright-driven by construction.
+- [ ] Raw state, PKCE verifier, auth code, provider response bodies, access tokens, refresh tokens, secret handles, and PAT values never rendered in UI/SSE → leak-detector regex scan in each E2E.
+- [ ] Write-approval gate fires after auth → asserted in `test_v2_github_pat_flow.py::test_github_write_requires_approval`.
+- [ ] Multi-user isolation holds in browser E2E → asserted in `test_v2_gsuite_oauth_flow.py::test_per_user_isolation`.
+- [ ] No Notion native SDK integration (MCP only) → enforced by design — Notion E2E talks only to `mock_notion_mcp`.
+- [ ] No live Google/Notion/GitHub network calls → enforced by mock fixtures.
+- [ ] No second GSuite-specific OAuth route → enforced by P1 (reuse existing `oauth/start`).
+
+---
+
+## 6. Risks
+
+- **R1: P0 spike outcome.** If existing projection does NOT auto-clear the OAuth card on resume, β (new `AuthCompleted` event) is required and P2 grows by ~30 LoC. **Mitigation:** P0 is a 30-minute spike; gate P2 on its result.
+- **R2: `lookup_pending_challenge_for_gate` cross-store lookup.** Need to confirm the flow_manager + interaction_service are reachable from the projection's DI graph (`ProductAuthRouteState` carries them but `blocked_prompt_payload` is called from a separate path). **Mitigation:** verify by reading `crates/ironclaw_reborn_composition/src/projection/factory.rs` (or equivalent) during P1 hour-1; if not reachable, add the trait to the projection's existing service handle rather than threading a new dependency.
+- **R3: Notion MCP fixture parity.** MCP protocol is larger than HTTP Bearer. **Mitigation:** start with the minimum surface (`initialize`, `tools/list`, `tools/call` + OAuth handshake) needed by the issue; defer richer MCP features.
+- **R4: Browser E2E flakiness.** SSE timing + popup-window handoff are flake sources. **Mitigation:** Playwright `expect.poll()` with bounded timeouts; gate fixtures on health checks; mark E2E tests with `pytest.mark.slow` so they don't run on every PR.
+- **R5: Body-limit registry drift.** No new routes are added; the existing 16 KiB body limit covers all consumed paths. **No action needed.**
+
+---
+
+## 7. Files added/modified summary (MVP)
+
+**Modified (Rust)**
+- `crates/ironclaw_product_adapters/src/outbound.rs` — 5 optional fields on `AuthPromptView`, new `AuthPromptChallengeKind` enum.
+- `crates/ironclaw_reborn_composition/src/auth.rs` — `lookup_pending_challenge_for_gate` + `AuthChallengeProjection` redacted view.
+- `crates/ironclaw_reborn_composition/src/projection/turn_events.rs` — enrich `AuthPromptView` from lookup; (β) emit `AuthCompleted` on resume.
+- `crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs` — add wire-shape assertions for the new fields.
+- `docs/reborn/contracts/auth-product.md` — new "AuthPromptView v2 enrichment" section.
+
+**Modified (JS)**
+- `static/js/pages/chat/lib/gates.js` — read `challenge_kind`, `authorization_url`, `expires_at`.
+- `static/js/pages/chat/chat.js` — dispatch by `challengeKind`.
+- (β only) `static/js/pages/chat/hooks/useSSE.js`, `useChat.js`, `useChatEvents.js` — handle `auth_completed`.
+
+**Added (JS)**
+- `static/js/pages/chat/components/auth-oauth-card.js` — OAuthUrl UI.
+
+**Added (Python E2E)**
+- `tests/e2e/fixtures/mock_oauth_idp.py`
+- `tests/e2e/fixtures/mock_bearer_api.py`
+- `tests/e2e/fixtures/mock_notion_mcp.py`
+- `tests/e2e/conftest.py` — register new fixtures + `ironclaw_v2` handle.
+- `tests/e2e/scenarios/test_v2_github_pat_flow.py`
+- `tests/e2e/scenarios/test_v2_gsuite_oauth_flow.py`
+- `tests/e2e/scenarios/test_v2_notion_mcp_oauth_flow.py`
+
+---
+
+## 8. Deferred to follow-up tickets (NOT in 4112)
+
+- Account-selection UI card (`AccountSelectionRequired`) — file ticket `4112b`.
+- Reauthorize / setup-required UI cards — `4112b`.
+- Settings page for account list/refresh/disconnect — `4112c`.
+- Two-step `/manual-token/setup` + `/secret-submit` browser path — `4112d` (only needed if a non-gate-resume manual-token surface is added).
+- Google token refresh **implementation** (backend) — separate ticket, out of issue 4112 scope.
+- Live network tests with real credentials — out of scope.
+
+---
+
+## 9. Open questions for reviewer
+
+1. **P0 spike outcome** (α vs β) — should we add a dedicated `auth_completed` SSE event, or is the existing projection-update flip enough? **Recommendation:** spike before P1 lands.
+2. **`lookup_pending_challenge_for_gate` placement** — on `RebornProductAuthServices` directly, or behind a narrower projection trait? **Recommendation:** narrow trait so projection layer doesn't depend on the full auth service surface.
+3. **Provider naming on the wire.** `authorization_url` already carries an `AuthProviderId` internally — should the WebUI key off `provider` (string) or accept a typed discriminator? **Recommendation:** keep `provider: Option<String>` since `AuthProviderId` is a string newtype.
+4. **MVP scope confirmation.** This plan defers account-selection / reauth UI. Issue 4112 text does not require them in the chat-flow E2E, but the parent #4201 added the routes for a reason. Confirm they belong in a separate ticket.

--- a/docs/reborn/contracts/auth-product.md
+++ b/docs/reborn/contracts/auth-product.md
@@ -430,6 +430,52 @@ pretending cleanup succeeded.
 
 ---
 
+## Product Facing HTTP Surfaces (#4201)
+
+The Reborn composition mounts host-owned HTTP routes that enter
+`RebornProductAuthServices` (see
+`crates/ironclaw_reborn_composition/src/product_auth_serve.rs`). All mutation
+routes share the same `LocalGateway` + `BearerToken` + per-caller body and
+rate-limit posture as the original `oauth/start` route and derive
+`AuthProductScope` from the authenticated caller, never from caller-supplied
+tenant/user fields.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/reborn/product-auth/oauth/start` | Open an OAuth setup flow; returns redacted authorization URL + invocation scope. |
+| `GET`  | `/api/reborn/product-auth/oauth/callback/{flow_id}` | Public OAuth callback; validates scope/state hash before any product effect. |
+| `POST` | `/api/reborn/product-auth/manual-token/submit` | One-shot manual-token setup + secret-submit (legacy WebUI shape, compatibility). |
+| `POST` | `/api/reborn/product-auth/manual-token/setup` | Mint a manual-token interaction challenge; returns `interaction_id` + `invocation_id`. |
+| `POST` | `/api/reborn/product-auth/manual-token/secret-submit` | Submit the raw token for an existing `interaction_id`; model transcript, tool arguments, logs, and durable events only ever see the redacted `credential_submitted` / `auth_failed` projection. |
+| `POST` | `/api/reborn/product-auth/accounts/list` | List redacted credential account projections for a provider. |
+| `POST` | `/api/reborn/product-auth/accounts/select` | Select a single configured account by id; returns its redacted projection. |
+| `POST` | `/api/reborn/product-auth/accounts/recovery` | Project the stable recovery state for a provider (configured / setup_required / reauthorize_required / account_selection_required). |
+| `POST` | `/api/reborn/product-auth/accounts/refresh` | Refresh / reauthorize an account; returns `CredentialRefreshReport` + projected recovery state. |
+| `POST` | `/api/reborn/product-auth/lifecycle/cleanup` | Apply ownership-aware deactivate/uninstall cleanup for an extension; returns a redacted `SecretCleanupReport`. |
+
+Rules:
+
+- `secret-submit` is the only product-facing entry point for raw manual-token
+  material. The raw token never enters tool arguments, model transcript,
+  durable chat history, projections, debug output, or errors; only redacted
+  `credential_submitted` / `auth_failed` projections cross the boundary.
+- Manual-token setup and secret-submit are linked by `interaction_id` plus an
+  `invocation_id` round-tripped through the browser, matching the OAuth
+  start/callback pattern.
+- All routes project only adapter-safe DTOs (`CredentialAccountProjection`,
+  `CredentialAccountListPage`, `CredentialRecoveryProjection`,
+  `CredentialRefreshReport`, `SecretCleanupReport`). Raw secret handles,
+  backend error strings, and host paths must not be projected.
+- These routes are an explicit exemption from the "everything goes through
+  tools" `ToolDispatcher::dispatch()` invariant. Product-auth HTTP is a
+  host-owned auth/secret-ingress boundary: credential setup, secure
+  secret-submit, recovery, refresh, and lifecycle cleanup are not in-turn
+  tool calls and must not surface raw secrets through the model-visible tool
+  dispatch path. Routes still derive scope from authenticated caller context
+  and enter `RebornProductAuthServices`.
+
+---
+
 ## V1 Behavior Inventory
 
 | Product behavior | V1 evidence path | Reborn owner | First-slice status |


### PR DESCRIPTION
Design-only PR. Implements nothing yet — opens the design for review before code lands.

## What this is

Implementation design for #4112 (Reborn WebUI v2: GSuite OAuth + Notion MCP OAuth + GitHub PAT — browser E2E proof) stacked on top of #4245 (product-auth HTTP routes).

Doc: [`docs/reborn/2026-05-30-4112-webui-v2-auth-e2e-implementation.md`](docs/reborn/2026-05-30-4112-webui-v2-auth-e2e-implementation.md)

## Why design-first

The feature spans four layers (Rust wire-shape, Reborn projection, WebUI v2 JS, Python E2E + mock fixtures) and ~1600 LoC. Locking the wire contract and PR slicing before any code lands keeps reviewer load bounded.

## TL;DR

**Core finding:** WebUI v2's `gates.js` already reads `prompt.provider` and `prompt.account_label`, but the server's `AuthPromptView` (`crates/ironclaw_product_adapters/src/outbound.rs:539-545`) only emits `{turn_run_id, auth_request_ref, headline, body}`. There is no `authorization_url` on the wire at all, so OAuth flows cannot render.

**Fix shape:** additive optional fields on `AuthPromptView` (`Option<...>` + `skip_serializing_if`) so `Deserialize` round-trip stays backward-compatible for any consumer that persists or replays the event. Source the data via a new redacted lookup on `RebornProductAuthServices` (Option B in §2.1) rather than plumbing `AuthChallenge` through `TurnLifecycleEvent`.

**MVP scope (3 chat flows only):**
- `oauth_url` → new `auth-oauth-card.js` (GSuite + Notion).
- `manual_token` → existing `auth-token-card.js`, header copy becomes provider-aware.

**Deferred to follow-up tickets** (not on #4112's critical path): account-selection UI, reauth UI, settings page (list/refresh/disconnect), two-step `/manual-token/setup` + `/secret-submit` browser path.

## Phases & PR slicing

| Phase | LoC | PR |
|---|---|---|
| P0 — spike: does projection auto-clear OAuth card on resume? (α vs β) | 0 | — |
| P1 — Rust wire | ~150 | PR A |
| P2 — WebUI dispatch + OAuth card | ~150 | PR B |
| P3 — shared E2E fixtures (mock OAuth IDP, mock Bearer, mock Notion MCP) | ~400 | PR C |
| P4 — `test_v2_github_pat_flow.py` | ~250 | PR C |
| P5 — `test_v2_gsuite_oauth_flow.py` | ~300 | PR D |
| P6 — `test_v2_notion_mcp_oauth_flow.py` | ~350 | PR D |

## Key design decisions

1. **`AuthPromptView` additions are all `Option<...>` with `skip_serializing_if`** — not a flattened tagged enum. Forward+backward compatible.
2. **Lookup-at-projection (Option B)** over extending `TurnLifecycleEvent` — event-row schema change is too high blast radius for one consumer.
3. **Keep existing `/manual-token/submit`** for chat-flow gate-resume. The new `/setup` + `/secret-submit` two-step from #4245 is for an out-of-band ingress surface, not the chat path.
4. **`AuthPromptChallengeKind::Other` catch-all** so projection can enrich `AccountSelectionRequired`/`Reauthorize`/`SetupRequired` without breaking UI.
5. **Approval gate after auth** already wired — no new code, E2E just drives it.

## Open questions for reviewer (also in §9 of the doc)

1. **P0 spike outcome** — α (reuse existing `projection_update` status flip) or β (new `auth_completed` SSE event)?
2. **`lookup_pending_challenge_for_gate` placement** — directly on `RebornProductAuthServices` or behind a narrower projection trait?
3. **Provider wire type** — `provider: Option<String>` vs typed `AuthProviderId` newtype?
4. **MVP scope confirmation** — should account-selection / reauth UI be in this ticket or follow-up?

## Acceptance coverage (from issue #4112)

The design's §5 maps each acceptance criterion to a phase. Browser E2E asserts:
- All three flows use Reborn-native product-auth routes from #4031 (URL captures via `page.on("request")`).
- Each E2E drives the browser path, not service helpers (Playwright by construction).
- No raw `state` / PKCE verifier / auth code / access token / refresh token / secret handle / PAT in UI/SSE/DOM/`localStorage` (`leak_detector::GITHUB_PAT_REGEX` scan + manual regex set).
- Write-approval gate fires post-auth.
- Multi-user isolation.

## Out of scope (per #4112)

- Google token refresh **implementation** (backend).
- Live Google/Notion/GitHub network calls with real credentials.
- Second GSuite-specific OAuth route.
- Notion native SDK integration (MCP is the integration surface).

## Notes for reviewers

- Base is `codex/issue-4201-product-auth-http` (PR #4245). Once #4245 merges, this PR's base will need to flip to `reborn-integration`.
- No FEATURE_PARITY.md update needed yet — code lands in PR A onward.
- No tests in this PR. Tests are introduced phase-by-phase per §4.

Refs: #4112, #4245
