### PR TITLE
Add trigger fire claim contract

### DIFF
--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -234,6 +234,10 @@ impl TriggerRecord {
     pub fn is_due_at(&self, now: Timestamp) -> bool {
         self.state == TriggerState::Scheduled && self.next_run_at <= now
     }
+
+    pub fn has_active_fire(&self) -> bool {
+        self.active_fire_slot.is_some() || self.active_run_ref.is_some()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -337,6 +341,68 @@ pub struct TriggerFire {
     pub prompt: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimDueFireRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub now: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimedTriggerFire {
+    pub record: TriggerRecord,
+    pub fire_slot: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimDueFireOutcome {
+    Claimed(ClaimedTriggerFire),
+    NotFound,
+    NotDue {
+        record: TriggerRecord,
+    },
+    AlreadyActive {
+        active_fire_slot: Option<Timestamp>,
+        active_run_ref: Option<TurnRunId>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireAcceptedRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub run_id: TurnRunId,
+    pub submitted_at: Timestamp,
+    pub next_run_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireReplayedRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub original_run_id: TurnRunId,
+    pub replayed_at: Timestamp,
+    pub next_run_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireRetryableFailedRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirePermanentFailedRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub next_run_at: Timestamp,
+}
+
 #[async_trait]
 pub trait TriggerSourceProvider: Send + Sync {
     async fn evaluate(
@@ -409,6 +475,41 @@ pub trait TriggerRepository: Send + Sync {
         now: Timestamp,
         limit: usize,
     ) -> Result<Vec<TriggerRecord>, TriggerError>;
+
+    async fn claim_due_fire(
+        &self,
+        _request: ClaimDueFireRequest,
+    ) -> Result<ClaimDueFireOutcome, TriggerError> {
+        Err(fire_claim_pr13_backend_error())
+    }
+
+    async fn mark_fire_accepted(
+        &self,
+        _request: FireAcceptedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        Err(fire_claim_pr13_backend_error())
+    }
+
+    async fn mark_fire_replayed(
+        &self,
+        _request: FireReplayedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        Err(fire_claim_pr13_backend_error())
+    }
+
+    async fn mark_fire_retryable_failed(
+        &self,
+        _request: FireRetryableFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        Err(fire_claim_pr13_backend_error())
+    }
+
+    async fn mark_fire_permanently_failed(
+        &self,
+        _request: FirePermanentFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        Err(fire_claim_pr13_backend_error())
+    }
 }
 
 /// Feature-gated durable libSQL repository type for composition/test wiring.
@@ -519,6 +620,150 @@ impl TriggerRepository for InMemoryTriggerRepository {
             .filter_map(|(_, _, _, key)| state.get(&key).cloned())
             .collect())
     }
+
+    async fn claim_due_fire(
+        &self,
+        request: ClaimDueFireRequest,
+    ) -> Result<ClaimDueFireOutcome, TriggerError> {
+        let mut state = self.lock_state()?;
+        let key = TriggerRepositoryKey::new(&request.tenant_id, request.trigger_id);
+        let Some(record) = state.get_mut(&key) else {
+            return Ok(ClaimDueFireOutcome::NotFound);
+        };
+
+        if record.has_active_fire() {
+            return Ok(ClaimDueFireOutcome::AlreadyActive {
+                active_fire_slot: record.active_fire_slot,
+                active_run_ref: record.active_run_ref,
+            });
+        }
+
+        if record.state != TriggerState::Scheduled
+            || record.next_run_at != request.fire_slot
+            || request.fire_slot > request.now
+        {
+            return Ok(ClaimDueFireOutcome::NotDue {
+                record: record.clone(),
+            });
+        }
+
+        record.active_fire_slot = Some(request.fire_slot);
+        record.active_run_ref = None;
+        Ok(ClaimDueFireOutcome::Claimed(ClaimedTriggerFire {
+            record: record.clone(),
+            fire_slot: request.fire_slot,
+        }))
+    }
+
+    async fn mark_fire_accepted(
+        &self,
+        request: FireAcceptedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let Some(record) = self.update_claimed_fire(
+            &request.tenant_id,
+            request.trigger_id,
+            request.fire_slot,
+            |record| {
+                if let Some(active_run_ref) = record.active_run_ref {
+                    reject_run_ref_rewrite(active_run_ref, request.run_id)?;
+                    return Ok(());
+                }
+                reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
+                record.last_run_at = Some(request.submitted_at);
+                record.last_fired_slot = Some(request.fire_slot);
+                record.last_status = Some(TriggerRunStatus::Ok);
+                record.next_run_at = request.next_run_at;
+                record.active_fire_slot = Some(request.fire_slot);
+                record.active_run_ref = Some(request.run_id);
+                Ok(())
+            },
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_replayed(
+        &self,
+        request: FireReplayedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let Some(record) = self.update_claimed_fire(
+            &request.tenant_id,
+            request.trigger_id,
+            request.fire_slot,
+            |record| {
+                if let Some(active_run_ref) = record.active_run_ref {
+                    reject_run_ref_rewrite(active_run_ref, request.original_run_id)?;
+                    return Ok(());
+                }
+                reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
+                record.last_run_at = Some(request.replayed_at);
+                record.last_fired_slot = Some(request.fire_slot);
+                record.last_status = Some(TriggerRunStatus::Ok);
+                record.next_run_at = request.next_run_at;
+                record.active_fire_slot = Some(request.fire_slot);
+                record.active_run_ref = Some(request.original_run_id);
+                Ok(())
+            },
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_retryable_failed(
+        &self,
+        request: FireRetryableFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let Some(record) = self.update_claimed_fire(
+            &request.tenant_id,
+            request.trigger_id,
+            request.fire_slot,
+            |record| {
+                reject_failed_result_after_active_run(record.active_run_ref)?;
+                if record.next_run_at > request.fire_slot {
+                    return Err(TriggerError::InvalidRecord {
+                        reason: "retryable fire failure must leave next_run_at at or before the failed fire slot"
+                            .to_string(),
+                    });
+                }
+                record.last_status = Some(TriggerRunStatus::Error);
+                record.active_fire_slot = None;
+                record.active_run_ref = None;
+                Ok(())
+            },
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_permanently_failed(
+        &self,
+        request: FirePermanentFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let Some(record) = self.update_claimed_fire(
+            &request.tenant_id,
+            request.trigger_id,
+            request.fire_slot,
+            |record| {
+                reject_failed_result_after_active_run(record.active_run_ref)?;
+                reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
+                record.last_status = Some(TriggerRunStatus::Error);
+                record.next_run_at = request.next_run_at;
+                record.active_fire_slot = None;
+                record.active_run_ref = None;
+                Ok(())
+            },
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(record))
+    }
 }
 
 impl InMemoryTriggerRepository {
@@ -530,6 +775,66 @@ impl InMemoryTriggerRepository {
             reason: "trigger repository mutex poisoned".to_string(),
         })
     }
+
+    fn update_claimed_fire(
+        &self,
+        tenant_id: &TenantId,
+        trigger_id: TriggerId,
+        fire_slot: Timestamp,
+        update: impl FnOnce(&mut TriggerRecord) -> Result<(), TriggerError>,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let mut state = self.lock_state()?;
+        let key = TriggerRepositoryKey::new(tenant_id, trigger_id);
+        let Some(record) = state.get_mut(&key) else {
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(fire_slot) {
+            return Ok(None);
+        }
+        update(record)?;
+        Ok(Some(record.clone()))
+    }
+}
+
+fn fire_claim_pr13_backend_error() -> TriggerError {
+    TriggerError::Backend {
+        reason: "atomic trigger fire claim persistence for this backend lands in PR 13".to_string(),
+    }
+}
+
+fn reject_non_future_next_run_at(
+    fire_slot: Timestamp,
+    next_run_at: Timestamp,
+) -> Result<(), TriggerError> {
+    if next_run_at > fire_slot {
+        return Ok(());
+    }
+    Err(TriggerError::InvalidRecord {
+        reason: "fire result next_run_at must be after the claimed fire slot".to_string(),
+    })
+}
+
+fn reject_run_ref_rewrite(
+    active_run_ref: TurnRunId,
+    incoming_run_ref: TurnRunId,
+) -> Result<(), TriggerError> {
+    if active_run_ref == incoming_run_ref {
+        return Ok(());
+    }
+    Err(TriggerError::InvalidRecord {
+        reason: "fire result must not rewrite an existing active_run_ref".to_string(),
+    })
+}
+
+fn reject_failed_result_after_active_run(
+    active_run_ref: Option<TurnRunId>,
+) -> Result<(), TriggerError> {
+    if active_run_ref.is_none() {
+        return Ok(());
+    }
+    Err(TriggerError::InvalidRecord {
+        reason: "fire failure result must not clear an accepted active_run_ref".to_string(),
+    })
 }
 
 fn normalize_cron_expression(expression: &str) -> Result<String, TriggerError> {

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -631,19 +631,19 @@ impl TriggerRepository for InMemoryTriggerRepository {
             return Ok(ClaimDueFireOutcome::NotFound);
         };
 
-        if record.has_active_fire() {
-            return Ok(ClaimDueFireOutcome::AlreadyActive {
-                active_fire_slot: record.active_fire_slot,
-                active_run_ref: record.active_run_ref,
-            });
-        }
-
         if record.state != TriggerState::Scheduled
             || record.next_run_at != request.fire_slot
             || request.fire_slot > request.now
         {
             return Ok(ClaimDueFireOutcome::NotDue {
                 record: record.clone(),
+            });
+        }
+
+        if record.has_active_fire() {
+            return Ok(ClaimDueFireOutcome::AlreadyActive {
+                active_fire_slot: record.active_fire_slot,
+                active_run_ref: record.active_run_ref,
             });
         }
 

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -480,35 +480,35 @@ pub trait TriggerRepository: Send + Sync {
         &self,
         _request: ClaimDueFireRequest,
     ) -> Result<ClaimDueFireOutcome, TriggerError> {
-        Err(fire_claim_pr13_backend_error())
+        Err(unimplemented_durable_backend_error())
     }
 
     async fn mark_fire_accepted(
         &self,
         _request: FireAcceptedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(fire_claim_pr13_backend_error())
+        Err(unimplemented_durable_backend_error())
     }
 
     async fn mark_fire_replayed(
         &self,
         _request: FireReplayedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(fire_claim_pr13_backend_error())
+        Err(unimplemented_durable_backend_error())
     }
 
     async fn mark_fire_retryable_failed(
         &self,
         _request: FireRetryableFailedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(fire_claim_pr13_backend_error())
+        Err(unimplemented_durable_backend_error())
     }
 
     async fn mark_fire_permanently_failed(
         &self,
         _request: FirePermanentFailedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(fire_claim_pr13_backend_error())
+        Err(unimplemented_durable_backend_error())
     }
 }
 
@@ -601,7 +601,7 @@ impl TriggerRepository for InMemoryTriggerRepository {
         let state = self.lock_state()?;
         let mut selected_keys = state
             .iter()
-            .filter(|(_, record)| record.is_due_at(now))
+            .filter(|(_, record)| record.is_due_at(now) && !record.has_active_fire())
             .map(|(key, record)| {
                 (
                     record.next_run_at,
@@ -796,7 +796,7 @@ impl InMemoryTriggerRepository {
     }
 }
 
-fn fire_claim_pr13_backend_error() -> TriggerError {
+fn unimplemented_durable_backend_error() -> TriggerError {
     TriggerError::Backend {
         reason: "atomic trigger fire claim persistence for this backend lands in PR 13".to_string(),
     }
@@ -1438,6 +1438,27 @@ mod tests {
         let error = repo
             .lock_state()
             .expect_err("poisoned mutex maps to backend");
+        assert!(matches!(error, TriggerError::Backend { .. }));
+    }
+
+    #[tokio::test]
+    async fn in_memory_repository_claim_due_fire_returns_backend_error_when_mutex_is_poisoned() {
+        let repo = InMemoryTriggerRepository::default();
+        let poison_repo = repo.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = poison_repo.state.lock().expect("lock before poison");
+            panic!("poison trigger repository mutex");
+        });
+
+        let error = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant("tenant-a"),
+                trigger_id: TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+                fire_slot: ts(1_704_067_200),
+                now: ts(1_704_067_200),
+            })
+            .await
+            .expect_err("poisoned mutex maps to backend through claim API");
         assert!(matches!(error, TriggerError::Backend { .. }));
     }
 }

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -313,7 +313,10 @@ impl TriggerRepository for LibSqlTriggerRepository {
                 &format!(
                     "SELECT {TRIGGER_COLUMNS}
                      FROM {TRIGGER_TABLE}
-                     WHERE state = ?1 AND next_run_at <= ?2
+                     WHERE state = ?1
+                       AND next_run_at <= ?2
+                       AND active_fire_slot IS NULL
+                       AND active_run_ref IS NULL
                      ORDER BY next_run_at, tenant_id, trigger_id
                      LIMIT ?3"
                 ),

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -216,7 +216,10 @@ impl TriggerRepository for PostgresTriggerRepository {
                 &format!(
                     "SELECT {TRIGGER_COLUMNS}
                      FROM {TRIGGER_TABLE}
-                     WHERE state = $1 AND next_run_at <= $2
+                     WHERE state = $1
+                       AND next_run_at <= $2
+                       AND active_fire_slot IS NULL
+                       AND active_run_ref IS NULL
                      ORDER BY next_run_at, tenant_id, trigger_id
                      LIMIT $3"
                 ),

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1177,6 +1177,21 @@ mod fire_claim_contract {
             .await
             .expect("insert paused");
 
+        let paused_active = {
+            let mut record = sample_record(
+                TriggerId::parse("01J0000000000000000000000B").expect("ulid"),
+                tenant("tenant-paused-active"),
+                fire_slot,
+            );
+            record.state = TriggerState::Paused;
+            record.active_run_ref =
+                Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5f").expect("valid run"));
+            record
+        };
+        repo.upsert_trigger(paused_active.clone())
+            .await
+            .expect("insert paused active");
+
         let completed = {
             let mut record = sample_record(
                 TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZX").expect("ulid"),
@@ -1236,6 +1251,19 @@ mod fire_claim_contract {
             .expect("paused claim")
             .matches_not_due(),
             "paused row must not be claimable"
+        );
+
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: paused_active.tenant_id.clone(),
+                trigger_id: paused_active.trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("paused active claim")
+            .matches_not_due(),
+            "paused row with stale active metadata must not be claimable"
         );
 
         assert!(

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -247,6 +247,25 @@ async fn assert_due_query_clamps_limit_and_respects_state_gate(repo: &impl Trigg
         record.state = TriggerState::Completed;
         record
     };
+    let active_claim = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000004").expect("ulid"),
+            tenant("tenant-active-claim"),
+            due_slot,
+        );
+        record.active_fire_slot = Some(due_slot);
+        record
+    };
+    let active_run_claim = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000005").expect("ulid"),
+            tenant("tenant-active-run"),
+            due_slot,
+        );
+        record.active_run_ref =
+            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("valid run"));
+        record
+    };
     repo.upsert_trigger(paused.clone())
         .await
         .expect("insert paused");
@@ -256,6 +275,12 @@ async fn assert_due_query_clamps_limit_and_respects_state_gate(repo: &impl Trigg
     repo.upsert_trigger(completed.clone())
         .await
         .expect("insert completed");
+    repo.upsert_trigger(active_claim.clone())
+        .await
+        .expect("insert active claim");
+    repo.upsert_trigger(active_run_claim.clone())
+        .await
+        .expect("insert active run claim");
 
     let small_a = sample_record(
         TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
@@ -360,6 +385,18 @@ async fn assert_due_query_clamps_limit_and_respects_state_gate(repo: &impl Trigg
             .iter()
             .any(|record| record.tenant_id == completed.tenant_id),
         "completed record must not be returned as due"
+    );
+    assert!(
+        !due_records
+            .iter()
+            .any(|record| record.tenant_id == active_claim.tenant_id),
+        "active fire claim must not be returned as due"
+    );
+    assert!(
+        !due_records
+            .iter()
+            .any(|record| record.tenant_id == active_run_claim.tenant_id),
+        "active run claim must not be returned as due"
     );
 }
 
@@ -806,7 +843,7 @@ async fn clear_postgres_triggers(pool: &deadpool_postgres::Pool) {
         .expect("clear trigger records");
 }
 
-mod pr12_fire_claim_contract {
+mod fire_claim_contract {
     use super::*;
 
     use ironclaw_triggers::{
@@ -1319,7 +1356,7 @@ mod pr12_fire_claim_contract {
                 tenant_id: status_only.tenant_id.clone(),
                 trigger_id: status_only.trigger_id,
                 fire_slot,
-                now: fire_slot,
+                now: ts(1_704_067_260),
             })
             .await
             .expect("status-only claim");

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -3,8 +3,8 @@
 use chrono::{TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_triggers::{
-    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
-    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    InMemoryTriggerRepository, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
+    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use ironclaw_turns::TurnRunId;
 
@@ -804,4 +804,671 @@ async fn clear_postgres_triggers(pool: &deadpool_postgres::Pool) {
         .execute("DELETE FROM trigger_records", &[])
         .await
         .expect("clear trigger records");
+}
+
+mod pr12_fire_claim_contract {
+    use super::*;
+
+    use ironclaw_triggers::{
+        ClaimDueFireOutcome, ClaimDueFireRequest, FireAcceptedRequest, FirePermanentFailedRequest,
+        FireReplayedRequest, FireRetryableFailedRequest,
+    };
+
+    async fn assert_fire_claim_and_update_contract(repo: &impl TriggerRepository) {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let tenant_id = tenant("tenant-a");
+        let fire_slot = ts(1_704_067_200);
+        let accepted_at = ts(1_704_067_205);
+        let mut record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
+        let expected_next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next slot calculation")
+            .expect("future slot");
+        record.last_status = Some(TriggerRunStatus::Error);
+        repo.upsert_trigger(record.clone())
+            .await
+            .expect("insert record");
+
+        let claimed = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim due fire");
+        let ClaimDueFireOutcome::Claimed(claimed) = claimed else {
+            panic!("record should be claimable, got {claimed:?}");
+        };
+        assert_eq!(claimed.record.active_fire_slot, Some(fire_slot));
+        assert_eq!(claimed.record.active_run_ref, None);
+
+        let persisted = repo
+            .get_trigger(tenant_id.clone(), trigger_id)
+            .await
+            .expect("reload claimed record")
+            .expect("record present");
+        assert_eq!(persisted.active_fire_slot, Some(fire_slot));
+        assert_eq!(persisted.active_run_ref, None);
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+
+        let accepted_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("valid run");
+        let accepted = repo
+            .mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id: accepted_run_id,
+                submitted_at: accepted_at,
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect("mark accepted")
+            .expect("accepted fire should persist");
+        assert_eq!(accepted.last_run_at, Some(accepted_at));
+        assert_eq!(accepted.last_fired_slot, Some(fire_slot));
+        assert_eq!(accepted.last_status, Some(TriggerRunStatus::Ok));
+        assert_eq!(accepted.active_fire_slot, Some(fire_slot));
+        assert_eq!(accepted.active_run_ref, Some(accepted_run_id));
+        assert_eq!(accepted.next_run_at, expected_next_run_at);
+
+        let accepted_again = repo
+            .mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id: accepted_run_id,
+                submitted_at: ts(1_704_067_206),
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect("idempotent accepted result")
+            .expect("accepted result returns existing record");
+        assert_eq!(accepted_again, accepted);
+
+        let different_accepted_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5c").expect("valid run");
+        let error = repo
+            .mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id: different_accepted_run_id,
+                submitted_at: accepted_at,
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect_err("different accepted run id must not rewrite active_run_ref");
+        assert_error_contains(error, "must not rewrite an existing active_run_ref");
+
+        let error = repo
+            .mark_fire_retryable_failed(FireRetryableFailedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+            })
+            .await
+            .expect_err("stale retryable failure must not clear accepted run ref");
+        assert_error_contains(error, "must not clear an accepted active_run_ref");
+
+        let replayed_trigger_id = TriggerId::parse("01J00000000000000000000006").expect("ulid");
+        let replayed_tenant_id = tenant("tenant-replayed");
+        let replayed_record =
+            sample_record(replayed_trigger_id, replayed_tenant_id.clone(), fire_slot);
+        repo.upsert_trigger(replayed_record)
+            .await
+            .expect("insert replayed record");
+        let replayed_claim = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: replayed_tenant_id.clone(),
+                trigger_id: replayed_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim replayed record");
+        assert!(matches!(replayed_claim, ClaimDueFireOutcome::Claimed(_)));
+
+        let replayed_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("valid run");
+        let replayed = repo
+            .mark_fire_replayed(FireReplayedRequest {
+                tenant_id: replayed_tenant_id.clone(),
+                trigger_id: replayed_trigger_id,
+                fire_slot,
+                original_run_id: replayed_run_id,
+                replayed_at: accepted_at,
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect("mark replayed")
+            .expect("replayed fire should persist");
+        assert_eq!(replayed.last_run_at, Some(accepted_at));
+        assert_eq!(replayed.last_fired_slot, Some(fire_slot));
+        assert_eq!(replayed.last_status, Some(TriggerRunStatus::Ok));
+        assert_eq!(replayed.active_fire_slot, Some(fire_slot));
+        assert_eq!(replayed.active_run_ref, Some(replayed_run_id));
+        assert_eq!(replayed.next_run_at, expected_next_run_at);
+
+        let replayed_again = repo
+            .mark_fire_replayed(FireReplayedRequest {
+                tenant_id: replayed_tenant_id.clone(),
+                trigger_id: replayed_trigger_id,
+                fire_slot,
+                original_run_id: replayed_run_id,
+                replayed_at: ts(1_704_067_207),
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect("idempotent replayed result")
+            .expect("replayed result returns existing record");
+        assert_eq!(replayed_again, replayed);
+
+        let different_replayed_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5d").expect("valid run");
+        let error = repo
+            .mark_fire_replayed(FireReplayedRequest {
+                tenant_id: replayed_tenant_id.clone(),
+                trigger_id: replayed_trigger_id,
+                fire_slot,
+                original_run_id: different_replayed_run_id,
+                replayed_at: accepted_at,
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect_err("different replayed run id must not rewrite active_run_ref");
+        assert_error_contains(error, "must not rewrite an existing active_run_ref");
+
+        let error = repo
+            .mark_fire_permanently_failed(FirePermanentFailedRequest {
+                tenant_id: replayed_tenant_id,
+                trigger_id: replayed_trigger_id,
+                fire_slot,
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect_err("stale permanent failure must not clear replayed run ref");
+        assert_error_contains(error, "must not clear an accepted active_run_ref");
+
+        let failure_previous_run_at = ts(1_704_066_900);
+        let failure_previous_slot = ts(1_704_066_840);
+        let retryable_trigger_id = TriggerId::parse("01J00000000000000000000004").expect("ulid");
+        let retryable_tenant_id = tenant("tenant-retryable");
+        let mut retryable_record =
+            sample_record(retryable_trigger_id, retryable_tenant_id.clone(), fire_slot);
+        retryable_record.last_run_at = Some(failure_previous_run_at);
+        retryable_record.last_fired_slot = Some(failure_previous_slot);
+        repo.upsert_trigger(retryable_record)
+            .await
+            .expect("insert retryable record");
+        let retryable_claim = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: retryable_tenant_id.clone(),
+                trigger_id: retryable_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim retryable record");
+        assert!(matches!(retryable_claim, ClaimDueFireOutcome::Claimed(_)));
+
+        let retryable_failed = repo
+            .mark_fire_retryable_failed(FireRetryableFailedRequest {
+                tenant_id: retryable_tenant_id,
+                trigger_id: retryable_trigger_id,
+                fire_slot,
+            })
+            .await
+            .expect("mark retryable failed")
+            .expect("retryable failure should persist");
+        assert_eq!(retryable_failed.last_run_at, Some(failure_previous_run_at));
+        assert_eq!(
+            retryable_failed.last_fired_slot,
+            Some(failure_previous_slot)
+        );
+        assert_eq!(retryable_failed.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(retryable_failed.active_fire_slot, None);
+        assert_eq!(retryable_failed.active_run_ref, None);
+        assert!(retryable_failed.next_run_at <= fire_slot);
+
+        let permanent_trigger_id = TriggerId::parse("01J00000000000000000000005").expect("ulid");
+        let permanent_tenant_id = tenant("tenant-permanent");
+        let mut permanent_record =
+            sample_record(permanent_trigger_id, permanent_tenant_id.clone(), fire_slot);
+        permanent_record.last_run_at = Some(failure_previous_run_at);
+        permanent_record.last_fired_slot = Some(failure_previous_slot);
+        repo.upsert_trigger(permanent_record)
+            .await
+            .expect("insert permanent-failure record");
+        let permanent_claim = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: permanent_tenant_id.clone(),
+                trigger_id: permanent_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim permanent-failure record");
+        assert!(matches!(permanent_claim, ClaimDueFireOutcome::Claimed(_)));
+
+        let permanent_failed = repo
+            .mark_fire_permanently_failed(FirePermanentFailedRequest {
+                tenant_id: permanent_tenant_id,
+                trigger_id: permanent_trigger_id,
+                fire_slot,
+                next_run_at: expected_next_run_at,
+            })
+            .await
+            .expect("mark permanently failed")
+            .expect("permanent failure should persist");
+        assert_eq!(permanent_failed.last_run_at, Some(failure_previous_run_at));
+        assert_eq!(
+            permanent_failed.last_fired_slot,
+            Some(failure_previous_slot)
+        );
+        assert_eq!(permanent_failed.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(permanent_failed.active_fire_slot, None);
+        assert_eq!(permanent_failed.active_run_ref, None);
+        assert!(permanent_failed.next_run_at > fire_slot);
+    }
+
+    async fn assert_fire_result_rejects_invalid_next_run_at(repo: &impl TriggerRepository) {
+        let fire_slot = ts(1_704_067_200);
+
+        let retryable_trigger_id = TriggerId::parse("01J00000000000000000000007").expect("ulid");
+        let retryable_tenant_id = tenant("tenant-invalid-retryable");
+        let mut retryable_record =
+            sample_record(retryable_trigger_id, retryable_tenant_id.clone(), fire_slot);
+        retryable_record.active_fire_slot = Some(fire_slot);
+        retryable_record.next_run_at = ts(1_704_067_260);
+        repo.upsert_trigger(retryable_record)
+            .await
+            .expect("insert invalid retryable record");
+        let error = repo
+            .mark_fire_retryable_failed(FireRetryableFailedRequest {
+                tenant_id: retryable_tenant_id,
+                trigger_id: retryable_trigger_id,
+                fire_slot,
+            })
+            .await
+            .expect_err("retryable failure rejects advanced next_run_at");
+        assert_error_contains(error, "at or before the failed fire slot");
+
+        let permanent_trigger_id = TriggerId::parse("01J00000000000000000000008").expect("ulid");
+        let permanent_tenant_id = tenant("tenant-invalid-permanent");
+        let mut permanent_record =
+            sample_record(permanent_trigger_id, permanent_tenant_id.clone(), fire_slot);
+        permanent_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(permanent_record)
+            .await
+            .expect("insert invalid permanent record");
+        let error = repo
+            .mark_fire_permanently_failed(FirePermanentFailedRequest {
+                tenant_id: permanent_tenant_id,
+                trigger_id: permanent_trigger_id,
+                fire_slot,
+                next_run_at: fire_slot,
+            })
+            .await
+            .expect_err("permanent failure rejects non-future next_run_at");
+        assert_error_contains(error, "must be after the claimed fire slot");
+    }
+
+    async fn assert_fire_claim_exclusions_and_active_gate_contract(repo: &impl TriggerRepository) {
+        let fire_slot = ts(1_704_067_200);
+        let tenant_id = tenant("tenant-a");
+
+        let base_trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let base = sample_record(base_trigger_id, tenant_id.clone(), fire_slot);
+        repo.upsert_trigger(base.clone())
+            .await
+            .expect("insert base");
+
+        let paused = {
+            let mut record = sample_record(
+                TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZY").expect("ulid"),
+                tenant("tenant-paused"),
+                fire_slot,
+            );
+            record.state = TriggerState::Paused;
+            record
+        };
+        repo.upsert_trigger(paused.clone())
+            .await
+            .expect("insert paused");
+
+        let completed = {
+            let mut record = sample_record(
+                TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZX").expect("ulid"),
+                tenant("tenant-completed"),
+                fire_slot,
+            );
+            record.state = TriggerState::Completed;
+            record
+        };
+        repo.upsert_trigger(completed.clone())
+            .await
+            .expect("insert completed");
+
+        let future = sample_record(
+            TriggerId::parse("01J00000000000000000000002").expect("ulid"),
+            tenant("tenant-future"),
+            ts(1_704_067_320),
+        );
+        repo.upsert_trigger(future.clone())
+            .await
+            .expect("insert future");
+
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id: base_trigger_id,
+                fire_slot: ts(1_704_067_260),
+                now: fire_slot,
+            })
+            .await
+            .expect("wrong fire slot claim")
+            .matches_not_due(),
+            "wrong fire slot must not be claimable"
+        );
+
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id: TriggerId::parse("01J00000000000000000000009").expect("ulid"),
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("missing row claim")
+            .matches_not_found(),
+            "missing row must not be claimable"
+        );
+
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: paused.tenant_id.clone(),
+                trigger_id: paused.trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("paused claim")
+            .matches_not_due(),
+            "paused row must not be claimable"
+        );
+
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: completed.tenant_id.clone(),
+                trigger_id: completed.trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("completed claim")
+            .matches_not_due(),
+            "completed row must not be claimable"
+        );
+
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: future.tenant_id.clone(),
+                trigger_id: future.trigger_id,
+                fire_slot: future.next_run_at,
+                now: fire_slot,
+            })
+            .await
+            .expect("future claim")
+            .matches_not_due(),
+            "future next_run_at must not be claimable"
+        );
+
+        let claimed = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id: base_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim base row");
+        let ClaimDueFireOutcome::Claimed(claimed) = claimed else {
+            panic!("base row should be claimable, got {claimed:?}");
+        };
+        assert_eq!(claimed.record.active_fire_slot, Some(fire_slot));
+        assert_eq!(claimed.record.active_run_ref, None);
+
+        let mut active_fire = claimed.record.clone();
+        active_fire.last_status = Some(TriggerRunStatus::Error);
+        repo.upsert_trigger(active_fire)
+            .await
+            .expect("persist active row with error status");
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id: base_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("active fire slot claim")
+            .matches_already_active(Some(fire_slot), None),
+            "active fire slot must block a second claim"
+        );
+
+        let active_run_ref =
+            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("valid run"));
+        let mut active_run = claimed.record.clone();
+        active_run.active_run_ref = active_run_ref;
+        repo.upsert_trigger(active_run)
+            .await
+            .expect("persist active row with run ref");
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id: base_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("active run ref claim")
+            .matches_already_active(Some(fire_slot), active_run_ref),
+            "active run ref must block a second claim"
+        );
+
+        let run_only_trigger_id = TriggerId::parse("01J0000000000000000000000A").expect("ulid");
+        let run_only_tenant_id = tenant("tenant-run-only");
+        let mut run_only =
+            sample_record(run_only_trigger_id, run_only_tenant_id.clone(), fire_slot);
+        run_only.active_fire_slot = None;
+        run_only.active_run_ref =
+            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5e").expect("valid run"));
+        assert!(run_only.has_active_fire());
+        let expected_run_only_ref = run_only.active_run_ref;
+        repo.upsert_trigger(run_only)
+            .await
+            .expect("persist active row with run ref only");
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: run_only_tenant_id,
+                trigger_id: run_only_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("active run-ref-only claim")
+            .matches_already_active(None, expected_run_only_ref),
+            "active run ref without fire slot must block a second claim"
+        );
+
+        let mut status_only = sample_record(
+            TriggerId::parse("01J00000000000000000000003").expect("ulid"),
+            tenant("tenant-status"),
+            fire_slot,
+        );
+        status_only.last_status = Some(TriggerRunStatus::Error);
+        repo.upsert_trigger(status_only.clone())
+            .await
+            .expect("insert status-only record");
+        let status_claim = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: status_only.tenant_id.clone(),
+                trigger_id: status_only.trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("status-only claim");
+        let ClaimDueFireOutcome::Claimed(status_claim) = status_claim else {
+            panic!("status-only row should still be claimable, got {status_claim:?}");
+        };
+        assert_eq!(status_claim.record.active_fire_slot, Some(fire_slot));
+        assert_eq!(status_claim.record.active_run_ref, None);
+        assert_eq!(
+            status_claim.record.last_status,
+            Some(TriggerRunStatus::Error)
+        );
+    }
+
+    trait ClaimDueFireOutcomeAssertions {
+        fn matches_not_found(&self) -> bool;
+        fn matches_not_due(&self) -> bool;
+        fn matches_already_active(
+            &self,
+            active_fire_slot: Option<Timestamp>,
+            active_run_ref: Option<TurnRunId>,
+        ) -> bool;
+    }
+
+    impl ClaimDueFireOutcomeAssertions for ClaimDueFireOutcome {
+        fn matches_not_found(&self) -> bool {
+            matches!(self, Self::NotFound)
+        }
+
+        fn matches_not_due(&self) -> bool {
+            matches!(self, Self::NotDue { .. })
+        }
+
+        fn matches_already_active(
+            &self,
+            active_fire_slot: Option<Timestamp>,
+            active_run_ref: Option<TurnRunId>,
+        ) -> bool {
+            matches!(
+                self,
+                Self::AlreadyActive {
+                    active_fire_slot: actual_fire_slot,
+                    active_run_ref: actual_run_ref,
+                } if *actual_fire_slot == active_fire_slot && *actual_run_ref == active_run_ref
+            )
+        }
+    }
+
+    async fn assert_durable_fire_claim_defaults_to_pr13(repo: &impl TriggerRepository) {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let tenant_id = tenant("tenant-a");
+        let fire_slot = ts(1_704_067_200);
+        assert_pr13_backend_error(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect_err("durable claim implementation lands in PR13"),
+        );
+        assert_pr13_backend_error(
+            repo.mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a")
+                    .expect("valid run"),
+                submitted_at: fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect_err("durable accepted implementation lands in PR13"),
+        );
+        assert_pr13_backend_error(
+            repo.mark_fire_replayed(FireReplayedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                original_run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a")
+                    .expect("valid run"),
+                replayed_at: fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect_err("durable replayed implementation lands in PR13"),
+        );
+        assert_pr13_backend_error(
+            repo.mark_fire_retryable_failed(FireRetryableFailedRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+            })
+            .await
+            .expect_err("durable retryable failure implementation lands in PR13"),
+        );
+        assert_pr13_backend_error(
+            repo.mark_fire_permanently_failed(FirePermanentFailedRequest {
+                tenant_id,
+                trigger_id,
+                fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect_err("durable permanent failure implementation lands in PR13"),
+        );
+    }
+
+    fn assert_pr13_backend_error(error: TriggerError) {
+        assert!(
+            error
+                .to_string()
+                .contains("atomic trigger fire claim persistence for this backend lands in PR 13"),
+            "unexpected durable default error: {error}"
+        );
+    }
+
+    fn assert_error_contains(error: TriggerError, expected: &str) {
+        assert!(
+            error.to_string().contains(expected),
+            "expected error to contain {expected:?}, got {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_repository_fire_claim_contract() {
+        let repo = InMemoryTriggerRepository::default();
+        assert_fire_claim_and_update_contract(&repo).await;
+        assert_fire_claim_exclusions_and_active_gate_contract(&repo).await;
+        assert_fire_result_rejects_invalid_next_run_at(&repo).await;
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn libsql_repository_fire_claim_contract() {
+        let (_dir, repo) = build_libsql_repo().await;
+        assert_durable_fire_claim_defaults_to_pr13(&repo).await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn postgres_repository_fire_claim_contract() {
+        let Some((_container, pool)) = postgres_pool_or_skip().await else {
+            return;
+        };
+        let repo = PostgresTriggerRepository::new(pool.clone());
+        repo.run_migrations().await.expect("run migrations");
+        assert_durable_fire_claim_defaults_to_pr13(&repo).await;
+        clear_postgres_triggers(&pool).await;
+    }
 }

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -491,37 +491,46 @@ Expected size: less than 1000 lines.
 Add the backend-agnostic repository claim/lease API that makes
 `max_concurrent_fires_per_trigger = 1` enforceable across concurrent pollers:
 
-- `claim_due_fire`-style request/response types and trait method.
-- claim operation contract covers due-row read, trigger state check,
-  active-fire check, and claim write in one database transaction or equivalent
-  backend primitive.
+- `claim_due_fire` request/response types and trait method, plus the in-memory
+  default behavior used by tests and non-durable harnesses.
+- claim operation contract atomically covers due-row read, trigger state
+  check, active-fire check, and claim write; durable PostgreSQL/libSQL
+  transaction or CAS implementations land in PR 13.
 - explicit submit-result update methods for accepted, replayed, retryable
   failed, and permanent failed outcomes.
-- write-order contract for `last_run_at`, `last_fired_slot`, `last_status`,
-  `next_run_at`, `active_fire_slot`, and `active_run_ref`.
+- write-order contract for accepted/replayed fires:
+  `last_run_at`, `last_fired_slot`, `last_status = Ok`, `next_run_at`,
+  `active_fire_slot`, `active_run_ref`.
+- `active_fire_slot` is written before turn submission; `active_run_ref` is
+  populated only after the accepted/replayed submit result returns a
+  `TurnRunId`.
+- retryable failed writes `last_status = Error`, clears active fields, leaves
+  `last_fired_slot` and `last_run_at` unchanged, and keeps `next_run_at` at or
+  before the failed fire slot.
+- permanent failed writes `last_status = Error`, clears active fields, leaves
+  `last_fired_slot` and `last_run_at` unchanged, and advances `next_run_at`
+  beyond the failed fire slot.
 - active-fire claim never uses `last_status` as the in-flight sentinel.
-- claim/clear code reads `active_run_ref` as a `TurnRunId` and consults the
-  turn-state system for terminal status; PR 10 only persists the field.
+- turn terminal lookup and clearing remain on the later PR 14+ seam; PR 12 and
+  PR 13 do not consult turn state yet.
 
 Expected size: less than 600 lines.
 
 ### PR 13 — Atomic Claim Backend Implementations
 
-Implement the atomic claim API for both durable backends:
+Implement the durable backend versions of the PR 12 claim API and prove the
+concurrency invariant:
 
 - PostgreSQL implementation with transaction/row-lock or compare-and-swap
   semantics.
 - libSQL implementation with equivalent transaction/compare-and-swap semantics.
 - in-memory implementation only for tests; it is not proof of the durable
   invariant.
-- retryable submit failure keeps `last_fired_slot` unchanged, leaves active
-  claim unset, and keeps `next_run_at` at or before the failed slot's scheduled
-  time.
+- backend parity tests for concurrent claim attempts, accepted/replayed write
+  order, retryable failure bookkeeping, and permanent failure bookkeeping.
 - duplicate replay for the same fire identity returns the original accepted
   message and turn submission; terminal run failure does not mint a second V1
   turn for the same fire slot.
-- PostgreSQL/libSQL parity tests for concurrent claim attempts and retryable
-  failure bookkeeping.
 
 Expected size: less than 1000 lines; split by backend if implementation or
 tests exceed the line budget.

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -528,6 +528,13 @@ concurrency invariant:
   invariant.
 - backend parity tests for concurrent claim attempts, accepted/replayed write
   order, retryable failure bookkeeping, and permanent failure bookkeeping.
+- durable claim implementations must preserve PR 12 state-first eligibility:
+  `Paused` or `Completed` rows return not-due even if stale active-fire metadata
+  is still present.
+- replace the PR 12 durable-backend sentinel defaults deliberately. Decide in
+  PR 13 whether the trait keeps explicit temporary backend errors during rollout
+  or moves to compile-time enforcement once PostgreSQL/libSQL implement every
+  method.
 - duplicate replay for the same fire identity returns the original accepted
   message and turn submission; terminal run failure does not mint a second V1
   turn for the same fire slot.

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -169,6 +169,10 @@ atomically covers due-row read, trigger-state check, active-fire check, and
 claim write, and PR 13 owns the durable PostgreSQL/libSQL transaction/CAS
 implementations plus concurrency proof.
 
+Claim eligibility checks the trigger state before active-fire metadata. A
+`Paused` or `Completed` trigger with stale active-fire metadata is not due; it
+must not be surfaced as an active scheduled fire.
+
 The skip policy is per-trigger, not global. Other triggers may continue to fire on the same tick.
 
 ---

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -161,11 +161,13 @@ V1 has one provider: a schedule provider.
 - A skipped tick does not create a second fire, does not create a second thread, and does not fork a parallel trigger loop.
 - Active means the previous fire has not yet reached a terminal turn outcome.
 
-`last_status` is not the active-fire sentinel. Active-fire state is tracked by
-the separate `active_fire_slot` / `active_run_ref` claim fields and cleared only
-after the referenced turn reaches a terminal outcome. PostgreSQL and libSQL
-backends must provide equivalent atomic claim semantics; in-memory tests are
-not sufficient evidence for this invariant.
+`last_status` is not the active-fire sentinel. Active means either
+`active_fire_slot` or `active_run_ref` is set; `last_status` never marks a
+trigger active. PR 12 defines the backend-agnostic `claim_due_fire`
+request/response contract and in-memory default behavior; the request/response
+atomically covers due-row read, trigger-state check, active-fire check, and
+claim write, and PR 13 owns the durable PostgreSQL/libSQL transaction/CAS
+implementations plus concurrency proof.
 
 The skip policy is per-trigger, not global. Other triggers may continue to fire on the same tick.
 
@@ -227,15 +229,23 @@ identity policy.
 
 Slot bookkeeping is tied to acceptance, not merely polling:
 
-- accepted or replayed fires advance `last_fired_slot`, set `last_status = Ok`,
-  set the active-fire claim to the accepted/submitted turn reference, and
-  compute the next future slot;
-- retryable submit failures leave `last_fired_slot` unchanged, set
-  `last_status = Error`, leave the active-fire claim unset, and leave the slot
-  retryable. `next_run_at` must remain at or before the failed slot's scheduled
-  time so the poller can retry it on the next tick;
-- permanent validation or authorization failures set `last_status = Error` and
-  must not silently create a different route, actor, or scope.
+- accepted or replayed fires write `last_run_at`, `last_fired_slot`,
+  `last_status = Ok`, `next_run_at`, `active_fire_slot`, and `active_run_ref`
+  in that order; `active_fire_slot` is written before turn submission and
+  `active_run_ref` is populated only after the accepted/replayed submit result
+  returns a `TurnRunId`;
+- retryable submit failures write `last_status = Error`, clear
+  `active_fire_slot` and `active_run_ref`, leave `last_fired_slot` and
+  `last_run_at` unchanged, and keep `next_run_at` at or before the failed
+  fire_slot so the poller can retry it on the next tick;
+- permanent validation or authorization failures write `last_status = Error`,
+  clear `active_fire_slot` and `active_run_ref`, leave `last_fired_slot` and
+  `last_run_at` unchanged, and advance `next_run_at` beyond the failed
+  fire_slot.
+
+Turn terminal lookup and clearing stay on the later PR 14+ seam; PR 12 and
+PR 13 define the fire-claim contract and submit-result bookkeeping but do not
+consult turn state yet.
 
 ---
 


### PR DESCRIPTION
## Summary

PR12 adds the backend-agnostic trigger fire claim contract for Reborn scheduled triggers.

This is intentionally the API/contract slice before durable backend atomics:

- adds `claim_due_fire` request/response types and repository trait method
- adds submit-result update request types and repository trait methods for accepted, replayed, retryable failed, and permanent failed outcomes
- implements the PR12 behavior for `InMemoryTriggerRepository` under one mutex for test/non-durable harnesses
- leaves PostgreSQL/libSQL on explicit PR13 backend errors for the new methods
- updates trigger docs and the implementation plan to pin the PR12/PR13 boundary

## Contract Details

Claim behavior:

- reads the scoped trigger row by `(tenant_id, trigger_id)`
- returns `NotFound`, `NotDue`, `AlreadyActive`, or `Claimed`
- only claims `Scheduled` records whose `next_run_at == fire_slot` and `fire_slot <= now`
- treats either `active_fire_slot` or `active_run_ref` as active back-pressure
- does not use `last_status` as the active/in-flight sentinel

Submit-result behavior:

- accepted/replayed writes `last_run_at`, `last_fired_slot`, `last_status = Ok`, `next_run_at`, `active_fire_slot`, and `active_run_ref`
- accepted/replayed are idempotent for the same existing `TurnRunId` and reject attempts to rewrite `active_run_ref`
- retryable failure writes `last_status = Error`, clears active fields, leaves `last_run_at` and `last_fired_slot` unchanged, and requires `next_run_at <= fire_slot`
- permanent failure writes `last_status = Error`, clears active fields, leaves `last_run_at` and `last_fired_slot` unchanged, and requires `next_run_at > fire_slot`
- stale failure updates are rejected once an accepted/replayed `active_run_ref` exists

## Explicitly Deferred

PR13 owns the durable PostgreSQL/libSQL implementation and concurrency proof:

- transaction/row-lock or CAS implementation
- durable two-poller no-double-claim parity tests
- retryable submit failure durability behavior
- duplicate replay returning the original accepted/submitted turn

This PR does not add poller logic, materialization, first-party capabilities, lifecycle wiring, claim clearing, turn-state terminal lookup, or outbound delivery.

## Review Notes

Two review points are intentional and should be read against the phase plan:

- Durable backends fail fast for the new methods until PR13. This is deliberate to keep PR12 as the shared API/contract slice.
- The API uses explicit request structs per submit-result outcome because PR12’s handoff contract called for separate accepted/replayed/retryable/permanent update APIs and write-order rules.

## Verification

- `cargo fmt -p ironclaw_triggers`
- `cargo test -p ironclaw_triggers --features libsql --test repository_contract`
- `cargo test -p ironclaw_triggers --features libsql`
- `cargo test -p ironclaw_triggers --all-features`
- `cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `git diff --check`

## Review Process

Used 5.4-mini subagents for parallel implementation, then two review rounds:

- implementation workers split domain API/in-memory behavior, repository contract tests, and docs
- dedicated boundary verifier confirmed ownership/scope cleanliness
- round 1 found and fixed stale submit-result state-machine issues plus missing edge/error-path coverage
- round 2 current-source sanity review returned clean after adding active-run-ref-only and replay-mismatch tests
