### PR TITLE
[codex] Add outbound validation bridge

### DIFF
--- a/crates/ironclaw_outbound/src/lib.rs
+++ b/crates/ironclaw_outbound/src/lib.rs
@@ -42,8 +42,9 @@ pub use types::{
     AdvanceSubscriptionCursorRequest, DeliveryFailureKind, LoadSubscriptionCursorRequest,
     OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryStatus,
     OutboundPushCandidate, OutboundPushKind, OutboundPushPlan, OutboundPushTargetRequest,
-    PrepareOutboundDeliveryRequest, ProjectionSubscriptionRecord, ProjectionSubscriptionRequest,
-    ReplyTargetBindingClaim, ReplyTargetValidationRequest, ThreadNotificationPolicy,
-    ThreadNotificationTarget, ThreadProjectionAccessClaim, ThreadProjectionAccessGrant,
-    ThreadProjectionAccessRequest, UpdateDeliveryStatusRequest, ValidatedReplyTargetBinding,
+    PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
+    ProjectionSubscriptionRecord, ProjectionSubscriptionRequest, ReplyTargetBindingClaim,
+    ReplyTargetValidationRequest, ThreadNotificationPolicy, ThreadNotificationTarget,
+    ThreadProjectionAccessClaim, ThreadProjectionAccessGrant, ThreadProjectionAccessRequest,
+    UpdateDeliveryStatusRequest, ValidatedReplyTargetBinding,
 };

--- a/crates/ironclaw_outbound/src/service.rs
+++ b/crates/ironclaw_outbound/src/service.rs
@@ -1,9 +1,12 @@
 use async_trait::async_trait;
 
+use crate::resolution_engine::OutboundResolutionEngine;
 use crate::validation::validate_delivery_scope_candidate;
 use crate::{
+    CommunicationDeliveryKind, CommunicationDeliveryResolution, CommunicationPreferenceRepository,
     DeliveryFailureKind, OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryId,
-    OutboundDeliveryStatus, OutboundError, OutboundStateStore, PrepareOutboundDeliveryRequest,
+    OutboundDeliveryStatus, OutboundError, OutboundPushCandidate, OutboundPushKind,
+    OutboundStateStore, PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
     ProjectionSubscriptionRecord, ProjectionSubscriptionRequest, ReplyTargetBindingClaim,
     ReplyTargetValidationRequest, ThreadProjectionAccessClaim, ThreadProjectionAccessGrant,
     ThreadProjectionAccessRequest, ValidatedReplyTargetBinding,
@@ -141,6 +144,72 @@ impl<'a> OutboundPolicyService<'a> {
             Err(error) => Err(error),
         }
     }
+
+    pub async fn prepare_communication_delivery_attempt(
+        &self,
+        request: PrepareCommunicationDeliveryRequest,
+        communication_preferences: &dyn CommunicationPreferenceRepository,
+    ) -> Result<Option<OutboundDeliveryDecision>, OutboundError> {
+        let engine = OutboundResolutionEngine::new(communication_preferences);
+        let resolution = engine.resolve(&request.resolution_request).await?;
+        self.prepare_communication_delivery_attempt_from_resolution(request, resolution)
+            .await
+    }
+
+    async fn prepare_communication_delivery_attempt_from_resolution(
+        &self,
+        request: PrepareCommunicationDeliveryRequest,
+        resolution: CommunicationDeliveryResolution,
+    ) -> Result<Option<OutboundDeliveryDecision>, OutboundError> {
+        let Some(request) = lower_communication_delivery_resolution(request, resolution)? else {
+            return Ok(None);
+        };
+
+        self.prepare_delivery_attempt(request).await.map(Some)
+    }
+}
+
+fn lower_communication_delivery_resolution(
+    request: PrepareCommunicationDeliveryRequest,
+    resolution: CommunicationDeliveryResolution,
+) -> Result<Option<PrepareOutboundDeliveryRequest>, OutboundError> {
+    let PrepareCommunicationDeliveryRequest {
+        resolution_request,
+        turn_run_id,
+        projection_ref,
+        attempted_at,
+    } = request;
+    let CommunicationDeliveryResolution::Candidate { candidate } = resolution else {
+        return Ok(None);
+    };
+    let kind = outbound_push_kind(candidate.kind)?;
+
+    let scope = resolution_request.scope;
+    Ok(Some(PrepareOutboundDeliveryRequest {
+        scope: scope.clone(),
+        candidate: OutboundPushCandidate {
+            tenant_id: scope.tenant_id,
+            agent_id: scope.agent_id,
+            project_id: scope.project_id,
+            thread_id: scope.thread_id,
+            turn_run_id,
+            target: candidate.target,
+            kind,
+            projection_ref,
+            requires_reply_target_revalidation: true,
+        },
+        attempted_at,
+    }))
+}
+
+fn outbound_push_kind(kind: CommunicationDeliveryKind) -> Result<OutboundPushKind, OutboundError> {
+    match kind {
+        CommunicationDeliveryKind::FinalReply => Ok(OutboundPushKind::FinalReply),
+        CommunicationDeliveryKind::ProgressUpdate => Ok(OutboundPushKind::Progress),
+        CommunicationDeliveryKind::ApprovalPrompt => Ok(OutboundPushKind::GateRequired),
+        CommunicationDeliveryKind::AuthPrompt => Ok(OutboundPushKind::AuthPrompt),
+        CommunicationDeliveryKind::DeliveryStatus => Ok(OutboundPushKind::DeliveryStatus),
+    }
 }
 
 fn validate_access_claim(
@@ -176,5 +245,225 @@ fn is_transient_validator_error(error: &OutboundError) -> bool {
         | OutboundError::SubscriptionScopeMismatch
         | OutboundError::AccessDenied
         | OutboundError::DeliveryNotFound => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+    use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnScope};
+
+    use super::*;
+    use crate::{
+        CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
+        CommunicationPreferenceRecord, InMemoryOutboundStateStore, OutboundPushKind,
+        RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin,
+        SourceRouteContext, SystemEventReasonCode,
+    };
+
+    #[tokio::test]
+    async fn prepare_communication_delivery_attempt_returns_none_for_no_delivery() {
+        let store = InMemoryOutboundStateStore::default();
+        let validator = TestReplyTargetBindingValidator::default();
+        let access_policy = AllowAllProjectionAccessPolicy;
+        let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+        let scope = turn_scope("thread-no-delivery");
+        let request = PrepareCommunicationDeliveryRequest {
+            resolution_request: CommunicationDeliveryResolutionRequest {
+                scope: scope.clone(),
+                actor: actor("alice"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::DeliveryStatus,
+                    origin: RunNotificationOrigin::SystemEvent {
+                        reason: SystemEventReasonCode::Generic,
+                    },
+                }),
+            },
+            turn_run_id: None,
+            projection_ref: projection_ref("projection:no-delivery"),
+            attempted_at: now(),
+        };
+
+        let decision = service
+            .prepare_communication_delivery_attempt(request, &store)
+            .await
+            .expect("no-delivery resolution succeeds");
+
+        assert!(decision.is_none());
+        assert!(
+            store
+                .list_delivery_attempts(scope)
+                .await
+                .expect("list delivery attempts")
+                .is_empty()
+        );
+        assert_eq!(validator.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn prepare_communication_delivery_attempt_lowers_prompt_kinds_to_gate_required() {
+        let store = InMemoryOutboundStateStore::default();
+        let validator = TestReplyTargetBindingValidator::default();
+        let access_policy = AllowAllProjectionAccessPolicy;
+        let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+        let scope = turn_scope("thread-approval");
+        let approval_target = reply_ref("reply:approval");
+        validator.allow(approval_target.clone());
+        store
+            .put_communication_preference(preference_record(
+                &scope,
+                Some("reply:final"),
+                Some("reply:progress"),
+                Some("reply:approval"),
+                Some("reply:auth"),
+            ))
+            .await
+            .expect("seed preferences");
+
+        let request = PrepareCommunicationDeliveryRequest {
+            resolution_request: CommunicationDeliveryResolutionRequest {
+                scope: scope.clone(),
+                actor: actor("alice"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::ApprovalNeeded,
+                    origin: RunNotificationOrigin::LiveSourceRoute {
+                        source_route: SourceRouteContext {
+                            reply_target_binding_ref: reply_ref("reply:source"),
+                        },
+                    },
+                }),
+            },
+            turn_run_id: None,
+            projection_ref: projection_ref("projection:approval"),
+            attempted_at: now(),
+        };
+
+        let decision = service
+            .prepare_communication_delivery_attempt(request, &store)
+            .await
+            .expect("approval prompt resolves");
+        let Some(OutboundDeliveryDecision::Authorized { attempt, target }) = decision else {
+            panic!("expected an authorized delivery decision");
+        };
+
+        assert_eq!(attempt.candidate.kind, OutboundPushKind::GateRequired);
+        assert_eq!(target.target(), &approval_target);
+        assert_eq!(validator.calls(), 1);
+        assert_eq!(
+            store
+                .list_delivery_attempts(scope)
+                .await
+                .expect("list delivery attempts")
+                .len(),
+            1
+        );
+    }
+
+    #[derive(Default)]
+    struct TestReplyTargetBindingValidator {
+        allowed: Mutex<HashSet<ReplyTargetBindingRef>>,
+        calls: Mutex<usize>,
+    }
+
+    #[async_trait]
+    impl ReplyTargetBindingValidator for TestReplyTargetBindingValidator {
+        async fn validate_reply_target(
+            &self,
+            request: ReplyTargetValidationRequest,
+        ) -> Result<ReplyTargetBindingClaim, OutboundError> {
+            *self.calls.lock().expect("lock calls") += 1;
+            if self
+                .allowed
+                .lock()
+                .expect("lock allowed")
+                .contains(&request.candidate.target)
+            {
+                Ok(ReplyTargetBindingClaim::new(request.candidate.target))
+            } else {
+                Err(OutboundError::AccessDenied)
+            }
+        }
+    }
+
+    impl TestReplyTargetBindingValidator {
+        fn allow(&self, target: ReplyTargetBindingRef) {
+            self.allowed.lock().expect("lock allowed").insert(target);
+        }
+
+        fn calls(&self) -> usize {
+            *self.calls.lock().expect("lock calls")
+        }
+    }
+
+    struct AllowAllProjectionAccessPolicy;
+
+    #[async_trait]
+    impl ThreadProjectionAccessPolicy for AllowAllProjectionAccessPolicy {
+        async fn authorize_projection_access(
+            &self,
+            request: ThreadProjectionAccessRequest,
+        ) -> Result<ThreadProjectionAccessClaim, OutboundError> {
+            Ok(ThreadProjectionAccessClaim {
+                actor: request.actor,
+                scope: request.scope,
+                thread_id: request.thread_id,
+            })
+        }
+    }
+
+    fn preference_record(
+        scope: &TurnScope,
+        final_reply_target: Option<&str>,
+        progress_target: Option<&str>,
+        approval_prompt_target: Option<&str>,
+        auth_prompt_target: Option<&str>,
+    ) -> CommunicationPreferenceRecord {
+        CommunicationPreferenceRecord {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: user_id("alice"),
+            final_reply_target: final_reply_target.map(reply_ref),
+            progress_target: progress_target.map(reply_ref),
+            approval_prompt_target: approval_prompt_target.map(reply_ref),
+            auth_prompt_target: auth_prompt_target.map(reply_ref),
+            default_modality: Some(CommunicationModality::Text),
+            updated_at: now(),
+            updated_by: user_id("alice"),
+        }
+    }
+
+    fn turn_scope(thread_id: &str) -> TurnScope {
+        TurnScope::new(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            Some(AgentId::new("agent-a").expect("valid agent")),
+            Some(ProjectId::new("project-a").expect("valid project")),
+            ThreadId::new(thread_id).expect("valid thread"),
+        )
+    }
+
+    fn actor(user_id_value: &str) -> TurnActor {
+        TurnActor::new(user_id(user_id_value))
+    }
+
+    fn user_id(value: &str) -> UserId {
+        UserId::new(value).expect("valid user")
+    }
+
+    fn reply_ref(value: &str) -> ReplyTargetBindingRef {
+        ReplyTargetBindingRef::new(value).expect("valid reply target")
+    }
+
+    fn projection_ref(value: &str) -> crate::ProjectionUpdateRef {
+        crate::ProjectionUpdateRef::new(value).expect("valid projection ref")
+    }
+
+    fn now() -> chrono::DateTime<Utc> {
+        Utc::now()
     }
 }

--- a/crates/ironclaw_outbound/src/service.rs
+++ b/crates/ironclaw_outbound/src/service.rs
@@ -3,10 +3,10 @@ use async_trait::async_trait;
 use crate::resolution_engine::OutboundResolutionEngine;
 use crate::validation::validate_delivery_scope_candidate;
 use crate::{
-    CommunicationDeliveryKind, CommunicationDeliveryResolution, CommunicationPreferenceRepository,
-    DeliveryFailureKind, OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryId,
-    OutboundDeliveryStatus, OutboundError, OutboundPushCandidate, OutboundPushKind,
-    OutboundStateStore, PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
+    CommunicationDeliveryResolution, CommunicationPreferenceRepository, DeliveryFailureKind,
+    OutboundDeliveryAttempt, OutboundDeliveryDecision, OutboundDeliveryId, OutboundDeliveryStatus,
+    OutboundError, OutboundPushCandidate, OutboundPushKind, OutboundStateStore,
+    PrepareCommunicationDeliveryRequest, PrepareOutboundDeliveryRequest,
     ProjectionSubscriptionRecord, ProjectionSubscriptionRequest, ReplyTargetBindingClaim,
     ReplyTargetValidationRequest, ThreadProjectionAccessClaim, ThreadProjectionAccessGrant,
     ThreadProjectionAccessRequest, ValidatedReplyTargetBinding,
@@ -161,7 +161,7 @@ impl<'a> OutboundPolicyService<'a> {
         request: PrepareCommunicationDeliveryRequest,
         resolution: CommunicationDeliveryResolution,
     ) -> Result<Option<OutboundDeliveryDecision>, OutboundError> {
-        let Some(request) = lower_communication_delivery_resolution(request, resolution)? else {
+        let Some(request) = lower_communication_delivery_resolution(request, resolution) else {
             return Ok(None);
         };
 
@@ -172,7 +172,7 @@ impl<'a> OutboundPolicyService<'a> {
 fn lower_communication_delivery_resolution(
     request: PrepareCommunicationDeliveryRequest,
     resolution: CommunicationDeliveryResolution,
-) -> Result<Option<PrepareOutboundDeliveryRequest>, OutboundError> {
+) -> Option<PrepareOutboundDeliveryRequest> {
     let PrepareCommunicationDeliveryRequest {
         resolution_request,
         turn_run_id,
@@ -180,36 +180,29 @@ fn lower_communication_delivery_resolution(
         attempted_at,
     } = request;
     let CommunicationDeliveryResolution::Candidate { candidate } = resolution else {
-        return Ok(None);
+        return None;
     };
-    let kind = outbound_push_kind(candidate.kind)?;
+    let kind = OutboundPushKind::from(candidate.kind);
 
     let scope = resolution_request.scope;
-    Ok(Some(PrepareOutboundDeliveryRequest {
-        scope: scope.clone(),
-        candidate: OutboundPushCandidate {
-            tenant_id: scope.tenant_id,
-            agent_id: scope.agent_id,
-            project_id: scope.project_id,
-            thread_id: scope.thread_id,
-            turn_run_id,
-            target: candidate.target,
-            kind,
-            projection_ref,
-            requires_reply_target_revalidation: true,
-        },
+    let candidate = OutboundPushCandidate {
+        tenant_id: scope.tenant_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        thread_id: scope.thread_id.clone(),
+        turn_run_id,
+        target: candidate.target,
+        kind,
+        projection_ref,
+        // Resolution only selects a candidate; every lowered candidate must
+        // pass reply-target validation before it can be rendered or sent.
+        requires_reply_target_revalidation: true,
+    };
+    Some(PrepareOutboundDeliveryRequest {
+        scope,
+        candidate,
         attempted_at,
-    }))
-}
-
-fn outbound_push_kind(kind: CommunicationDeliveryKind) -> Result<OutboundPushKind, OutboundError> {
-    match kind {
-        CommunicationDeliveryKind::FinalReply => Ok(OutboundPushKind::FinalReply),
-        CommunicationDeliveryKind::ProgressUpdate => Ok(OutboundPushKind::Progress),
-        CommunicationDeliveryKind::ApprovalPrompt => Ok(OutboundPushKind::GateRequired),
-        CommunicationDeliveryKind::AuthPrompt => Ok(OutboundPushKind::AuthPrompt),
-        CommunicationDeliveryKind::DeliveryStatus => Ok(OutboundPushKind::DeliveryStatus),
-    }
+    })
 }
 
 fn validate_access_claim(

--- a/crates/ironclaw_outbound/src/store.rs
+++ b/crates/ironclaw_outbound/src/store.rs
@@ -96,6 +96,7 @@ fn plan_push_targets_from_policy(
             OutboundPushKind::FinalReply => target.final_replies,
             OutboundPushKind::Progress
             | OutboundPushKind::GateRequired
+            | OutboundPushKind::AuthPrompt
             | OutboundPushKind::DeliveryStatus => target.progress,
         };
         if allowed {

--- a/crates/ironclaw_outbound/src/types.rs
+++ b/crates/ironclaw_outbound/src/types.rs
@@ -3,7 +3,9 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp};
 use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
 use serde::{Deserialize, Serialize};
 
-use crate::delivery_resolution::CommunicationDeliveryResolutionRequest;
+use crate::delivery_resolution::{
+    CommunicationDeliveryKind, CommunicationDeliveryResolutionRequest,
+};
 use crate::{OutboundDeliveryId, OutboundError, ProjectionSubscriptionId, ProjectionUpdateRef};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -14,6 +16,18 @@ pub enum OutboundPushKind {
     GateRequired,
     AuthPrompt,
     DeliveryStatus,
+}
+
+impl From<CommunicationDeliveryKind> for OutboundPushKind {
+    fn from(kind: CommunicationDeliveryKind) -> Self {
+        match kind {
+            CommunicationDeliveryKind::FinalReply => Self::FinalReply,
+            CommunicationDeliveryKind::ProgressUpdate => Self::Progress,
+            CommunicationDeliveryKind::ApprovalPrompt => Self::GateRequired,
+            CommunicationDeliveryKind::AuthPrompt => Self::AuthPrompt,
+            CommunicationDeliveryKind::DeliveryStatus => Self::DeliveryStatus,
+        }
+    }
 }
 
 #[allow(dead_code)] // retained for future debug/log surfaces — not yet wired

--- a/crates/ironclaw_outbound/src/types.rs
+++ b/crates/ironclaw_outbound/src/types.rs
@@ -3,6 +3,7 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, Timestamp};
 use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
 use serde::{Deserialize, Serialize};
 
+use crate::delivery_resolution::CommunicationDeliveryResolutionRequest;
 use crate::{OutboundDeliveryId, OutboundError, ProjectionSubscriptionId, ProjectionUpdateRef};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -11,6 +12,7 @@ pub enum OutboundPushKind {
     FinalReply,
     Progress,
     GateRequired,
+    AuthPrompt,
     DeliveryStatus,
 }
 
@@ -21,6 +23,7 @@ impl OutboundPushKind {
             Self::FinalReply => "final_reply",
             Self::Progress => "progress",
             Self::GateRequired => "gate_required",
+            Self::AuthPrompt => "auth_prompt",
             Self::DeliveryStatus => "delivery_status",
         }
     }
@@ -273,6 +276,14 @@ impl ValidatedReplyTargetBinding {
 pub struct PrepareOutboundDeliveryRequest {
     pub scope: TurnScope,
     pub candidate: OutboundPushCandidate,
+    pub attempted_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrepareCommunicationDeliveryRequest {
+    pub resolution_request: CommunicationDeliveryResolutionRequest,
+    pub turn_run_id: Option<TurnRunId>,
+    pub projection_ref: ProjectionUpdateRef,
     pub attempted_at: Timestamp,
 }
 

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -316,6 +316,444 @@ async fn delivery_preparation_propagates_validator_caller_bug_errors() {
     );
 }
 
+#[tokio::test]
+async fn communication_delivery_requested_outbound_validates_requested_target() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request =
+        requested_outbound_request("reply:requested", RequestedOutboundKind::ProductMessage);
+    validator.allow(reply_ref("reply:requested"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:preferred"),
+            Some("reply:progress"),
+            None,
+            None,
+        ))
+        .await
+        .expect("seed preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("requested outbound resolves and prepares")
+        .expect("requested outbound has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:requested"));
+    assert_eq!(attempt.candidate.target, reply_ref("reply:requested"));
+    assert_eq!(attempt.candidate.kind, OutboundPushKind::FinalReply);
+    assert_eq!(attempt.candidate.turn_run_id, Some(turn_run_id()));
+    assert_eq!(attempt.status, OutboundDeliveryStatus::Pending);
+    assert_eq!(validator.calls(), 1);
+}
+
+#[tokio::test]
+async fn communication_delivery_live_source_route_final_reply_validates_source_target() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request = run_notification_request(
+        RunNotificationEventKind::FinalReplyReady,
+        RunNotificationOrigin::LiveSourceRoute {
+            source_route: SourceRouteContext {
+                reply_target_binding_ref: reply_ref("reply:source-route"),
+            },
+        },
+    );
+    validator.allow(reply_ref("reply:source-route"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:preferred"),
+            Some("reply:progress"),
+            None,
+            None,
+        ))
+        .await
+        .expect("seed preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("live source route resolves and prepares")
+        .expect("live source route has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:source-route"));
+    assert_eq!(attempt.candidate.kind, OutboundPushKind::FinalReply);
+    assert_eq!(validator.calls(), 1);
+}
+
+#[tokio::test]
+async fn communication_delivery_triggered_default_target_validates_preference_target() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request = run_notification_request(
+        RunNotificationEventKind::FinalReplyReady,
+        RunNotificationOrigin::Triggered {
+            trigger: trigger_context(),
+        },
+    );
+    validator.allow(reply_ref("reply:triggered-default"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:triggered-default"),
+            Some("reply:progress"),
+            None,
+            None,
+        ))
+        .await
+        .expect("seed preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("triggered default resolves and prepares")
+        .expect("triggered default has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:triggered-default"));
+    assert_eq!(attempt.candidate.kind, OutboundPushKind::FinalReply);
+    assert_eq!(validator.calls(), 1);
+}
+
+#[tokio::test]
+async fn communication_delivery_lowers_progress_update_to_progress_push_kind() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request = run_notification_request(
+        RunNotificationEventKind::ProgressUpdate,
+        RunNotificationOrigin::Triggered {
+            trigger: trigger_context(),
+        },
+    );
+    validator.allow(reply_ref("reply:progress"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:final"),
+            Some("reply:progress"),
+            None,
+            None,
+        ))
+        .await
+        .expect("seed preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("progress update resolves and prepares")
+        .expect("progress update has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:progress"));
+    assert_eq!(attempt.candidate.kind, OutboundPushKind::Progress);
+    assert_eq!(validator.calls(), 1);
+}
+
+#[tokio::test]
+async fn communication_delivery_lowers_delivery_status_to_delivery_status_push_kind() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request = requested_outbound_request("reply:status", RequestedOutboundKind::DeliveryStatus);
+    validator.allow(reply_ref("reply:status"));
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("delivery status resolves and prepares")
+        .expect("delivery status has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:status"));
+    assert_eq!(attempt.candidate.kind, OutboundPushKind::DeliveryStatus);
+    assert_eq!(validator.calls(), 1);
+}
+
+#[tokio::test]
+async fn communication_delivery_auth_prompt_lowers_to_distinct_push_kind() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = turn_scope("thread-1");
+    let request = run_notification_request_with_scope(
+        scope.clone(),
+        RunNotificationEventKind::AuthRequired,
+        RunNotificationOrigin::Triggered {
+            trigger: trigger_context(),
+        },
+    );
+    validator.allow(reply_ref("reply:auth"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:final"),
+            Some("reply:progress"),
+            None,
+            Some("reply:auth"),
+        ))
+        .await
+        .expect("seed preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("auth prompt resolves and prepares")
+        .expect("auth prompt has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:auth"));
+    assert_eq!(attempt.candidate.kind, OutboundPushKind::AuthPrompt);
+    assert_eq!(validator.calls(), 1);
+    assert_eq!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .as_slice(),
+        std::slice::from_ref(&attempt)
+    );
+}
+
+#[tokio::test]
+async fn communication_delivery_propagates_preference_repository_errors() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let preferences = BackendErrorPreferenceRepository;
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = turn_scope("thread-1");
+    let request = run_notification_request_with_scope(
+        scope.clone(),
+        RunNotificationEventKind::FinalReplyReady,
+        RunNotificationOrigin::Triggered {
+            trigger: trigger_context(),
+        },
+    );
+
+    let err = service
+        .prepare_communication_delivery_attempt(
+            prepare_communication_request(request),
+            &preferences,
+        )
+        .await
+        .expect_err("preference backend errors propagate through the public seam");
+
+    assert!(matches!(err, OutboundError::Backend));
+    assert_eq!(validator.calls(), 0);
+    assert!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn communication_delivery_triggered_from_source_route_final_reply_prefers_source_target() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request = run_notification_request(
+        RunNotificationEventKind::FinalReplyReady,
+        RunNotificationOrigin::TriggeredFromSourceRoute {
+            trigger: trigger_context(),
+            source_route: SourceRouteContext {
+                reply_target_binding_ref: reply_ref("reply:source-route"),
+            },
+        },
+    );
+    validator.allow(reply_ref("reply:source-route"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:triggered-default"),
+            Some("reply:progress"),
+            None,
+            None,
+        ))
+        .await
+        .expect("seed preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("triggered source-route resolves and prepares")
+        .expect("triggered source-route has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:source-route"));
+    assert_eq!(attempt.candidate.target, reply_ref("reply:source-route"));
+    assert_eq!(validator.calls(), 1);
+}
+
+#[tokio::test]
+async fn communication_delivery_system_event_returns_no_delivery_without_records() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = turn_scope("thread-1");
+    let request = run_notification_request_with_scope(
+        scope.clone(),
+        RunNotificationEventKind::ProgressUpdate,
+        RunNotificationOrigin::SystemEvent {
+            reason: SystemEventReasonCode::Operator,
+        },
+    );
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("system event resolves");
+
+    assert!(decision.is_none());
+    assert_eq!(validator.calls(), 0);
+    assert!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn communication_delivery_revoked_target_records_sanitized_failure_without_target() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request =
+        requested_outbound_request("reply:revoked", RequestedOutboundKind::ProductMessage);
+    let scope = request.scope.clone();
+    validator.deny(reply_ref("reply:revoked"));
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("revocation is recorded as rejected")
+        .expect("requested outbound has a delivery target");
+
+    let OutboundDeliveryDecision::Rejected { attempt } = decision else {
+        panic!("expected rejected delivery");
+    };
+    assert_eq!(attempt.status, OutboundDeliveryStatus::Failed);
+    assert_eq!(
+        attempt.failure_kind,
+        Some(DeliveryFailureKind::AuthorizationRevoked)
+    );
+    assert_eq!(validator.calls(), 1);
+    assert_eq!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .as_slice(),
+        std::slice::from_ref(&attempt)
+    );
+}
+
+#[tokio::test]
+async fn communication_delivery_exact_owner_validation_rejects_target_substitution() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let request = run_notification_request(
+        RunNotificationEventKind::ApprovalNeeded,
+        RunNotificationOrigin::Triggered {
+            trigger: trigger_context(),
+        },
+    );
+    validator.redirect(reply_ref("reply:approval-target"), reply_ref("reply:other"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:final"),
+            Some("reply:progress"),
+            Some("reply:approval-target"),
+            Some("reply:auth"),
+        ))
+        .await
+        .expect("seed preference");
+
+    let err = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect_err("validator must not substitute a different prompt target");
+
+    assert!(matches!(err, OutboundError::InvalidRequest { .. }));
+    assert_eq!(validator.calls(), 1);
+    assert!(
+        store
+            .list_delivery_attempts(turn_scope("thread-1"))
+            .await
+            .expect("list delivery attempts")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn communication_delivery_scope_candidate_mismatch_rejects_before_validator_io() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = turn_scope("thread-1");
+    let other_scope = TurnScope::new(
+        TenantId::new("tenant-b").expect("valid tenant"),
+        Some(AgentId::new("agent-b").expect("valid agent")),
+        Some(ProjectId::new("project-b").expect("valid project")),
+        thread_id("thread-b"),
+    );
+    let candidate = candidate(
+        &other_scope,
+        "reply:requested",
+        OutboundPushKind::FinalReply,
+    );
+
+    let err = service
+        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
+            scope: scope.clone(),
+            candidate,
+            attempted_at: now(),
+        })
+        .await
+        .expect_err("scope mismatch must fail before validator IO");
+    assert!(matches!(err, OutboundError::InvalidRequest { .. }));
+    assert_eq!(validator.calls(), 0);
+    assert!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .is_empty()
+    );
+}
+
 struct InvalidRequestValidator;
 
 #[async_trait]
@@ -327,6 +765,25 @@ impl ReplyTargetBindingValidator for InvalidRequestValidator {
         Err(OutboundError::InvalidRequest {
             reason: "validator received bad input",
         })
+    }
+}
+
+struct BackendErrorPreferenceRepository;
+
+#[async_trait]
+impl CommunicationPreferenceRepository for BackendErrorPreferenceRepository {
+    async fn put_communication_preference(
+        &self,
+        _record: CommunicationPreferenceRecord,
+    ) -> Result<(), OutboundError> {
+        Ok(())
+    }
+
+    async fn load_communication_preference(
+        &self,
+        _key: CommunicationPreferenceKey,
+    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        Err(OutboundError::Backend)
     }
 }
 
@@ -470,6 +927,92 @@ fn candidate(scope: &TurnScope, target: &str, kind: OutboundPushKind) -> Outboun
     }
 }
 
+fn prepare_communication_request(
+    resolution_request: CommunicationDeliveryResolutionRequest,
+) -> PrepareCommunicationDeliveryRequest {
+    PrepareCommunicationDeliveryRequest {
+        resolution_request,
+        turn_run_id: Some(turn_run_id()),
+        projection_ref: ProjectionUpdateRef::new("projection:update-1")
+            .expect("valid projection ref"),
+        attempted_at: now(),
+    }
+}
+
+fn requested_outbound_request(
+    target: &str,
+    kind: RequestedOutboundKind,
+) -> CommunicationDeliveryResolutionRequest {
+    requested_outbound_request_with_scope(turn_scope("thread-1"), target, kind)
+}
+
+fn requested_outbound_request_with_scope(
+    scope: TurnScope,
+    target: &str,
+    kind: RequestedOutboundKind,
+) -> CommunicationDeliveryResolutionRequest {
+    CommunicationDeliveryResolutionRequest {
+        scope,
+        actor: actor("user-a"),
+        modality: CommunicationModality::Text,
+        intent: CommunicationDeliveryIntent::RequestedOutbound(RequestedOutboundContext {
+            requested_target: reply_ref(target),
+            requested_kind: kind,
+        }),
+    }
+}
+
+fn run_notification_request(
+    event_kind: RunNotificationEventKind,
+    origin: RunNotificationOrigin,
+) -> CommunicationDeliveryResolutionRequest {
+    run_notification_request_with_scope(turn_scope("thread-1"), event_kind, origin)
+}
+
+fn run_notification_request_with_scope(
+    scope: TurnScope,
+    event_kind: RunNotificationEventKind,
+    origin: RunNotificationOrigin,
+) -> CommunicationDeliveryResolutionRequest {
+    CommunicationDeliveryResolutionRequest {
+        scope,
+        actor: actor("user-a"),
+        modality: CommunicationModality::Text,
+        intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+            event_kind,
+            origin,
+        }),
+    }
+}
+
+fn preference_record(
+    final_reply_target: Option<&str>,
+    progress_target: Option<&str>,
+    approval_prompt_target: Option<&str>,
+    auth_prompt_target: Option<&str>,
+) -> CommunicationPreferenceRecord {
+    CommunicationPreferenceRecord {
+        tenant_id: TenantId::new("tenant-a").expect("valid tenant"),
+        user_id: UserId::new("user-a").expect("valid user"),
+        final_reply_target: final_reply_target.map(reply_ref),
+        progress_target: progress_target.map(reply_ref),
+        approval_prompt_target: approval_prompt_target.map(reply_ref),
+        auth_prompt_target: auth_prompt_target.map(reply_ref),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-a").expect("valid user"),
+    }
+}
+
+fn trigger_context() -> TriggerCommunicationContext {
+    TriggerCommunicationContext {
+        trigger_origin_ref: TriggerOriginRef::new("trigger:daily")
+            .expect("valid trigger origin ref"),
+        trigger_source_kind: TriggerSourceKind::Schedule,
+        fire_slot: TriggerFireSlot::new("2026-05-29T09:00:00Z").expect("valid fire slot"),
+    }
+}
+
 fn subscription_id(value: &str) -> ProjectionSubscriptionId {
     ProjectionSubscriptionId::new(value).expect("valid subscription id")
 }
@@ -509,6 +1052,10 @@ fn thread_id(value: &str) -> ThreadId {
 
 fn reply_ref(value: &str) -> ReplyTargetBindingRef {
     ReplyTargetBindingRef::new(value).expect("valid reply target")
+}
+
+fn turn_run_id() -> TurnRunId {
+    TurnRunId::parse("11111111-1111-4111-8111-111111111111").expect("valid turn run id")
 }
 
 fn now() -> ironclaw_host_api::Timestamp {

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -401,6 +401,21 @@ async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateSto
         .unwrap();
     assert_eq!(
         targets(&progress_plan),
+        vec![progress_target.clone(), default_reply.clone()]
+    );
+
+    let auth_prompt_plan = store
+        .plan_push_targets(OutboundPushTargetRequest {
+            scope: scope.clone(),
+            turn_run_id: None,
+            reply_target: default_reply.clone(),
+            kind: OutboundPushKind::AuthPrompt,
+            projection_ref: ProjectionUpdateRef::new("projection:auth-prompt-1").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        targets(&auth_prompt_plan),
         vec![progress_target, default_reply.clone()]
     );
 


### PR DESCRIPTION
## Summary

Implements Phase 6 / PR 6: the outbound validation integration seam. This connects resolved communication delivery candidates to the existing outbound policy validation path without adding adapter rendering, transport send, or product orchestration.

Changes:
- add `PrepareCommunicationDeliveryRequest` as the public request shape for resolve-and-prepare
- add `OutboundPolicyService::prepare_communication_delivery_attempt(...)`
- lower `CommunicationDeliveryCandidate` into `OutboundPushCandidate` using trusted scope from the original resolution request
- preserve `turn_run_id` on the lowered candidate for attempt correlation
- add distinct `OutboundPushKind::AuthPrompt` so auth prompts do not collapse into gate prompts
- keep `NoDelivery` as `Ok(None)` with no validator call and no attempt record

## Design Notes

`CommunicationDeliveryCandidate` remains selector-only. Scope identity is deliberately reattached during lowering from `CommunicationDeliveryResolutionRequest.scope`, not added back to the candidate.

`OutboundPolicyService::prepare_delivery_attempt` remains the validation and delivery-attempt authority. The new method resolves and lowers, then delegates to that existing path before anything can be rendered or sent.

PR7 should own adapter `render_outbound` and transport orchestration.

## Validation

- `cargo test -p ironclaw_outbound`
- `cargo clippy -p ironclaw_outbound --all-targets -- -D warnings`

## Review Coverage

Ran the requested multi-agent code review with `gpt-5.4-mini` reviewers plus a separate boundary/ownership check. Actionable findings were fixed: `turn_run_id` is preserved, auth prompts use a distinct outbound kind, resolver failure propagation is covered, and non-final kind lowering is covered.
