### PR TITLE
[codex] Add trigger materialization turn-state seams

### DIFF
--- a/crates/ironclaw_reborn_traces/src/contribution.rs
+++ b/crates/ironclaw_reborn_traces/src/contribution.rs
@@ -10095,11 +10095,12 @@ mod tests {
     #[tokio::test]
     async fn queue_flush_holds_failed_submission_and_still_returns_due_credit_notice() {
         let scope = format!("trace-flush-submit-failure-test-{}", Uuid::new_v4());
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_FLUSH_HOLD_TEST_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         let policy = StandingTraceContributionPolicy {
             enabled: true,
             ingestion_endpoint: Some("http://127.0.0.1:9/v1/traces".to_string()),
-            bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+            bearer_token_env: token_env.to_string(),
             auto_submit_high_value_traces: true,
             min_submission_score: 0.0,
             credit_notice_interval_hours: 168,
@@ -10171,11 +10172,12 @@ mod tests {
     #[tokio::test]
     async fn queue_flush_records_typed_retry_state_and_defers_until_backoff_expires() {
         let scope = format!("trace-flush-typed-retry-state-test-{}", Uuid::new_v4());
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_TYPED_RETRY_TEST_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         let policy = StandingTraceContributionPolicy {
             enabled: true,
             ingestion_endpoint: Some("http://127.0.0.1:9/v1/traces".to_string()),
-            bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+            bearer_token_env: token_env.to_string(),
             auto_submit_high_value_traces: true,
             min_submission_score: 0.0,
             ..Default::default()
@@ -10359,7 +10361,8 @@ mod tests {
     #[tokio::test]
     async fn queue_flush_classifies_upload_http_rejection_through_submit_call_site() {
         let scope = format!("trace-upload-http-classification-test-{}", Uuid::new_v4());
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_UPLOAD_HTTP_CLASSIFICATION_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         let app = axum::Router::new().route(
             "/v1/traces",
             axum::routing::post(|| async {
@@ -10385,7 +10388,7 @@ mod tests {
             &StandingTraceContributionPolicy {
                 enabled: true,
                 ingestion_endpoint: Some(endpoint),
-                bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+                bearer_token_env: token_env.to_string(),
                 auto_submit_high_value_traces: true,
                 min_submission_score: 0.0,
                 ..Default::default()
@@ -10473,7 +10476,8 @@ mod tests {
             "trace-status-sync-auth-classification-test-{}",
             Uuid::new_v4()
         );
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_STATUS_SYNC_AUTH_CLASSIFICATION_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         let app = axum::Router::new().route(
             "/v1/contributors/me/submission-status",
             axum::routing::post(|| async {
@@ -10499,7 +10503,7 @@ mod tests {
             &StandingTraceContributionPolicy {
                 enabled: true,
                 ingestion_endpoint: Some(endpoint),
-                bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+                bearer_token_env: token_env.to_string(),
                 auto_submit_high_value_traces: true,
                 min_submission_score: 0.0,
                 ..Default::default()
@@ -10842,7 +10846,8 @@ mod tests {
 
     #[tokio::test]
     async fn policy_aware_submit_rejects_redirects_without_resending_bearer_token() {
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_REDIRECT_TEST_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         let redirected_authorizations = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
         let redirected_authorizations_for_handler = redirected_authorizations.clone();
         let app = axum::Router::new()
@@ -10907,7 +10912,7 @@ mod tests {
             &StandingTraceContributionPolicy {
                 enabled: true,
                 ingestion_endpoint: Some(endpoint.clone()),
-                bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+                bearer_token_env: token_env.to_string(),
                 ..Default::default()
             },
         )
@@ -10926,7 +10931,8 @@ mod tests {
 
     #[tokio::test]
     async fn policy_aware_submit_uses_bounded_request_timeout() {
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_TIMEOUT_TEST_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         let _timeout_guard = EnvVarRestore::set("IRONCLAW_TRACE_REMOTE_REQUEST_TIMEOUT_MS", "50");
         let app = axum::Router::new().route(
             "/v1/traces",
@@ -10971,7 +10977,7 @@ mod tests {
                 &StandingTraceContributionPolicy {
                     enabled: true,
                     ingestion_endpoint: Some(endpoint.clone()),
-                    bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+                    bearer_token_env: token_env.to_string(),
                     ..Default::default()
                 },
             ),
@@ -11561,13 +11567,14 @@ mod tests {
         );
 
         let network_scope = format!("trace-queue-network-classification-{}", Uuid::new_v4());
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_QUEUE_NETWORK_CLASSIFICATION_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         write_trace_policy_for_scope(
             Some(&network_scope),
             &StandingTraceContributionPolicy {
                 enabled: true,
                 ingestion_endpoint: Some("http://127.0.0.1:9/v1/traces".to_string()),
-                bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+                bearer_token_env: token_env.to_string(),
                 auto_submit_high_value_traces: true,
                 min_submission_score: 0.0,
                 ..Default::default()
@@ -11662,11 +11669,12 @@ mod tests {
     #[tokio::test]
     async fn trace_queue_worker_tick_flushes_scopes_and_returns_credit_notices_for_delivery() {
         let scope = format!("trace-worker-tick-test-{}", Uuid::new_v4());
-        let _token_guard = EnvVarRestore::set("TRACE_COMMONS_TEST_TOKEN", "super-secret-token");
+        let token_env = "TRACE_COMMONS_WORKER_TICK_TEST_TOKEN";
+        let _token_guard = EnvVarRestore::set(token_env, "super-secret-token");
         let policy = StandingTraceContributionPolicy {
             enabled: true,
             ingestion_endpoint: Some("http://127.0.0.1:9/v1/traces".to_string()),
-            bearer_token_env: "TRACE_COMMONS_TEST_TOKEN".to_string(),
+            bearer_token_env: token_env.to_string(),
             auto_submit_high_value_traces: true,
             min_submission_score: 0.0,
             credit_notice_interval_hours: 168,

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -159,8 +159,7 @@ impl TryFrom<String> for TriggerExternalEventId {
 ///
 /// Values must be non-empty, at most 512 bytes, and free of control
 /// characters. The concrete content store is owned by composition.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TriggerInboundContentRef(String);
 
 impl TriggerInboundContentRef {
@@ -191,12 +190,32 @@ impl std::fmt::Display for TriggerInboundContentRef {
     }
 }
 
+impl TryFrom<String> for TriggerInboundContentRef {
+    type Error = TriggerError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate_inbound_content_ref(&value)?;
+        Ok(Self(value))
+    }
+}
+
+impl Serialize for TriggerInboundContentRef {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
 impl<'de> Deserialize<'de> for TriggerInboundContentRef {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+        String::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -832,9 +851,7 @@ impl TriggerRepository for InMemoryTriggerRepository {
         let Some(record) = state.get_mut(&key) else {
             return Ok(None);
         };
-        if record.tenant_id != request.tenant_id
-            || record.trigger_id != request.trigger_id
-            || record.active_fire_slot != Some(request.fire_slot)
+        if record.active_fire_slot != Some(request.fire_slot)
             || record.active_run_ref != Some(request.run_id)
         {
             return Ok(None);

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -43,6 +43,8 @@ pub enum TriggerError {
     InvalidRecord { reason: String },
     #[error("invalid schedule: {reason}")]
     InvalidSchedule { reason: String },
+    #[error("invalid trigger materialization: {reason}")]
+    InvalidMaterialization { reason: String },
     #[error("trigger repository backend unavailable: {reason}")]
     Backend { reason: String },
     #[error("trigger not found")]
@@ -150,6 +152,43 @@ impl TryFrom<String> for TriggerExternalEventId {
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         validate_lower_hex_identifier("external event id", value).map(Self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct TriggerInboundContentRef(String);
+
+impl TriggerInboundContentRef {
+    pub fn new(value: impl Into<String>) -> Result<Self, TriggerError> {
+        let value = value.into();
+        validate_inbound_content_ref(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for TriggerInboundContentRef {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for TriggerInboundContentRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for TriggerInboundContentRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
     }
 }
 
@@ -341,6 +380,14 @@ pub struct TriggerFire {
     pub prompt: String,
 }
 
+#[async_trait]
+pub trait TriggerPromptMaterializer: Send + Sync {
+    async fn materialize_prompt(
+        &self,
+        fire: TriggerFire,
+    ) -> Result<TriggerInboundContentRef, TriggerError>;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClaimDueFireRequest {
     pub tenant_id: TenantId,
@@ -401,6 +448,23 @@ pub struct FirePermanentFailedRequest {
     pub trigger_id: TriggerId,
     pub fire_slot: Timestamp,
     pub next_run_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClearActiveFireRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub run_id: TurnRunId,
+}
+
+impl ClearActiveFireRequest {
+    pub fn matches_record_active_fire(&self, record: &TriggerRecord) -> bool {
+        record.tenant_id == self.tenant_id
+            && record.trigger_id == self.trigger_id
+            && record.active_fire_slot == Some(self.fire_slot)
+            && record.active_run_ref == Some(self.run_id)
+    }
 }
 
 #[async_trait]
@@ -499,6 +563,11 @@ pub trait TriggerRepository: Send + Sync {
     async fn mark_fire_permanently_failed(
         &self,
         request: FirePermanentFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError>;
+
+    async fn clear_active_fire(
+        &self,
+        request: ClearActiveFireRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError>;
 }
 
@@ -754,6 +823,23 @@ impl TriggerRepository for InMemoryTriggerRepository {
         };
         Ok(Some(record))
     }
+
+    async fn clear_active_fire(
+        &self,
+        request: ClearActiveFireRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let mut state = self.lock_state()?;
+        let key = TriggerRepositoryKey::new(&request.tenant_id, request.trigger_id);
+        let Some(record) = state.get_mut(&key) else {
+            return Ok(None);
+        };
+        if !request.matches_record_active_fire(record) {
+            return Ok(None);
+        }
+        record.active_fire_slot = None;
+        record.active_run_ref = None;
+        Ok(Some(record.clone()))
+    }
 }
 
 impl InMemoryTriggerRepository {
@@ -895,6 +981,25 @@ fn validate_lower_hex_identifier(label: &str, value: String) -> Result<String, T
         label: label.to_string(),
         reason: "must be 64 lowercase hex characters".to_string(),
     })
+}
+
+fn validate_inbound_content_ref(value: &str) -> Result<(), TriggerError> {
+    if value.is_empty() {
+        return Err(TriggerError::InvalidMaterialization {
+            reason: "inbound content ref must not be empty".to_string(),
+        });
+    }
+    if value.len() > 512 {
+        return Err(TriggerError::InvalidMaterialization {
+            reason: "inbound content ref must be at most 512 bytes".to_string(),
+        });
+    }
+    if value.chars().any(|ch| ch == '\0' || ch.is_control()) {
+        return Err(TriggerError::InvalidMaterialization {
+            reason: "inbound content ref must not contain control characters".to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn derive_fire_digest(
@@ -1143,6 +1248,100 @@ mod tests {
         assert_eq!(fire.identity.trigger_id, trigger_id);
         assert_eq!(fire.identity.fire_slot, record.next_run_at);
         assert_eq!(fire.prompt, record.prompt);
+    }
+
+    #[test]
+    fn trigger_inbound_content_ref_is_opaque_validated_materialization_output() {
+        let content_ref =
+            TriggerInboundContentRef::new("content:trigger-fire-01").expect("valid content ref");
+
+        assert_eq!(content_ref.as_str(), "content:trigger-fire-01");
+        assert_eq!(content_ref.as_ref(), "content:trigger-fire-01");
+        assert_eq!(content_ref.to_string(), "content:trigger-fire-01");
+        assert_eq!(
+            to_value(&content_ref).unwrap(),
+            json!("content:trigger-fire-01")
+        );
+        assert_eq!(
+            from_value::<TriggerInboundContentRef>(json!("content:trigger-fire-01")).unwrap(),
+            content_ref
+        );
+        assert!(TriggerInboundContentRef::new("x".repeat(512)).is_ok());
+
+        assert!(TriggerInboundContentRef::new("").is_err());
+        assert!(TriggerInboundContentRef::new("content:\ntrigger").is_err());
+        assert!(TriggerInboundContentRef::new("x".repeat(513)).is_err());
+    }
+
+    #[tokio::test]
+    async fn prompt_materializer_port_receives_fire_and_returns_content_ref() {
+        struct RecordingMaterializer;
+
+        #[async_trait]
+        impl TriggerPromptMaterializer for RecordingMaterializer {
+            async fn materialize_prompt(
+                &self,
+                fire: TriggerFire,
+            ) -> Result<TriggerInboundContentRef, TriggerError> {
+                assert_eq!(fire.creator_user_id, user("user-a"));
+                assert_eq!(fire.agent_id, Some(AgentId::new("agent-a").unwrap()));
+                assert_eq!(fire.project_id, Some(ProjectId::new("project-a").unwrap()));
+                assert_eq!(fire.prompt, "summarize unread mail");
+                TriggerInboundContentRef::new(format!(
+                    "content:{}",
+                    fire.identity.external_event_id
+                ))
+            }
+        }
+
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let record = sample_record(trigger_id, tenant("tenant-a"), ts(1_704_067_200));
+        let fire = ScheduleTriggerSourceProvider
+            .evaluate(&record, ts(1_704_067_200))
+            .await
+            .expect("due")
+            .expect("fire");
+
+        let materialized = RecordingMaterializer
+            .materialize_prompt(fire.clone())
+            .await
+            .expect("materialized");
+
+        assert_eq!(
+            materialized.as_str(),
+            format!("content:{}", fire.identity.external_event_id)
+        );
+    }
+
+    #[test]
+    fn clear_active_fire_request_matches_only_the_active_fire_and_run_ref() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::new();
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        record.active_fire_slot = Some(fire_slot);
+        record.active_run_ref = Some(run_id);
+        record.last_status = Some(TriggerRunStatus::Error);
+        let request = ClearActiveFireRequest {
+            tenant_id: record.tenant_id.clone(),
+            trigger_id,
+            fire_slot,
+            run_id,
+        };
+
+        assert!(request.matches_record_active_fire(&record));
+
+        let mut wrong_slot = record.clone();
+        wrong_slot.active_fire_slot = Some(fire_slot + chrono::Duration::minutes(1));
+        assert!(!request.matches_record_active_fire(&wrong_slot));
+
+        let mut wrong_run = record.clone();
+        wrong_run.active_run_ref = Some(TurnRunId::new());
+        assert!(!request.matches_record_active_fire(&wrong_run));
+
+        let mut unaccepted_claim = record;
+        unaccepted_claim.active_run_ref = None;
+        assert!(!request.matches_record_active_fire(&unaccepted_claim));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -155,11 +155,19 @@ impl TryFrom<String> for TriggerExternalEventId {
     }
 }
 
+/// Opaque reference to materialized trigger prompt content.
+///
+/// Values must be non-empty, at most 512 bytes, and free of control
+/// characters. The concrete content store is owned by composition.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct TriggerInboundContentRef(String);
 
 impl TriggerInboundContentRef {
+    /// Create a validated inbound content reference.
+    ///
+    /// Validation is byte-based: the value must be non-empty, at most 512
+    /// bytes, and free of control characters.
     pub fn new(value: impl Into<String>) -> Result<Self, TriggerError> {
         let value = value.into();
         validate_inbound_content_ref(&value)?;
@@ -456,15 +464,6 @@ pub struct ClearActiveFireRequest {
     pub trigger_id: TriggerId,
     pub fire_slot: Timestamp,
     pub run_id: TurnRunId,
-}
-
-impl ClearActiveFireRequest {
-    pub fn matches_record_active_fire(&self, record: &TriggerRecord) -> bool {
-        record.tenant_id == self.tenant_id
-            && record.trigger_id == self.trigger_id
-            && record.active_fire_slot == Some(self.fire_slot)
-            && record.active_run_ref == Some(self.run_id)
-    }
 }
 
 #[async_trait]
@@ -833,7 +832,11 @@ impl TriggerRepository for InMemoryTriggerRepository {
         let Some(record) = state.get_mut(&key) else {
             return Ok(None);
         };
-        if !request.matches_record_active_fire(record) {
+        if record.tenant_id != request.tenant_id
+            || record.trigger_id != request.trigger_id
+            || record.active_fire_slot != Some(request.fire_slot)
+            || record.active_run_ref != Some(request.run_id)
+        {
             return Ok(None);
         }
         record.active_fire_slot = None;
@@ -1271,6 +1274,10 @@ mod tests {
         assert!(TriggerInboundContentRef::new("").is_err());
         assert!(TriggerInboundContentRef::new("content:\ntrigger").is_err());
         assert!(TriggerInboundContentRef::new("x".repeat(513)).is_err());
+
+        assert!(from_value::<TriggerInboundContentRef>(json!("")).is_err());
+        assert!(from_value::<TriggerInboundContentRef>(json!("content:\ntrigger")).is_err());
+        assert!(from_value::<TriggerInboundContentRef>(json!("x".repeat(513))).is_err());
     }
 
     #[tokio::test]
@@ -1311,37 +1318,6 @@ mod tests {
             materialized.as_str(),
             format!("content:{}", fire.identity.external_event_id)
         );
-    }
-
-    #[test]
-    fn clear_active_fire_request_matches_only_the_active_fire_and_run_ref() {
-        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
-        let fire_slot = ts(1_704_067_200);
-        let run_id = TurnRunId::new();
-        let mut record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
-        record.active_fire_slot = Some(fire_slot);
-        record.active_run_ref = Some(run_id);
-        record.last_status = Some(TriggerRunStatus::Error);
-        let request = ClearActiveFireRequest {
-            tenant_id: record.tenant_id.clone(),
-            trigger_id,
-            fire_slot,
-            run_id,
-        };
-
-        assert!(request.matches_record_active_fire(&record));
-
-        let mut wrong_slot = record.clone();
-        wrong_slot.active_fire_slot = Some(fire_slot + chrono::Duration::minutes(1));
-        assert!(!request.matches_record_active_fire(&wrong_slot));
-
-        let mut wrong_run = record.clone();
-        wrong_run.active_run_ref = Some(TurnRunId::new());
-        assert!(!request.matches_record_active_fire(&wrong_run));
-
-        let mut unaccepted_claim = record;
-        unaccepted_claim.active_run_ref = None;
-        assert!(!request.matches_record_active_fire(&unaccepted_claim));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -234,7 +234,6 @@ impl TriggerRepository for LibSqlTriggerRepository {
         trigger_id: TriggerId,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
         let conn = self.connect().await?;
-        // Keep active-fire clearing atomic as one predicate-guarded write.
         let mut rows = conn
             .query(
                 &format!(
@@ -516,6 +515,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
         request: ClearActiveFireRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
         let conn = self.connect().await?;
+        // Keep active-fire clearing atomic as one predicate-guarded write.
         let mut rows = conn
             .query(
                 &format!(

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -184,7 +184,6 @@ impl TriggerRepository for LibSqlTriggerRepository {
         trigger_id: TriggerId,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
         let conn = self.connect().await?;
-        // Keep active-fire clearing atomic as one predicate-guarded write.
         let mut rows = conn
             .query(
                 &format!(
@@ -235,6 +234,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
         trigger_id: TriggerId,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
         let conn = self.connect().await?;
+        // Keep active-fire clearing atomic as one predicate-guarded write.
         let mut rows = conn
             .query(
                 &format!(

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -184,6 +184,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
         trigger_id: TriggerId,
     ) -> Result<Option<TriggerRecord>, TriggerError> {
         let conn = self.connect().await?;
+        // Keep active-fire clearing atomic as one predicate-guarded write.
         let mut rows = conn
             .query(
                 &format!(

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -14,10 +14,10 @@ use libsql::params;
 
 #[cfg(feature = "libsql")]
 use crate::{
-    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, FireAcceptedRequest,
-    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest,
-    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
-    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, ClearActiveFireRequest,
+    FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
+    FireRetryableFailedRequest, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
+    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
     reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
 };
 
@@ -508,6 +508,35 @@ impl TriggerRepository for LibSqlTriggerRepository {
         }
         resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None, None)
             .await
+    }
+
+    async fn clear_active_fire(
+        &self,
+        request: ClearActiveFireRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = ?1
+                       AND trigger_id = ?2
+                       AND active_fire_slot = ?3
+                       AND active_run_ref = ?4
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![
+                    request.tenant_id.as_str(),
+                    request.trigger_id.to_string(),
+                    fmt_ts(&request.fire_slot),
+                    request.run_id.to_string(),
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("clear active trigger fire", error))?;
+        returned_record(&mut rows, "read cleared trigger fire").await
     }
 }
 

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -531,6 +531,7 @@ impl TriggerRepository for PostgresTriggerRepository {
         let trigger_id = request.trigger_id.to_string();
         let fire_slot = fmt_ts(&request.fire_slot);
         let run_id = request.run_id.to_string();
+        // Keep active-fire clearing atomic as one predicate-guarded write.
         let row = client
             .query_opt(
                 &format!(

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -5,10 +5,10 @@ use ironclaw_turns::TurnRunId;
 use tokio_postgres::Row;
 
 use crate::{
-    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, FireAcceptedRequest,
-    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest,
-    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
-    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, ClearActiveFireRequest,
+    FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
+    FireRetryableFailedRequest, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
+    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
     reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
 };
 
@@ -521,6 +521,41 @@ impl TriggerRepository for PostgresTriggerRepository {
             .await
             .map_err(|error| backend_error("commit permanent trigger fire failure", error))?;
         Ok(Some(record))
+    }
+
+    async fn clear_active_fire(
+        &self,
+        request: ClearActiveFireRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let client = self.connect().await?;
+        let trigger_id = request.trigger_id.to_string();
+        let fire_slot = fmt_ts(&request.fire_slot);
+        let run_id = request.run_id.to_string();
+        let row = client
+            .query_opt(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = $1
+                       AND trigger_id = $2
+                       AND active_fire_slot = $3
+                       AND active_run_ref = $4
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                &[
+                    &request.tenant_id.as_str(),
+                    &trigger_id,
+                    &fire_slot,
+                    &run_id,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("clear active trigger fire", error))?;
+        match row {
+            Some(row) => Ok(Some(row_to_record(&row)?)),
+            None => Ok(None),
+        }
     }
 }
 

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -3,8 +3,9 @@
 use chrono::{TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_triggers::{
-    InMemoryTriggerRepository, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
-    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    ClearActiveFireRequest, InMemoryTriggerRepository, TriggerCompletionPolicy, TriggerError,
+    TriggerId, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
+    TriggerSourceKind, TriggerState,
 };
 use ironclaw_turns::TurnRunId;
 
@@ -1346,6 +1347,102 @@ mod fire_claim_contract {
         assert_error_contains(error, "must be after the claimed fire slot");
     }
 
+    async fn assert_fire_clear_contract(repo: &impl TriggerRepository) {
+        let trigger_id = TriggerId::parse("01J00000000000000000000016").expect("ulid");
+        let tenant_id = tenant("tenant-clear");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f66").expect("valid run");
+        let mut active_record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
+        active_record.active_fire_slot = Some(fire_slot);
+        active_record.active_run_ref = Some(run_id);
+        repo.upsert_trigger(active_record.clone())
+            .await
+            .expect("insert active record");
+
+        let wrong_run_clear = repo
+            .clear_active_fire(ClearActiveFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f67")
+                    .expect("valid run"),
+            })
+            .await
+            .expect("clear with wrong run ref");
+        assert!(
+            wrong_run_clear.is_none(),
+            "mismatched run ref must not clear"
+        );
+        let reloaded = repo
+            .get_trigger(tenant_id.clone(), trigger_id)
+            .await
+            .expect("reload mismatched clear")
+            .expect("record present");
+        assert_eq!(reloaded, active_record);
+
+        let wrong_slot_clear = repo
+            .clear_active_fire(ClearActiveFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot: fire_slot + chrono::Duration::minutes(1),
+                run_id,
+            })
+            .await
+            .expect("clear with wrong fire slot");
+        assert!(
+            wrong_slot_clear.is_none(),
+            "mismatched fire slot must not clear"
+        );
+        let reloaded = repo
+            .get_trigger(tenant_id.clone(), trigger_id)
+            .await
+            .expect("reload wrong-slot clear")
+            .expect("record present");
+        assert_eq!(reloaded, active_record);
+
+        let wrong_tenant_clear = repo
+            .clear_active_fire(ClearActiveFireRequest {
+                tenant_id: tenant("tenant-clear-other"),
+                trigger_id,
+                fire_slot,
+                run_id,
+            })
+            .await
+            .expect("clear with wrong tenant");
+        assert!(
+            wrong_tenant_clear.is_none(),
+            "mismatched tenant must not clear"
+        );
+        let reloaded = repo
+            .get_trigger(tenant_id.clone(), trigger_id)
+            .await
+            .expect("reload wrong-tenant clear")
+            .expect("record present");
+        assert_eq!(reloaded, active_record);
+
+        let cleared = repo
+            .clear_active_fire(ClearActiveFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                run_id,
+            })
+            .await
+            .expect("clear active fire")
+            .expect("active fire should clear");
+        let mut expected = active_record;
+        expected.active_fire_slot = None;
+        expected.active_run_ref = None;
+        assert_eq!(cleared, expected);
+
+        let persisted = repo
+            .get_trigger(tenant_id, trigger_id)
+            .await
+            .expect("reload cleared record")
+            .expect("record present");
+        assert_eq!(persisted, expected);
+    }
+
     async fn assert_fire_claim_exclusions_and_active_gate_contract(repo: &impl TriggerRepository) {
         let fire_slot = ts(1_704_067_200);
         let tenant_id = tenant("tenant-a");
@@ -1708,6 +1805,7 @@ mod fire_claim_contract {
         assert_fire_claim_and_update_contract(repo).await;
         assert_fire_claim_exclusions_and_active_gate_contract(repo).await;
         assert_fire_result_rejects_invalid_next_run_at(repo).await;
+        assert_fire_clear_contract(repo).await;
     }
 
     fn assert_error_contains(error: TriggerError, expected: &str) {
@@ -1723,6 +1821,7 @@ mod fire_claim_contract {
         assert_fire_claim_and_update_contract(&repo).await;
         assert_fire_claim_exclusions_and_active_gate_contract(&repo).await;
         assert_fire_result_rejects_invalid_next_run_at(&repo).await;
+        assert_fire_clear_contract(&repo).await;
     }
 
     #[cfg(feature = "libsql")]

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -89,12 +89,13 @@ pub use run_profile::{
 pub use scope::{TurnActor, TurnScope};
 pub use status::{
     AdmissionRejection, AdmissionRejectionReason, BlockedReason, SanitizedCancelReason,
-    SanitizedFailure, TurnCapacityResource, TurnError, TurnErrorCategory, TurnRunProfile,
-    TurnRunState, TurnStatus,
+    SanitizedFailure, TurnActiveRunRefState, TurnCapacityResource, TurnError, TurnErrorCategory,
+    TurnRunProfile, TurnRunState, TurnStatus,
 };
 pub use store::{
     SpawnTreeReservation, SpawnTreeReservationKey, TurnActiveLockKey, TurnActiveLockRecord,
     TurnCheckpointRecord, TurnIdempotencyErrorReplay, TurnIdempotencyOperationKind,
     TurnIdempotencyOutcomeKind, TurnIdempotencyRecord, TurnIdempotencyReplay, TurnLockVersion,
     TurnPersistenceSnapshot, TurnRecord, TurnRunRecord, TurnSpawnTreeStateStore, TurnStateStore,
+    active_run_ref_state,
 };

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -43,20 +43,6 @@ pub enum TurnActiveRunRefState {
     Terminal,
 }
 
-impl TurnActiveRunRefState {
-    pub fn is_missing(self) -> bool {
-        matches!(self, Self::Missing)
-    }
-
-    pub fn is_nonterminal(self) -> bool {
-        matches!(self, Self::Nonterminal)
-    }
-
-    pub fn is_terminal(self) -> bool {
-        matches!(self, Self::Terminal)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TurnRunProfile {
     pub id: RunProfileId,

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -36,6 +36,27 @@ impl TurnStatus {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnActiveRunRefState {
+    Missing,
+    Nonterminal,
+    Terminal,
+}
+
+impl TurnActiveRunRefState {
+    pub fn is_missing(self) -> bool {
+        matches!(self, Self::Missing)
+    }
+
+    pub fn is_nonterminal(self) -> bool {
+        matches!(self, Self::Nonterminal)
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Terminal)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TurnRunProfile {
     pub id: RunProfileId,

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -35,6 +35,11 @@ pub trait TurnStateStore: Send + Sync {
         request: CancelRunRequest,
     ) -> Result<CancelRunResponse, TurnError>;
 
+    /// Return the run state when the run exists in the supplied exact scope.
+    ///
+    /// Missing runs and runs outside the supplied scope must both return
+    /// [`TurnError::ScopeNotFound`]. This keeps scoped lookups non-enumerating
+    /// and gives higher-level helpers one canonical missing-run shape.
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError>;
 }
 

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -7,10 +7,11 @@ use crate::{
     AcceptedMessageRef, AdmissionRejection, CancelRunRequest, CancelRunResponse, GateRef,
     GetRunStateRequest, IdempotencyKey, LoopCheckpointRecord, ReplyTargetBindingRef,
     ResumeTurnRequest, ResumeTurnResponse, RunProfileResolver, SourceBindingRef,
-    SubmitChildRunRequest, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
-    TurnAdmissionPolicy, TurnAdmissionReservationRecord, TurnCapacityResource, TurnCheckpointId,
-    TurnError, TurnErrorCategory, TurnId, TurnLeaseToken, TurnLifecycleEvent, TurnRunId,
-    TurnRunProfile, TurnRunState, TurnRunnerId, TurnScope, TurnStatus, TurnTimestamp,
+    SubmitChildRunRequest, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
+    TurnActiveRunRefState, TurnActor, TurnAdmissionPolicy, TurnAdmissionReservationRecord,
+    TurnCapacityResource, TurnCheckpointId, TurnError, TurnErrorCategory, TurnId, TurnLeaseToken,
+    TurnLifecycleEvent, TurnRunId, TurnRunProfile, TurnRunState, TurnRunnerId, TurnScope,
+    TurnStatus, TurnTimestamp,
     events::EventCursor,
     run_profile::{LoopCheckpointKind, LoopCheckpointStateRef, LoopModelRouteSnapshot},
 };
@@ -35,6 +36,32 @@ pub trait TurnStateStore: Send + Sync {
     ) -> Result<CancelRunResponse, TurnError>;
 
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError>;
+}
+
+/// Classify an active run reference through the shared turn-state lookup.
+///
+/// `None` and missing records both map to [`TurnActiveRunRefState::Missing`];
+/// only looked-up terminal records map to [`TurnActiveRunRefState::Terminal`].
+pub async fn active_run_ref_state<S>(
+    store: &S,
+    scope: TurnScope,
+    active_run_ref: Option<TurnRunId>,
+) -> Result<TurnActiveRunRefState, TurnError>
+where
+    S: TurnStateStore + ?Sized,
+{
+    let Some(run_id) = active_run_ref else {
+        return Ok(TurnActiveRunRefState::Missing);
+    };
+    match store
+        .get_run_state(GetRunStateRequest { scope, run_id })
+        .await
+    {
+        Ok(state) if state.status.is_terminal() => Ok(TurnActiveRunRefState::Terminal),
+        Ok(_) => Ok(TurnActiveRunRefState::Nonterminal),
+        Err(TurnError::ScopeNotFound) => Ok(TurnActiveRunRefState::Missing),
+        Err(error) => Err(error),
+    }
 }
 
 #[async_trait]

--- a/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
+++ b/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
@@ -1,0 +1,120 @@
+use chrono::{TimeZone, Utc};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_turns::{
+    AcceptedMessageRef, AllowAllTurnAdmissionPolicy, IdempotencyKey, InMemoryRunProfileResolver,
+    ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef, TurnActiveRunRefState, TurnActor,
+    TurnRunId, TurnScope, TurnStateStore, TurnStatus,
+};
+
+fn turn_scope(thread: &str) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant1").unwrap(),
+        Some(AgentId::new("agent1").unwrap()),
+        Some(ProjectId::new("project1").unwrap()),
+        ThreadId::new(thread).unwrap(),
+    )
+}
+
+fn turn_actor() -> TurnActor {
+    TurnActor::new(UserId::new("user1").unwrap())
+}
+
+fn submit_request_for(
+    scope: TurnScope,
+    idempotency_key: &str,
+) -> ironclaw_turns::SubmitTurnRequest {
+    ironclaw_turns::SubmitTurnRequest {
+        scope,
+        actor: turn_actor(),
+        accepted_message_ref: AcceptedMessageRef::new(format!("message-{idempotency_key}"))
+            .unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+        requested_run_profile: Some(RunProfileRequest::new("default").unwrap()),
+        idempotency_key: IdempotencyKey::new(idempotency_key).unwrap(),
+        received_at: Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap(),
+        requested_run_id: None,
+        parent_run_id: None,
+        subagent_depth: 0,
+        spawn_tree_root_run_id: None,
+    }
+}
+
+#[test]
+fn turn_active_run_ref_state_helper_flags_cover_all_variants() {
+    assert!(TurnActiveRunRefState::Missing.is_missing());
+    assert!(!TurnActiveRunRefState::Missing.is_nonterminal());
+    assert!(!TurnActiveRunRefState::Missing.is_terminal());
+
+    assert!(!TurnActiveRunRefState::Nonterminal.is_missing());
+    assert!(TurnActiveRunRefState::Nonterminal.is_nonterminal());
+    assert!(!TurnActiveRunRefState::Nonterminal.is_terminal());
+
+    assert!(!TurnActiveRunRefState::Terminal.is_missing());
+    assert!(!TurnActiveRunRefState::Terminal.is_nonterminal());
+    assert!(TurnActiveRunRefState::Terminal.is_terminal());
+}
+
+#[tokio::test]
+async fn active_run_ref_state_classifies_missing_nonterminal_and_terminal() {
+    let store = ironclaw_turns::InMemoryTurnStateStore::default();
+    let resolver = InMemoryRunProfileResolver::default();
+    let scope = turn_scope("active-run-ref-state");
+
+    assert_eq!(
+        ironclaw_turns::active_run_ref_state(&store, scope.clone(), None)
+            .await
+            .unwrap(),
+        TurnActiveRunRefState::Missing
+    );
+
+    let accepted = store
+        .submit_turn(
+            submit_request_for(scope.clone(), "active-run-ref-state"),
+            &AllowAllTurnAdmissionPolicy,
+            &resolver,
+        )
+        .await
+        .unwrap();
+    let ironclaw_turns::SubmitTurnResponse::Accepted { run_id, status, .. } = accepted;
+    assert_eq!(status, TurnStatus::Queued);
+
+    assert_eq!(
+        ironclaw_turns::active_run_ref_state(&store, scope.clone(), Some(run_id))
+            .await
+            .unwrap(),
+        TurnActiveRunRefState::Nonterminal
+    );
+
+    let cancel = store
+        .request_cancel(ironclaw_turns::CancelRunRequest {
+            scope: scope.clone(),
+            actor: turn_actor(),
+            run_id,
+            reason: ironclaw_turns::SanitizedCancelReason::UserRequested,
+            idempotency_key: IdempotencyKey::new("active-run-ref-state-cancel").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(cancel.status, TurnStatus::Cancelled);
+
+    assert_eq!(
+        ironclaw_turns::active_run_ref_state(&store, scope.clone(), Some(run_id))
+            .await
+            .unwrap(),
+        TurnActiveRunRefState::Terminal
+    );
+}
+
+#[tokio::test]
+async fn active_run_ref_state_treats_missing_lookup_as_missing() {
+    let store = ironclaw_turns::InMemoryTurnStateStore::default();
+    let scope = turn_scope("active-run-ref-missing");
+
+    assert_eq!(
+        ironclaw_turns::active_run_ref_state(&store, scope, Some(TurnRunId::new()))
+            .await
+            .unwrap(),
+        TurnActiveRunRefState::Missing
+    );
+}

--- a/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
+++ b/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
@@ -3,8 +3,45 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, AllowAllTurnAdmissionPolicy, IdempotencyKey, InMemoryRunProfileResolver,
     ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef, TurnActiveRunRefState, TurnActor,
-    TurnRunId, TurnScope, TurnStateStore, TurnStatus,
+    TurnError, TurnRunId, TurnScope, TurnStateStore, TurnStatus,
 };
+
+struct FailingTurnStateStore;
+
+#[async_trait::async_trait]
+impl TurnStateStore for FailingTurnStateStore {
+    async fn submit_turn(
+        &self,
+        _request: ironclaw_turns::SubmitTurnRequest,
+        _admission_policy: &dyn ironclaw_turns::TurnAdmissionPolicy,
+        _run_profile_resolver: &dyn ironclaw_turns::RunProfileResolver,
+    ) -> Result<ironclaw_turns::SubmitTurnResponse, TurnError> {
+        unreachable!("active_run_ref_state only calls get_run_state")
+    }
+
+    async fn resume_turn(
+        &self,
+        _request: ironclaw_turns::ResumeTurnRequest,
+    ) -> Result<ironclaw_turns::ResumeTurnResponse, TurnError> {
+        unreachable!("active_run_ref_state only calls get_run_state")
+    }
+
+    async fn request_cancel(
+        &self,
+        _request: ironclaw_turns::CancelRunRequest,
+    ) -> Result<ironclaw_turns::CancelRunResponse, TurnError> {
+        unreachable!("active_run_ref_state only calls get_run_state")
+    }
+
+    async fn get_run_state(
+        &self,
+        _request: ironclaw_turns::GetRunStateRequest,
+    ) -> Result<ironclaw_turns::TurnRunState, TurnError> {
+        Err(TurnError::Unavailable {
+            reason: "backend unavailable".to_string(),
+        })
+    }
+}
 
 fn turn_scope(thread: &str) -> TurnScope {
     TurnScope::new(
@@ -102,4 +139,16 @@ async fn active_run_ref_state_treats_missing_lookup_as_missing() {
             .unwrap(),
         TurnActiveRunRefState::Missing
     );
+}
+
+#[tokio::test]
+async fn active_run_ref_state_propagates_non_scope_not_found_errors() {
+    let result = ironclaw_turns::active_run_ref_state(
+        &FailingTurnStateStore,
+        turn_scope("active-run-ref-error"),
+        Some(TurnRunId::new()),
+    )
+    .await;
+
+    assert!(matches!(result, Err(TurnError::Unavailable { .. })));
 }

--- a/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
+++ b/crates/ironclaw_turns/tests/active_run_ref_state_contract.rs
@@ -40,21 +40,6 @@ fn submit_request_for(
     }
 }
 
-#[test]
-fn turn_active_run_ref_state_helper_flags_cover_all_variants() {
-    assert!(TurnActiveRunRefState::Missing.is_missing());
-    assert!(!TurnActiveRunRefState::Missing.is_nonterminal());
-    assert!(!TurnActiveRunRefState::Missing.is_terminal());
-
-    assert!(!TurnActiveRunRefState::Nonterminal.is_missing());
-    assert!(TurnActiveRunRefState::Nonterminal.is_nonterminal());
-    assert!(!TurnActiveRunRefState::Nonterminal.is_terminal());
-
-    assert!(!TurnActiveRunRefState::Terminal.is_missing());
-    assert!(!TurnActiveRunRefState::Terminal.is_nonterminal());
-    assert!(TurnActiveRunRefState::Terminal.is_terminal());
-}
-
 #[tokio::test]
 async fn active_run_ref_state_classifies_missing_nonterminal_and_terminal() {
     let store = ironclaw_turns::InMemoryTurnStateStore::default();

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -204,6 +204,12 @@ Trusted trigger ingress request fields are:
 - `actor`: `TurnActor` for `creator_user_id`;
 - `content_ref`: materialized trigger prompt.
 
+PR 14 adds the trigger-owned materialization seam without making
+`ironclaw_triggers` depend on conversation or product-workflow crates:
+`TriggerPromptMaterializer` accepts a `TriggerFire` and returns an opaque
+`TriggerInboundContentRef`. Composition owns the concrete adapter that writes or
+resolves that content ref for the trusted inbound path.
+
 The sealed marker/installation/actor/conversation tuple must resolve to the same
 `SourceBindingRef` on every retry of the same tenant-scoped fire identity. Replay
 must happen before any new binding creation, so retried fires reuse the original
@@ -250,6 +256,15 @@ Slot bookkeeping is tied to acceptance, not merely polling:
 Turn terminal lookup and clearing stay on the later PR 14+ seam; PR 12 and
 PR 13 define the fire-claim contract and submit-result bookkeeping but do not
 consult turn state yet.
+
+PR 14 provides that seam as two narrow pieces:
+
+- `ironclaw_turns::active_run_ref_state` classifies
+  `active_run_ref` through `get_run_state` and `TurnStatus::is_terminal`;
+- `ironclaw_triggers::ClearActiveFireRequest` plus
+  `TriggerRepository::clear_active_fire` clears only the exact matching
+  `(tenant_id, trigger_id, active_fire_slot, active_run_ref)` after the caller
+  has observed a terminal turn outcome.
 
 ---
 

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -204,11 +204,11 @@ Trusted trigger ingress request fields are:
 - `actor`: `TurnActor` for `creator_user_id`;
 - `content_ref`: materialized trigger prompt.
 
-PR 14 adds the trigger-owned materialization seam without making
-`ironclaw_triggers` depend on conversation or product-workflow crates:
-`TriggerPromptMaterializer` accepts a `TriggerFire` and returns an opaque
-`TriggerInboundContentRef`. Composition owns the concrete adapter that writes or
-resolves that content ref for the trusted inbound path.
+The trigger-owned materialization seam keeps `ironclaw_triggers` free of
+conversation and product-workflow dependencies: `TriggerPromptMaterializer`
+accepts a `TriggerFire` and returns an opaque `TriggerInboundContentRef`.
+Composition owns the concrete adapter that writes or resolves that content ref
+for the trusted inbound path.
 
 The sealed marker/installation/actor/conversation tuple must resolve to the same
 `SourceBindingRef` on every retry of the same tenant-scoped fire identity. Replay
@@ -253,11 +253,8 @@ Slot bookkeeping is tied to acceptance, not merely polling:
   `last_run_at` unchanged, and advance `next_run_at` beyond the failed
   fire_slot.
 
-Turn terminal lookup and clearing stay on the later PR 14+ seam; PR 12 and
-PR 13 define the fire-claim contract and submit-result bookkeeping but do not
-consult turn state yet.
-
-PR 14 provides that seam as two narrow pieces:
+Turn terminal lookup and clearing are a narrow seam layered above fire-claim
+and submit-result bookkeeping:
 
 - `ironclaw_turns::active_run_ref_state` classifies
   `active_run_ref` through `get_run_state` and `TurnStatus::is_terminal`;


### PR DESCRIPTION
## Summary

PR14 adds the next trigger-loop seams without wiring the poller yet:

- adds a trigger-owned `TriggerPromptMaterializer` port that accepts a `TriggerFire` and returns an opaque `TriggerInboundContentRef`;
- adds `ironclaw_turns::active_run_ref_state` to classify a persisted `active_run_ref` as missing, nonterminal, or terminal using existing turn state;
- adds backend-agnostic `ClearActiveFireRequest` / `TriggerRepository::clear_active_fire` so a caller can clear active-fire metadata only after it has observed the matching turn run become terminal;
- implements active-fire clearing for in-memory, libSQL, and PostgreSQL repositories with parity coverage;
- updates the trigger contract with the PR14 materialization and terminal-clear seams.

## Scope boundaries

This intentionally does not add:

- trigger poller logic;
- claim API changes beyond the PR13 claim/result APIs already present;
- capability handlers;
- lifecycle wiring;
- product workflow or conversation ingress dependencies from `ironclaw_triggers`;
- outbound delivery.

`ironclaw_triggers` still owns trigger-domain records and repository operations. Composition remains responsible for providing the concrete materializer adapter that writes or resolves trusted inbound content.

## Review-driven changes

This branch went through two 5.4-mini review rounds plus one dedicated 5.4-mini ownership/boundary verification pass.

Changes made from review:

- flattened the prompt-materialization seam so the trait takes `TriggerFire` directly and returns `TriggerInboundContentRef` directly;
- kept active-run classification out of the core `TurnStateStore` trait by exposing it as a free helper over the existing store API;
- added edge coverage for `TriggerInboundContentRef` at the 512-byte boundary;
- added helper-predicate coverage for `TurnActiveRunRefState`;
- expanded repository parity tests so mismatched run id, fire slot, and tenant do not clear active-fire state.

Boundary verifier result: no findings.

## Callout

`active_run_ref_state` currently uses `get_run_state`, which hydrates the full run state. A review pass noted that a future status-only lookup could be cheaper if the poller path becomes hot. I left that out of PR14 because adding a new status-only persistence method would broaden the turn persistence contract before there is a real caller pressure point.

## Validation

- `cargo fmt --all --check`
- `git diff --check origin/reborn-integration...HEAD`
- `cargo test -p ironclaw_turns --test active_run_ref_state_contract`
- `cargo test -p ironclaw_triggers --lib`
- `cargo test -p ironclaw_triggers --test repository_contract --features libsql,postgres`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries`
- `cargo clippy -p ironclaw_triggers --all-targets --features libsql,postgres`
- `cargo clippy -p ironclaw_turns --all-targets`
