### PR TITLE
fix(capability-info): allow synthetic capabilities to be introspected via capability_info

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -3279,6 +3279,52 @@ mod tests {
         assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
     }
 
+    /// Regression: `capability_info` previously used `as_runtime()` for
+    /// surface lookup, which excluded synthetic capabilities. A model calling
+    /// `capability_info { name: "capability_info" }` (to introspect the tool
+    /// itself before using it) got `target is not on the visible surface` →
+    /// `InvalidInvocation` → terminal run failure instead of a helpful schema
+    /// response.
+    #[tokio::test]
+    async fn capability_info_can_describe_itself() {
+        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+        let provider_id = ExtensionId::new("demo").expect("valid provider id");
+        let context = execution_context("thread-capability-info-self-lookup");
+        let run_context = loop_run_context(&context).await;
+        let runtime = Arc::new(RecordingHostRuntime::new(vec![visible_capability(
+            capability_id,
+            provider_id,
+        )]));
+        let port = HostRuntimeLoopCapabilityPortFactory::new(
+            runtime,
+            visible_request(context),
+            dummy_input_resolver(),
+            dummy_result_writer(),
+            dummy_milestone_sink(),
+        )
+        .port_for_run_context(run_context);
+        port.visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible capabilities load");
+
+        // Query by provider tool name
+        let mut call = provider_tool_call();
+        call.name = capability_info::TOOL_NAME.to_string();
+        call.arguments = serde_json::json!({ "name": capability_info::TOOL_NAME });
+        port.register_provider_tool_call(call)
+            .await
+            .expect("capability_info should be able to describe itself by tool name");
+
+        // Query by canonical capability id
+        let mut call2 = provider_tool_call();
+        call2.id = "call_2".to_string();
+        call2.name = capability_info::TOOL_NAME.to_string();
+        call2.arguments = serde_json::json!({ "name": capability_info::CAPABILITY_ID });
+        port.register_provider_tool_call(call2)
+            .await
+            .expect("capability_info should be able to describe itself by capability id");
+    }
+
     #[tokio::test]
     async fn capability_info_returns_names_and_summary_details() {
         let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");

--- a/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
@@ -231,15 +231,14 @@ impl SyntheticSurfaceCapabilitySnapshot {
         match self.kind {
             SyntheticCapabilityKind::CapabilityInfo => {
                 debug_assert!(capability_info::is_capability_id(capability_id));
-                let definition = capability_info::tool_definition()?;
                 Ok(CapabilityDescriptorView {
                     capability_id: capability_id.clone(),
                     provider: None,
                     runtime: RuntimeKind::System,
                     safe_name: self.provider_tool_name.clone(),
-                    safe_description: definition.description,
+                    safe_description: self.safe_description.clone(),
                     concurrency_hint: ConcurrencyHint::SafeForParallel,
-                    parameters_schema: definition.parameters,
+                    parameters_schema: self.parameters_schema.clone(),
                 })
             }
         }
@@ -252,9 +251,12 @@ impl SyntheticSurfaceCapabilitySnapshot {
         match self.kind {
             SyntheticCapabilityKind::CapabilityInfo => {
                 debug_assert!(capability_info::is_capability_id(capability_id));
-                let mut definition = capability_info::tool_definition()?;
-                definition.name = self.provider_tool_name.clone();
-                Ok(definition)
+                Ok(ProviderToolDefinition {
+                    capability_id: capability_id.clone(),
+                    name: self.provider_tool_name.clone(),
+                    description: self.safe_description.clone(),
+                    parameters: self.parameters_schema.clone(),
+                })
             }
         }
     }
@@ -269,7 +271,7 @@ impl SyntheticSurfaceCapabilitySnapshot {
             SyntheticCapabilityKind::CapabilityInfo => {
                 let normalized_arguments = super::normalize_provider_arguments(
                     &tool_call.arguments,
-                    &capability_info::schema(),
+                    &self.parameters_schema,
                     "provider arguments",
                 )?;
                 super::validate_provider_arguments(&normalized_arguments)?;

--- a/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
@@ -22,6 +22,8 @@ pub(super) struct RuntimeSurfaceCapabilitySnapshot {
 #[derive(Clone)]
 pub(super) struct SyntheticSurfaceCapabilitySnapshot {
     provider_tool_name: String,
+    safe_description: String,
+    parameters_schema: serde_json::Value,
     kind: SyntheticCapabilityKind,
 }
 
@@ -65,6 +67,8 @@ impl SurfaceSnapshot {
             capability_id,
             SurfaceCapabilitySnapshot::Synthetic(SyntheticSurfaceCapabilitySnapshot {
                 provider_tool_name: capability_info::TOOL_NAME.to_string(),
+                safe_description: capability_info::tool_definition()?.description,
+                parameters_schema: capability_info::schema(),
                 kind: SyntheticCapabilityKind::CapabilityInfo,
             }),
         );
@@ -72,22 +76,13 @@ impl SurfaceSnapshot {
     }
 
     pub(super) fn capability_info(&self, requested: &str) -> Option<CapabilityInfoEntry<'_>> {
-        if let Some(capability_id) = self.provider_names.get(requested)
-            && let Some(capability) = self
-                .capabilities
-                .get(capability_id)
-                .and_then(SurfaceCapabilitySnapshot::as_runtime)
-        {
+        if let Some(capability_id) = self.provider_names.get(requested) {
+            let capability = self.capabilities.get(capability_id)?;
             return Some(capability.capability_info(capability_id));
         }
         let requested_id = CapabilityId::new(requested).ok()?;
         self.capabilities
             .get_key_value(&requested_id)
-            .and_then(|(capability_id, capability)| {
-                capability
-                    .as_runtime()
-                    .map(|capability| (capability_id, capability))
-            })
             .map(|(capability_id, capability)| capability.capability_info(capability_id))
     }
 
@@ -138,11 +133,26 @@ impl RuntimeSurfaceCapabilitySnapshot {
     }
 }
 
+impl SyntheticSurfaceCapabilitySnapshot {
+    fn capability_info<'a>(&'a self, capability_id: &'a CapabilityId) -> CapabilityInfoEntry<'a> {
+        CapabilityInfoEntry {
+            capability_id,
+            provider_tool_name: &self.provider_tool_name,
+            safe_description: &self.safe_description,
+            parameters_schema: &self.parameters_schema,
+            // Synthetic capabilities are built into the loop itself; they have
+            // no external runtime and carry no side-effect declarations.
+            runtime: RuntimeKind::System,
+            effects: &[],
+        }
+    }
+}
+
 impl SurfaceCapabilitySnapshot {
-    fn as_runtime(&self) -> Option<&RuntimeSurfaceCapabilitySnapshot> {
+    fn capability_info<'a>(&'a self, capability_id: &'a CapabilityId) -> CapabilityInfoEntry<'a> {
         match self {
-            Self::Runtime(capability) => Some(capability.as_ref()),
-            Self::Synthetic(_) => None,
+            Self::Runtime(c) => c.capability_info(capability_id),
+            Self::Synthetic(c) => c.capability_info(capability_id),
         }
     }
 


### PR DESCRIPTION
## Bug

When a model called `capability_info { name: "capability_info" }` to inspect the tool's own schema before using it, it got:

```
InvalidInvocation: capability_info target is not on the visible surface
→ terminal run failure
```

Observed in the wild: model issued two parallel tool calls — `builtin__skill_activate` and `capability_info { name: "capability_info" }` — the second failed with `InvalidInvocation`, which is classified as a terminal run failure (stage: Model), killing the entire run.

## Root cause

`SurfaceSnapshot::capability_info()` called `.and_then(SurfaceCapabilitySnapshot::as_runtime())` on both the provider-name and capability-id lookup paths. `as_runtime()` returns `None` for `Synthetic` variants, so any synthetic capability (currently just `capability_info` itself) could never be the target of a `capability_info` introspection call.

## Fix

- Added `safe_description` and `parameters_schema` to `SyntheticSurfaceCapabilitySnapshot`, populated at construction from the canonical `capability_info` tool definition.
- Added `capability_info()` to `SyntheticSurfaceCapabilitySnapshot` returning a `CapabilityInfoEntry` with `RuntimeKind::System` and no side-effect declarations.
- Added a `capability_info()` dispatch method on `SurfaceCapabilitySnapshot` covering both `Runtime` and `Synthetic` variants.
- Simplified `SurfaceSnapshot::capability_info()` to use the dispatch method, removing the `as_runtime()` filter.
- Removed the now-dead `as_runtime()` method.

Both lookup forms work after the fix:
```
capability_info { "name": "capability_info" }
capability_info { "name": "ironclaw.loop.capability_info" }
```

## Test

`capability_info_can_describe_itself` — verifies both the provider tool name and canonical capability id lookup paths return success.

## Quality gate

`cargo fmt + clippy` clean; 237/237 `ironclaw_loop_support` tests pass.