### PR TITLE
[codex] Fix auth submit frontend transition

### DIFF
--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/manual_token.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/manual_token.rs
@@ -23,12 +23,10 @@ pub(super) async fn manual_token_submit_handler(
         .token
         .into_validated()
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
-    // This legacy combined submit route only persists a scoped credential and
-    // returns its account id. It intentionally does not resume the gate: the
-    // browser must still call WebUI v2 resolve_gate, where the turn coordinator
-    // validates the authenticated caller against the run id and gate ref before
-    // any turn can continue. New callers should prefer the setup + secret-submit
-    // split route, which binds submissions to the invocation returned by setup.
+    // This legacy combined submit route creates a scoped credential and passes
+    // the completed turn-gate continuation to product-auth dispatch. New callers
+    // should prefer the setup + secret-submit split route, which binds
+    // submissions to the invocation returned by setup.
     let continuation = AuthContinuationRef::TurnGateResume {
         turn_run_ref: TurnRunRef::new(request.run_id)
             .map_err(|_| ProductAuthRouteFailure::invalid_request())?,

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
@@ -541,9 +541,10 @@ async fn product_auth_manual_token_submit_returns_credential_ref_without_exposin
         json["continuation"]["turn_run_ref"].as_str(),
         Some("11111111-1111-1111-1111-111111111111")
     );
-    assert!(
-        dispatcher.events().is_empty(),
-        "manual token submit should return credential_ref; resolve_gate owns turn resumption"
+    assert_eq!(
+        dispatcher.events().len(),
+        1,
+        "manual token submit should dispatch the completed turn-gate continuation"
     );
 }
 

--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -62,6 +62,7 @@ mod tests {
         let use_chat = asset_text("js/pages/chat/hooks/useChat.js");
         assert!(use_chat.contains("AUTH_TOKEN_FLOW_TIMEOUT_MS"));
         assert!(use_chat.contains("authTokenSubmitRef"));
+        assert!(use_chat.contains("submitResponseResumedTurnGate"));
         assert!(use_chat.contains("submitManualToken({"));
         assert!(use_chat.contains("authTokenSubmitRef.current.credentialRef"));
         assert!(use_chat.contains("authTokenSubmitRef.current.inFlight"));
@@ -72,6 +73,7 @@ mod tests {
         );
         assert!(use_chat.contains("resolveGateRequest({"));
         assert!(use_chat.contains("resolution: \"credential_provided\""));
+        assert!(use_chat.contains("continuation?.type === \"turn_gate_resume\""));
         assert!(use_chat.contains("credentialRef"));
         assert!(use_chat.contains("safeAuthGateCode"));
     }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
@@ -32,6 +32,10 @@ function credentialStoredGateResolutionError(cause) {
   return error;
 }
 
+function submitResponseResumedTurnGate(response) {
+  return response?.continuation?.type === "turn_gate_resume";
+}
+
 // v2 chat hook. Differences from the fork's v1 hook:
 // - No image / attachment plumbing — v2 SendMessage carries `content` only.
 // - No /api/chat/approval — approvals fold into gate/resolve in v2.
@@ -260,8 +264,9 @@ export function useChat(threadId) {
 
       try {
         let credentialRef = authTokenSubmitRef.current.credentialRef;
+        let submitted = null;
         if (!credentialRef) {
-          const submitted = await withAuthTokenTimeout((signal) =>
+          submitted = await withAuthTokenTimeout((signal) =>
             submitManualToken({
               provider,
               accountLabel,
@@ -279,19 +284,21 @@ export function useChat(threadId) {
           authTokenSubmitRef.current.credentialRef = credentialRef;
         }
 
-        try {
-          await withAuthTokenTimeout((signal) =>
-            resolveGateRequest({
-              threadId,
-              runId,
-              gateRef,
-              resolution: "credential_provided",
-              credentialRef,
-              signal,
-            }),
-          );
-        } catch (err) {
-          throw credentialStoredGateResolutionError(err);
+        if (!submitResponseResumedTurnGate(submitted)) {
+          try {
+            await withAuthTokenTimeout((signal) =>
+              resolveGateRequest({
+                threadId,
+                runId,
+                gateRef,
+                resolution: "credential_provided",
+                credentialRef,
+                signal,
+              }),
+            );
+          } catch (err) {
+            throw credentialStoredGateResolutionError(err);
+          }
         }
 
         authTokenSubmitRef.current = {


### PR DESCRIPTION
## Summary

- treat manual-token submit responses with `continuation.type === "turn_gate_resume"` as a successful gate transition in the web UI
- skip the stale follow-up `resolve_gate` call when token submit already resumed the blocked turn
- update the manual-token route comment and test to match the dispatch behavior

## Why

The backend can save the token and resume the turn during manual-token submit. The UI still called `resolve_gate` afterward, so a stale/conflicting resolve response could leave the auth card visible with “Token saved. Could not resume the blocked run” even though the run had moved forward.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_webui_v2_static chat_auth_gate_assets_submit_manual_token_then_resolve_gate`
- `cargo test -p ironclaw_reborn_composition product_auth_manual_token_submit_returns_credential_ref_without_exposing_pat --features libsql,webui-v2-beta`
- `git diff --check`