### PR TITLE
[codex] Pass reply-target validation context

### DIFF
--- a/crates/ironclaw_outbound/src/service.rs
+++ b/crates/ironclaw_outbound/src/service.rs
@@ -98,7 +98,7 @@ impl<'a> OutboundPolicyService<'a> {
             .reply_target_validator
             .validate_reply_target(ReplyTargetValidationRequest {
                 scope: request.scope.clone(),
-                actor: request.actor.clone(),
+                actor: request.actor,
                 modality: request.modality,
                 candidate: request.candidate.clone(),
             })

--- a/crates/ironclaw_outbound/src/service.rs
+++ b/crates/ironclaw_outbound/src/service.rs
@@ -98,6 +98,8 @@ impl<'a> OutboundPolicyService<'a> {
             .reply_target_validator
             .validate_reply_target(ReplyTargetValidationRequest {
                 scope: request.scope.clone(),
+                actor: request.actor.clone(),
+                modality: request.modality,
                 candidate: request.candidate.clone(),
             })
             .await;
@@ -185,6 +187,8 @@ fn lower_communication_delivery_resolution(
     let kind = OutboundPushKind::from(candidate.kind);
 
     let scope = resolution_request.scope;
+    let actor = resolution_request.actor;
+    let modality = resolution_request.modality;
     let candidate = OutboundPushCandidate {
         tenant_id: scope.tenant_id.clone(),
         agent_id: scope.agent_id.clone(),
@@ -200,6 +204,8 @@ fn lower_communication_delivery_resolution(
     };
     Some(PrepareOutboundDeliveryRequest {
         scope,
+        actor,
+        modality,
         candidate,
         attempted_at,
     })

--- a/crates/ironclaw_outbound/src/types.rs
+++ b/crates/ironclaw_outbound/src/types.rs
@@ -4,7 +4,7 @@ use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
 use serde::{Deserialize, Serialize};
 
 use crate::delivery_resolution::{
-    CommunicationDeliveryKind, CommunicationDeliveryResolutionRequest,
+    CommunicationDeliveryKind, CommunicationDeliveryResolutionRequest, CommunicationModality,
 };
 use crate::{OutboundDeliveryId, OutboundError, ProjectionSubscriptionId, ProjectionUpdateRef};
 
@@ -225,6 +225,8 @@ pub enum DeliveryFailureKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplyTargetValidationRequest {
     pub scope: TurnScope,
+    pub actor: TurnActor,
+    pub modality: CommunicationModality,
     pub candidate: OutboundPushCandidate,
 }
 
@@ -289,6 +291,8 @@ impl ValidatedReplyTargetBinding {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrepareOutboundDeliveryRequest {
     pub scope: TurnScope,
+    pub actor: TurnActor,
+    pub modality: CommunicationModality,
     pub candidate: OutboundPushCandidate,
     pub attempted_at: Timestamp,
 }

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -88,11 +88,7 @@ async fn delivery_preparation_revalidates_each_push_and_records_auth_failure_wit
 
     validator.allow(candidate.target.clone());
     let first = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate: candidate.clone(),
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate.clone()))
         .await
         .expect("first authorized delivery attempt");
     let OutboundDeliveryDecision::Authorized { attempt, target } = first else {
@@ -102,11 +98,7 @@ async fn delivery_preparation_revalidates_each_push_and_records_auth_failure_wit
     assert_eq!(target.target(), &candidate.target);
 
     let second = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate: candidate.clone(),
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate.clone()))
         .await
         .expect("second authorized delivery attempt");
     assert!(matches!(
@@ -121,11 +113,7 @@ async fn delivery_preparation_revalidates_each_push_and_records_auth_failure_wit
 
     validator.deny(candidate.target.clone());
     let rejected = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate: candidate.clone(),
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate.clone()))
         .await
         .expect("authorization failure is recorded, not surfaced as send target");
     let OutboundDeliveryDecision::Rejected { attempt } = rejected else {
@@ -169,11 +157,7 @@ async fn delivery_preparation_rejects_validator_target_substitution() {
     validator.redirect(candidate.target.clone(), reply_ref("reply-other"));
 
     let err = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate,
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate))
         .await
         .expect_err("validator must not substitute a different send target");
     assert!(matches!(err, OutboundError::InvalidRequest { .. }));
@@ -202,11 +186,7 @@ async fn delivery_preparation_rejects_scope_candidate_mismatch_before_validator_
     let candidate = candidate(&other_scope, "reply-default", OutboundPushKind::FinalReply);
 
     let err = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate,
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate))
         .await
         .expect_err("scope/candidate mismatch must fail before validator IO");
     assert!(matches!(err, OutboundError::InvalidRequest { .. }));
@@ -232,11 +212,7 @@ async fn delivery_preparation_fails_closed_when_candidate_skips_revalidation() {
     candidate.requires_reply_target_revalidation = false;
 
     let err = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate,
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate))
         .await
         .expect_err("delivery must fail closed without revalidation marker");
     assert!(matches!(err, OutboundError::InvalidRequest { .. }));
@@ -260,11 +236,7 @@ async fn delivery_preparation_records_transient_validator_error_separately_from_
     validator.fail_transient(candidate.target.clone());
 
     let rejected = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate: candidate.clone(),
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate.clone()))
         .await
         .expect("transient validator error is classified, not propagated");
     let OutboundDeliveryDecision::Rejected { attempt } = rejected else {
@@ -298,11 +270,7 @@ async fn delivery_preparation_propagates_validator_caller_bug_errors() {
     let candidate = candidate(&scope, "reply-default", OutboundPushKind::FinalReply);
 
     let err = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate,
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate))
         .await
         .expect_err("caller-bug validator errors must propagate, not be cached as transient");
     assert!(matches!(err, OutboundError::InvalidRequest { .. }));
@@ -717,6 +685,98 @@ async fn communication_delivery_exact_owner_validation_rejects_target_substituti
 }
 
 #[tokio::test]
+async fn communication_delivery_validator_can_enforce_prompt_actor_context() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = turn_scope("thread-1");
+    let request = run_notification_request_with_scope(
+        scope.clone(),
+        RunNotificationEventKind::ApprovalNeeded,
+        RunNotificationOrigin::Triggered {
+            trigger: trigger_context(),
+        },
+    );
+    validator.allow(reply_ref("reply:approval-target"));
+    validator.require_actor(actor("exact-owner"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:final"),
+            Some("reply:progress"),
+            Some("reply:approval-target"),
+            Some("reply:auth"),
+        ))
+        .await
+        .expect("seed preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("actor mismatch is a validator rejection, not a service error")
+        .expect("approval prompt has a delivery target");
+
+    let OutboundDeliveryDecision::Rejected { attempt } = decision else {
+        panic!("expected rejected delivery");
+    };
+    assert_eq!(attempt.status, OutboundDeliveryStatus::Failed);
+    assert_eq!(
+        attempt.failure_kind,
+        Some(DeliveryFailureKind::AuthorizationRevoked)
+    );
+    assert_eq!(validator.calls(), 1);
+    assert_eq!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .as_slice(),
+        std::slice::from_ref(&attempt)
+    );
+}
+
+#[tokio::test]
+async fn communication_delivery_validator_can_enforce_requested_modality() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = turn_scope("thread-1");
+    let mut request = requested_outbound_request_with_scope(
+        scope.clone(),
+        "reply:requested",
+        RequestedOutboundKind::ProductMessage,
+    );
+    request.modality = CommunicationModality::Voice;
+    validator.allow(reply_ref("reply:requested"));
+    validator.require_modality(CommunicationModality::Text);
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("modality mismatch is a validator rejection, not a service error")
+        .expect("requested outbound has a delivery target");
+
+    let OutboundDeliveryDecision::Rejected { attempt } = decision else {
+        panic!("expected rejected delivery");
+    };
+    assert_eq!(attempt.status, OutboundDeliveryStatus::Failed);
+    assert_eq!(
+        attempt.failure_kind,
+        Some(DeliveryFailureKind::AuthorizationRevoked)
+    );
+    assert_eq!(validator.calls(), 1);
+    assert_eq!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .as_slice(),
+        std::slice::from_ref(&attempt)
+    );
+}
+
+#[tokio::test]
 async fn communication_delivery_scope_candidate_mismatch_rejects_before_validator_io() {
     let store = InMemoryOutboundStateStore::default();
     let access_policy = FakeThreadProjectionAccessPolicy::default();
@@ -736,11 +796,7 @@ async fn communication_delivery_scope_candidate_mismatch_rejects_before_validato
     );
 
     let err = service
-        .prepare_delivery_attempt(PrepareOutboundDeliveryRequest {
-            scope: scope.clone(),
-            candidate,
-            attempted_at: now(),
-        })
+        .prepare_delivery_attempt(prepare_outbound_request(scope.clone(), candidate))
         .await
         .expect_err("scope mismatch must fail before validator IO");
     assert!(matches!(err, OutboundError::InvalidRequest { .. }));
@@ -830,6 +886,8 @@ struct FakeReplyTargetBindingValidator {
     denied: Mutex<HashSet<ReplyTargetBindingRef>>,
     transient: Mutex<HashSet<ReplyTargetBindingRef>>,
     redirects: Mutex<HashMap<ReplyTargetBindingRef, ReplyTargetBindingRef>>,
+    required_actor: Mutex<Option<TurnActor>>,
+    required_modality: Mutex<Option<CommunicationModality>>,
     calls: Mutex<usize>,
 }
 
@@ -862,6 +920,20 @@ impl FakeReplyTargetBindingValidator {
             .insert(from, to);
     }
 
+    fn require_actor(&self, actor: TurnActor) {
+        *self
+            .required_actor
+            .lock()
+            .expect("fake validator lock poisoned") = Some(actor);
+    }
+
+    fn require_modality(&self, modality: CommunicationModality) {
+        *self
+            .required_modality
+            .lock()
+            .expect("fake validator lock poisoned") = Some(modality);
+    }
+
     fn calls(&self) -> usize {
         *self.calls.lock().expect("fake validator lock poisoned")
     }
@@ -874,6 +946,23 @@ impl ReplyTargetBindingValidator for FakeReplyTargetBindingValidator {
         request: ReplyTargetValidationRequest,
     ) -> Result<ReplyTargetBindingClaim, OutboundError> {
         *self.calls.lock().expect("fake validator lock poisoned") += 1;
+        if self
+            .required_actor
+            .lock()
+            .expect("fake validator lock poisoned")
+            .as_ref()
+            .is_some_and(|actor| actor != &request.actor)
+        {
+            return Err(OutboundError::AccessDenied);
+        }
+        if self
+            .required_modality
+            .lock()
+            .expect("fake validator lock poisoned")
+            .is_some_and(|modality| modality != request.modality)
+        {
+            return Err(OutboundError::AccessDenied);
+        }
         if self
             .transient
             .lock()
@@ -924,6 +1013,19 @@ fn candidate(scope: &TurnScope, target: &str, kind: OutboundPushKind) -> Outboun
         projection_ref: ProjectionUpdateRef::new("projection:update-1")
             .expect("valid projection ref"),
         requires_reply_target_revalidation: true,
+    }
+}
+
+fn prepare_outbound_request(
+    scope: TurnScope,
+    candidate: OutboundPushCandidate,
+) -> PrepareOutboundDeliveryRequest {
+    PrepareOutboundDeliveryRequest {
+        scope,
+        actor: actor("user-a"),
+        modality: CommunicationModality::Text,
+        candidate,
+        attempted_at: now(),
     }
 }
 

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -736,6 +736,48 @@ async fn communication_delivery_validator_can_enforce_prompt_actor_context() {
 }
 
 #[tokio::test]
+async fn communication_delivery_actor_and_modality_forwarded_through_lowering() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = turn_scope("thread-1");
+    let expected_actor = actor("exact-owner");
+    let expected_modality = CommunicationModality::Voice;
+    let mut request = requested_outbound_request_with_scope(
+        scope.clone(),
+        "reply:requested",
+        RequestedOutboundKind::ProductMessage,
+    );
+    request.actor = expected_actor.clone();
+    request.modality = expected_modality;
+    validator.allow(reply_ref("reply:requested"));
+    validator.require_actor(expected_actor);
+    validator.require_modality(expected_modality);
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("matching actor and modality authorize")
+        .expect("requested outbound has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(attempt.status, OutboundDeliveryStatus::Pending);
+    assert_eq!(target.target(), &reply_ref("reply:requested"));
+    assert_eq!(validator.calls(), 1);
+    assert_eq!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .as_slice(),
+        std::slice::from_ref(&attempt)
+    );
+}
+
+#[tokio::test]
 async fn communication_delivery_validator_can_enforce_requested_modality() {
     let store = InMemoryOutboundStateStore::default();
     let access_policy = FakeThreadProjectionAccessPolicy::default();


### PR DESCRIPTION
## Summary

Follow-up to merged PR #4271. The outbound validation bridge was preserving scope and candidate identity, but `ReplyTargetValidationRequest` did not carry the original delivery actor or modality. That meant reply-target validators could not enforce exact-owner checks for approval/auth prompts or modality capability checks before `OutboundPolicyService` minted a validated target.

Changes:
- add `actor` and `modality` to `PrepareOutboundDeliveryRequest`
- add `actor` and `modality` to `ReplyTargetValidationRequest`
- forward both fields from `CommunicationDeliveryResolutionRequest` during communication delivery lowering
- pass both fields to `ReplyTargetBindingValidator::validate_reply_target`
- add caller-level regressions proving validators can reject by actor and requested modality without returning an authorized/pending send target

## Why

The conversation-binding contract requires egress validation for the current actor/thread, with exact-owner validation for authority-bearing approval/auth prompt routes. The communication delivery contract also says the validator owns modality support checks. Those checks require actor and modality to be available at the validation boundary.

## Validation

- `cargo test -p ironclaw_outbound`
- `cargo clippy -p ironclaw_outbound --all-targets -- -D warnings`
