### PR TITLE
fix(host-runtime): route dispatch failures through PR #4236 disposition + coerce oneOf/anyOf stringified containers

### DIFF
--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -132,17 +132,32 @@ impl CapabilityRunStateTransition {
 }
 
 impl CapabilityInvocationError {
-    pub(crate) fn run_state_transition(&self) -> CapabilityRunStateTransition {
+    /// Returns the run-state transition to apply for this error, or `None`
+    /// when no transition is appropriate at the capability-host layer.
+    ///
+    /// Dispatch failures intentionally return `None`: per the
+    /// `capability_failure_disposition` policy introduced in PR #4236, every
+    /// `DispatchFailureKind` is either a `ModelVisibleToolError` (the model
+    /// observes the failure as an ordinary tool error and can retry with
+    /// corrected input) or a `RetrySameCall` (the caller retries
+    /// transparently). Neither path wants the run marked failed at this
+    /// layer; doing so would short-circuit the disposition policy and turn
+    /// recoverable failures (notably `InputEncode`) into terminal run
+    /// failures.
+    pub(crate) fn run_state_transition(&self) -> Option<CapabilityRunStateTransition> {
         match self {
-            Self::UnsupportedObligations { .. } => CapabilityRunStateTransition::Fail {
+            Self::UnsupportedObligations { .. } => Some(CapabilityRunStateTransition::Fail {
                 error_kind: "UnsupportedObligations",
-            },
-            Self::ObligationFailed { .. } => CapabilityRunStateTransition::Fail {
+            }),
+            Self::ObligationFailed { .. } => Some(CapabilityRunStateTransition::Fail {
                 error_kind: "ObligationFailed",
-            },
-            Self::AuthorizationRequiresAuth { .. } => CapabilityRunStateTransition::BlockAuth {
-                error_kind: "AuthRequired",
-            },
+            }),
+            Self::AuthorizationRequiresAuth { .. } => {
+                Some(CapabilityRunStateTransition::BlockAuth {
+                    error_kind: "AuthRequired",
+                })
+            }
+            Self::Dispatch { .. } => None,
             Self::UnknownCapability { .. }
             | Self::AuthorizationDenied { .. }
             | Self::AuthorizationRequiresApproval { .. }
@@ -158,10 +173,9 @@ impl CapabilityInvocationError {
             | Self::ResumeContextMismatch { .. }
             | Self::Lease(_)
             | Self::RunState(_)
-            | Self::Process(_)
-            | Self::Dispatch { .. } => CapabilityRunStateTransition::Fail {
+            | Self::Process(_) => Some(CapabilityRunStateTransition::Fail {
                 error_kind: "Obligation",
-            },
+            }),
         }
     }
 }
@@ -175,7 +189,12 @@ pub(crate) async fn apply_run_state_transition_if_configured(
     let Some(run_state) = run_state else {
         return;
     };
-    match error.run_state_transition() {
+    let Some(transition) = error.run_state_transition() else {
+        // No run-state transition at this layer; PR #4236 disposition policy
+        // handles the failure on the outcome path.
+        return;
+    };
+    match transition {
         CapabilityRunStateTransition::Fail { error_kind } => {
             fail_run_if_configured(Some(run_state), scope, invocation_id, error_kind).await;
         }
@@ -283,5 +302,76 @@ pub(crate) fn run_state_error_kind(error: &RunStateError) -> &'static str {
         RunStateError::Serialization(_) => "Serialization",
         RunStateError::Deserialization(_) => "Deserialization",
         RunStateError::Backend(_) => "Backend",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CapabilityInvocationError;
+    use ironclaw_host_api::{CapabilityId, DispatchFailureKind, RuntimeDispatchErrorKind};
+
+    fn capability() -> CapabilityId {
+        CapabilityId::new("test.capability").expect("capability id")
+    }
+
+    /// Regression for PR #4236: dispatch failures must not transition the run
+    /// state at this layer. The `capability_failure_disposition` policy in
+    /// host_runtime maps every `DispatchFailureKind` to either
+    /// `ModelVisibleToolError` or `RetrySameCall`; both want the run to keep
+    /// going. Calling `run_state.fail()` here would short-circuit that policy
+    /// and turn recoverable input errors (notably `InputEncode`) into
+    /// terminal run failures invisible to the model.
+    #[test]
+    fn dispatch_input_encode_returns_no_run_state_transition() {
+        let error = CapabilityInvocationError::Dispatch {
+            kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InputEncode),
+        };
+        assert!(error.run_state_transition().is_none());
+    }
+
+    #[test]
+    fn dispatch_backend_returns_no_run_state_transition() {
+        let error = CapabilityInvocationError::Dispatch {
+            kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend),
+        };
+        assert!(error.run_state_transition().is_none());
+    }
+
+    #[test]
+    fn dispatch_unknown_capability_returns_no_run_state_transition() {
+        let error = CapabilityInvocationError::Dispatch {
+            kind: DispatchFailureKind::UnknownCapability,
+        };
+        assert!(error.run_state_transition().is_none());
+    }
+
+    #[test]
+    fn unknown_capability_still_fails_run_state() {
+        let error = CapabilityInvocationError::UnknownCapability {
+            capability: capability(),
+        };
+        let transition = error
+            .run_state_transition()
+            .expect("non-dispatch errors keep their fail transition");
+        assert!(matches!(
+            transition,
+            CapabilityRunStateTransition::Fail { .. }
+        ));
+    }
+
+    #[test]
+    fn authorization_requires_auth_still_blocks_auth() {
+        let error = CapabilityInvocationError::AuthorizationRequiresAuth {
+            capability: capability(),
+            required_secrets: Vec::new(),
+        };
+        let transition = error
+            .run_state_transition()
+            .expect("auth-required errors keep their block-auth transition");
+        assert!(matches!(
+            transition,
+            CapabilityRunStateTransition::BlockAuth { .. }
+        ));
     }
 }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -12,7 +12,7 @@ use ironclaw_run_state::{
 use tracing::{debug, warn};
 
 use crate::helpers::{
-    CapabilityActionKind, apply_run_state_transition_if_configured,
+    CapabilityActionKind, CapabilityRunStateTransition, apply_run_state_transition_if_configured,
     approval_not_approved_error_kind, capability_lease_error_kind,
     claim_error_may_be_concurrent_resume, complete_run_after_side_effect, fail_run_if_configured,
     invocation_fingerprint_for_kind, matching_approval_lease, resume_context_mismatch_kind,
@@ -1685,5 +1685,12 @@ fn completion_obligation_error_to_invocation(
 }
 
 fn obligation_invocation_error_kind(error: &CapabilityInvocationError) -> &'static str {
-    error.run_state_transition().error_kind()
+    // `run_state_transition` returns `None` for `CapabilityInvocationError::Dispatch`
+    // because PR #4236 handles those failures via the disposition policy on the
+    // outcome path. The obligation call sites only see this function for
+    // diagnostic logging; fall back to a stable "Dispatch" label in that case.
+    error
+        .run_state_transition()
+        .map(CapabilityRunStateTransition::error_kind)
+        .unwrap_or("Dispatch")
 }

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -860,8 +860,14 @@ async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume(
             kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend)
         }
     ));
+    // Per PR #4236 disposition policy, the capability host no longer
+    // transitions run state on dispatch failures — the higher host_runtime
+    // layer consults `capability_failure_disposition` and either retries
+    // (for `Backend`/`RetrySameCall`) or surfaces the failure to the model
+    // (`ModelVisibleToolError`). The run therefore stays in its prior state
+    // (`BlockedApproval`, set by the initial invoke).
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
-    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.status, RunStatus::BlockedApproval);
     let revoked = leases.get(&scope, lease.grant.id).await.unwrap();
     assert_eq!(revoked.status, CapabilityLeaseStatus::Revoked);
 }

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -1186,6 +1186,17 @@ fn normalize_provider_value(
     schema: &serde_json::Value,
     label: &'static str,
 ) -> Result<serde_json::Value, AgentLoopHostError> {
+    // `oneOf` / `anyOf`: pick the variant whose declared `type` matches the
+    // value's shape, after attempting to coerce stringified containers. This
+    // lets schemas like `{ oneOf: [{type:object}, {type:array}] }` accept both
+    // a real array and a stringified array (e.g. an LLM that double-encoded
+    // the argument). Without this, the variant-less top-level schema slips
+    // through the type-matched branches below as a no-op and the stringified
+    // container is forwarded raw to the tool.
+    if let Some(variants) = schema_variants(schema) {
+        return normalize_one_of_variants(value, variants, label);
+    }
+
     if schema_type_matches(schema, "object") {
         let object_value = coerce_json_string(value, label)?;
         let Some(object) = object_value.as_object() else {
@@ -1243,6 +1254,43 @@ fn normalize_provider_value(
     }
 
     Ok(value.clone())
+}
+
+fn schema_variants(schema: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    schema
+        .get("oneOf")
+        .or_else(|| schema.get("anyOf"))
+        .and_then(serde_json::Value::as_array)
+}
+
+fn normalize_one_of_variants(
+    value: &serde_json::Value,
+    variants: &[serde_json::Value],
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    // Coerce stringified containers up front so we match by parsed shape.
+    let candidate = coerce_json_string(value, label)?;
+    let shape = value_shape(&candidate);
+    for variant in variants {
+        if schema_type_matches(variant, shape) {
+            return normalize_provider_value(&candidate, variant, label);
+        }
+    }
+    // No declared variant matches the value's shape; leave the original value
+    // alone so the tool's own input validation can produce a precise error.
+    Ok(value.clone())
+}
+
+fn value_shape(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Object(_) => "object",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Null => "null",
+    }
 }
 
 fn schema_type_matches(schema: &serde_json::Value, expected: &str) -> bool {
@@ -2394,6 +2442,130 @@ mod tests {
         .expect_err("stringified object should not satisfy array schema without items");
 
         assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    }
+
+    /// Regression: schemas like `headers` in `builtin.http` declare
+    /// `{ oneOf: [{type:object}, {type:array}] }` and have no top-level
+    /// `type`. Without `oneOf` handling, the normalizer's type-matched
+    /// branches never fire and a stringified array is forwarded raw to the
+    /// tool, which then rejects it with `InputEncode`.
+    #[test]
+    fn provider_argument_normalization_coerces_stringified_array_into_oneof_variant() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "headers": {
+                    "oneOf": [
+                        { "type": "object", "additionalProperties": { "type": "string" } },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "value": { "type": "string" }
+                                },
+                                "required": ["name", "value"]
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+
+        let normalized = normalize_provider_arguments(
+            &serde_json::json!({
+                "headers": "[{\"name\":\"User-Agent\",\"value\":\"IronClaw/1.0\"}]"
+            }),
+            &schema,
+            "provider arguments",
+        )
+        .expect("oneOf array variant should accept stringified array");
+
+        assert_eq!(
+            normalized,
+            serde_json::json!({
+                "headers": [{ "name": "User-Agent", "value": "IronClaw/1.0" }]
+            })
+        );
+    }
+
+    #[test]
+    fn provider_argument_normalization_coerces_stringified_object_into_oneof_variant() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "headers": {
+                    "oneOf": [
+                        { "type": "object", "additionalProperties": { "type": "string" } },
+                        { "type": "array", "items": { "type": "object" } }
+                    ]
+                }
+            }
+        });
+
+        let normalized = normalize_provider_arguments(
+            &serde_json::json!({
+                "headers": "{\"User-Agent\":\"IronClaw/1.0\"}"
+            }),
+            &schema,
+            "provider arguments",
+        )
+        .expect("oneOf object variant should accept stringified object");
+
+        assert_eq!(
+            normalized,
+            serde_json::json!({
+                "headers": { "User-Agent": "IronClaw/1.0" }
+            })
+        );
+    }
+
+    #[test]
+    fn provider_argument_normalization_passes_through_oneof_when_value_already_matches_variant() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "headers": {
+                    "oneOf": [
+                        { "type": "object", "additionalProperties": { "type": "string" } },
+                        { "type": "array", "items": { "type": "object" } }
+                    ]
+                }
+            }
+        });
+
+        let input = serde_json::json!({
+            "headers": [{ "name": "X", "value": "y" }]
+        });
+        let normalized = normalize_provider_arguments(&input, &schema, "provider arguments")
+            .expect("real array value should pass oneOf normalization unchanged");
+
+        assert_eq!(normalized, input);
+    }
+
+    #[test]
+    fn provider_argument_normalization_anyof_behaves_like_oneof() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "payload": {
+                    "anyOf": [
+                        { "type": "object" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                }
+            }
+        });
+
+        let normalized = normalize_provider_arguments(
+            &serde_json::json!({ "payload": "[\"a\",\"b\"]" }),
+            &schema,
+            "provider arguments",
+        )
+        .expect("anyOf array variant should accept stringified array");
+
+        assert_eq!(normalized, serde_json::json!({ "payload": ["a", "b"] }));
     }
 
     fn provider_tool_call() -> ProviderToolCall {

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -1269,10 +1269,19 @@ fn normalize_one_of_variants(
     label: &'static str,
 ) -> Result<serde_json::Value, AgentLoopHostError> {
     // Coerce stringified containers up front so we match by parsed shape.
-    let candidate = coerce_json_string(value, label)?;
+    // Coerce stringified containers up front so we match by parsed shape.
+    // Use `unwrap_or_else` rather than `?` so that an unparseable string
+    // (e.g. a plain string that starts with `{` or `[` but is not valid
+    // JSON) can still fall through to a `string` variant in the schema
+    // instead of producing a false-positive `InvalidInvocation` error.
+    let candidate = coerce_json_string(value, label).unwrap_or_else(|_| value.clone());
     let shape = value_shape(&candidate);
     for variant in variants {
-        if schema_type_matches(variant, shape) {
+        // In JSON Schema every `integer` is also a valid `number`, so allow
+        // integer-shaped values to match `number` variants as well.
+        if schema_type_matches(variant, shape)
+            || (shape == "integer" && schema_type_matches(variant, "number"))
+        {
             return normalize_provider_value(&candidate, variant, label);
         }
     }
@@ -2566,6 +2575,65 @@ mod tests {
         .expect("anyOf array variant should accept stringified array");
 
         assert_eq!(normalized, serde_json::json!({ "payload": ["a", "b"] }));
+    }
+
+    /// Regression for Gemini review comment: a plain string that starts with
+    /// `{` or `[` but is not valid JSON must not cause an `InvalidInvocation`
+    /// error when a `string` variant is available. The coercion attempt should
+    /// fail gracefully and fall through to the string branch.
+    #[test]
+    fn provider_argument_normalization_oneof_string_variant_accepts_non_json_string() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "oneOf": [
+                        { "type": "object" },
+                        { "type": "string" }
+                    ]
+                }
+            }
+        });
+
+        // Looks like JSON but is malformed — must not error; string variant matches.
+        let normalized = normalize_provider_arguments(
+            &serde_json::json!({ "query": "{not valid json" }),
+            &schema,
+            "provider arguments",
+        )
+        .expect("malformed JSON-like string should fall through to the string variant");
+
+        assert_eq!(
+            normalized,
+            serde_json::json!({ "query": "{not valid json" })
+        );
+    }
+
+    /// Regression for Gemini review comment: JSON Schema treats every integer
+    /// as a valid number, so an integer-shaped value must match a `number`
+    /// variant in a `oneOf`/`anyOf` schema.
+    #[test]
+    fn provider_argument_normalization_oneof_integer_matches_number_variant() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "value": {
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "number" }
+                    ]
+                }
+            }
+        });
+
+        let normalized = normalize_provider_arguments(
+            &serde_json::json!({ "value": 42 }),
+            &schema,
+            "provider arguments",
+        )
+        .expect("integer value should match the number variant");
+
+        assert_eq!(normalized, serde_json::json!({ "value": 42 }));
     }
 
     fn provider_tool_call() -> ProviderToolCall {


### PR DESCRIPTION
## Summary

Two related bugs caused the agent loop to mark a run as terminally `Failed` (and trigger the legacy "RecoveryRequired" path that PR #4236 was supposed to eliminate) instead of surfacing a tool error to the model when the LLM passed a stringified JSON array for a `builtin.http` `headers` argument.

Repro from the wild:
```
ironclaw_host_runtime::first_party_tools::http: first-party HTTP tool input validation failed validation_stage="headers"
ironclaw_dispatcher: runtime dispatcher observed event event_kind=DispatchFailed ... error_kind="input_encode"
ironclaw_capabilities::host: capability dispatch failed dispatch_failure_kind=InputEncode
→ run marked Failed; model never sees the tool error
```

## Root cause

PR #4236 introduced `capability_failure_disposition` and explicitly mapped **every** `DispatchFailureKind` to either `ModelVisibleToolError` (model retries with corrected input) or `RetrySameCall` (caller retries transparently). The policy never returns `Fail` — that's the whole point of "stop generic RecoveryRequired transitions."

But two paths still bypass the disposition:

### Bug 1 — `run_state_transition` short-circuits the disposition

`crates/ironclaw_capabilities/src/helpers.rs`:
```rust
| Self::Dispatch { .. } => CapabilityRunStateTransition::Fail {
    error_kind: "Obligation",
},
```

The wildcard ignores `kind` and unconditionally fails the run **before** the host_runtime layer's disposition check runs. `InputEncode` should be `ModelVisibleToolError` per PR #4236 — model sees "your headers were stringified, retry" and recovers.

### Bug 2 — `normalize_provider_value` ignores `oneOf`/`anyOf`

`crates/ironclaw_loop_support/src/capability_port.rs`:

The `builtin.http` `headers` schema is `{ oneOf: [{type:object}, {type:array}] }` with no top-level `type`. The normalizer only descends into top-level `type: "object"` / `type: "array"`, so stringified containers in `oneOf` parameters slip through and hit the tool unchanged. Without bug 1 this would be a recoverable `InputEncode`; with bug 1 it's terminal.

## Fix

### `helpers.rs`: `run_state_transition` returns `Option<...>`

The `Self::Dispatch { .. }` arm returns `None` — the capability host explicitly delegates the policy decision to the host_runtime layer's `capability_failure_disposition`. No new abstraction; just delete the wrong branch and let the existing PR #4236 plumbing be authoritative.

### `capability_port.rs`: descend into `oneOf`/`anyOf`

Before the explicit type-matched branches, detect `oneOf`/`anyOf`, coerce stringified containers, pick the variant whose declared `type` matches the value's shape, recurse. Defense-in-depth — even without bug 1's fix, the LLM's stringified-array mistake gets transparently corrected at normalization time.

## Tests

`helpers::tests` (new):
- `dispatch_input_encode_returns_no_run_state_transition` (the reported bug)
- `dispatch_backend_returns_no_run_state_transition` (RetrySameCall path)
- `dispatch_unknown_capability_returns_no_run_state_transition` (top-level dispatch failure)
- `unknown_capability_still_fails_run_state` (regression guard: non-Dispatch errors still transition)
- `authorization_requires_auth_still_blocks_auth` (regression guard: BlockAuth still works)

`capability_port::tests` (new):
- `provider_argument_normalization_coerces_stringified_array_into_oneof_variant` (the schema from `builtin.http` exactly)
- `provider_argument_normalization_coerces_stringified_object_into_oneof_variant`
- `provider_argument_normalization_passes_through_oneof_when_value_already_matches_variant` (no false coercion)
- `provider_argument_normalization_anyof_behaves_like_oneof`

`capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume`: assertion updated to `BlockedApproval` (lease revocation still verified; the run-state transition was the bug, not the lease behavior).

## Quality gate

- `cargo fmt` clean
- `cargo clippy --all-features --tests` zero warnings
- `cargo test -p ironclaw_capabilities` 23+17 pass
- `cargo test -p ironclaw_loop_support` 234+10+... pass
- One pre-existing `render_shell_output_reports_redacted_saved_output` failure on `reborn-integration` is unrelated (verified by stashing the diff).

## Risk

Low. Both fixes align with PR #4236's stated contract; the diff deletes incorrect branching and adds disposition coverage where it was missed. No production code path that previously called `run_state.fail()` for a Dispatch error was actually correct to do so — the disposition policy already routes those failures via `runtime_failure_to_loop`.