### PR TITLE
Implement durable trigger fire claims

### DIFF
--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1445,4 +1445,30 @@ mod tests {
             .expect_err("poisoned mutex maps to backend through claim API");
         assert!(matches!(error, TriggerError::Backend { .. }));
     }
+
+    #[tokio::test]
+    async fn in_memory_repository_mark_fire_accepted_returns_backend_error_when_mutex_is_poisoned()
+    {
+        let repo = InMemoryTriggerRepository::default();
+        let poison_repo = repo.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = poison_repo.state.lock().expect("lock before poison");
+            panic!("poison trigger repository mutex");
+        });
+
+        let fire_slot = ts(1_704_067_200);
+        let error = repo
+            .mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: tenant("tenant-a"),
+                trigger_id: TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+                fire_slot,
+                run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a")
+                    .expect("valid run"),
+                submitted_at: fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect_err("poisoned mutex maps to backend through accepted-result API");
+        assert!(matches!(error, TriggerError::Backend { .. }));
+    }
 }

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -478,38 +478,28 @@ pub trait TriggerRepository: Send + Sync {
 
     async fn claim_due_fire(
         &self,
-        _request: ClaimDueFireRequest,
-    ) -> Result<ClaimDueFireOutcome, TriggerError> {
-        Err(unimplemented_durable_backend_error())
-    }
+        request: ClaimDueFireRequest,
+    ) -> Result<ClaimDueFireOutcome, TriggerError>;
 
     async fn mark_fire_accepted(
         &self,
-        _request: FireAcceptedRequest,
-    ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(unimplemented_durable_backend_error())
-    }
+        request: FireAcceptedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError>;
 
     async fn mark_fire_replayed(
         &self,
-        _request: FireReplayedRequest,
-    ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(unimplemented_durable_backend_error())
-    }
+        request: FireReplayedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError>;
 
     async fn mark_fire_retryable_failed(
         &self,
-        _request: FireRetryableFailedRequest,
-    ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(unimplemented_durable_backend_error())
-    }
+        request: FireRetryableFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError>;
 
     async fn mark_fire_permanently_failed(
         &self,
-        _request: FirePermanentFailedRequest,
-    ) -> Result<Option<TriggerRecord>, TriggerError> {
-        Err(unimplemented_durable_backend_error())
-    }
+        request: FirePermanentFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError>;
 }
 
 /// Feature-gated durable libSQL repository type for composition/test wiring.
@@ -796,13 +786,7 @@ impl InMemoryTriggerRepository {
     }
 }
 
-fn unimplemented_durable_backend_error() -> TriggerError {
-    TriggerError::Backend {
-        reason: "atomic trigger fire claim persistence for this backend lands in PR 13".to_string(),
-    }
-}
-
-fn reject_non_future_next_run_at(
+pub(crate) fn reject_non_future_next_run_at(
     fire_slot: Timestamp,
     next_run_at: Timestamp,
 ) -> Result<(), TriggerError> {
@@ -814,7 +798,7 @@ fn reject_non_future_next_run_at(
     })
 }
 
-fn reject_run_ref_rewrite(
+pub(crate) fn reject_run_ref_rewrite(
     active_run_ref: TurnRunId,
     incoming_run_ref: TurnRunId,
 ) -> Result<(), TriggerError> {
@@ -826,7 +810,7 @@ fn reject_run_ref_rewrite(
     })
 }
 
-fn reject_failed_result_after_active_run(
+pub(crate) fn reject_failed_result_after_active_run(
     active_run_ref: Option<TurnRunId>,
 ) -> Result<(), TriggerError> {
     if active_run_ref.is_none() {

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -14,8 +14,11 @@ use libsql::params;
 
 #[cfg(feature = "libsql")]
 use crate::{
+    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, FireAcceptedRequest,
+    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest,
     TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
     TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
 };
 
 #[cfg(feature = "libsql")]
@@ -171,56 +174,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
     async fn upsert_trigger(&self, record: TriggerRecord) -> Result<(), TriggerError> {
         record.validate()?;
         let conn = self.connect().await?;
-        let affected = conn
-            .execute(
-                &format!(
-                    "INSERT INTO {TRIGGER_TABLE} (
-                    trigger_id, tenant_id, creator_user_id, agent_id, project_id,
-                    name, source, schedule_expression, completion_policy, prompt,
-                    state, next_run_at, last_run_at, last_fired_slot, last_status,
-                    active_fire_slot, active_run_ref, created_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
-                ON CONFLICT (tenant_id, trigger_id) DO UPDATE SET
-                    creator_user_id = excluded.creator_user_id,
-                    agent_id = excluded.agent_id,
-                    project_id = excluded.project_id,
-                    name = excluded.name,
-                    source = excluded.source,
-                    schedule_expression = excluded.schedule_expression,
-                    completion_policy = excluded.completion_policy,
-                    prompt = excluded.prompt,
-                    state = excluded.state,
-                    next_run_at = excluded.next_run_at,
-                    last_run_at = excluded.last_run_at,
-                    last_fired_slot = excluded.last_fired_slot,
-                    last_status = excluded.last_status,
-                    active_fire_slot = excluded.active_fire_slot,
-                    active_run_ref = excluded.active_run_ref"
-                ),
-                params![
-                    record.trigger_id.to_string(),
-                    record.tenant_id.as_str(),
-                    record.creator_user_id.as_str(),
-                    opt_text(record.agent_id.as_ref().map(AgentId::as_str)),
-                    opt_text(record.project_id.as_ref().map(ProjectId::as_str)),
-                    record.name,
-                    source_kind_text(record.source),
-                    schedule_expression_text(&record.schedule),
-                    completion_policy_text(record.completion_policy),
-                    record.prompt,
-                    state_text(record.state),
-                    fmt_ts(&record.next_run_at),
-                    opt_ts(record.last_run_at.as_ref()),
-                    opt_ts(record.last_fired_slot.as_ref()),
-                    opt_status(record.last_status),
-                    opt_ts(record.active_fire_slot.as_ref()),
-                    opt_turn_run_id(record.active_run_ref.as_ref()),
-                    fmt_ts(&record.created_at),
-                ],
-            )
-            .await
-            .map_err(|error| backend_error("upsert trigger record", error))?;
-        debug_assert!(affected >= 1, "libSQL upsert must affect at least one row");
+        write_record(&conn, &record).await?;
         Ok(())
     }
 
@@ -338,6 +292,315 @@ impl TriggerRepository for LibSqlTriggerRepository {
         }
         Ok(records)
     }
+
+    async fn claim_due_fire(
+        &self,
+        request: ClaimDueFireRequest,
+    ) -> Result<ClaimDueFireOutcome, TriggerError> {
+        let conn = self.connect().await?;
+        let fire_slot = fmt_ts(&request.fire_slot);
+        let now = fmt_ts(&request.now);
+        let mut rows = conn
+            .query(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET active_fire_slot = ?4,
+                         active_run_ref = NULL
+                     WHERE tenant_id = ?1
+                       AND trigger_id = ?2
+                       AND state = ?3
+                       AND next_run_at = ?4
+                       AND ?4 <= ?5
+                       AND active_fire_slot IS NULL
+                       AND active_run_ref IS NULL
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![
+                    request.tenant_id.as_str(),
+                    request.trigger_id.to_string(),
+                    state_text(TriggerState::Scheduled),
+                    fire_slot,
+                    now,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("claim trigger fire", error))?;
+        if let Some(record) = returned_record(&mut rows, "read claimed trigger fire").await? {
+            return Ok(ClaimDueFireOutcome::Claimed(ClaimedTriggerFire {
+                record,
+                fire_slot: request.fire_slot,
+            }));
+        }
+
+        let Some(record) = fetch_record(&conn, &request.tenant_id, request.trigger_id).await?
+        else {
+            return Ok(ClaimDueFireOutcome::NotFound);
+        };
+        if record.state != TriggerState::Scheduled
+            || record.next_run_at != request.fire_slot
+            || request.fire_slot > request.now
+        {
+            return Ok(ClaimDueFireOutcome::NotDue { record });
+        }
+        if record.has_active_fire() {
+            return Ok(ClaimDueFireOutcome::AlreadyActive {
+                active_fire_slot: record.active_fire_slot,
+                active_run_ref: record.active_run_ref,
+            });
+        }
+        Err(backend_error(
+            "claim trigger fire",
+            "claim predicate failed without a visible row-state change",
+        ))
+    }
+
+    async fn mark_fire_accepted(
+        &self,
+        request: FireAcceptedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let FireAcceptedRequest {
+            tenant_id,
+            trigger_id,
+            fire_slot,
+            run_id,
+            submitted_at,
+            next_run_at,
+        } = request;
+        let conn = self.connect().await?;
+        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(fire_slot) {
+            return Ok(None);
+        }
+        if let Some(active_run_ref) = record.active_run_ref {
+            reject_run_ref_rewrite(active_run_ref, run_id)?;
+            return Ok(Some(record));
+        }
+        reject_non_future_next_run_at(fire_slot, next_run_at)?;
+
+        let fire_slot_text = fmt_ts(&fire_slot);
+        let submitted_at = fmt_ts(&submitted_at);
+        let next_run_at = fmt_ts(&next_run_at);
+        let active_run_ref = run_id.to_string();
+        let last_status = status_text(TriggerRunStatus::Ok);
+        let mut rows = conn
+            .query(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_run_at = ?3,
+                         last_fired_slot = ?4,
+                         last_status = ?5,
+                         next_run_at = ?6,
+                         active_fire_slot = ?4,
+                         active_run_ref = ?7
+                     WHERE tenant_id = ?1
+                       AND trigger_id = ?2
+                       AND active_fire_slot = ?4
+                       AND active_run_ref IS NULL
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![
+                    tenant_id.as_str(),
+                    trigger_id.to_string(),
+                    submitted_at,
+                    fire_slot_text,
+                    last_status,
+                    next_run_at,
+                    active_run_ref,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark accepted trigger fire", error))?;
+        if let Some(record) = returned_record(&mut rows, "read accepted trigger fire").await? {
+            return Ok(Some(record));
+        }
+        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, Some(run_id))
+            .await
+    }
+
+    async fn mark_fire_replayed(
+        &self,
+        request: FireReplayedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let FireReplayedRequest {
+            tenant_id,
+            trigger_id,
+            fire_slot,
+            original_run_id,
+            replayed_at,
+            next_run_at,
+        } = request;
+        let conn = self.connect().await?;
+        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(fire_slot) {
+            return Ok(None);
+        }
+        if let Some(active_run_ref) = record.active_run_ref {
+            reject_run_ref_rewrite(active_run_ref, original_run_id)?;
+            return Ok(Some(record));
+        }
+        reject_non_future_next_run_at(fire_slot, next_run_at)?;
+
+        let fire_slot_text = fmt_ts(&fire_slot);
+        let replayed_at = fmt_ts(&replayed_at);
+        let next_run_at = fmt_ts(&next_run_at);
+        let active_run_ref = original_run_id.to_string();
+        let last_status = status_text(TriggerRunStatus::Ok);
+        let mut rows = conn
+            .query(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_run_at = ?3,
+                         last_fired_slot = ?4,
+                         last_status = ?5,
+                         next_run_at = ?6,
+                         active_fire_slot = ?4,
+                         active_run_ref = ?7
+                     WHERE tenant_id = ?1
+                       AND trigger_id = ?2
+                       AND active_fire_slot = ?4
+                       AND active_run_ref IS NULL
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![
+                    tenant_id.as_str(),
+                    trigger_id.to_string(),
+                    replayed_at,
+                    fire_slot_text,
+                    last_status,
+                    next_run_at,
+                    active_run_ref,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark replayed trigger fire", error))?;
+        if let Some(record) = returned_record(&mut rows, "read replayed trigger fire").await? {
+            return Ok(Some(record));
+        }
+        resolve_missed_fire_result_update(
+            &conn,
+            &tenant_id,
+            trigger_id,
+            fire_slot,
+            Some(original_run_id),
+        )
+        .await
+    }
+
+    async fn mark_fire_retryable_failed(
+        &self,
+        request: FireRetryableFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let FireRetryableFailedRequest {
+            tenant_id,
+            trigger_id,
+            fire_slot,
+        } = request;
+        let conn = self.connect().await?;
+        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(fire_slot) {
+            return Ok(None);
+        }
+        reject_failed_result_after_active_run(record.active_run_ref)?;
+        if record.next_run_at > fire_slot {
+            return Err(TriggerError::InvalidRecord {
+                reason: "retryable fire failure must leave next_run_at at or before the failed fire slot"
+                    .to_string(),
+            });
+        }
+
+        let fire_slot_text = fmt_ts(&fire_slot);
+        let last_status = status_text(TriggerRunStatus::Error);
+        let mut rows = conn
+            .query(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_status = ?3,
+                         active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = ?1
+                       AND trigger_id = ?2
+                       AND active_fire_slot = ?4
+                       AND active_run_ref IS NULL
+                       AND next_run_at <= ?4
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![
+                    tenant_id.as_str(),
+                    trigger_id.to_string(),
+                    last_status,
+                    fire_slot_text,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark retryable trigger fire failure", error))?;
+        if let Some(record) =
+            returned_record(&mut rows, "read retryable trigger fire failure").await?
+        {
+            return Ok(Some(record));
+        }
+        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None).await
+    }
+
+    async fn mark_fire_permanently_failed(
+        &self,
+        request: FirePermanentFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let FirePermanentFailedRequest {
+            tenant_id,
+            trigger_id,
+            fire_slot,
+            next_run_at,
+        } = request;
+        let conn = self.connect().await?;
+        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(fire_slot) {
+            return Ok(None);
+        }
+        reject_failed_result_after_active_run(record.active_run_ref)?;
+        reject_non_future_next_run_at(fire_slot, next_run_at)?;
+
+        let fire_slot_text = fmt_ts(&fire_slot);
+        let next_run_at = fmt_ts(&next_run_at);
+        let last_status = status_text(TriggerRunStatus::Error);
+        let mut rows = conn
+            .query(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_status = ?3,
+                         next_run_at = ?5,
+                         active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = ?1
+                       AND trigger_id = ?2
+                       AND active_fire_slot = ?4
+                       AND active_run_ref IS NULL
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![
+                    tenant_id.as_str(),
+                    trigger_id.to_string(),
+                    last_status,
+                    fire_slot_text,
+                    next_run_at,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark permanent trigger fire failure", error))?;
+        if let Some(record) =
+            returned_record(&mut rows, "read permanent trigger fire failure").await?
+        {
+            return Ok(Some(record));
+        }
+        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None).await
+    }
 }
 
 #[cfg(feature = "libsql")]
@@ -410,6 +673,123 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
     };
     record.validate()?;
     Ok(record)
+}
+
+#[cfg(feature = "libsql")]
+async fn fetch_record(
+    conn: &libsql::Connection,
+    tenant_id: &TenantId,
+    trigger_id: TriggerId,
+) -> Result<Option<TriggerRecord>, TriggerError> {
+    let mut rows = conn
+        .query(
+            &format!(
+                "SELECT {TRIGGER_COLUMNS}
+                 FROM {TRIGGER_TABLE}
+                 WHERE tenant_id = ?1 AND trigger_id = ?2
+                 LIMIT 1"
+            ),
+            params![tenant_id.as_str(), trigger_id.to_string()],
+        )
+        .await
+        .map_err(|error| backend_error("query trigger record", error))?;
+    match rows.next().await {
+        Ok(Some(row)) => Ok(Some(row_to_record(&row)?)),
+        Ok(None) => Ok(None),
+        Err(error) => Err(backend_error("read trigger record row", error)),
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn returned_record(
+    rows: &mut libsql::Rows,
+    operation: &str,
+) -> Result<Option<TriggerRecord>, TriggerError> {
+    match rows.next().await {
+        Ok(Some(row)) => Ok(Some(row_to_record(&row)?)),
+        Ok(None) => Ok(None),
+        Err(error) => Err(backend_error(operation, error)),
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn write_record(
+    conn: &libsql::Connection,
+    record: &TriggerRecord,
+) -> Result<(), TriggerError> {
+    conn.execute(
+        &format!(
+            "INSERT INTO {TRIGGER_TABLE} (
+                trigger_id, tenant_id, creator_user_id, agent_id, project_id,
+                name, source, schedule_expression, completion_policy, prompt,
+                state, next_run_at, last_run_at, last_fired_slot, last_status,
+                active_fire_slot, active_run_ref, created_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+            ON CONFLICT (tenant_id, trigger_id) DO UPDATE SET
+                creator_user_id = excluded.creator_user_id,
+                agent_id = excluded.agent_id,
+                project_id = excluded.project_id,
+                name = excluded.name,
+                source = excluded.source,
+                schedule_expression = excluded.schedule_expression,
+                completion_policy = excluded.completion_policy,
+                prompt = excluded.prompt,
+                state = excluded.state,
+                next_run_at = excluded.next_run_at,
+                last_run_at = excluded.last_run_at,
+                last_fired_slot = excluded.last_fired_slot,
+                last_status = excluded.last_status,
+                active_fire_slot = excluded.active_fire_slot,
+                active_run_ref = excluded.active_run_ref"
+        ),
+        params![
+            record.trigger_id.to_string(),
+            record.tenant_id.as_str(),
+            record.creator_user_id.as_str(),
+            opt_text(record.agent_id.as_ref().map(AgentId::as_str)),
+            opt_text(record.project_id.as_ref().map(ProjectId::as_str)),
+            record.name.clone(),
+            source_kind_text(record.source),
+            schedule_expression_text(&record.schedule),
+            completion_policy_text(record.completion_policy),
+            record.prompt.clone(),
+            state_text(record.state),
+            fmt_ts(&record.next_run_at),
+            opt_ts(record.last_run_at.as_ref()),
+            opt_ts(record.last_fired_slot.as_ref()),
+            opt_status(record.last_status),
+            opt_ts(record.active_fire_slot.as_ref()),
+            opt_turn_run_id(record.active_run_ref.as_ref()),
+            fmt_ts(&record.created_at),
+        ],
+    )
+    .await
+    .map_err(|error| backend_error("upsert trigger record", error))?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn resolve_missed_fire_result_update(
+    conn: &libsql::Connection,
+    tenant_id: &TenantId,
+    trigger_id: TriggerId,
+    fire_slot: Timestamp,
+    expected_run_ref: Option<TurnRunId>,
+) -> Result<Option<TriggerRecord>, TriggerError> {
+    let Some(record) = fetch_record(conn, tenant_id, trigger_id).await? else {
+        return Ok(None);
+    };
+    if record.active_fire_slot != Some(fire_slot) {
+        return Ok(None);
+    }
+    if let Some(active_run_ref) = record.active_run_ref {
+        if let Some(expected_run_ref) = expected_run_ref {
+            reject_run_ref_rewrite(active_run_ref, expected_run_ref)?;
+            return Ok(Some(record));
+        }
+        reject_failed_result_after_active_run(Some(active_run_ref))?;
+    }
+    Ok(None)
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -348,144 +348,50 @@ impl TriggerRepository for LibSqlTriggerRepository {
                 active_run_ref: record.active_run_ref,
             });
         }
-        Err(backend_error(
-            "claim trigger fire",
-            "claim predicate failed without a visible row-state change",
-        ))
+        // A competing poller can claim and clear the fire before this
+        // diagnostic read. The row may be due again, but this attempt did not
+        // claim it; let a later poll cycle observe it normally.
+        Ok(ClaimDueFireOutcome::NotDue { record })
     }
 
     async fn mark_fire_accepted(
         &self,
         request: FireAcceptedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
-        let FireAcceptedRequest {
-            tenant_id,
-            trigger_id,
-            fire_slot,
-            run_id,
-            submitted_at,
-            next_run_at,
-        } = request;
         let conn = self.connect().await?;
-        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
-            return Ok(None);
-        };
-        if record.active_fire_slot != Some(fire_slot) {
-            return Ok(None);
-        }
-        if let Some(active_run_ref) = record.active_run_ref {
-            reject_run_ref_rewrite(active_run_ref, run_id)?;
-            return Ok(Some(record));
-        }
-        reject_non_future_next_run_at(fire_slot, next_run_at)?;
-
-        let fire_slot_text = fmt_ts(&fire_slot);
-        let submitted_at = fmt_ts(&submitted_at);
-        let next_run_at = fmt_ts(&next_run_at);
-        let active_run_ref = run_id.to_string();
-        let last_status = status_text(TriggerRunStatus::Ok);
-        let mut rows = conn
-            .query(
-                &format!(
-                    "UPDATE {TRIGGER_TABLE}
-                     SET last_run_at = ?3,
-                         last_fired_slot = ?4,
-                         last_status = ?5,
-                         next_run_at = ?6,
-                         active_fire_slot = ?4,
-                         active_run_ref = ?7
-                     WHERE tenant_id = ?1
-                       AND trigger_id = ?2
-                       AND active_fire_slot = ?4
-                       AND active_run_ref IS NULL
-                     RETURNING {TRIGGER_COLUMNS}"
-                ),
-                params![
-                    tenant_id.as_str(),
-                    trigger_id.to_string(),
-                    submitted_at,
-                    fire_slot_text,
-                    last_status,
-                    next_run_at,
-                    active_run_ref,
-                ],
-            )
-            .await
-            .map_err(|error| backend_error("mark accepted trigger fire", error))?;
-        if let Some(record) = returned_record(&mut rows, "read accepted trigger fire").await? {
-            return Ok(Some(record));
-        }
-        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, Some(run_id))
-            .await
+        mark_successful_fire_result(
+            &conn,
+            SuccessfulFireResultUpdate {
+                tenant_id: &request.tenant_id,
+                trigger_id: request.trigger_id,
+                fire_slot: request.fire_slot,
+                run_id: request.run_id,
+                result_at: request.submitted_at,
+                next_run_at: request.next_run_at,
+                update_operation: "mark accepted trigger fire",
+                read_operation: "read accepted trigger fire",
+            },
+        )
+        .await
     }
 
     async fn mark_fire_replayed(
         &self,
         request: FireReplayedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
-        let FireReplayedRequest {
-            tenant_id,
-            trigger_id,
-            fire_slot,
-            original_run_id,
-            replayed_at,
-            next_run_at,
-        } = request;
         let conn = self.connect().await?;
-        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
-            return Ok(None);
-        };
-        if record.active_fire_slot != Some(fire_slot) {
-            return Ok(None);
-        }
-        if let Some(active_run_ref) = record.active_run_ref {
-            reject_run_ref_rewrite(active_run_ref, original_run_id)?;
-            return Ok(Some(record));
-        }
-        reject_non_future_next_run_at(fire_slot, next_run_at)?;
-
-        let fire_slot_text = fmt_ts(&fire_slot);
-        let replayed_at = fmt_ts(&replayed_at);
-        let next_run_at = fmt_ts(&next_run_at);
-        let active_run_ref = original_run_id.to_string();
-        let last_status = status_text(TriggerRunStatus::Ok);
-        let mut rows = conn
-            .query(
-                &format!(
-                    "UPDATE {TRIGGER_TABLE}
-                     SET last_run_at = ?3,
-                         last_fired_slot = ?4,
-                         last_status = ?5,
-                         next_run_at = ?6,
-                         active_fire_slot = ?4,
-                         active_run_ref = ?7
-                     WHERE tenant_id = ?1
-                       AND trigger_id = ?2
-                       AND active_fire_slot = ?4
-                       AND active_run_ref IS NULL
-                     RETURNING {TRIGGER_COLUMNS}"
-                ),
-                params![
-                    tenant_id.as_str(),
-                    trigger_id.to_string(),
-                    replayed_at,
-                    fire_slot_text,
-                    last_status,
-                    next_run_at,
-                    active_run_ref,
-                ],
-            )
-            .await
-            .map_err(|error| backend_error("mark replayed trigger fire", error))?;
-        if let Some(record) = returned_record(&mut rows, "read replayed trigger fire").await? {
-            return Ok(Some(record));
-        }
-        resolve_missed_fire_result_update(
+        mark_successful_fire_result(
             &conn,
-            &tenant_id,
-            trigger_id,
-            fire_slot,
-            Some(original_run_id),
+            SuccessfulFireResultUpdate {
+                tenant_id: &request.tenant_id,
+                trigger_id: request.trigger_id,
+                fire_slot: request.fire_slot,
+                run_id: request.original_run_id,
+                result_at: request.replayed_at,
+                next_run_at: request.next_run_at,
+                update_operation: "mark replayed trigger fire",
+                read_operation: "read replayed trigger fire",
+            },
         )
         .await
     }
@@ -544,7 +450,8 @@ impl TriggerRepository for LibSqlTriggerRepository {
         {
             return Ok(Some(record));
         }
-        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None).await
+        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None, None)
+            .await
     }
 
     async fn mark_fire_permanently_failed(
@@ -599,7 +506,8 @@ impl TriggerRepository for LibSqlTriggerRepository {
         {
             return Ok(Some(record));
         }
-        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None).await
+        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None, None)
+            .await
     }
 }
 
@@ -775,6 +683,7 @@ async fn resolve_missed_fire_result_update(
     trigger_id: TriggerId,
     fire_slot: Timestamp,
     expected_run_ref: Option<TurnRunId>,
+    next_run_at: Option<Timestamp>,
 ) -> Result<Option<TriggerRecord>, TriggerError> {
     let Some(record) = fetch_record(conn, tenant_id, trigger_id).await? else {
         return Ok(None);
@@ -789,7 +698,78 @@ async fn resolve_missed_fire_result_update(
         }
         reject_failed_result_after_active_run(Some(active_run_ref))?;
     }
-    Ok(None)
+    if let Some(next_run_at) = next_run_at {
+        reject_non_future_next_run_at(fire_slot, next_run_at)?;
+    }
+    Err(backend_error(
+        "reconcile missed trigger fire result update",
+        "update predicate failed while claimed fire remained active without a run ref",
+    ))
+}
+
+#[cfg(feature = "libsql")]
+async fn mark_successful_fire_result(
+    conn: &libsql::Connection,
+    update: SuccessfulFireResultUpdate<'_>,
+) -> Result<Option<TriggerRecord>, TriggerError> {
+    let fire_slot_text = fmt_ts(&update.fire_slot);
+    let result_at = fmt_ts(&update.result_at);
+    let next_run_at_text = fmt_ts(&update.next_run_at);
+    let active_run_ref = update.run_id.to_string();
+    let last_status = status_text(TriggerRunStatus::Ok);
+    let mut rows = conn
+        .query(
+            &format!(
+                "UPDATE {TRIGGER_TABLE}
+                 SET last_run_at = ?3,
+                     last_fired_slot = ?4,
+                     last_status = ?5,
+                     next_run_at = ?6,
+                     active_fire_slot = ?4,
+                     active_run_ref = ?7
+                 WHERE tenant_id = ?1
+                   AND trigger_id = ?2
+                   AND active_fire_slot = ?4
+                   AND active_run_ref IS NULL
+                   AND ?6 > ?4
+                 RETURNING {TRIGGER_COLUMNS}"
+            ),
+            params![
+                update.tenant_id.as_str(),
+                update.trigger_id.to_string(),
+                result_at,
+                fire_slot_text,
+                last_status,
+                next_run_at_text,
+                active_run_ref,
+            ],
+        )
+        .await
+        .map_err(|error| backend_error(update.update_operation, error))?;
+    if let Some(record) = returned_record(&mut rows, update.read_operation).await? {
+        return Ok(Some(record));
+    }
+    resolve_missed_fire_result_update(
+        conn,
+        update.tenant_id,
+        update.trigger_id,
+        update.fire_slot,
+        Some(update.run_id),
+        Some(update.next_run_at),
+    )
+    .await
+}
+
+#[cfg(feature = "libsql")]
+struct SuccessfulFireResultUpdate<'a> {
+    tenant_id: &'a TenantId,
+    trigger_id: TriggerId,
+    fire_slot: Timestamp,
+    run_id: TurnRunId,
+    result_at: Timestamp,
+    next_run_at: Timestamp,
+    update_operation: &'static str,
+    read_operation: &'static str,
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -5,8 +5,11 @@ use ironclaw_turns::TurnRunId;
 use tokio_postgres::Row;
 
 use crate::{
+    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, FireAcceptedRequest,
+    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest,
     TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
     TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
 };
 
 const TRIGGER_TABLE: &str = "trigger_records";
@@ -229,6 +232,334 @@ impl TriggerRepository for PostgresTriggerRepository {
             .map_err(|error| backend_error("query due trigger records", error))?;
         rows.into_iter().map(|row| row_to_record(&row)).collect()
     }
+
+    async fn claim_due_fire(
+        &self,
+        request: ClaimDueFireRequest,
+    ) -> Result<ClaimDueFireOutcome, TriggerError> {
+        let mut client = self.connect().await?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|error| backend_error("begin trigger fire claim", error))?;
+        let trigger_id = request.trigger_id.to_string();
+        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
+        else {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit missing trigger fire claim", error))?;
+            return Ok(ClaimDueFireOutcome::NotFound);
+        };
+
+        if record.state != TriggerState::Scheduled
+            || record.next_run_at != request.fire_slot
+            || request.fire_slot > request.now
+        {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit not-due trigger fire claim", error))?;
+            return Ok(ClaimDueFireOutcome::NotDue { record });
+        }
+
+        if record.has_active_fire() {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit active trigger fire claim", error))?;
+            return Ok(ClaimDueFireOutcome::AlreadyActive {
+                active_fire_slot: record.active_fire_slot,
+                active_run_ref: record.active_run_ref,
+            });
+        }
+
+        let fire_slot = fmt_ts(&request.fire_slot);
+        let row = tx
+            .query_one(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET active_fire_slot = $3,
+                         active_run_ref = NULL
+                     WHERE tenant_id = $1 AND trigger_id = $2
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                &[&request.tenant_id.as_str(), &trigger_id, &fire_slot],
+            )
+            .await
+            .map_err(|error| backend_error("claim trigger fire", error))?;
+        let record = row_to_record(&row)?;
+        tx.commit()
+            .await
+            .map_err(|error| backend_error("commit trigger fire claim", error))?;
+        Ok(ClaimDueFireOutcome::Claimed(ClaimedTriggerFire {
+            record,
+            fire_slot: request.fire_slot,
+        }))
+    }
+
+    async fn mark_fire_accepted(
+        &self,
+        request: FireAcceptedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let mut client = self.connect().await?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|error| backend_error("begin accepted trigger fire update", error))?;
+        let trigger_id = request.trigger_id.to_string();
+        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
+        else {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit missing accepted trigger fire", error))?;
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(request.fire_slot) {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit stale accepted trigger fire", error))?;
+            return Ok(None);
+        }
+        if let Some(active_run_ref) = record.active_run_ref {
+            reject_run_ref_rewrite(active_run_ref, request.run_id)?;
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit idempotent accepted trigger fire", error))?;
+            return Ok(Some(record));
+        }
+        reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
+
+        let submitted_at = fmt_ts(&request.submitted_at);
+        let fire_slot = fmt_ts(&request.fire_slot);
+        let next_run_at = fmt_ts(&request.next_run_at);
+        let active_run_ref = request.run_id.to_string();
+        let last_status = status_text(TriggerRunStatus::Ok);
+        let row = tx
+            .query_one(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_run_at = $3,
+                         last_fired_slot = $4,
+                         last_status = $5,
+                         next_run_at = $6,
+                         active_fire_slot = $4,
+                         active_run_ref = $7
+                     WHERE tenant_id = $1 AND trigger_id = $2
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                &[
+                    &request.tenant_id.as_str(),
+                    &trigger_id,
+                    &submitted_at,
+                    &fire_slot,
+                    &last_status,
+                    &next_run_at,
+                    &active_run_ref,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark accepted trigger fire", error))?;
+        let record = row_to_record(&row)?;
+        tx.commit()
+            .await
+            .map_err(|error| backend_error("commit accepted trigger fire", error))?;
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_replayed(
+        &self,
+        request: FireReplayedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let mut client = self.connect().await?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|error| backend_error("begin replayed trigger fire update", error))?;
+        let trigger_id = request.trigger_id.to_string();
+        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
+        else {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit missing replayed trigger fire", error))?;
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(request.fire_slot) {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit stale replayed trigger fire", error))?;
+            return Ok(None);
+        }
+        if let Some(active_run_ref) = record.active_run_ref {
+            reject_run_ref_rewrite(active_run_ref, request.original_run_id)?;
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit idempotent replayed trigger fire", error))?;
+            return Ok(Some(record));
+        }
+        reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
+
+        let replayed_at = fmt_ts(&request.replayed_at);
+        let fire_slot = fmt_ts(&request.fire_slot);
+        let next_run_at = fmt_ts(&request.next_run_at);
+        let active_run_ref = request.original_run_id.to_string();
+        let last_status = status_text(TriggerRunStatus::Ok);
+        let row = tx
+            .query_one(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_run_at = $3,
+                         last_fired_slot = $4,
+                         last_status = $5,
+                         next_run_at = $6,
+                         active_fire_slot = $4,
+                         active_run_ref = $7
+                     WHERE tenant_id = $1 AND trigger_id = $2
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                &[
+                    &request.tenant_id.as_str(),
+                    &trigger_id,
+                    &replayed_at,
+                    &fire_slot,
+                    &last_status,
+                    &next_run_at,
+                    &active_run_ref,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark replayed trigger fire", error))?;
+        let record = row_to_record(&row)?;
+        tx.commit()
+            .await
+            .map_err(|error| backend_error("commit replayed trigger fire", error))?;
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_retryable_failed(
+        &self,
+        request: FireRetryableFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let mut client = self.connect().await?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|error| backend_error("begin retryable trigger fire failure", error))?;
+        let trigger_id = request.trigger_id.to_string();
+        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
+        else {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit missing retryable trigger fire", error))?;
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(request.fire_slot) {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit stale retryable trigger fire", error))?;
+            return Ok(None);
+        }
+        reject_failed_result_after_active_run(record.active_run_ref)?;
+        if record.next_run_at > request.fire_slot {
+            return Err(TriggerError::InvalidRecord {
+                reason: "retryable fire failure must leave next_run_at at or before the failed fire slot"
+                    .to_string(),
+            });
+        }
+
+        let last_status = status_text(TriggerRunStatus::Error);
+        let row = tx
+            .query_one(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_status = $3,
+                         active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = $1 AND trigger_id = $2
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                &[&request.tenant_id.as_str(), &trigger_id, &last_status],
+            )
+            .await
+            .map_err(|error| backend_error("mark retryable trigger fire failure", error))?;
+        let record = row_to_record(&row)?;
+        tx.commit()
+            .await
+            .map_err(|error| backend_error("commit retryable trigger fire failure", error))?;
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_permanently_failed(
+        &self,
+        request: FirePermanentFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let mut client = self.connect().await?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|error| backend_error("begin permanent trigger fire failure", error))?;
+        let trigger_id = request.trigger_id.to_string();
+        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
+        else {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit missing permanent trigger fire", error))?;
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(request.fire_slot) {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit stale permanent trigger fire", error))?;
+            return Ok(None);
+        }
+        reject_failed_result_after_active_run(record.active_run_ref)?;
+        reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
+
+        let last_status = status_text(TriggerRunStatus::Error);
+        let next_run_at = fmt_ts(&request.next_run_at);
+        let row = tx
+            .query_one(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET last_status = $3,
+                         next_run_at = $4,
+                         active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = $1 AND trigger_id = $2
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                &[
+                    &request.tenant_id.as_str(),
+                    &trigger_id,
+                    &last_status,
+                    &next_run_at,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark permanent trigger fire failure", error))?;
+        let record = row_to_record(&row)?;
+        tx.commit()
+            .await
+            .map_err(|error| backend_error("commit permanent trigger fire failure", error))?;
+        Ok(Some(record))
+    }
+}
+
+async fn locked_record(
+    tx: &tokio_postgres::Transaction<'_>,
+    tenant_id: &str,
+    trigger_id: &str,
+) -> Result<Option<TriggerRecord>, TriggerError> {
+    let row = tx
+        .query_opt(
+            &format!(
+                "SELECT {TRIGGER_COLUMNS}
+                 FROM {TRIGGER_TABLE}
+                 WHERE tenant_id = $1 AND trigger_id = $2
+                 FOR UPDATE"
+            ),
+            &[&tenant_id, &trigger_id],
+        )
+        .await
+        .map_err(|error| backend_error("lock trigger record", error))?;
+    row.map(|row| row_to_record(&row)).transpose()
 }
 
 fn row_to_record(row: &Row) -> Result<TriggerRecord, TriggerError> {

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -245,9 +245,6 @@ impl TriggerRepository for PostgresTriggerRepository {
         let trigger_id = request.trigger_id.to_string();
         let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
         else {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit missing trigger fire claim", error))?;
             return Ok(ClaimDueFireOutcome::NotFound);
         };
 
@@ -255,16 +252,10 @@ impl TriggerRepository for PostgresTriggerRepository {
             || record.next_run_at != request.fire_slot
             || request.fire_slot > request.now
         {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit not-due trigger fire claim", error))?;
             return Ok(ClaimDueFireOutcome::NotDue { record });
         }
 
         if record.has_active_fire() {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit active trigger fire claim", error))?;
             return Ok(ClaimDueFireOutcome::AlreadyActive {
                 active_fire_slot: record.active_fire_slot,
                 active_run_ref: record.active_run_ref,
@@ -307,22 +298,13 @@ impl TriggerRepository for PostgresTriggerRepository {
         let trigger_id = request.trigger_id.to_string();
         let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
         else {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit missing accepted trigger fire", error))?;
             return Ok(None);
         };
         if record.active_fire_slot != Some(request.fire_slot) {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit stale accepted trigger fire", error))?;
             return Ok(None);
         }
         if let Some(active_run_ref) = record.active_run_ref {
             reject_run_ref_rewrite(active_run_ref, request.run_id)?;
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit idempotent accepted trigger fire", error))?;
             return Ok(Some(record));
         }
         reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
@@ -342,7 +324,10 @@ impl TriggerRepository for PostgresTriggerRepository {
                          next_run_at = $6,
                          active_fire_slot = $4,
                          active_run_ref = $7
-                     WHERE tenant_id = $1 AND trigger_id = $2
+                     WHERE tenant_id = $1
+                       AND trigger_id = $2
+                       AND active_fire_slot = $4
+                       AND active_run_ref IS NULL
                      RETURNING {TRIGGER_COLUMNS}"
                 ),
                 &[
@@ -376,22 +361,13 @@ impl TriggerRepository for PostgresTriggerRepository {
         let trigger_id = request.trigger_id.to_string();
         let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
         else {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit missing replayed trigger fire", error))?;
             return Ok(None);
         };
         if record.active_fire_slot != Some(request.fire_slot) {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit stale replayed trigger fire", error))?;
             return Ok(None);
         }
         if let Some(active_run_ref) = record.active_run_ref {
             reject_run_ref_rewrite(active_run_ref, request.original_run_id)?;
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit idempotent replayed trigger fire", error))?;
             return Ok(Some(record));
         }
         reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
@@ -411,7 +387,10 @@ impl TriggerRepository for PostgresTriggerRepository {
                          next_run_at = $6,
                          active_fire_slot = $4,
                          active_run_ref = $7
-                     WHERE tenant_id = $1 AND trigger_id = $2
+                     WHERE tenant_id = $1
+                       AND trigger_id = $2
+                       AND active_fire_slot = $4
+                       AND active_run_ref IS NULL
                      RETURNING {TRIGGER_COLUMNS}"
                 ),
                 &[
@@ -445,15 +424,9 @@ impl TriggerRepository for PostgresTriggerRepository {
         let trigger_id = request.trigger_id.to_string();
         let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
         else {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit missing retryable trigger fire", error))?;
             return Ok(None);
         };
         if record.active_fire_slot != Some(request.fire_slot) {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit stale retryable trigger fire", error))?;
             return Ok(None);
         }
         reject_failed_result_after_active_run(record.active_run_ref)?;
@@ -465,6 +438,7 @@ impl TriggerRepository for PostgresTriggerRepository {
         }
 
         let last_status = status_text(TriggerRunStatus::Error);
+        let fire_slot = fmt_ts(&request.fire_slot);
         let row = tx
             .query_one(
                 &format!(
@@ -472,10 +446,19 @@ impl TriggerRepository for PostgresTriggerRepository {
                      SET last_status = $3,
                          active_fire_slot = NULL,
                          active_run_ref = NULL
-                     WHERE tenant_id = $1 AND trigger_id = $2
+                     WHERE tenant_id = $1
+                       AND trigger_id = $2
+                       AND active_fire_slot = $4
+                       AND active_run_ref IS NULL
+                       AND next_run_at <= $4
                      RETURNING {TRIGGER_COLUMNS}"
                 ),
-                &[&request.tenant_id.as_str(), &trigger_id, &last_status],
+                &[
+                    &request.tenant_id.as_str(),
+                    &trigger_id,
+                    &last_status,
+                    &fire_slot,
+                ],
             )
             .await
             .map_err(|error| backend_error("mark retryable trigger fire failure", error))?;
@@ -498,15 +481,9 @@ impl TriggerRepository for PostgresTriggerRepository {
         let trigger_id = request.trigger_id.to_string();
         let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
         else {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit missing permanent trigger fire", error))?;
             return Ok(None);
         };
         if record.active_fire_slot != Some(request.fire_slot) {
-            tx.commit()
-                .await
-                .map_err(|error| backend_error("commit stale permanent trigger fire", error))?;
             return Ok(None);
         }
         reject_failed_result_after_active_run(record.active_run_ref)?;
@@ -514,6 +491,7 @@ impl TriggerRepository for PostgresTriggerRepository {
 
         let last_status = status_text(TriggerRunStatus::Error);
         let next_run_at = fmt_ts(&request.next_run_at);
+        let fire_slot = fmt_ts(&request.fire_slot);
         let row = tx
             .query_one(
                 &format!(
@@ -522,7 +500,10 @@ impl TriggerRepository for PostgresTriggerRepository {
                          next_run_at = $4,
                          active_fire_slot = NULL,
                          active_run_ref = NULL
-                     WHERE tenant_id = $1 AND trigger_id = $2
+                     WHERE tenant_id = $1
+                       AND trigger_id = $2
+                       AND active_fire_slot = $5
+                       AND active_run_ref IS NULL
                      RETURNING {TRIGGER_COLUMNS}"
                 ),
                 &[
@@ -530,6 +511,7 @@ impl TriggerRepository for PostgresTriggerRepository {
                     &trigger_id,
                     &last_status,
                     &next_run_at,
+                    &fire_slot,
                 ],
             )
             .await

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1069,7 +1069,7 @@ mod fire_claim_contract {
         assert_eq!(retryable_failed.last_status, Some(TriggerRunStatus::Error));
         assert_eq!(retryable_failed.active_fire_slot, None);
         assert_eq!(retryable_failed.active_run_ref, None);
-        assert!(retryable_failed.next_run_at <= fire_slot);
+        assert_eq!(retryable_failed.next_run_at, fire_slot);
 
         let permanent_trigger_id = TriggerId::parse("01J00000000000000000000005").expect("ulid");
         let permanent_tenant_id = tenant("tenant-permanent");
@@ -1114,6 +1114,198 @@ mod fire_claim_contract {
 
     async fn assert_fire_result_rejects_invalid_next_run_at(repo: &impl TriggerRepository) {
         let fire_slot = ts(1_704_067_200);
+        let stale_fire_slot = ts(1_704_067_140);
+
+        let early_claim_trigger_id = TriggerId::parse("01J0000000000000000000000D").expect("ulid");
+        let early_claim_tenant_id = tenant("tenant-early-claim");
+        repo.upsert_trigger(sample_record(
+            early_claim_trigger_id,
+            early_claim_tenant_id.clone(),
+            fire_slot,
+        ))
+        .await
+        .expect("insert early-claim record");
+        assert!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: early_claim_tenant_id,
+                trigger_id: early_claim_trigger_id,
+                fire_slot,
+                now: ts(1_704_067_199),
+            })
+            .await
+            .expect("early claim")
+            .matches_not_due(),
+            "scheduled row must not be claimable before the requested fire slot is due"
+        );
+
+        let stale_accepted_trigger_id =
+            TriggerId::parse("01J00000000000000000000010").expect("ulid");
+        let stale_accepted_tenant_id = tenant("tenant-stale-accepted");
+        let mut stale_accepted_record = sample_record(
+            stale_accepted_trigger_id,
+            stale_accepted_tenant_id.clone(),
+            fire_slot,
+        );
+        stale_accepted_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(stale_accepted_record.clone())
+            .await
+            .expect("insert stale accepted record");
+        assert!(
+            repo.mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: stale_accepted_tenant_id.clone(),
+                trigger_id: stale_accepted_trigger_id,
+                fire_slot: stale_fire_slot,
+                run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f62")
+                    .expect("valid run"),
+                submitted_at: fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect("stale accepted update")
+            .is_none()
+        );
+        let reloaded = repo
+            .get_trigger(stale_accepted_tenant_id, stale_accepted_trigger_id)
+            .await
+            .expect("reload stale accepted")
+            .expect("record present");
+        assert_eq!(reloaded, stale_accepted_record);
+
+        let stale_replayed_trigger_id =
+            TriggerId::parse("01J00000000000000000000011").expect("ulid");
+        let stale_replayed_tenant_id = tenant("tenant-stale-replayed");
+        let mut stale_replayed_record = sample_record(
+            stale_replayed_trigger_id,
+            stale_replayed_tenant_id.clone(),
+            fire_slot,
+        );
+        stale_replayed_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(stale_replayed_record.clone())
+            .await
+            .expect("insert stale replayed record");
+        assert!(
+            repo.mark_fire_replayed(FireReplayedRequest {
+                tenant_id: stale_replayed_tenant_id.clone(),
+                trigger_id: stale_replayed_trigger_id,
+                fire_slot: stale_fire_slot,
+                original_run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f63")
+                    .expect("valid run"),
+                replayed_at: fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect("stale replayed update")
+            .is_none()
+        );
+        let reloaded = repo
+            .get_trigger(stale_replayed_tenant_id, stale_replayed_trigger_id)
+            .await
+            .expect("reload stale replayed")
+            .expect("record present");
+        assert_eq!(reloaded, stale_replayed_record);
+
+        let stale_retryable_trigger_id =
+            TriggerId::parse("01J00000000000000000000012").expect("ulid");
+        let stale_retryable_tenant_id = tenant("tenant-stale-retryable");
+        let mut stale_retryable_record = sample_record(
+            stale_retryable_trigger_id,
+            stale_retryable_tenant_id.clone(),
+            fire_slot,
+        );
+        stale_retryable_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(stale_retryable_record.clone())
+            .await
+            .expect("insert stale retryable record");
+        assert!(
+            repo.mark_fire_retryable_failed(FireRetryableFailedRequest {
+                tenant_id: stale_retryable_tenant_id.clone(),
+                trigger_id: stale_retryable_trigger_id,
+                fire_slot: stale_fire_slot,
+            })
+            .await
+            .expect("stale retryable update")
+            .is_none()
+        );
+        let reloaded = repo
+            .get_trigger(stale_retryable_tenant_id, stale_retryable_trigger_id)
+            .await
+            .expect("reload stale retryable")
+            .expect("record present");
+        assert_eq!(reloaded, stale_retryable_record);
+
+        let stale_permanent_trigger_id =
+            TriggerId::parse("01J00000000000000000000013").expect("ulid");
+        let stale_permanent_tenant_id = tenant("tenant-stale-permanent");
+        let mut stale_permanent_record = sample_record(
+            stale_permanent_trigger_id,
+            stale_permanent_tenant_id.clone(),
+            fire_slot,
+        );
+        stale_permanent_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(stale_permanent_record.clone())
+            .await
+            .expect("insert stale permanent record");
+        assert!(
+            repo.mark_fire_permanently_failed(FirePermanentFailedRequest {
+                tenant_id: stale_permanent_tenant_id.clone(),
+                trigger_id: stale_permanent_trigger_id,
+                fire_slot: stale_fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect("stale permanent update")
+            .is_none()
+        );
+        let reloaded = repo
+            .get_trigger(stale_permanent_tenant_id, stale_permanent_trigger_id)
+            .await
+            .expect("reload stale permanent")
+            .expect("record present");
+        assert_eq!(reloaded, stale_permanent_record);
+
+        let accepted_trigger_id = TriggerId::parse("01J0000000000000000000000E").expect("ulid");
+        let accepted_tenant_id = tenant("tenant-invalid-accepted");
+        let mut accepted_record =
+            sample_record(accepted_trigger_id, accepted_tenant_id.clone(), fire_slot);
+        accepted_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(accepted_record)
+            .await
+            .expect("insert invalid accepted record");
+        let error = repo
+            .mark_fire_accepted(FireAcceptedRequest {
+                tenant_id: accepted_tenant_id,
+                trigger_id: accepted_trigger_id,
+                fire_slot,
+                run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f60")
+                    .expect("valid run"),
+                submitted_at: fire_slot,
+                next_run_at: fire_slot,
+            })
+            .await
+            .expect_err("accepted result rejects non-future next_run_at");
+        assert_error_contains(error, "must be after the claimed fire slot");
+
+        let replayed_trigger_id = TriggerId::parse("01J0000000000000000000000F").expect("ulid");
+        let replayed_tenant_id = tenant("tenant-invalid-replayed");
+        let mut replayed_record =
+            sample_record(replayed_trigger_id, replayed_tenant_id.clone(), fire_slot);
+        replayed_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(replayed_record)
+            .await
+            .expect("insert invalid replayed record");
+        let error = repo
+            .mark_fire_replayed(FireReplayedRequest {
+                tenant_id: replayed_tenant_id,
+                trigger_id: replayed_trigger_id,
+                fire_slot,
+                original_run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f61")
+                    .expect("valid run"),
+                replayed_at: fire_slot,
+                next_run_at: fire_slot,
+            })
+            .await
+            .expect_err("replayed result rejects non-future next_run_at");
+        assert_error_contains(error, "must be after the claimed fire slot");
 
         let retryable_trigger_id = TriggerId::parse("01J00000000000000000000007").expect("ulid");
         let retryable_tenant_id = tenant("tenant-invalid-retryable");
@@ -1399,6 +1591,85 @@ mod fire_claim_contract {
         );
     }
 
+    async fn assert_durable_claim_is_atomic<R>(repo: std::sync::Arc<R>)
+    where
+        R: TriggerRepository + 'static,
+    {
+        let trigger_id = TriggerId::parse("01J0000000000000000000000C").expect("ulid");
+        let tenant_id = tenant("tenant-atomic");
+        let fire_slot = ts(1_704_067_200);
+        let now = fire_slot;
+        repo.upsert_trigger(sample_record(trigger_id, tenant_id.clone(), fire_slot))
+            .await
+            .expect("insert atomic record");
+
+        let first_repo = repo.clone();
+        let second_repo = repo.clone();
+        let first_tenant_id = tenant_id.clone();
+        let second_tenant_id = tenant_id;
+        let first = async move {
+            tokio::task::yield_now().await;
+            first_repo
+                .claim_due_fire(ClaimDueFireRequest {
+                    tenant_id: first_tenant_id,
+                    trigger_id,
+                    fire_slot,
+                    now,
+                })
+                .await
+        };
+        let second = async move {
+            tokio::task::yield_now().await;
+            second_repo
+                .claim_due_fire(ClaimDueFireRequest {
+                    tenant_id: second_tenant_id,
+                    trigger_id,
+                    fire_slot,
+                    now,
+                })
+                .await
+        };
+
+        let (first, second) = tokio::join!(first, second);
+        let outcomes = [first.expect("first claim"), second.expect("second claim")];
+
+        let claimed = outcomes
+            .iter()
+            .find_map(|outcome| match outcome {
+                ClaimDueFireOutcome::Claimed(claimed) => Some(claimed.clone()),
+                _ => None,
+            })
+            .expect("one poller must claim the fire");
+        let already_active_count = outcomes
+            .iter()
+            .filter(|outcome| {
+                matches!(
+                    outcome,
+                    ClaimDueFireOutcome::AlreadyActive {
+                        active_fire_slot: Some(slot),
+                        active_run_ref: None,
+                    } if *slot == fire_slot
+                )
+            })
+            .count();
+
+        assert_eq!(
+            already_active_count, 1,
+            "one poller must observe the active claim"
+        );
+        assert_eq!(claimed.fire_slot, fire_slot);
+        assert_eq!(claimed.record.active_fire_slot, Some(fire_slot));
+        assert_eq!(claimed.record.active_run_ref, None);
+
+        let persisted = repo
+            .get_trigger(tenant("tenant-atomic"), trigger_id)
+            .await
+            .expect("reload atomic record")
+            .expect("record present");
+        assert_eq!(persisted.active_fire_slot, Some(fire_slot));
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
     trait ClaimDueFireOutcomeAssertions {
         fn matches_not_found(&self) -> bool;
         fn matches_not_due(&self) -> bool;
@@ -1433,74 +1704,10 @@ mod fire_claim_contract {
         }
     }
 
-    async fn assert_durable_fire_claim_defaults_to_pr13(repo: &impl TriggerRepository) {
-        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
-        let tenant_id = tenant("tenant-a");
-        let fire_slot = ts(1_704_067_200);
-        assert_pr13_backend_error(
-            repo.claim_due_fire(ClaimDueFireRequest {
-                tenant_id: tenant_id.clone(),
-                trigger_id,
-                fire_slot,
-                now: fire_slot,
-            })
-            .await
-            .expect_err("durable claim implementation lands in PR13"),
-        );
-        assert_pr13_backend_error(
-            repo.mark_fire_accepted(FireAcceptedRequest {
-                tenant_id: tenant_id.clone(),
-                trigger_id,
-                fire_slot,
-                run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a")
-                    .expect("valid run"),
-                submitted_at: fire_slot,
-                next_run_at: ts(1_704_067_260),
-            })
-            .await
-            .expect_err("durable accepted implementation lands in PR13"),
-        );
-        assert_pr13_backend_error(
-            repo.mark_fire_replayed(FireReplayedRequest {
-                tenant_id: tenant_id.clone(),
-                trigger_id,
-                fire_slot,
-                original_run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a")
-                    .expect("valid run"),
-                replayed_at: fire_slot,
-                next_run_at: ts(1_704_067_260),
-            })
-            .await
-            .expect_err("durable replayed implementation lands in PR13"),
-        );
-        assert_pr13_backend_error(
-            repo.mark_fire_retryable_failed(FireRetryableFailedRequest {
-                tenant_id: tenant_id.clone(),
-                trigger_id,
-                fire_slot,
-            })
-            .await
-            .expect_err("durable retryable failure implementation lands in PR13"),
-        );
-        assert_pr13_backend_error(
-            repo.mark_fire_permanently_failed(FirePermanentFailedRequest {
-                tenant_id,
-                trigger_id,
-                fire_slot,
-                next_run_at: ts(1_704_067_260),
-            })
-            .await
-            .expect_err("durable permanent failure implementation lands in PR13"),
-        );
-    }
-
-    fn assert_pr13_backend_error(error: TriggerError) {
-        assert!(
-            error
-                .to_string()
-                .contains("atomic trigger fire claim persistence for this backend lands in PR 13"),
-            "unexpected durable default error: {error}"
-        );
+    async fn assert_durable_fire_claim_contract(repo: &impl TriggerRepository) {
+        assert_fire_claim_and_update_contract(repo).await;
+        assert_fire_claim_exclusions_and_active_gate_contract(repo).await;
+        assert_fire_result_rejects_invalid_next_run_at(repo).await;
     }
 
     fn assert_error_contains(error: TriggerError, expected: &str) {
@@ -1522,7 +1729,14 @@ mod fire_claim_contract {
     #[tokio::test]
     async fn libsql_repository_fire_claim_contract() {
         let (_dir, repo) = build_libsql_repo().await;
-        assert_durable_fire_claim_defaults_to_pr13(&repo).await;
+        assert_durable_fire_claim_contract(&repo).await;
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn libsql_repository_fire_claim_is_atomic() {
+        let (_dir, repo) = build_libsql_repo().await;
+        assert_durable_claim_is_atomic(std::sync::Arc::new(repo)).await;
     }
 
     #[cfg(feature = "postgres")]
@@ -1533,7 +1747,19 @@ mod fire_claim_contract {
         };
         let repo = PostgresTriggerRepository::new(pool.clone());
         repo.run_migrations().await.expect("run migrations");
-        assert_durable_fire_claim_defaults_to_pr13(&repo).await;
+        assert_durable_fire_claim_contract(&repo).await;
+        clear_postgres_triggers(&pool).await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn postgres_repository_fire_claim_is_atomic() {
+        let Some((_container, pool)) = postgres_pool_or_skip().await else {
+            return;
+        };
+        let repo = PostgresTriggerRepository::new(pool.clone());
+        repo.run_migrations().await.expect("run migrations");
+        assert_durable_claim_is_atomic(std::sync::Arc::new(repo)).await;
         clear_postgres_triggers(&pool).await;
     }
 }

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1739,6 +1739,151 @@ mod fire_claim_contract {
         assert_durable_claim_is_atomic(std::sync::Arc::new(repo)).await;
     }
 
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn libsql_repository_mark_fire_accepted_is_idempotent_under_concurrency() {
+        let (_dir, repo) = build_libsql_repo().await;
+        let repo = std::sync::Arc::new(repo);
+        let trigger_id = TriggerId::parse("01J00000000000000000000014").expect("ulid");
+        let tenant_id = tenant("tenant-accepted-concurrent");
+        let fire_slot = ts(1_704_067_200);
+        let accepted_at = ts(1_704_067_205);
+        let record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
+        let next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next slot calculation")
+            .expect("future slot");
+        repo.upsert_trigger(record).await.expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f64").expect("valid run");
+        let request = FireAcceptedRequest {
+            tenant_id: tenant_id.clone(),
+            trigger_id,
+            fire_slot,
+            run_id,
+            submitted_at: accepted_at,
+            next_run_at,
+        };
+        let first_repo = repo.clone();
+        let second_repo = repo.clone();
+        let first_request = request.clone();
+        let second_request = request;
+        let first = async move {
+            tokio::task::yield_now().await;
+            first_repo.mark_fire_accepted(first_request).await
+        };
+        let second = async move {
+            tokio::task::yield_now().await;
+            second_repo.mark_fire_accepted(second_request).await
+        };
+
+        let (first, second) = tokio::join!(first, second);
+        let first = first
+            .expect("first accepted result")
+            .expect("first accepted record");
+        let second = second
+            .expect("second accepted result")
+            .expect("second accepted record");
+        assert_eq!(first, second);
+        assert_eq!(first.active_fire_slot, Some(fire_slot));
+        assert_eq!(first.active_run_ref, Some(run_id));
+        assert_eq!(first.last_run_at, Some(accepted_at));
+        assert_eq!(first.last_fired_slot, Some(fire_slot));
+        assert_eq!(first.last_status, Some(TriggerRunStatus::Ok));
+
+        let persisted = repo
+            .get_trigger(tenant_id, trigger_id)
+            .await
+            .expect("reload accepted result")
+            .expect("record present");
+        assert_eq!(persisted, first);
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn libsql_repository_mark_fire_replayed_is_idempotent_under_concurrency() {
+        let (_dir, repo) = build_libsql_repo().await;
+        let repo = std::sync::Arc::new(repo);
+        let trigger_id = TriggerId::parse("01J00000000000000000000015").expect("ulid");
+        let tenant_id = tenant("tenant-replayed-concurrent");
+        let fire_slot = ts(1_704_067_200);
+        let replayed_at = ts(1_704_067_205);
+        let record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
+        let next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next slot calculation")
+            .expect("future slot");
+        repo.upsert_trigger(record).await.expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+
+        let original_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f65").expect("valid run");
+        let request = FireReplayedRequest {
+            tenant_id: tenant_id.clone(),
+            trigger_id,
+            fire_slot,
+            original_run_id,
+            replayed_at,
+            next_run_at,
+        };
+        let first_repo = repo.clone();
+        let second_repo = repo.clone();
+        let first_request = request.clone();
+        let second_request = request;
+        let first = async move {
+            tokio::task::yield_now().await;
+            first_repo.mark_fire_replayed(first_request).await
+        };
+        let second = async move {
+            tokio::task::yield_now().await;
+            second_repo.mark_fire_replayed(second_request).await
+        };
+
+        let (first, second) = tokio::join!(first, second);
+        let first = first
+            .expect("first replayed result")
+            .expect("first replayed record");
+        let second = second
+            .expect("second replayed result")
+            .expect("second replayed record");
+        assert_eq!(first, second);
+        assert_eq!(first.active_fire_slot, Some(fire_slot));
+        assert_eq!(first.active_run_ref, Some(original_run_id));
+        assert_eq!(first.last_run_at, Some(replayed_at));
+        assert_eq!(first.last_fired_slot, Some(fire_slot));
+        assert_eq!(first.last_status, Some(TriggerRunStatus::Ok));
+
+        let persisted = repo
+            .get_trigger(tenant_id, trigger_id)
+            .await
+            .expect("reload replayed result")
+            .expect("record present");
+        assert_eq!(persisted, first);
+    }
+
     #[cfg(feature = "postgres")]
     #[tokio::test]
     async fn postgres_repository_fire_claim_contract() {


### PR DESCRIPTION
## Summary

PR13 implements durable trigger fire claim persistence for both durable backends:

- adds PostgreSQL `claim_due_fire` and fire-result update implementations using transactions and row locks;
- adds libSQL `claim_due_fire` and fire-result update implementations using guarded `UPDATE ... RETURNING` CAS-style writes on hot paths;
- removes the temporary trait default errors so `TriggerRepository` implementations must provide the claim/update surface;
- replaces the PR12 durable placeholder tests with shared fire-claim parity coverage and durable atomic-claim tests.

## Contract Notes

- Preserves PR12 state-first eligibility: `Paused`, `Completed`, future `next_run_at`, wrong fire slot, and `now < fire_slot` return `NotDue` before stale active metadata is considered.
- Uses `active_fire_slot` plus `active_run_ref` for active-fire back-pressure; `last_status` remains synchronous outcome metadata only.
- Accepted/replayed submit results are idempotent for the same `TurnRunId` and reject rewrites for a different run id.
- Retryable/permanent submit failures reject attempts to clear an already accepted `active_run_ref`.
- Retryable failures clear active fields, write `last_status = Error`, and leave the fire retryable at the same slot.
- Permanent failures clear active fields, write `last_status = Error`, and require/advance `next_run_at` beyond the failed slot.

## Tests / Verification

- `cargo test -p ironclaw_triggers --features libsql --test repository_contract`
- `cargo test -p ironclaw_triggers --features postgres --test repository_contract --no-run`
- `cargo test -p ironclaw_triggers --features postgres --test repository_contract postgres_repository_fire_claim -- --nocapture`
- `cargo test -p ironclaw_triggers --all-features`
- `cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `git diff --check`

Note: live PostgreSQL test execution skipped locally where Docker was unavailable; the Postgres feature test binary compiles, and the harness cleanly skips when `/var/run/docker.sock` is absent.

## Review

- Implementation used 5.4-mini subagents split by backend/tests plus one read-only ownership-boundary verifier.
- `$code-review` was run in two rounds with 5.4-mini reviewer agents.
- Round 1 fixes added shared coverage for `now < fire_slot` and accepted/replayed `next_run_at <= fire_slot`.
- Round 2 fixes changed libSQL hot paths from broad `BEGIN IMMEDIATE` full-row rewrites to narrow guarded updates and added stale fire-slot result coverage.
- Remaining maintainability comments were readability/refactor suggestions, not correctness blockers; they are intentionally left out of this PR to keep the durable semantics slice focused.
