### PR TITLE
[codex] Fix durable auth gate manual-token resume

### DIFF
--- a/crates/ironclaw_auth/src/credential.rs
+++ b/crates/ironclaw_auth/src/credential.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, fmt, sync::Arc, sync::Mutex};
 
 use async_trait::async_trait;
-use ironclaw_host_api::{ExtensionId, SecretHandle};
+use ironclaw_host_api::{
+    AgentId, ExtensionId, MissionId, ProjectId, SecretHandle, TenantId, ThreadId, UserId,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::OwnedMutexGuard;
 
@@ -93,6 +95,19 @@ impl CredentialAccount {
             owner_extension: self.owner_extension.clone(),
             granted_extensions: self.granted_extensions.clone(),
             secret_handle_count,
+        }
+    }
+
+    pub fn is_authorized_for_requester(&self, requester_extension: Option<&ExtensionId>) -> bool {
+        match self.ownership {
+            CredentialOwnership::UserReusable => true,
+            CredentialOwnership::ExtensionOwned => self
+                .owner_extension
+                .as_ref()
+                .is_some_and(|owner_extension| requester_extension == Some(owner_extension)),
+            CredentialOwnership::SharedAdminManaged => requester_extension
+                .is_some_and(|requester| self.granted_extensions.contains(requester)),
+            CredentialOwnership::System => false,
         }
     }
 }
@@ -511,6 +526,89 @@ pub trait CredentialAccountService: Send + Sync {
         &self,
         request: CredentialRefreshRequest,
     ) -> Result<CredentialRefreshReport, AuthProductError>;
+}
+
+/// Stable credential-account owner fields used by read models that need to
+/// find accounts across transient invocation ids or product surfaces.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialAccountOwnerScope {
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+    pub agent_id: Option<AgentId>,
+    pub project_id: Option<ProjectId>,
+    pub mission_id: Option<MissionId>,
+    pub thread_id: Option<ThreadId>,
+    pub session_id: Option<crate::AuthSessionId>,
+}
+
+impl CredentialAccountOwnerScope {
+    pub fn from_scope(scope: &AuthProductScope) -> Self {
+        Self {
+            tenant_id: scope.resource.tenant_id.clone(),
+            user_id: scope.resource.user_id.clone(),
+            agent_id: scope.resource.agent_id.clone(),
+            project_id: scope.resource.project_id.clone(),
+            mission_id: scope.resource.mission_id.clone(),
+            thread_id: scope.resource.thread_id.clone(),
+            session_id: scope.session_id.clone(),
+        }
+    }
+
+    pub fn matches(&self, account: &CredentialAccount) -> bool {
+        let resource = &account.scope.resource;
+        resource.tenant_id == self.tenant_id
+            && resource.user_id == self.user_id
+            && resource.agent_id == self.agent_id
+            && resource.project_id == self.project_id
+            && resource.mission_id == self.mission_id
+            && resource.thread_id == self.thread_id
+            && self
+                .session_id
+                .as_ref()
+                .is_none_or(|session_id| account.scope.session_id.as_ref() == Some(session_id))
+    }
+}
+
+/// Read-only credential-account projection source for account owner queries.
+///
+/// This intentionally does not encode host-runtime credential selection. It
+/// only exposes accounts owned by a stable product-auth owner; composition
+/// layers decide which account, provider, or requester policy to apply.
+#[async_trait]
+pub trait CredentialAccountRecordSource: Send + Sync {
+    async fn accounts_for_owner(
+        &self,
+        scope: &AuthProductScope,
+    ) -> Result<Vec<CredentialAccount>, AuthProductError>;
+
+    async fn select_unique_configured_account_for_owner(
+        &self,
+        request: CredentialAccountSelectionRequest,
+    ) -> Result<CredentialAccount, AuthProductError> {
+        let configured = self
+            .accounts_for_owner(&request.scope)
+            .await?
+            .into_iter()
+            .filter(|account| {
+                account.provider == request.provider
+                    && account.status == CredentialAccountStatus::Configured
+            })
+            .collect::<Vec<_>>();
+        if configured.is_empty() {
+            return Err(AuthProductError::CredentialMissing);
+        }
+        let selectable = configured
+            .into_iter()
+            .filter(|account| {
+                account.is_authorized_for_requester(request.requester_extension.as_ref())
+            })
+            .collect::<Vec<_>>();
+        match selectable.as_slice() {
+            [] => Err(AuthProductError::CrossScopeDenied),
+            [account] => Ok(account.clone()),
+            _ => Err(AuthProductError::AccountSelectionRequired),
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/ironclaw_auth/src/domain.rs
+++ b/crates/ironclaw_auth/src/domain.rs
@@ -4,8 +4,8 @@ use crate::{
     AuthChallenge, AuthErrorCode, AuthFlowRecord, AuthFlowStatus, AuthProductError,
     CredentialAccount, CredentialAccountUpdateBinding, CredentialOwnership, CredentialRecoveryKind,
     CredentialRecoveryProjection, CredentialRecoveryReason, CredentialRefreshRequest,
-    CredentialSelectionInput, ManualTokenSetupRequest, NewAuthFlow, NewCredentialAccount,
-    OAuthCallbackClaimRequest, OAuthProviderExchange, Timestamp,
+    CredentialSelectionInput, ManualTokenCompletionInput, ManualTokenSetupRequest, NewAuthFlow,
+    NewCredentialAccount, OAuthCallbackClaimRequest, OAuthProviderExchange, Timestamp,
     flow::credential_status_for_completed_flow, scope_matches,
 };
 
@@ -126,6 +126,51 @@ pub fn validate_selection_flow(
             && account.status == crate::CredentialAccountStatus::Configured
     }) {
         return Err(AuthProductError::CredentialMissing);
+    }
+    Ok(())
+}
+
+pub fn validate_manual_token_flow(
+    record: &mut AuthFlowRecord,
+    scope: &crate::AuthProductScope,
+    input: &ManualTokenCompletionInput,
+    now: Timestamp,
+) -> Result<(), AuthProductError> {
+    if !scope_matches(scope, &record.scope) {
+        return Err(AuthProductError::CrossScopeDenied);
+    }
+    let Some(AuthChallenge::ManualTokenRequired {
+        interaction_id,
+        provider,
+        ..
+    }) = &record.challenge
+    else {
+        return Err(AuthProductError::invalid_request(
+            "auth flow is not awaiting manual token",
+        ));
+    };
+    if interaction_id != &input.interaction_id {
+        return Err(AuthProductError::CrossScopeDenied);
+    }
+    if provider != &record.provider {
+        return Err(AuthProductError::invalid_request(
+            "auth flow manual-token provider mismatch",
+        ));
+    }
+    if crate::is_terminal_status(record.status) {
+        return match (record.status, record.credential_account_id) {
+            (AuthFlowStatus::Completed, Some(completed))
+                if completed == input.credential_account_id =>
+            {
+                Ok(())
+            }
+            (AuthFlowStatus::Canceled, _) => Err(AuthProductError::Canceled),
+            _ => Err(AuthProductError::FlowAlreadyTerminal),
+        };
+    }
+    expire_if_needed(record, now)?;
+    if record.status != AuthFlowStatus::AwaitingUser {
+        return Err(AuthProductError::FlowAlreadyTerminal);
     }
     Ok(())
 }
@@ -266,16 +311,7 @@ pub fn account_is_authorized_for_requester(
     account: &CredentialAccount,
     requester_extension: Option<&ExtensionId>,
 ) -> bool {
-    match account.ownership {
-        CredentialOwnership::UserReusable => true,
-        CredentialOwnership::ExtensionOwned => account
-            .owner_extension
-            .as_ref()
-            .is_some_and(|owner_extension| requester_extension == Some(owner_extension)),
-        CredentialOwnership::SharedAdminManaged => requester_extension
-            .is_some_and(|requester| account.granted_extensions.contains(requester)),
-        CredentialOwnership::System => false,
-    }
+    account.is_authorized_for_requester(requester_extension)
 }
 
 pub fn validate_new_credential_account(

--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -10,17 +10,18 @@ use crate::{
     AuthFlowRecordSource, AuthFlowStatus, AuthInteractionId, AuthInteractionService,
     AuthProductError, AuthProviderClient, CredentialAccount, CredentialAccountChoiceRequest,
     CredentialAccountId, CredentialAccountListPage, CredentialAccountListRequest,
-    CredentialAccountLookupRequest, CredentialAccountMutation, CredentialAccountProjection,
-    CredentialAccountSelectionRequest, CredentialAccountService, CredentialAccountStatus,
-    CredentialOwnership, CredentialRecoveryProjection, CredentialRecoveryReason,
-    CredentialRecoveryRequest, CredentialRefreshReport, CredentialRefreshRequest,
-    CredentialSelectionInput, CredentialSetupService, ManualTokenSetupRequest, NewAuthFlow,
+    CredentialAccountLookupRequest, CredentialAccountMutation, CredentialAccountOwnerScope,
+    CredentialAccountProjection, CredentialAccountRecordSource, CredentialAccountSelectionRequest,
+    CredentialAccountService, CredentialAccountStatus, CredentialOwnership,
+    CredentialRecoveryProjection, CredentialRecoveryReason, CredentialRecoveryRequest,
+    CredentialRefreshReport, CredentialRefreshRequest, CredentialSelectionInput,
+    CredentialSetupService, ManualTokenCompletionInput, ManualTokenSetupRequest, NewAuthFlow,
     NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
     OAuthProviderCallbackRequest, OAuthProviderExchange, OAuthProviderExchangeContext,
     OAuthProviderRefresh, OAuthProviderRefreshRequest, ProviderCallbackOutcome,
     SecretCleanupAction, SecretCleanupQuarantine, SecretCleanupQuarantineReason,
     SecretCleanupReport, SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest,
-    SecretSubmitResult, Timestamp,
+    SecretSubmitResult, Timestamp, TurnGateAuthFlowQuery,
     cleanup::SecretCleanupAction::Deactivate,
     domain::{
         PreparedCallbackFlow, account_is_authorized_for_requester, prepare_callback_flow,
@@ -28,10 +29,11 @@ use crate::{
         update_account_from_exchange, update_account_from_request, validate_account_update_target,
         validate_bound_update_authority, validate_callback_claim,
         validate_credential_status_transition, validate_flow_update_binding,
-        validate_manual_token_update_binding, validate_new_credential_account,
-        validate_refresh_target, validate_selection_flow,
+        validate_manual_token_flow, validate_manual_token_update_binding,
+        validate_new_credential_account, validate_refresh_target, validate_selection_flow,
     },
     flow::credential_status_for_completed_flow,
+    flow_matches_turn_gate_query,
     interaction::PendingSecretInteraction,
     provider::validate_provider_callback_request,
     scope_matches,
@@ -108,17 +110,33 @@ impl InMemoryAuthProductServices {
     }
 }
 
+#[async_trait]
 impl AuthFlowRecordSource for InMemoryAuthProductServices {
-    fn flow_records_snapshot(&self) -> Vec<AuthFlowRecord> {
-        Self::flow_records_snapshot(self)
+    async fn flow_for_turn_gate(
+        &self,
+        query: TurnGateAuthFlowQuery,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        let state = self.lock_state();
+        Ok(state
+            .flows
+            .values()
+            .find(|flow| flow_matches_turn_gate_query(flow, &query))
+            .cloned())
     }
 
-    fn flow_record_matching(
+    async fn flows_for_owner(
         &self,
-        predicate: &mut dyn FnMut(&AuthFlowRecord) -> bool,
-    ) -> Option<AuthFlowRecord> {
+        owner: crate::AuthFlowOwnerScope,
+    ) -> Result<Vec<AuthFlowRecord>, AuthProductError> {
         let state = self.lock_state();
-        state.flows.values().find(|flow| predicate(flow)).cloned()
+        let mut flows = state
+            .flows
+            .values()
+            .filter(|flow| owner.matches(flow))
+            .cloned()
+            .collect::<Vec<_>>();
+        flows.sort_by_key(|flow| flow.id);
+        Ok(flows)
     }
 }
 
@@ -295,6 +313,97 @@ impl AuthFlowManager for InMemoryAuthProductServices {
             emitted_at: now,
         });
         Ok(completed)
+    }
+
+    async fn complete_manual_token(
+        &self,
+        scope: &crate::AuthProductScope,
+        input: ManualTokenCompletionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        let now = Utc::now();
+        let mut state = self.lock_state();
+        let flow_id = state
+            .flows
+            .iter()
+            .find_map(|(flow_id, record)| {
+                let matches_interaction = matches!(
+                    &record.challenge,
+                    Some(AuthChallenge::ManualTokenRequired { interaction_id, .. })
+                        if interaction_id == &input.interaction_id
+                );
+                matches_interaction.then_some(*flow_id)
+            })
+            .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
+        let (flow_scope, flow_provider) = {
+            let record = state
+                .flows
+                .get_mut(&flow_id)
+                .ok_or(AuthProductError::BackendUnavailable)?;
+            validate_manual_token_flow(record, scope, &input, now)?;
+            if record.status == AuthFlowStatus::Completed {
+                return Ok(record.clone());
+            }
+            (record.scope.clone(), record.provider.clone())
+        };
+        let account = state
+            .accounts
+            .get(&input.credential_account_id)
+            .ok_or(AuthProductError::CredentialMissing)?;
+        if !scope_matches(&flow_scope, &account.scope) || account.provider != flow_provider {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if account.status != CredentialAccountStatus::Configured {
+            return Err(AuthProductError::CredentialMissing);
+        }
+        let record = state
+            .flows
+            .get_mut(&flow_id)
+            .ok_or(AuthProductError::BackendUnavailable)?;
+        record.status = AuthFlowStatus::Completed;
+        record.error = None;
+        record.credential_account_id = Some(input.credential_account_id);
+        record.updated_at = now;
+        let completed = record.clone();
+        state.continuations.push(AuthContinuationEvent {
+            flow_id: completed.id,
+            scope: completed.scope.clone(),
+            continuation: completed.continuation.clone(),
+            credential_account_id: completed.credential_account_id,
+            emitted_at: now,
+        });
+        Ok(completed)
+    }
+
+    async fn cancel_manual_token(
+        &self,
+        scope: &crate::AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        let now = Utc::now();
+        let mut state = self.lock_state();
+        let Some(flow_id) = state.flows.iter().find_map(|(flow_id, record)| {
+            let matches_interaction = matches!(
+                &record.challenge,
+                Some(AuthChallenge::ManualTokenRequired { interaction_id: id, .. })
+                    if id == &interaction_id
+            );
+            matches_interaction.then_some(*flow_id)
+        }) else {
+            return Ok(None);
+        };
+        let record = state
+            .flows
+            .get_mut(&flow_id)
+            .ok_or(AuthProductError::BackendUnavailable)?;
+        if !scope_matches(scope, &record.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if !crate::is_terminal_status(record.status) {
+            record.status = AuthFlowStatus::Canceled;
+            record.error = Some(crate::AuthErrorCode::Canceled);
+            record.updated_at = now;
+        }
+        Ok(Some(record.clone()))
     }
 
     async fn fail_oauth_callback(
@@ -663,6 +772,25 @@ impl CredentialAccountService for InMemoryAuthProductServices {
             }
             Err(error) => Err(error),
         }
+    }
+}
+
+#[async_trait]
+impl CredentialAccountRecordSource for InMemoryAuthProductServices {
+    async fn accounts_for_owner(
+        &self,
+        scope: &crate::AuthProductScope,
+    ) -> Result<Vec<CredentialAccount>, AuthProductError> {
+        let owner = CredentialAccountOwnerScope::from_scope(scope);
+        let state = self.lock_state();
+        let mut accounts = state
+            .accounts
+            .values()
+            .filter(|account| owner.matches(account))
+            .cloned()
+            .collect::<Vec<_>>();
+        accounts.sort_by_key(|account| account.id);
+        Ok(accounts)
     }
 }
 

--- a/crates/ironclaw_auth/src/flow.rs
+++ b/crates/ironclaw_auth/src/flow.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use ironclaw_host_api::ExtensionId;
+use ironclaw_host_api::{AgentId, ExtensionId, ProjectId, TenantId, ThreadId, UserId};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -135,6 +135,40 @@ pub struct AuthFlowRecord {
     pub expires_at: Timestamp,
 }
 
+/// Stable owner fields used by read models that project auth flows.
+///
+/// Invocation id, surface, session, and mission are intentionally excluded:
+/// they describe how setup happened, not who owns the blocked auth interaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthFlowOwnerScope {
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+    pub agent_id: Option<AgentId>,
+    pub project_id: Option<ProjectId>,
+    pub thread_id: ThreadId,
+}
+
+impl AuthFlowOwnerScope {
+    pub fn matches(&self, flow: &AuthFlowRecord) -> bool {
+        let resource = &flow.scope.resource;
+        resource.tenant_id == self.tenant_id
+            && resource.user_id == self.user_id
+            && resource.agent_id == self.agent_id
+            && resource.project_id == self.project_id
+            && resource.mission_id.is_none()
+            && resource.thread_id.as_ref() == Some(&self.thread_id)
+    }
+}
+
+/// Query for one auth flow that backs a blocked turn gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnGateAuthFlowQuery {
+    pub owner: AuthFlowOwnerScope,
+    pub turn_run_ref: TurnRunRef,
+    pub gate_ref: AuthGateRef,
+    pub include_terminal: bool,
+}
+
 /// Input used to create an auth flow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewAuthFlow {
@@ -184,6 +218,13 @@ pub struct CredentialSelectionInput {
     pub credential_account_id: CredentialAccountId,
 }
 
+/// User-submitted manual token that completed a manual-token auth flow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManualTokenCompletionInput {
+    pub interaction_id: AuthInteractionId,
+    pub credential_account_id: CredentialAccountId,
+}
+
 /// Pre-egress claim for an authorized OAuth callback. This validates and marks
 /// the scoped flow before one-shot provider exchange can consume a raw code.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -222,6 +263,18 @@ pub trait AuthFlowManager: Send + Sync {
         input: CredentialSelectionInput,
     ) -> Result<AuthFlowRecord, AuthProductError>;
 
+    async fn complete_manual_token(
+        &self,
+        scope: &AuthProductScope,
+        input: ManualTokenCompletionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError>;
+
+    async fn cancel_manual_token(
+        &self,
+        scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError>;
+
     async fn fail_oauth_callback(
         &self,
         scope: &AuthProductScope,
@@ -247,32 +300,33 @@ pub trait AuthFlowManager: Send + Sync {
 /// This is intentionally smaller than [`AuthFlowManager`]: callers can list
 /// sanitized flow records for scoped read-model composition, but cannot mutate
 /// auth-flow state or bypass manager validation.
+#[async_trait]
 pub trait AuthFlowRecordSource: Send + Sync {
-    /// Returns a durable snapshot of auth-flow records.
-    ///
-    /// Implementations may return a broader snapshot than the caller's
-    /// current scope. Any consumer that projects these records into
-    /// product/user-facing views must scope-filter before exposing them.
-    fn flow_records_snapshot(&self) -> Vec<AuthFlowRecord>;
-
-    /// Returns the first flow record matching `predicate`.
-    ///
-    /// Implementations with an indexed or locked in-memory backing store can
-    /// avoid cloning unrelated flow records for single-record projection
-    /// lookups. The default keeps the trait backward-compatible.
-    ///
-    /// # Performance
-    ///
-    /// The default falls back to [`Self::flow_records_snapshot`], which may
-    /// allocate and clone every record before filtering. Non-trivial stores MUST
-    /// override this method so hot projection paths do not do an O(N) clone per
-    /// lookup.
-    fn flow_record_matching(
+    async fn flow_for_turn_gate(
         &self,
-        predicate: &mut dyn FnMut(&AuthFlowRecord) -> bool,
-    ) -> Option<AuthFlowRecord> {
-        self.flow_records_snapshot().into_iter().find(predicate)
+        query: TurnGateAuthFlowQuery,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError>;
+
+    async fn flows_for_owner(
+        &self,
+        owner: AuthFlowOwnerScope,
+    ) -> Result<Vec<AuthFlowRecord>, AuthProductError>;
+}
+
+pub fn flow_matches_turn_gate_query(flow: &AuthFlowRecord, query: &TurnGateAuthFlowQuery) -> bool {
+    if !query.include_terminal && crate::is_terminal_status(flow.status) {
+        return false;
     }
+    if !query.owner.matches(flow) {
+        return false;
+    }
+    matches!(
+        &flow.continuation,
+        AuthContinuationRef::TurnGateResume {
+            turn_run_ref,
+            gate_ref,
+        } if turn_run_ref == &query.turn_run_ref && gate_ref == &query.gate_ref
+    )
 }
 
 pub fn credential_status_for_completed_flow() -> CredentialAccountStatus {

--- a/crates/ironclaw_auth/src/lib.rs
+++ b/crates/ironclaw_auth/src/lib.rs
@@ -28,8 +28,9 @@ pub use cleanup::{
 pub use credential::{
     CredentialAccount, CredentialAccountChoiceRequest, CredentialAccountListPage,
     CredentialAccountListRequest, CredentialAccountLookupRequest, CredentialAccountMutation,
-    CredentialAccountProjection, CredentialAccountSelectionRequest, CredentialAccountService,
-    CredentialAccountStatus, CredentialAccountUpdate, CredentialOwnership, CredentialRecoveryKind,
+    CredentialAccountOwnerScope, CredentialAccountProjection, CredentialAccountRecordSource,
+    CredentialAccountSelectionRequest, CredentialAccountService, CredentialAccountStatus,
+    CredentialAccountUpdate, CredentialOwnership, CredentialRecoveryKind,
     CredentialRecoveryProjection, CredentialRecoveryReason, CredentialRecoveryRequest,
     CredentialRecoveryState, CredentialRefreshReport, CredentialRefreshRequest,
     CredentialSetupService, NewCredentialAccount, ProviderBackedCredentialAccountService,
@@ -38,9 +39,11 @@ pub use error::{AuthErrorCode, AuthProductError};
 pub use fakes::InMemoryAuthProductServices;
 pub use flow::{
     AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthFlowKind, AuthFlowManager,
-    AuthFlowRecord, AuthFlowRecordSource, AuthFlowStatus, CredentialAccountUpdateBinding,
-    CredentialSelectionInput, NewAuthFlow, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
-    OAuthCallbackInput, ProviderCallbackOutcome, credential_status_for_completed_flow,
+    AuthFlowOwnerScope, AuthFlowRecord, AuthFlowRecordSource, AuthFlowStatus,
+    CredentialAccountUpdateBinding, CredentialSelectionInput, ManualTokenCompletionInput,
+    NewAuthFlow, OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
+    ProviderCallbackOutcome, TurnGateAuthFlowQuery, credential_status_for_completed_flow,
+    flow_matches_turn_gate_query,
 };
 pub use ids::{
     AuthFlowId, AuthGateRef, AuthInteractionId, AuthProviderId, AuthSessionId,

--- a/crates/ironclaw_auth/src/scope.rs
+++ b/crates/ironclaw_auth/src/scope.rs
@@ -15,6 +15,18 @@ pub enum AuthSurface {
     Callback,
 }
 
+impl AuthSurface {
+    pub const ALL: [Self; 7] = [
+        Self::Api,
+        Self::Callback,
+        Self::Web,
+        Self::Chat,
+        Self::Cli,
+        Self::Tui,
+        Self::SetupAdmin,
+    ];
+}
+
 /// Scoped product auth owner.
 ///
 /// Durable implementations should key records by this scope plus the opaque

--- a/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/oauth_flow_contract.rs
@@ -136,7 +136,7 @@ async fn auth_flow_record_source_returns_stable_sorted_snapshot() {
     let alice = oauth_flow(&services, scope("alice")).await;
     let bob = oauth_flow(&services, scope("bob")).await;
 
-    let snapshot = ironclaw_auth::AuthFlowRecordSource::flow_records_snapshot(&services);
+    let snapshot = services.flow_records_snapshot();
 
     let ids = snapshot.iter().map(|flow| flow.id).collect::<Vec<_>>();
     let mut sorted = ids.clone();

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -7,8 +7,9 @@ use ironclaw_auth::{
     AuthFlowStatus, AuthGateRef, AuthProductError, AuthProductScope, AuthSurface,
     CredentialAccountId, CredentialAccountLabel, CredentialAccountProjection,
     CredentialAccountStatus, CredentialAccountUpdateBinding, CredentialOwnership,
-    CredentialSelectionInput, NewAuthFlow, OAuthAuthorizationUrl, OAuthCallbackClaimRequest,
-    OAuthCallbackFailureInput, OAuthCallbackInput, Timestamp, TurnRunRef,
+    CredentialSelectionInput, ManualTokenCompletionInput, NewAuthFlow, OAuthAuthorizationUrl,
+    OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput, Timestamp,
+    TurnRunRef,
 };
 use ironclaw_host_api::{
     AgentId, ExtensionId, InvocationId, ProjectId, ResourceScope, TenantId, ThreadId, UserId,
@@ -155,6 +156,22 @@ impl AuthFlowManager for RecordingFlowManager {
         record.credential_account_id = Some(input.credential_account_id);
         record.updated_at = Utc::now();
         Ok(record.clone())
+    }
+
+    async fn complete_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        _input: ManualTokenCompletionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        Err(AuthProductError::BackendUnavailable)
+    }
+
+    async fn cancel_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        _interaction_id: ironclaw_auth::AuthInteractionId,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        Err(AuthProductError::BackendUnavailable)
     }
 
     async fn fail_oauth_callback(

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -35,9 +35,10 @@
   through chat commands, model-visible messages, serializable DTOs,
   projections, or route-local pending maps.
 - `RebornProductAuthServices::flow_record_source` is an optional WebUI/local-dev
-  read-projection port, not a required product-auth capability. Local-dev
-  in-memory composition wires it so pending auth gates can be rendered from
-  blocked turn state plus auth-flow records. If a supplied product-auth bundle
+  read-projection port, not a required product-auth capability. Filesystem-backed
+  local-dev composition wires the durable product-auth service itself as this
+  source so pending auth gates can be rendered from blocked turn state plus
+  auth-flow records. If a supplied product-auth bundle
   omits it, runtime composition must expose the WebUI auth interaction surface
   as explicitly unavailable; do not fabricate a route-local or unscoped pending
   auth read model.

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -4,18 +4,20 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_auth::{
     AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId,
-    AuthFlowKind, AuthFlowManager, AuthFlowRecord, AuthFlowRecordSource, AuthFlowStatus,
-    AuthInteractionId, AuthInteractionService, AuthProductError, AuthProductScope,
-    AuthProviderClient, AuthProviderId, CredentialAccountChoiceRequest, CredentialAccountId,
-    CredentialAccountLabel, CredentialAccountListPage, CredentialAccountListRequest,
-    CredentialAccountProjection, CredentialAccountService, CredentialAccountStatus,
+    AuthFlowKind, AuthFlowManager, AuthFlowOwnerScope, AuthFlowRecord, AuthFlowRecordSource,
+    AuthFlowStatus, AuthGateRef, AuthInteractionId, AuthInteractionService, AuthProductError,
+    AuthProductScope, AuthProviderClient, AuthProviderId, CredentialAccountChoiceRequest,
+    CredentialAccountId, CredentialAccountLabel, CredentialAccountListPage,
+    CredentialAccountListRequest, CredentialAccountLookupRequest, CredentialAccountProjection,
+    CredentialAccountRecordSource, CredentialAccountService, CredentialAccountStatus,
     CredentialAccountUpdateBinding, CredentialRecoveryProjection, CredentialRecoveryRequest,
     CredentialRefreshReport, CredentialRefreshRequest, CredentialSetupService,
     InMemoryAuthProductServices, ManualTokenSetupRequest, NewAuthFlow, OAuthAuthorizationUrl,
     OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
     OAuthProviderCallbackRequest, OAuthProviderExchangeContext, OpaqueStateHash, PkceVerifierHash,
     ProviderBackedCredentialAccountService, ProviderCallbackOutcome, SecretCleanupReport,
-    SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest, Timestamp,
+    SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult, Timestamp,
+    TurnGateAuthFlowQuery, TurnRunRef, scope_matches,
 };
 use ironclaw_product_adapters::AuthPromptChallengeKind;
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
@@ -25,6 +27,10 @@ use serde::{Deserialize, Serialize};
 use ironclaw_host_api::UserId;
 use ironclaw_turns::{TurnRunId, TurnScope};
 
+use crate::manual_token_flow::{PortBackedManualTokenFlowService, RebornManualTokenFlowService};
+use crate::product_auth_runtime_credentials::{
+    ProductAuthRuntimeCredentialAccountSelector, RuntimeCredentialAccountSelectionService,
+};
 use crate::projection::{AuthChallengeProvider, AuthChallengeView};
 
 /// Dispatches a typed continuation event once an OAuth callback flow has
@@ -246,16 +252,27 @@ fn is_retryable_auth_error(code: AuthErrorCode) -> bool {
     matches!(code, AuthErrorCode::BackendUnavailable)
 }
 
-/// Product-auth ports supplied to Reborn composition before the turn coordinator
-/// exists. The factory turns these ports into a complete
-/// [`RebornProductAuthServices`] after composing the coordinator, so auth
-/// continuations cannot accidentally keep a stale or no-op resume dispatcher.
+#[derive(Debug)]
+struct UnsupportedCredentialAccountRecordSource;
+
+#[async_trait]
+impl CredentialAccountRecordSource for UnsupportedCredentialAccountRecordSource {
+    async fn accounts_for_owner(
+        &self,
+        _scope: &AuthProductScope,
+    ) -> Result<Vec<ironclaw_auth::CredentialAccount>, AuthProductError> {
+        Err(AuthProductError::BackendUnavailable)
+    }
+}
+
 #[derive(Clone)]
 pub struct RebornProductAuthServicePorts {
     flow_manager: Arc<dyn AuthFlowManager>,
     interaction_service: Arc<dyn AuthInteractionService>,
+    manual_token_flow_service: Arc<dyn RebornManualTokenFlowService>,
     credential_setup_service: Arc<dyn CredentialSetupService>,
     credential_account_service: Arc<dyn CredentialAccountService>,
+    credential_account_record_source: Arc<dyn CredentialAccountRecordSource>,
     provider_client: Arc<dyn AuthProviderClient>,
     cleanup_service: Arc<dyn SecretCleanupService>,
 }
@@ -267,12 +284,20 @@ impl std::fmt::Debug for RebornProductAuthServicePorts {
             .field("flow_manager", &"Arc<dyn AuthFlowManager>")
             .field("interaction_service", &"Arc<dyn AuthInteractionService>")
             .field(
+                "manual_token_flow_service",
+                &"Arc<dyn RebornManualTokenFlowService>",
+            )
+            .field(
                 "credential_setup_service",
                 &"Arc<dyn CredentialSetupService>",
             )
             .field(
                 "credential_account_service",
                 &"Arc<dyn CredentialAccountService>",
+            )
+            .field(
+                "credential_account_record_source",
+                &"Arc<dyn CredentialAccountRecordSource>",
             )
             .field("provider_client", &"Arc<dyn AuthProviderClient>")
             .field("cleanup_service", &"Arc<dyn SecretCleanupService>")
@@ -289,11 +314,18 @@ impl RebornProductAuthServicePorts {
         provider_client: Arc<dyn AuthProviderClient>,
         cleanup_service: Arc<dyn SecretCleanupService>,
     ) -> Self {
+        let manual_token_flow_service = Arc::new(PortBackedManualTokenFlowService::new(
+            flow_manager.clone(),
+            interaction_service.clone(),
+            credential_account_service.clone(),
+        ));
         Self {
             flow_manager,
             interaction_service,
+            manual_token_flow_service,
             credential_setup_service,
             credential_account_service,
+            credential_account_record_source: Arc::new(UnsupportedCredentialAccountRecordSource),
             provider_client,
             cleanup_service,
         }
@@ -305,8 +337,10 @@ impl RebornProductAuthServicePorts {
             + AuthInteractionService
             + CredentialSetupService
             + CredentialAccountService
+            + CredentialAccountRecordSource
             + AuthProviderClient
             + SecretCleanupService
+            + RebornManualTokenFlowService
             + 'static,
     {
         let provider_client: Arc<dyn AuthProviderClient> = services.clone();
@@ -322,23 +356,31 @@ impl RebornProductAuthServicePorts {
             + AuthInteractionService
             + CredentialSetupService
             + CredentialAccountService
+            + CredentialAccountRecordSource
             + SecretCleanupService
+            + RebornManualTokenFlowService
             + 'static,
     {
         let flow_manager: Arc<dyn AuthFlowManager> = services.clone();
         let interaction_service: Arc<dyn AuthInteractionService> = services.clone();
+        let manual_token_flow_service: Arc<dyn RebornManualTokenFlowService> = services.clone();
         let credential_setup_service: Arc<dyn CredentialSetupService> = services.clone();
         let credential_account_service: Arc<dyn CredentialAccountService> = services.clone();
+        let credential_account_record_source: Arc<dyn CredentialAccountRecordSource> =
+            services.clone();
         let cleanup_service: Arc<dyn SecretCleanupService> = services;
 
-        Self::new(
+        let mut ports = Self::new(
             flow_manager,
             interaction_service,
             credential_setup_service,
             credential_account_service,
             provider_client,
             cleanup_service,
-        )
+        );
+        ports.manual_token_flow_service = manual_token_flow_service;
+        ports.credential_account_record_source = credential_account_record_source;
+        ports
     }
 
     pub fn credential_account_service(&self) -> Arc<dyn CredentialAccountService> {
@@ -358,6 +400,8 @@ impl RebornProductAuthServicePorts {
             self.cleanup_service,
             continuation_dispatcher,
         )
+        .with_manual_token_flow_service(self.manual_token_flow_service)
+        .with_credential_account_record_source(self.credential_account_record_source)
     }
 
     pub fn with_provider_client(mut self, provider_client: Arc<dyn AuthProviderClient>) -> Self {
@@ -382,8 +426,10 @@ impl RebornProductAuthServicePorts {
 pub struct RebornProductAuthServices {
     flow_manager: Arc<dyn AuthFlowManager>,
     interaction_service: Arc<dyn AuthInteractionService>,
+    manual_token_flow_service: Arc<dyn RebornManualTokenFlowService>,
     credential_setup_service: Arc<dyn CredentialSetupService>,
     credential_account_service: Arc<dyn CredentialAccountService>,
+    credential_account_record_source: Arc<dyn CredentialAccountRecordSource>,
     provider_client: Arc<dyn AuthProviderClient>,
     cleanup_service: Arc<dyn SecretCleanupService>,
     continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
@@ -408,12 +454,20 @@ impl std::fmt::Debug for RebornProductAuthServices {
             .field("flow_manager", &"Arc<dyn AuthFlowManager>")
             .field("interaction_service", &"Arc<dyn AuthInteractionService>")
             .field(
+                "manual_token_flow_service",
+                &"Arc<dyn RebornManualTokenFlowService>",
+            )
+            .field(
                 "credential_setup_service",
                 &"Arc<dyn CredentialSetupService>",
             )
             .field(
                 "credential_account_service",
                 &"Arc<dyn CredentialAccountService>",
+            )
+            .field(
+                "credential_account_record_source",
+                &"Arc<dyn CredentialAccountRecordSource>",
             )
             .field("provider_client", &"Arc<dyn AuthProviderClient>")
             .field("cleanup_service", &"Arc<dyn SecretCleanupService>")
@@ -436,11 +490,18 @@ impl RebornProductAuthServices {
         cleanup_service: Arc<dyn SecretCleanupService>,
         continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
     ) -> Self {
+        let manual_token_flow_service = Arc::new(PortBackedManualTokenFlowService::new(
+            flow_manager.clone(),
+            interaction_service.clone(),
+            credential_account_service.clone(),
+        ));
         Self {
             flow_manager,
             interaction_service,
+            manual_token_flow_service,
             credential_setup_service,
             credential_account_service,
+            credential_account_record_source: Arc::new(UnsupportedCredentialAccountRecordSource),
             provider_client,
             cleanup_service,
             continuation_dispatcher,
@@ -463,14 +524,19 @@ impl RebornProductAuthServices {
             + AuthInteractionService
             + CredentialSetupService
             + CredentialAccountService
+            + CredentialAccountRecordSource
             + AuthProviderClient
             + SecretCleanupService
+            + RebornManualTokenFlowService
             + 'static,
     {
         let flow_manager: Arc<dyn AuthFlowManager> = services.clone();
         let interaction_service: Arc<dyn AuthInteractionService> = services.clone();
+        let manual_token_flow_service: Arc<dyn RebornManualTokenFlowService> = services.clone();
         let credential_setup_service: Arc<dyn CredentialSetupService> = services.clone();
         let credential_account_service: Arc<dyn CredentialAccountService> = services.clone();
+        let credential_account_record_source: Arc<dyn CredentialAccountRecordSource> =
+            services.clone();
         let provider_client: Arc<dyn AuthProviderClient> = services.clone();
         let cleanup_service: Arc<dyn SecretCleanupService> = services;
 
@@ -483,6 +549,8 @@ impl RebornProductAuthServices {
             cleanup_service,
             continuation_dispatcher,
         )
+        .with_manual_token_flow_service(manual_token_flow_service)
+        .with_credential_account_record_source(credential_account_record_source)
     }
 
     #[cfg(test)]
@@ -492,8 +560,10 @@ impl RebornProductAuthServices {
             + AuthInteractionService
             + CredentialSetupService
             + CredentialAccountService
+            + CredentialAccountRecordSource
             + AuthProviderClient
             + SecretCleanupService
+            + RebornManualTokenFlowService
             + 'static,
     {
         Self::from_shared(services, Arc::new(NoopAuthContinuationDispatcher))
@@ -524,6 +594,20 @@ impl RebornProductAuthServices {
         self.credential_account_service.clone()
     }
 
+    pub(crate) fn credential_account_record_source(
+        &self,
+    ) -> Arc<dyn CredentialAccountRecordSource> {
+        self.credential_account_record_source.clone()
+    }
+
+    pub(crate) fn runtime_credential_account_selection_service(
+        &self,
+    ) -> Arc<dyn RuntimeCredentialAccountSelectionService> {
+        Arc::new(ProductAuthRuntimeCredentialAccountSelector::new(
+            self.credential_account_record_source(),
+        ))
+    }
+
     pub fn provider_client(&self) -> Arc<dyn AuthProviderClient> {
         self.provider_client.clone()
     }
@@ -539,6 +623,22 @@ impl RebornProductAuthServices {
             provider_client.clone(),
         ));
         self.provider_client = provider_client;
+        self
+    }
+
+    fn with_manual_token_flow_service(
+        mut self,
+        service: Arc<dyn RebornManualTokenFlowService>,
+    ) -> Self {
+        self.manual_token_flow_service = service;
+        self
+    }
+
+    fn with_credential_account_record_source(
+        mut self,
+        source: Arc<dyn CredentialAccountRecordSource>,
+    ) -> Self {
+        self.credential_account_record_source = source;
         self
     }
 
@@ -772,35 +872,8 @@ impl RebornProductAuthServices {
         };
 
         if should_dispatch_continuation {
-            let emitted_at = Utc::now();
-            let event = AuthContinuationEvent {
-                flow_id: completed.id,
-                scope: completed.scope.clone(),
-                continuation: completed.continuation.clone(),
-                credential_account_id: completed.credential_account_id,
-                emitted_at,
-            };
-            if let Err(error) = self
-                .continuation_dispatcher
-                .dispatch_auth_continuation(event)
-                .await
-            {
-                tracing::debug!(
-                    flow_id = %completed.id,
-                    error_code = ?error.code(),
-                    "reborn auth callback completed but continuation dispatch failed"
-                );
-                let error = match error {
-                    AuthProductError::TokenExchangeFailed
-                    | AuthProductError::ProviderDenied
-                    | AuthProductError::MalformedCallback => AuthProductError::BackendUnavailable,
-                    error => error,
-                };
-                return Err(error.into());
-            }
             completed = self
-                .flow_manager
-                .mark_continuation_dispatched(&completed.scope, completed.id, emitted_at)
+                .dispatch_completed_continuation(completed)
                 .await
                 .map_err(RebornOAuthCallbackError::from)?;
         }
@@ -861,8 +934,8 @@ impl RebornProductAuthServices {
         request: RebornManualTokenSetupRequest,
     ) -> Result<RebornManualTokenChallenge, RebornManualTokenError> {
         let challenge = self
-            .interaction_service
-            .request_secret_input(ManualTokenSetupRequest {
+            .manual_token_flow_service
+            .request_manual_token_flow(ManualTokenSetupRequest {
                 scope: request.scope,
                 provider: request.provider,
                 label: request.label,
@@ -896,15 +969,28 @@ impl RebornProductAuthServices {
         &self,
         request: RebornManualTokenSubmitRequest,
     ) -> Result<RebornManualTokenSubmitResponse, RebornManualTokenError> {
-        let result = self
-            .interaction_service
-            .submit_manual_token(
-                &request.scope,
+        let scope = request.scope;
+        let interaction_id = request.interaction_id;
+        let submit = self
+            .manual_token_flow_service
+            .submit_manual_token_flow(
+                &scope,
                 SecretSubmitRequest {
-                    interaction_id: request.interaction_id,
+                    interaction_id,
                     secret: request.secret,
                 },
             )
+            .await;
+        let (result, completed) = match submit {
+            Ok(completed) => completed,
+            Err(AuthProductError::UnknownOrExpiredFlow) => self
+                .recover_completed_manual_token_submit(&scope, interaction_id)
+                .await?
+                .ok_or(AuthProductError::UnknownOrExpiredFlow)
+                .map_err(RebornManualTokenError::from)?,
+            Err(error) => return Err(RebornManualTokenError::from(error)),
+        };
+        self.dispatch_completed_continuation(completed)
             .await
             .map_err(RebornManualTokenError::from)?;
 
@@ -915,17 +1001,115 @@ impl RebornProductAuthServices {
         })
     }
 
+    async fn recover_completed_manual_token_submit(
+        &self,
+        scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<Option<(SecretSubmitResult, AuthFlowRecord)>, RebornManualTokenError> {
+        let Some(source) = &self.flow_record_source else {
+            return Ok(None);
+        };
+        let Some(thread_id) = scope.resource.thread_id.clone() else {
+            return Ok(None);
+        };
+        let flows = source
+            .flows_for_owner(AuthFlowOwnerScope {
+                tenant_id: scope.resource.tenant_id.clone(),
+                user_id: scope.resource.user_id.clone(),
+                agent_id: scope.resource.agent_id.clone(),
+                project_id: scope.resource.project_id.clone(),
+                thread_id,
+            })
+            .await
+            .map_err(RebornManualTokenError::from)?;
+        let Some(completed) = flows.into_iter().find(|flow| {
+            flow.status == AuthFlowStatus::Completed
+                && flow.continuation_emitted_at.is_none()
+                && scope_matches(scope, &flow.scope)
+                && matches!(
+                    &flow.challenge,
+                    Some(AuthChallenge::ManualTokenRequired { interaction_id: id, .. })
+                        if id == &interaction_id
+                )
+        }) else {
+            return Ok(None);
+        };
+        let Some(account_id) = completed.credential_account_id else {
+            return Ok(None);
+        };
+        let account = self
+            .credential_account_service
+            .get_account(CredentialAccountLookupRequest::new(
+                completed.scope.clone(),
+                account_id,
+            ))
+            .await
+            .map_err(RebornManualTokenError::from)?
+            .ok_or(AuthProductError::CredentialMissing)
+            .map_err(RebornManualTokenError::from)?;
+        Ok(Some((
+            SecretSubmitResult {
+                account_id,
+                status: account.status,
+                continuation: completed.continuation.clone(),
+            },
+            completed,
+        )))
+    }
+
     pub async fn abandon_manual_token(
         &self,
         scope: &AuthProductScope,
         interaction_id: AuthInteractionId,
     ) -> Result<bool, RebornManualTokenError> {
-        self.interaction_service
-            .abandon_manual_token(scope, interaction_id)
+        self.manual_token_flow_service
+            .abandon_manual_token_flow(scope, interaction_id)
             .await
             .map_err(RebornManualTokenError::from)
     }
 
+    async fn dispatch_completed_continuation(
+        &self,
+        completed: AuthFlowRecord,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        if completed.continuation_emitted_at.is_some() {
+            return Ok(completed);
+        }
+        let emitted_at = Utc::now();
+        let event = AuthContinuationEvent {
+            flow_id: completed.id,
+            scope: completed.scope.clone(),
+            continuation: completed.continuation.clone(),
+            credential_account_id: completed.credential_account_id,
+            emitted_at,
+        };
+        if let Err(error) = self
+            .continuation_dispatcher
+            .dispatch_auth_continuation(event)
+            .await
+        {
+            tracing::debug!(
+                flow_id = %completed.id,
+                error_code = ?error.code(),
+                "reborn auth flow completed but continuation dispatch failed"
+            );
+            let error = match error {
+                AuthProductError::TokenExchangeFailed
+                | AuthProductError::ProviderDenied
+                | AuthProductError::MalformedCallback => AuthProductError::BackendUnavailable,
+                error => error,
+            };
+            return Err(error);
+        }
+        self.flow_manager
+            .mark_continuation_dispatched(&completed.scope, completed.id, emitted_at)
+            .await
+    }
+
+    #[allow(
+        dead_code,
+        reason = "used by feature-scoped product-auth route tests that do not compile in every lib-test target"
+    )]
     pub(crate) fn local_dev_in_memory(
         continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
     ) -> Self {
@@ -934,47 +1118,6 @@ impl RebornProductAuthServices {
             .into_services(continuation_dispatcher)
             .with_flow_record_source(services)
     }
-}
-
-/// Verify that an auth flow record belongs to the same user and
-/// tenant/agent/project/thread as the caller's `TurnScope`.
-///
-/// `TurnScope` deliberately does not carry `session_id`; session isolation is
-/// enforced when creating/submitting the auth interaction, and this projection
-/// gate additionally requires the exact run id and gate ref. The axes available
-/// here are still fail-closed: a flow with no `thread_id` does not match a
-/// thread-scoped request. Pre-thread or test flows should be stored with a
-/// `thread_id` once a real turn is in progress; a flow missing one must not
-/// leak into an unrelated thread's gate.
-fn flow_scope_matches_turn_scope(
-    flow: &ironclaw_auth::AuthFlowRecord,
-    scope: &TurnScope,
-    owner_user_id: &UserId,
-) -> bool {
-    let resource = &flow.scope.resource;
-    resource.tenant_id == scope.tenant_id
-        && resource.user_id == *owner_user_id
-        && resource.agent_id.as_ref() == scope.agent_id.as_ref()
-        && resource.project_id.as_ref() == scope.project_id.as_ref()
-        // Fail-closed: a flow with no thread_id cannot match a thread-scoped request.
-        && match (&resource.thread_id, &scope.thread_id) {
-            (None, _) => false,
-            (Some(t), s) => t == s,
-        }
-}
-
-fn flow_matches_turn_gate(
-    flow: &ironclaw_auth::AuthFlowRecord,
-    run_id: &str,
-    gate_ref: &str,
-) -> bool {
-    matches!(
-        &flow.continuation,
-        ironclaw_auth::AuthContinuationRef::TurnGateResume {
-            turn_run_ref,
-            gate_ref: g,
-        } if turn_run_ref.as_str() == run_id && g.as_str() == gate_ref
-    )
 }
 
 fn auth_challenge_to_view(
@@ -1026,15 +1169,24 @@ impl AuthChallengeProvider for RebornProductAuthServices {
         gate_ref: &str,
     ) -> Option<AuthChallengeView> {
         let source = self.flow_record_source.as_ref()?;
-        // The flow store is process-wide; always verify user, turn scope,
-        // run id, and gate ref before exposing challenge metadata.
-        let run_id = run_id.to_string();
-        let mut matches_challenge = |flow: &ironclaw_auth::AuthFlowRecord| {
-            !ironclaw_auth::is_terminal_status(flow.status)
-                && flow_scope_matches_turn_scope(flow, scope, owner_user_id)
-                && flow_matches_turn_gate(flow, &run_id, gate_ref)
-        };
-        let flow = source.flow_record_matching(&mut matches_challenge)?;
+        // The flow source may include records from multiple product surfaces;
+        // query by stable owner and gate continuation before exposing metadata.
+        let gate_ref = AuthGateRef::new(gate_ref.to_string()).ok()?;
+        let flow = source
+            .flow_for_turn_gate(TurnGateAuthFlowQuery {
+                owner: AuthFlowOwnerScope {
+                    tenant_id: scope.tenant_id.clone(),
+                    user_id: owner_user_id.clone(),
+                    agent_id: scope.agent_id.clone(),
+                    project_id: scope.project_id.clone(),
+                    thread_id: scope.thread_id.clone(),
+                },
+                turn_run_ref: TurnRunRef::new(run_id.to_string()).ok()?,
+                gate_ref,
+                include_terminal: false,
+            })
+            .await
+            .ok()??;
         let challenge = flow.challenge.as_ref()?;
         Some(auth_challenge_to_view(challenge, &flow))
     }
@@ -1044,7 +1196,7 @@ impl AuthChallengeProvider for RebornProductAuthServices {
 mod tests {
     use super::*;
     use ironclaw_auth::{
-        AuthChallenge, AuthFlowId, AuthFlowRecord, AuthProductError, AuthProductScope, AuthSurface,
+        AuthChallenge, AuthFlowId, AuthFlowRecord, AuthProductError, AuthProductScope,
         CredentialAccount, CredentialAccountChoiceRequest, CredentialAccountId,
         CredentialAccountListPage, CredentialAccountListRequest, CredentialAccountLookupRequest,
         CredentialAccountMutation, CredentialAccountProjection, CredentialAccountSelectionRequest,
@@ -1060,96 +1212,6 @@ mod tests {
 
     fn arc_data_ptr<T: ?Sized>(arc: &Arc<T>) -> *const () {
         Arc::as_ptr(arc) as *const ()
-    }
-
-    fn test_turn_scope(thread_id: ironclaw_host_api::ThreadId) -> TurnScope {
-        TurnScope::new(
-            ironclaw_host_api::TenantId::new("tenant-auth-scope").expect("tenant id"),
-            Some(ironclaw_host_api::AgentId::new("agent-auth-scope").expect("agent id")),
-            Some(ironclaw_host_api::ProjectId::new("project-auth-scope").expect("project id")),
-            thread_id,
-        )
-    }
-
-    fn test_flow_record(
-        owner_user_id: &UserId,
-        scope: &TurnScope,
-        thread_id: Option<ironclaw_host_api::ThreadId>,
-    ) -> AuthFlowRecord {
-        let now = Utc::now();
-        AuthFlowRecord {
-            id: AuthFlowId::new(),
-            scope: AuthProductScope::new(
-                ironclaw_host_api::ResourceScope {
-                    tenant_id: scope.tenant_id.clone(),
-                    user_id: owner_user_id.clone(),
-                    agent_id: scope.agent_id.clone(),
-                    project_id: scope.project_id.clone(),
-                    mission_id: None,
-                    thread_id,
-                    invocation_id: ironclaw_host_api::InvocationId::new(),
-                },
-                AuthSurface::Chat,
-            ),
-            kind: AuthFlowKind::IntegrationCredential,
-            status: AuthFlowStatus::AwaitingUser,
-            provider: AuthProviderId::new("github").expect("provider id"),
-            challenge: None,
-            continuation: AuthContinuationRef::SetupOnly,
-            credential_account_id: None,
-            update_binding: None,
-            opaque_state_hash: None,
-            pkce_verifier_hash: None,
-            authorization_code_hash: None,
-            error: None,
-            continuation_emitted_at: None,
-            created_at: now,
-            updated_at: now,
-            expires_at: now,
-        }
-    }
-
-    #[test]
-    fn flow_scope_matches_turn_scope_none_thread_id_never_matches() {
-        let owner = UserId::new("user-auth-scope").expect("user id");
-        let thread = ironclaw_host_api::ThreadId::new("thread-auth-scope").expect("thread id");
-        let scope = test_turn_scope(thread);
-        let flow = test_flow_record(&owner, &scope, None);
-
-        assert!(!flow_scope_matches_turn_scope(&flow, &scope, &owner));
-    }
-
-    #[test]
-    fn flow_scope_matches_turn_scope_thread_id_mismatch_returns_false() {
-        let owner = UserId::new("user-auth-scope").expect("user id");
-        let request_thread =
-            ironclaw_host_api::ThreadId::new("thread-auth-scope").expect("thread id");
-        let flow_thread = ironclaw_host_api::ThreadId::new("thread-auth-other").expect("thread id");
-        let scope = test_turn_scope(request_thread);
-        let flow = test_flow_record(&owner, &scope, Some(flow_thread));
-
-        assert!(!flow_scope_matches_turn_scope(&flow, &scope, &owner));
-    }
-
-    #[test]
-    fn flow_scope_matches_turn_scope_user_id_mismatch_returns_false() {
-        let owner = UserId::new("user-auth-scope").expect("user id");
-        let other = UserId::new("user-auth-other").expect("user id");
-        let thread = ironclaw_host_api::ThreadId::new("thread-auth-scope").expect("thread id");
-        let scope = test_turn_scope(thread.clone());
-        let flow = test_flow_record(&owner, &scope, Some(thread));
-
-        assert!(!flow_scope_matches_turn_scope(&flow, &scope, &other));
-    }
-
-    #[test]
-    fn flow_scope_matches_turn_scope_all_fields_match_returns_true() {
-        let owner = UserId::new("user-auth-scope").expect("user id");
-        let thread = ironclaw_host_api::ThreadId::new("thread-auth-scope").expect("thread id");
-        let scope = test_turn_scope(thread.clone());
-        let flow = test_flow_record(&owner, &scope, Some(thread));
-
-        assert!(flow_scope_matches_turn_scope(&flow, &scope, &owner));
     }
 
     #[test]
@@ -1289,6 +1351,22 @@ mod tests {
             unreachable!("constructor tests do not call auth-flow methods")
         }
 
+        async fn complete_manual_token(
+            &self,
+            _scope: &AuthProductScope,
+            _input: ironclaw_auth::ManualTokenCompletionInput,
+        ) -> Result<AuthFlowRecord, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
+        async fn cancel_manual_token(
+            &self,
+            _scope: &AuthProductScope,
+            _interaction_id: AuthInteractionId,
+        ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+            unreachable!("constructor tests do not call auth-flow methods")
+        }
+
         async fn fail_oauth_callback(
             &self,
             _scope: &AuthProductScope,
@@ -1409,6 +1487,42 @@ mod tests {
             _request: CredentialRefreshRequest,
         ) -> Result<CredentialRefreshReport, AuthProductError> {
             unreachable!("constructor tests do not call credential-account methods")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CredentialAccountRecordSource for SharedAuthTestDouble {
+        async fn accounts_for_owner(
+            &self,
+            _scope: &AuthProductScope,
+        ) -> Result<Vec<CredentialAccount>, AuthProductError> {
+            unreachable!("constructor tests do not call credential-account read-model methods")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RebornManualTokenFlowService for SharedAuthTestDouble {
+        async fn request_manual_token_flow(
+            &self,
+            _request: ironclaw_auth::ManualTokenSetupRequest,
+        ) -> Result<AuthChallenge, AuthProductError> {
+            unreachable!("constructor tests do not call manual-token flow methods")
+        }
+
+        async fn submit_manual_token_flow(
+            &self,
+            _scope: &AuthProductScope,
+            _request: SecretSubmitRequest,
+        ) -> Result<(SecretSubmitResult, AuthFlowRecord), AuthProductError> {
+            unreachable!("constructor tests do not call manual-token flow methods")
+        }
+
+        async fn abandon_manual_token_flow(
+            &self,
+            _scope: &AuthProductScope,
+            _interaction_id: AuthInteractionId,
+        ) -> Result<bool, AuthProductError> {
+            unreachable!("constructor tests do not call manual-token flow methods")
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -562,17 +562,38 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
             compose_product_auth_services(ports, turn_coordinator.clone(), google_provider_client)
         }
         None => {
-            let services = RebornProductAuthServices::local_dev_in_memory(
-                auth_continuation_dispatcher(turn_coordinator.clone()),
-            );
-            Arc::new(match google_provider_client {
-                Some(provider_client) => services.with_provider_client(provider_client),
-                None => services,
-            })
+            #[cfg(any(feature = "libsql", feature = "postgres"))]
+            {
+                let durable_services = Arc::new(FilesystemAuthProductServices::new(
+                    local_dev_scoped_filesystem(Arc::clone(&filesystem)),
+                    Arc::clone(&secret_store),
+                ));
+                let provider_client: Arc<dyn AuthProviderClient> = google_provider_client
+                    .unwrap_or_else(|| Arc::new(UnavailableAuthProviderClient));
+                let services = RebornProductAuthServicePorts::from_shared_with_provider(
+                    Arc::clone(&durable_services),
+                    provider_client,
+                )
+                .into_services(auth_continuation_dispatcher(turn_coordinator.clone()))
+                .with_flow_record_source(durable_services);
+                Arc::new(services)
+            }
+            #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+            {
+                let services = RebornProductAuthServices::local_dev_in_memory(
+                    auth_continuation_dispatcher(turn_coordinator.clone()),
+                );
+                Arc::new(match google_provider_client {
+                    Some(provider_client) => services.with_provider_client(provider_client),
+                    None => services,
+                })
+            }
         }
     };
     services = services.with_runtime_credential_account_resolver(Arc::new(
-        ProductAuthRuntimeCredentialResolver::new(product_auth.credential_account_service()),
+        ProductAuthRuntimeCredentialResolver::new(
+            product_auth.runtime_credential_account_selection_service(),
+        ),
     ));
     register_bundled_gsuite_first_party_handlers(
         &mut first_party_registry,
@@ -1754,7 +1775,7 @@ where
     // always exists (durable filesystem fallback from #4234).
     let services = services.with_runtime_credential_account_resolver(Arc::new(
         ProductAuthRuntimeCredentialResolver::new(
-            product_auth_services.credential_account_service(),
+            product_auth_services.runtime_credential_account_selection_service(),
         ),
     ));
     register_bundled_gsuite_first_party_handlers(
@@ -1898,6 +1919,81 @@ mod tests {
                 .is_some()
         );
         assert_eq!(services.readiness.state, RebornReadinessState::DevOnly);
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn local_dev_default_product_auth_uses_durable_manual_token_accounts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let owner = "local-dev-durable-auth-owner";
+        let services = build_reborn_services(RebornBuildInput::local_dev(
+            owner,
+            dir.path().join("local-dev"),
+        ))
+        .await
+        .expect("local-dev services build");
+        let product_auth = services.product_auth.as_ref().expect("product auth");
+        let scope = AuthProductScope::new(
+            ResourceScope::local_default(UserId::new(owner).unwrap(), InvocationId::new()).unwrap(),
+            AuthSurface::Callback,
+        );
+        let mut scope = scope;
+        scope.resource.thread_id = Some(ironclaw_host_api::ThreadId::new("auth-thread").unwrap());
+
+        let challenge = product_auth
+            .request_manual_token_setup(crate::RebornManualTokenSetupRequest::new(
+                scope.clone(),
+                ironclaw_auth::AuthProviderId::new("github").unwrap(),
+                CredentialAccountLabel::new("work github").unwrap(),
+                ironclaw_auth::AuthContinuationRef::SetupOnly,
+                chrono::Utc::now() + chrono::Duration::minutes(5),
+            ))
+            .await
+            .unwrap();
+        let submitted = product_auth
+            .submit_manual_token(crate::RebornManualTokenSubmitRequest::new(
+                scope.clone(),
+                challenge.interaction_id,
+                secrecy::SecretString::from("ghp_local_dev_pat"),
+            ))
+            .await
+            .unwrap();
+
+        let account = product_auth
+            .credential_account_service()
+            .get_account(ironclaw_auth::CredentialAccountLookupRequest::new(
+                scope.clone(),
+                submitted.account_id,
+            ))
+            .await
+            .unwrap()
+            .expect("manual-token submit should create account");
+        let access_secret = account.access_secret.expect("manual token access secret");
+        assert!(
+            access_secret.as_str().starts_with("product-auth-manual-"),
+            "local-dev default product-auth must create durable SecretStore-backed handles"
+        );
+
+        let flows = product_auth
+            .flow_record_source()
+            .expect("local-dev product-auth flow source")
+            .flows_for_owner(ironclaw_auth::AuthFlowOwnerScope {
+                tenant_id: scope.resource.tenant_id.clone(),
+                user_id: scope.resource.user_id.clone(),
+                agent_id: scope.resource.agent_id.clone(),
+                project_id: scope.resource.project_id.clone(),
+                thread_id: scope.resource.thread_id.clone().unwrap(),
+            })
+            .await
+            .unwrap();
+        let completed_flow = flows
+            .iter()
+            .find(|flow| flow.credential_account_id == Some(submitted.account_id))
+            .expect("manual-token completion should remain visible to auth gates");
+        assert_eq!(
+            completed_flow.status,
+            ironclaw_auth::AuthFlowStatus::Completed
+        );
     }
 
     /// Verify that `attach_hosted_mcp_runtime` is soft-disabled when the host

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -39,6 +39,7 @@ mod llm_catalog;
 mod local_dev_capability_policy;
 mod local_dev_mounts;
 mod local_runtime_profile;
+mod manual_token_flow;
 mod mcp;
 mod mcp_router;
 mod nearai_mcp;

--- a/crates/ironclaw_reborn_composition/src/manual_token_flow.rs
+++ b/crates/ironclaw_reborn_composition/src/manual_token_flow.rs
@@ -1,0 +1,278 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_auth::{
+    AuthChallenge, AuthFlowKind, AuthFlowManager, AuthFlowRecord, AuthInteractionId,
+    AuthInteractionService, AuthProductError, AuthProductScope, CredentialAccountService,
+    CredentialAccountStatus, InMemoryAuthProductServices, ManualTokenCompletionInput,
+    ManualTokenSetupRequest, NewAuthFlow, SecretSubmitRequest, SecretSubmitResult,
+};
+use ironclaw_filesystem::RootFilesystem;
+
+use crate::product_auth_durable::FilesystemAuthProductServices;
+
+#[async_trait]
+#[doc(hidden)]
+pub trait RebornManualTokenFlowService: Send + Sync {
+    async fn request_manual_token_flow(
+        &self,
+        request: ManualTokenSetupRequest,
+    ) -> Result<AuthChallenge, AuthProductError>;
+
+    async fn submit_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        request: SecretSubmitRequest,
+    ) -> Result<(SecretSubmitResult, AuthFlowRecord), AuthProductError>;
+
+    async fn abandon_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<bool, AuthProductError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct PortBackedManualTokenFlowService {
+    flow_manager: Arc<dyn AuthFlowManager>,
+    interaction_service: Arc<dyn AuthInteractionService>,
+    credential_account_service: Arc<dyn CredentialAccountService>,
+}
+
+impl PortBackedManualTokenFlowService {
+    pub(crate) fn new(
+        flow_manager: Arc<dyn AuthFlowManager>,
+        interaction_service: Arc<dyn AuthInteractionService>,
+        credential_account_service: Arc<dyn CredentialAccountService>,
+    ) -> Self {
+        Self {
+            flow_manager,
+            interaction_service,
+            credential_account_service,
+        }
+    }
+}
+
+#[async_trait]
+impl RebornManualTokenFlowService for PortBackedManualTokenFlowService {
+    async fn request_manual_token_flow(
+        &self,
+        request: ManualTokenSetupRequest,
+    ) -> Result<AuthChallenge, AuthProductError> {
+        request_manual_token_flow_with(
+            self.flow_manager.as_ref(),
+            self.interaction_service.as_ref(),
+            request,
+        )
+        .await
+    }
+
+    async fn submit_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        request: SecretSubmitRequest,
+    ) -> Result<(SecretSubmitResult, AuthFlowRecord), AuthProductError> {
+        submit_manual_token_flow_with(
+            self.flow_manager.as_ref(),
+            self.interaction_service.as_ref(),
+            self.credential_account_service.as_ref(),
+            scope,
+            request,
+        )
+        .await
+    }
+
+    async fn abandon_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<bool, AuthProductError> {
+        abandon_manual_token_flow_with(
+            self.flow_manager.as_ref(),
+            self.interaction_service.as_ref(),
+            scope,
+            interaction_id,
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl RebornManualTokenFlowService for InMemoryAuthProductServices {
+    async fn request_manual_token_flow(
+        &self,
+        request: ManualTokenSetupRequest,
+    ) -> Result<AuthChallenge, AuthProductError> {
+        request_manual_token_flow_with(self, self, request).await
+    }
+
+    async fn submit_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        request: SecretSubmitRequest,
+    ) -> Result<(SecretSubmitResult, AuthFlowRecord), AuthProductError> {
+        submit_manual_token_flow_with(self, self, self, scope, request).await
+    }
+
+    async fn abandon_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<bool, AuthProductError> {
+        abandon_manual_token_flow_with(self, self, scope, interaction_id).await
+    }
+}
+
+#[async_trait]
+impl<F> RebornManualTokenFlowService for FilesystemAuthProductServices<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn request_manual_token_flow(
+        &self,
+        request: ManualTokenSetupRequest,
+    ) -> Result<AuthChallenge, AuthProductError> {
+        request_manual_token_flow_with(self, self, request).await
+    }
+
+    async fn submit_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        request: SecretSubmitRequest,
+    ) -> Result<(SecretSubmitResult, AuthFlowRecord), AuthProductError> {
+        submit_manual_token_flow_with(self, self, self, scope, request).await
+    }
+
+    async fn abandon_manual_token_flow(
+        &self,
+        scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<bool, AuthProductError> {
+        abandon_manual_token_flow_with(self, self, scope, interaction_id).await
+    }
+}
+
+async fn request_manual_token_flow_with(
+    flow_manager: &dyn AuthFlowManager,
+    interaction_service: &dyn AuthInteractionService,
+    request: ManualTokenSetupRequest,
+) -> Result<AuthChallenge, AuthProductError> {
+    let flow_scope = request.scope.clone();
+    let flow_provider = request.provider.clone();
+    let flow_continuation = request.continuation.clone();
+    let flow_update_binding = request.update_binding.clone();
+    let flow_expires_at = request.expires_at;
+    let challenge = interaction_service.request_secret_input(request).await?;
+    let AuthChallenge::ManualTokenRequired {
+        interaction_id,
+        provider,
+        label,
+        expires_at,
+    } = &challenge
+    else {
+        return Err(AuthProductError::InvalidRequest {
+            reason: "manual token setup returned an unexpected challenge".to_string(),
+        });
+    };
+    if let Err(error) = flow_manager
+        .create_flow(NewAuthFlow {
+            scope: flow_scope.clone(),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: flow_provider,
+            challenge: AuthChallenge::ManualTokenRequired {
+                interaction_id: *interaction_id,
+                provider: provider.clone(),
+                label: label.clone(),
+                expires_at: *expires_at,
+            },
+            continuation: flow_continuation,
+            update_binding: flow_update_binding,
+            opaque_state_hash: None,
+            pkce_verifier_hash: None,
+            expires_at: flow_expires_at,
+        })
+        .await
+    {
+        if let Err(cleanup_error) = interaction_service
+            .abandon_manual_token(&flow_scope, *interaction_id)
+            .await
+        {
+            tracing::warn!(
+                interaction_id = %interaction_id,
+                error_code = ?error.code(),
+                cleanup_error_code = ?cleanup_error.code(),
+                "manual-token flow creation failed and interaction cleanup failed"
+            );
+        }
+        return Err(error);
+    }
+    Ok(challenge)
+}
+
+async fn submit_manual_token_flow_with(
+    flow_manager: &dyn AuthFlowManager,
+    interaction_service: &dyn AuthInteractionService,
+    credential_account_service: &dyn CredentialAccountService,
+    scope: &AuthProductScope,
+    request: SecretSubmitRequest,
+) -> Result<(SecretSubmitResult, AuthFlowRecord), AuthProductError> {
+    let interaction_id = request.interaction_id;
+    let result = interaction_service
+        .submit_manual_token(scope, request)
+        .await?;
+    let completed = match flow_manager
+        .complete_manual_token(
+            scope,
+            ManualTokenCompletionInput {
+                interaction_id,
+                credential_account_id: result.account_id,
+            },
+        )
+        .await
+    {
+        Ok(completed) => completed,
+        Err(error) => {
+            if let Err(cleanup_error) = flow_manager
+                .cancel_manual_token(scope, interaction_id)
+                .await
+            {
+                tracing::warn!(
+                    interaction_id = %interaction_id,
+                    error_code = ?error.code(),
+                    cleanup_error_code = ?cleanup_error.code(),
+                    "manual-token flow completion failed and flow cleanup failed"
+                );
+            }
+            if let Err(cleanup_error) = credential_account_service
+                .update_status(scope, result.account_id, CredentialAccountStatus::Revoked)
+                .await
+            {
+                tracing::warn!(
+                    interaction_id = %interaction_id,
+                    account_id = %result.account_id,
+                    error_code = ?error.code(),
+                    cleanup_error_code = ?cleanup_error.code(),
+                    "manual-token flow completion failed and account compensation failed"
+                );
+            }
+            return Err(error);
+        }
+    };
+    Ok((result, completed))
+}
+
+async fn abandon_manual_token_flow_with(
+    flow_manager: &dyn AuthFlowManager,
+    interaction_service: &dyn AuthInteractionService,
+    scope: &AuthProductScope,
+    interaction_id: AuthInteractionId,
+) -> Result<bool, AuthProductError> {
+    let interaction_abandoned = interaction_service
+        .abandon_manual_token(scope, interaction_id)
+        .await?;
+    let flow_abandoned = flow_manager
+        .cancel_manual_token(scope, interaction_id)
+        .await?
+        .is_some();
+    Ok(interaction_abandoned || flow_abandoned)
+}

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
@@ -7,7 +7,7 @@ use futures::{StreamExt as _, TryStreamExt as _, stream};
 
 use chrono::Utc;
 use ironclaw_filesystem::{
-    CasExpectation, ContentType, Entry, FilesystemError, RecordVersion, RootFilesystem,
+    CasExpectation, ContentType, Entry, FileType, FilesystemError, RecordVersion, RootFilesystem,
     ScopedFilesystem,
 };
 use ironclaw_host_api::{ResourceScope, ScopedPath};
@@ -15,12 +15,15 @@ use ironclaw_secrets::SecretStore;
 use serde::{Serialize, de::DeserializeOwned};
 
 use ironclaw_auth::{
-    AuthFlowId, AuthFlowRecord, AuthProductError, CredentialAccount, CredentialAccountId,
-    NewCredentialAccount,
+    AuthFlowId, AuthFlowOwnerScope, AuthFlowRecord, AuthProductError, AuthSessionId, AuthSurface,
+    CredentialAccount, CredentialAccountId, CredentialAccountOwnerScope,
+    CredentialAccountSelectionRequest, CredentialAccountStatus, NewCredentialAccount,
 };
 
 use self::domain::validate_new_credential_account;
-use self::paths::{account_path, account_root, flow_path, fs_error, join_scoped};
+use self::paths::{
+    account_path, account_root, flow_path, flow_root, fs_error, join_scoped, surface_sessions_root,
+};
 
 mod accounts;
 mod cleanup;
@@ -31,6 +34,9 @@ mod paths;
 mod provider;
 #[cfg(test)]
 mod tests;
+
+const MAX_OWNER_SESSION_ROOTS_PER_SURFACE: usize = 64;
+const MAX_OWNER_RECORDS_PER_ROOT: usize = 64;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) use provider::UnavailableAuthProviderClient;
@@ -153,6 +159,115 @@ where
             .await
     }
 
+    async fn flows_for_scope(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+    ) -> Result<Vec<(AuthFlowRecord, RecordVersion)>, AuthProductError> {
+        let mut flows = self.flow_records_under_scope_root(scope).await?;
+        flows.retain(|(flow, _)| scope_matches(scope, &flow.scope));
+        flows.sort_by_key(|(flow, _)| flow.id);
+        Ok(flows)
+    }
+
+    async fn flow_records_under_scope_root(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+    ) -> Result<Vec<(AuthFlowRecord, RecordVersion)>, AuthProductError> {
+        let root = flow_root(scope)?;
+        let entries = match self.filesystem.list_dir(&scope.resource, &root).await {
+            Ok(entries) => entries,
+            Err(FilesystemError::NotFound { .. }) => return Ok(Vec::new()),
+            Err(error) => return Err(fs_error(error)),
+        };
+        const MAX_CONCURRENT_READS: usize = 16;
+        let mut flows: Vec<(AuthFlowRecord, RecordVersion)> = stream::iter(
+            entries
+                .into_iter()
+                .filter(|e| e.name.ends_with(".json"))
+                .map(|entry| {
+                    let path = join_scoped(&root, &entry.name);
+                    async move {
+                        let path = path?;
+                        self.read_record::<AuthFlowRecord>(&scope.resource, &path)
+                            .await
+                    }
+                }),
+        )
+        .buffer_unordered(MAX_CONCURRENT_READS)
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
+        flows.sort_by_key(|(flow, _)| flow.id);
+        Ok(flows)
+    }
+
+    async fn flow_records_for_owner(
+        &self,
+        owner: &AuthFlowOwnerScope,
+    ) -> Result<Vec<AuthFlowRecord>, AuthProductError> {
+        let resource = ResourceScope {
+            tenant_id: owner.tenant_id.clone(),
+            user_id: owner.user_id.clone(),
+            agent_id: owner.agent_id.clone(),
+            project_id: owner.project_id.clone(),
+            mission_id: None,
+            thread_id: Some(owner.thread_id.clone()),
+            invocation_id: ironclaw_host_api::InvocationId::new(),
+        };
+        let mut flows = Vec::new();
+        for surface in AuthSurface::ALL {
+            let scope = ironclaw_auth::AuthProductScope::new(resource.clone(), surface);
+            flows.extend(
+                self.flow_records_under_scope_root(&scope)
+                    .await?
+                    .into_iter()
+                    .map(|(flow, _)| flow)
+                    .filter(|flow| owner.matches(flow)),
+            );
+            let sessions_root = surface_sessions_root(&resource, surface)?;
+            let mut entries = match self
+                .filesystem
+                .list_dir_bounded(
+                    &resource,
+                    &sessions_root,
+                    MAX_OWNER_SESSION_ROOTS_PER_SURFACE.saturating_add(1),
+                )
+                .await
+            {
+                Ok(entries) => entries,
+                Err(FilesystemError::NotFound { .. }) => continue,
+                Err(error) => return Err(fs_error(error)),
+            };
+            if entries.len() > MAX_OWNER_SESSION_ROOTS_PER_SURFACE {
+                return Err(AuthProductError::BackendUnavailable);
+            }
+            entries.sort_by(|left, right| left.name.cmp(&right.name));
+            for entry in entries {
+                if entry.file_type != FileType::Directory {
+                    continue;
+                }
+                let Ok(session_id) = AuthSessionId::new(entry.name) else {
+                    continue;
+                };
+                let mut session_scope =
+                    ironclaw_auth::AuthProductScope::new(resource.clone(), surface);
+                session_scope.session_id = Some(session_id);
+                flows.extend(
+                    self.flow_records_under_scope_root(&session_scope)
+                        .await?
+                        .into_iter()
+                        .map(|(flow, _)| flow)
+                        .filter(|flow| owner.matches(flow)),
+                );
+            }
+        }
+        flows.sort_by_key(|flow| flow.id);
+        flows.dedup_by_key(|flow| flow.id);
+        Ok(flows)
+    }
+
     async fn read_account(
         &self,
         scope: &ironclaw_auth::AuthProductScope,
@@ -181,12 +296,52 @@ where
         &self,
         scope: &ironclaw_auth::AuthProductScope,
     ) -> Result<Vec<CredentialAccount>, AuthProductError> {
+        let mut accounts = self
+            .account_records_under_scope_root(scope)
+            .await?
+            .into_iter()
+            .filter(|account| scope_matches(scope, &account.scope))
+            .collect::<Vec<_>>();
+        accounts.sort_by_key(|account| account.id);
+        Ok(accounts)
+    }
+
+    /// Returns all credential accounts stored under `scope`'s durable root.
+    ///
+    /// Normal product-auth lookups still apply exact `AuthProductScope`
+    /// filtering through `accounts_for_scope`; runtime credential selection uses
+    /// this lower-level scan because setup and runtime invocations necessarily
+    /// carry different invocation ids.
+    async fn account_records_under_scope_root(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+    ) -> Result<Vec<CredentialAccount>, AuthProductError> {
+        self.account_records_under_scope_root_with_limit(scope, None)
+            .await
+    }
+
+    async fn account_records_under_scope_root_with_limit(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+        max_records: Option<usize>,
+    ) -> Result<Vec<CredentialAccount>, AuthProductError> {
         let root = account_root(scope)?;
-        let entries = match self.filesystem.list_dir(&scope.resource, &root).await {
+        let entries = match max_records {
+            Some(max_records) => {
+                self.filesystem
+                    .list_dir_bounded(&scope.resource, &root, max_records.saturating_add(1))
+                    .await
+            }
+            None => self.filesystem.list_dir(&scope.resource, &root).await,
+        };
+        let entries = match entries {
             Ok(entries) => entries,
             Err(FilesystemError::NotFound { .. }) => return Ok(Vec::new()),
             Err(error) => return Err(fs_error(error)),
         };
+        if max_records.is_some_and(|max_records| entries.len() > max_records) {
+            return Err(AuthProductError::BackendUnavailable);
+        }
         // Read records concurrently, capped at 16 in-flight ops to avoid
         // exhausting file-descriptor or connection limits on large scopes.
         const MAX_CONCURRENT_READS: usize = 16;
@@ -208,10 +363,129 @@ where
         .await?
         .into_iter()
         .flatten()
-        .filter_map(|(account, _)| scope_matches(scope, &account.scope).then_some(account))
+        .map(|(account, _)| account)
         .collect();
         accounts.sort_by_key(|account| account.id);
         Ok(accounts)
+    }
+
+    async fn account_scopes_for_owner(
+        &self,
+        owner: &CredentialAccountOwnerScope,
+    ) -> Result<Vec<ironclaw_auth::AuthProductScope>, AuthProductError> {
+        let resource = ResourceScope {
+            tenant_id: owner.tenant_id.clone(),
+            user_id: owner.user_id.clone(),
+            agent_id: owner.agent_id.clone(),
+            project_id: owner.project_id.clone(),
+            mission_id: owner.mission_id.clone(),
+            thread_id: owner.thread_id.clone(),
+            invocation_id: ironclaw_host_api::InvocationId::new(),
+        };
+        let mut scopes = Vec::new();
+        for surface in AuthSurface::ALL {
+            scopes.push(ironclaw_auth::AuthProductScope::new(
+                resource.clone(),
+                surface,
+            ));
+            if let Some(session_id) = &owner.session_id {
+                scopes.push(
+                    ironclaw_auth::AuthProductScope::new(resource.clone(), surface)
+                        .with_session_id(session_id.clone()),
+                );
+                continue;
+            }
+            let sessions_root = surface_sessions_root(&resource, surface)?;
+            let mut entries = match self
+                .filesystem
+                .list_dir_bounded(
+                    &resource,
+                    &sessions_root,
+                    MAX_OWNER_SESSION_ROOTS_PER_SURFACE.saturating_add(1),
+                )
+                .await
+            {
+                Ok(entries) => entries,
+                Err(FilesystemError::NotFound { .. }) => continue,
+                Err(error) => return Err(fs_error(error)),
+            };
+            if entries.len() > MAX_OWNER_SESSION_ROOTS_PER_SURFACE {
+                return Err(AuthProductError::BackendUnavailable);
+            }
+            entries.sort_by(|left, right| left.name.cmp(&right.name));
+            for entry in entries {
+                if entry.file_type != FileType::Directory {
+                    continue;
+                }
+                let Ok(session_id) = AuthSessionId::new(entry.name) else {
+                    continue;
+                };
+                scopes.push(
+                    ironclaw_auth::AuthProductScope::new(resource.clone(), surface)
+                        .with_session_id(session_id),
+                );
+            }
+        }
+        Ok(scopes)
+    }
+
+    async fn account_records_for_owner(
+        &self,
+        owner: &CredentialAccountOwnerScope,
+    ) -> Result<Vec<CredentialAccount>, AuthProductError> {
+        let mut accounts = Vec::new();
+        for scope in self.account_scopes_for_owner(owner).await? {
+            accounts.extend(
+                self.account_records_under_scope_root_with_limit(
+                    &scope,
+                    Some(MAX_OWNER_RECORDS_PER_ROOT),
+                )
+                .await?
+                .into_iter()
+                .filter(|account| owner.matches(account)),
+            );
+        }
+        accounts.sort_by_key(|account| account.id);
+        accounts.dedup_by_key(|account| account.id);
+        Ok(accounts)
+    }
+
+    async fn select_configured_account_for_owner(
+        &self,
+        request: CredentialAccountSelectionRequest,
+    ) -> Result<CredentialAccount, AuthProductError> {
+        let owner = CredentialAccountOwnerScope::from_scope(&request.scope);
+        let mut saw_configured = false;
+        let mut selected = None;
+        for scope in self.account_scopes_for_owner(&owner).await? {
+            for account in self
+                .account_records_under_scope_root_with_limit(
+                    &scope,
+                    Some(MAX_OWNER_RECORDS_PER_ROOT),
+                )
+                .await?
+            {
+                if !owner.matches(&account)
+                    || account.provider != request.provider
+                    || account.status != CredentialAccountStatus::Configured
+                {
+                    continue;
+                }
+                saw_configured = true;
+                if !account.is_authorized_for_requester(request.requester_extension.as_ref()) {
+                    continue;
+                }
+                if selected.is_some() {
+                    return Err(AuthProductError::AccountSelectionRequired);
+                }
+                selected = Some(account);
+            }
+        }
+        match (selected, saw_configured) {
+            (Some(account), _) => Ok(account),
+            (None, true) => Err(AuthProductError::CrossScopeDenied),
+            (None, false) => Err(AuthProductError::CredentialMissing),
+        }
     }
 
     async fn create_account_with_id(

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/accounts.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/accounts.rs
@@ -11,10 +11,11 @@ use super::{FilesystemAuthProductServices, scope_matches};
 use ironclaw_auth::{
     AuthProductError, CredentialAccount, CredentialAccountChoiceRequest, CredentialAccountId,
     CredentialAccountListPage, CredentialAccountListRequest, CredentialAccountLookupRequest,
-    CredentialAccountMutation, CredentialAccountProjection, CredentialAccountSelectionRequest,
-    CredentialAccountService, CredentialAccountStatus, CredentialRecoveryProjection,
-    CredentialRecoveryReason, CredentialRecoveryRequest, CredentialRefreshReport,
-    CredentialRefreshRequest, CredentialSetupService, NewCredentialAccount,
+    CredentialAccountMutation, CredentialAccountOwnerScope, CredentialAccountProjection,
+    CredentialAccountRecordSource, CredentialAccountSelectionRequest, CredentialAccountService,
+    CredentialAccountStatus, CredentialRecoveryProjection, CredentialRecoveryReason,
+    CredentialRecoveryRequest, CredentialRefreshReport, CredentialRefreshRequest,
+    CredentialSetupService, NewCredentialAccount,
 };
 
 #[async_trait]
@@ -231,6 +232,27 @@ where
         _request: CredentialRefreshRequest,
     ) -> Result<CredentialRefreshReport, AuthProductError> {
         Err(AuthProductError::BackendUnavailable)
+    }
+}
+
+#[async_trait]
+impl<F> CredentialAccountRecordSource for FilesystemAuthProductServices<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn accounts_for_owner(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+    ) -> Result<Vec<CredentialAccount>, AuthProductError> {
+        let owner = CredentialAccountOwnerScope::from_scope(scope);
+        self.account_records_for_owner(&owner).await
+    }
+
+    async fn select_unique_configured_account_for_owner(
+        &self,
+        request: CredentialAccountSelectionRequest,
+    ) -> Result<CredentialAccount, AuthProductError> {
+        self.select_configured_account_for_owner(request).await
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/domain.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/domain.rs
@@ -7,5 +7,6 @@ pub(super) use ironclaw_auth::domain::{
     update_account_from_exchange, update_account_from_request, validate_account_update_target,
     validate_bound_update_authority, validate_callback_claim,
     validate_credential_status_transition, validate_flow_update_binding,
-    validate_manual_token_update_binding, validate_new_credential_account, validate_selection_flow,
+    validate_manual_token_flow, validate_manual_token_update_binding,
+    validate_new_credential_account, validate_selection_flow,
 };

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/flows.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/flows.rs
@@ -5,17 +5,19 @@ use ironclaw_filesystem::{CasExpectation, RootFilesystem};
 use super::domain::{
     PreparedCallbackFlow, prepare_callback_flow, update_account_from_exchange,
     update_account_from_request, validate_bound_update_authority, validate_callback_claim,
-    validate_flow_update_binding, validate_selection_flow,
+    validate_flow_update_binding, validate_manual_token_flow, validate_selection_flow,
 };
 use super::{
     FilesystemAuthProductServices, credential_status_for_completed_flow, is_terminal_status,
     scope_matches,
 };
 use ironclaw_auth::{
-    AuthErrorCode, AuthFlowId, AuthFlowManager, AuthFlowRecord, AuthFlowStatus, AuthProductError,
-    CredentialAccountId, CredentialAccountStatus, CredentialOwnership, CredentialSelectionInput,
-    NewAuthFlow, NewCredentialAccount, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
-    OAuthCallbackInput, OAuthProviderExchange, ProviderCallbackOutcome,
+    AuthChallenge, AuthErrorCode, AuthFlowId, AuthFlowManager, AuthFlowRecord,
+    AuthFlowRecordSource, AuthFlowStatus, AuthProductError, CredentialAccountId,
+    CredentialAccountStatus, CredentialOwnership, CredentialSelectionInput,
+    ManualTokenCompletionInput, NewAuthFlow, NewCredentialAccount, OAuthCallbackClaimRequest,
+    OAuthCallbackFailureInput, OAuthCallbackInput, OAuthProviderExchange, ProviderCallbackOutcome,
+    TurnGateAuthFlowQuery, flow_matches_turn_gate_query,
 };
 
 #[async_trait]
@@ -197,6 +199,102 @@ where
         Ok(record)
     }
 
+    async fn complete_manual_token(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+        input: ManualTokenCompletionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        let flow_id = self
+            .flows_for_scope(scope)
+            .await?
+            .into_iter()
+            .find_map(|(flow, _)| {
+                let matches_interaction = matches!(
+                    &flow.challenge,
+                    Some(AuthChallenge::ManualTokenRequired { interaction_id, .. })
+                        if interaction_id == &input.interaction_id
+                );
+                matches_interaction.then_some(flow.id)
+            })
+            .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
+        let lock = self.lock_for(format!("flow:{flow_id}"));
+        let _guard = lock.lock().await;
+        let now = Utc::now();
+        let (mut record, version) = self
+            .read_flow(scope, flow_id)
+            .await?
+            .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
+        match validate_manual_token_flow(&mut record, scope, &input, now) {
+            Ok(()) => {}
+            Err(AuthProductError::UnknownOrExpiredFlow) => {
+                self.write_flow(scope, &record, CasExpectation::Version(version))
+                    .await?;
+                return Err(AuthProductError::UnknownOrExpiredFlow);
+            }
+            Err(error) => return Err(error),
+        }
+        if record.status == AuthFlowStatus::Completed {
+            return Ok(record);
+        }
+        let account = self
+            .read_account(scope, input.credential_account_id)
+            .await?
+            .map(|(account, _)| account)
+            .ok_or(AuthProductError::CredentialMissing)?;
+        if !scope_matches(&record.scope, &account.scope)
+            || account.provider != record.provider
+            || account.status != CredentialAccountStatus::Configured
+        {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        record.status = AuthFlowStatus::Completed;
+        record.error = None;
+        record.credential_account_id = Some(input.credential_account_id);
+        record.updated_at = now;
+        self.write_flow(scope, &record, CasExpectation::Version(version))
+            .await?;
+        Ok(record)
+    }
+
+    async fn cancel_manual_token(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+        interaction_id: ironclaw_auth::AuthInteractionId,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        let Some(flow_id) = self
+            .flows_for_scope(scope)
+            .await?
+            .into_iter()
+            .find_map(|(flow, _)| {
+                let matches_interaction = matches!(
+                    &flow.challenge,
+                    Some(AuthChallenge::ManualTokenRequired { interaction_id: id, .. })
+                        if id == &interaction_id
+                );
+                matches_interaction.then_some(flow.id)
+            })
+        else {
+            return Ok(None);
+        };
+        let lock = self.lock_for(format!("flow:{flow_id}"));
+        let _guard = lock.lock().await;
+        let (mut record, version) = self
+            .read_flow(scope, flow_id)
+            .await?
+            .ok_or(AuthProductError::UnknownOrExpiredFlow)?;
+        if !scope_matches(scope, &record.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if !is_terminal_status(record.status) {
+            record.status = AuthFlowStatus::Canceled;
+            record.error = Some(AuthErrorCode::Canceled);
+            record.updated_at = Utc::now();
+            self.write_flow(scope, &record, CasExpectation::Version(version))
+                .await?;
+        }
+        Ok(Some(record))
+    }
+
     async fn fail_oauth_callback(
         &self,
         scope: &ironclaw_auth::AuthProductScope,
@@ -282,6 +380,30 @@ where
         self.write_flow(scope, &record, CasExpectation::Version(version))
             .await?;
         Ok(record)
+    }
+}
+
+#[async_trait]
+impl<F> AuthFlowRecordSource for FilesystemAuthProductServices<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn flow_for_turn_gate(
+        &self,
+        query: TurnGateAuthFlowQuery,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        Ok(self
+            .flow_records_for_owner(&query.owner)
+            .await?
+            .into_iter()
+            .find(|flow| flow_matches_turn_gate_query(flow, &query)))
+    }
+
+    async fn flows_for_owner(
+        &self,
+        owner: ironclaw_auth::AuthFlowOwnerScope,
+    ) -> Result<Vec<AuthFlowRecord>, AuthProductError> {
+        self.flow_records_for_owner(&owner).await
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/paths.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/paths.rs
@@ -1,7 +1,9 @@
 use ironclaw_filesystem::FilesystemError;
-use ironclaw_host_api::{ScopedPath, SecretHandle};
+use ironclaw_host_api::{ResourceScope, ScopedPath, SecretHandle};
 
-use ironclaw_auth::{AuthFlowId, AuthInteractionId, AuthProductError, CredentialAccountId};
+use ironclaw_auth::{
+    AuthFlowId, AuthInteractionId, AuthProductError, AuthSurface, CredentialAccountId,
+};
 
 pub(super) fn flow_path(
     scope: &ironclaw_auth::AuthProductScope,
@@ -10,6 +12,23 @@ pub(super) fn flow_path(
     scoped_path(&format!(
         "{}/flows/{flow_id}.json",
         product_auth_root(scope)
+    ))
+}
+
+pub(super) fn flow_root(
+    scope: &ironclaw_auth::AuthProductScope,
+) -> Result<ScopedPath, AuthProductError> {
+    scoped_path(&format!("{}/flows", product_auth_root(scope)))
+}
+
+pub(super) fn surface_sessions_root(
+    resource: &ResourceScope,
+    surface: AuthSurface,
+) -> Result<ScopedPath, AuthProductError> {
+    scoped_path(&format!(
+        "{}/{}/sessions",
+        product_auth_base_root(resource),
+        surface_path_segment(surface)
     ))
 }
 
@@ -40,18 +59,32 @@ pub(super) fn account_root(
 }
 
 fn product_auth_root(scope: &ironclaw_auth::AuthProductScope) -> String {
+    let mut base = product_auth_base_root(&scope.resource);
+    base.push('/');
+    base.push_str(surface_path_segment(scope.surface));
+    if let Some(session_id) = &scope.session_id {
+        base.push_str("/sessions/");
+        base.push_str(session_id.as_str());
+    }
+    base
+}
+
+fn product_auth_base_root(resource: &ResourceScope) -> String {
     let mut base = String::from("/secrets");
-    if let Some(agent_id) = &scope.resource.agent_id {
+    if let Some(agent_id) = &resource.agent_id {
         base.push_str("/agents/");
         base.push_str(agent_id.as_str());
     }
-    if let Some(project_id) = &scope.resource.project_id {
+    if let Some(project_id) = &resource.project_id {
         base.push_str("/projects/");
         base.push_str(project_id.as_str());
     }
     base.push_str("/product-auth");
-    base.push('/');
-    base.push_str(match scope.surface {
+    base
+}
+
+fn surface_path_segment(surface: AuthSurface) -> &'static str {
+    match surface {
         ironclaw_auth::AuthSurface::Chat => "chat",
         ironclaw_auth::AuthSurface::Web => "web",
         ironclaw_auth::AuthSurface::Cli => "cli",
@@ -59,12 +92,7 @@ fn product_auth_root(scope: &ironclaw_auth::AuthProductScope) -> String {
         ironclaw_auth::AuthSurface::Api => "api",
         ironclaw_auth::AuthSurface::SetupAdmin => "setup-admin",
         ironclaw_auth::AuthSurface::Callback => "callback",
-    });
-    if let Some(session_id) = &scope.session_id {
-        base.push_str("/sessions/");
-        base.push_str(session_id.as_str());
     }
-    base
 }
 
 fn scoped_path(raw: &str) -> Result<ScopedPath, AuthProductError> {

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -3,22 +3,27 @@ use std::sync::Arc;
 use chrono::{Duration, Utc};
 use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
 use ironclaw_host_api::{
-    InvocationId, MountAlias, MountGrant, MountPermissions, SecretHandle, UserId, VirtualPath,
+    InvocationId, MountAlias, MountGrant, MountPermissions, SecretHandle, ThreadId, UserId,
+    VirtualPath,
 };
 use ironclaw_secrets::{InMemorySecretStore, SecretStore};
 use secrecy::SecretString;
 use tokio::task::JoinSet;
 
 use super::*;
+use crate::product_auth_runtime_credentials::{
+    ProductAuthRuntimeCredentialAccountSelector, RuntimeCredentialAccountSelectionService,
+};
 use ironclaw_auth::{
-    AuthChallenge, AuthContinuationRef, AuthFlowKind, AuthFlowManager, AuthFlowStatus,
-    AuthInteractionService, AuthProductError, AuthProductScope, AuthProviderId, AuthSurface,
+    AuthChallenge, AuthContinuationRef, AuthFlowKind, AuthFlowManager, AuthFlowOwnerScope,
+    AuthFlowRecordSource, AuthFlowStatus, AuthInteractionId, AuthInteractionService,
+    AuthProductError, AuthProductScope, AuthProviderId, AuthSessionId, AuthSurface,
     AuthorizationCodeHash, CredentialAccountChoiceRequest, CredentialAccountLabel,
-    CredentialAccountListRequest, CredentialAccountLookupRequest,
+    CredentialAccountListRequest, CredentialAccountLookupRequest, CredentialAccountRecordSource,
     CredentialAccountSelectionRequest, CredentialAccountService, CredentialAccountStatus,
-    CredentialOwnership, ManualTokenSetupRequest, NewAuthFlow, NewCredentialAccount,
-    OAuthAuthorizationUrl, OAuthCallbackClaimRequest, OAuthCallbackInput, OAuthProviderExchange,
-    OpaqueStateHash, PkceVerifierHash, ProviderScope, SecretSubmitRequest,
+    CredentialOwnership, ManualTokenCompletionInput, ManualTokenSetupRequest, NewAuthFlow,
+    NewCredentialAccount, OAuthAuthorizationUrl, OAuthCallbackClaimRequest, OAuthCallbackInput,
+    OAuthProviderExchange, OpaqueStateHash, PkceVerifierHash, ProviderScope, SecretSubmitRequest,
 };
 
 fn test_scope() -> AuthProductScope {
@@ -76,6 +81,53 @@ fn code_hash(value: &str) -> AuthorizationCodeHash {
     AuthorizationCodeHash::new(fake_digest(value)).unwrap()
 }
 
+async fn create_manual_token_flow(
+    service: &FilesystemAuthProductServices<InMemoryBackend>,
+    scope: &AuthProductScope,
+    expires_at: chrono::DateTime<Utc>,
+) -> AuthInteractionId {
+    let challenge = service
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            expires_at,
+        })
+        .await
+        .unwrap();
+    let AuthChallenge::ManualTokenRequired {
+        interaction_id,
+        provider,
+        label,
+        expires_at: challenge_expires_at,
+    } = challenge
+    else {
+        panic!("expected manual token challenge");
+    };
+    service
+        .create_flow(NewAuthFlow {
+            scope: scope.clone(),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider,
+            challenge: AuthChallenge::ManualTokenRequired {
+                interaction_id,
+                provider: google_provider(),
+                label,
+                expires_at: challenge_expires_at,
+            },
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            opaque_state_hash: None,
+            pkce_verifier_hash: None,
+            expires_at,
+        })
+        .await
+        .unwrap();
+    interaction_id
+}
+
 #[tokio::test]
 async fn filesystem_accounts_survive_service_recreation() {
     let filesystem = test_filesystem();
@@ -117,6 +169,47 @@ async fn filesystem_accounts_survive_service_recreation() {
         .unwrap();
     assert_eq!(page.accounts.len(), 1);
     assert_eq!(page.accounts[0].id, created.id);
+}
+
+#[tokio::test]
+async fn filesystem_runtime_account_selection_matches_setup_invocation_account() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let mut setup_scope = test_scope();
+    setup_scope.surface = AuthSurface::Callback;
+    setup_scope.resource.thread_id = Some(ThreadId::new("thread-auth-1").unwrap());
+    let mut runtime_scope = AuthProductScope::new(setup_scope.resource.clone(), AuthSurface::Api);
+    runtime_scope.resource.invocation_id = InvocationId::new();
+    let service = Arc::new(test_service(filesystem, secret_store));
+    let access_secret = SecretHandle::new("google-access").unwrap();
+
+    let created = service
+        .create_account(NewCredentialAccount {
+            scope: setup_scope,
+            provider: google_provider(),
+            label: account_label(),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(access_secret.clone()),
+            refresh_secret: None,
+            scopes: vec![ProviderScope::new("gmail.readonly").unwrap()],
+        })
+        .await
+        .unwrap();
+
+    let selector = ProductAuthRuntimeCredentialAccountSelector::new(service.clone());
+    let selected = selector
+        .select_unique_configured_runtime_account(CredentialAccountSelectionRequest::new(
+            runtime_scope,
+            google_provider(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(selected.id, created.id);
+    assert_eq!(selected.access_secret, Some(access_secret));
 }
 
 #[tokio::test]
@@ -182,6 +275,357 @@ async fn filesystem_manual_token_submit_stores_secret_and_dedupes_replay() {
         .await
         .expect_err("manual token submit should be one-shot");
     assert_eq!(replay, AuthProductError::UnknownOrExpiredFlow);
+}
+
+#[tokio::test]
+async fn filesystem_manual_token_completion_persists_auth_flow_account() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let scope = test_scope();
+    let service = test_service(filesystem, secret_store);
+    let expires_at = Utc::now() + Duration::minutes(5);
+
+    let challenge = service
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            expires_at,
+        })
+        .await
+        .unwrap();
+    let AuthChallenge::ManualTokenRequired {
+        interaction_id,
+        provider,
+        label,
+        expires_at: challenge_expires_at,
+    } = challenge
+    else {
+        panic!("expected manual token challenge");
+    };
+
+    let flow = service
+        .create_flow(NewAuthFlow {
+            scope: scope.clone(),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: google_provider(),
+            challenge: AuthChallenge::ManualTokenRequired {
+                interaction_id,
+                provider,
+                label,
+                expires_at: challenge_expires_at,
+            },
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            opaque_state_hash: None,
+            pkce_verifier_hash: None,
+            expires_at,
+        })
+        .await
+        .unwrap();
+
+    let submitted = service
+        .submit_manual_token(
+            &scope,
+            SecretSubmitRequest {
+                interaction_id,
+                secret: SecretString::from("manual-token-value"),
+            },
+        )
+        .await
+        .unwrap();
+
+    let completed = service
+        .complete_manual_token(
+            &scope,
+            ManualTokenCompletionInput {
+                interaction_id,
+                credential_account_id: submitted.account_id,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(completed.id, flow.id);
+    assert_eq!(completed.status, AuthFlowStatus::Completed);
+    assert_eq!(completed.credential_account_id, Some(submitted.account_id));
+}
+
+#[tokio::test]
+async fn filesystem_manual_token_completion_rejects_invalid_completed_account() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let scope = test_scope();
+    let service = test_service(filesystem, secret_store);
+    let interaction_id =
+        create_manual_token_flow(&service, &scope, Utc::now() + Duration::minutes(5)).await;
+
+    let missing = service
+        .complete_manual_token(
+            &scope,
+            ManualTokenCompletionInput {
+                interaction_id,
+                credential_account_id: CredentialAccountId::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(missing, AuthProductError::CredentialMissing);
+
+    let account = service
+        .create_account(NewCredentialAccount {
+            scope: scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            status: CredentialAccountStatus::PendingSetup,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: vec![],
+            access_secret: None,
+            refresh_secret: None,
+            scopes: vec![],
+        })
+        .await
+        .unwrap();
+    let unconfigured = service
+        .complete_manual_token(
+            &scope,
+            ManualTokenCompletionInput {
+                interaction_id,
+                credential_account_id: account.id,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(unconfigured, AuthProductError::CrossScopeDenied);
+
+    let mut foreign_scope = scope.clone();
+    foreign_scope.resource.user_id = UserId::new("bob").unwrap();
+    let foreign = service
+        .create_account(NewCredentialAccount {
+            scope: foreign_scope,
+            provider: google_provider(),
+            label: account_label(),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: vec![],
+            access_secret: Some(SecretHandle::new("foreign-access").unwrap()),
+            refresh_secret: None,
+            scopes: vec![],
+        })
+        .await
+        .unwrap();
+    let cross_scope = service
+        .complete_manual_token(
+            &scope,
+            ManualTokenCompletionInput {
+                interaction_id,
+                credential_account_id: foreign.id,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(cross_scope, AuthProductError::CrossScopeDenied);
+}
+
+#[tokio::test]
+async fn filesystem_manual_token_completion_expires_stale_auth_flow() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let scope = test_scope();
+    let service = test_service(filesystem, secret_store);
+    let interaction_id =
+        create_manual_token_flow(&service, &scope, Utc::now() - Duration::minutes(1)).await;
+
+    let submitted = service
+        .submit_manual_token(
+            &scope,
+            SecretSubmitRequest {
+                interaction_id,
+                secret: SecretString::from("manual-token-value"),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(submitted, AuthProductError::UnknownOrExpiredFlow);
+
+    let err = service
+        .complete_manual_token(
+            &scope,
+            ManualTokenCompletionInput {
+                interaction_id,
+                credential_account_id: CredentialAccountId::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err, AuthProductError::UnknownOrExpiredFlow);
+    let flows = service.flows_for_scope(&scope).await.unwrap();
+    assert_eq!(flows.len(), 1);
+    assert_eq!(flows[0].0.status, AuthFlowStatus::Expired);
+}
+
+#[tokio::test]
+async fn filesystem_manual_token_cancel_marks_flow_canceled_and_is_idempotent() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let scope = test_scope();
+    let service = test_service(filesystem, secret_store);
+    let interaction_id =
+        create_manual_token_flow(&service, &scope, Utc::now() + Duration::minutes(5)).await;
+
+    let canceled = service
+        .cancel_manual_token(&scope, interaction_id)
+        .await
+        .unwrap()
+        .expect("manual-token flow should be canceled");
+    assert_eq!(canceled.status, AuthFlowStatus::Canceled);
+    let still_canceled = service
+        .cancel_manual_token(&scope, interaction_id)
+        .await
+        .unwrap()
+        .expect("terminal flow should still be returned");
+    assert_eq!(still_canceled.status, AuthFlowStatus::Canceled);
+    let unknown = service
+        .cancel_manual_token(&scope, AuthInteractionId::new())
+        .await
+        .unwrap();
+    assert!(unknown.is_none());
+}
+
+#[tokio::test]
+async fn filesystem_flow_record_source_projects_session_scoped_manual_flows() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let mut scope = test_scope();
+    scope.surface = AuthSurface::Callback;
+    scope.resource.thread_id = Some(ThreadId::new("thread-auth-flow").unwrap());
+    scope.session_id = Some(AuthSessionId::new("session-auth-flow").unwrap());
+    let service = FilesystemAuthProductServices::new(filesystem, secret_store);
+    let expires_at = Utc::now() + Duration::minutes(5);
+
+    let challenge = service
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            expires_at,
+        })
+        .await
+        .unwrap();
+    let AuthChallenge::ManualTokenRequired {
+        interaction_id,
+        provider,
+        label,
+        expires_at: challenge_expires_at,
+    } = challenge
+    else {
+        panic!("expected manual token challenge");
+    };
+    let flow = service
+        .create_flow(NewAuthFlow {
+            scope: scope.clone(),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: google_provider(),
+            challenge: AuthChallenge::ManualTokenRequired {
+                interaction_id,
+                provider,
+                label,
+                expires_at: challenge_expires_at,
+            },
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            opaque_state_hash: None,
+            pkce_verifier_hash: None,
+            expires_at,
+        })
+        .await
+        .unwrap();
+
+    let submitted = service
+        .submit_manual_token(
+            &scope,
+            SecretSubmitRequest {
+                interaction_id,
+                secret: SecretString::from("manual-token-value"),
+            },
+        )
+        .await
+        .unwrap();
+    service
+        .complete_manual_token(
+            &scope,
+            ManualTokenCompletionInput {
+                interaction_id,
+                credential_account_id: submitted.account_id,
+            },
+        )
+        .await
+        .unwrap();
+
+    let owner = AuthFlowOwnerScope {
+        tenant_id: scope.resource.tenant_id.clone(),
+        user_id: scope.resource.user_id.clone(),
+        agent_id: scope.resource.agent_id.clone(),
+        project_id: scope.resource.project_id.clone(),
+        thread_id: scope.resource.thread_id.clone().unwrap(),
+    };
+    let snapshot = service.flows_for_owner(owner).await.unwrap();
+    let projected = snapshot
+        .iter()
+        .find(|record| record.id == flow.id)
+        .expect("session-scoped flow should be projected for auth gates");
+
+    assert_eq!(projected.status, AuthFlowStatus::Completed);
+    assert_eq!(projected.scope.session_id, scope.session_id);
+    assert_eq!(
+        projected.credential_account_id,
+        Some(submitted.account_id),
+        "manual-token completion must remain visible to the auth read model"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_account_record_source_projects_session_scoped_accounts_for_runtime_owner() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let mut setup_scope = test_scope();
+    setup_scope.surface = AuthSurface::Callback;
+    setup_scope.resource.thread_id = Some(ThreadId::new("thread-auth-account").unwrap());
+    setup_scope.session_id = Some(AuthSessionId::new("session-auth-account").unwrap());
+    let service = FilesystemAuthProductServices::new(filesystem, secret_store);
+    let account = service
+        .create_account(NewCredentialAccount {
+            scope: setup_scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(SecretHandle::new("session-scoped-access").unwrap()),
+            refresh_secret: None,
+            scopes: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let mut runtime_resource = setup_scope.resource.clone();
+    runtime_resource.invocation_id = InvocationId::new();
+    let runtime_scope = AuthProductScope::new(runtime_resource, AuthSurface::Api);
+
+    let projected = service.accounts_for_owner(&runtime_scope).await.unwrap();
+    let projected_account = projected
+        .iter()
+        .find(|candidate| candidate.id == account.id)
+        .expect("runtime owner projection should include session-scoped setup account");
+
+    assert_eq!(projected_account.scope.session_id, setup_scope.session_id);
+    assert_eq!(projected_account.provider, google_provider());
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -2,21 +2,59 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_auth::{
-    AuthProductError, AuthProductScope, AuthProviderId, AuthSurface,
-    CredentialAccountLookupRequest, CredentialAccountSelectionRequest, CredentialAccountService,
-    CredentialAccountStatus,
+    AuthProductError, AuthProductScope, AuthProviderId, AuthSurface, CredentialAccount,
+    CredentialAccountRecordSource, CredentialAccountSelectionRequest, CredentialAccountStatus,
 };
 use ironclaw_host_api::{CredentialStageError, SecretHandle};
 use ironclaw_host_runtime::{RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver};
 
 #[derive(Clone)]
 pub(crate) struct ProductAuthRuntimeCredentialResolver {
-    accounts: Arc<dyn CredentialAccountService>,
+    accounts: Arc<dyn RuntimeCredentialAccountSelectionService>,
 }
 
 impl ProductAuthRuntimeCredentialResolver {
-    pub(crate) fn new(accounts: Arc<dyn CredentialAccountService>) -> Self {
+    pub(crate) fn new(accounts: Arc<dyn RuntimeCredentialAccountSelectionService>) -> Self {
         Self { accounts }
+    }
+}
+
+#[async_trait]
+pub(crate) trait RuntimeCredentialAccountSelectionService: Send + Sync {
+    async fn select_unique_configured_runtime_account(
+        &self,
+        request: CredentialAccountSelectionRequest,
+    ) -> Result<CredentialAccount, AuthProductError>;
+}
+
+pub(crate) struct ProductAuthRuntimeCredentialAccountSelector {
+    accounts: Arc<dyn CredentialAccountRecordSource>,
+}
+
+impl ProductAuthRuntimeCredentialAccountSelector {
+    pub(crate) fn new(accounts: Arc<dyn CredentialAccountRecordSource>) -> Self {
+        Self { accounts }
+    }
+}
+
+impl std::fmt::Debug for ProductAuthRuntimeCredentialAccountSelector {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProductAuthRuntimeCredentialAccountSelector")
+            .field("accounts", &"<credential_account_record_source>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl RuntimeCredentialAccountSelectionService for ProductAuthRuntimeCredentialAccountSelector {
+    async fn select_unique_configured_runtime_account(
+        &self,
+        request: CredentialAccountSelectionRequest,
+    ) -> Result<CredentialAccount, AuthProductError> {
+        self.accounts
+            .select_unique_configured_account_for_owner(request)
+            .await
     }
 }
 
@@ -44,23 +82,14 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
             );
             CredentialStageError::Backend
         })?;
-        let selected = self
+        let account = self
             .accounts
-            .select_unique_configured_account(
-                CredentialAccountSelectionRequest::new(auth_scope.clone(), provider)
+            .select_unique_configured_runtime_account(
+                CredentialAccountSelectionRequest::new(auth_scope, provider)
                     .for_extension(request.requester_extension.clone()),
             )
             .await
             .map_err(map_account_error)?;
-        let account = self
-            .accounts
-            .get_account(
-                CredentialAccountLookupRequest::new(auth_scope, selected.id)
-                    .for_extension(request.requester_extension.clone()),
-            )
-            .await
-            .map_err(map_account_error)?
-            .ok_or(CredentialStageError::AuthRequired)?;
         if account.status != CredentialAccountStatus::Configured {
             return Err(CredentialStageError::AuthRequired);
         }
@@ -86,11 +115,12 @@ fn map_account_error(error: AuthProductError) -> CredentialStageError {
 #[cfg(test)]
 mod tests {
     use ironclaw_auth::{
-        CredentialAccountLabel, CredentialOwnership, InMemoryAuthProductServices,
-        NewCredentialAccount,
+        CredentialAccountLabel, CredentialAccountService, CredentialOwnership,
+        InMemoryAuthProductServices, NewCredentialAccount,
     };
     use ironclaw_host_api::{
-        ExtensionId, InvocationId, ResourceScope, RuntimeCredentialAccountProviderId, UserId,
+        ExtensionId, InvocationId, ResourceScope, RuntimeCredentialAccountProviderId, ThreadId,
+        UserId,
     };
 
     use super::*;
@@ -118,7 +148,9 @@ mod tests {
             })
             .await
             .unwrap();
-        let resolver = ProductAuthRuntimeCredentialResolver::new(accounts);
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
 
         let resolved = resolver
             .resolve_access_secret(RuntimeCredentialAccountRequest {
@@ -133,9 +165,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolver_matches_callback_setup_account_from_runtime_invocation() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let mut setup_scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        setup_scope.thread_id = Some(ThreadId::new("thread-auth-1").unwrap());
+        let mut runtime_scope = setup_scope.clone();
+        runtime_scope.invocation_id = InvocationId::new();
+        let access_secret = SecretHandle::new("github_manual_access").unwrap();
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: AuthProductScope::new(setup_scope, AuthSurface::Callback),
+                provider: AuthProviderId::new("github").unwrap(),
+                label: CredentialAccountLabel::new("work github").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(access_secret.clone()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+
+        let resolved = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &runtime_scope,
+                provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                requester_extension: &ExtensionId::new("github").unwrap(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, access_secret);
+    }
+
+    #[tokio::test]
     async fn resolver_maps_missing_account_to_auth_required() {
-        let resolver =
-            ProductAuthRuntimeCredentialResolver::new(Arc::new(InMemoryAuthProductServices::new()));
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
         let scope =
             ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
                 .unwrap();
@@ -174,7 +249,9 @@ mod tests {
             })
             .await
             .unwrap();
-        let resolver = ProductAuthRuntimeCredentialResolver::new(accounts);
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
 
         let error = resolver
             .resolve_access_secret(RuntimeCredentialAccountRequest {
@@ -210,7 +287,9 @@ mod tests {
             })
             .await
             .unwrap();
-        let resolver = ProductAuthRuntimeCredentialResolver::new(accounts);
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
 
         let error = resolver
             .resolve_access_secret(RuntimeCredentialAccountRequest {
@@ -253,7 +332,9 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let resolver = ProductAuthRuntimeCredentialResolver::new(accounts);
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
 
         let error = resolver
             .resolve_access_secret(RuntimeCredentialAccountRequest {

--- a/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ironclaw_auth::{AuthContinuationRef, AuthFlowRecord, AuthFlowRecordSource};
+use ironclaw_auth::{
+    AuthFlowOwnerScope, AuthFlowRecord, AuthFlowRecordSource, AuthGateRef, TurnGateAuthFlowQuery,
+    TurnRunRef, flow_matches_turn_gate_query,
+};
 use ironclaw_product_workflow::{
     AuthGateRecord, AuthInteractionReadModel, AuthInteractionRejectionKind, AuthInteractionScope,
     AuthInteractionService, ListPendingAuthInteractionsRequest,
@@ -146,16 +149,72 @@ impl LocalDevAuthInteractionReadModel {
         Ok(historical.into_iter().next())
     }
 
-    fn flow_for_gate(
+    async fn flow_for_gate(
         &self,
         scope: &AuthInteractionScope,
         run_id: TurnRunId,
         gate_ref: &GateRef,
-    ) -> Option<AuthFlowRecord> {
+    ) -> Result<Option<AuthFlowRecord>, ProductWorkflowError> {
         self.flow_records
-            .flow_records_snapshot()
-            .into_iter()
-            .find(|flow| same_auth_owner(flow, scope) && flow_matches_gate(flow, run_id, gate_ref))
+            .flow_for_turn_gate(turn_gate_query(scope, run_id, gate_ref)?)
+            .await
+            .map_err(|_| auth_read_model_unavailable())
+    }
+}
+
+fn owner_scope_for_interaction(scope: &AuthInteractionScope) -> AuthFlowOwnerScope {
+    AuthFlowOwnerScope {
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        thread_id: scope.thread_id.clone(),
+    }
+}
+
+fn turn_gate_query(
+    scope: &AuthInteractionScope,
+    run_id: TurnRunId,
+    gate_ref: &GateRef,
+) -> Result<TurnGateAuthFlowQuery, ProductWorkflowError> {
+    Ok(TurnGateAuthFlowQuery {
+        owner: owner_scope_for_interaction(scope),
+        turn_run_ref: TurnRunRef::new(run_id.to_string())
+            .map_err(|_| auth_read_model_unavailable())?,
+        gate_ref: AuthGateRef::new(gate_ref.as_str()).map_err(|_| auth_read_model_unavailable())?,
+        include_terminal: false,
+    })
+}
+
+async fn flows_for_owner(
+    source: &Arc<dyn AuthFlowRecordSource>,
+    scope: &AuthInteractionScope,
+) -> Result<Vec<AuthFlowRecord>, ProductWorkflowError> {
+    source
+        .flows_for_owner(owner_scope_for_interaction(scope))
+        .await
+        .map_err(|_| auth_read_model_unavailable())
+}
+
+fn matching_flow_for_run(
+    flows: &[AuthFlowRecord],
+    scope: &AuthInteractionScope,
+    run_id: TurnRunId,
+    gate_ref: &GateRef,
+) -> Result<Option<AuthFlowRecord>, ProductWorkflowError> {
+    let query = turn_gate_query(scope, run_id, gate_ref)?;
+    Ok(flows
+        .iter()
+        .find(|flow| flow_matches_turn_gate_query(flow, &query))
+        .cloned())
+}
+
+impl LocalDevAuthInteractionReadModel {
+    async fn owner_flows(
+        &self,
+        scope: &AuthInteractionScope,
+    ) -> Result<Vec<AuthFlowRecord>, ProductWorkflowError> {
+        flows_for_owner(&self.flow_records, scope).await
     }
 }
 
@@ -166,8 +225,9 @@ impl AuthInteractionReadModel for LocalDevAuthInteractionReadModel {
         scope: &AuthInteractionScope,
     ) -> Result<Vec<AuthGateRecord>, ProductWorkflowError> {
         let mut gates = Vec::new();
+        let flows = self.owner_flows(scope).await?;
         for run in self.blocked_auth_runs(scope).await? {
-            if let Some(flow) = self.flow_for_gate(scope, run.run_id, &run.gate_ref) {
+            if let Some(flow) = matching_flow_for_run(&flows, scope, run.run_id, &run.gate_ref)? {
                 gates.push(AuthGateRecord::new(run.run_id, run.gate_ref, flow)?);
             }
         }
@@ -189,7 +249,7 @@ impl AuthInteractionReadModel for LocalDevAuthInteractionReadModel {
                 run_id
             }
         };
-        let Some(flow) = self.flow_for_gate(scope, run_id, gate_ref) else {
+        let Some(flow) = self.flow_for_gate(scope, run_id, gate_ref).await? else {
             return Ok(None);
         };
         Ok(Some(AuthGateRecord::new(run_id, gate_ref.clone(), flow)?))
@@ -203,30 +263,6 @@ fn turn_scope_for_interaction(scope: &AuthInteractionScope) -> TurnScope {
         scope.project_id.clone(),
         scope.thread_id.clone(),
     )
-}
-
-fn same_auth_owner(flow: &AuthFlowRecord, scope: &AuthInteractionScope) -> bool {
-    let resource = &flow.scope.resource;
-    // Surface/session/invocation are not authority for this UI bridge; the
-    // caller must own the tenant/user/agent/project/thread that is blocked.
-    resource.tenant_id == scope.tenant_id
-        && resource.user_id == scope.user_id
-        && resource.agent_id == scope.agent_id
-        && resource.project_id == scope.project_id
-        && resource.mission_id.is_none()
-        && resource.thread_id.as_ref() == Some(&scope.thread_id)
-}
-
-fn flow_matches_gate(flow: &AuthFlowRecord, run_id: TurnRunId, gate_ref: &GateRef) -> bool {
-    let AuthContinuationRef::TurnGateResume {
-        turn_run_ref,
-        gate_ref: continuation_gate_ref,
-    } = &flow.continuation
-    else {
-        return false;
-    };
-    turn_run_ref.as_str() == run_id.to_string()
-        && continuation_gate_ref.as_str() == gate_ref.as_str()
 }
 
 fn snapshot_run_actor_matches(

--- a/crates/ironclaw_reborn_composition/tests/manual_tokens.rs
+++ b/crates/ironclaw_reborn_composition/tests/manual_tokens.rs
@@ -1,15 +1,17 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use ironclaw_auth::{
-    AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowManager,
-    AuthInteractionId, AuthInteractionService, AuthProductError, AuthProductScope,
-    AuthProviderClient, AuthProviderId, AuthSessionId, AuthSurface, CredentialAccountLabel,
-    CredentialAccountListRequest, CredentialAccountService, CredentialAccountStatus,
-    CredentialAccountUpdateBinding, CredentialOwnership, CredentialSetupService,
-    InMemoryAuthProductServices, ManualTokenSetupRequest, NewCredentialAccount,
-    OAuthAuthorizationUrl, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult,
+    AuthChallenge, AuthContinuationEvent, AuthContinuationRef, AuthErrorCode, AuthFlowId,
+    AuthFlowManager, AuthFlowRecord, AuthFlowStatus, AuthInteractionId, AuthInteractionService,
+    AuthProductError, AuthProductScope, AuthProviderClient, AuthProviderId, AuthSessionId,
+    AuthSurface, CredentialAccountLabel, CredentialAccountListRequest, CredentialAccountService,
+    CredentialAccountStatus, CredentialAccountUpdateBinding, CredentialOwnership,
+    CredentialSelectionInput, CredentialSetupService, InMemoryAuthProductServices,
+    ManualTokenCompletionInput, ManualTokenSetupRequest, NewAuthFlow, NewCredentialAccount,
+    OAuthAuthorizationUrl, OAuthCallbackClaimRequest, OAuthCallbackFailureInput,
+    OAuthCallbackInput, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult, Timestamp,
 };
 use ironclaw_host_api::{InvocationId, ResourceScope, SecretHandle, UserId};
 use ironclaw_reborn_composition::{
@@ -29,6 +31,56 @@ impl RebornAuthContinuationDispatcher for NoopContinuationDispatcher {
         &self,
         _event: AuthContinuationEvent,
     ) -> Result<(), AuthProductError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct RecordingContinuationDispatcher {
+    events: Mutex<Vec<AuthContinuationEvent>>,
+}
+
+impl RecordingContinuationDispatcher {
+    fn events(&self) -> Vec<AuthContinuationEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for RecordingContinuationDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        self.events.lock().unwrap().push(event);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct FailsFirstContinuationDispatcher {
+    attempts: Mutex<usize>,
+    events: Mutex<Vec<AuthContinuationEvent>>,
+}
+
+impl FailsFirstContinuationDispatcher {
+    fn events(&self) -> Vec<AuthContinuationEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl RebornAuthContinuationDispatcher for FailsFirstContinuationDispatcher {
+    async fn dispatch_auth_continuation(
+        &self,
+        event: AuthContinuationEvent,
+    ) -> Result<(), AuthProductError> {
+        let mut attempts = self.attempts.lock().unwrap();
+        *attempts += 1;
+        if *attempts == 1 {
+            return Err(AuthProductError::BackendUnavailable);
+        }
+        self.events.lock().unwrap().push(event);
         Ok(())
     }
 }
@@ -97,6 +149,177 @@ impl AuthInteractionService for UnexpectedChallengeInteractionService {
     }
 }
 
+#[derive(Debug)]
+struct SuccessfulManualTokenInteractionService {
+    interaction_id: AuthInteractionId,
+    abandoned: Mutex<Vec<AuthInteractionId>>,
+}
+
+impl SuccessfulManualTokenInteractionService {
+    fn new(interaction_id: AuthInteractionId) -> Self {
+        Self {
+            interaction_id,
+            abandoned: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn abandoned(&self) -> Vec<AuthInteractionId> {
+        self.abandoned.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl AuthInteractionService for SuccessfulManualTokenInteractionService {
+    async fn request_secret_input(
+        &self,
+        request: ManualTokenSetupRequest,
+    ) -> Result<AuthChallenge, AuthProductError> {
+        Ok(AuthChallenge::ManualTokenRequired {
+            interaction_id: self.interaction_id,
+            provider: request.provider,
+            label: request.label,
+            expires_at: request.expires_at,
+        })
+    }
+
+    async fn submit_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        _request: SecretSubmitRequest,
+    ) -> Result<SecretSubmitResult, AuthProductError> {
+        Ok(SecretSubmitResult {
+            account_id: ironclaw_auth::CredentialAccountId::new(),
+            status: CredentialAccountStatus::Configured,
+            continuation: AuthContinuationRef::SetupOnly,
+        })
+    }
+
+    async fn abandon_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<bool, AuthProductError> {
+        self.abandoned.lock().unwrap().push(interaction_id);
+        Ok(true)
+    }
+}
+
+#[derive(Debug)]
+struct FailingManualTokenFlowManager {
+    create_error: Option<AuthProductError>,
+    complete_error: Option<AuthProductError>,
+    canceled: Mutex<Vec<AuthInteractionId>>,
+}
+
+impl FailingManualTokenFlowManager {
+    fn create_fails(error: AuthProductError) -> Self {
+        Self {
+            create_error: Some(error),
+            complete_error: None,
+            canceled: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn complete_fails(error: AuthProductError) -> Self {
+        Self {
+            create_error: None,
+            complete_error: Some(error),
+            canceled: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn canceled(&self) -> Vec<AuthInteractionId> {
+        self.canceled.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl AuthFlowManager for FailingManualTokenFlowManager {
+    async fn create_flow(&self, _request: NewAuthFlow) -> Result<AuthFlowRecord, AuthProductError> {
+        Err(self
+            .create_error
+            .clone()
+            .unwrap_or(AuthProductError::BackendUnavailable))
+    }
+
+    async fn get_flow(
+        &self,
+        _scope: &AuthProductScope,
+        _flow_id: AuthFlowId,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        unreachable!("manual-token cleanup tests do not read flows")
+    }
+
+    async fn claim_oauth_callback(
+        &self,
+        _scope: &AuthProductScope,
+        _request: OAuthCallbackClaimRequest,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        unreachable!("manual-token cleanup tests do not claim OAuth callbacks")
+    }
+
+    async fn complete_oauth_callback(
+        &self,
+        _scope: &AuthProductScope,
+        _input: OAuthCallbackInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        unreachable!("manual-token cleanup tests do not complete OAuth callbacks")
+    }
+
+    async fn complete_credential_selection(
+        &self,
+        _scope: &AuthProductScope,
+        _input: CredentialSelectionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        unreachable!("manual-token cleanup tests do not complete account selection")
+    }
+
+    async fn complete_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        _input: ManualTokenCompletionInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        Err(self
+            .complete_error
+            .clone()
+            .unwrap_or(AuthProductError::BackendUnavailable))
+    }
+
+    async fn cancel_manual_token(
+        &self,
+        _scope: &AuthProductScope,
+        interaction_id: AuthInteractionId,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        self.canceled.lock().unwrap().push(interaction_id);
+        Ok(None)
+    }
+
+    async fn fail_oauth_callback(
+        &self,
+        _scope: &AuthProductScope,
+        _input: OAuthCallbackFailureInput,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        unreachable!("manual-token cleanup tests do not fail OAuth callbacks")
+    }
+
+    async fn mark_continuation_dispatched(
+        &self,
+        _scope: &AuthProductScope,
+        _flow_id: AuthFlowId,
+        _emitted_at: Timestamp,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        unreachable!("manual-token cleanup tests do not mark continuations")
+    }
+
+    async fn cancel_flow(
+        &self,
+        _scope: &AuthProductScope,
+        _flow_id: AuthFlowId,
+    ) -> Result<AuthFlowRecord, AuthProductError> {
+        unreachable!("manual-token cleanup tests do not cancel generic flows")
+    }
+}
+
 fn auth_services() -> RebornProductAuthServices {
     RebornProductAuthServices::from_shared(
         Arc::new(InMemoryAuthProductServices::new()),
@@ -109,6 +332,27 @@ fn auth_services_with_interaction(
 ) -> RebornProductAuthServices {
     let shared = Arc::new(InMemoryAuthProductServices::new());
     let flow_manager: Arc<dyn AuthFlowManager> = shared.clone();
+    let credential_setup_service: Arc<dyn CredentialSetupService> = shared.clone();
+    let credential_account_service: Arc<dyn CredentialAccountService> = shared.clone();
+    let provider_client: Arc<dyn AuthProviderClient> = shared.clone();
+    let cleanup_service: Arc<dyn SecretCleanupService> = shared;
+
+    RebornProductAuthServices::new(
+        flow_manager,
+        interaction_service,
+        credential_setup_service,
+        credential_account_service,
+        provider_client,
+        cleanup_service,
+        Arc::new(NoopContinuationDispatcher),
+    )
+}
+
+fn auth_services_with_flow_and_interaction(
+    flow_manager: Arc<dyn AuthFlowManager>,
+    interaction_service: Arc<dyn AuthInteractionService>,
+) -> RebornProductAuthServices {
+    let shared = Arc::new(InMemoryAuthProductServices::new());
     let credential_setup_service: Arc<dyn CredentialSetupService> = shared.clone();
     let credential_account_service: Arc<dyn CredentialAccountService> = shared.clone();
     let provider_client: Arc<dyn AuthProviderClient> = shared.clone();
@@ -303,6 +547,94 @@ async fn manual_token_facade_submits_secret_without_exposing_token() {
 }
 
 #[tokio::test]
+async fn manual_token_facade_tracks_setup_and_submit_in_auth_flow() {
+    let shared = Arc::new(InMemoryAuthProductServices::new());
+    let dispatcher = Arc::new(RecordingContinuationDispatcher::default());
+    let services = RebornProductAuthServices::from_shared(shared.clone(), dispatcher.clone());
+    let owner = scope("alice");
+
+    let challenge = services
+        .request_manual_token_setup(setup_request(owner.clone()))
+        .await
+        .expect("manual-token challenge");
+
+    let flows = shared.flow_records_snapshot();
+    assert_eq!(flows.len(), 1);
+    assert_eq!(flows[0].status, AuthFlowStatus::AwaitingUser);
+    assert!(matches!(
+        &flows[0].challenge,
+        Some(AuthChallenge::ManualTokenRequired { interaction_id, .. })
+            if interaction_id == &challenge.interaction_id
+    ));
+
+    let response = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner,
+            challenge.interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect("manual token submit succeeds");
+
+    let flows = shared.flow_records_snapshot();
+    assert_eq!(flows.len(), 1);
+    assert_eq!(flows[0].status, AuthFlowStatus::Completed);
+    assert_eq!(flows[0].credential_account_id, Some(response.account_id));
+    assert!(
+        flows[0].continuation_emitted_at.is_some(),
+        "manual-token submit should mark continuation dispatch"
+    );
+    let events = dispatcher.events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].flow_id, flows[0].id);
+    assert_eq!(events[0].credential_account_id, Some(response.account_id));
+}
+
+#[tokio::test]
+async fn manual_token_facade_retries_completed_flow_when_continuation_dispatch_fails() {
+    let shared = Arc::new(InMemoryAuthProductServices::new());
+    let dispatcher = Arc::new(FailsFirstContinuationDispatcher::default());
+    let services = RebornProductAuthServices::from_shared(shared.clone(), dispatcher.clone())
+        .with_flow_record_source(shared.clone());
+    let mut owner = scope("alice");
+    owner.resource.thread_id = Some(ironclaw_host_api::ThreadId::new("thread-retry").unwrap());
+
+    let challenge = services
+        .request_manual_token_setup(setup_request(owner.clone()))
+        .await
+        .expect("manual-token challenge");
+
+    let error = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner.clone(),
+            challenge.interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect_err("first dispatch fails after flow completion");
+    assert_eq!(error.code, AuthErrorCode::BackendUnavailable);
+    assert!(error.retryable);
+
+    let response = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            owner,
+            challenge.interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect("retry dispatches the completed manual-token flow");
+    assert_eq!(response.status, CredentialAccountStatus::Configured);
+    let flows = shared.flow_records_snapshot();
+    assert_eq!(flows.len(), 1);
+    assert_eq!(flows[0].status, AuthFlowStatus::Completed);
+    assert_eq!(flows[0].credential_account_id, Some(response.account_id));
+    assert!(flows[0].continuation_emitted_at.is_some());
+    let events = dispatcher.events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].flow_id, flows[0].id);
+}
+
+#[tokio::test]
 async fn manual_token_facade_denies_cross_scope_submit_without_consuming_interaction() {
     let services = auth_services();
     let owner = scope("alice");
@@ -420,6 +752,50 @@ async fn manual_token_facade_returns_sanitized_backend_and_canceled_failures() {
     assert_eq!(canceled_error.code, AuthErrorCode::Canceled);
     assert!(!canceled_error.retryable);
     assert_error_safe(&canceled_error);
+}
+
+#[tokio::test]
+async fn manual_token_facade_abandons_interaction_when_flow_creation_fails() {
+    let interaction_id = AuthInteractionId::new();
+    let interaction = Arc::new(SuccessfulManualTokenInteractionService::new(interaction_id));
+    let services = auth_services_with_flow_and_interaction(
+        Arc::new(FailingManualTokenFlowManager::create_fails(
+            AuthProductError::BackendUnavailable,
+        )),
+        interaction.clone(),
+    );
+
+    let error = services
+        .request_manual_token_setup(setup_request(scope("alice")))
+        .await
+        .expect_err("flow creation failure should surface");
+
+    assert_eq!(error.code, AuthErrorCode::BackendUnavailable);
+    assert_eq!(interaction.abandoned(), vec![interaction_id]);
+}
+
+#[tokio::test]
+async fn manual_token_facade_cancels_flow_when_completion_fails() {
+    let interaction_id = AuthInteractionId::new();
+    let flow_manager = Arc::new(FailingManualTokenFlowManager::complete_fails(
+        AuthProductError::BackendUnavailable,
+    ));
+    let services = auth_services_with_flow_and_interaction(
+        flow_manager.clone(),
+        Arc::new(SuccessfulManualTokenInteractionService::new(interaction_id)),
+    );
+
+    let error = services
+        .submit_manual_token(RebornManualTokenSubmitRequest::new(
+            scope("alice"),
+            interaction_id,
+            secret(RAW_TOKEN),
+        ))
+        .await
+        .expect_err("flow completion failure should surface");
+
+    assert_eq!(error.code, AuthErrorCode::BackendUnavailable);
+    assert_eq!(flow_manager.canceled(), vec![interaction_id]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- route manual-token setup, submit, and abandon through durable product-auth flow records
- replace auth-flow snapshot scans with owner/query-shaped read projections
- move runtime credential selection policy into composition, backed by a credential owner read model
- canonicalize auth surface scans with `AuthSurface::ALL`

## Root Cause

The fallback manual-token path could create credential material without a durable auth-flow record that the blocked turn gate could later resolve. After token submission, runtime credential staging could still ask for auth again because the gate and runtime credential lookup were using mismatched transient identifiers and surfaces.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_auth`
- `cargo test -p ironclaw_reborn_composition product_auth_runtime_credentials::tests:: --lib`
- `cargo test -p ironclaw_reborn_composition product_auth_durable::tests:: --lib`
- `cargo test -p ironclaw_reborn_composition --test manual_tokens`
- `cargo test -p ironclaw_product_workflow --test auth_interaction_contract`
- `cargo test -p ironclaw_first_party_extensions --test gsuite_core`
- `cargo test -p ironclaw_reborn_composition --features libsql factory::tests::local_dev_default_product_auth_uses_durable_manual_token_accounts --lib`
- `cargo test -p ironclaw_reborn_composition local_dev_runtime_auth_interactions --lib`
- `cargo test -p ironclaw_reborn_composition --test auth_callbacks`
- `cargo test -p ironclaw_reborn_composition reborn_product_auth_services --lib`
