### PR TITLE
feat(triggers): add libsql repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,11 +5204,14 @@ dependencies = [
  "cron",
  "hex",
  "ironclaw_host_api",
+ "libsql",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "ulid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,6 +5204,7 @@ dependencies = [
  "cron",
  "hex",
  "ironclaw_host_api",
+ "ironclaw_turns",
  "libsql",
  "serde",
  "serde_json",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -1183,7 +1183,8 @@ fn reborn_product_auth_contract_stays_reborn_native() {
         &forbidden,
         &mut violations,
     );
-    collect_forbidden_reborn_auth_file_uses(
+    collect_forbidden_reborn_auth_path_uses(
+        &root.join("crates/ironclaw_reborn_composition/src/product_auth_serve"),
         &root.join("crates/ironclaw_reborn_composition/src/product_auth_serve.rs"),
         &root,
         &forbidden,
@@ -2416,6 +2417,20 @@ fn collect_forbidden_uses(
             }
         }
     }
+}
+
+fn collect_forbidden_reborn_auth_path_uses(
+    module_dir: &std::path::Path,
+    legacy_file: &std::path::Path,
+    root: &std::path::Path,
+    forbidden: &[ForbiddenUse],
+    violations: &mut Vec<String>,
+) {
+    if module_dir.is_dir() {
+        collect_forbidden_uses(module_dir, root, forbidden, violations);
+        return;
+    }
+    collect_forbidden_reborn_auth_file_uses(legacy_file, root, forbidden, violations);
 }
 
 fn collect_forbidden_reborn_auth_file_uses(

--- a/crates/ironclaw_triggers/AGENTS.md
+++ b/crates/ironclaw_triggers/AGENTS.md
@@ -11,6 +11,8 @@
 - Trigger records, schedule validation, source-provider evaluation, deterministic fire identity, and repository contracts.
 - In-memory test behavior and durable trigger repository backends.
 - Cron validation, including rejection of schedules that can fire more often than once per minute.
+- Backend-specific trigger repository implementations may accept already-open database handles such as `Arc<libsql::Database>`.
+- This crate must not own database URL/path/env parsing, bootstrap config, or generic database accessors.
 
 ## Do Not Move In Here
 
@@ -18,6 +20,8 @@
 - First-party trigger capabilities such as create/list/remove.
 - Trusted inbound turn wiring, product adapter behavior, or outbound delivery resolution.
 - Active-run reservation/back-pressure enforcement; later poller slices own that policy.
+- libSQL/PostgreSQL handle construction, connection-string validation, production substrate selection, or shared Reborn database bootstrap.
+- Composition/bootstrap owns those boundaries and passes typed handles into repository constructors.
 
 ## Validation
 

--- a/crates/ironclaw_triggers/AGENTS.md
+++ b/crates/ironclaw_triggers/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Map - ironclaw_triggers
+
+## Start Here
+
+- Read `Cargo.toml` for backend feature shape.
+- Read `src/lib.rs` for trigger domain contracts and repository traits.
+- Use `docs/reborn/contracts/triggers.md` as the source of truth before changing behavior.
+
+## What This Crate Owns
+
+- Trigger records, schedule validation, source-provider evaluation, deterministic fire identity, and repository contracts.
+- In-memory test behavior and durable trigger repository backends.
+- Cron validation, including rejection of schedules that can fire more often than once per minute.
+
+## Do Not Move In Here
+
+- Poller lifecycle, worker startup/shutdown, routine bridges, or composition wiring.
+- First-party trigger capabilities such as create/list/remove.
+- Trusted inbound turn wiring, product adapter behavior, or outbound delivery resolution.
+- Active-run reservation/back-pressure enforcement; later poller slices own that policy.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_triggers`
+- Backend check: `cargo test -p ironclaw_triggers --features libsql`
+- Lint check: `cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings`
+- Boundary check after dependency changes: `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
+
+## Agent Notes
+
+- Fire identity is deterministic from `(tenant_id, trigger_id, fire_slot)`; do not add a separate fire-id ledger for replay/idempotency.
+- `TriggerRepository` and `TriggerSourceProvider` are the extension points; use them instead of cross-crate shortcuts.
+- Preserve tenant/trigger scoping in every repository operation, including global due queries.
+- Validate records at repository boundaries and keep focused tests for schedule, identity, round-trip, due-query, and scoped remove behavior.

--- a/crates/ironclaw_triggers/Cargo.toml
+++ b/crates/ironclaw_triggers/Cargo.toml
@@ -6,17 +6,24 @@ rust-version = "1.92"
 description = "Scheduled trigger domain and source-provider contracts for IronClaw Reborn"
 publish = false
 
+[features]
+default = []
+libsql = ["dep:libsql"]
+
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 cron = "0.13"
 hex = "0.4"
 ironclaw_host_api = { path = "../ironclaw_host_api" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "2"
+tracing = "0.1"
 ulid = { version = "1", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_triggers/Cargo.toml
+++ b/crates/ironclaw_triggers/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cron = "0.13"
 hex = "0.4"
 ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_turns = { path = "../ironclaw_turns" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
 use cron::Schedule;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
+use ironclaw_turns::TurnRunId;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -215,6 +216,8 @@ pub struct TriggerRecord {
     pub last_run_at: Option<Timestamp>,
     pub last_fired_slot: Option<Timestamp>,
     pub last_status: Option<TriggerRunStatus>,
+    pub active_fire_slot: Option<Timestamp>,
+    pub active_run_ref: Option<TurnRunId>,
     pub created_at: Timestamp,
 }
 
@@ -675,6 +678,8 @@ mod tests {
             last_run_at: None,
             last_fired_slot: None,
             last_status: None,
+            active_fire_slot: None,
+            active_run_ref: None,
             created_at: ts(1_704_067_200),
         }
     }

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -21,6 +21,9 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 use ulid::Ulid;
 
+#[cfg(feature = "libsql")]
+mod libsql;
+
 const MIN_FIRE_CADENCE: Duration = Duration::from_secs(60);
 const MAX_DUE_TRIGGER_POLL_LIMIT: usize = 128;
 const IDENTITY_VERSION_LABEL: &str = "ironclaw.trigger-fire.v1";
@@ -393,12 +396,23 @@ pub trait TriggerRepository: Send + Sync {
         trigger_id: TriggerId,
     ) -> Result<Option<TriggerRecord>, TriggerError>;
 
+    /// Lists due triggers across all tenants for the trusted poller path.
+    ///
+    /// # Safety / Authorization
+    ///
+    /// This is a global query and must not be used for tenant-scoped or
+    /// user-facing list operations. Callers must preserve each returned
+    /// record's tenant/user authority when materializing a fire.
     async fn list_due_triggers(
         &self,
         now: Timestamp,
         limit: usize,
     ) -> Result<Vec<TriggerRecord>, TriggerError>;
 }
+
+#[cfg(feature = "libsql")]
+/// Feature-gated durable repository constructor for composition/test wiring.
+pub use libsql::LibSqlTriggerRepository;
 
 #[derive(Clone, Default)]
 pub struct InMemoryTriggerRepository {
@@ -484,15 +498,24 @@ impl TriggerRepository for InMemoryTriggerRepository {
             state
                 .iter()
                 .filter(|(_, record)| record.is_due_at(now))
-                .map(|(key, record)| (record.next_run_at, record.trigger_id, key.clone()))
+                .map(|(key, record)| {
+                    (
+                        record.next_run_at,
+                        record.tenant_id.clone(),
+                        record.trigger_id,
+                        key.clone(),
+                    )
+                })
                 .collect::<Vec<_>>()
         };
-        keys.sort_by_key(|(next_run_at, trigger_id, _)| (*next_run_at, *trigger_id));
+        keys.sort_by_key(|(next_run_at, tenant_id, trigger_id, _)| {
+            (*next_run_at, tenant_id.clone(), *trigger_id)
+        });
         keys.truncate(limit);
         let state = self.lock_state()?;
         Ok(keys
             .into_iter()
-            .filter_map(|(_, _, key)| state.get(&key).cloned())
+            .filter_map(|(_, _, _, key)| state.get(&key).cloned())
             .collect())
     }
 }
@@ -1024,6 +1047,53 @@ mod tests {
             .expect("list due");
         assert_eq!(due_records.len(), 1);
         assert_eq!(due_records[0].trigger_id, first.trigger_id);
+    }
+
+    #[tokio::test]
+    async fn in_memory_repository_list_due_triggers_orders_same_slot_by_tenant_then_trigger_id() {
+        let repo = InMemoryTriggerRepository::default();
+        let due_slot = ts(1_704_067_200);
+        let tenant_a_high = sample_record(
+            TriggerId::parse("01J00000000000000000000000").expect("ulid"),
+            tenant("tenant-a"),
+            due_slot,
+        );
+        let tenant_b_low = sample_record(
+            TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+            tenant("tenant-b"),
+            due_slot,
+        );
+        let tenant_a_low = sample_record(
+            TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZY").expect("ulid"),
+            tenant("tenant-a"),
+            due_slot,
+        );
+        repo.upsert_trigger(tenant_b_low.clone())
+            .await
+            .expect("insert tenant b");
+        repo.upsert_trigger(tenant_a_high.clone())
+            .await
+            .expect("insert tenant a high");
+        repo.upsert_trigger(tenant_a_low.clone())
+            .await
+            .expect("insert tenant a low");
+
+        let due_records = repo
+            .list_due_triggers(due_slot, 10)
+            .await
+            .expect("list due");
+
+        assert_eq!(
+            due_records
+                .iter()
+                .map(|record| (record.tenant_id.clone(), record.trigger_id))
+                .collect::<Vec<_>>(),
+            vec![
+                (tenant_a_low.tenant_id.clone(), tenant_a_low.trigger_id),
+                (tenant_a_high.tenant_id.clone(), tenant_a_high.trigger_id),
+                (tenant_b_low.tenant_id.clone(), tenant_b_low.trigger_id),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -388,6 +388,10 @@ pub trait TriggerRepository: Send + Sync {
         trigger_id: TriggerId,
     ) -> Result<Option<TriggerRecord>, TriggerError>;
 
+    /// Returns all triggers for a tenant in creation order.
+    ///
+    /// This method is currently unbounded. Callers must apply any product or
+    /// API pagination before exposing user-facing list surfaces.
     async fn list_triggers(&self, tenant_id: TenantId) -> Result<Vec<TriggerRecord>, TriggerError>;
 
     async fn remove_trigger(
@@ -493,28 +497,26 @@ impl TriggerRepository for InMemoryTriggerRepository {
             return Ok(Vec::new());
         }
         let limit = limit.min(MAX_DUE_TRIGGER_POLL_LIMIT);
-        let mut records = {
-            let state = self.lock_state()?;
-            state
-                .iter()
-                .filter(|(_, record)| record.is_due_at(now))
-                .map(|(_, record)| {
-                    (
-                        record.next_run_at,
-                        record.tenant_id.clone(),
-                        record.trigger_id,
-                        record.clone(),
-                    )
-                })
-                .collect::<Vec<_>>()
-        };
-        records.sort_by_key(|(next_run_at, tenant_id, trigger_id, _)| {
+        let state = self.lock_state()?;
+        let mut selected_keys = state
+            .iter()
+            .filter(|(_, record)| record.is_due_at(now))
+            .map(|(key, record)| {
+                (
+                    record.next_run_at,
+                    record.tenant_id.clone(),
+                    record.trigger_id,
+                    key.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        selected_keys.sort_by_key(|(next_run_at, tenant_id, trigger_id, _)| {
             (*next_run_at, tenant_id.clone(), *trigger_id)
         });
-        records.truncate(limit);
-        Ok(records
+        selected_keys.truncate(limit);
+        Ok(selected_keys
             .into_iter()
-            .map(|(_, _, _, record)| record)
+            .filter_map(|(_, _, _, key)| state.get(&key).cloned())
             .collect())
     }
 }

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -40,8 +40,8 @@ pub enum TriggerError {
     InvalidRecord { reason: String },
     #[error("invalid schedule: {reason}")]
     InvalidSchedule { reason: String },
-    #[error("trigger repository backend unavailable")]
-    Backend,
+    #[error("trigger repository backend unavailable: {reason}")]
+    Backend { reason: String },
     #[error("trigger not found")]
     NotFound,
 }
@@ -525,7 +525,9 @@ impl InMemoryTriggerRepository {
         &self,
     ) -> Result<std::sync::MutexGuard<'_, HashMap<TriggerRepositoryKey, TriggerRecord>>, TriggerError>
     {
-        self.state.lock().map_err(|_| TriggerError::Backend)
+        self.state.lock().map_err(|_| TriggerError::Backend {
+            reason: "trigger repository mutex poisoned".to_string(),
+        })
     }
 }
 
@@ -1128,6 +1130,6 @@ mod tests {
         let error = repo
             .lock_state()
             .expect_err("poisoned mutex maps to backend");
-        assert!(matches!(error, TriggerError::Backend));
+        assert!(matches!(error, TriggerError::Backend { .. }));
     }
 }

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -410,8 +410,8 @@ pub trait TriggerRepository: Send + Sync {
     ) -> Result<Vec<TriggerRecord>, TriggerError>;
 }
 
-#[cfg(feature = "libsql")]
 /// Feature-gated durable repository constructor for composition/test wiring.
+#[cfg(feature = "libsql")]
 pub use libsql::LibSqlTriggerRepository;
 
 #[derive(Clone, Default)]
@@ -493,29 +493,28 @@ impl TriggerRepository for InMemoryTriggerRepository {
             return Ok(Vec::new());
         }
         let limit = limit.min(MAX_DUE_TRIGGER_POLL_LIMIT);
-        let mut keys = {
+        let mut records = {
             let state = self.lock_state()?;
             state
                 .iter()
                 .filter(|(_, record)| record.is_due_at(now))
-                .map(|(key, record)| {
+                .map(|(_, record)| {
                     (
                         record.next_run_at,
                         record.tenant_id.clone(),
                         record.trigger_id,
-                        key.clone(),
+                        record.clone(),
                     )
                 })
                 .collect::<Vec<_>>()
         };
-        keys.sort_by_key(|(next_run_at, tenant_id, trigger_id, _)| {
+        records.sort_by_key(|(next_run_at, tenant_id, trigger_id, _)| {
             (*next_run_at, tenant_id.clone(), *trigger_id)
         });
-        keys.truncate(limit);
-        let state = self.lock_state()?;
-        Ok(keys
+        records.truncate(limit);
+        Ok(records
             .into_iter()
-            .filter_map(|(_, _, _, key)| state.get(&key).cloned())
+            .map(|(_, _, _, record)| record)
             .collect())
     }
 }

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -75,7 +75,7 @@ impl LibSqlTriggerRepository {
         let conn = self.connect().await?;
         conn.execute("BEGIN IMMEDIATE", ())
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("begin trigger migration", error))?;
 
         let result = async {
             conn.execute(
@@ -103,7 +103,7 @@ impl LibSqlTriggerRepository {
                 (),
             )
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("create trigger_records table", error))?;
             conn.execute(
                 &format!(
                     "CREATE INDEX IF NOT EXISTS trigger_records_state_next_run_at_idx
@@ -112,7 +112,7 @@ impl LibSqlTriggerRepository {
                 (),
             )
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("create trigger due index", error))?;
             Ok::<(), TriggerError>(())
         }
         .await;
@@ -122,11 +122,12 @@ impl LibSqlTriggerRepository {
                 .execute("COMMIT", ())
                 .await
                 .map(|_| ())
-                .map_err(|_| TriggerError::Backend),
+                .map_err(|error| backend_error("commit trigger migration", error)),
             Err(error) => {
                 if let Err(rollback_error) = conn.execute("ROLLBACK", ()).await {
                     tracing::warn!(
-                        error = %rollback_error,
+                        migration_error = %error,
+                        rollback_error = %rollback_error,
                         "ROLLBACK failed after libSQL trigger migration error"
                     );
                 }
@@ -136,10 +137,13 @@ impl LibSqlTriggerRepository {
     }
 
     async fn connect(&self) -> Result<libsql::Connection, TriggerError> {
-        let conn = self.db.connect().map_err(|_| TriggerError::Backend)?;
+        let conn = self
+            .db
+            .connect()
+            .map_err(|error| backend_error("connect trigger repository", error))?;
         conn.query("PRAGMA busy_timeout = 5000", ())
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("set trigger repository busy_timeout", error))?;
         Ok(conn)
     }
 }
@@ -193,7 +197,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
             ],
         )
         .await
-        .map_err(|_| TriggerError::Backend)?;
+        .map_err(|error| backend_error("upsert trigger record", error))?;
         Ok(())
     }
 
@@ -214,11 +218,11 @@ impl TriggerRepository for LibSqlTriggerRepository {
                 params![tenant_id.as_str(), trigger_id.to_string()],
             )
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("query trigger record", error))?;
         match rows.next().await {
             Ok(Some(row)) => Ok(Some(row_to_record(&row)?)),
             Ok(None) => Ok(None),
-            Err(_) => Err(TriggerError::Backend),
+            Err(error) => Err(backend_error("read trigger record row", error)),
         }
     }
 
@@ -235,13 +239,13 @@ impl TriggerRepository for LibSqlTriggerRepository {
                 params![tenant_id.as_str()],
             )
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("query tenant trigger records", error))?;
         let mut records = Vec::new();
         loop {
             match rows.next().await {
                 Ok(Some(row)) => records.push(row_to_record(&row)?),
                 Ok(None) => break,
-                Err(_) => return Err(TriggerError::Backend),
+                Err(error) => return Err(backend_error("read tenant trigger record row", error)),
             }
         }
         Ok(records)
@@ -263,11 +267,11 @@ impl TriggerRepository for LibSqlTriggerRepository {
                 params![tenant_id.as_str(), trigger_id.to_string()],
             )
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("remove trigger record", error))?;
         match rows.next().await {
             Ok(Some(row)) => Ok(Some(row_to_record(&row)?)),
             Ok(None) => Ok(None),
-            Err(_) => Err(TriggerError::Backend),
+            Err(error) => Err(backend_error("read removed trigger record row", error)),
         }
     }
 
@@ -297,13 +301,13 @@ impl TriggerRepository for LibSqlTriggerRepository {
                 ],
             )
             .await
-            .map_err(|_| TriggerError::Backend)?;
+            .map_err(|error| backend_error("query due trigger records", error))?;
         let mut records = Vec::new();
         loop {
             match rows.next().await {
                 Ok(Some(row)) => records.push(row_to_record(&row)?),
                 Ok(None) => break,
-                Err(_) => return Err(TriggerError::Backend),
+                Err(error) => return Err(backend_error("read due trigger record row", error)),
             }
         }
         Ok(records)
@@ -382,9 +386,10 @@ fn required_text(row: &libsql::Row, index: usize, field: &str) -> Result<String,
 fn optional_text(
     row: &libsql::Row,
     index: usize,
-    _field: &str,
+    field: &str,
 ) -> Result<Option<String>, TriggerError> {
-    row.get(index as i32).map_err(|_| TriggerError::Backend)
+    row.get(index as i32)
+        .map_err(|error| backend_error(&format!("read optional trigger field {field}"), error))
 }
 
 #[cfg(feature = "libsql")]
@@ -514,5 +519,12 @@ fn schedule_expression_text(schedule: &TriggerSchedule) -> String {
 fn invalid_record(field: &str, reason: impl Into<String>) -> TriggerError {
     TriggerError::InvalidRecord {
         reason: format!("{field}: {}", reason.into()),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn backend_error(operation: &str, error: impl std::fmt::Display) -> TriggerError {
+    TriggerError::Backend {
+        reason: format!("{operation}: {error}"),
     }
 }

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -8,6 +8,8 @@ use chrono::{DateTime, SecondsFormat, Utc};
 #[cfg(feature = "libsql")]
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 #[cfg(feature = "libsql")]
+use ironclaw_turns::TurnRunId;
+#[cfg(feature = "libsql")]
 use libsql::params;
 
 #[cfg(feature = "libsql")]
@@ -24,7 +26,7 @@ const TRIGGER_COLUMNS: &str = "\
     trigger_id, tenant_id, creator_user_id, agent_id, project_id, \
     name, source, schedule_expression, completion_policy, prompt, \
     state, next_run_at, last_run_at, last_fired_slot, last_status, \
-    created_at";
+    active_fire_slot, active_run_ref, created_at";
 
 #[cfg(feature = "libsql")]
 const TRIGGER_ID_COL: usize = 0;
@@ -57,7 +59,11 @@ const LAST_FIRED_SLOT_COL: usize = 13;
 #[cfg(feature = "libsql")]
 const LAST_STATUS_COL: usize = 14;
 #[cfg(feature = "libsql")]
-const CREATED_AT_COL: usize = 15;
+const ACTIVE_FIRE_SLOT_COL: usize = 15;
+#[cfg(feature = "libsql")]
+const ACTIVE_RUN_REF_COL: usize = 16;
+#[cfg(feature = "libsql")]
+const CREATED_AT_COL: usize = 17;
 
 /// Durable libSQL trigger repository.
 #[cfg(feature = "libsql")]
@@ -96,6 +102,8 @@ impl LibSqlTriggerRepository {
                         last_run_at TEXT,
                         last_fired_slot TEXT,
                         last_status TEXT,
+                        active_fire_slot TEXT,
+                        active_run_ref TEXT,
                         created_at TEXT NOT NULL,
                         PRIMARY KEY (tenant_id, trigger_id)
                     )"
@@ -161,8 +169,8 @@ impl TriggerRepository for LibSqlTriggerRepository {
                     trigger_id, tenant_id, creator_user_id, agent_id, project_id,
                     name, source, schedule_expression, completion_policy, prompt,
                     state, next_run_at, last_run_at, last_fired_slot, last_status,
-                    created_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+                    active_fire_slot, active_run_ref, created_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
                 ON CONFLICT (tenant_id, trigger_id) DO UPDATE SET
                     creator_user_id = excluded.creator_user_id,
                     agent_id = excluded.agent_id,
@@ -176,7 +184,9 @@ impl TriggerRepository for LibSqlTriggerRepository {
                     next_run_at = excluded.next_run_at,
                     last_run_at = excluded.last_run_at,
                     last_fired_slot = excluded.last_fired_slot,
-                    last_status = excluded.last_status"
+                    last_status = excluded.last_status,
+                    active_fire_slot = excluded.active_fire_slot,
+                    active_run_ref = excluded.active_run_ref"
                 ),
                 params![
                     record.trigger_id.to_string(),
@@ -194,6 +204,8 @@ impl TriggerRepository for LibSqlTriggerRepository {
                     opt_ts(record.last_run_at.as_ref()),
                     opt_ts(record.last_fired_slot.as_ref()),
                     opt_status(record.last_status),
+                    opt_ts(record.active_fire_slot.as_ref()),
+                    opt_turn_run_id(record.active_run_ref.as_ref()),
                     fmt_ts(&record.created_at),
                 ],
             )
@@ -347,6 +359,12 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
     let last_status = optional_text(row, LAST_STATUS_COL, "last_status")?
         .map(|value| parse_run_status(&value))
         .transpose()?;
+    let active_fire_slot = optional_text(row, ACTIVE_FIRE_SLOT_COL, "active_fire_slot")?
+        .map(|value| parse_timestamp(&value, "active_fire_slot"))
+        .transpose()?;
+    let active_run_ref = optional_text(row, ACTIVE_RUN_REF_COL, "active_run_ref")?
+        .map(|value| parse_turn_run_id(&value))
+        .transpose()?;
 
     let record = TriggerRecord {
         trigger_id,
@@ -371,6 +389,8 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
         last_run_at,
         last_fired_slot,
         last_status,
+        active_fire_slot,
+        active_run_ref,
         created_at: parse_timestamp(
             &required_text(row, CREATED_AT_COL, "created_at")?,
             "created_at",
@@ -404,6 +424,11 @@ fn parse_timestamp(value: &str, field: &str) -> Result<Timestamp, TriggerError> 
 }
 
 #[cfg(feature = "libsql")]
+fn parse_turn_run_id(value: &str) -> Result<TurnRunId, TriggerError> {
+    TurnRunId::parse(value).map_err(|error| invalid_record("active_run_ref", error.to_string()))
+}
+
+#[cfg(feature = "libsql")]
 fn fmt_ts(value: &Timestamp) -> String {
     value.to_rfc3339_opts(SecondsFormat::Nanos, true)
 }
@@ -428,6 +453,14 @@ fn opt_text(value: Option<&str>) -> libsql::Value {
 fn opt_status(value: Option<TriggerRunStatus>) -> libsql::Value {
     match value {
         Some(value) => libsql::Value::Text(status_text(value).to_string()),
+        None => libsql::Value::Null,
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn opt_turn_run_id(value: Option<&TurnRunId>) -> libsql::Value {
+    match value {
+        Some(value) => libsql::Value::Text(value.to_string()),
         None => libsql::Value::Null,
     }
 }

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -59,8 +59,8 @@ const LAST_STATUS_COL: usize = 14;
 #[cfg(feature = "libsql")]
 const CREATED_AT_COL: usize = 15;
 
-#[cfg(feature = "libsql")]
 /// Durable libSQL trigger repository.
+#[cfg(feature = "libsql")]
 pub struct LibSqlTriggerRepository {
     db: Arc<libsql::Database>,
 }
@@ -154,9 +154,10 @@ impl TriggerRepository for LibSqlTriggerRepository {
     async fn upsert_trigger(&self, record: TriggerRecord) -> Result<(), TriggerError> {
         record.validate()?;
         let conn = self.connect().await?;
-        conn.execute(
-            &format!(
-                "INSERT INTO {TRIGGER_TABLE} (
+        let affected = conn
+            .execute(
+                &format!(
+                    "INSERT INTO {TRIGGER_TABLE} (
                     trigger_id, tenant_id, creator_user_id, agent_id, project_id,
                     name, source, schedule_expression, completion_policy, prompt,
                     state, next_run_at, last_run_at, last_fired_slot, last_status,
@@ -176,28 +177,34 @@ impl TriggerRepository for LibSqlTriggerRepository {
                     last_run_at = excluded.last_run_at,
                     last_fired_slot = excluded.last_fired_slot,
                     last_status = excluded.last_status"
-            ),
-            params![
-                record.trigger_id.to_string(),
-                record.tenant_id.as_str(),
-                record.creator_user_id.as_str(),
-                opt_text(record.agent_id.as_ref().map(AgentId::as_str)),
-                opt_text(record.project_id.as_ref().map(ProjectId::as_str)),
-                record.name,
-                source_kind_text(record.source),
-                schedule_expression_text(&record.schedule),
-                completion_policy_text(record.completion_policy),
-                record.prompt,
-                state_text(record.state),
-                fmt_ts(&record.next_run_at),
-                opt_ts(record.last_run_at.as_ref()),
-                opt_ts(record.last_fired_slot.as_ref()),
-                opt_status(record.last_status),
-                fmt_ts(&record.created_at),
-            ],
-        )
-        .await
-        .map_err(|error| backend_error("upsert trigger record", error))?;
+                ),
+                params![
+                    record.trigger_id.to_string(),
+                    record.tenant_id.as_str(),
+                    record.creator_user_id.as_str(),
+                    opt_text(record.agent_id.as_ref().map(AgentId::as_str)),
+                    opt_text(record.project_id.as_ref().map(ProjectId::as_str)),
+                    record.name,
+                    source_kind_text(record.source),
+                    schedule_expression_text(&record.schedule),
+                    completion_policy_text(record.completion_policy),
+                    record.prompt,
+                    state_text(record.state),
+                    fmt_ts(&record.next_run_at),
+                    opt_ts(record.last_run_at.as_ref()),
+                    opt_ts(record.last_fired_slot.as_ref()),
+                    opt_status(record.last_status),
+                    fmt_ts(&record.created_at),
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("upsert trigger record", error))?;
+        if affected == 0 {
+            return Err(backend_error(
+                "upsert trigger record",
+                "libSQL reported 0 affected rows",
+            ));
+        }
         Ok(())
     }
 

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -199,12 +199,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
             )
             .await
             .map_err(|error| backend_error("upsert trigger record", error))?;
-        if affected == 0 {
-            return Err(backend_error(
-                "upsert trigger record",
-                "libSQL reported 0 affected rows",
-            ));
-        }
+        debug_assert!(affected >= 1, "libSQL upsert must affect at least one row");
         Ok(())
     }
 
@@ -353,7 +348,7 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
         .map(|value| parse_run_status(&value))
         .transpose()?;
 
-    Ok(TriggerRecord {
+    let record = TriggerRecord {
         trigger_id,
         tenant_id,
         creator_user_id,
@@ -380,7 +375,9 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
             &required_text(row, CREATED_AT_COL, "created_at")?,
             "created_at",
         )?,
-    })
+    };
+    record.validate()?;
+    Ok(record)
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -1,0 +1,518 @@
+#[cfg(feature = "libsql")]
+use std::sync::Arc;
+
+#[cfg(feature = "libsql")]
+use async_trait::async_trait;
+#[cfg(feature = "libsql")]
+use chrono::{DateTime, SecondsFormat, Utc};
+#[cfg(feature = "libsql")]
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
+#[cfg(feature = "libsql")]
+use libsql::params;
+
+#[cfg(feature = "libsql")]
+use crate::{
+    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
+    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+};
+
+#[cfg(feature = "libsql")]
+const TRIGGER_TABLE: &str = "trigger_records";
+
+#[cfg(feature = "libsql")]
+const TRIGGER_COLUMNS: &str = "\
+    trigger_id, tenant_id, creator_user_id, agent_id, project_id, \
+    name, source, schedule_expression, completion_policy, prompt, \
+    state, next_run_at, last_run_at, last_fired_slot, last_status, \
+    created_at";
+
+#[cfg(feature = "libsql")]
+const TRIGGER_ID_COL: usize = 0;
+#[cfg(feature = "libsql")]
+const TENANT_ID_COL: usize = 1;
+#[cfg(feature = "libsql")]
+const CREATOR_USER_ID_COL: usize = 2;
+#[cfg(feature = "libsql")]
+const AGENT_ID_COL: usize = 3;
+#[cfg(feature = "libsql")]
+const PROJECT_ID_COL: usize = 4;
+#[cfg(feature = "libsql")]
+const NAME_COL: usize = 5;
+#[cfg(feature = "libsql")]
+const SOURCE_COL: usize = 6;
+#[cfg(feature = "libsql")]
+const SCHEDULE_EXPRESSION_COL: usize = 7;
+#[cfg(feature = "libsql")]
+const COMPLETION_POLICY_COL: usize = 8;
+#[cfg(feature = "libsql")]
+const PROMPT_COL: usize = 9;
+#[cfg(feature = "libsql")]
+const STATE_COL: usize = 10;
+#[cfg(feature = "libsql")]
+const NEXT_RUN_AT_COL: usize = 11;
+#[cfg(feature = "libsql")]
+const LAST_RUN_AT_COL: usize = 12;
+#[cfg(feature = "libsql")]
+const LAST_FIRED_SLOT_COL: usize = 13;
+#[cfg(feature = "libsql")]
+const LAST_STATUS_COL: usize = 14;
+#[cfg(feature = "libsql")]
+const CREATED_AT_COL: usize = 15;
+
+#[cfg(feature = "libsql")]
+/// Durable libSQL trigger repository.
+pub struct LibSqlTriggerRepository {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlTriggerRepository {
+    pub fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), TriggerError> {
+        let conn = self.connect().await?;
+        conn.execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+
+        let result = async {
+            conn.execute(
+                &format!(
+                    "CREATE TABLE IF NOT EXISTS {TRIGGER_TABLE} (
+                        trigger_id TEXT NOT NULL,
+                        tenant_id TEXT NOT NULL,
+                        creator_user_id TEXT NOT NULL,
+                        agent_id TEXT,
+                        project_id TEXT,
+                        name TEXT NOT NULL,
+                        source TEXT NOT NULL,
+                        schedule_expression TEXT NOT NULL,
+                        completion_policy TEXT NOT NULL,
+                        prompt TEXT NOT NULL,
+                        state TEXT NOT NULL,
+                        next_run_at TEXT NOT NULL,
+                        last_run_at TEXT,
+                        last_fired_slot TEXT,
+                        last_status TEXT,
+                        created_at TEXT NOT NULL,
+                        PRIMARY KEY (tenant_id, trigger_id)
+                    )"
+                ),
+                (),
+            )
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+            conn.execute(
+                &format!(
+                    "CREATE INDEX IF NOT EXISTS trigger_records_state_next_run_at_idx
+                     ON {TRIGGER_TABLE} (state, next_run_at, tenant_id, trigger_id)"
+                ),
+                (),
+            )
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+            Ok::<(), TriggerError>(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => conn
+                .execute("COMMIT", ())
+                .await
+                .map(|_| ())
+                .map_err(|_| TriggerError::Backend),
+            Err(error) => {
+                if let Err(rollback_error) = conn.execute("ROLLBACK", ()).await {
+                    tracing::warn!(
+                        error = %rollback_error,
+                        "ROLLBACK failed after libSQL trigger migration error"
+                    );
+                }
+                Err(error)
+            }
+        }
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, TriggerError> {
+        let conn = self.db.connect().map_err(|_| TriggerError::Backend)?;
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+        Ok(conn)
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl TriggerRepository for LibSqlTriggerRepository {
+    async fn upsert_trigger(&self, record: TriggerRecord) -> Result<(), TriggerError> {
+        record.validate()?;
+        let conn = self.connect().await?;
+        conn.execute(
+            &format!(
+                "INSERT INTO {TRIGGER_TABLE} (
+                    trigger_id, tenant_id, creator_user_id, agent_id, project_id,
+                    name, source, schedule_expression, completion_policy, prompt,
+                    state, next_run_at, last_run_at, last_fired_slot, last_status,
+                    created_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+                ON CONFLICT (tenant_id, trigger_id) DO UPDATE SET
+                    creator_user_id = excluded.creator_user_id,
+                    agent_id = excluded.agent_id,
+                    project_id = excluded.project_id,
+                    name = excluded.name,
+                    source = excluded.source,
+                    schedule_expression = excluded.schedule_expression,
+                    completion_policy = excluded.completion_policy,
+                    prompt = excluded.prompt,
+                    state = excluded.state,
+                    next_run_at = excluded.next_run_at,
+                    last_run_at = excluded.last_run_at,
+                    last_fired_slot = excluded.last_fired_slot,
+                    last_status = excluded.last_status"
+            ),
+            params![
+                record.trigger_id.to_string(),
+                record.tenant_id.as_str(),
+                record.creator_user_id.as_str(),
+                opt_text(record.agent_id.as_ref().map(AgentId::as_str)),
+                opt_text(record.project_id.as_ref().map(ProjectId::as_str)),
+                record.name,
+                source_kind_text(record.source),
+                schedule_expression_text(&record.schedule),
+                completion_policy_text(record.completion_policy),
+                record.prompt,
+                state_text(record.state),
+                fmt_ts(&record.next_run_at),
+                opt_ts(record.last_run_at.as_ref()),
+                opt_ts(record.last_fired_slot.as_ref()),
+                opt_status(record.last_status),
+                fmt_ts(&record.created_at),
+            ],
+        )
+        .await
+        .map_err(|_| TriggerError::Backend)?;
+        Ok(())
+    }
+
+    async fn get_trigger(
+        &self,
+        tenant_id: TenantId,
+        trigger_id: TriggerId,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                &format!(
+                    "SELECT {TRIGGER_COLUMNS}
+                     FROM {TRIGGER_TABLE}
+                     WHERE tenant_id = ?1 AND trigger_id = ?2
+                     LIMIT 1"
+                ),
+                params![tenant_id.as_str(), trigger_id.to_string()],
+            )
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+        match rows.next().await {
+            Ok(Some(row)) => Ok(Some(row_to_record(&row)?)),
+            Ok(None) => Ok(None),
+            Err(_) => Err(TriggerError::Backend),
+        }
+    }
+
+    async fn list_triggers(&self, tenant_id: TenantId) -> Result<Vec<TriggerRecord>, TriggerError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                &format!(
+                    "SELECT {TRIGGER_COLUMNS}
+                     FROM {TRIGGER_TABLE}
+                     WHERE tenant_id = ?1
+                     ORDER BY created_at, trigger_id"
+                ),
+                params![tenant_id.as_str()],
+            )
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+        let mut records = Vec::new();
+        loop {
+            match rows.next().await {
+                Ok(Some(row)) => records.push(row_to_record(&row)?),
+                Ok(None) => break,
+                Err(_) => return Err(TriggerError::Backend),
+            }
+        }
+        Ok(records)
+    }
+
+    async fn remove_trigger(
+        &self,
+        tenant_id: TenantId,
+        trigger_id: TriggerId,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                &format!(
+                    "DELETE FROM {TRIGGER_TABLE}
+                     WHERE tenant_id = ?1 AND trigger_id = ?2
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![tenant_id.as_str(), trigger_id.to_string()],
+            )
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+        match rows.next().await {
+            Ok(Some(row)) => Ok(Some(row_to_record(&row)?)),
+            Ok(None) => Ok(None),
+            Err(_) => Err(TriggerError::Backend),
+        }
+    }
+
+    async fn list_due_triggers(
+        &self,
+        now: Timestamp,
+        limit: usize,
+    ) -> Result<Vec<TriggerRecord>, TriggerError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = limit.min(super::MAX_DUE_TRIGGER_POLL_LIMIT);
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                &format!(
+                    "SELECT {TRIGGER_COLUMNS}
+                     FROM {TRIGGER_TABLE}
+                     WHERE state = ?1 AND next_run_at <= ?2
+                     ORDER BY next_run_at, tenant_id, trigger_id
+                     LIMIT ?3"
+                ),
+                params![
+                    state_text(TriggerState::Scheduled),
+                    fmt_ts(&now),
+                    limit as i64,
+                ],
+            )
+            .await
+            .map_err(|_| TriggerError::Backend)?;
+        let mut records = Vec::new();
+        loop {
+            match rows.next().await {
+                Ok(Some(row)) => records.push(row_to_record(&row)?),
+                Ok(None) => break,
+                Err(_) => return Err(TriggerError::Backend),
+            }
+        }
+        Ok(records)
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
+    let trigger_id = TriggerId::parse(&required_text(row, TRIGGER_ID_COL, "trigger_id")?)?;
+    let tenant_id = TenantId::new(required_text(row, TENANT_ID_COL, "tenant_id")?)
+        .map_err(|error| invalid_record("tenant_id", error.to_string()))?;
+    let creator_user_id = UserId::new(required_text(row, CREATOR_USER_ID_COL, "creator_user_id")?)
+        .map_err(|error| invalid_record("creator_user_id", error.to_string()))?;
+    let agent_id = optional_text(row, AGENT_ID_COL, "agent_id")?
+        .map(|value| {
+            AgentId::new(value).map_err(|error| invalid_record("agent_id", error.to_string()))
+        })
+        .transpose()?;
+    let project_id = optional_text(row, PROJECT_ID_COL, "project_id")?
+        .map(|value| {
+            ProjectId::new(value).map_err(|error| invalid_record("project_id", error.to_string()))
+        })
+        .transpose()?;
+    let schedule = TriggerSchedule::cron(required_text(
+        row,
+        SCHEDULE_EXPRESSION_COL,
+        "schedule_expression",
+    )?)?;
+    let last_run_at = optional_text(row, LAST_RUN_AT_COL, "last_run_at")?
+        .map(|value| parse_timestamp(&value, "last_run_at"))
+        .transpose()?;
+    let last_fired_slot = optional_text(row, LAST_FIRED_SLOT_COL, "last_fired_slot")?
+        .map(|value| parse_timestamp(&value, "last_fired_slot"))
+        .transpose()?;
+    let last_status = optional_text(row, LAST_STATUS_COL, "last_status")?
+        .map(|value| parse_run_status(&value))
+        .transpose()?;
+
+    Ok(TriggerRecord {
+        trigger_id,
+        tenant_id,
+        creator_user_id,
+        agent_id,
+        project_id,
+        name: required_text(row, NAME_COL, "name")?,
+        source: parse_source_kind(&required_text(row, SOURCE_COL, "source")?)?,
+        schedule,
+        completion_policy: parse_completion_policy(&required_text(
+            row,
+            COMPLETION_POLICY_COL,
+            "completion_policy",
+        )?)?,
+        prompt: required_text(row, PROMPT_COL, "prompt")?,
+        state: parse_state(&required_text(row, STATE_COL, "state")?)?,
+        next_run_at: parse_timestamp(
+            &required_text(row, NEXT_RUN_AT_COL, "next_run_at")?,
+            "next_run_at",
+        )?,
+        last_run_at,
+        last_fired_slot,
+        last_status,
+        created_at: parse_timestamp(
+            &required_text(row, CREATED_AT_COL, "created_at")?,
+            "created_at",
+        )?,
+    })
+}
+
+#[cfg(feature = "libsql")]
+fn required_text(row: &libsql::Row, index: usize, field: &str) -> Result<String, TriggerError> {
+    row.get(index as i32)
+        .map_err(|error| invalid_record(field, error.to_string()))
+}
+
+#[cfg(feature = "libsql")]
+fn optional_text(
+    row: &libsql::Row,
+    index: usize,
+    _field: &str,
+) -> Result<Option<String>, TriggerError> {
+    row.get(index as i32).map_err(|_| TriggerError::Backend)
+}
+
+#[cfg(feature = "libsql")]
+fn parse_timestamp(value: &str, field: &str) -> Result<Timestamp, TriggerError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| invalid_record(field, error.to_string()))
+}
+
+#[cfg(feature = "libsql")]
+fn fmt_ts(value: &Timestamp) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+#[cfg(feature = "libsql")]
+fn opt_ts(value: Option<&Timestamp>) -> libsql::Value {
+    match value {
+        Some(value) => libsql::Value::Text(fmt_ts(value)),
+        None => libsql::Value::Null,
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn opt_text(value: Option<&str>) -> libsql::Value {
+    match value {
+        Some(value) => libsql::Value::Text(value.to_string()),
+        None => libsql::Value::Null,
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn opt_status(value: Option<TriggerRunStatus>) -> libsql::Value {
+    match value {
+        Some(value) => libsql::Value::Text(status_text(value).to_string()),
+        None => libsql::Value::Null,
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn source_kind_text(value: TriggerSourceKind) -> &'static str {
+    match value {
+        TriggerSourceKind::Schedule => "schedule",
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn parse_source_kind(value: &str) -> Result<TriggerSourceKind, TriggerError> {
+    match value {
+        "schedule" => Ok(TriggerSourceKind::Schedule),
+        other => Err(invalid_record(
+            "source",
+            format!("unsupported trigger source `{other}`"),
+        )),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn state_text(value: TriggerState) -> &'static str {
+    match value {
+        TriggerState::Scheduled => "scheduled",
+        TriggerState::Paused => "paused",
+        TriggerState::Completed => "completed",
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn parse_state(value: &str) -> Result<TriggerState, TriggerError> {
+    match value {
+        "scheduled" => Ok(TriggerState::Scheduled),
+        "paused" => Ok(TriggerState::Paused),
+        "completed" => Ok(TriggerState::Completed),
+        other => Err(invalid_record(
+            "state",
+            format!("unsupported trigger state `{other}`"),
+        )),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn completion_policy_text(value: TriggerCompletionPolicy) -> &'static str {
+    match value {
+        TriggerCompletionPolicy::Recurring => "recurring",
+        TriggerCompletionPolicy::CompleteAfterFirstFire => "complete_after_first_fire",
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn parse_completion_policy(value: &str) -> Result<TriggerCompletionPolicy, TriggerError> {
+    match value {
+        "recurring" => Ok(TriggerCompletionPolicy::Recurring),
+        "complete_after_first_fire" => Ok(TriggerCompletionPolicy::CompleteAfterFirstFire),
+        other => Err(invalid_record(
+            "completion_policy",
+            format!("unsupported completion policy `{other}`"),
+        )),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn status_text(value: TriggerRunStatus) -> &'static str {
+    match value {
+        TriggerRunStatus::Ok => "ok",
+        TriggerRunStatus::Error => "error",
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn parse_run_status(value: &str) -> Result<TriggerRunStatus, TriggerError> {
+    match value {
+        "ok" => Ok(TriggerRunStatus::Ok),
+        "error" => Ok(TriggerRunStatus::Error),
+        other => Err(invalid_record(
+            "last_status",
+            format!("unsupported trigger run status `{other}`"),
+        )),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn schedule_expression_text(schedule: &TriggerSchedule) -> String {
+    match schedule {
+        TriggerSchedule::Cron { expression } => expression.clone(),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn invalid_record(field: &str, reason: impl Into<String>) -> TriggerError {
+    TriggerError::InvalidRecord {
+        reason: format!("{field}: {}", reason.into()),
+    }
+}

--- a/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
@@ -105,6 +105,13 @@ async fn libsql_repository_round_trip_and_scoped_isolation() {
         .expect("record present");
     assert_eq!(fetched, due);
 
+    assert!(
+        repo.get_trigger(tenant("tenant-b"), due.trigger_id)
+            .await
+            .expect("wrong-tenant lookup")
+            .is_none()
+    );
+
     let tenant_records = repo
         .list_triggers(tenant("tenant-a"))
         .await
@@ -135,12 +142,24 @@ async fn libsql_repository_round_trip_and_scoped_isolation() {
             .expect("lookup other tenant")
             .is_some()
     );
-
-    let missing = repo
-        .remove_trigger(tenant("tenant-a"), due.trigger_id)
-        .await
-        .expect("remove missing trigger");
-    assert!(missing.is_none());
+    assert_eq!(
+        repo.remove_trigger(tenant("tenant-a"), other_tenant.trigger_id)
+            .await
+            .expect("wrong-tenant remove"),
+        None
+    );
+    assert!(
+        repo.get_trigger(tenant("tenant-b"), other_tenant.trigger_id)
+            .await
+            .expect("other tenant remains")
+            .is_some()
+    );
+    assert!(
+        repo.remove_trigger(tenant("tenant-a"), due.trigger_id)
+            .await
+            .expect("remove missing trigger")
+            .is_none()
+    );
 }
 
 #[tokio::test]
@@ -318,6 +337,18 @@ async fn libsql_repository_due_query_clamps_limit_and_respects_state_gate() {
     repo.upsert_trigger(paused.clone())
         .await
         .expect("insert paused");
+    let completed = {
+        let mut record = sample_record(
+            TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZX").expect("ulid"),
+            tenant("tenant-completed"),
+            due_slot,
+        );
+        record.state = TriggerState::Completed;
+        record
+    };
+    repo.upsert_trigger(completed.clone())
+        .await
+        .expect("insert completed");
 
     let small_a = sample_record(
         TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
@@ -387,6 +418,28 @@ async fn libsql_repository_due_query_clamps_limit_and_respects_state_gate() {
             .any(|record| record.tenant_id == paused.tenant_id),
         "paused record must not be returned as due"
     );
+    assert!(
+        !due_records
+            .iter()
+            .any(|record| record.tenant_id == completed.tenant_id),
+        "completed record must not be returned as due"
+    );
+}
+
+#[tokio::test]
+async fn libsql_repository_run_migrations_is_idempotent() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("triggers.db");
+    let db = Arc::new(
+        libsql::Builder::new_local(db_path.display().to_string())
+            .build()
+            .await
+            .expect("build libsql db"),
+    );
+    let repo = LibSqlTriggerRepository::new(db);
+
+    repo.run_migrations().await.expect("first run migrations");
+    repo.run_migrations().await.expect("second run migrations");
 }
 
 #[tokio::test]

--- a/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
@@ -1,0 +1,467 @@
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+
+use chrono::{TimeZone, Utc};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
+use ironclaw_triggers::{
+    LibSqlTriggerRepository, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
+    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+};
+use libsql::params;
+use tempfile::tempdir;
+
+fn ts(seconds: i64) -> Timestamp {
+    Utc.timestamp_opt(seconds, 0).single().expect("valid ts")
+}
+
+fn tenant(value: &str) -> TenantId {
+    TenantId::new(value).expect("valid tenant")
+}
+
+fn user(value: &str) -> UserId {
+    UserId::new(value).expect("valid user")
+}
+
+fn sample_record(
+    trigger_id: TriggerId,
+    tenant_id: TenantId,
+    next_run_at: Timestamp,
+) -> TriggerRecord {
+    TriggerRecord {
+        trigger_id,
+        tenant_id,
+        creator_user_id: user("user-a"),
+        agent_id: Some(AgentId::new("agent-a").expect("valid agent")),
+        project_id: Some(ProjectId::new("project-a").expect("valid project")),
+        name: "daily summary".to_string(),
+        source: TriggerSourceKind::Schedule,
+        schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),
+        completion_policy: TriggerCompletionPolicy::Recurring,
+        prompt: "summarize unread mail".to_string(),
+        state: TriggerState::Scheduled,
+        next_run_at,
+        last_run_at: None,
+        last_fired_slot: None,
+        last_status: None,
+        created_at: ts(1_704_067_200),
+    }
+}
+
+async fn build_repo_with_db() -> (
+    tempfile::TempDir,
+    Arc<libsql::Database>,
+    LibSqlTriggerRepository,
+) {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("triggers.db");
+    let db = Arc::new(
+        libsql::Builder::new_local(db_path.display().to_string())
+            .build()
+            .await
+            .expect("build libsql db"),
+    );
+    let repo = LibSqlTriggerRepository::new(db.clone());
+    repo.run_migrations().await.expect("run migrations");
+    (dir, db, repo)
+}
+
+async fn build_repo() -> (tempfile::TempDir, LibSqlTriggerRepository) {
+    let (dir, _db, repo) = build_repo_with_db().await;
+    (dir, repo)
+}
+
+#[tokio::test]
+async fn libsql_repository_round_trip_and_scoped_isolation() {
+    let (_dir, repo) = build_repo().await;
+    let due = sample_record(
+        TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+        tenant("tenant-a"),
+        ts(1_704_067_200),
+    );
+    let later = sample_record(
+        TriggerId::parse("01J00000000000000000000000").expect("ulid"),
+        tenant("tenant-a"),
+        ts(1_704_067_260),
+    );
+    let other_tenant = sample_record(
+        TriggerId::parse("01J00000000000000000000001").expect("ulid"),
+        tenant("tenant-b"),
+        ts(1_704_067_200),
+    );
+
+    repo.upsert_trigger(due.clone()).await.expect("insert due");
+    repo.upsert_trigger(later.clone())
+        .await
+        .expect("insert later");
+    repo.upsert_trigger(other_tenant.clone())
+        .await
+        .expect("insert other tenant");
+
+    let fetched = repo
+        .get_trigger(tenant("tenant-a"), due.trigger_id)
+        .await
+        .expect("get trigger")
+        .expect("record present");
+    assert_eq!(fetched, due);
+
+    let tenant_records = repo
+        .list_triggers(tenant("tenant-a"))
+        .await
+        .expect("list tenant");
+    assert_eq!(
+        tenant_records
+            .iter()
+            .map(|record| record.trigger_id)
+            .collect::<Vec<_>>(),
+        vec![due.trigger_id, later.trigger_id]
+    );
+
+    let removed = repo
+        .remove_trigger(tenant("tenant-a"), due.trigger_id)
+        .await
+        .expect("remove trigger")
+        .expect("removed record");
+    assert_eq!(removed.trigger_id, due.trigger_id);
+    assert!(
+        repo.get_trigger(tenant("tenant-a"), due.trigger_id)
+            .await
+            .expect("lookup removed")
+            .is_none()
+    );
+    assert!(
+        repo.get_trigger(tenant("tenant-b"), other_tenant.trigger_id)
+            .await
+            .expect("lookup other tenant")
+            .is_some()
+    );
+
+    let missing = repo
+        .remove_trigger(tenant("tenant-a"), due.trigger_id)
+        .await
+        .expect("remove missing trigger");
+    assert!(missing.is_none());
+}
+
+#[tokio::test]
+async fn libsql_repository_round_trip_preserves_optional_run_metadata_and_completion_policy() {
+    let (_dir, repo) = build_repo().await;
+    let mut record = sample_record(
+        TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+        tenant("tenant-a"),
+        ts(1_704_067_260),
+    );
+    record.completion_policy = TriggerCompletionPolicy::CompleteAfterFirstFire;
+    record.last_run_at = Some(ts(1_704_067_200));
+    record.last_fired_slot = Some(ts(1_704_067_140));
+    record.last_status = Some(TriggerRunStatus::Error);
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("insert record with run metadata");
+
+    let fetched = repo
+        .get_trigger(tenant("tenant-a"), record.trigger_id)
+        .await
+        .expect("get trigger")
+        .expect("record present");
+
+    assert_eq!(fetched, record);
+}
+
+#[tokio::test]
+async fn libsql_repository_round_trip_preserves_null_optional_scope_fields() {
+    let (_dir, repo) = build_repo().await;
+    let mut record = sample_record(
+        TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+        tenant("tenant-a"),
+        ts(1_704_067_260),
+    );
+    record.agent_id = None;
+    record.project_id = None;
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("insert record with null optional fields");
+
+    let fetched = repo
+        .get_trigger(tenant("tenant-a"), record.trigger_id)
+        .await
+        .expect("get trigger")
+        .expect("record present");
+
+    assert_eq!(fetched, record);
+}
+
+#[tokio::test]
+async fn libsql_repository_upsert_preserves_original_created_at() {
+    let (_dir, repo) = build_repo().await;
+    let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+    let tenant_id = tenant("tenant-a");
+    let original_created_at = ts(1_704_067_200);
+    let mut record = sample_record(trigger_id, tenant_id.clone(), ts(1_704_067_260));
+    record.created_at = original_created_at;
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("insert record");
+
+    let mut update = record;
+    update.name = "renamed trigger".to_string();
+    update.created_at = ts(1_704_067_900);
+    repo.upsert_trigger(update)
+        .await
+        .expect("update existing record");
+
+    let fetched = repo
+        .get_trigger(tenant_id, trigger_id)
+        .await
+        .expect("get trigger")
+        .expect("record present");
+
+    assert_eq!(fetched.name, "renamed trigger");
+    assert_eq!(fetched.created_at, original_created_at);
+}
+
+#[tokio::test]
+async fn libsql_repository_rejects_malformed_persisted_rows() {
+    let (_dir, db, repo) = build_repo_with_db().await;
+    let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+    let tenant_id = tenant("tenant-a");
+    let record = sample_record(trigger_id, tenant_id.clone(), ts(1_704_067_260));
+
+    repo.upsert_trigger(record).await.expect("insert record");
+
+    let conn = db.connect().expect("connect raw libsql");
+    for (column, value, expected_field, read_mode) in [
+        ("trigger_id", "not-a-ulid", "invalid length", "list"),
+        ("tenant_id", "", "tenant_id", "due"),
+        ("creator_user_id", "", "creator_user_id", "get"),
+        ("agent_id", "", "agent_id", "get"),
+        ("project_id", "", "project_id", "get"),
+        ("source", "webhook", "source", "get"),
+        ("state", "unknown", "state", "get"),
+        ("completion_policy", "once", "completion_policy", "get"),
+        ("next_run_at", "not-a-timestamp", "next_run_at", "get"),
+        ("last_run_at", "not-a-timestamp", "last_run_at", "get"),
+        (
+            "last_fired_slot",
+            "not-a-timestamp",
+            "last_fired_slot",
+            "get",
+        ),
+        ("last_status", "timed_out", "last_status", "get"),
+    ] {
+        conn.execute(
+            &format!(
+                "UPDATE trigger_records SET {column} = ?1 WHERE tenant_id = ?2 AND trigger_id = ?3"
+            ),
+            params![value, tenant_id.as_str(), trigger_id.to_string()],
+        )
+        .await
+        .expect("corrupt persisted row");
+
+        let error = match read_mode {
+            "get" => repo.get_trigger(tenant_id.clone(), trigger_id).await,
+            "list" => repo
+                .list_triggers(tenant_id.clone())
+                .await
+                .map(|records| records.first().cloned()),
+            "due" => repo
+                .list_due_triggers(ts(1_704_067_260), 10)
+                .await
+                .map(|records| records.first().cloned()),
+            _ => unreachable!("known read mode"),
+        }
+        .expect_err("malformed row must fail hydration");
+        assert!(
+            if column == "trigger_id" {
+                matches!(
+                    error,
+                    TriggerError::InvalidTriggerId { ref reason } if reason.contains(expected_field)
+                )
+            } else {
+                matches!(
+                    error,
+                    TriggerError::InvalidRecord { ref reason } if reason.contains(expected_field)
+                )
+            },
+            "expected malformed {column} to report {expected_field}, got {error:?}"
+        );
+
+        conn.execute("DELETE FROM trigger_records", ())
+            .await
+            .expect("clear malformed row");
+        repo.upsert_trigger(sample_record(
+            trigger_id,
+            tenant_id.clone(),
+            ts(1_704_067_260),
+        ))
+        .await
+        .expect("restore valid row");
+    }
+}
+
+#[tokio::test]
+async fn libsql_repository_due_query_clamps_limit_and_respects_state_gate() {
+    let (_dir, repo) = build_repo().await;
+    let due_slot = ts(1_704_067_200);
+    let paused = {
+        let mut record = sample_record(
+            TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZY").expect("ulid"),
+            tenant("tenant-paused"),
+            due_slot,
+        );
+        record.state = TriggerState::Paused;
+        record
+    };
+    repo.upsert_trigger(paused.clone())
+        .await
+        .expect("insert paused");
+
+    let small_a = sample_record(
+        TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+        tenant("tenant-a"),
+        due_slot,
+    );
+    let small_b = sample_record(
+        TriggerId::parse("01J00000000000000000000000").expect("ulid"),
+        tenant("tenant-b"),
+        due_slot,
+    );
+    let small_c = sample_record(
+        TriggerId::parse("01J00000000000000000000000").expect("ulid"),
+        tenant("tenant-c"),
+        due_slot,
+    );
+    repo.upsert_trigger(small_b.clone())
+        .await
+        .expect("insert small_b");
+    repo.upsert_trigger(small_c.clone())
+        .await
+        .expect("insert small_c");
+    repo.upsert_trigger(small_a.clone())
+        .await
+        .expect("insert small_a");
+
+    let ordered_due_records = repo
+        .list_due_triggers(due_slot, 3)
+        .await
+        .expect("list due ordered");
+    assert_eq!(
+        ordered_due_records
+            .iter()
+            .map(|record| (record.tenant_id.clone(), record.trigger_id))
+            .collect::<Vec<_>>(),
+        vec![
+            (small_a.tenant_id.clone(), small_a.trigger_id),
+            (small_b.tenant_id.clone(), small_b.trigger_id),
+            (small_c.tenant_id.clone(), small_c.trigger_id),
+        ]
+    );
+
+    for index in 0..127 {
+        let record = sample_record(
+            TriggerId::parse("01Z00000000000000000000000").expect("ulid"),
+            tenant(&format!("tenant-z-{index:03}")),
+            due_slot,
+        );
+        repo.upsert_trigger(record).await.expect("insert filler");
+    }
+
+    assert!(
+        repo.list_due_triggers(due_slot, 0)
+            .await
+            .expect("zero limit")
+            .is_empty()
+    );
+
+    let due_records = repo
+        .list_due_triggers(due_slot, 128 + 10)
+        .await
+        .expect("list due");
+    assert_eq!(due_records.len(), 128);
+    assert!(
+        !due_records
+            .iter()
+            .any(|record| record.tenant_id == paused.tenant_id),
+        "paused record must not be returned as due"
+    );
+}
+
+#[tokio::test]
+async fn libsql_repository_rejects_validation_failures_before_persistence() {
+    let (_dir, repo) = build_repo().await;
+    let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+    let tenant_id = tenant("tenant-a");
+    let next_run_at = ts(1_704_067_200);
+
+    let mut name_error = sample_record(trigger_id, tenant_id.clone(), next_run_at);
+    name_error.name.clear();
+    assert!(matches!(
+        repo.upsert_trigger(name_error).await,
+        Err(TriggerError::InvalidRecord { .. })
+    ));
+
+    let mut prompt_error = sample_record(trigger_id, tenant_id.clone(), next_run_at);
+    prompt_error.prompt.clear();
+    assert!(matches!(
+        repo.upsert_trigger(prompt_error).await,
+        Err(TriggerError::InvalidRecord { .. })
+    ));
+
+    let mut schedule_error = sample_record(trigger_id, tenant_id, next_run_at);
+    schedule_error.schedule = TriggerSchedule::Cron {
+        expression: "*/30 * * * * *".to_string(),
+    };
+    assert!(matches!(
+        repo.upsert_trigger(schedule_error).await,
+        Err(TriggerError::InvalidSchedule { .. })
+    ));
+
+    assert!(
+        repo.list_triggers(tenant("tenant-a"))
+            .await
+            .expect("list after failures")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn libsql_repository_persists_trigger_state_fire_gate() {
+    let (_dir, repo) = build_repo().await;
+    let trigger_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+    let tenant_id = tenant("tenant-a");
+    let mut record = sample_record(trigger_id, tenant_id.clone(), ts(1_704_067_200));
+    record.state = TriggerState::Paused;
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("insert paused");
+
+    let fetched = repo
+        .get_trigger(tenant_id.clone(), trigger_id)
+        .await
+        .expect("get paused")
+        .expect("paused record");
+    assert_eq!(fetched.state, TriggerState::Paused);
+    assert_eq!(fetched.schedule, record.schedule);
+    assert!(
+        repo.list_due_triggers(ts(1_704_067_200), 10)
+            .await
+            .expect("list due")
+            .is_empty()
+    );
+
+    record.state = TriggerState::Scheduled;
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("reactivate");
+    let due_records = repo
+        .list_due_triggers(ts(1_704_067_200), 10)
+        .await
+        .expect("list due after reactivation");
+    assert_eq!(due_records.len(), 1);
+    assert_eq!(due_records[0].state, TriggerState::Scheduled);
+    assert_eq!(due_records[0].trigger_id, trigger_id);
+}

--- a/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
@@ -8,6 +8,7 @@ use ironclaw_triggers::{
     LibSqlTriggerRepository, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
     TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
+use ironclaw_turns::TurnRunId;
 use libsql::params;
 use tempfile::tempdir;
 
@@ -44,6 +45,8 @@ fn sample_record(
         last_run_at: None,
         last_fired_slot: None,
         last_status: None,
+        active_fire_slot: None,
+        active_run_ref: None,
         created_at: ts(1_704_067_200),
     }
 }
@@ -174,6 +177,8 @@ async fn libsql_repository_round_trip_preserves_optional_run_metadata_and_comple
     record.last_run_at = Some(ts(1_704_067_200));
     record.last_fired_slot = Some(ts(1_704_067_140));
     record.last_status = Some(TriggerRunStatus::Error);
+    record.active_fire_slot = Some(ts(1_704_067_260));
+    record.active_run_ref = Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").unwrap());
 
     repo.upsert_trigger(record.clone())
         .await
@@ -273,6 +278,13 @@ async fn libsql_repository_rejects_malformed_persisted_rows() {
             "last_fired_slot",
             "get",
         ),
+        (
+            "active_fire_slot",
+            "not-a-timestamp",
+            "active_fire_slot",
+            "get",
+        ),
+        ("active_run_ref", "not-a-uuid", "active_run_ref", "get"),
         ("last_status", "timed_out", "last_status", "get"),
     ] {
         conn.execute(

--- a/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/libsql_repository_contract.rs
@@ -258,9 +258,13 @@ async fn libsql_repository_rejects_malformed_persisted_rows() {
         ("creator_user_id", "", "creator_user_id", "get"),
         ("agent_id", "", "agent_id", "get"),
         ("project_id", "", "project_id", "get"),
+        ("name", "", "name", "get"),
+        ("name", "   ", "name", "get"),
         ("source", "webhook", "source", "get"),
         ("state", "unknown", "state", "get"),
         ("completion_policy", "once", "completion_policy", "get"),
+        ("prompt", "", "prompt", "get"),
+        ("prompt", "\t  ", "prompt", "get"),
         ("next_run_at", "not-a-timestamp", "next_run_at", "get"),
         ("last_run_at", "not-a-timestamp", "last_run_at", "get"),
         (
@@ -325,6 +329,11 @@ async fn libsql_repository_rejects_malformed_persisted_rows() {
 async fn libsql_repository_due_query_clamps_limit_and_respects_state_gate() {
     let (_dir, repo) = build_repo().await;
     let due_slot = ts(1_704_067_200);
+    let future = sample_record(
+        TriggerId::parse("01J00000000000000000000002").expect("ulid"),
+        tenant("tenant-future"),
+        ts(1_704_067_320),
+    );
     let paused = {
         let mut record = sample_record(
             TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZY").expect("ulid"),
@@ -337,6 +346,9 @@ async fn libsql_repository_due_query_clamps_limit_and_respects_state_gate() {
     repo.upsert_trigger(paused.clone())
         .await
         .expect("insert paused");
+    repo.upsert_trigger(future.clone())
+        .await
+        .expect("insert future");
     let completed = {
         let mut record = sample_record(
             TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZX").expect("ulid"),
@@ -412,6 +424,12 @@ async fn libsql_repository_due_query_clamps_limit_and_respects_state_gate() {
         .await
         .expect("list due");
     assert_eq!(due_records.len(), 128);
+    assert!(
+        !due_records
+            .iter()
+            .any(|record| record.tenant_id == future.tenant_id),
+        "future scheduled record must not be returned as due"
+    );
     assert!(
         !due_records
             .iter()

--- a/crates/ironclaw_turns/src/ids.rs
+++ b/crates/ironclaw_turns/src/ids.rs
@@ -40,6 +40,10 @@ impl TurnRunId {
         Self(Uuid::new_v4())
     }
 
+    pub fn parse(value: &str) -> Result<Self, uuid::Error> {
+        Uuid::parse_str(value).map(Self)
+    }
+
     pub fn from_uuid(value: Uuid) -> Self {
         Self(value)
     }
@@ -58,6 +62,14 @@ impl Default for TurnRunId {
 impl std::fmt::Display for TurnRunId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl std::str::FromStr for TurnRunId {
+    type Err = uuid::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
     }
 }
 
@@ -251,7 +263,7 @@ impl PartialEq<GateRef> for LoopGateRef {
 
 #[cfg(test)]
 mod tests {
-    use super::{GateRef, LoopGateRef};
+    use super::{GateRef, LoopGateRef, TurnRunId};
 
     #[test]
     fn gate_ref_eq_loop_gate_ref_matches_exact_gate_string() {
@@ -264,6 +276,14 @@ mod tests {
         assert_eq!(loop_gate_ref, gate_ref);
         assert_ne!(gate_ref, other_loop_gate_ref);
         assert_ne!(loop_gate_ref, other_gate_ref);
+    }
+
+    #[test]
+    fn turn_run_id_parse_round_trips_display_string() {
+        let run_id = TurnRunId::new();
+        let parsed = TurnRunId::parse(&run_id.to_string()).expect("parse run id");
+        assert_eq!(parsed, run_id);
+        assert!("not-a-uuid".parse::<TurnRunId>().is_err());
     }
 }
 

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -444,6 +444,9 @@ Add the first durable `TriggerRepository` backend:
   be derived from `state == Scheduled`, not written as independent fire state
 - `active_fire_slot` and `active_run_ref` persistence fields separate from
   `last_status`
+- `active_run_ref` is persisted and round-tripped as the submitted Reborn
+  `TurnRunId`; it is not an auth-layer `TurnRunRef` or a trigger-local opaque
+  wrapper, and PR 10 does not interpret it as a claim/clear decision
 - due-trigger query with limit
 - scoped list/remove behavior
 - backend-specific tests
@@ -497,6 +500,8 @@ Add the backend-agnostic repository claim/lease API that makes
 - write-order contract for `last_run_at`, `last_fired_slot`, `last_status`,
   `next_run_at`, `active_fire_slot`, and `active_run_ref`.
 - active-fire claim never uses `last_status` as the in-flight sentinel.
+- claim/clear code reads `active_run_ref` as a `TurnRunId` and consults the
+  turn-state system for terminal status; PR 10 only persists the field.
 
 Expected size: less than 600 lines.
 

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -448,6 +448,23 @@ Add the first durable `TriggerRepository` backend:
 - scoped list/remove behavior
 - backend-specific tests
 
+Reborn storage boundary: `ironclaw_triggers` may own the trigger repository
+backend because it owns trigger schema, row decoding, due-query semantics, and
+trigger-scoped persistence tests. It must not own generic database accessors,
+database URL/path/env parsing, production substrate selection, or shared
+connection bootstrap. Composition/bootstrap opens `Arc<libsql::Database>` or a
+PostgreSQL pool, then passes the already-constructed handle into the trigger
+repository constructor. This mirrors Reborn's substrate boundary: storage crates
+own domain persistence adapters; composition owns backend selection and handle
+construction.
+
+Because Reborn has moved several tenant-scoped stores away from raw database
+handles toward scoped filesystem storage, PR 10 must keep tenant boundaries
+explicit in the repository contract. Scoped create/list/remove remain
+tenant-scoped. The global due query is allowed only for the trusted host poller,
+and returned records must carry tenant/user/agent/project authority forward to
+later trusted-ingress materialization.
+
 Expected size: less than 1000 lines.
 
 ### PR 11 — Trigger Persistence, Backend 2 and Parity
@@ -458,6 +475,11 @@ Add the second required backend and parity coverage:
 - shared parity tests across both backends
 - parity for active-fire fields and retryable `next_run_at` behavior
 - any schema compatibility fixes from PR 10
+
+PR 11 must preserve the same boundary as PR 10: add the second backend-specific
+repository implementation and parity tests in the trigger storage layer, but do
+not introduce a trigger-owned generic DB bootstrap or connection-string parser.
+Backend construction remains composition-owned.
 
 Expected size: less than 1000 lines.
 


### PR DESCRIPTION
## Summary

Adds the first durable `TriggerRepository` backend for Reborn triggers using libSQL.

This PR is intentionally **backend 1 only**. It implements trigger persistence inside `ironclaw_triggers`; it does not wire the poller, composition lifecycle, trigger capabilities, active-run back-pressure, routines, trusted inbound, or outbound delivery.

## What changed

- Adds a libSQL-backed `LibSqlTriggerRepository`.
- Adds durable storage for trigger records with scoped CRUD behavior.
- Adds global due-trigger listing with deterministic ordering and limit clamping.
- Uses `TriggerState::Scheduled` as the V1 fire gate; there is intentionally no separate `enabled` column.
- Persists nullable active-fire metadata fields: `active_fire_slot` and `active_run_ref`.
- Stores `active_run_ref` as the submitted Reborn `TurnRunId`, not an auth-layer `TurnRunRef` or a trigger-local opaque wrapper.
- Preserves tenant/trigger scoping on get/list/remove while allowing the global poller-style due query to return records carrying tenant/user authority.
- Adds `TurnRunId::parse` / `FromStr` in the owning `ironclaw_turns` crate for durable hydration.
- Adds backend contract tests for:
  - round-trip persistence and scoped isolation;
  - remove-missing behavior;
  - due-query ordering, state gating, zero limit, future-scheduled exclusion, and max-limit clamp;
  - validation before persistence;
  - optional run metadata, active-fire metadata, and `CompleteAfterFirstFire`;
  - malformed persisted-row hydration;
  - state fire-gate persistence.
- Updates the Reborn architecture boundary test to scan either the legacy `product_auth_serve.rs` file or the current `product_auth_serve/` module directory on PR merge refs.
- Adds a concise `crates/ironclaw_triggers/AGENTS.md` so future agents do not move poller/composition/outbound/capability work into the repository crate.

## Review decisions and scope notes

- No migration-failure test is added.
  - Reborn trigger persistence is new and not launched, so backwards-compatible migration-path coverage is intentionally out of scope here.
  - The schema setup path is still exercised by every libSQL repository test through `run_migrations()`.
  - I did add rollback-failure warning logs so startup/schema diagnostics are not silently dropped.
- `active_run_ref` is persisted and round-tripped only in this PR.
  - Claim/clear interpretation belongs to PR12/PR13.
  - Later claim/clear code should read this as a `TurnRunId` and consult the turn-state system for terminal status.
- `TriggerError::Backend` is now a struct variant carrying `reason`; callers matching this variant must use `Backend { .. }`.
- The repeated row shape is centralized in one column-list constant.
  - This keeps SQL projection order and row decoding easier to audit as PR11 adds the second backend.
- This is libSQL backend 1 only.
  - PostgreSQL parity belongs to PR11.
  - Shared parity coverage belongs to PR11 once both backends exist.
- This PR deliberately does **not** add:
  - active-run reservation or `max_concurrent_fires_per_trigger` enforcement;
  - poller worker logic;
  - trigger create/list/remove capabilities;
  - composition startup/shutdown wiring;
  - routine bridges;
  - delivery resolution or outbound sends.

## Tests

- `cargo test -p ironclaw_triggers --features libsql`
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_turns ids::tests::turn_run_id_parse_round_trips_display_string`
- `cargo test -p ironclaw_architecture reborn_product_auth_contract_stays_reborn_native --test reborn_dependency_boundaries`
- `cargo test -p ironclaw_architecture reborn --test reborn_dependency_boundaries`
- `cargo clippy -p ironclaw_triggers --features libsql -- -D warnings`
- `git diff --check`
