### PR TITLE
Add trigger trusted ingress contract

### DIFF
--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -63,10 +63,11 @@ PRs should record them as contract language.
    `adapter_kind`, `external_actor_ref`, `external_conversation_ref`, and
    `external_event_id` values, but not rely on a raw reserved string alone for
    trust.
-3. Trusted trigger scope flows through
-   `handle_inbound_turn_with_trusted_scope` parameters. Synthetic trigger
-   requests should not carry normal untrusted requested scope hints as the
-   authority source.
+3. Trusted trigger scope flows through a planned typed
+   `handle_inbound_turn_with_trusted_scope` request bundling host-owned
+   `tenant_id`, `creator_user_id`, `agent_id`, and `project_id` authority.
+   Synthetic trigger requests should not carry normal untrusted requested scope
+   hints as the authority source.
 4. V1 `TriggerRunStatus` stays synchronous: `Ok` means submitted, `Error` means
    submission failed. `ApprovalBlocked` and `TimedOut` are fast-follow unless a
    later PR explicitly wires turn-lifecycle observation.
@@ -122,14 +123,15 @@ Trigger execution track
   PR 2 ─> PR 8 Trusted Inbound Facade ─> PR 9 ironclaw_triggers Crate Skeleton
                                            └─> PR 10 Trigger Persistence, Backend 1
                                                 └─> PR 11 Trigger Persistence, Backend 2 and Parity
-                                                     └─> PR 12 Materialization and Back-Pressure Seams
-                                                          └─> PR 13 Trigger Poller Core
-                                                               └─> PR 14 Poller Caller-Level Harness
-                                                                    ├─> PR 15 trigger_* First-Party Capabilities
-                                                                    └─> PR 16 Trigger Composition and Worker Lifecycle
+                                                     └─> PR 12 Atomic Fire Claim and Active-Run Lease
+                                                          └─> PR 13 Materialization and Turn-State Seams
+                                                               └─> PR 14 Trigger Poller Core
+                                                                    └─> PR 15 Poller Caller-Level Harness
+                                                                         ├─> PR 16 trigger_* First-Party Capabilities
+                                                                         └─> PR 17 Trigger Composition and Worker Lifecycle
 
 External trigger result delivery
-  PR 7 + PR 16 + named adapter readiness ─> PR 17 Trigger Delivery Integration Fast-Follow
+  PR 7 + PR 17 + named adapter readiness ─> PR 18 Trigger Delivery Integration Fast-Follow
 ```
 
 Parallelization notes:
@@ -141,25 +143,27 @@ Parallelization notes:
 - After PR 2 merges, PR 8 can proceed without waiting for delivery work.
 - PR 4 and PR 8 can run in parallel because they touch different crates and
   solve different prerequisites.
-- PR 5/6/7 are delivery-only. They do not block PR 9 through PR 16 unless the
+- PR 5/6/7 are delivery-only. They do not block PR 9 through PR 17 unless the
   chosen milestone is "trigger result is pushed externally" rather than
   "trigger event fires and creates a persisted thread."
 - PR 10 and PR 11 are serial if PR 11 is the parity backend, but they can be
   reversed if backend ownership prefers implementing libSQL first or PostgreSQL
   first.
-- PR 15 and PR 16 can start from the same post-PR14 baseline, but they should
+- PR 12 must land after both persistence backends because atomic claim/lease
+  semantics need PostgreSQL/libSQL parity before the poller depends on them.
+- PR 16 and PR 17 can start from the same post-PR15 baseline, but they should
   merge carefully because both need repository/config wiring from composition.
-- PR 17 should remain fast-follow until PR 7 is merged and a concrete outbound
+- PR 18 should remain fast-follow until PR 7 is merged and a concrete outbound
   adapter path is declared ready.
 
 Milestone gates:
 
 - **Trigger event MVP:** PR 2, PR 8, PR 9, PR 10, PR 11, PR 12, PR 13, PR 14,
-  and PR 16. PR 15 is required if the MVP includes user-facing `trigger_*`
+  PR 15, and PR 17. PR 16 is required if the MVP includes user-facing `trigger_*`
   management rather than seeded/test-created triggers.
-- **User-managed trigger MVP:** Trigger event MVP plus PR 15.
+- **User-managed trigger MVP:** Trigger event MVP plus PR 16.
 - **Externally delivered trigger result:** User-managed trigger MVP plus PR 1,
-  PR 3, PR 4, PR 5, PR 6, PR 7, and PR 17.
+  PR 3, PR 4, PR 5, PR 6, PR 7, and PR 18.
 
 ## PR Sequence
 
@@ -188,7 +192,8 @@ Expected size: docs only.
 Ratify trigger-specific contract changes before code:
 
 - Add host-trusted inbound ingress semantics to `conversation-binding.md`.
-- Define `InboundTurnService::handle_inbound_turn_with_trusted_scope`.
+- Define planned `InboundTurnService::handle_inbound_turn_with_trusted_scope`
+  and its typed trusted request.
 - Define every synthetic `InboundTurnRequest` field used by trigger fires:
   `adapter_kind`, `external_actor_ref`, `external_conversation_ref`,
   `external_event_id`, route kind, actor, content ref, and scope flow.
@@ -312,9 +317,13 @@ and adapter call sites heavily.
 
 ### PR 8 — Trusted Inbound Facade
 
-Implement `InboundTurnService::handle_inbound_turn_with_trusted_scope` in
+Implement the planned
+`InboundTurnService::handle_inbound_turn_with_trusted_scope` facade in
 `ironclaw_conversations` after PR 2:
 
+- Add a typed trusted request shape that bundles the ordinary inbound request
+  with host-owned `tenant_id`, `creator_user_id`, `agent_id`, and `project_id`
+  authority.
 - Keep replay lookup first, exactly like `handle_inbound_turn`, so duplicate
   scheduled-slot retries hit existing inbound idempotency.
 - Route fresh binding resolution through
@@ -350,6 +359,9 @@ Add the trigger crate with domain and in-memory behavior:
 Include unit tests for schedule validation, serde, and deterministic fire
 identity. Include tests proving expressions with sub-minute cadence are
 rejected. The workspace already has `cron = "0.13"` available.
+Identity derivation must use the contract's length-prefixed, domain-separated,
+collision-resistant digest over `(tenant_id, trigger_id, fire_slot)`; do not
+use raw string concatenation.
 
 Expected size: less than 1000 lines.
 
@@ -359,6 +371,8 @@ Add the first durable `TriggerRepository` backend:
 
 - migrations/schema for one chosen backend
 - composite poller index on `(tenant_id, enabled, state, next_run_at)`
+- `active_fire_slot` and `active_run_ref` persistence fields separate from
+  `last_status`
 - due-trigger query with limit
 - scoped list/remove behavior
 - backend-specific tests
@@ -371,32 +385,55 @@ Add the second required backend and parity coverage:
 
 - migrations/schema for the second backend
 - shared parity tests across both backends
+- parity for active-fire fields and retryable `next_run_at` behavior
 - any schema compatibility fixes from PR 10
 
 Expected size: less than 1000 lines.
 
-### PR 12 — Trigger Materialization and Back-Pressure Seams
+### PR 12 — Atomic Fire Claim and Active-Run Lease
+
+Add the repository-level claim/lease seam that makes
+`max_concurrent_fires_per_trigger = 1` enforceable across concurrent pollers:
+
+- atomic `claim_due_fire`-style operation that covers due-row read, trigger
+  state check, active-fire check, and claim write in one database transaction or
+  equivalent backend primitive.
+- claim writes `active_fire_slot` / `active_run_ref` only after a fire is
+  accepted/submitted, and never uses `last_status` as the in-flight sentinel.
+- retryable submit failure keeps `last_fired_slot` unchanged, leaves active
+  claim unset, and keeps `next_run_at` at or before the failed slot's scheduled
+  time.
+- duplicate replay for the same fire identity returns the original accepted
+  message and turn submission; terminal run failure does not mint a second V1
+  turn for the same fire slot.
+- PostgreSQL/libSQL parity tests for concurrent claim attempts and retryable
+  failure bookkeeping.
+
+Expected size: less than 1000 lines; split backend-specific claim
+implementation if needed.
+
+### PR 13 — Trigger Materialization and Turn-State Seams
 
 Add the narrow ports/helpers the poller needs before the worker implementation:
 
 - deterministic trigger prompt materialization into the inbound content-ref
   model without letting `ironclaw_triggers` reach into composition or product
   adapters.
-- active-run counting/back-pressure seam for threads belonging to a trigger.
-  V1 policy is exactly one active fire per trigger; later concurrency can be an
-  explicit config expansion.
+- turn-state lookup/clear seam for the active-fire claim. V1 policy is exactly
+  one active fire per trigger; later concurrency can be an explicit config
+  expansion.
 - tests for both seams at the owning crate boundary.
 
 Expected size: less than 800 lines.
 
-### PR 13 — Trigger Poller Core
+### PR 14 — Trigger Poller Core
 
 Implement `TriggerPollerWorker` core logic:
 
 - poll due schedule triggers
 - cap fires per tick
-- apply per-trigger active-run back-pressure with
-  `max_concurrent_fires_per_trigger = 1`
+- apply per-trigger active-run back-pressure by using the repository atomic
+  fire-claim seam, not an in-memory `last_status` check
 - construct deterministic synthetic `InboundTurnRequest`
 - call `handle_inbound_turn_with_trusted_scope`
 - persist synchronous submit status and next-run bookkeeping
@@ -407,7 +444,7 @@ the lifecycle observer in V1.
 
 Expected size: less than 1000 lines.
 
-### PR 14 — Trigger Poller Caller-Level Harness
+### PR 15 — Trigger Poller Caller-Level Harness
 
 Add the heavier caller-level tests separately from the worker core:
 
@@ -418,10 +455,14 @@ Add the heavier caller-level tests separately from the worker core:
 - active-run back-pressure behavior
 - proof that a second due fire is skipped while one fire for the same trigger
   is active
+- concurrent poller claim attempts cannot both submit the same trigger/slot
+- retryable submit failure leaves `next_run_at` retryable
+- terminal run failure for an already accepted/submitted slot does not mint a
+  second V1 turn for the same fire identity
 
 Expected size: less than 1000 lines; split further if the harness grows.
 
-### PR 15 — `trigger_*` First-Party Capabilities
+### PR 16 — `trigger_*` First-Party Capabilities
 
 Expose trigger management through the composition-owned first-party capability
 registry, not local-dev synthetic capabilities:
@@ -439,7 +480,7 @@ do not assume `InvocationServices` already carries a trigger repository.
 
 Expected size: less than 1000 lines.
 
-### PR 16 — Trigger Composition and Worker Lifecycle
+### PR 17 — Trigger Composition and Worker Lifecycle
 
 Wire the trigger poller into Reborn composition:
 
@@ -454,7 +495,7 @@ Wire the trigger poller into Reborn composition:
 
 Expected size: less than 1000 lines; split into config and lifecycle if needed.
 
-### PR 17 — Trigger Delivery Integration Fast-Follow
+### PR 18 — Trigger Delivery Integration Fast-Follow
 
 Only after delivery-resolution PRs are merged and a concrete adapter path is
 ready, connect trigger-origin final reply delivery:

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -128,7 +128,7 @@ Delivery track
              ├─> PR 4 Communication Preferences Store
              └───────────────┐
   PR 4 ──────────────────────┴─> PR 5 Outbound Resolution Engine
-                                     └─> PR 6 Outbound Validation Bridge
+                                     └─> PR 6 Outbound Validation Integration
                                           └─> PR 7 Product Outbound Orchestration
 
 Trigger execution track
@@ -318,7 +318,7 @@ the selected target is missing or revoked, P0 fails closed; no implicit fallback
 
 Expected size: less than 900 lines.
 
-### PR 6 — Outbound Validation Bridge
+### PR 6 — Outbound Validation Integration
 
 Connect resolved candidates to existing outbound validation without touching
 adapter transport rendering:
@@ -337,7 +337,7 @@ Expected size: less than 1000 lines.
 ### PR 7 — Product Outbound Orchestration
 
 Wire the host/composition-side outbound orchestration point for a named real
-adapter path. Do not treat the current WebUI projection bridge as the outbound
+adapter path. Do not treat the current WebUI projection path as the outbound
 orchestration path unless this PR explicitly refactors it to enter
 `ironclaw_outbound`.
 
@@ -348,7 +348,7 @@ orchestration path unless this PR explicitly refactors it to enter
 - Name the concrete first path being wired and keep adapter-specific behavior
   behind adapter capability/validation boundaries.
 - Keep WebUI projection envelopes separate from product outbound delivery
-  unless the PR deliberately routes that bridge through the same outbound
+  unless the PR deliberately routes that path through the same outbound
   policy service.
 
 Expected size: less than 1000 lines; split if this touches both composition
@@ -572,7 +572,7 @@ Only after delivery-resolution PRs are merged and a concrete adapter path is
 ready, connect trigger-origin final reply delivery:
 
 - name the first real adapter path and readiness gate. Do not use the WebUI
-  projection bridge as a stand-in unless it is explicitly routed through
+  projection path as a stand-in unless it is explicitly routed through
   `ironclaw_outbound`.
 - construct `RunNotificationOrigin::Triggered`.
 - construct `RunNotificationOrigin::TriggeredFromSourceRoute` when a trigger

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -55,9 +55,11 @@ through trusted ingress, runs in a dedicated thread, and persists the result.
 These decisions are now locked for the first implementation pass; the two doc
 PRs should record them as contract language.
 
-1. PR 1 and PR 2 are parallel contract tracks. If we choose a single first PR,
-   prioritize PR 2 because trusted ingress is the hard prerequisite for trigger
-   execution.
+1. PR 1 and PR 2 are parallel contract tracks, but PR 2 is the sole owner of
+   trusted-ingress semantics and trigger-boundary changes in
+   `conversation-binding.md`. PR 1 stays outbound/reply-target only. If we
+   choose a single first PR, prioritize PR 2 because trusted ingress is the hard
+   prerequisite for trigger execution.
 2. Trigger fires need a host-internal ingress representation that product
    adapters cannot construct. The contract must define deterministic
    `adapter_kind`, `external_actor_ref`, `external_conversation_ref`, and
@@ -83,11 +85,14 @@ PRs should record them as contract language.
    adapters, or transcript internals directly.
 8. V1 active-run back-pressure is required:
    `max_concurrent_fires_per_trigger = 1`. A trigger skips a tick while its
-   previous fire is still active.
+   previous fire is still active. This is enforced by an atomic repository
+   claim/lease plus turn-state lookup, not by `last_status` or an in-memory
+   poller counter.
 9. `trigger_create`, `trigger_list`, and `trigger_remove` are required
-   user-facing first-party capabilities, registered through the
-   composition-owned first-party registry and available in local-dev and
-   production.
+   user-facing first-party capabilities, registered first in
+   `ironclaw_host_runtime::first_party_tools` and then consumed by composition.
+   The host-runtime package, handlers, and registry entries must stay in
+   lockstep.
 10. Trigger poll settings are composition-owned, and V1 schedules must reject
     sub-minute cadence. No trigger may fire more frequently than once per
     minute.
@@ -98,6 +103,13 @@ PRs should record them as contract language.
     policy. Approval/auth prompt delivery must resolve through exact-owner
     prompt targets first; requested outbound may only apply to ordinary
     non-authority delivery or narrow to the same exact-owner prompt target.
+13. Trigger fires bypass `ironclaw_product_workflow` ingress entirely. Product
+    workflow remains adapter-facing; scheduled triggers enter only through the
+    planned `ironclaw_conversations::InboundTurnService` trusted facade.
+14. The sealed host-trusted ingress marker and witness are owned by
+    `ironclaw_conversations::trusted_ingress`; host composition constructs them
+    for trigger submission. Product adapters must not receive constructors or
+    model them in product payload DTOs.
 
 ## Dependency DAG
 
@@ -121,17 +133,18 @@ Delivery track
 
 Trigger execution track
   PR 2 ─> PR 8 Trusted Inbound Facade ─> PR 9 ironclaw_triggers Crate Skeleton
-                                           └─> PR 10 Trigger Persistence, Backend 1
-                                                └─> PR 11 Trigger Persistence, Backend 2 and Parity
-                                                     └─> PR 12 Atomic Fire Claim and Active-Run Lease
-                                                          └─> PR 13 Materialization and Turn-State Seams
-                                                               └─> PR 14 Trigger Poller Core
-                                                                    └─> PR 15 Poller Caller-Level Harness
-                                                                         ├─> PR 16 trigger_* First-Party Capabilities
-                                                                         └─> PR 17 Trigger Composition and Worker Lifecycle
+                                           └─> PR 10 Trigger Persistence Model and Backend 1
+                                                └─> PR 11 Trigger Persistence Backend 2 and Parity
+                                                     └─> PR 12 Atomic Fire Claim API
+                                                          └─> PR 13 Atomic Claim Backend Implementations
+                                                               └─> PR 14 Materialization and Turn-State Seams
+                                                                    └─> PR 15 Trigger Poller Core
+                                                                         └─> PR 16 Poller Caller-Level Harness
+                                                                              ├─> PR 17 trigger_* First-Party Capabilities
+                                                                              └─> PR 18 Trigger Worker Config and Lifecycle
 
 External trigger result delivery
-  PR 7 + PR 17 + named adapter readiness ─> PR 18 Trigger Delivery Integration Fast-Follow
+  PR 7 + PR 18 + named adapter readiness ─> PR 19 Trigger Delivery Integration Fast-Follow
 ```
 
 Parallelization notes:
@@ -143,27 +156,28 @@ Parallelization notes:
 - After PR 2 merges, PR 8 can proceed without waiting for delivery work.
 - PR 4 and PR 8 can run in parallel because they touch different crates and
   solve different prerequisites.
-- PR 5/6/7 are delivery-only. They do not block PR 9 through PR 17 unless the
+- PR 5/6/7 are delivery-only. They do not block PR 9 through PR 18 unless the
   chosen milestone is "trigger result is pushed externally" rather than
   "trigger event fires and creates a persisted thread."
 - PR 10 and PR 11 are serial if PR 11 is the parity backend, but they can be
   reversed if backend ownership prefers implementing libSQL first or PostgreSQL
   first.
-- PR 12 must land after both persistence backends because atomic claim/lease
-  semantics need PostgreSQL/libSQL parity before the poller depends on them.
-- PR 16 and PR 17 can start from the same post-PR15 baseline, but they should
+- PR 12 and PR 13 must land after both persistence backends because atomic
+  claim/lease semantics need PostgreSQL/libSQL parity before the poller depends
+  on them.
+- PR 17 and PR 18 can start from the same post-PR16 baseline, but they should
   merge carefully because both need repository/config wiring from composition.
-- PR 18 should remain fast-follow until PR 7 is merged and a concrete outbound
+- PR 19 should remain fast-follow until PR 7 is merged and a concrete outbound
   adapter path is declared ready.
 
 Milestone gates:
 
 - **Trigger event MVP:** PR 2, PR 8, PR 9, PR 10, PR 11, PR 12, PR 13, PR 14,
-  PR 15, and PR 17. PR 16 is required if the MVP includes user-facing `trigger_*`
+  PR 15, PR 16, and PR 18. PR 17 is required if the MVP includes user-facing `trigger_*`
   management rather than seeded/test-created triggers.
-- **User-managed trigger MVP:** Trigger event MVP plus PR 16.
+- **User-managed trigger MVP:** Trigger event MVP plus PR 17.
 - **Externally delivered trigger result:** User-managed trigger MVP plus PR 1,
-  PR 3, PR 4, PR 5, PR 6, PR 7, and PR 18.
+  PR 3, PR 4, PR 5, PR 6, PR 7, and PR 19.
 
 ## PR Sequence
 
@@ -179,8 +193,10 @@ Promote the delivery-resolution design into Reborn contracts before code:
 - Update auth/product runtime contracts to state that auth prompt notification
   is separate from auth-flow creation, callback handling, credential exchange,
   and token storage.
-- Update `conversation-binding.md` to keep reply-target binding semantics
-  distinct from synthetic trigger ingress identity.
+- Update `conversation-binding.md` only for reply-target binding semantics that
+  are needed by outbound delivery; all trusted-ingress semantics belong to PR 2.
+- Update `runtime-workflows.md` where needed so approval/auth prompt delivery
+  ownership is reflected in the runtime interaction loop contracts.
 - Define the typed resolution envelope, preference fields, and deterministic P0
   order before implementation so PR 3 and PR 5 do not reinterpret prompt
   authority, trigger/source-route precedence, or system-event behavior.
@@ -199,11 +215,12 @@ Ratify trigger-specific contract changes before code:
   `external_event_id`, route kind, actor, content ref, and scope flow.
 - Specify that host-internal ingress values are type-sealed or otherwise
   unconstructible by product adapters, not merely conventional reserved strings.
-- Add a trigger-system contract covering `TriggerRecord`,
+- Update and promote `docs/reborn/contracts/triggers.md` as the only
+  trigger-system contract source of truth, covering `TriggerRecord`,
   `TriggerSourceProvider`, `TriggerFireIdentity`, poller semantics,
   deterministic-slot idempotency, and scope rules.
-- Decide whether post-run `ApprovalBlocked` / `TimedOut` status updates are V1
-  or fast-follow.
+- State that post-run `ApprovalBlocked` / `TimedOut` status updates are
+  fast-follow in V1.
 - State the V1 schedule granularity rule: cron and other schedule providers
   must reject schedules that can fire more frequently than once per minute.
 
@@ -256,9 +273,26 @@ operator/user-settings shaped and not tenant/user typed delivery policy.
 Imitate the DB store pattern where useful, but keep communication preferences a
 typed outbound-owned repository.
 
+The repository, DTOs, and backend/migration code live under the
+`ironclaw_outbound` ownership boundary, not `src/db` generic settings. Backend
+integration may reuse workspace migration conventions, but schema ownership and
+tests belong with the outbound crate/module that owns communication policy.
+
+Existing `ThreadNotificationPolicy` remains thread-scoped push policy for
+projection subscriptions and legacy thread notifications. Tenant/user
+communication preferences are a separate candidate-source layer. PR 5 must
+define precedence explicitly: authority-bearing prompt preferences are
+consulted first; explicit requested outbound and source-route rules follow the
+delivery-resolution contract; thread policy can suppress push attempts for
+ordinary progress/final reply notifications but must not grant authority or
+retarget approval/auth prompts.
+
 The repository fields should map directly to the delivery contract names:
 `final_reply_target`, `progress_target`, `approval_prompt_target`,
 `auth_prompt_target`, and `default_modality`.
+`final_reply_target` is the canonical schema/DTO name; any plural
+`final_replies_target` wording in older specs should be treated as legacy
+terminology and normalized before implementation.
 
 Expected size: less than 1000 lines. If PostgreSQL + libSQL parity pushes past
 the line budget, split this into model/trait + first backend, then second
@@ -302,8 +336,10 @@ Expected size: less than 1000 lines.
 
 ### PR 7 — Product Outbound Orchestration
 
-Wire the host/composition-side outbound orchestration point that currently
-builds product outbound envelopes:
+Wire the host/composition-side outbound orchestration point for a named real
+adapter path. Do not treat the current WebUI projection bridge as the outbound
+orchestration path unless this PR explicitly refactors it to enter
+`ironclaw_outbound`.
 
 - Own the sequence
   `resolve candidate -> prepare delivery attempt -> adapter render_outbound`.
@@ -311,6 +347,9 @@ builds product outbound envelopes:
   lookup.
 - Name the concrete first path being wired and keep adapter-specific behavior
   behind adapter capability/validation boundaries.
+- Keep WebUI projection envelopes separate from product outbound delivery
+  unless the PR deliberately routes that bridge through the same outbound
+  policy service.
 
 Expected size: less than 1000 lines; split if this touches both composition
 and adapter call sites heavily.
@@ -324,6 +363,12 @@ Implement the planned
 - Add a typed trusted request shape that bundles the ordinary inbound request
   with host-owned `tenant_id`, `creator_user_id`, `agent_id`, and `project_id`
   authority.
+- Add `ironclaw_conversations::trusted_ingress` sealed marker/witness types and
+  constructors. Host composition can construct them for scheduled triggers;
+  product adapters cannot model or construct them.
+- Trigger fires call only this `ironclaw_conversations` facade. They must not
+  pass through `ironclaw_product_workflow::InboundTurnService`, which remains
+  adapter-facing.
 - Keep replay lookup first, exactly like `handle_inbound_turn`, so duplicate
   scheduled-slot retries hit existing inbound idempotency.
 - Route fresh binding resolution through
@@ -365,10 +410,12 @@ use raw string concatenation.
 
 Expected size: less than 1000 lines.
 
-### PR 10 — Trigger Persistence, Backend 1
+### PR 10 — Trigger Persistence Model and Backend 1
 
 Add the first durable `TriggerRepository` backend:
 
+- repository trait methods for create/list/remove, due-trigger lookup, and
+  submit-result bookkeeping, but not the atomic claim API yet
 - migrations/schema for one chosen backend
 - composite poller index on `(tenant_id, enabled, state, next_run_at)`
 - `active_fire_slot` and `active_run_ref` persistence fields separate from
@@ -390,16 +437,32 @@ Add the second required backend and parity coverage:
 
 Expected size: less than 1000 lines.
 
-### PR 12 — Atomic Fire Claim and Active-Run Lease
+### PR 12 — Atomic Fire Claim API
 
-Add the repository-level claim/lease seam that makes
+Add the backend-agnostic repository claim/lease API that makes
 `max_concurrent_fires_per_trigger = 1` enforceable across concurrent pollers:
 
-- atomic `claim_due_fire`-style operation that covers due-row read, trigger
-  state check, active-fire check, and claim write in one database transaction or
-  equivalent backend primitive.
-- claim writes `active_fire_slot` / `active_run_ref` only after a fire is
-  accepted/submitted, and never uses `last_status` as the in-flight sentinel.
+- `claim_due_fire`-style request/response types and trait method.
+- claim operation contract covers due-row read, trigger state check,
+  active-fire check, and claim write in one database transaction or equivalent
+  backend primitive.
+- explicit submit-result update methods for accepted, replayed, retryable
+  failed, and permanent failed outcomes.
+- write-order contract for `last_run_at`, `last_fired_slot`, `last_status`,
+  `next_run_at`, `active_fire_slot`, and `active_run_ref`.
+- active-fire claim never uses `last_status` as the in-flight sentinel.
+
+Expected size: less than 600 lines.
+
+### PR 13 — Atomic Claim Backend Implementations
+
+Implement the atomic claim API for both durable backends:
+
+- PostgreSQL implementation with transaction/row-lock or compare-and-swap
+  semantics.
+- libSQL implementation with equivalent transaction/compare-and-swap semantics.
+- in-memory implementation only for tests; it is not proof of the durable
+  invariant.
 - retryable submit failure keeps `last_fired_slot` unchanged, leaves active
   claim unset, and keeps `next_run_at` at or before the failed slot's scheduled
   time.
@@ -409,24 +472,26 @@ Add the repository-level claim/lease seam that makes
 - PostgreSQL/libSQL parity tests for concurrent claim attempts and retryable
   failure bookkeeping.
 
-Expected size: less than 1000 lines; split backend-specific claim
-implementation if needed.
+Expected size: less than 1000 lines; split by backend if implementation or
+tests exceed the line budget.
 
-### PR 13 — Trigger Materialization and Turn-State Seams
+### PR 14 — Trigger Materialization and Turn-State Seams
 
 Add the narrow ports/helpers the poller needs before the worker implementation:
 
-- deterministic trigger prompt materialization into the inbound content-ref
-  model without letting `ironclaw_triggers` reach into composition or product
-  adapters.
-- turn-state lookup/clear seam for the active-fire claim. V1 policy is exactly
-  one active fire per trigger; later concurrency can be an explicit config
-  expansion.
+- `ironclaw_triggers` owns the prompt-materialization port trait and asks for an
+  inbound content ref. Composition provides the adapter from trigger prompt data
+  to the conversation/thread content-ref boundary.
+- `ironclaw_triggers` owns the active-fire clear request type, but the concrete
+  turn-state lookup adapter is supplied by composition over `ironclaw_turns` /
+  turn-persistence APIs. It is not a trigger-local counter.
+- V1 policy is exactly one active fire per trigger; later concurrency can be an
+  explicit config expansion.
 - tests for both seams at the owning crate boundary.
 
 Expected size: less than 800 lines.
 
-### PR 14 — Trigger Poller Core
+### PR 15 — Trigger Poller Core
 
 Implement `TriggerPollerWorker` core logic:
 
@@ -439,12 +504,11 @@ Implement `TriggerPollerWorker` core logic:
 - persist synchronous submit status and next-run bookkeeping
 - preserve replay safety across crash retry or dual poller attempts
 
-Keep post-run async statuses fast-follow unless PR 2 explicitly chooses to wire
-the lifecycle observer in V1.
+Keep post-run async statuses fast-follow.
 
 Expected size: less than 1000 lines.
 
-### PR 15 — Trigger Poller Caller-Level Harness
+### PR 16 — Trigger Poller Caller-Level Harness
 
 Add the heavier caller-level tests separately from the worker core:
 
@@ -462,17 +526,20 @@ Add the heavier caller-level tests separately from the worker core:
 
 Expected size: less than 1000 lines; split further if the harness grows.
 
-### PR 16 — `trigger_*` First-Party Capabilities
+### PR 17 — `trigger_*` First-Party Capabilities
 
-Expose trigger management through the composition-owned first-party capability
-registry, not local-dev synthetic capabilities:
+Expose trigger management through the host-runtime first-party capability
+registry first, not local-dev synthetic capabilities:
 
 - `trigger_create`
 - `trigger_list`
 - `trigger_remove`
-- package/registry declarations
-- production wiring checks
-- tests that capability IDs are present in both package manifest and registry
+- package declarations in `ironclaw_host_runtime::first_party_tools`
+- handler registration in `ironclaw_host_runtime::first_party_tools`
+- `FirstPartyCapabilityRegistry` entries in `ironclaw_host_runtime`
+- production composition wiring that injects the trigger repository dependency
+- tests that capability IDs are present in package manifest, handlers, and
+  registry
 
 Scope must be stamped from invocation context and rechecked on list/remove.
 Repository access must be injected through an explicit composition-owned seam;
@@ -480,14 +547,18 @@ do not assume `InvocationServices` already carries a trigger repository.
 
 Expected size: less than 1000 lines.
 
-### PR 17 — Trigger Composition and Worker Lifecycle
+### PR 18 — Trigger Worker Config and Lifecycle
 
 Wire the trigger poller into Reborn composition:
 
-- config ownership for poll interval, fires per tick, and per-trigger active-run
-  cap. V1 default and maximum for per-trigger active fires is 1.
-- second background-worker handle or a background-task bundle
-- startup/shutdown behavior alongside `TurnRunnerWorker`
+- a dedicated `TriggerPollerWorkerConfig` or equivalent composition-owned type
+  for poll interval, fires per tick, and per-trigger active-run cap. Do not
+  reuse `RebornRuntimeInput::PollSettings`, which is request-completion polling.
+- background task bundle or worker-supervisor type that owns both turn-runner
+  and trigger-poller handles, cancellation, await/shutdown ordering, and panic
+  or early-exit reporting.
+- readiness semantics for whether a disabled trigger poller is allowed and
+  whether a failed trigger worker marks Reborn runtime readiness degraded.
 - architecture tests for `ironclaw_triggers` dependency edges
 - current architecture map update
 - `FEATURE_PARITY.md` update with a distinct Reborn trigger-loop note rather
@@ -495,12 +566,14 @@ Wire the trigger poller into Reborn composition:
 
 Expected size: less than 1000 lines; split into config and lifecycle if needed.
 
-### PR 18 — Trigger Delivery Integration Fast-Follow
+### PR 19 — Trigger Delivery Integration Fast-Follow
 
 Only after delivery-resolution PRs are merged and a concrete adapter path is
 ready, connect trigger-origin final reply delivery:
 
-- name the first adapter path and readiness gate.
+- name the first real adapter path and readiness gate. Do not use the WebUI
+  projection bridge as a stand-in unless it is explicitly routed through
+  `ironclaw_outbound`.
 - construct `RunNotificationOrigin::Triggered`.
 - construct `RunNotificationOrigin::TriggeredFromSourceRoute` when a trigger
   run also has a live source route, and verify live source route precedence.
@@ -533,3 +606,10 @@ Reborn code. Their main findings are incorporated above:
 - Communication preferences should be DB-backed from day one as a typed
   tenant/user repository, not stored in legacy profile/TOML config or generic
   JSON settings.
+- Trigger fires bypass product-workflow ingress and use only the conversations
+  trusted inbound facade.
+- Atomic fire claim APIs, durable backend implementations, and poller harnesses
+  are separate slices to keep the line budget realistic.
+- Trigger worker configuration must be distinct from request-completion
+  `PollSettings`, and worker supervision needs explicit shutdown/readiness
+  semantics.

--- a/docs/reborn/2026-04-25-current-architecture-map.md
+++ b/docs/reborn/2026-04-25-current-architecture-map.md
@@ -33,6 +33,7 @@ docs/reborn/contracts/settings-config.md
 docs/reborn/contracts/turns-agent-loop.md
 docs/reborn/contracts/turn-persistence.md
 docs/reborn/contracts/conversation-binding.md
+docs/reborn/contracts/triggers.md
 docs/reborn/contracts/migration-compatibility.md
 ```
 
@@ -43,6 +44,11 @@ https://github.com/nearai/ironclaw/issues/2987
 ```
 
 These docs record the delegation-ready system decisions: kernel as security perimeter, loops/userland running on the kernel surface, first-class optional `AgentId`, hybrid storage placement, typed repositories for structured state, split memory services over shared backends, durable event streams with replay cursors, all built-in obligations for V1, all three runtime lanes as first-class, and schema reuse where viable.
+
+Trigger system status: `[planned]`. The contract is frozen in
+`docs/reborn/contracts/triggers.md`; the `ironclaw_triggers` crate, durable
+repositories, poller, and first-party `trigger_*` capabilities are planned
+follow-up slices.
 
 ---
 

--- a/docs/reborn/README.md
+++ b/docs/reborn/README.md
@@ -46,6 +46,7 @@ docs/reborn/contracts/host-api.md
 docs/reborn/contracts/capability-access.md
 docs/reborn/contracts/dispatcher.md
 docs/reborn/contracts/events-projections.md
+docs/reborn/contracts/triggers.md
 docs/reborn/contracts/memory.md
 docs/reborn/contracts/secrets.md
 docs/reborn/contracts/network.md

--- a/docs/reborn/contracts/_contract-freeze-index.md
+++ b/docs/reborn/contracts/_contract-freeze-index.md
@@ -51,6 +51,7 @@ If a task needs to change one of those answers, it is not implementation work; i
 | Obligations | All built-in obligations must be implemented for V1; unsupported obligations fail closed. |
 | Migration | Reuse existing schemas where viable; bridge only when necessary. |
 | Runtime lanes | WASM, Script, and MCP are all first-class V1 lanes. |
+| Triggers | Trigger intake is a planned Reborn substrate slice. V1 is cron/schedule-only, enters through host-trusted ingress, and must not introduce a parallel agent loop. |
 
 ---
 
@@ -90,6 +91,7 @@ If a task needs to change one of those answers, it is not implementation work; i
 - [`turn-persistence.md`](turn-persistence.md)
 - [`turn-runner.md`](turn-runner.md)
 - [`conversation-binding.md`](conversation-binding.md)
+- [`triggers.md`](triggers.md)
 - [`migration-compatibility.md`](migration-compatibility.md)
 - [`product-adapters.md`](product-adapters.md) (issue #3269 first-slice)
 - [`telegram-v2.md`](telegram-v2.md) (issue #3285 first-slice)

--- a/docs/reborn/contracts/conversation-binding.md
+++ b/docs/reborn/contracts/conversation-binding.md
@@ -9,6 +9,7 @@
 ## 1. Purpose
 
 Conversation binding is the adapter-safe ingress boundary between external product surfaces and `ironclaw_turns::TurnCoordinator`.
+It also defines the host-trusted ingress seam used by scheduler and trigger fires.
 
 Adapters pass structured external actor/conversation refs to this boundary. The boundary returns canonical Reborn refs:
 
@@ -30,7 +31,7 @@ Reply-target binding is separate from external ingress identity. This contract b
 | --- | --- | --- |
 | `ConversationBindingService` | Pairing/authenticated actor resolution, external conversation binding lookup/creation keyed by stable conversation identity, explicit conversation-to-thread links, source/reply target binding refs, reply-target validation with adapter installation and external routing data | Raw transcript content, run lifecycle, product payload parsing |
 | `SessionThreadService` | Accepted inbound message refs, external event idempotency, message-to-thread/source/reply refs | Durable transcript schema details owned by #3204, turn/run locks |
-| `InboundTurnService` | Facade composition: resolve binding, accept message, submit canonical turn | Adapter protocol parsing, assistant egress fanout |
+| `InboundTurnService` | Facade composition: resolve binding, accept message, submit canonical turn; untrusted and host-trusted ingress entry points | Adapter protocol parsing, assistant egress fanout |
 | `TurnCoordinator` | Turn/run admission and lifecycle after accepted message refs exist | External actor/conversation parsing, raw message storage |
 
 ---
@@ -71,6 +72,8 @@ This is not the final durable transcript store. The conversation contract stores
 18. Public serialized external refs must enforce the same invariants as constructors. Deserialization cannot bypass empty/control-character/oversized ref validation.
 19. Public external route components may be up to 512 bytes for adapter compatibility. Durable PostgreSQL/libSQL implementations must not rely on a raw wide composite btree key for `(tenant, adapter_kind, installation, space, conversation, thread)` uniqueness; use typed rows plus a collision-resistant digest/indirection key derived from length-prefixed components.
 20. Message content crosses this boundary as a content ref. Raw user text is owned by the transcript/content storage boundary, not turn state.
+21. Host-trusted ingress is a host-only boundary for schedulers and trigger fires. `InboundTurnService::handle_inbound_turn_with_trusted_scope(request, trusted_agent_id, trusted_project_id)` must perform the same replay lookup as `handle_inbound_turn()` first, before any new binding creation or trusted-scope application, so duplicate scheduled-slot retries hit the existing inbound idempotency record instead of minting a second turn.
+22. Host-trusted ingress requests are minted only by host-owned services from durable host state. Product adapters cannot construct the trusted ingress marker or witness. Trusted trigger ingress details live in [`triggers.md`](triggers.md); this contract owns only the generic replay-first trusted-scope facade. No delivery target data belongs in `ExternalConversationRef`, `TurnActor`, `adapter_kind`, or any trusted ingress identity.
 
 ---
 
@@ -87,3 +90,7 @@ Run:
 ```bash
 cargo test -p ironclaw_conversations --test inbound_contract
 ```
+
+Trusted ingress implementations must add a caller-level regression proving that
+a duplicate trusted trigger fire performs replay before binding creation and
+reuses the original accepted message and turn submission.

--- a/docs/reborn/contracts/conversation-binding.md
+++ b/docs/reborn/contracts/conversation-binding.md
@@ -9,7 +9,8 @@
 ## 1. Purpose
 
 Conversation binding is the adapter-safe ingress boundary between external product surfaces and `ironclaw_turns::TurnCoordinator`.
-It also defines the host-trusted ingress seam used by scheduler and trigger fires.
+It also defines the planned host-trusted ingress seam used by scheduler and
+trigger fires.
 
 Adapters pass structured external actor/conversation refs to this boundary. The boundary returns canonical Reborn refs:
 
@@ -31,7 +32,7 @@ Reply-target binding is separate from external ingress identity. This contract b
 | --- | --- | --- |
 | `ConversationBindingService` | Pairing/authenticated actor resolution, external conversation binding lookup/creation keyed by stable conversation identity, explicit conversation-to-thread links, source/reply target binding refs, reply-target validation with adapter installation and external routing data | Raw transcript content, run lifecycle, product payload parsing |
 | `SessionThreadService` | Accepted inbound message refs, external event idempotency, message-to-thread/source/reply refs | Durable transcript schema details owned by #3204, turn/run locks |
-| `InboundTurnService` | Facade composition: resolve binding, accept message, submit canonical turn; untrusted and host-trusted ingress entry points | Adapter protocol parsing, assistant egress fanout |
+| `InboundTurnService` | Facade composition: resolve binding, accept message, submit canonical turn; current untrusted ingress entry point and planned host-trusted ingress entry point | Adapter protocol parsing, assistant egress fanout |
 | `TurnCoordinator` | Turn/run admission and lifecycle after accepted message refs exist | External actor/conversation parsing, raw message storage |
 
 ---
@@ -72,7 +73,7 @@ This is not the final durable transcript store. The conversation contract stores
 18. Public serialized external refs must enforce the same invariants as constructors. Deserialization cannot bypass empty/control-character/oversized ref validation.
 19. Public external route components may be up to 512 bytes for adapter compatibility. Durable PostgreSQL/libSQL implementations must not rely on a raw wide composite btree key for `(tenant, adapter_kind, installation, space, conversation, thread)` uniqueness; use typed rows plus a collision-resistant digest/indirection key derived from length-prefixed components.
 20. Message content crosses this boundary as a content ref. Raw user text is owned by the transcript/content storage boundary, not turn state.
-21. Host-trusted ingress is a host-only boundary for schedulers and trigger fires. `InboundTurnService::handle_inbound_turn_with_trusted_scope(request, trusted_agent_id, trusted_project_id)` must perform the same replay lookup as `handle_inbound_turn()` first, before any new binding creation or trusted-scope application, so duplicate scheduled-slot retries hit the existing inbound idempotency record instead of minting a second turn.
+21. Planned host-trusted ingress is a host-only boundary for schedulers and trigger fires. `InboundTurnService::handle_inbound_turn_with_trusted_scope(trusted_request)` must perform the same replay lookup as `handle_inbound_turn()` first, before any new binding creation or trusted-scope application, so duplicate scheduled-slot retries hit the existing inbound idempotency record instead of minting a second turn. The trusted request bundles the ordinary inbound request with host-owned `tenant_id`, `creator_user_id`, `agent_id`, and `project_id` authority; product adapters cannot provide those authority fields.
 22. Host-trusted ingress requests are minted only by host-owned services from durable host state. Product adapters cannot construct the trusted ingress marker or witness. Trusted trigger ingress details live in [`triggers.md`](triggers.md); this contract owns only the generic replay-first trusted-scope facade. No delivery target data belongs in `ExternalConversationRef`, `TurnActor`, `adapter_kind`, or any trusted ingress identity.
 
 ---
@@ -91,6 +92,6 @@ Run:
 cargo test -p ironclaw_conversations --test inbound_contract
 ```
 
-Trusted ingress implementations must add a caller-level regression proving that
-a duplicate trusted trigger fire performs replay before binding creation and
-reuses the original accepted message and turn submission.
+The planned trusted ingress implementation must add a caller-level regression
+proving that a duplicate trusted trigger fire performs replay before binding
+creation and reuses the original accepted message and turn submission.

--- a/docs/reborn/contracts/product-adapters.md
+++ b/docs/reborn/contracts/product-adapters.md
@@ -50,6 +50,10 @@ projection update
   `ironclaw_product_adapters::auth` (which take a crate-private
   `HostAuthSeal`) can construct one. WASM components and downstream adapters
   cannot fabricate verification.
+- Product adapters cannot construct host-trusted trigger ingress markers or
+  witnesses. Trigger and scheduler fires use the host-trusted ingress seam in
+  `ironclaw_conversations`, not a public adapter payload or a reserved string
+  in adapter-controlled DTOs.
 - `ProtocolHttpEgress` is the only network capability. Adapters declare
   egress hosts up front (`DeclaredEgressHost`) and address credentials via
   opaque handles (`EgressCredentialHandle`). The host resolves credential
@@ -82,6 +86,11 @@ projection update
 - `received_at: DateTime<Utc>`
 - `payload: ProductInboundPayload` — UserMessage / Command /
   ApprovalResolution / AuthResolution / SubscriptionRequest / NoOp.
+
+`ProductInboundEnvelope` does not model host-internal trigger or scheduler
+ingress. Synthetic trusted ingress is handled directly by
+`InboundTurnService::handle_inbound_turn_with_trusted_scope(...)` on the host
+side and is not constructible by product adapters.
 
 `ProductInboundAck` outcomes:
 

--- a/docs/reborn/contracts/product-adapters.md
+++ b/docs/reborn/contracts/product-adapters.md
@@ -88,9 +88,9 @@ projection update
   ApprovalResolution / AuthResolution / SubscriptionRequest / NoOp.
 
 `ProductInboundEnvelope` does not model host-internal trigger or scheduler
-ingress. Synthetic trusted ingress is handled directly by
-`InboundTurnService::handle_inbound_turn_with_trusted_scope(...)` on the host
-side and is not constructible by product adapters.
+ingress. Synthetic trusted ingress is handled by the planned
+`InboundTurnService::handle_inbound_turn_with_trusted_scope(...)` host-side
+facade and is not constructible by product adapters.
 
 `ProductInboundAck` outcomes:
 

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -1,4 +1,4 @@
-# Reborn Contract - Trigger System
+# Reborn Contract — Trigger System
 
 **Status:** Contract-freeze draft
 **Date:** 2026-05-29
@@ -49,6 +49,8 @@ The trigger system is owned by `ironclaw_triggers` in implementation terms, but 
 | `last_run_at` | Last time a fire was submitted |
 | `last_fired_slot` | Last canonical fire slot submitted for this trigger |
 | `last_status` | Synchronous submission outcome |
+| `active_fire_slot` | Optional claimed slot whose submitted turn has not reached a terminal outcome |
+| `active_run_ref` | Optional accepted/submitted turn reference used to check or clear the active fire |
 | `created_at` | Creation timestamp |
 
 ### 3.1 Source kinds
@@ -106,12 +108,21 @@ TriggerFire {
 `TriggerFireIdentity` is the deterministic boundary between trigger evaluation and inbound turn submission.
 
 - `fire_slot` is the provider's canonical dedupe coordinate for the scheduled fire.
-- `route_thread_id` and `external_event_id` are both derived from `tenant_id + trigger_id + fire_slot`.
+- `route_thread_id` and `external_event_id` are both derived from the same
+  tenant-scoped fire identity, but with separate domain labels.
 - The same `tenant_id`, `trigger_id`, and `fire_slot` must always yield the same identity.
 - A different slot must yield a different identity.
 - A different tenant must yield a different identity even if imported data reuses
   a `trigger_id`.
 - V1 does not add a separate trigger-fire idempotency ledger; the conversation layer owns inbound idempotency storage.
+
+The canonical derivation input is a length-prefixed sequence of the canonical
+UTF-8 bytes for `tenant_id`, `trigger_id`, and `fire_slot`, prefixed by the
+literal version label `ironclaw.trigger-fire.v1`. Implementations must not use
+raw string concatenation. `route_thread_id` uses the domain label
+`route-thread`; `external_event_id` uses the domain label `external-event`.
+Each output is encoded from a collision-resistant digest over
+`version_label || domain_label || length_prefixed_components`.
 
 ### 4.2 Provider boundary
 
@@ -134,10 +145,18 @@ V1 has one provider: a schedule provider.
 `TriggerPollerWorker` is the background evaluator that scans eligible triggers and submits fires through trusted inbound.
 
 - The worker may poll on a configured interval and batch due triggers.
-- The worker must enforce `max_concurrent_fires_per_trigger = 1` in V1.
+- The worker must enforce `max_concurrent_fires_per_trigger = 1` in V1 through
+  an atomic repository claim/lease operation that covers read, eligibility
+  check, active-fire check, and claim write.
 - If a previous fire for the same trigger is still active, the current tick for that trigger is skipped.
 - A skipped tick does not create a second fire, does not create a second thread, and does not fork a parallel trigger loop.
 - Active means the previous fire has not yet reached a terminal turn outcome.
+
+`last_status` is not the active-fire sentinel. Active-fire state is tracked by
+the separate `active_fire_slot` / `active_run_ref` claim fields and cleared only
+after the referenced turn reaches a terminal outcome. PostgreSQL and libSQL
+backends must provide equivalent atomic claim semantics; in-memory tests are
+not sufficient evidence for this invariant.
 
 The skip policy is per-trigger, not global. Other triggers may continue to fire on the same tick.
 
@@ -148,7 +167,9 @@ The skip policy is per-trigger, not global. Other triggers may continue to fire 
 A trigger fire is synthetic inbound, not a parallel agent loop.
 
 - The fire must enter the normal Reborn inbound/turn pipeline.
-- The trusted facade is `InboundTurnService::handle_inbound_turn_with_trusted_scope(...)`.
+- Planned facade: `InboundTurnService::handle_inbound_turn_with_trusted_scope(...)`.
+  This method does not exist in the current implemented conversation slice; PR 8
+  in the implementation plan owns adding it and its caller-level tests.
 - Binding resolution for trigger fires must use the trusted-scope path from `conversation-binding.md`.
 - The host-trusted ingress marker and witness used for trigger submission must be type-sealed and unconstructible by product adapters.
 - The host mints the trusted trigger ingress request from `TriggerRecord` state:
@@ -170,10 +191,16 @@ Synthetic trigger `InboundTurnRequest` fields are:
 - `actor`: `TurnActor` for `creator_user_id`;
 - `content_ref`: materialized trigger prompt.
 
-The sealed marker/installation/actor/conversation tuple must resolve to the
-same `SourceBindingRef` on every retry of the same tenant-scoped fire identity.
-Replay must happen before any new binding creation, so retried fires reuse the
-original accepted message and turn submission.
+The planned trusted facade takes a typed trusted request that bundles the
+ordinary `InboundTurnRequest` fields with host-owned `tenant_id`,
+`creator_user_id`, `agent_id`, and `project_id` authority. `creator_user_id` is
+converted into the canonical `TurnActor` by the host-owned trusted path; product
+adapters cannot supply or override it.
+
+The sealed marker/installation/actor/conversation tuple must resolve to the same
+`SourceBindingRef` on every retry of the same tenant-scoped fire identity. Replay
+must happen before any new binding creation, so retried fires reuse the original
+accepted message and turn submission.
 
 The turn pipeline remains the source of truth for admission, active-lock handling, runner lease handling, approvals, blocking, recovery, and completion.
 
@@ -188,14 +215,24 @@ The turn pipeline remains the source of truth for admission, active-lock handlin
 - `Error` means the fire could not be submitted.
 - `ApprovalBlocked` and `TimedOut` are fast-follow statuses and must not appear in the V1 persisted status model unless later lifecycle-observer work is added and ratified.
 
-In V1, `last_status` reflects submit outcome only. It does not wait for agent-loop completion feedback.
+In V1, `last_status` reflects submit outcome only. It is separate from the
+active-fire claim and does not become an in-flight sentinel.
+
+Replay of an already accepted/submitted slot returns the original accepted
+message and turn submission. If that submitted turn later reaches a terminal
+failure, V1 does not mint a second turn for the same `fire_slot`; retry-on-run-
+failure requires a later lifecycle-observer contract and a distinct retry
+identity policy.
 
 Slot bookkeeping is tied to acceptance, not merely polling:
 
 - accepted or replayed fires advance `last_fired_slot`, set `last_status = Ok`,
-  and compute the next future slot;
+  set the active-fire claim to the accepted/submitted turn reference, and
+  compute the next future slot;
 - retryable submit failures leave `last_fired_slot` unchanged, set
-  `last_status = Error`, and leave the slot retryable;
+  `last_status = Error`, leave the active-fire claim unset, and leave the slot
+  retryable. `next_run_at` must remain at or before the failed slot's scheduled
+  time so the poller can retry it on the next tick;
 - permanent validation or authorization failures set `last_status = Error` and
   must not silently create a different route, actor, or scope.
 
@@ -238,3 +275,8 @@ V1 acceptance does not require external delivery. A valid V1 trigger fire is one
   creation.
 - Poller caller-level tests must prove the worker skips a due fire while another
   fire for the same trigger is active.
+- Persistence tests must prove atomic active-fire claim behavior for both
+  PostgreSQL and libSQL, including concurrent claim attempts for the same
+  trigger and slot.
+- Unit tests must prove trigger fire identity derivation is collision-safe for
+  delimiter-like or prefix-overlapping component values.

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -1,0 +1,240 @@
+# Reborn Contract - Trigger System
+
+**Status:** Contract-freeze draft
+**Date:** 2026-05-29
+**Depends on:** [`conversation-binding.md`](conversation-binding.md), [`turn-persistence.md`](turn-persistence.md), [`turn-runner.md`](turn-runner.md), [`turns-agent-loop.md`](turns-agent-loop.md)
+
+---
+
+## 1. Purpose
+
+The trigger system owns scheduled trigger intake, trigger records, source-provider evaluation, and conversion of a due trigger into a synthetic inbound turn.
+
+It does **not** own a parallel agent loop, product adapter lifecycles, or outbound delivery targets. A trigger fire is routed into the normal Reborn turn pipeline and then persists through the same turn, run, and recovery machinery as any other inbound submission.
+
+---
+
+## 2. Ownership
+
+| Component | Owns | Does not own |
+| --- | --- | --- |
+| `TriggerRecord` / `TriggerRepository` | Trigger definitions, schedule state, eligibility state, run summary fields, PostgreSQL/libSQL persistence | Turn execution, reply delivery, product payload parsing |
+| `TriggerSourceProvider` | Determining whether a stored trigger should fire and computing the canonical fire slot | Turn submission, binding internals, delivery resolution |
+| `TriggerFire` / `TriggerFireIdentity` | Normalized fire output and deterministic identity for a scheduled slot | Notification targets, reply routing policy, ad hoc retries |
+| `TriggerPollerWorker` | Polling eligible triggers and submitting due fires | Alternate execution loops, hidden queues, outbound send logic |
+| `trigger_create` / `trigger_list` / `trigger_remove` | First-party trigger management capabilities | Legacy tool-only management paths |
+
+The trigger system is owned by `ironclaw_triggers` in implementation terms, but this contract freezes the behavior before code lands.
+
+---
+
+## 3. Trigger record model
+
+`TriggerRecord` is the durable trigger definition and poller bookkeeping record. All identifiers are newtypes and all enums are wire-stable.
+
+| Field | Meaning |
+| --- | --- |
+| `trigger_id` | Stable trigger identity |
+| `tenant_id` | Owning tenant |
+| `creator_user_id` | User who created the trigger |
+| `agent_id` | Captured agent scope at create time |
+| `project_id` | Captured project scope at create time |
+| `name` | Human-readable label |
+| `source` | Trigger source kind |
+| `schedule` | V1 schedule definition |
+| `prompt` | Materialized instruction content |
+| `enabled` | Optional denormalized query flag derived from `state`; not an independent fire gate |
+| `state` | Lifecycle state for the trigger definition |
+| `next_run_at` | Next eligible fire time |
+| `last_run_at` | Last time a fire was submitted |
+| `last_fired_slot` | Last canonical fire slot submitted for this trigger |
+| `last_status` | Synchronous submission outcome |
+| `created_at` | Creation timestamp |
+
+### 3.1 Source kinds
+
+V1 source kind is schedule-only.
+
+- `Schedule` is the only V1 source kind.
+- Webhook, regex, and internal system-event sources are fast-follow and must not be accepted by the V1 contract.
+
+### 3.2 Schedule shape and cadence
+
+V1 schedule shape is cron-backed schedule intake only.
+
+- Schedules that can fire more often than once per minute must be rejected.
+- Second-level cron fields, sub-minute intervals, and any equivalent cadence below one minute are invalid in V1.
+- The create path must reject invalid schedules before persistence, not at poll time.
+
+### 3.3 Trigger state
+
+`TriggerRecord.state` is the trigger-definition state, not the turn-run state.
+It is the source of truth for fire eligibility.
+
+- `Scheduled` means the trigger may be polled and fired.
+- `Paused` means the trigger is retained but must not fire.
+- `Completed` is reserved for future finite schedules and must not be treated as a V1 cron-state requirement.
+- If an implementation stores `enabled` for index/query convenience, it must be
+  derived from `state == Scheduled` and must never override `state`.
+
+---
+
+## 4. Trigger fire model
+
+Trigger source providers emit a normalized `TriggerFire`.
+
+```text
+TriggerFireIdentity {
+    tenant_id,
+    trigger_id,
+    fire_slot,
+    route_thread_id,
+    external_event_id,
+}
+
+TriggerFire {
+    identity,
+    creator_user_id,
+    agent_id,
+    project_id,
+    prompt,
+}
+```
+
+### 4.1 Identity derivation
+
+`TriggerFireIdentity` is the deterministic boundary between trigger evaluation and inbound turn submission.
+
+- `fire_slot` is the provider's canonical dedupe coordinate for the scheduled fire.
+- `route_thread_id` and `external_event_id` are both derived from `tenant_id + trigger_id + fire_slot`.
+- The same `tenant_id`, `trigger_id`, and `fire_slot` must always yield the same identity.
+- A different slot must yield a different identity.
+- A different tenant must yield a different identity even if imported data reuses
+  a `trigger_id`.
+- V1 does not add a separate trigger-fire idempotency ledger; the conversation layer owns inbound idempotency storage.
+
+### 4.2 Provider boundary
+
+`TriggerSourceProvider` decides whether a persisted trigger should fire, computes the canonical fire slot, and emits `TriggerFire`.
+
+- The provider boundary is source evaluation only.
+- It does not submit turns directly.
+- It does not resolve delivery targets.
+- It does not own binding creation or turn-run recovery.
+
+V1 has one provider: a schedule provider.
+
+- The schedule provider is cron-backed.
+- Webhook, regex, and system-event providers are fast-follow and must emit the same `TriggerFire` shape when they are later added.
+
+---
+
+## 5. Polling and concurrency
+
+`TriggerPollerWorker` is the background evaluator that scans eligible triggers and submits fires through trusted inbound.
+
+- The worker may poll on a configured interval and batch due triggers.
+- The worker must enforce `max_concurrent_fires_per_trigger = 1` in V1.
+- If a previous fire for the same trigger is still active, the current tick for that trigger is skipped.
+- A skipped tick does not create a second fire, does not create a second thread, and does not fork a parallel trigger loop.
+- Active means the previous fire has not yet reached a terminal turn outcome.
+
+The skip policy is per-trigger, not global. Other triggers may continue to fire on the same tick.
+
+---
+
+## 6. Trusted inbound and turn execution
+
+A trigger fire is synthetic inbound, not a parallel agent loop.
+
+- The fire must enter the normal Reborn inbound/turn pipeline.
+- The trusted facade is `InboundTurnService::handle_inbound_turn_with_trusted_scope(...)`.
+- Binding resolution for trigger fires must use the trusted-scope path from `conversation-binding.md`.
+- The host-trusted ingress marker and witness used for trigger submission must be type-sealed and unconstructible by product adapters.
+- The host mints the trusted trigger ingress request from `TriggerRecord` state:
+  `tenant_id`, `creator_user_id`, `agent_id`, and `project_id` are host state,
+  not product payload data.
+- The synthetic inbound request may carry only ingress identity and turn scope data needed to create the canonical turn.
+- It must not encode delivery targets, notification targets, or any other outbound routing policy.
+
+Synthetic trigger `InboundTurnRequest` fields are:
+
+- `adapter_kind`: sealed host-trusted ingress marker, not a product adapter kind;
+- `adapter_installation_id`: sealed host-trusted trigger installation marker;
+- `external_actor_ref`: canonical actor route for the trigger creator authority;
+- `external_conversation_ref`: synthetic dedicated-thread route for this fire,
+  derived from `tenant_id + trigger_id + fire_slot`;
+- `external_event_id`: deterministic replay key derived from the same
+  tenant-scoped fire identity;
+- `route_kind`: direct;
+- `actor`: `TurnActor` for `creator_user_id`;
+- `content_ref`: materialized trigger prompt.
+
+The sealed marker/installation/actor/conversation tuple must resolve to the
+same `SourceBindingRef` on every retry of the same tenant-scoped fire identity.
+Replay must happen before any new binding creation, so retried fires reuse the
+original accepted message and turn submission.
+
+The turn pipeline remains the source of truth for admission, active-lock handling, runner lease handling, approvals, blocking, recovery, and completion.
+
+---
+
+## 7. Run status
+
+`TriggerRunStatus` is synchronous in V1.
+
+- `Ok` means the fire was accepted and submitted into the normal turn pipeline,
+  or replayed an already accepted/submitted fire for the same slot.
+- `Error` means the fire could not be submitted.
+- `ApprovalBlocked` and `TimedOut` are fast-follow statuses and must not appear in the V1 persisted status model unless later lifecycle-observer work is added and ratified.
+
+In V1, `last_status` reflects submit outcome only. It does not wait for agent-loop completion feedback.
+
+Slot bookkeeping is tied to acceptance, not merely polling:
+
+- accepted or replayed fires advance `last_fired_slot`, set `last_status = Ok`,
+  and compute the next future slot;
+- retryable submit failures leave `last_fired_slot` unchanged, set
+  `last_status = Error`, and leave the slot retryable;
+- permanent validation or authorization failures set `last_status = Error` and
+  must not silently create a different route, actor, or scope.
+
+---
+
+## 8. Capability surface
+
+The trigger system must expose `trigger_create`, `trigger_list`, and `trigger_remove` as first-party Reborn capabilities.
+
+- `trigger_create` validates the schedule, captures caller scope, and persists the trigger.
+- `trigger_list` is caller-scoped and surfaces the current schedule state plus `last_status`.
+- `trigger_remove` is caller-scoped delete.
+
+Exact wiring of the capability registry and handler dependencies may land in later implementation PRs, but the capability names and semantics are frozen here.
+
+---
+
+## 9. Delivery
+
+Trigger delivery is fast-follow.
+
+- Trigger ingress identity must not include delivery targets.
+- Trigger record identity must not include delivery targets.
+- Trigger fire identity must not include delivery targets.
+- When delivery is added, it must flow through the delivery-resolution/outbound contract track, not through trigger ingress identity.
+
+V1 acceptance does not require external delivery. A valid V1 trigger fire is one that submits a cron-backed synthetic inbound turn and persists through the normal Reborn turn path.
+
+---
+
+## 10. Verification
+
+- Unit tests should cover schedule validation, identity stability, and status serialization.
+- Caller-level tests should drive the poller through trusted inbound and into the normal turn pipeline.
+- PostgreSQL/libSQL parity is required for trigger persistence.
+- `trigger_create` caller-level tests must prove sub-minute and second-level
+  schedules are rejected before persistence.
+- Trusted inbound caller-level tests must prove duplicate scheduled-slot retries
+  replay the original accepted message and turn submission before binding
+  creation.
+- Poller caller-level tests must prove the worker skips a due fire while another
+  fire for the same trigger is active.


### PR DESCRIPTION
Summary:
- Add the Reborn trigger system contract for V1 cron-backed scheduled trigger intake.
- Freeze host-trusted ingress, tenant-scoped fire identity, replay-first inbound submission, max_concurrent_fires_per_trigger = 1, trigger_create/list/remove semantics, and sub-minute schedule rejection.
- Cross-link the trigger contract from the freeze index, README, architecture map, conversation binding, and product adapter boundary docs.

Review coverage:
- Addressed 5.4-mini reviewer callouts for state/enabled precedence, tenant-scoped replay identity, retryable status semantics, sealed host-trusted ingress markers, canonical terminology, architecture map/index inclusion, and required caller-level tests.

Tests:
- git diff --cached --check
- git diff --check