### PR TITLE
[codex] Add trigger claim follow-up coverage

### DIFF
--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -939,6 +939,14 @@ mod tests {
         TenantId::new(value).expect("valid tenant")
     }
 
+    fn poison_in_memory_repo(repo: &InMemoryTriggerRepository) {
+        let poison_repo = repo.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = poison_repo.state.lock().expect("lock before poison");
+            panic!("poison trigger repository mutex");
+        });
+    }
+
     fn user(value: &str) -> UserId {
         UserId::new(value).expect("valid user")
     }
@@ -1428,11 +1436,7 @@ mod tests {
     #[tokio::test]
     async fn in_memory_repository_claim_due_fire_returns_backend_error_when_mutex_is_poisoned() {
         let repo = InMemoryTriggerRepository::default();
-        let poison_repo = repo.clone();
-        let _ = std::panic::catch_unwind(move || {
-            let _guard = poison_repo.state.lock().expect("lock before poison");
-            panic!("poison trigger repository mutex");
-        });
+        poison_in_memory_repo(&repo);
 
         let error = repo
             .claim_due_fire(ClaimDueFireRequest {
@@ -1450,11 +1454,7 @@ mod tests {
     async fn in_memory_repository_mark_fire_accepted_returns_backend_error_when_mutex_is_poisoned()
     {
         let repo = InMemoryTriggerRepository::default();
-        let poison_repo = repo.clone();
-        let _ = std::panic::catch_unwind(move || {
-            let _guard = poison_repo.state.lock().expect("lock before poison");
-            panic!("poison trigger repository mutex");
-        });
+        poison_in_memory_repo(&repo);
 
         let fire_slot = ts(1_704_067_200);
         let error = repo
@@ -1469,6 +1469,65 @@ mod tests {
             })
             .await
             .expect_err("poisoned mutex maps to backend through accepted-result API");
+        assert!(matches!(error, TriggerError::Backend { .. }));
+    }
+
+    #[tokio::test]
+    async fn in_memory_repository_mark_fire_replayed_returns_backend_error_when_mutex_is_poisoned()
+    {
+        let repo = InMemoryTriggerRepository::default();
+        poison_in_memory_repo(&repo);
+
+        let fire_slot = ts(1_704_067_200);
+        let error = repo
+            .mark_fire_replayed(FireReplayedRequest {
+                tenant_id: tenant("tenant-a"),
+                trigger_id: TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+                fire_slot,
+                original_run_id: TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a")
+                    .expect("valid run"),
+                replayed_at: fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect_err("poisoned mutex maps to backend through replayed-result API");
+        assert!(matches!(error, TriggerError::Backend { .. }));
+    }
+
+    #[tokio::test]
+    async fn in_memory_repository_mark_fire_retryable_failed_returns_backend_error_when_mutex_is_poisoned()
+     {
+        let repo = InMemoryTriggerRepository::default();
+        poison_in_memory_repo(&repo);
+
+        let fire_slot = ts(1_704_067_200);
+        let error = repo
+            .mark_fire_retryable_failed(FireRetryableFailedRequest {
+                tenant_id: tenant("tenant-a"),
+                trigger_id: TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+                fire_slot,
+            })
+            .await
+            .expect_err("poisoned mutex maps to backend through retryable-failure API");
+        assert!(matches!(error, TriggerError::Backend { .. }));
+    }
+
+    #[tokio::test]
+    async fn in_memory_repository_mark_fire_permanently_failed_returns_backend_error_when_mutex_is_poisoned()
+     {
+        let repo = InMemoryTriggerRepository::default();
+        poison_in_memory_repo(&repo);
+
+        let fire_slot = ts(1_704_067_200);
+        let error = repo
+            .mark_fire_permanently_failed(FirePermanentFailedRequest {
+                tenant_id: tenant("tenant-a"),
+                trigger_id: TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid"),
+                fire_slot,
+                next_run_at: ts(1_704_067_260),
+            })
+            .await
+            .expect_err("poisoned mutex maps to backend through permanent-failure API");
         assert!(matches!(error, TriggerError::Backend { .. }));
     }
 }

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -309,40 +309,19 @@ impl TriggerRepository for PostgresTriggerRepository {
         }
         reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
 
-        let submitted_at = fmt_ts(&request.submitted_at);
-        let fire_slot = fmt_ts(&request.fire_slot);
-        let next_run_at = fmt_ts(&request.next_run_at);
-        let active_run_ref = request.run_id.to_string();
-        let last_status = status_text(TriggerRunStatus::Ok);
-        let row = tx
-            .query_one(
-                &format!(
-                    "UPDATE {TRIGGER_TABLE}
-                     SET last_run_at = $3,
-                         last_fired_slot = $4,
-                         last_status = $5,
-                         next_run_at = $6,
-                         active_fire_slot = $4,
-                         active_run_ref = $7
-                     WHERE tenant_id = $1
-                       AND trigger_id = $2
-                       AND active_fire_slot = $4
-                       AND active_run_ref IS NULL
-                     RETURNING {TRIGGER_COLUMNS}"
-                ),
-                &[
-                    &request.tenant_id.as_str(),
-                    &trigger_id,
-                    &submitted_at,
-                    &fire_slot,
-                    &last_status,
-                    &next_run_at,
-                    &active_run_ref,
-                ],
-            )
-            .await
-            .map_err(|error| backend_error("mark accepted trigger fire", error))?;
-        let record = row_to_record(&row)?;
+        let record = mark_successful_fire_result(
+            &tx,
+            SuccessfulFireResultUpdate {
+                tenant_id: request.tenant_id.as_str(),
+                trigger_id: &trigger_id,
+                fire_slot: request.fire_slot,
+                run_id: request.run_id,
+                result_at: request.submitted_at,
+                next_run_at: request.next_run_at,
+                operation: "mark accepted trigger fire",
+            },
+        )
+        .await?;
         tx.commit()
             .await
             .map_err(|error| backend_error("commit accepted trigger fire", error))?;
@@ -372,40 +351,19 @@ impl TriggerRepository for PostgresTriggerRepository {
         }
         reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
 
-        let replayed_at = fmt_ts(&request.replayed_at);
-        let fire_slot = fmt_ts(&request.fire_slot);
-        let next_run_at = fmt_ts(&request.next_run_at);
-        let active_run_ref = request.original_run_id.to_string();
-        let last_status = status_text(TriggerRunStatus::Ok);
-        let row = tx
-            .query_one(
-                &format!(
-                    "UPDATE {TRIGGER_TABLE}
-                     SET last_run_at = $3,
-                         last_fired_slot = $4,
-                         last_status = $5,
-                         next_run_at = $6,
-                         active_fire_slot = $4,
-                         active_run_ref = $7
-                     WHERE tenant_id = $1
-                       AND trigger_id = $2
-                       AND active_fire_slot = $4
-                       AND active_run_ref IS NULL
-                     RETURNING {TRIGGER_COLUMNS}"
-                ),
-                &[
-                    &request.tenant_id.as_str(),
-                    &trigger_id,
-                    &replayed_at,
-                    &fire_slot,
-                    &last_status,
-                    &next_run_at,
-                    &active_run_ref,
-                ],
-            )
-            .await
-            .map_err(|error| backend_error("mark replayed trigger fire", error))?;
-        let record = row_to_record(&row)?;
+        let record = mark_successful_fire_result(
+            &tx,
+            SuccessfulFireResultUpdate {
+                tenant_id: request.tenant_id.as_str(),
+                trigger_id: &trigger_id,
+                fire_slot: request.fire_slot,
+                run_id: request.original_run_id,
+                result_at: request.replayed_at,
+                next_run_at: request.next_run_at,
+                operation: "mark replayed trigger fire",
+            },
+        )
+        .await?;
         tx.commit()
             .await
             .map_err(|error| backend_error("commit replayed trigger fire", error))?;
@@ -542,6 +500,56 @@ async fn locked_record(
         .await
         .map_err(|error| backend_error("lock trigger record", error))?;
     row.map(|row| row_to_record(&row)).transpose()
+}
+
+async fn mark_successful_fire_result(
+    tx: &tokio_postgres::Transaction<'_>,
+    update: SuccessfulFireResultUpdate<'_>,
+) -> Result<TriggerRecord, TriggerError> {
+    let result_at = fmt_ts(&update.result_at);
+    let fire_slot = fmt_ts(&update.fire_slot);
+    let next_run_at = fmt_ts(&update.next_run_at);
+    let active_run_ref = update.run_id.to_string();
+    let last_status = status_text(TriggerRunStatus::Ok);
+    let row = tx
+        .query_one(
+            &format!(
+                "UPDATE {TRIGGER_TABLE}
+                 SET last_run_at = $3,
+                     last_fired_slot = $4,
+                     last_status = $5,
+                     next_run_at = $6,
+                     active_fire_slot = $4,
+                     active_run_ref = $7
+                 WHERE tenant_id = $1
+                   AND trigger_id = $2
+                   AND active_fire_slot = $4
+                   AND active_run_ref IS NULL
+                 RETURNING {TRIGGER_COLUMNS}"
+            ),
+            &[
+                &update.tenant_id,
+                &update.trigger_id,
+                &result_at,
+                &fire_slot,
+                &last_status,
+                &next_run_at,
+                &active_run_ref,
+            ],
+        )
+        .await
+        .map_err(|error| backend_error(update.operation, error))?;
+    row_to_record(&row)
+}
+
+struct SuccessfulFireResultUpdate<'a> {
+    tenant_id: &'a str,
+    trigger_id: &'a str,
+    fire_slot: Timestamp,
+    run_id: TurnRunId,
+    result_at: Timestamp,
+    next_run_at: Timestamp,
+    operation: &'static str,
 }
 
 fn row_to_record(row: &Row) -> Result<TriggerRecord, TriggerError> {

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1670,6 +1670,151 @@ mod fire_claim_contract {
         assert_eq!(persisted.active_run_ref, None);
     }
 
+    async fn assert_mark_fire_accepted_is_idempotent_under_concurrency<R>(
+        repo: std::sync::Arc<R>,
+        trigger_id: TriggerId,
+        tenant_id: TenantId,
+    ) where
+        R: TriggerRepository + 'static,
+    {
+        let fire_slot = ts(1_704_067_200);
+        let accepted_at = ts(1_704_067_205);
+        let record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
+        let next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next slot calculation")
+            .expect("future slot");
+        repo.upsert_trigger(record).await.expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f64").expect("valid run");
+        let request = FireAcceptedRequest {
+            tenant_id: tenant_id.clone(),
+            trigger_id,
+            fire_slot,
+            run_id,
+            submitted_at: accepted_at,
+            next_run_at,
+        };
+        let first_repo = repo.clone();
+        let second_repo = repo.clone();
+        let first_request = request.clone();
+        let second_request = request;
+        let first = async move {
+            tokio::task::yield_now().await;
+            first_repo.mark_fire_accepted(first_request).await
+        };
+        let second = async move {
+            tokio::task::yield_now().await;
+            second_repo.mark_fire_accepted(second_request).await
+        };
+
+        let (first, second) = tokio::join!(first, second);
+        let first = first
+            .expect("first accepted result")
+            .expect("first accepted record");
+        let second = second
+            .expect("second accepted result")
+            .expect("second accepted record");
+        assert_eq!(first, second);
+        assert_eq!(first.active_fire_slot, Some(fire_slot));
+        assert_eq!(first.active_run_ref, Some(run_id));
+        assert_eq!(first.last_run_at, Some(accepted_at));
+        assert_eq!(first.last_fired_slot, Some(fire_slot));
+        assert_eq!(first.last_status, Some(TriggerRunStatus::Ok));
+
+        let persisted = repo
+            .get_trigger(tenant_id, trigger_id)
+            .await
+            .expect("reload accepted result")
+            .expect("record present");
+        assert_eq!(persisted, first);
+    }
+
+    async fn assert_mark_fire_replayed_is_idempotent_under_concurrency<R>(
+        repo: std::sync::Arc<R>,
+        trigger_id: TriggerId,
+        tenant_id: TenantId,
+    ) where
+        R: TriggerRepository + 'static,
+    {
+        let fire_slot = ts(1_704_067_200);
+        let replayed_at = ts(1_704_067_205);
+        let record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
+        let next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next slot calculation")
+            .expect("future slot");
+        repo.upsert_trigger(record).await.expect("insert record");
+        assert!(matches!(
+            repo.claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim fire"),
+            ClaimDueFireOutcome::Claimed(_)
+        ));
+
+        let original_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f65").expect("valid run");
+        let request = FireReplayedRequest {
+            tenant_id: tenant_id.clone(),
+            trigger_id,
+            fire_slot,
+            original_run_id,
+            replayed_at,
+            next_run_at,
+        };
+        let first_repo = repo.clone();
+        let second_repo = repo.clone();
+        let first_request = request.clone();
+        let second_request = request;
+        let first = async move {
+            tokio::task::yield_now().await;
+            first_repo.mark_fire_replayed(first_request).await
+        };
+        let second = async move {
+            tokio::task::yield_now().await;
+            second_repo.mark_fire_replayed(second_request).await
+        };
+
+        let (first, second) = tokio::join!(first, second);
+        let first = first
+            .expect("first replayed result")
+            .expect("first replayed record");
+        let second = second
+            .expect("second replayed result")
+            .expect("second replayed record");
+        assert_eq!(first, second);
+        assert_eq!(first.active_fire_slot, Some(fire_slot));
+        assert_eq!(first.active_run_ref, Some(original_run_id));
+        assert_eq!(first.last_run_at, Some(replayed_at));
+        assert_eq!(first.last_fired_slot, Some(fire_slot));
+        assert_eq!(first.last_status, Some(TriggerRunStatus::Ok));
+
+        let persisted = repo
+            .get_trigger(tenant_id, trigger_id)
+            .await
+            .expect("reload replayed result")
+            .expect("record present");
+        assert_eq!(persisted, first);
+    }
+
     trait ClaimDueFireOutcomeAssertions {
         fn matches_not_found(&self) -> bool;
         fn matches_not_due(&self) -> bool;
@@ -1743,145 +1888,24 @@ mod fire_claim_contract {
     #[tokio::test]
     async fn libsql_repository_mark_fire_accepted_is_idempotent_under_concurrency() {
         let (_dir, repo) = build_libsql_repo().await;
-        let repo = std::sync::Arc::new(repo);
-        let trigger_id = TriggerId::parse("01J00000000000000000000014").expect("ulid");
-        let tenant_id = tenant("tenant-accepted-concurrent");
-        let fire_slot = ts(1_704_067_200);
-        let accepted_at = ts(1_704_067_205);
-        let record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
-        let next_run_at = record
-            .schedule
-            .next_slot_after(fire_slot)
-            .expect("next slot calculation")
-            .expect("future slot");
-        repo.upsert_trigger(record).await.expect("insert record");
-        assert!(matches!(
-            repo.claim_due_fire(ClaimDueFireRequest {
-                tenant_id: tenant_id.clone(),
-                trigger_id,
-                fire_slot,
-                now: fire_slot,
-            })
-            .await
-            .expect("claim fire"),
-            ClaimDueFireOutcome::Claimed(_)
-        ));
-
-        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f64").expect("valid run");
-        let request = FireAcceptedRequest {
-            tenant_id: tenant_id.clone(),
-            trigger_id,
-            fire_slot,
-            run_id,
-            submitted_at: accepted_at,
-            next_run_at,
-        };
-        let first_repo = repo.clone();
-        let second_repo = repo.clone();
-        let first_request = request.clone();
-        let second_request = request;
-        let first = async move {
-            tokio::task::yield_now().await;
-            first_repo.mark_fire_accepted(first_request).await
-        };
-        let second = async move {
-            tokio::task::yield_now().await;
-            second_repo.mark_fire_accepted(second_request).await
-        };
-
-        let (first, second) = tokio::join!(first, second);
-        let first = first
-            .expect("first accepted result")
-            .expect("first accepted record");
-        let second = second
-            .expect("second accepted result")
-            .expect("second accepted record");
-        assert_eq!(first, second);
-        assert_eq!(first.active_fire_slot, Some(fire_slot));
-        assert_eq!(first.active_run_ref, Some(run_id));
-        assert_eq!(first.last_run_at, Some(accepted_at));
-        assert_eq!(first.last_fired_slot, Some(fire_slot));
-        assert_eq!(first.last_status, Some(TriggerRunStatus::Ok));
-
-        let persisted = repo
-            .get_trigger(tenant_id, trigger_id)
-            .await
-            .expect("reload accepted result")
-            .expect("record present");
-        assert_eq!(persisted, first);
+        assert_mark_fire_accepted_is_idempotent_under_concurrency(
+            std::sync::Arc::new(repo),
+            TriggerId::parse("01J00000000000000000000014").expect("ulid"),
+            tenant("tenant-accepted-concurrent"),
+        )
+        .await;
     }
 
     #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn libsql_repository_mark_fire_replayed_is_idempotent_under_concurrency() {
         let (_dir, repo) = build_libsql_repo().await;
-        let repo = std::sync::Arc::new(repo);
-        let trigger_id = TriggerId::parse("01J00000000000000000000015").expect("ulid");
-        let tenant_id = tenant("tenant-replayed-concurrent");
-        let fire_slot = ts(1_704_067_200);
-        let replayed_at = ts(1_704_067_205);
-        let record = sample_record(trigger_id, tenant_id.clone(), fire_slot);
-        let next_run_at = record
-            .schedule
-            .next_slot_after(fire_slot)
-            .expect("next slot calculation")
-            .expect("future slot");
-        repo.upsert_trigger(record).await.expect("insert record");
-        assert!(matches!(
-            repo.claim_due_fire(ClaimDueFireRequest {
-                tenant_id: tenant_id.clone(),
-                trigger_id,
-                fire_slot,
-                now: fire_slot,
-            })
-            .await
-            .expect("claim fire"),
-            ClaimDueFireOutcome::Claimed(_)
-        ));
-
-        let original_run_id =
-            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f65").expect("valid run");
-        let request = FireReplayedRequest {
-            tenant_id: tenant_id.clone(),
-            trigger_id,
-            fire_slot,
-            original_run_id,
-            replayed_at,
-            next_run_at,
-        };
-        let first_repo = repo.clone();
-        let second_repo = repo.clone();
-        let first_request = request.clone();
-        let second_request = request;
-        let first = async move {
-            tokio::task::yield_now().await;
-            first_repo.mark_fire_replayed(first_request).await
-        };
-        let second = async move {
-            tokio::task::yield_now().await;
-            second_repo.mark_fire_replayed(second_request).await
-        };
-
-        let (first, second) = tokio::join!(first, second);
-        let first = first
-            .expect("first replayed result")
-            .expect("first replayed record");
-        let second = second
-            .expect("second replayed result")
-            .expect("second replayed record");
-        assert_eq!(first, second);
-        assert_eq!(first.active_fire_slot, Some(fire_slot));
-        assert_eq!(first.active_run_ref, Some(original_run_id));
-        assert_eq!(first.last_run_at, Some(replayed_at));
-        assert_eq!(first.last_fired_slot, Some(fire_slot));
-        assert_eq!(first.last_status, Some(TriggerRunStatus::Ok));
-
-        let persisted = repo
-            .get_trigger(tenant_id, trigger_id)
-            .await
-            .expect("reload replayed result")
-            .expect("record present");
-        assert_eq!(persisted, first);
+        assert_mark_fire_replayed_is_idempotent_under_concurrency(
+            std::sync::Arc::new(repo),
+            TriggerId::parse("01J00000000000000000000015").expect("ulid"),
+            tenant("tenant-replayed-concurrent"),
+        )
+        .await;
     }
 
     #[cfg(feature = "postgres")]
@@ -1905,6 +1929,40 @@ mod fire_claim_contract {
         let repo = PostgresTriggerRepository::new(pool.clone());
         repo.run_migrations().await.expect("run migrations");
         assert_durable_claim_is_atomic(std::sync::Arc::new(repo)).await;
+        clear_postgres_triggers(&pool).await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn postgres_repository_mark_fire_accepted_is_idempotent_under_concurrency() {
+        let Some((_container, pool)) = postgres_pool_or_skip().await else {
+            return;
+        };
+        let repo = PostgresTriggerRepository::new(pool.clone());
+        repo.run_migrations().await.expect("run migrations");
+        assert_mark_fire_accepted_is_idempotent_under_concurrency(
+            std::sync::Arc::new(repo),
+            TriggerId::parse("01J00000000000000000000016").expect("ulid"),
+            tenant("tenant-postgres-accepted-concurrent"),
+        )
+        .await;
+        clear_postgres_triggers(&pool).await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn postgres_repository_mark_fire_replayed_is_idempotent_under_concurrency() {
+        let Some((_container, pool)) = postgres_pool_or_skip().await else {
+            return;
+        };
+        let repo = PostgresTriggerRepository::new(pool.clone());
+        repo.run_migrations().await.expect("run migrations");
+        assert_mark_fire_replayed_is_idempotent_under_concurrency(
+            std::sync::Arc::new(repo),
+            TriggerId::parse("01J00000000000000000000017").expect("ulid"),
+            tenant("tenant-postgres-replayed-concurrent"),
+        )
+        .await;
         clear_postgres_triggers(&pool).await;
     }
 }


### PR DESCRIPTION
## Summary

Follow-up from merged PR #4276 after validating deferred review batches with 5.4-mini subagents.

- extracts the duplicated Postgres accepted/replayed successful-fire update into a shared helper;
- adds remaining in-memory poison-path API coverage for mark_fire_replayed, mark_fire_retryable_failed, and mark_fire_permanently_failed;
- shares accepted/replayed concurrency test helpers and adds Postgres idempotency coverage matching the existing libSQL coverage.

## Batch triage

Fixed now:
- Postgres mark_fire_accepted / mark_fire_replayed duplication: straightforward no-behavior refactor.
- InMemoryTriggerRepository poison-path coverage for the remaining mark_fire_* APIs.
- Postgres accepted/replayed concurrent idempotency tests.

Deferred for discussion:
- Postgres query_one / extra UPDATE predicates are hardening-only under the current SELECT FOR UPDATE flow.
- libSQL claim_due_fire fallback TOCTOU is real but intentionally normalized to NotDue/AlreadyActive semantics.
- libSQL failed-result single-CAS rewrite and obscure CAS-miss public tests need deliberate race-harness design.
- Moving reject_* helpers to validation.rs is low-value organization cleanup.

## Verification

- cargo test -p ironclaw_triggers --features libsql --test repository_contract
- cargo test -p ironclaw_triggers --features libsql in_memory_repository_mark_fire_ -- --nocapture
- cargo test -p ironclaw_triggers --features postgres --test repository_contract postgres_repository_mark_fire_ -- --nocapture
- cargo test -p ironclaw_triggers --all-features -- --test-threads=1
- cargo test -p ironclaw_triggers --all-features
- cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings
- git diff --check

Note: one initial default parallel all-features run hit a libSQL bad parameter/API misuse failure in the replayed concurrency test. The exact test passed in isolation, the serial all-features suite passed, and a rerun of the default all-features suite passed.