### PR TITLE
Recover malformed capability_info calls

### DIFF
--- a/crates/ironclaw_llm/src/tool_schema.rs
+++ b/crates/ironclaw_llm/src/tool_schema.rs
@@ -132,6 +132,13 @@ fn merge_top_level_variant_properties(schema: &JsonValue) -> serde_json::Map<Str
     let Some(obj) = schema.as_object() else {
         return merged;
     };
+    if top_level_declares_object_type(obj)
+        && let Some(props) = obj.get("properties").and_then(|v| v.as_object())
+    {
+        for (key, value) in props {
+            merged.insert(key.clone(), value.clone());
+        }
+    }
     for keyword in &["oneOf", "anyOf", "allOf"] {
         let Some(JsonValue::Array(variants)) = obj.get(*keyword) else {
             continue;
@@ -148,6 +155,17 @@ fn merge_top_level_variant_properties(schema: &JsonValue) -> serde_json::Map<Str
         }
     }
     merged
+}
+
+fn top_level_declares_object_type(map: &serde_json::Map<String, JsonValue>) -> bool {
+    match map.get("type") {
+        Some(JsonValue::String(s)) => s == "object",
+        Some(JsonValue::Array(arr)) => arr
+            .iter()
+            .any(|v| matches!(v, JsonValue::String(s) if s == "object")),
+        None => map.contains_key("properties"),
+        _ => false,
+    }
 }
 
 pub(crate) struct CappedJson {
@@ -456,6 +474,37 @@ mod tests {
         assert_eq!(result["properties"]["mode"]["const"], "by_name");
         assert_eq!(result["properties"]["name"]["type"], "string");
         assert_eq!(result["properties"]["id"]["type"], "string");
+        assert!(description.contains("Upstream JSON schema"));
+    }
+
+    #[test]
+    fn test_flatten_top_level_anyof_preserves_parent_properties() {
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "capability_id": { "type": "string" },
+                "detail": { "type": "string", "enum": ["names", "summary", "schema"] }
+            },
+            "anyOf": [
+                { "required": ["name"] },
+                { "required": ["capability_id"] }
+            ]
+        });
+        let mut description = "Capability info".to_string();
+
+        let result = shape_tool_schema(ToolSchemaPolicy::FlattenOnly, &input, &mut description);
+
+        assert_eq!(result["type"], "object");
+        assert!(result.get("anyOf").is_none());
+        assert_eq!(result["additionalProperties"], true);
+        assert_eq!(result["required"], serde_json::json!([]));
+        assert_eq!(result["properties"]["name"]["type"], "string");
+        assert_eq!(result["properties"]["capability_id"]["type"], "string");
+        assert_eq!(
+            result["properties"]["detail"]["enum"],
+            serde_json::json!(["names", "summary", "schema"])
+        );
         assert!(description.contains("Upstream JSON schema"));
     }
 

--- a/crates/ironclaw_llm/src/tool_schema.rs
+++ b/crates/ironclaw_llm/src/tool_schema.rs
@@ -81,17 +81,7 @@ fn needs_top_level_flatten(schema: &JsonValue) -> bool {
     match schema {
         JsonValue::Object(map) => {
             let has_forbidden = FORBIDDEN_TOP_LEVEL.iter().any(|k| map.contains_key(*k));
-            let has_properties = map.contains_key("properties");
-            let type_value = map.get("type");
-            let is_object_type = match type_value {
-                Some(JsonValue::String(s)) => s == "object",
-                Some(JsonValue::Array(arr)) => arr
-                    .iter()
-                    .any(|v| matches!(v, JsonValue::String(s) if s == "object")),
-                _ => false,
-            };
-            let missing_type_with_properties = type_value.is_none() && has_properties;
-            has_forbidden || (!is_object_type && !missing_type_with_properties)
+            has_forbidden || !top_level_accepts_object_properties(map)
         }
         _ => true,
     }
@@ -132,7 +122,7 @@ fn merge_top_level_variant_properties(schema: &JsonValue) -> serde_json::Map<Str
     let Some(obj) = schema.as_object() else {
         return merged;
     };
-    if top_level_declares_object_type(obj)
+    if top_level_accepts_object_properties(obj)
         && let Some(props) = obj.get("properties").and_then(|v| v.as_object())
     {
         for (key, value) in props {
@@ -157,7 +147,7 @@ fn merge_top_level_variant_properties(schema: &JsonValue) -> serde_json::Map<Str
     merged
 }
 
-fn top_level_declares_object_type(map: &serde_json::Map<String, JsonValue>) -> bool {
+fn top_level_accepts_object_properties(map: &serde_json::Map<String, JsonValue>) -> bool {
     match map.get("type") {
         Some(JsonValue::String(s)) => s == "object",
         Some(JsonValue::Array(arr)) => arr

--- a/crates/ironclaw_loop_support/src/capability_info.rs
+++ b/crates/ironclaw_loop_support/src/capability_info.rs
@@ -153,7 +153,7 @@ pub(super) fn output<'a>(
     Ok(output)
 }
 
-fn requested_name(input: &serde_json::Value) -> Result<&str, AgentLoopHostError> {
+pub(super) fn requested_name(input: &serde_json::Value) -> Result<&str, AgentLoopHostError> {
     let requested = input
         .get("name")
         .or_else(|| input.get("capability_id"))

--- a/crates/ironclaw_loop_support/src/capability_info.rs
+++ b/crates/ironclaw_loop_support/src/capability_info.rs
@@ -121,10 +121,7 @@ pub(super) fn schema() -> serde_json::Value {
                 "description": "Compatibility alias for detail=schema."
             }
         },
-        "anyOf": [
-            { "required": ["name"] },
-            { "required": ["capability_id"] }
-        ],
+        "required": ["name"],
     })
 }
 

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -3259,7 +3259,10 @@ mod tests {
 
             assert_eq!(
                 candidate.effective_capability_ids,
-                vec![CapabilityId::new(capability_info::CAPABILITY_ID).expect("synthetic id")]
+                vec![
+                    CapabilityId::new(capability_info::CAPABILITY_ID).expect("synthetic id"),
+                    capability_id.clone()
+                ]
             );
 
             let outcome = port
@@ -3398,6 +3401,16 @@ mod tests {
         let error = port
             .provider_tool_call_capability_ids(&call)
             .expect_err("approval-time capability id lookup should reject unknown targets");
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+
+        let mut malformed_call = provider_tool_call();
+        malformed_call.id = "call_malformed_unknown_target".to_string();
+        malformed_call.name = capability_info::TOOL_NAME.to_string();
+        malformed_call.arguments =
+            serde_json::json!({ "name": "demo.missing", "detail": "everything" });
+        let error = port
+            .provider_tool_call_capability_ids(&malformed_call)
+            .expect_err("approval-time target lookup should still reject unknown targets");
         assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
 
         let candidate = port

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -238,6 +238,7 @@ struct PreparedProviderToolCall {
     provider_turn_id: String,
     normalized_arguments: serde_json::Value,
     effective_capability_ids: Vec<CapabilityId>,
+    capability_info_target_missing: bool,
 }
 
 const MAX_IN_MEMORY_DISPATCH_RECORDS: usize = 128;
@@ -810,6 +811,7 @@ impl HostRuntimeLoopCapabilityPort {
             provider_turn_id,
             normalized_arguments: prepared.normalized_arguments,
             effective_capability_ids: prepared.effective_capability_ids,
+            capability_info_target_missing: prepared.capability_info_target_missing,
         })
     }
 }
@@ -837,7 +839,7 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
     ) -> Result<ProviderToolCallCapabilityIds, AgentLoopHostError> {
         let prepared = self.prepare_provider_tool_call(tool_call)?;
         if prepared.capability_id.as_str() == crate::capability_info::CAPABILITY_ID
-            && prepared.effective_capability_ids.len() == 1
+            && prepared.capability_info_target_missing
         {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::InvalidInvocation,
@@ -3037,11 +3039,8 @@ mod tests {
             .find(|definition| definition.name == capability_info::TOOL_NAME)
             .expect("capability_info definition is advertised");
         assert_eq!(
-            capability_info_definition.parameters["anyOf"],
-            serde_json::json!([
-                { "required": ["name"] },
-                { "required": ["capability_id"] }
-            ])
+            capability_info_definition.parameters["required"],
+            serde_json::json!(["name"])
         );
         assert!(
             tool_definitions
@@ -3209,7 +3208,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn capability_info_rejects_invalid_detail_arguments() {
+    async fn capability_info_reports_invalid_detail_arguments_as_model_visible_failure() {
         let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
         let provider_id = ExtensionId::new("demo").expect("valid provider id");
         let context = execution_context("thread-capability-info-invalid-detail");
@@ -3218,35 +3217,80 @@ mod tests {
             capability_id.clone(),
             provider_id,
         )]));
+        let result_writer = Arc::new(RecordingResultWriter::default());
         let port = HostRuntimeLoopCapabilityPortFactory::new(
-            runtime,
+            runtime.clone(),
             visible_request(context),
             dummy_input_resolver(),
-            dummy_result_writer(),
+            result_writer.clone(),
             dummy_milestone_sink(),
         )
         .port_for_run_context(run_context);
-        port.visible_capabilities(VisibleCapabilityRequest {})
+        let surface = port
+            .visible_capabilities(VisibleCapabilityRequest {})
             .await
             .expect("visible capabilities load");
 
-        for arguments in [
-            serde_json::json!({ "name": capability_id.as_str(), "include_schema": 1 }),
-            serde_json::json!({ "name": capability_id.as_str(), "detail": "everything" }),
-        ] {
+        for (index, (arguments, expected_summary)) in [
+            (
+                serde_json::json!({ "name": capability_id.as_str(), "include_schema": 1 }),
+                "capability_info include_schema must be boolean",
+            ),
+            (
+                serde_json::json!({ "name": capability_id.as_str(), "detail": "everything" }),
+                "capability_info detail must be names, summary, or schema",
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        {
             let mut call = provider_tool_call();
+            call.id = format!("call_invalid_detail_{index}");
             call.name = capability_info::TOOL_NAME.to_string();
             call.arguments = arguments;
-            let error = port
+
+            port.validate_provider_tool_call(&call).expect(
+                "invalid capability_info arguments should be staged for model-visible failure",
+            );
+            let candidate = port
                 .register_provider_tool_call(call)
                 .await
-                .expect_err("invalid capability_info arguments should fail");
-            assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+                .expect("invalid capability_info arguments should stage");
+
+            assert_eq!(
+                candidate.effective_capability_ids,
+                vec![CapabilityId::new(capability_info::CAPABILITY_ID).expect("synthetic id")]
+            );
+
+            let outcome = port
+                .invoke_capability(CapabilityInvocation {
+                    surface_version: surface.version.clone(),
+                    capability_id: candidate.capability_id,
+                    input_ref: candidate.input_ref,
+                })
+                .await
+                .expect("invalid arguments should return a capability failure, not a host error");
+
+            assert!(matches!(
+                outcome,
+                CapabilityOutcome::Failed(CapabilityFailure {
+                    error_kind: CapabilityFailureKind::InvalidInput,
+                    safe_summary
+                }) if safe_summary == expected_summary
+            ));
         }
+        assert!(
+            result_writer.records().is_empty(),
+            "failed capability_info calls are reported through the provider error-result path"
+        );
+        assert!(
+            runtime.take_requests().is_empty(),
+            "capability_info failure must not dispatch to the host runtime"
+        );
     }
 
     #[tokio::test]
-    async fn capability_info_rejects_invalid_name_inputs() {
+    async fn capability_info_reports_invalid_name_inputs_as_model_visible_failure() {
         let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
         let provider_id = ExtensionId::new("demo").expect("valid provider id");
         let context = execution_context("thread-capability-info-invalid-name");
@@ -3255,35 +3299,73 @@ mod tests {
             capability_id,
             provider_id,
         )]));
+        let result_writer = Arc::new(RecordingResultWriter::default());
         let port = HostRuntimeLoopCapabilityPortFactory::new(
-            runtime,
+            runtime.clone(),
             visible_request(context),
             dummy_input_resolver(),
-            dummy_result_writer(),
+            result_writer.clone(),
             dummy_milestone_sink(),
         )
         .port_for_run_context(run_context);
-        port.visible_capabilities(VisibleCapabilityRequest {})
+        let surface = port
+            .visible_capabilities(VisibleCapabilityRequest {})
             .await
             .expect("visible capabilities load");
 
-        for arguments in [
+        for (index, arguments) in [
             serde_json::json!({}),
             serde_json::json!({ "name": "" }),
             serde_json::json!({ "name": "demo echo" }),
             serde_json::json!({ "name": "demo.echo!" }),
             serde_json::json!({ "name": "demo.écho" }),
             serde_json::json!({ "name": "a".repeat(161) }),
-        ] {
+        ]
+        .into_iter()
+        .enumerate()
+        {
             let mut call = provider_tool_call();
+            call.id = format!("call_invalid_name_{index}");
             call.name = capability_info::TOOL_NAME.to_string();
             call.arguments = arguments;
-            let error = port
+
+            port.validate_provider_tool_call(&call)
+                .expect("invalid capability_info names should be staged for model-visible failure");
+            let candidate = port
                 .register_provider_tool_call(call)
                 .await
-                .expect_err("invalid capability_info name should fail");
-            assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+                .expect("invalid capability_info name should stage");
+
+            assert_eq!(
+                candidate.effective_capability_ids,
+                vec![CapabilityId::new(capability_info::CAPABILITY_ID).expect("synthetic id")]
+            );
+
+            let outcome = port
+                .invoke_capability(CapabilityInvocation {
+                    surface_version: surface.version.clone(),
+                    capability_id: candidate.capability_id,
+                    input_ref: candidate.input_ref,
+                })
+                .await
+                .expect("invalid name should return a capability failure, not a host error");
+
+            assert!(matches!(
+                outcome,
+                CapabilityOutcome::Failed(CapabilityFailure {
+                    error_kind: CapabilityFailureKind::InvalidInput,
+                    ..
+                })
+            ));
         }
+        assert!(
+            result_writer.records().is_empty(),
+            "failed capability_info calls are reported through the provider error-result path"
+        );
+        assert!(
+            runtime.take_requests().is_empty(),
+            "capability_info failure must not dispatch to the host runtime"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
@@ -48,6 +48,7 @@ pub(super) struct PreparedSurfaceCapabilityCall {
     pub(super) capability_id: CapabilityId,
     pub(super) normalized_arguments: serde_json::Value,
     pub(super) effective_capability_ids: Vec<CapabilityId>,
+    pub(super) capability_info_target_missing: bool,
 }
 
 impl SurfaceSnapshot {
@@ -219,6 +220,7 @@ impl RuntimeSurfaceCapabilitySnapshot {
             capability_id: capability_id.clone(),
             normalized_arguments,
             effective_capability_ids: vec![capability_id.clone()],
+            capability_info_target_missing: false,
         })
     }
 }
@@ -275,16 +277,29 @@ impl SyntheticSurfaceCapabilitySnapshot {
                     "provider arguments",
                 )?;
                 super::validate_provider_arguments(&normalized_arguments)?;
-                let request = capability_info::CapabilityInfoRequest::parse(&normalized_arguments)?;
                 let mut effective_capability_ids = Vec::with_capacity(2);
                 effective_capability_ids.push(capability_id.clone());
-                if let Some(target) = snapshot.capability_info(request.requested_name()) {
-                    effective_capability_ids.push(target.capability_id.clone());
-                }
+                let capability_info_target_missing =
+                    match capability_info::CapabilityInfoRequest::parse(&normalized_arguments) {
+                        Ok(request) => {
+                            if let Some(target) = snapshot.capability_info(request.requested_name())
+                            {
+                                effective_capability_ids.push(target.capability_id.clone());
+                                false
+                            } else {
+                                true
+                            }
+                        }
+                        Err(error) if error.kind == AgentLoopHostErrorKind::InvalidInvocation => {
+                            false
+                        }
+                        Err(error) => return Err(error),
+                    };
                 Ok(PreparedSurfaceCapabilityCall {
                     capability_id: capability_id.clone(),
                     normalized_arguments,
                     effective_capability_ids,
+                    capability_info_target_missing,
                 })
             }
         }

--- a/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
@@ -280,10 +280,9 @@ impl SyntheticSurfaceCapabilitySnapshot {
                 let mut effective_capability_ids = Vec::with_capacity(2);
                 effective_capability_ids.push(capability_id.clone());
                 let capability_info_target_missing =
-                    match capability_info::CapabilityInfoRequest::parse(&normalized_arguments) {
-                        Ok(request) => {
-                            if let Some(target) = snapshot.capability_info(request.requested_name())
-                            {
+                    match capability_info::requested_name(&normalized_arguments) {
+                        Ok(requested_name) => {
+                            if let Some(target) = snapshot.capability_info(requested_name) {
                                 effective_capability_ids.push(target.capability_id.clone());
                                 false
                             } else {


### PR DESCRIPTION
## Summary
- advertise capability_info with a provider-safe required name schema instead of a top-level anyOf
- preserve parent properties when flattening object-shaped top-level anyOf/oneOf schemas
- stage malformed capability_info arguments as model-visible InvalidInput failures while preserving strict unknown-target checks

## Tests
- cargo test -p ironclaw_llm tool_schema
- cargo test -p ironclaw_loop_support capability_info
- cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway gateway_with_tool_surface_calls_complete_with_tools_and_returns_capability_calls