### PR TITLE
[codex] Stop processing after cancelled gate resolution

### DIFF
--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -77,4 +77,21 @@ mod tests {
         assert!(use_chat.contains("credentialRef"));
         assert!(use_chat.contains("safeAuthGateCode"));
     }
+
+    #[test]
+    fn chat_cancelled_gate_resolution_exits_processing_state() {
+        let use_chat = asset_text("js/pages/chat/hooks/useChat.js");
+        assert!(
+            use_chat
+                .contains("resolution === \"approved\" || resolution === \"credential_provided\"")
+        );
+        assert!(use_chat.contains("setIsProcessing(shouldContinueProcessing);"));
+        assert!(use_chat.contains("setActiveRun(null);"));
+
+        let events = asset_text("js/pages/chat/lib/useChatEvents.js");
+        assert!(events.contains("TERMINAL_RUN_STATUSES.has(status)"));
+        assert!(events.contains("setPendingGate(null);"));
+        assert!(events.contains("setActiveRun?.(null);"));
+        assert!(events.contains("latestRunIdRef.current = null;"));
+    }
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/hooks/useChat.js
@@ -234,8 +234,13 @@ export function useChat(threadId) {
         always: opts.always,
         credentialRef: opts.credentialRef,
       });
+      const shouldContinueProcessing =
+        resolution === "approved" || resolution === "credential_provided";
       setPendingGate(null);
-      setIsProcessing(true);
+      setIsProcessing(shouldContinueProcessing);
+      if (!shouldContinueProcessing) {
+        setActiveRun(null);
+      }
     },
     [pendingGate, threadId],
   );

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -227,6 +227,10 @@ function applyProjectionItems({
       }
       if (TERMINAL_RUN_STATUSES.has(status)) {
         setIsProcessing(false);
+        setPendingGate(null);
+        setActiveRun?.(null);
+        activeRunId = null;
+        if (latestRunIdRef) latestRunIdRef.current = null;
         if (
           SUCCESS_RUN_STATUSES.has(status) &&
           onRunCompleted &&


### PR DESCRIPTION
## Summary

- Stop the Reborn WebUI from returning to a processing state after a gate resolves as denied or cancelled.
- Clear stale pending gate and active run state when projection snapshots report a terminal run status.
- Add a static asset regression test covering the cancel/terminal-state behavior.

## Root Cause

The Reborn browser hook treated every successful gate resolution as a resume path and set `isProcessing` back to true. For cancel/deny responses, the backend already terminates the run, but the UI could keep showing a blocked turn until a later event corrected it.

## Validation

- `cargo fmt --package ironclaw_webui_v2_static`
- `cargo test -p ironclaw_webui_v2_static chat_cancelled_gate_resolution_exits_processing_state`
- `cargo test -p ironclaw_product_workflow --test reborn_services_contract denial`
- `cargo test -p ironclaw_product_workflow --test reborn_services_contract denied_gate_resolution_cancels_run`
- `cargo test -p ironclaw_product_workflow --test auth_interaction_contract denied_auth_cancels_flow_and_run`
