### PR TITLE
[codex] Add outbound communication preferences store

### DIFF
--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -54,14 +54,3 @@ pub trait CommunicationPreferenceRepository: Send + Sync {
         key: CommunicationPreferenceKey,
     ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError>;
 }
-
-pub(crate) fn validate_communication_preference(
-    record: &CommunicationPreferenceRecord,
-) -> Result<(), OutboundError> {
-    if record.updated_by.as_str().is_empty() {
-        return Err(OutboundError::InvalidRequest {
-            reason: "communication preference updater is required",
-        });
-    }
-    Ok(())
-}

--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -1,0 +1,65 @@
+use async_trait::async_trait;
+use ironclaw_host_api::{TenantId, Timestamp, UserId};
+use ironclaw_turns::ReplyTargetBindingRef;
+use serde::{Deserialize, Serialize};
+
+use crate::{CommunicationModality, OutboundError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CommunicationPreferenceKey {
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+}
+
+impl CommunicationPreferenceKey {
+    pub fn new(tenant_id: TenantId, user_id: UserId) -> Self {
+        Self { tenant_id, user_id }
+    }
+}
+
+/// Durable tenant/user communication defaults owned by outbound policy.
+///
+/// Stored reply targets are candidates only. Callers must revalidate every
+/// target through the outbound validation path before sending externally.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunicationPreferenceRecord {
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+    pub final_reply_target: Option<ReplyTargetBindingRef>,
+    pub progress_target: Option<ReplyTargetBindingRef>,
+    pub approval_prompt_target: Option<ReplyTargetBindingRef>,
+    pub auth_prompt_target: Option<ReplyTargetBindingRef>,
+    pub default_modality: Option<CommunicationModality>,
+    pub updated_at: Timestamp,
+    pub updated_by: UserId,
+}
+
+impl CommunicationPreferenceRecord {
+    pub fn key(&self) -> CommunicationPreferenceKey {
+        CommunicationPreferenceKey::new(self.tenant_id.clone(), self.user_id.clone())
+    }
+}
+
+#[async_trait]
+pub trait CommunicationPreferenceRepository: Send + Sync {
+    async fn put_communication_preference(
+        &self,
+        record: CommunicationPreferenceRecord,
+    ) -> Result<(), OutboundError>;
+
+    async fn load_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError>;
+}
+
+pub(crate) fn validate_communication_preference(
+    record: &CommunicationPreferenceRecord,
+) -> Result<(), OutboundError> {
+    if record.updated_by.as_str().is_empty() {
+        return Err(OutboundError::InvalidRequest {
+            reason: "communication preference updater is required",
+        });
+    }
+    Ok(())
+}

--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{CommunicationModality, OutboundError};
 
+/// Tenant/user lookup key for outbound-owned communication preferences.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CommunicationPreferenceKey {
     pub tenant_id: TenantId,
@@ -40,6 +41,7 @@ impl CommunicationPreferenceRecord {
     }
 }
 
+/// Store for durable tenant/user communication delivery preferences.
 #[async_trait]
 pub trait CommunicationPreferenceRepository: Send + Sync {
     async fn put_communication_preference(

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -26,7 +26,7 @@
 //!   `delivery_id`. An indexed `scope` projection allows
 //!   `list_delivery_attempts(scope)` to filter within the tenant-scoped
 //!   subtree without materializing every row.
-//! - `/outbound/communication-preferences/<tenant-user-key>.json` — tenant/user
+//! - `/outbound/communication-preferences/<tenant>/<user>.json` — tenant/user
 //!   communication preference row. Reply-target refs remain candidates and do
 //!   not grant send authority.
 
@@ -85,7 +85,6 @@ const TENANT_ID_INDEX_KEY: &str = "tenant_id";
 const TENANT_ID_INDEX_NAME: &str = "outbound_by_tenant";
 const POLICIES_ROOT: &str = "/outbound/policies";
 const SUBSCRIPTIONS_ROOT: &str = "/outbound/subscriptions";
-const COMMUNICATION_PREFERENCES_ROOT: &str = "/outbound/communication-preferences";
 
 /// Filesystem-backed outbound store. Construct with a [`ScopedFilesystem`]
 /// over any [`RootFilesystem`] implementation (libSQL, Postgres, in-memory,
@@ -248,8 +247,6 @@ where
         let path = communication_preference_path(&record.tenant_id, &record.user_id)?;
         let resource_scope =
             communication_preference_resource_scope(&record.tenant_id, &record.user_id);
-        self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
-            .await?;
         self.put_json(
             &resource_scope,
             &path,
@@ -587,18 +584,10 @@ fn communication_preference_path(
     tenant_id: &TenantId,
     user_id: &UserId,
 ) -> Result<ScopedPath, OutboundError> {
-    #[derive(Serialize)]
-    struct PreferenceIdentity<'a> {
-        tenant_id: &'a TenantId,
-        user_id: &'a UserId,
-    }
-    let identity = PreferenceIdentity { tenant_id, user_id };
-    let serialized = serde_json::to_string(&identity).map_err(|_| OutboundError::Serialization)?;
-    let mut hasher = Sha256::new();
-    hasher.update(serialized.as_bytes());
-    let digest = hex::encode(hasher.finalize());
-    ScopedPath::new(format!("/outbound/communication-preferences/{digest}.json"))
-        .map_err(|_| OutboundError::Backend)
+    ScopedPath::new(format!(
+        "/outbound/communication-preferences/{tenant_id}/{user_id}.json"
+    ))
+    .map_err(|_| OutboundError::Backend)
 }
 
 fn communication_preference_resource_scope(
@@ -621,10 +610,6 @@ fn policies_root() -> Result<ScopedPath, OutboundError> {
 
 fn subscriptions_root() -> Result<ScopedPath, OutboundError> {
     ScopedPath::new(SUBSCRIPTIONS_ROOT).map_err(|_| OutboundError::Backend)
-}
-
-fn communication_preferences_root() -> Result<ScopedPath, OutboundError> {
-    ScopedPath::new(COMMUNICATION_PREFERENCES_ROOT).map_err(|_| OutboundError::Backend)
 }
 
 fn tenant_id_index_key() -> IndexKey {

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -26,7 +26,7 @@
 //!   `delivery_id`. An indexed `scope` projection allows
 //!   `list_delivery_attempts(scope)` to filter within the tenant-scoped
 //!   subtree without materializing every row.
-//! - `/outbound/communication-preferences/<sha256(key)>.json` — tenant/user
+//! - `/outbound/communication-preferences/<sha256(v1-length-prefixed-key)>.json` — tenant/user
 //!   communication preference row keyed by a hashed `CommunicationPreferenceKey`.
 //!   Reply-target refs remain candidates and do not grant send authority.
 
@@ -247,8 +247,6 @@ where
         let key = record.key();
         let path = communication_preference_path(&key)?;
         let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
-        self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
-            .await?;
         for _ in 0..MAX_CAS_RETRIES {
             let (cas, existing) = match self
                 .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
@@ -264,6 +262,8 @@ where
             {
                 return Err(OutboundError::Backend);
             }
+            self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
+                .await?;
             match self
                 .put_json(&resource_scope, &path, &record, &record.tenant_id, cas)
                 .await
@@ -602,9 +602,17 @@ fn delivery_path(delivery_id: &OutboundDeliveryId) -> Result<ScopedPath, Outboun
 fn communication_preference_path(
     key: &CommunicationPreferenceKey,
 ) -> Result<ScopedPath, OutboundError> {
-    let serialized = serde_json::to_string(key).map_err(|_| OutboundError::Serialization)?;
     let mut hasher = Sha256::new();
-    hasher.update(serialized.as_bytes());
+    let tenant = key.tenant_id.as_str();
+    let user = key.user_id.as_str();
+    hasher.update(b"v1:");
+    hasher.update(tenant.len().to_string().as_bytes());
+    hasher.update(b":");
+    hasher.update(tenant.as_bytes());
+    hasher.update(b":");
+    hasher.update(user.len().to_string().as_bytes());
+    hasher.update(b":");
+    hasher.update(user.as_bytes());
     let digest = hex::encode(hasher.finalize());
     ScopedPath::new(format!("{COMMUNICATION_PREFERENCES_ROOT}/{digest}.json"))
         .map_err(|_| OutboundError::Backend)

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -26,9 +26,9 @@
 //!   `delivery_id`. An indexed `scope` projection allows
 //!   `list_delivery_attempts(scope)` to filter within the tenant-scoped
 //!   subtree without materializing every row.
-//! - `/outbound/communication-preferences/<tenant>/<user>.json` — tenant/user
-//!   communication preference row. Reply-target refs remain candidates and do
-//!   not grant send authority.
+//! - `/outbound/communication-preferences/<sha256(key)>.json` — tenant/user
+//!   communication preference row keyed by a hashed `CommunicationPreferenceKey`.
+//!   Reply-target refs remain candidates and do not grant send authority.
 
 use std::sync::Arc;
 
@@ -43,11 +43,10 @@ use ironclaw_turns::{TurnActor, TurnScope};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::communication_preferences::validate_communication_preference;
 use crate::validation::{
-    validate_advance_request, validate_delivery_attempt, validate_delivery_identity,
-    validate_delivery_status_request, validate_policy, validate_subscription_identity,
-    validate_subscription_record, validate_subscription_request,
+    validate_advance_request, validate_communication_preference, validate_delivery_attempt,
+    validate_delivery_identity, validate_delivery_status_request, validate_policy,
+    validate_subscription_identity, validate_subscription_record, validate_subscription_request,
 };
 use crate::{
     AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
@@ -74,6 +73,7 @@ const MAX_CAS_RETRIES: usize = 5;
 const DELIVERY_SCOPE_INDEX_KEY: &str = "scope";
 const DELIVERY_SCOPE_INDEX_NAME: &str = "outbound_delivery_scope";
 const DELIVERIES_ROOT: &str = "/outbound/deliveries";
+const COMMUNICATION_PREFERENCES_ROOT: &str = "/outbound/communication-preferences";
 
 /// Indexed projection key for the tenant id, written alongside every
 /// outbound write as a defense-in-depth measure beyond path-prefix
@@ -244,24 +244,43 @@ where
         record: CommunicationPreferenceRecord,
     ) -> Result<(), OutboundError> {
         validate_communication_preference(&record)?;
-        let path = communication_preference_path(&record.tenant_id, &record.user_id)?;
-        let resource_scope =
-            communication_preference_resource_scope(&record.tenant_id, &record.user_id);
-        self.put_json(
-            &resource_scope,
-            &path,
-            &record,
-            &record.tenant_id,
-            CasExpectation::Any,
-        )
-        .await
+        let key = record.key();
+        let path = communication_preference_path(&key)?;
+        let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
+        self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
+            .await?;
+        for _ in 0..MAX_CAS_RETRIES {
+            let (cas, existing) = match self
+                .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
+                .await?
+            {
+                Some((existing, versioned)) => {
+                    (CasExpectation::Version(versioned.version), Some(existing))
+                }
+                None => (CasExpectation::Absent, None),
+            };
+            if let Some(existing) = existing.as_ref()
+                && existing.key() != key
+            {
+                return Err(OutboundError::Backend);
+            }
+            match self
+                .put_json(&resource_scope, &path, &record, &record.tenant_id, cas)
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(OutboundError::CasConflict) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(OutboundError::Backend)
     }
 
     async fn load_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
     ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
-        let path = communication_preference_path(&key.tenant_id, &key.user_id)?;
+        let path = communication_preference_path(&key)?;
         let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
         let Some(record) = self
             .get_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
@@ -581,13 +600,14 @@ fn delivery_path(delivery_id: &OutboundDeliveryId) -> Result<ScopedPath, Outboun
 }
 
 fn communication_preference_path(
-    tenant_id: &TenantId,
-    user_id: &UserId,
+    key: &CommunicationPreferenceKey,
 ) -> Result<ScopedPath, OutboundError> {
-    ScopedPath::new(format!(
-        "/outbound/communication-preferences/{tenant_id}/{user_id}.json"
-    ))
-    .map_err(|_| OutboundError::Backend)
+    let serialized = serde_json::to_string(key).map_err(|_| OutboundError::Serialization)?;
+    let mut hasher = Sha256::new();
+    hasher.update(serialized.as_bytes());
+    let digest = hex::encode(hasher.finalize());
+    ScopedPath::new(format!("{COMMUNICATION_PREFERENCES_ROOT}/{digest}.json"))
+        .map_err(|_| OutboundError::Backend)
 }
 
 fn communication_preference_resource_scope(
@@ -602,6 +622,10 @@ fn communication_preference_resource_scope(
 
 fn deliveries_root() -> Result<ScopedPath, OutboundError> {
     ScopedPath::new(DELIVERIES_ROOT).map_err(|_| OutboundError::Backend)
+}
+
+fn communication_preferences_root() -> Result<ScopedPath, OutboundError> {
+    ScopedPath::new(COMMUNICATION_PREFERENCES_ROOT).map_err(|_| OutboundError::Backend)
 }
 
 fn policies_root() -> Result<ScopedPath, OutboundError> {

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -26,6 +26,9 @@
 //!   `delivery_id`. An indexed `scope` projection allows
 //!   `list_delivery_attempts(scope)` to filter within the tenant-scoped
 //!   subtree without materializing every row.
+//! - `/outbound/communication-preferences/<tenant-user-key>.json` — tenant/user
+//!   communication preference row. Reply-target refs remain candidates and do
+//!   not grant send authority.
 
 use std::sync::Arc;
 
@@ -35,18 +38,20 @@ use ironclaw_filesystem::{
     CasExpectation, ContentType, Entry, FilesystemError, Filter, IndexKey, IndexKind, IndexName,
     IndexSpec, IndexValue, Page, RootFilesystem, ScopedFilesystem, VersionedEntry,
 };
-use ironclaw_host_api::{ResourceScope, ScopedPath, TenantId, ThreadId};
+use ironclaw_host_api::{ResourceScope, ScopedPath, TenantId, ThreadId, UserId};
 use ironclaw_turns::{TurnActor, TurnScope};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
+use crate::communication_preferences::validate_communication_preference;
 use crate::validation::{
     validate_advance_request, validate_delivery_attempt, validate_delivery_identity,
     validate_delivery_status_request, validate_policy, validate_subscription_identity,
     validate_subscription_record, validate_subscription_request,
 };
 use crate::{
-    AdvanceSubscriptionCursorRequest, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
+    AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
+    CommunicationPreferenceRepository, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
     OutboundDeliveryId, OutboundError, OutboundStateStore, ProjectionSubscriptionId,
     ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
 };
@@ -80,6 +85,7 @@ const TENANT_ID_INDEX_KEY: &str = "tenant_id";
 const TENANT_ID_INDEX_NAME: &str = "outbound_by_tenant";
 const POLICIES_ROOT: &str = "/outbound/policies";
 const SUBSCRIPTIONS_ROOT: &str = "/outbound/subscriptions";
+const COMMUNICATION_PREFERENCES_ROOT: &str = "/outbound/communication-preferences";
 
 /// Filesystem-backed outbound store. Construct with a [`ScopedFilesystem`]
 /// over any [`RootFilesystem`] implementation (libSQL, Postgres, in-memory,
@@ -226,6 +232,50 @@ where
             .get_versioned_json::<T>(scope, path)
             .await?
             .map(|(value, _)| value))
+    }
+}
+
+#[async_trait]
+impl<F> CommunicationPreferenceRepository for FilesystemOutboundStateStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn put_communication_preference(
+        &self,
+        record: CommunicationPreferenceRecord,
+    ) -> Result<(), OutboundError> {
+        validate_communication_preference(&record)?;
+        let path = communication_preference_path(&record.tenant_id, &record.user_id)?;
+        let resource_scope =
+            communication_preference_resource_scope(&record.tenant_id, &record.user_id);
+        self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
+            .await?;
+        self.put_json(
+            &resource_scope,
+            &path,
+            &record,
+            &record.tenant_id,
+            CasExpectation::Any,
+        )
+        .await
+    }
+
+    async fn load_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        let path = communication_preference_path(&key.tenant_id, &key.user_id)?;
+        let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
+        let Some(record) = self
+            .get_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if record.tenant_id != key.tenant_id || record.user_id != key.user_id {
+            return Err(OutboundError::Backend);
+        }
+        Ok(Some(record))
     }
 }
 
@@ -533,6 +583,34 @@ fn delivery_path(delivery_id: &OutboundDeliveryId) -> Result<ScopedPath, Outboun
         .map_err(|_| OutboundError::Backend)
 }
 
+fn communication_preference_path(
+    tenant_id: &TenantId,
+    user_id: &UserId,
+) -> Result<ScopedPath, OutboundError> {
+    #[derive(Serialize)]
+    struct PreferenceIdentity<'a> {
+        tenant_id: &'a TenantId,
+        user_id: &'a UserId,
+    }
+    let identity = PreferenceIdentity { tenant_id, user_id };
+    let serialized = serde_json::to_string(&identity).map_err(|_| OutboundError::Serialization)?;
+    let mut hasher = Sha256::new();
+    hasher.update(serialized.as_bytes());
+    let digest = hex::encode(hasher.finalize());
+    ScopedPath::new(format!("/outbound/communication-preferences/{digest}.json"))
+        .map_err(|_| OutboundError::Backend)
+}
+
+fn communication_preference_resource_scope(
+    tenant_id: &TenantId,
+    user_id: &UserId,
+) -> ResourceScope {
+    let mut scope = ResourceScope::system();
+    scope.tenant_id = tenant_id.clone();
+    scope.user_id = user_id.clone();
+    scope
+}
+
 fn deliveries_root() -> Result<ScopedPath, OutboundError> {
     ScopedPath::new(DELIVERIES_ROOT).map_err(|_| OutboundError::Backend)
 }
@@ -543,6 +621,10 @@ fn policies_root() -> Result<ScopedPath, OutboundError> {
 
 fn subscriptions_root() -> Result<ScopedPath, OutboundError> {
     ScopedPath::new(SUBSCRIPTIONS_ROOT).map_err(|_| OutboundError::Backend)
+}
+
+fn communication_preferences_root() -> Result<ScopedPath, OutboundError> {
+    ScopedPath::new(COMMUNICATION_PREFERENCES_ROOT).map_err(|_| OutboundError::Backend)
 }
 
 fn tenant_id_index_key() -> IndexKey {

--- a/crates/ironclaw_outbound/src/lib.rs
+++ b/crates/ironclaw_outbound/src/lib.rs
@@ -5,6 +5,7 @@
 //! status. It never owns transport delivery, transcript content, projection
 //! payloads, prompts, tool I/O, secrets, host paths, or backend detail strings.
 
+mod communication_preferences;
 mod delivery_resolution;
 mod error;
 mod filesystem_store;
@@ -15,6 +16,9 @@ mod store;
 mod types;
 mod validation;
 
+pub use communication_preferences::{
+    CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
+};
 pub use delivery_resolution::{
     CommunicationDeliveryCandidate, CommunicationDeliveryIntent, CommunicationDeliveryKind,
     CommunicationDeliveryResolutionRequest, CommunicationModality, DeliveryTargetCapabilities,

--- a/crates/ironclaw_outbound/src/memory.rs
+++ b/crates/ironclaw_outbound/src/memory.rs
@@ -3,17 +3,19 @@ use std::sync::Mutex;
 
 use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
-use ironclaw_host_api::ThreadId;
+use ironclaw_host_api::{TenantId, ThreadId, UserId};
 use ironclaw_turns::{TurnActor, TurnScope};
 use serde::Serialize;
 
+use crate::communication_preferences::validate_communication_preference;
 use crate::validation::{
     validate_advance_request, validate_delivery_attempt, validate_delivery_identity,
     validate_delivery_status_request, validate_policy, validate_subscription_identity,
     validate_subscription_record, validate_subscription_request,
 };
 use crate::{
-    AdvanceSubscriptionCursorRequest, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
+    AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
+    CommunicationPreferenceRepository, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
     OutboundDeliveryId, OutboundError, OutboundStateStore, ProjectionSubscriptionId,
     ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
 };
@@ -25,9 +27,17 @@ pub struct InMemoryOutboundStateStore {
 
 #[derive(Default)]
 struct InMemoryOutboundState {
+    communication_preferences:
+        HashMap<CommunicationPreferenceMemoryKey, CommunicationPreferenceRecord>,
     policies: HashMap<ThreadScopeKey, ThreadNotificationPolicy>,
     subscriptions: HashMap<ProjectionSubscriptionKey, ProjectionSubscriptionRecord>,
     deliveries: HashMap<OutboundDeliveryId, OutboundDeliveryAttempt>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CommunicationPreferenceMemoryKey {
+    tenant_id: String,
+    user_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -40,6 +50,23 @@ struct ThreadScopeKey {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ProjectionSubscriptionKey(String);
+
+impl CommunicationPreferenceMemoryKey {
+    fn new(tenant_id: &TenantId, user_id: &UserId) -> Self {
+        Self {
+            tenant_id: tenant_id.to_string(),
+            user_id: user_id.to_string(),
+        }
+    }
+
+    fn from_key(key: &CommunicationPreferenceKey) -> Self {
+        Self::new(&key.tenant_id, &key.user_id)
+    }
+
+    fn from_record(record: &CommunicationPreferenceRecord) -> Self {
+        Self::new(&record.tenant_id, &record.user_id)
+    }
+}
 
 impl ThreadScopeKey {
     fn new(scope: &TurnScope) -> Self {
@@ -84,6 +111,33 @@ impl ProjectionSubscriptionKey {
         })
         .map(Self)
         .map_err(|_| OutboundError::Serialization)
+    }
+}
+
+#[async_trait]
+impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
+    async fn put_communication_preference(
+        &self,
+        record: CommunicationPreferenceRecord,
+    ) -> Result<(), OutboundError> {
+        validate_communication_preference(&record)?;
+        let mut state = self.lock_state()?;
+        state.communication_preferences.insert(
+            CommunicationPreferenceMemoryKey::from_record(&record),
+            record,
+        );
+        Ok(())
+    }
+
+    async fn load_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        let state = self.lock_state()?;
+        Ok(state
+            .communication_preferences
+            .get(&CommunicationPreferenceMemoryKey::from_key(&key))
+            .cloned())
     }
 }
 

--- a/crates/ironclaw_outbound/src/memory.rs
+++ b/crates/ironclaw_outbound/src/memory.rs
@@ -3,15 +3,14 @@ use std::sync::Mutex;
 
 use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
-use ironclaw_host_api::{TenantId, ThreadId, UserId};
+use ironclaw_host_api::ThreadId;
 use ironclaw_turns::{TurnActor, TurnScope};
 use serde::Serialize;
 
-use crate::communication_preferences::validate_communication_preference;
 use crate::validation::{
-    validate_advance_request, validate_delivery_attempt, validate_delivery_identity,
-    validate_delivery_status_request, validate_policy, validate_subscription_identity,
-    validate_subscription_record, validate_subscription_request,
+    validate_advance_request, validate_communication_preference, validate_delivery_attempt,
+    validate_delivery_identity, validate_delivery_status_request, validate_policy,
+    validate_subscription_identity, validate_subscription_record, validate_subscription_request,
 };
 use crate::{
     AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
@@ -27,17 +26,10 @@ pub struct InMemoryOutboundStateStore {
 
 #[derive(Default)]
 struct InMemoryOutboundState {
-    communication_preferences:
-        HashMap<CommunicationPreferenceMemoryKey, CommunicationPreferenceRecord>,
+    communication_preferences: HashMap<CommunicationPreferenceKey, CommunicationPreferenceRecord>,
     policies: HashMap<ThreadScopeKey, ThreadNotificationPolicy>,
     subscriptions: HashMap<ProjectionSubscriptionKey, ProjectionSubscriptionRecord>,
     deliveries: HashMap<OutboundDeliveryId, OutboundDeliveryAttempt>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct CommunicationPreferenceMemoryKey {
-    tenant_id: String,
-    user_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -50,23 +42,6 @@ struct ThreadScopeKey {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ProjectionSubscriptionKey(String);
-
-impl CommunicationPreferenceMemoryKey {
-    fn new(tenant_id: &TenantId, user_id: &UserId) -> Self {
-        Self {
-            tenant_id: tenant_id.to_string(),
-            user_id: user_id.to_string(),
-        }
-    }
-
-    fn from_key(key: &CommunicationPreferenceKey) -> Self {
-        Self::new(&key.tenant_id, &key.user_id)
-    }
-
-    fn from_record(record: &CommunicationPreferenceRecord) -> Self {
-        Self::new(&record.tenant_id, &record.user_id)
-    }
-}
 
 impl ThreadScopeKey {
     fn new(scope: &TurnScope) -> Self {
@@ -122,10 +97,7 @@ impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
     ) -> Result<(), OutboundError> {
         validate_communication_preference(&record)?;
         let mut state = self.lock_state()?;
-        state.communication_preferences.insert(
-            CommunicationPreferenceMemoryKey::from_record(&record),
-            record,
-        );
+        state.communication_preferences.insert(record.key(), record);
         Ok(())
     }
 
@@ -134,10 +106,7 @@ impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
         key: CommunicationPreferenceKey,
     ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
         let state = self.lock_state()?;
-        Ok(state
-            .communication_preferences
-            .get(&CommunicationPreferenceMemoryKey::from_key(&key))
-            .cloned())
+        Ok(state.communication_preferences.get(&key).cloned())
     }
 }
 

--- a/crates/ironclaw_outbound/src/validation.rs
+++ b/crates/ironclaw_outbound/src/validation.rs
@@ -175,6 +175,16 @@ pub(crate) fn validate_delivery_identity(
 pub(crate) fn validate_communication_preference(
     record: &CommunicationPreferenceRecord,
 ) -> Result<(), OutboundError> {
+    if record.tenant_id.as_str().is_empty() {
+        return Err(OutboundError::InvalidRequest {
+            reason: "communication preference tenant is required",
+        });
+    }
+    if record.user_id.as_str().is_empty() {
+        return Err(OutboundError::InvalidRequest {
+            reason: "communication preference user is required",
+        });
+    }
     if record.updated_by.as_str().is_empty() {
         return Err(OutboundError::InvalidRequest {
             reason: "communication preference updater is required",

--- a/crates/ironclaw_outbound/src/validation.rs
+++ b/crates/ironclaw_outbound/src/validation.rs
@@ -3,9 +3,9 @@ use std::collections::HashSet;
 use ironclaw_turns::ReplyTargetBindingRef;
 
 use crate::{
-    AdvanceSubscriptionCursorRequest, DeliveryFailureKind, LoadSubscriptionCursorRequest,
-    OutboundDeliveryAttempt, OutboundDeliveryStatus, OutboundError, ProjectionSubscriptionRecord,
-    ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    AdvanceSubscriptionCursorRequest, CommunicationPreferenceRecord, DeliveryFailureKind,
+    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryStatus, OutboundError,
+    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
 };
 
 const MAX_NOTIFICATION_TARGETS: usize = 32;
@@ -168,6 +168,17 @@ pub(crate) fn validate_delivery_identity(
         || existing.attempted_at != incoming.attempted_at
     {
         return Err(OutboundError::Backend);
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_communication_preference(
+    record: &CommunicationPreferenceRecord,
+) -> Result<(), OutboundError> {
+    if record.updated_by.as_str().is_empty() {
+        return Err(OutboundError::InvalidRequest {
+            reason: "communication preference updater is required",
+        });
     }
     Ok(())
 }

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -46,6 +46,7 @@ fn build_outbound_store_for_backend(
 #[tokio::test]
 async fn in_memory_defaults_policy_progress_opt_in_and_subscription_scope() {
     let store = InMemoryOutboundStateStore::default();
+    communication_preferences_are_tenant_user_scoped(&store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
     subscription_ids_are_scoped_not_global(&store).await;
@@ -64,6 +65,7 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     // HSM-decorated mount, with no consumer-side code change.
     let backend = std::sync::Arc::new(ironclaw_filesystem::InMemoryBackend::new());
     let store = build_outbound_store_for_backend(backend);
+    communication_preferences_are_tenant_user_scoped(&store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
     subscription_ids_are_scoped_not_global(&store).await;
@@ -78,6 +80,89 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
 // them; durability across reopen is now a property of the
 // `RootFilesystem` backend, not of an outbound-specific persistence
 // implementation.
+
+async fn communication_preferences_are_tenant_user_scoped<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound").unwrap();
+    let user_id = UserId::new("user-outbound").unwrap();
+    let updated_by = UserId::new("tenant-admin-outbound").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        tenant_id: tenant_id.clone(),
+        user_id: user_id.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-final")),
+        progress_target: Some(reply_ref("reply-pref-progress")),
+        approval_prompt_target: Some(reply_ref("reply-pref-approval")),
+        auth_prompt_target: Some(reply_ref("reply-pref-auth")),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: updated_by.clone(),
+    };
+
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .load_communication_preference(key.clone())
+            .await
+            .unwrap(),
+        Some(record.clone())
+    );
+
+    let sibling_user_key = CommunicationPreferenceKey::new(
+        tenant_id.clone(),
+        UserId::new("user-outbound-sibling").unwrap(),
+    );
+    assert!(
+        store
+            .load_communication_preference(sibling_user_key)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let sibling_tenant_key =
+        CommunicationPreferenceKey::new(TenantId::new("tenant-outbound-sibling").unwrap(), user_id);
+    assert!(
+        store
+            .load_communication_preference(sibling_tenant_key)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let updated = CommunicationPreferenceRecord {
+        final_reply_target: Some(reply_ref("reply-pref-final-updated")),
+        progress_target: None,
+        approval_prompt_target: Some(reply_ref("reply-pref-approval")),
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Voice),
+        updated_at: now(),
+        updated_by,
+        ..record
+    };
+    store
+        .put_communication_preference(updated.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        store.load_communication_preference(key).await.unwrap(),
+        Some(updated)
+    );
+
+    let thread_policy = store
+        .load_thread_notification_policy(turn_scope())
+        .await
+        .unwrap();
+    assert!(
+        thread_policy.targets.is_empty(),
+        "user communication preferences must not mutate thread notification policy"
+    );
+}
 
 async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateStore) {
     let scope = turn_scope();

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
 use ironclaw_events::{EventCursor, EventStreamKey, ReadScope};
 use ironclaw_filesystem::{
-    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError, Filter,
-    InMemoryBackend, IndexSpec, Page, RecordVersion, RootFilesystem, ScopedFilesystem,
+    BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FilesystemError,
+    Filter, InMemoryBackend, IndexSpec, Page, RecordVersion, RootFilesystem, ScopedFilesystem,
     VersionedEntry,
 };
 use ironclaw_host_api::{
@@ -15,6 +15,8 @@ use ironclaw_host_api::{
 use ironclaw_outbound::*;
 use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
 use tokio::sync::Mutex;
+
+const TEST_OUTBOUND_ROOT: &str = "/engine/tenants/test/users/test/outbound";
 
 /// Build a `ScopedFilesystem<F>` with full read/write/list/delete permissions
 /// on the `/outbound` alias, mapped to a distinct tenant-scoped
@@ -37,16 +39,14 @@ fn build_scoped_fs<F: RootFilesystem>(
 fn build_outbound_store_for_backend(
     backend: Arc<InMemoryBackend>,
 ) -> FilesystemOutboundStateStore<InMemoryBackend> {
-    FilesystemOutboundStateStore::new(build_scoped_fs(
-        backend,
-        "/engine/tenants/test/users/test/outbound",
-    ))
+    FilesystemOutboundStateStore::new(build_scoped_fs(backend, TEST_OUTBOUND_ROOT))
 }
 
 #[tokio::test]
 async fn in_memory_defaults_policy_progress_opt_in_and_subscription_scope() {
     let store = InMemoryOutboundStateStore::default();
     communication_preferences_are_tenant_user_scoped(&store).await;
+    communication_preferences_reject_empty_updated_by(&store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
     subscription_ids_are_scoped_not_global(&store).await;
@@ -64,8 +64,10 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     // this would be a libSQL- or Postgres-backed RootFilesystem, or an
     // HSM-decorated mount, with no consumer-side code change.
     let backend = std::sync::Arc::new(ironclaw_filesystem::InMemoryBackend::new());
-    let store = build_outbound_store_for_backend(backend);
+    let store = build_outbound_store_for_backend(Arc::clone(&backend));
     communication_preferences_are_tenant_user_scoped(&store).await;
+    communication_preferences_reject_empty_updated_by(&store).await;
+    filesystem_store_rejects_mismatched_communication_preference_identity(&backend, &store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
     subscription_ids_are_scoped_not_global(&store).await;
@@ -100,6 +102,7 @@ where
         updated_at: now(),
         updated_by: updated_by.clone(),
     };
+    assert_eq!(record.key(), key);
 
     store
         .put_communication_preference(record.clone())
@@ -162,6 +165,62 @@ where
         thread_policy.targets.is_empty(),
         "user communication preferences must not mutate thread notification policy"
     );
+}
+
+async fn communication_preferences_reject_empty_updated_by<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let result = store
+        .put_communication_preference(CommunicationPreferenceRecord {
+            tenant_id: TenantId::new("tenant-outbound-validation").unwrap(),
+            user_id: UserId::new("user-outbound-validation").unwrap(),
+            final_reply_target: Some(reply_ref("reply-pref-validation")),
+            progress_target: None,
+            approval_prompt_target: None,
+            auth_prompt_target: None,
+            default_modality: Some(CommunicationModality::Text),
+            updated_at: now(),
+            updated_by: UserId::from_trusted(String::new()),
+        })
+        .await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+}
+
+async fn filesystem_store_rejects_mismatched_communication_preference_identity(
+    backend: &Arc<InMemoryBackend>,
+    store: &FilesystemOutboundStateStore<InMemoryBackend>,
+) {
+    let tenant_id = TenantId::new("tenant-outbound-corrupt").unwrap();
+    let user_id = UserId::new("user-outbound-corrupt").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let mut record = CommunicationPreferenceRecord {
+        tenant_id: tenant_id.clone(),
+        user_id: user_id.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-corrupt")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-corrupt").unwrap(),
+    };
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+
+    record.user_id = UserId::new("user-outbound-corrupt-other").unwrap();
+    let path = communication_preference_virtual_path(&tenant_id, &user_id);
+    let entry =
+        Entry::bytes(serde_json::to_vec(&record).unwrap()).with_content_type(ContentType::json());
+    backend
+        .put(&path, entry, CasExpectation::Any)
+        .await
+        .unwrap();
+
+    let result = store.load_communication_preference(key).await;
+    assert!(matches!(result, Err(OutboundError::Backend)));
 }
 
 async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateStore) {
@@ -762,6 +821,13 @@ fn reply_ref(value: &str) -> ReplyTargetBindingRef {
 
 fn now() -> ironclaw_host_api::Timestamp {
     chrono::Utc::now()
+}
+
+fn communication_preference_virtual_path(tenant_id: &TenantId, user_id: &UserId) -> VirtualPath {
+    VirtualPath::new(format!(
+        "{TEST_OUTBOUND_ROOT}/communication-preferences/{tenant_id}/{user_id}.json"
+    ))
+    .unwrap()
 }
 
 // ── F4 — CAS retry / drain / backwards-race regression tests ─────────────

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -14,6 +14,7 @@ use ironclaw_host_api::{
 };
 use ironclaw_outbound::*;
 use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
+use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
 const TEST_OUTBOUND_ROOT: &str = "/engine/tenants/test/users/test/outbound";
@@ -67,6 +68,7 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     let store = build_outbound_store_for_backend(Arc::clone(&backend));
     communication_preferences_are_tenant_user_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
+    filesystem_store_retries_communication_preference_put_through_cas_conflict(&backend).await;
     filesystem_store_rejects_mismatched_communication_preference_identity(&backend, &store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
@@ -219,8 +221,74 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
         .await
         .unwrap();
 
+    let result = store.load_communication_preference(key.clone()).await;
+    assert!(matches!(result, Err(OutboundError::Backend)));
+
+    let tenant_mismatch_record = CommunicationPreferenceRecord {
+        tenant_id: TenantId::new("tenant-outbound-corrupt-other").unwrap(),
+        user_id: user_id.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-corrupt-tenant")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-corrupt-tenant").unwrap(),
+    };
+    let tenant_mismatch_path = communication_preference_virtual_path(&tenant_id, &user_id);
+    let tenant_mismatch_entry = Entry::bytes(serde_json::to_vec(&tenant_mismatch_record).unwrap())
+        .with_content_type(ContentType::json());
+    backend
+        .put(
+            &tenant_mismatch_path,
+            tenant_mismatch_entry,
+            CasExpectation::Any,
+        )
+        .await
+        .unwrap();
+
     let result = store.load_communication_preference(key).await;
     assert!(matches!(result, Err(OutboundError::Backend)));
+}
+
+async fn filesystem_store_retries_communication_preference_put_through_cas_conflict(
+    backend: &Arc<InMemoryBackend>,
+) {
+    let racing = Arc::new(VersionRacingBackend::new(Arc::clone(backend)));
+    let store =
+        FilesystemOutboundStateStore::new(build_scoped_fs(Arc::clone(&racing), TEST_OUTBOUND_ROOT));
+    let tenant_id = TenantId::new("tenant-outbound-cas").unwrap();
+    let user_id = UserId::new("user-outbound-cas").unwrap();
+    racing
+        .arm(
+            &format!("{TEST_OUTBOUND_ROOT}/communication-preferences/"),
+            1,
+        )
+        .await;
+
+    let record = CommunicationPreferenceRecord {
+        tenant_id: tenant_id.clone(),
+        user_id: user_id.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-cas")),
+        progress_target: Some(reply_ref("reply-pref-cas-progress")),
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-cas").unwrap(),
+    };
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .load_communication_preference(CommunicationPreferenceKey::new(tenant_id, user_id))
+            .await
+            .unwrap(),
+        Some(record)
+    );
+    assert_eq!(racing.injected_count().await, 1);
 }
 
 async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateStore) {
@@ -824,8 +892,13 @@ fn now() -> ironclaw_host_api::Timestamp {
 }
 
 fn communication_preference_virtual_path(tenant_id: &TenantId, user_id: &UserId) -> VirtualPath {
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let serialized = serde_json::to_string(&key).unwrap();
+    let mut hasher = Sha256::new();
+    hasher.update(serialized.as_bytes());
+    let digest = hex::encode(hasher.finalize());
     VirtualPath::new(format!(
-        "{TEST_OUTBOUND_ROOT}/communication-preferences/{tenant_id}/{user_id}.json"
+        "{TEST_OUTBOUND_ROOT}/communication-preferences/{digest}.json"
     ))
     .unwrap()
 }

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -14,7 +14,6 @@ use ironclaw_host_api::{
 };
 use ironclaw_outbound::*;
 use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
-use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
 const TEST_OUTBOUND_ROOT: &str = "/engine/tenants/test/users/test/outbound";
@@ -173,19 +172,31 @@ async fn communication_preferences_reject_empty_updated_by<S>(store: &S)
 where
     S: CommunicationPreferenceRepository + OutboundStateStore,
 {
-    let result = store
-        .put_communication_preference(CommunicationPreferenceRecord {
-            tenant_id: TenantId::new("tenant-outbound-validation").unwrap(),
-            user_id: UserId::new("user-outbound-validation").unwrap(),
-            final_reply_target: Some(reply_ref("reply-pref-validation")),
-            progress_target: None,
-            approval_prompt_target: None,
-            auth_prompt_target: None,
-            default_modality: Some(CommunicationModality::Text),
-            updated_at: now(),
-            updated_by: UserId::from_trusted(String::new()),
-        })
-        .await;
+    let valid_record = CommunicationPreferenceRecord {
+        tenant_id: TenantId::new("tenant-outbound-validation").unwrap(),
+        user_id: UserId::new("user-outbound-validation").unwrap(),
+        final_reply_target: Some(reply_ref("reply-pref-validation")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-validation-updater").unwrap(),
+    };
+
+    let mut missing_updater = valid_record.clone();
+    missing_updater.updated_by = UserId::from_trusted(String::new());
+    let result = store.put_communication_preference(missing_updater).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+
+    let mut missing_tenant = valid_record.clone();
+    missing_tenant.tenant_id = TenantId::from_trusted(String::new());
+    let result = store.put_communication_preference(missing_tenant).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+
+    let mut missing_user = valid_record;
+    missing_user.user_id = UserId::from_trusted(String::new());
+    let result = store.put_communication_preference(missing_user).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 }
 
@@ -195,8 +206,7 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
 ) {
     let tenant_id = TenantId::new("tenant-outbound-corrupt").unwrap();
     let user_id = UserId::new("user-outbound-corrupt").unwrap();
-    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
-    let mut record = CommunicationPreferenceRecord {
+    let record = CommunicationPreferenceRecord {
         tenant_id: tenant_id.clone(),
         user_id: user_id.clone(),
         final_reply_target: Some(reply_ref("reply-pref-corrupt")),
@@ -207,15 +217,12 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-corrupt").unwrap(),
     };
-    store
-        .put_communication_preference(record.clone())
-        .await
-        .unwrap();
+    let (key, path) = put_preference_and_find_virtual_path(backend, store, record.clone()).await;
 
-    record.user_id = UserId::new("user-outbound-corrupt-other").unwrap();
-    let path = communication_preference_virtual_path(&tenant_id, &user_id);
-    let entry =
-        Entry::bytes(serde_json::to_vec(&record).unwrap()).with_content_type(ContentType::json());
+    let mut user_mismatch_record = record;
+    user_mismatch_record.user_id = UserId::new("user-outbound-corrupt-other").unwrap();
+    let entry = Entry::bytes(serde_json::to_vec(&user_mismatch_record).unwrap())
+        .with_content_type(ContentType::json());
     backend
         .put(&path, entry, CasExpectation::Any)
         .await
@@ -224,9 +231,24 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let result = store.load_communication_preference(key.clone()).await;
     assert!(matches!(result, Err(OutboundError::Backend)));
 
+    let tenant_mismatch_tenant_id = TenantId::new("tenant-outbound-corrupt-tenant").unwrap();
+    let tenant_mismatch_user_id = UserId::new("user-outbound-corrupt-tenant").unwrap();
+    let tenant_mismatch_seed = CommunicationPreferenceRecord {
+        tenant_id: tenant_mismatch_tenant_id,
+        user_id: tenant_mismatch_user_id.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-corrupt-tenant-seed")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-corrupt-tenant-seed").unwrap(),
+    };
+    let (tenant_mismatch_key, tenant_mismatch_path) =
+        put_preference_and_find_virtual_path(backend, store, tenant_mismatch_seed).await;
     let tenant_mismatch_record = CommunicationPreferenceRecord {
         tenant_id: TenantId::new("tenant-outbound-corrupt-other").unwrap(),
-        user_id: user_id.clone(),
+        user_id: tenant_mismatch_user_id,
         final_reply_target: Some(reply_ref("reply-pref-corrupt-tenant")),
         progress_target: None,
         approval_prompt_target: None,
@@ -235,7 +257,6 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-corrupt-tenant").unwrap(),
     };
-    let tenant_mismatch_path = communication_preference_virtual_path(&tenant_id, &user_id);
     let tenant_mismatch_entry = Entry::bytes(serde_json::to_vec(&tenant_mismatch_record).unwrap())
         .with_content_type(ContentType::json());
     backend
@@ -247,7 +268,9 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
         .await
         .unwrap();
 
-    let result = store.load_communication_preference(key).await;
+    let result = store
+        .load_communication_preference(tenant_mismatch_key)
+        .await;
     assert!(matches!(result, Err(OutboundError::Backend)));
 }
 
@@ -891,16 +914,36 @@ fn now() -> ironclaw_host_api::Timestamp {
     chrono::Utc::now()
 }
 
-fn communication_preference_virtual_path(tenant_id: &TenantId, user_id: &UserId) -> VirtualPath {
-    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
-    let serialized = serde_json::to_string(&key).unwrap();
-    let mut hasher = Sha256::new();
-    hasher.update(serialized.as_bytes());
-    let digest = hex::encode(hasher.finalize());
-    VirtualPath::new(format!(
-        "{TEST_OUTBOUND_ROOT}/communication-preferences/{digest}.json"
-    ))
-    .unwrap()
+async fn put_preference_and_find_virtual_path(
+    backend: &Arc<InMemoryBackend>,
+    store: &FilesystemOutboundStateStore<InMemoryBackend>,
+    record: CommunicationPreferenceRecord,
+) -> (CommunicationPreferenceKey, VirtualPath) {
+    let before = communication_preference_virtual_paths(backend).await;
+    let key = record.key();
+    store.put_communication_preference(record).await.unwrap();
+    let mut added = communication_preference_virtual_paths(backend)
+        .await
+        .into_iter()
+        .filter(|path| !before.contains(path))
+        .collect::<Vec<_>>();
+    assert_eq!(added.len(), 1);
+    (key, added.remove(0))
+}
+
+async fn communication_preference_virtual_paths(
+    backend: &Arc<InMemoryBackend>,
+) -> Vec<VirtualPath> {
+    let root = VirtualPath::new(format!("{TEST_OUTBOUND_ROOT}/communication-preferences")).unwrap();
+    let mut paths = backend
+        .list_dir(&root)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.path)
+        .collect::<Vec<_>>();
+    paths.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    paths
 }
 
 // ── F4 — CAS retry / drain / backwards-race regression tests ─────────────


### PR DESCRIPTION
## Summary
- Add an outbound-owned typed `CommunicationPreferenceRepository` for tenant/user delivery preferences.
- Store `final_reply_target`, `progress_target`, `approval_prompt_target`, `auth_prompt_target`, `default_modality`, timestamps, and updater identity.
- Add in-memory and filesystem-backed repository behavior plus contract coverage for tenant/user scoping and validation.

## Scope and later phases
This PR intentionally adds the typed preference store that PR5 will consume. It does not implement the outbound resolution engine, product egress, adapter rendering, or trigger delivery integration.

Stored `ReplyTargetBindingRef` values are candidates only. They still need to flow through the later outbound validation path before any send authority is granted.

The repository surface is intentionally present now so the next delivery-resolution phase can depend on a typed outbound-owned policy source instead of profile/TOML config or the generic JSON settings store.

## Verification
- `cargo fmt --all`
- `cargo test -p ironclaw_outbound`
- `cargo clippy -p ironclaw_outbound --all-targets --all-features -- -D warnings`
- subset `$code-review` with `gpt-5.4-mini`, then fix pass
