### PR TITLE
[codex] Register Reborn WASM runtime

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
@@ -323,6 +323,11 @@ mod tests {
         let after_activate = active_extension_capability_ids(&extension_management).await;
         assert!(after_activate.iter().any(|id| id == "github.search_issues"));
         assert!(after_activate.iter().any(|id| id == "github.get_issue"));
+        let health = runtime.health().await.expect("runtime health");
+        assert!(
+            !health.missing_runtime_backends.contains(&RuntimeKind::Wasm),
+            "activated GitHub WASM capabilities require a registered WASM runtime"
+        );
 
         let remove = invoke_json(
             runtime.as_ref(),

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -257,6 +257,22 @@ where
     ))))
 }
 
+fn attach_wasm_runtime<F, G, S, R>(
+    services: HostRuntimeServices<F, G, S, R>,
+) -> Result<HostRuntimeServices<F, G, S, R>, RebornBuildError>
+where
+    F: ironclaw_filesystem::RootFilesystem + 'static,
+    G: ironclaw_resources::ResourceGovernor + 'static,
+    S: ironclaw_processes::ProcessStore + 'static,
+    R: ironclaw_processes::ProcessResultStore + 'static,
+{
+    services
+        .try_with_default_wasm_runtime()
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("WASM runtime could not be initialized: {error}"),
+        })
+}
+
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) fn apply_production_runtime_process_binding<F, G, S, R>(
     services: HostRuntimeServices<F, G, S, R>,
@@ -536,6 +552,7 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     }
     services = apply_runtime_process_binding(services, runtime_process_binding);
     services = attach_hosted_mcp_runtime(services)?;
+    services = attach_wasm_runtime(services)?;
     let product_auth_runtime_ports = require_product_auth_runtime_ports(&services)?;
     let google_provider_client = google_oauth_config
         .map(|config| {
@@ -1865,6 +1882,7 @@ where
         services,
         production_wiring.runtime_process_binding,
     );
+    let services = attach_wasm_runtime(services)?;
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);


### PR DESCRIPTION
## Summary

- attach the default WASM runtime in local-dev and production-shaped Reborn composition
- add a lifecycle capability assertion that activated GitHub WASM capabilities no longer report `RuntimeKind::Wasm` as missing

## Why

GitHub extension search dispatch can authenticate successfully but still fail with `MissingRuntimeBackend` unless Reborn composition registers the WASM runtime backend. The lower-level WASM search dispatch changes are already in `reborn-integration`; this PR wires the runtime into the composed host services.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_reborn_composition local_dev_extension_lifecycle_tools_manage_visible_extension_surface --features libsql`
- `git diff --check`