### PR TITLE
feat(outbound): add resolution engine

### DIFF
--- a/crates/ironclaw_outbound/CLAUDE.md
+++ b/crates/ironclaw_outbound/CLAUDE.md
@@ -4,6 +4,7 @@
 - Do not send transport messages, validate concrete Slack/Telegram/Web payloads, or mutate canonical transcript/projection state.
 - Persist metadata/refs/cursors only: no raw prompts, message bodies, tool inputs/outputs, secrets, host paths, or backend error details.
 - External push targets are candidates only; the outbound policy service must call the reply-target validator before every delivery attempt.
+- `OutboundResolutionEngine` is the read-only candidate selector above `OutboundPolicyService`; it resolves typed delivery requests into `CommunicationDeliveryCandidate` or `NoDelivery`, but never validates targets, records attempts, or mutates inbound/approval/auth state.
 - Authorization-revoked delivery attempts record sanitized failure status and must not return a sendable target.
 - Delivery failure records are separate from canonical transcript/projection state and must not mark turns/runs failed.
 - Trust-bearing types (`ThreadProjectionAccessGrant`, `ValidatedReplyTargetBinding`) are sealed: only `OutboundPolicyService` mints them via `pub(crate)` constructors. Policy and validator implementors return the corresponding untrusted `Claim` types (`ThreadProjectionAccessClaim`, `ReplyTargetBindingClaim`) and never construct a grant/binding directly. New trust-bearing types added to this crate follow the same claim/seal split, keep fields non-public, and must not derive `Deserialize`; public envelope types that carry them (for example `OutboundDeliveryDecision`) also must not derive `Deserialize`.

--- a/crates/ironclaw_outbound/src/delivery_resolution.rs
+++ b/crates/ironclaw_outbound/src/delivery_resolution.rs
@@ -204,10 +204,33 @@ pub struct CommunicationDeliveryCandidate {
     pub kind: CommunicationDeliveryKind,
 }
 
+/// Result of resolving a communication request.
+///
+/// Most intents produce a concrete delivery candidate. Host/system events are
+/// metadata-only in P0 unless a caller explicitly requested outbound delivery,
+/// so they resolve to `NoDelivery` rather than being treated as invalid input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum CommunicationDeliveryResolution {
+    Candidate {
+        candidate: CommunicationDeliveryCandidate,
+    },
+    NoDelivery {
+        reason: SystemEventReasonCode,
+    },
+}
+
+impl CommunicationDeliveryResolution {
+    pub fn candidate(candidate: CommunicationDeliveryCandidate) -> Self {
+        Self::Candidate { candidate }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+    use serde::Serialize;
     use serde::de::DeserializeOwned;
     use serde_json::{from_str, to_string};
 
@@ -381,6 +404,19 @@ mod tests {
     }
 
     #[test]
+    fn communication_delivery_resolution_serializes_all_variants() {
+        assert_json_serializes(CommunicationDeliveryResolution::candidate(
+            CommunicationDeliveryCandidate {
+                target: reply_ref("reply:candidate"),
+                kind: CommunicationDeliveryKind::FinalReply,
+            },
+        ));
+        assert_json_serializes(CommunicationDeliveryResolution::NoDelivery {
+            reason: SystemEventReasonCode::Operator,
+        });
+    }
+
+    #[test]
     fn delivery_target_capabilities_round_trip() {
         let capabilities = DeliveryTargetCapabilities {
             final_replies: true,
@@ -456,5 +492,12 @@ mod tests {
         let json = to_string(&value).expect("serialize value");
         let decoded: T = from_str(&json).expect("deserialize value");
         assert_eq!(decoded, value);
+    }
+
+    fn assert_json_serializes<T>(value: T)
+    where
+        T: Serialize + std::fmt::Debug,
+    {
+        to_string(&value).expect("serialize value");
     }
 }

--- a/crates/ironclaw_outbound/src/lib.rs
+++ b/crates/ironclaw_outbound/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod filesystem_store;
 mod ids;
 mod memory;
+mod resolution_engine;
 mod service;
 mod store;
 mod types;
@@ -21,10 +22,10 @@ pub use communication_preferences::{
 };
 pub use delivery_resolution::{
     CommunicationDeliveryCandidate, CommunicationDeliveryIntent, CommunicationDeliveryKind,
-    CommunicationDeliveryResolutionRequest, CommunicationModality, DeliveryTargetCapabilities,
-    RequestedOutboundContext, RequestedOutboundKind, RunNotificationContext,
-    RunNotificationEventKind, RunNotificationOrigin, SourceRouteContext, SystemEventReasonCode,
-    TriggerCommunicationContext, TriggerSourceKind,
+    CommunicationDeliveryResolution, CommunicationDeliveryResolutionRequest, CommunicationModality,
+    DeliveryTargetCapabilities, RequestedOutboundContext, RequestedOutboundKind,
+    RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin, SourceRouteContext,
+    SystemEventReasonCode, TriggerCommunicationContext, TriggerSourceKind,
 };
 pub use error::OutboundError;
 pub use filesystem_store::FilesystemOutboundStateStore;

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -209,6 +209,7 @@ fn missing_preference_error(kind: PreferenceTargetKind) -> OutboundError {
 
 #[cfg(test)]
 mod tests {
+    use async_trait::async_trait;
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
     use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnScope};
 
@@ -218,6 +219,25 @@ mod tests {
         RequestedOutboundKind, RunNotificationEventKind, SourceRouteContext, SystemEventReasonCode,
         TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
     };
+
+    struct BackendErrorPreferenceRepository;
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for BackendErrorPreferenceRepository {
+        async fn put_communication_preference(
+            &self,
+            _record: CommunicationPreferenceRecord,
+        ) -> Result<(), OutboundError> {
+            Ok(())
+        }
+
+        async fn load_communication_preference(
+            &self,
+            _key: CommunicationPreferenceKey,
+        ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+            Err(OutboundError::Backend)
+        }
+    }
 
     #[tokio::test]
     async fn requested_outbound_prefers_the_explicit_target() {
@@ -243,6 +263,52 @@ mod tests {
 
         assert_eq!(candidate.target, reply_ref("reply:requested"));
         assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn requested_outbound_delivery_status_preserves_the_explicit_target() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+        let request = requested_request_with_kind(
+            "reply:delivery-status",
+            RequestedOutboundKind::DeliveryStatus,
+        );
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:preferred"),
+                Some("reply:preferred-progress"),
+                Some("reply:preferred-approval"),
+                Some("reply:preferred-auth"),
+            ))
+            .await
+            .expect("seed preference");
+
+        let candidate = engine
+            .resolve(&request)
+            .await
+            .expect("requested delivery status resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:delivery-status"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::DeliveryStatus);
+    }
+
+    #[tokio::test]
+    async fn triggered_preference_load_backend_error_is_propagated() {
+        let engine = OutboundResolutionEngine::new(&BackendErrorPreferenceRepository);
+
+        let error = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::FinalReplyReady,
+                RunNotificationOrigin::Triggered {
+                    trigger: trigger_context(),
+                },
+            ))
+            .await
+            .expect_err("backend failure must propagate");
+
+        assert!(matches!(error, OutboundError::Backend));
     }
 
     #[tokio::test]
@@ -278,6 +344,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_source_route_approval_needed_uses_the_approval_prompt_preference() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                Some("reply:progress"),
+                Some("reply:approval"),
+                Some("reply:auth"),
+            ))
+            .await
+            .expect("seed preference");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ApprovalNeeded,
+            RunNotificationOrigin::LiveSourceRoute {
+                source_route: SourceRouteContext {
+                    reply_target_binding_ref: reply_ref("reply:source-route"),
+                },
+            },
+            "reply:approval",
+            CommunicationDeliveryKind::ApprovalPrompt,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn live_source_route_auth_required_uses_the_auth_prompt_preference() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                Some("reply:progress"),
+                Some("reply:approval"),
+                Some("reply:auth"),
+            ))
+            .await
+            .expect("seed preference");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::AuthRequired,
+            RunNotificationOrigin::LiveSourceRoute {
+                source_route: SourceRouteContext {
+                    reply_target_binding_ref: reply_ref("reply:source-route"),
+                },
+            },
+            "reply:auth",
+            CommunicationDeliveryKind::AuthPrompt,
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn triggered_final_reply_uses_the_creator_users_preferred_target() {
         let store = InMemoryOutboundStateStore::default();
         let engine = OutboundResolutionEngine::new(&store);
@@ -305,6 +429,66 @@ mod tests {
 
         assert_eq!(candidate.target, reply_ref("reply:triggered-default"));
         assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_from_source_route_approval_needed_uses_the_approval_prompt_preference() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                Some("reply:progress"),
+                Some("reply:approval"),
+                Some("reply:auth"),
+            ))
+            .await
+            .expect("seed preference");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ApprovalNeeded,
+            RunNotificationOrigin::TriggeredFromSourceRoute {
+                trigger: trigger_context(),
+                source_route: SourceRouteContext {
+                    reply_target_binding_ref: reply_ref("reply:source-route"),
+                },
+            },
+            "reply:approval",
+            CommunicationDeliveryKind::ApprovalPrompt,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn triggered_from_source_route_auth_required_uses_the_auth_prompt_preference() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                Some("reply:progress"),
+                Some("reply:approval"),
+                Some("reply:auth"),
+            ))
+            .await
+            .expect("seed preference");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::AuthRequired,
+            RunNotificationOrigin::TriggeredFromSourceRoute {
+                trigger: trigger_context(),
+                source_route: SourceRouteContext {
+                    reply_target_binding_ref: reply_ref("reply:source-route"),
+                },
+            },
+            "reply:auth",
+            CommunicationDeliveryKind::AuthPrompt,
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -453,13 +637,20 @@ mod tests {
     }
 
     fn requested_request(requested_target: &str) -> CommunicationDeliveryResolutionRequest {
+        requested_request_with_kind(requested_target, RequestedOutboundKind::ProductMessage)
+    }
+
+    fn requested_request_with_kind(
+        requested_target: &str,
+        requested_kind: RequestedOutboundKind,
+    ) -> CommunicationDeliveryResolutionRequest {
         CommunicationDeliveryResolutionRequest {
             scope: scope(),
             actor: actor("user-a"),
             modality: CommunicationModality::Text,
             intent: CommunicationDeliveryIntent::RequestedOutbound(RequestedOutboundContext {
                 requested_target: reply_ref(requested_target),
-                requested_kind: RequestedOutboundKind::ProductMessage,
+                requested_kind,
             }),
         }
     }

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -1,0 +1,561 @@
+use ironclaw_turns::ReplyTargetBindingRef;
+
+use crate::{
+    CommunicationDeliveryCandidate, CommunicationDeliveryIntent, CommunicationDeliveryKind,
+    CommunicationDeliveryResolution, CommunicationDeliveryResolutionRequest,
+    CommunicationPreferenceKey, CommunicationPreferenceRepository, OutboundError,
+    RequestedOutboundContext, RunNotificationContext, RunNotificationOrigin,
+};
+
+/// Deterministic host-owned outbound target selection.
+///
+/// The engine only chooses a `CommunicationDeliveryCandidate`. It does not
+/// validate the target, record attempts, or mutate any inbound / approval /
+/// auth / transcript state.
+#[allow(dead_code, reason = "wired into OutboundPolicyService in PR6")]
+pub(crate) struct OutboundResolutionEngine<'a> {
+    communication_preferences: &'a dyn CommunicationPreferenceRepository,
+}
+
+#[allow(dead_code, reason = "wired into OutboundPolicyService in PR6")]
+impl<'a> OutboundResolutionEngine<'a> {
+    pub(crate) fn new(
+        communication_preferences: &'a dyn CommunicationPreferenceRepository,
+    ) -> Self {
+        Self {
+            communication_preferences,
+        }
+    }
+
+    pub(crate) async fn resolve(
+        &self,
+        request: &CommunicationDeliveryResolutionRequest,
+    ) -> Result<CommunicationDeliveryResolution, OutboundError> {
+        let CommunicationDeliveryResolutionRequest {
+            scope,
+            actor,
+            modality: _,
+            intent,
+        } = request;
+        match intent {
+            CommunicationDeliveryIntent::RequestedOutbound(context) => {
+                Ok(CommunicationDeliveryResolution::candidate(
+                    self.candidate_from_requested_outbound(context),
+                ))
+            }
+            CommunicationDeliveryIntent::RunNotification(context) => {
+                self.resolve_run_notification_context(scope, actor, context)
+                    .await
+            }
+        }
+    }
+
+    fn candidate_from_requested_outbound(
+        &self,
+        context: &RequestedOutboundContext,
+    ) -> CommunicationDeliveryCandidate {
+        let kind = context.delivery_kind();
+        CommunicationDeliveryCandidate {
+            target: context.requested_target.clone(),
+            kind,
+        }
+    }
+
+    async fn resolve_run_notification_context(
+        &self,
+        scope: &ironclaw_turns::TurnScope,
+        actor: &ironclaw_turns::TurnActor,
+        context: &RunNotificationContext,
+    ) -> Result<CommunicationDeliveryResolution, OutboundError> {
+        let kind = context.delivery_kind();
+        let target = match &context.origin {
+            RunNotificationOrigin::LiveSourceRoute { source_route } => match kind {
+                CommunicationDeliveryKind::ApprovalPrompt => {
+                    self.load_preference_target(scope, actor, PreferenceTargetKind::ApprovalPrompt)
+                        .await?
+                }
+                CommunicationDeliveryKind::AuthPrompt => {
+                    self.load_preference_target(scope, actor, PreferenceTargetKind::AuthPrompt)
+                        .await?
+                }
+                CommunicationDeliveryKind::FinalReply
+                | CommunicationDeliveryKind::ProgressUpdate
+                | CommunicationDeliveryKind::DeliveryStatus => {
+                    source_route.reply_target_binding_ref.clone()
+                }
+            },
+            RunNotificationOrigin::Triggered { .. } => {
+                self.resolve_triggered_target(scope, actor, kind).await?
+            }
+            RunNotificationOrigin::TriggeredFromSourceRoute { source_route, .. } => {
+                self.resolve_triggered_from_source_route_target(
+                    kind,
+                    &source_route.reply_target_binding_ref,
+                    scope,
+                    actor,
+                )
+                .await?
+            }
+            RunNotificationOrigin::SystemEvent { reason } => {
+                return Ok(CommunicationDeliveryResolution::NoDelivery { reason: *reason });
+            }
+        };
+
+        Ok(CommunicationDeliveryResolution::candidate(
+            CommunicationDeliveryCandidate { target, kind },
+        ))
+    }
+
+    async fn resolve_triggered_from_source_route_target(
+        &self,
+        kind: CommunicationDeliveryKind,
+        source_route_target: &ReplyTargetBindingRef,
+        scope: &ironclaw_turns::TurnScope,
+        actor: &ironclaw_turns::TurnActor,
+    ) -> Result<ReplyTargetBindingRef, OutboundError> {
+        match kind {
+            CommunicationDeliveryKind::ApprovalPrompt => {
+                self.load_preference_target(scope, actor, PreferenceTargetKind::ApprovalPrompt)
+                    .await
+            }
+            CommunicationDeliveryKind::AuthPrompt => {
+                self.load_preference_target(scope, actor, PreferenceTargetKind::AuthPrompt)
+                    .await
+            }
+            CommunicationDeliveryKind::FinalReply
+            | CommunicationDeliveryKind::ProgressUpdate
+            | CommunicationDeliveryKind::DeliveryStatus => Ok(source_route_target.clone()),
+        }
+    }
+
+    async fn resolve_triggered_target(
+        &self,
+        scope: &ironclaw_turns::TurnScope,
+        actor: &ironclaw_turns::TurnActor,
+        kind: CommunicationDeliveryKind,
+    ) -> Result<ReplyTargetBindingRef, OutboundError> {
+        match kind {
+            CommunicationDeliveryKind::FinalReply => {
+                self.load_preference_target(scope, actor, PreferenceTargetKind::FinalReply)
+                    .await
+            }
+            CommunicationDeliveryKind::ProgressUpdate
+            | CommunicationDeliveryKind::DeliveryStatus => {
+                self.load_preference_target(scope, actor, PreferenceTargetKind::Progress)
+                    .await
+            }
+            CommunicationDeliveryKind::ApprovalPrompt => {
+                self.load_preference_target(scope, actor, PreferenceTargetKind::ApprovalPrompt)
+                    .await
+            }
+            CommunicationDeliveryKind::AuthPrompt => {
+                self.load_preference_target(scope, actor, PreferenceTargetKind::AuthPrompt)
+                    .await
+            }
+        }
+    }
+
+    async fn load_preference_target(
+        &self,
+        scope: &ironclaw_turns::TurnScope,
+        actor: &ironclaw_turns::TurnActor,
+        kind: PreferenceTargetKind,
+    ) -> Result<ReplyTargetBindingRef, OutboundError> {
+        let key = CommunicationPreferenceKey::new(scope.tenant_id.clone(), actor.user_id.clone());
+        let Some(record) = self
+            .communication_preferences
+            .load_communication_preference(key)
+            .await?
+        else {
+            return Err(missing_preference_error(kind));
+        };
+
+        let target = match kind {
+            PreferenceTargetKind::FinalReply => record.final_reply_target,
+            PreferenceTargetKind::Progress => record.progress_target,
+            PreferenceTargetKind::ApprovalPrompt => record.approval_prompt_target,
+            PreferenceTargetKind::AuthPrompt => record.auth_prompt_target,
+        };
+
+        target.ok_or_else(|| missing_preference_error(kind))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code, reason = "wired into OutboundPolicyService in PR6")]
+enum PreferenceTargetKind {
+    FinalReply,
+    Progress,
+    ApprovalPrompt,
+    AuthPrompt,
+}
+
+#[allow(dead_code, reason = "wired into OutboundPolicyService in PR6")]
+fn missing_preference_error(kind: PreferenceTargetKind) -> OutboundError {
+    let reason = match kind {
+        PreferenceTargetKind::FinalReply => {
+            "communication preference final reply target is missing"
+        }
+        PreferenceTargetKind::Progress => "communication preference progress target is missing",
+        PreferenceTargetKind::ApprovalPrompt => {
+            "communication preference approval prompt target is missing"
+        }
+        PreferenceTargetKind::AuthPrompt => {
+            "communication preference auth prompt target is missing"
+        }
+    };
+    OutboundError::InvalidRequest { reason }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+    use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnScope};
+
+    use super::*;
+    use crate::{
+        CommunicationModality, CommunicationPreferenceRecord, InMemoryOutboundStateStore,
+        RequestedOutboundKind, RunNotificationEventKind, SourceRouteContext, SystemEventReasonCode,
+        TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
+    };
+
+    #[tokio::test]
+    async fn requested_outbound_prefers_the_explicit_target() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+        let request = requested_request("reply:requested");
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:preferred"),
+                None,
+                None,
+                None,
+            ))
+            .await
+            .expect("seed preference");
+
+        let candidate = engine
+            .resolve(&request)
+            .await
+            .expect("requested outbound resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:requested"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn live_source_route_final_reply_prefers_the_source_route_over_preferences() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:preferred"),
+                Some("reply:preferred-progress"),
+                None,
+                None,
+            ))
+            .await
+            .expect("seed preference");
+
+        let candidate = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::FinalReplyReady,
+                RunNotificationOrigin::LiveSourceRoute {
+                    source_route: SourceRouteContext {
+                        reply_target_binding_ref: reply_ref("reply:source-route"),
+                    },
+                },
+            ))
+            .await
+            .expect("live source route final reply resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:source-route"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_final_reply_uses_the_creator_users_preferred_target() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:triggered-default"),
+                Some("reply:triggered-progress"),
+                None,
+                None,
+            ))
+            .await
+            .expect("seed preference");
+
+        let candidate = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::FinalReplyReady,
+                RunNotificationOrigin::Triggered {
+                    trigger: trigger_context(),
+                },
+            ))
+            .await
+            .expect("triggered final reply resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:triggered-default"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn system_event_notifications_are_metadata_only_without_candidate() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        let resolution = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::ProgressUpdate,
+                RunNotificationOrigin::SystemEvent {
+                    reason: SystemEventReasonCode::Operator,
+                },
+            ))
+            .await
+            .expect("system event resolves as metadata-only");
+
+        assert_eq!(
+            resolution,
+            CommunicationDeliveryResolution::NoDelivery {
+                reason: SystemEventReasonCode::Operator
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn triggered_final_reply_fails_closed_without_a_preference_target() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        let missing_record = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::FinalReplyReady,
+                RunNotificationOrigin::Triggered {
+                    trigger: trigger_context(),
+                },
+            ))
+            .await
+            .expect_err("missing preference record must fail closed");
+        assert!(matches!(
+            missing_record,
+            OutboundError::InvalidRequest { .. }
+        ));
+
+        store
+            .put_communication_preference(preference_record(None, None, None, None))
+            .await
+            .expect("seed empty preference row");
+
+        let missing_target = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::FinalReplyReady,
+                RunNotificationOrigin::Triggered {
+                    trigger: trigger_context(),
+                },
+            ))
+            .await
+            .expect_err("missing final reply target must fail closed");
+        assert!(matches!(
+            missing_target,
+            OutboundError::InvalidRequest { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn non_final_run_notifications_choose_the_correct_targets() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                Some("reply:progress"),
+                Some("reply:approval"),
+                Some("reply:auth"),
+            ))
+            .await
+            .expect("seed preference");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ProgressUpdate,
+            RunNotificationOrigin::Triggered {
+                trigger: trigger_context(),
+            },
+            "reply:progress",
+            CommunicationDeliveryKind::ProgressUpdate,
+        )
+        .await;
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::DeliveryStatus,
+            RunNotificationOrigin::Triggered {
+                trigger: trigger_context(),
+            },
+            "reply:progress",
+            CommunicationDeliveryKind::DeliveryStatus,
+        )
+        .await;
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ApprovalNeeded,
+            RunNotificationOrigin::Triggered {
+                trigger: trigger_context(),
+            },
+            "reply:approval",
+            CommunicationDeliveryKind::ApprovalPrompt,
+        )
+        .await;
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::AuthRequired,
+            RunNotificationOrigin::Triggered {
+                trigger: trigger_context(),
+            },
+            "reply:auth",
+            CommunicationDeliveryKind::AuthPrompt,
+        )
+        .await;
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ProgressUpdate,
+            RunNotificationOrigin::TriggeredFromSourceRoute {
+                trigger: trigger_context(),
+                source_route: SourceRouteContext {
+                    reply_target_binding_ref: reply_ref("reply:source-route"),
+                },
+            },
+            "reply:source-route",
+            CommunicationDeliveryKind::ProgressUpdate,
+        )
+        .await;
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::DeliveryStatus,
+            RunNotificationOrigin::TriggeredFromSourceRoute {
+                trigger: trigger_context(),
+                source_route: SourceRouteContext {
+                    reply_target_binding_ref: reply_ref("reply:source-route"),
+                },
+            },
+            "reply:source-route",
+            CommunicationDeliveryKind::DeliveryStatus,
+        )
+        .await;
+    }
+
+    fn requested_request(requested_target: &str) -> CommunicationDeliveryResolutionRequest {
+        CommunicationDeliveryResolutionRequest {
+            scope: scope(),
+            actor: actor("user-a"),
+            modality: CommunicationModality::Text,
+            intent: CommunicationDeliveryIntent::RequestedOutbound(RequestedOutboundContext {
+                requested_target: reply_ref(requested_target),
+                requested_kind: RequestedOutboundKind::ProductMessage,
+            }),
+        }
+    }
+
+    fn run_notification_request(
+        event_kind: RunNotificationEventKind,
+        origin: RunNotificationOrigin,
+    ) -> CommunicationDeliveryResolutionRequest {
+        CommunicationDeliveryResolutionRequest {
+            scope: scope(),
+            actor: actor("user-a"),
+            modality: CommunicationModality::Mixed,
+            intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                event_kind,
+                origin,
+            }),
+        }
+    }
+
+    fn preference_record(
+        final_reply_target: Option<&str>,
+        progress_target: Option<&str>,
+        approval_prompt_target: Option<&str>,
+        auth_prompt_target: Option<&str>,
+    ) -> CommunicationPreferenceRecord {
+        CommunicationPreferenceRecord {
+            tenant_id: TenantId::new("tenant-a").expect("valid tenant"),
+            user_id: UserId::new("user-a").expect("valid user"),
+            final_reply_target: final_reply_target.map(reply_ref),
+            progress_target: progress_target.map(reply_ref),
+            approval_prompt_target: approval_prompt_target.map(reply_ref),
+            auth_prompt_target: auth_prompt_target.map(reply_ref),
+            default_modality: Some(CommunicationModality::Text),
+            updated_at: now(),
+            updated_by: UserId::new("user-a").expect("valid user"),
+        }
+    }
+
+    fn scope() -> TurnScope {
+        TurnScope::new(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            Some(AgentId::new("agent-a").expect("valid agent")),
+            Some(ProjectId::new("project-a").expect("valid project")),
+            thread_id("thread-a"),
+        )
+    }
+
+    fn actor(user: &str) -> TurnActor {
+        TurnActor::new(UserId::new(user).expect("valid user"))
+    }
+
+    fn trigger_context() -> TriggerCommunicationContext {
+        TriggerCommunicationContext {
+            trigger_origin_ref: TriggerOriginRef::new("trigger:daily")
+                .expect("valid trigger origin ref"),
+            trigger_source_kind: TriggerSourceKind::Schedule,
+            fire_slot: TriggerFireSlot::new("2026-05-29T09:00:00Z").expect("valid fire slot"),
+        }
+    }
+
+    fn thread_id(value: &str) -> ThreadId {
+        ThreadId::new(value).expect("valid thread")
+    }
+
+    fn reply_ref(value: &str) -> ReplyTargetBindingRef {
+        ReplyTargetBindingRef::new(value).expect("valid reply target")
+    }
+
+    fn now() -> ironclaw_host_api::Timestamp {
+        chrono::Utc::now()
+    }
+
+    fn expect_candidate(
+        resolution: CommunicationDeliveryResolution,
+    ) -> CommunicationDeliveryCandidate {
+        match resolution {
+            CommunicationDeliveryResolution::Candidate { candidate } => candidate,
+            CommunicationDeliveryResolution::NoDelivery { reason } => {
+                panic!("expected candidate, got metadata-only resolution for {reason}")
+            }
+        }
+    }
+
+    async fn assert_resolves_to(
+        engine: &OutboundResolutionEngine<'_>,
+        event_kind: RunNotificationEventKind,
+        origin: RunNotificationOrigin,
+        expected_target: &str,
+        expected_kind: CommunicationDeliveryKind,
+    ) {
+        let candidate = engine
+            .resolve(&run_notification_request(event_kind, origin))
+            .await
+            .expect("run notification resolves");
+        let candidate = expect_candidate(candidate);
+        assert_eq!(candidate.target, reply_ref(expected_target));
+        assert_eq!(candidate.kind, expected_kind);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the P0 outbound communication resolution engine inside `ironclaw_outbound`.

This PR is intentionally **candidate selection only**. It chooses a typed `CommunicationDeliveryCandidate` or `NoDelivery`; it does not validate targets, record delivery attempts, render product payloads, send transport messages, or mutate inbound/approval/auth/run/transcript state.

## What changed

- Adds typed delivery-resolution requests and results for:
  - explicit requested outbound;
  - run notifications;
  - live source-route replies;
  - triggered runs;
  - triggered-from-source-route runs;
  - metadata-only system events.
- Adds a deterministic `OutboundResolutionEngine` as a crate-internal helper.
- Keeps the existing outbound policy boundary intact: candidates still need to flow through `OutboundPolicyService` validation in PR6 before any send.
- Adds focused serialization and resolver behavior coverage.
- Adds a short crate guardrail note documenting that the resolver is read-only candidate selection.

## Review decisions and scope notes

- `OutboundResolutionEngine` is **not public crate API**.
  - A review comment correctly pointed out that the contract describes this as an internal helper under `OutboundPolicyService`, not a caller boundary.
  - I removed the crate-root re-export and made the type `pub(crate)`.
  - The behavior coverage moved from an integration test to crate-local unit tests so we can test the helper without exposing it.
- There are temporary `#[allow(dead_code, reason = "...PR6")]` annotations on the crate-internal helper.
  - This PR intentionally lands the deterministic resolver before PR6 wires it into `OutboundPolicyService`.
  - PR6 should remove those allowances when the helper is used by the service boundary.
- Delivery-status routing follows the progress/status path for triggered runs.
  - Triggered `DeliveryStatus` now resolves through `progress_target`, not `final_reply_target`.
  - Live source-route and triggered-from-source-route status/progress notifications still prefer the source route.
- System events remain metadata-only unless a caller explicitly requests outbound delivery.
- This PR deliberately does **not** add:
  - validation bridge into `OutboundPolicyService`;
  - delivery-attempt mutation;
  - product adapter rendering;
  - composition/runtime wiring;
  - trigger-crate dependency.

## Tests

- `cargo test -p ironclaw_outbound`
- `cargo clippy -p ironclaw_outbound --all-targets --all-features -- -D warnings`
- `git diff --check`
