### PR TITLE
PR15: Add trigger poller core

### DIFF
--- a/crates/ironclaw_triggers/AGENTS.md
+++ b/crates/ironclaw_triggers/AGENTS.md
@@ -10,16 +10,16 @@
 
 - Trigger records, schedule validation, source-provider evaluation, deterministic fire identity, and repository contracts.
 - In-memory test behavior and durable trigger repository backends.
+- Deterministic poller tick logic behind trigger-owned repository/materializer/submitter/state-lookup ports.
 - Cron validation, including rejection of schedules that can fire more often than once per minute.
 - Backend-specific trigger repository implementations may accept already-open database handles such as `Arc<libsql::Database>`.
 - This crate must not own database URL/path/env parsing, bootstrap config, or generic database accessors.
 
 ## Do Not Move In Here
 
-- Poller lifecycle, worker startup/shutdown, routine bridges, or composition wiring.
+- Poller lifecycle, background worker startup/shutdown, routine bridges, or composition wiring.
 - First-party trigger capabilities such as create/list/remove.
 - Trusted inbound turn wiring, product adapter behavior, or outbound delivery resolution.
-- Active-run reservation/back-pressure enforcement; later poller slices own that policy.
 - libSQL/PostgreSQL handle construction, connection-string validation, production substrate selection, or shared Reborn database bootstrap.
 - Composition/bootstrap owns those boundaries and passes typed handles into repository constructors.
 

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -26,6 +26,7 @@ use ulid::Ulid;
 mod libsql;
 #[cfg(feature = "postgres")]
 mod postgres;
+mod worker;
 
 const MIN_FIRE_CADENCE: Duration = Duration::from_secs(60);
 const MAX_DUE_TRIGGER_POLL_LIMIT: usize = 128;
@@ -41,6 +42,8 @@ pub enum TriggerError {
     InvalidFireIdentityComponent { label: String, reason: String },
     #[error("invalid trigger record: {reason}")]
     InvalidRecord { reason: String },
+    #[error("invalid trigger poller configuration: {reason}")]
+    InvalidPollerConfig { reason: String },
     #[error("invalid schedule: {reason}")]
     InvalidSchedule { reason: String },
     #[error("invalid trigger materialization: {reason}")]
@@ -291,6 +294,11 @@ impl TriggerRecord {
         if self.prompt.trim().is_empty() {
             return Err(TriggerError::InvalidRecord {
                 reason: "trigger prompt must not be empty".to_string(),
+            });
+        }
+        if self.active_run_ref.is_some() && self.active_fire_slot.is_none() {
+            return Err(TriggerError::InvalidRecord {
+                reason: "active_run_ref requires active_fire_slot".to_string(),
             });
         }
         self.schedule.validate()?;
@@ -558,6 +566,13 @@ pub trait TriggerRepository: Send + Sync {
         limit: usize,
     ) -> Result<Vec<TriggerRecord>, TriggerError>;
 
+    /// Lists active trigger fires across all tenants for trusted poller cleanup.
+    ///
+    /// This is a global query and must not be used for tenant-scoped or
+    /// user-facing list operations. It exists so the poller can clear completed
+    /// active fires before future schedule slots become eligible.
+    async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError>;
+
     async fn claim_due_fire(
         &self,
         request: ClaimDueFireRequest,
@@ -595,6 +610,12 @@ pub use libsql::LibSqlTriggerRepository;
 /// Feature-gated durable PostgreSQL repository type for composition/test wiring.
 #[cfg(feature = "postgres")]
 pub use postgres::PostgresTriggerRepository;
+pub use worker::{
+    TriggerActiveRunLookup, TriggerActiveRunState, TriggerActiveRunStateRequest,
+    TriggerPollerFireOutcome, TriggerPollerFireReport, TriggerPollerTickReport,
+    TriggerPollerWorker, TriggerPollerWorkerConfig, TriggerPollerWorkerDeps,
+    TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest,
+};
 
 #[derive(Clone, Default)]
 pub struct InMemoryTriggerRepository {
@@ -690,6 +711,34 @@ impl TriggerRepository for InMemoryTriggerRepository {
             .collect::<Vec<_>>();
         selected_keys.sort_by_key(|(next_run_at, tenant_id, trigger_id, _)| {
             (*next_run_at, tenant_id.clone(), *trigger_id)
+        });
+        selected_keys.truncate(limit);
+        Ok(selected_keys
+            .into_iter()
+            .filter_map(|(_, _, _, key)| state.get(&key).cloned())
+            .collect())
+    }
+
+    async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = limit.min(MAX_DUE_TRIGGER_POLL_LIMIT);
+        let state = self.lock_state()?;
+        let mut selected_keys = state
+            .iter()
+            .filter(|(_, record)| record.active_fire_slot.is_some())
+            .map(|(key, record)| {
+                (
+                    record.active_fire_slot.unwrap_or(record.next_run_at),
+                    record.tenant_id.clone(),
+                    record.trigger_id,
+                    key.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        selected_keys.sort_by_key(|(active_fire_slot, tenant_id, trigger_id, _)| {
+            (*active_fire_slot, tenant_id.clone(), *trigger_id)
         });
         selected_keys.truncate(limit);
         Ok(selected_keys

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -486,6 +486,13 @@ pub struct FirePermanentFailedRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireTerminalFailedRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClearActiveFireRequest {
     pub tenant_id: TenantId,
     pub trigger_id: TriggerId,
@@ -600,6 +607,11 @@ pub trait TriggerRepository: Send + Sync {
     async fn mark_fire_permanently_failed(
         &self,
         request: FirePermanentFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError>;
+
+    async fn mark_fire_terminally_failed(
+        &self,
+        request: FireTerminalFailedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError>;
 
     async fn clear_active_fire(
@@ -884,6 +896,29 @@ impl TriggerRepository for InMemoryTriggerRepository {
                 reject_non_future_next_run_at(request.fire_slot, request.next_run_at)?;
                 record.last_status = Some(TriggerRunStatus::Error);
                 record.next_run_at = request.next_run_at;
+                record.active_fire_slot = None;
+                record.active_run_ref = None;
+                Ok(())
+            },
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_terminally_failed(
+        &self,
+        request: FireTerminalFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let Some(record) = self.update_claimed_fire(
+            &request.tenant_id,
+            request.trigger_id,
+            request.fire_slot,
+            |record| {
+                reject_failed_result_after_active_run(record.active_run_ref)?;
+                record.state = TriggerState::Completed;
+                record.last_status = Some(TriggerRunStatus::Error);
                 record.active_fire_slot = None;
                 record.active_run_ref = None;
                 Ok(())

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -609,6 +609,14 @@ pub trait TriggerRepository: Send + Sync {
         request: FirePermanentFailedRequest,
     ) -> Result<Option<TriggerRecord>, TriggerError>;
 
+    /// Marks a trusted poller-owned claimed fire as terminally failed.
+    ///
+    /// # Safety / Authorization
+    ///
+    /// This clears active-fire state and completes the trigger when a claimed
+    /// fire cannot advance to another schedule slot. Callers must derive the
+    /// tenant, trigger id, and fire slot from a trusted claimed record, not from
+    /// user input or a tenant-scoped list path.
     async fn mark_fire_terminally_failed(
         &self,
         request: FireTerminalFailedRequest,
@@ -743,14 +751,14 @@ impl TriggerRepository for InMemoryTriggerRepository {
         let state = self.lock_state()?;
         let mut selected_keys = state
             .iter()
-            .filter(|(_, record)| record.active_fire_slot.is_some())
-            .map(|(key, record)| {
-                (
-                    record.active_fire_slot.unwrap_or(record.next_run_at),
+            .filter_map(|(key, record)| {
+                let active_fire_slot = record.active_fire_slot?;
+                Some((
+                    active_fire_slot,
                     record.tenant_id.clone(),
                     record.trigger_id,
                     key.clone(),
-                )
+                ))
             })
             .collect::<Vec<_>>();
         selected_keys.sort_by_key(|(active_fire_slot, tenant_id, trigger_id, _)| {

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -636,9 +636,10 @@ pub use libsql::LibSqlTriggerRepository;
 pub use postgres::PostgresTriggerRepository;
 pub use worker::{
     TriggerActiveRunLookup, TriggerActiveRunState, TriggerActiveRunStateRequest,
-    TriggerPollerFireOutcome, TriggerPollerFireReport, TriggerPollerTickReport,
-    TriggerPollerWorker, TriggerPollerWorkerConfig, TriggerPollerWorkerDeps,
-    TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter, TrustedTriggerSubmitRequest,
+    TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerFireReport,
+    TriggerPollerTickReport, TriggerPollerWorker, TriggerPollerWorkerConfig,
+    TriggerPollerWorkerDeps, TrustedTriggerFireSubmitOutcome, TrustedTriggerFireSubmitter,
+    TrustedTriggerSubmitFailureReason, TrustedTriggerSubmitRequest,
 };
 
 #[derive(Clone, Default)]

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -568,9 +568,13 @@ pub trait TriggerRepository: Send + Sync {
 
     /// Lists active trigger fires across all tenants for trusted poller cleanup.
     ///
+    /// # Safety / Authorization
+    ///
     /// This is a global query and must not be used for tenant-scoped or
     /// user-facing list operations. It exists so the poller can clear completed
-    /// active fires before future schedule slots become eligible.
+    /// active fires before future schedule slots become eligible. Callers must
+    /// preserve each returned record's tenant authority when checking or
+    /// clearing active fire state.
     async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError>;
 
     async fn claim_due_fire(

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -306,7 +306,7 @@ impl TriggerRepository for LibSqlTriggerRepository {
                     "SELECT {TRIGGER_COLUMNS}
                      FROM {TRIGGER_TABLE}
                      WHERE active_fire_slot IS NOT NULL
-                     ORDER BY COALESCE(active_fire_slot, next_run_at), tenant_id, trigger_id
+                     ORDER BY active_fire_slot, tenant_id, trigger_id
                      LIMIT ?1"
                 ),
                 params![limit as i64],

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -16,9 +16,10 @@ use libsql::params;
 use crate::{
     ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, ClearActiveFireRequest,
     FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
-    FireRetryableFailedRequest, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
-    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
-    reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
+    FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerCompletionPolicy, TriggerError,
+    TriggerId, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
+    TriggerSourceKind, TriggerState, reject_failed_result_after_active_run,
+    reject_non_future_next_run_at, reject_run_ref_rewrite,
 };
 
 #[cfg(feature = "libsql")]
@@ -533,6 +534,60 @@ impl TriggerRepository for LibSqlTriggerRepository {
             .map_err(|error| backend_error("mark permanent trigger fire failure", error))?;
         if let Some(record) =
             returned_record(&mut rows, "read permanent trigger fire failure").await?
+        {
+            return Ok(Some(record));
+        }
+        resolve_missed_fire_result_update(&conn, &tenant_id, trigger_id, fire_slot, None, None)
+            .await
+    }
+
+    async fn mark_fire_terminally_failed(
+        &self,
+        request: FireTerminalFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let FireTerminalFailedRequest {
+            tenant_id,
+            trigger_id,
+            fire_slot,
+        } = request;
+        let conn = self.connect().await?;
+        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(fire_slot) {
+            return Ok(None);
+        }
+        reject_failed_result_after_active_run(record.active_run_ref)?;
+
+        let fire_slot_text = fmt_ts(&fire_slot);
+        let last_status = status_text(TriggerRunStatus::Error);
+        let completed = state_text(TriggerState::Completed);
+        let mut rows = conn
+            .query(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET state = ?3,
+                         last_status = ?4,
+                         active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = ?1
+                       AND trigger_id = ?2
+                       AND active_fire_slot = ?5
+                       AND active_run_ref IS NULL
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                params![
+                    tenant_id.as_str(),
+                    trigger_id.to_string(),
+                    completed,
+                    last_status,
+                    fire_slot_text,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark terminal trigger fire failure", error))?;
+        if let Some(record) =
+            returned_record(&mut rows, "read terminal trigger fire failure").await?
         {
             return Ok(Some(record));
         }

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -550,18 +550,10 @@ impl TriggerRepository for LibSqlTriggerRepository {
             trigger_id,
             fire_slot,
         } = request;
-        let conn = self.connect().await?;
-        let Some(record) = fetch_record(&conn, &tenant_id, trigger_id).await? else {
-            return Ok(None);
-        };
-        if record.active_fire_slot != Some(fire_slot) {
-            return Ok(None);
-        }
-        reject_failed_result_after_active_run(record.active_run_ref)?;
-
         let fire_slot_text = fmt_ts(&fire_slot);
         let last_status = status_text(TriggerRunStatus::Error);
         let completed = state_text(TriggerState::Completed);
+        let conn = self.connect().await?;
         let mut rows = conn
             .query(
                 &format!(

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -293,6 +293,36 @@ impl TriggerRepository for LibSqlTriggerRepository {
         Ok(records)
     }
 
+    async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = limit.min(super::MAX_DUE_TRIGGER_POLL_LIMIT);
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                &format!(
+                    "SELECT {TRIGGER_COLUMNS}
+                     FROM {TRIGGER_TABLE}
+                     WHERE active_fire_slot IS NOT NULL
+                     ORDER BY COALESCE(active_fire_slot, next_run_at), tenant_id, trigger_id
+                     LIMIT ?1"
+                ),
+                params![limit as i64],
+            )
+            .await
+            .map_err(|error| backend_error("query active trigger records", error))?;
+        let mut records = Vec::new();
+        loop {
+            match rows.next().await {
+                Ok(Some(row)) => records.push(row_to_record(&row)?),
+                Ok(None) => break,
+                Err(error) => return Err(backend_error("read active trigger record row", error)),
+            }
+        }
+        Ok(records)
+    }
+
     async fn claim_due_fire(
         &self,
         request: ClaimDueFireRequest,

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -246,7 +246,7 @@ impl TriggerRepository for PostgresTriggerRepository {
                     "SELECT {TRIGGER_COLUMNS}
                      FROM {TRIGGER_TABLE}
                      WHERE active_fire_slot IS NOT NULL
-                     ORDER BY COALESCE(active_fire_slot, next_run_at), tenant_id, trigger_id
+                     ORDER BY active_fire_slot, tenant_id, trigger_id
                      LIMIT $1"
                 ),
                 &[&limit],
@@ -321,9 +321,15 @@ impl TriggerRepository for PostgresTriggerRepository {
         let trigger_id = request.trigger_id.to_string();
         let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
         else {
+            tx.rollback()
+                .await
+                .map_err(|error| backend_error("rollback terminal trigger fire failure", error))?;
             return Ok(None);
         };
         if record.active_fire_slot != Some(request.fire_slot) {
+            tx.rollback()
+                .await
+                .map_err(|error| backend_error("rollback terminal trigger fire failure", error))?;
             return Ok(None);
         }
         if let Some(active_run_ref) = record.active_run_ref {

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -233,6 +233,28 @@ impl TriggerRepository for PostgresTriggerRepository {
         rows.into_iter().map(|row| row_to_record(&row)).collect()
     }
 
+    async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = limit.min(super::MAX_DUE_TRIGGER_POLL_LIMIT) as i64;
+        let client = self.connect().await?;
+        let rows = client
+            .query(
+                &format!(
+                    "SELECT {TRIGGER_COLUMNS}
+                     FROM {TRIGGER_TABLE}
+                     WHERE active_fire_slot IS NOT NULL
+                     ORDER BY COALESCE(active_fire_slot, next_run_at), tenant_id, trigger_id
+                     LIMIT $1"
+                ),
+                &[&limit],
+            )
+            .await
+            .map_err(|error| backend_error("query active trigger records", error))?;
+        rows.into_iter().map(|row| row_to_record(&row)).collect()
+    }
+
     async fn claim_due_fire(
         &self,
         request: ClaimDueFireRequest,

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -7,9 +7,10 @@ use tokio_postgres::Row;
 use crate::{
     ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, ClearActiveFireRequest,
     FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
-    FireRetryableFailedRequest, TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord,
-    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
-    reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
+    FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerCompletionPolicy, TriggerError,
+    TriggerId, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
+    TriggerSourceKind, TriggerState, reject_failed_result_after_active_run,
+    reject_non_future_next_run_at, reject_run_ref_rewrite,
 };
 
 const TRIGGER_TABLE: &str = "trigger_records";
@@ -500,6 +501,59 @@ impl TriggerRepository for PostgresTriggerRepository {
         tx.commit()
             .await
             .map_err(|error| backend_error("commit permanent trigger fire failure", error))?;
+        Ok(Some(record))
+    }
+
+    async fn mark_fire_terminally_failed(
+        &self,
+        request: FireTerminalFailedRequest,
+    ) -> Result<Option<TriggerRecord>, TriggerError> {
+        let mut client = self.connect().await?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|error| backend_error("begin terminal trigger fire failure", error))?;
+        let trigger_id = request.trigger_id.to_string();
+        let Some(record) = locked_record(&tx, request.tenant_id.as_str(), &trigger_id).await?
+        else {
+            return Ok(None);
+        };
+        if record.active_fire_slot != Some(request.fire_slot) {
+            return Ok(None);
+        }
+        reject_failed_result_after_active_run(record.active_run_ref)?;
+
+        let last_status = status_text(TriggerRunStatus::Error);
+        let completed = state_text(TriggerState::Completed);
+        let fire_slot = fmt_ts(&request.fire_slot);
+        let row = tx
+            .query_one(
+                &format!(
+                    "UPDATE {TRIGGER_TABLE}
+                     SET state = $3,
+                         last_status = $4,
+                         active_fire_slot = NULL,
+                         active_run_ref = NULL
+                     WHERE tenant_id = $1
+                       AND trigger_id = $2
+                       AND active_fire_slot = $5
+                       AND active_run_ref IS NULL
+                     RETURNING {TRIGGER_COLUMNS}"
+                ),
+                &[
+                    &request.tenant_id.as_str(),
+                    &trigger_id,
+                    &completed,
+                    &last_status,
+                    &fire_slot,
+                ],
+            )
+            .await
+            .map_err(|error| backend_error("mark terminal trigger fire failure", error))?;
+        let record = row_to_record(&row)?;
+        tx.commit()
+            .await
+            .map_err(|error| backend_error("commit terminal trigger fire failure", error))?;
         Ok(Some(record))
     }
 

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -527,7 +527,7 @@ impl TriggerRepository for PostgresTriggerRepository {
         let completed = state_text(TriggerState::Completed);
         let fire_slot = fmt_ts(&request.fire_slot);
         let row = tx
-            .query_one(
+            .query_opt(
                 &format!(
                     "UPDATE {TRIGGER_TABLE}
                      SET state = $3,
@@ -550,6 +550,12 @@ impl TriggerRepository for PostgresTriggerRepository {
             )
             .await
             .map_err(|error| backend_error("mark terminal trigger fire failure", error))?;
+        let Some(row) = row else {
+            tx.commit()
+                .await
+                .map_err(|error| backend_error("commit terminal trigger fire failure", error))?;
+            return Ok(None);
+        };
         let record = row_to_record(&row)?;
         tx.commit()
             .await

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -6,9 +6,9 @@ use ironclaw_turns::TurnRunId;
 
 use crate::{
     ClaimDueFireOutcome, ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest,
-    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest, TriggerError,
-    TriggerFire, TriggerId, TriggerInboundContentRef, TriggerPromptMaterializer, TriggerRecord,
-    TriggerRepository, TriggerSourceProvider,
+    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest,
+    FireTerminalFailedRequest, TriggerError, TriggerFire, TriggerId, TriggerInboundContentRef,
+    TriggerPromptMaterializer, TriggerRecord, TriggerRepository, TriggerSourceProvider,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,8 +82,23 @@ impl TriggerPollerWorker {
             .await?;
         report.due_records = due_records.len();
         for record in due_records {
+            let tenant_id = record.tenant_id.clone();
+            let trigger_id = record.trigger_id;
             let fire_slot = record.next_run_at;
-            let outcome = self.process_due_record(record, now).await?;
+            let outcome = match self.process_due_record(record, now).await {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    report.results.push(TriggerPollerFireReport {
+                        tenant_id,
+                        trigger_id,
+                        fire_slot,
+                        outcome: TriggerPollerFireOutcome::DueFireFailed {
+                            reason: error.to_string(),
+                        },
+                    });
+                    continue;
+                }
+            };
             report.results.push(TriggerPollerFireReport {
                 tenant_id: outcome.0,
                 trigger_id: outcome.1,
@@ -124,7 +139,7 @@ impl TriggerPollerWorker {
                 });
                 continue;
             };
-            let state = self
+            let state = match self
                 .deps
                 .active_run_lookup
                 .active_run_state(TriggerActiveRunStateRequest {
@@ -133,7 +148,22 @@ impl TriggerPollerWorker {
                     fire_slot,
                     run_id,
                 })
-                .await?;
+                .await
+            {
+                Ok(state) => state,
+                Err(error) => {
+                    report.results.push(TriggerPollerFireReport {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                        outcome: TriggerPollerFireOutcome::ActiveRunLookupFailed {
+                            run_id,
+                            reason: error.to_string(),
+                        },
+                    });
+                    continue;
+                }
+            };
             match state {
                 TriggerActiveRunState::Terminal => {
                     if self
@@ -391,10 +421,17 @@ impl TriggerPollerWorker {
                 Ok(TriggerPollerFireOutcome::RetryableFailed { reason })
             }
             SubmitFailureKind::Permanent => {
-                let next_run_at = next_run_at.ok_or_else(|| TriggerError::InvalidSchedule {
-                    reason: "permanent trigger fire failure requires a future next_run_at"
-                        .to_string(),
-                })?;
+                let Some(next_run_at) = next_run_at else {
+                    self.deps
+                        .repository
+                        .mark_fire_terminally_failed(FireTerminalFailedRequest {
+                            tenant_id: record.tenant_id,
+                            trigger_id: record.trigger_id,
+                            fire_slot,
+                        })
+                        .await?;
+                    return Ok(TriggerPollerFireOutcome::PermanentFailed { reason });
+                };
                 self.deps
                     .repository
                     .mark_fire_permanently_failed(FirePermanentFailedRequest {
@@ -454,12 +491,19 @@ pub enum TriggerPollerFireOutcome {
     ClearedTerminalActive {
         run_id: TurnRunId,
     },
+    ActiveRunLookupFailed {
+        run_id: TurnRunId,
+        reason: String,
+    },
     SkippedAlreadyCleared {
         run_id: TurnRunId,
     },
     SkippedAlreadyActive {
         active_fire_slot: Option<Timestamp>,
         active_run_ref: Option<TurnRunId>,
+    },
+    DueFireFailed {
+        reason: String,
     },
     SkippedNotDue,
     SkippedNotFound,
@@ -567,6 +611,12 @@ mod tests {
 
     fn ts(seconds: i64) -> Timestamp {
         Utc.timestamp_opt(seconds, 0).single().expect("valid ts")
+    }
+
+    fn ymd_hms(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> Timestamp {
+        Utc.with_ymd_and_hms(year, month, day, hour, minute, second)
+            .single()
+            .expect("valid ts")
     }
 
     fn tenant(value: &str) -> TenantId {
@@ -969,6 +1019,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tick_reports_active_lookup_error_and_continues_to_due_triggers() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let active_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let due_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut active = sample_record(active_id, tenant("tenant-a"), ts(1_704_067_260));
+        active.active_fire_slot = Some(fire_slot);
+        active.active_run_ref = Some(run_id);
+        repo.upsert_trigger(active).await.expect("insert active");
+        repo.upsert_trigger(sample_record(due_id, tenant("tenant-a"), fire_slot))
+            .await
+            .expect("insert due");
+        let due_run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+        let worker = worker(
+            repo,
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Accepted {
+                    run_id: due_run_id,
+                    submitted_at: fire_slot,
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::with_results(vec![Err(
+                TriggerError::Backend {
+                    reason: "turn state unavailable".to_string(),
+                },
+            )])),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == active_id
+                    && matches!(
+                        result.outcome,
+                        TriggerPollerFireOutcome::ActiveRunLookupFailed { run_id: actual_run_id, .. }
+                        if actual_run_id == run_id
+                    ))
+        );
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == due_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::Submitted { run_id: due_run_id })
+        );
+    }
+
+    #[tokio::test]
     async fn tick_keeps_missing_active_run_blocked() {
         let repo = Arc::new(InMemoryTriggerRepository::default());
         let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
@@ -1091,7 +1195,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tick_accepted_mark_fire_missing_propagates_backend_error() {
+    async fn tick_accepted_mark_fire_missing_reports_due_failure() {
         let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
         let fire_slot = ts(1_704_067_200);
         let mut claimed_record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
@@ -1112,13 +1216,67 @@ mod tests {
             Arc::new(RecordingActiveRunLookup::default()),
         );
 
-        let error = worker
-            .tick_once(fire_slot)
-            .await
-            .expect_err("missing claimed row after accepted submit must fail");
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
 
+        assert!(report.results.iter().any(|result| {
+            result.trigger_id == trigger_id
+                && matches!(
+                    &result.outcome,
+                    TriggerPollerFireOutcome::DueFireFailed { reason }
+                        if reason.contains("persisting accepted submit result")
+                )
+        }));
+    }
+
+    #[tokio::test]
+    async fn tick_reports_due_record_error_and_continues_to_later_due_trigger() {
+        let failed_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let success_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let mut failed = sample_record(failed_id, tenant("tenant-a"), fire_slot);
+        failed.active_fire_slot = Some(fire_slot);
+        let mut success = sample_record(success_id, tenant("tenant-b"), fire_slot);
+        success.active_fire_slot = Some(fire_slot);
+        let success_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let worker = worker(
+            Arc::new(DueErrorThenSuccessRepository {
+                failed_record: failed,
+                success_record: success,
+                fire_slot,
+            }),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Accepted {
+                    run_id: success_run_id,
+                    submitted_at: fire_slot,
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert_eq!(report.due_records, 2);
         assert!(
-            matches!(error, TriggerError::Backend { ref reason } if reason.contains("persisting accepted submit result"))
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == failed_id
+                    && matches!(
+                        result.outcome,
+                        TriggerPollerFireOutcome::DueFireFailed { .. }
+                    ))
+        );
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == success_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::Submitted {
+                            run_id: success_run_id
+                        })
         );
     }
 
@@ -1238,6 +1396,38 @@ mod tests {
         assert_eq!(persisted.active_run_ref, None);
     }
 
+    #[tokio::test]
+    async fn tick_permanent_failure_without_next_slot_completes_trigger() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ymd_hms(9999, 12, 31, 8, 0, 0);
+        repo.upsert_trigger(sample_record(trigger_id, tenant("tenant-a"), fire_slot))
+            .await
+            .expect("insert");
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+        ));
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.state, TriggerState::Completed);
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
     struct RecordingMaterializer {
         result: Mutex<Option<Result<TriggerInboundContentRef, TriggerError>>>,
         fires: Mutex<Vec<TriggerFire>>,
@@ -1317,14 +1507,18 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingActiveRunLookup {
-        state: Mutex<Option<TriggerActiveRunState>>,
+        results: Mutex<Vec<Result<TriggerActiveRunState, TriggerError>>>,
         requests: Mutex<Vec<TriggerActiveRunStateRequest>>,
     }
 
     impl RecordingActiveRunLookup {
         fn with_state(state: TriggerActiveRunState) -> Self {
+            Self::with_results(vec![Ok(state)])
+        }
+
+        fn with_results(results: Vec<Result<TriggerActiveRunState, TriggerError>>) -> Self {
             Self {
-                state: Mutex::new(Some(state)),
+                results: Mutex::new(results.into_iter().rev().collect()),
                 requests: Mutex::new(Vec::new()),
             }
         }
@@ -1341,11 +1535,11 @@ mod tests {
             request: TriggerActiveRunStateRequest,
         ) -> Result<TriggerActiveRunState, TriggerError> {
             self.requests.lock().expect("requests lock").push(request);
-            Ok(self
-                .state
+            self.results
                 .lock()
-                .expect("state lock")
-                .unwrap_or(TriggerActiveRunState::Nonterminal))
+                .expect("results lock")
+                .pop()
+                .unwrap_or(Ok(TriggerActiveRunState::Nonterminal))
         }
     }
 
@@ -1430,6 +1624,13 @@ mod tests {
             _request: FirePermanentFailedRequest,
         ) -> Result<Option<TriggerRecord>, TriggerError> {
             unreachable!("active-clear-race repository should not persist permanent failures")
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository should not persist terminal failures")
         }
 
         async fn clear_active_fire(
@@ -1527,11 +1728,129 @@ mod tests {
             unreachable!("accepted-missing repository should not persist permanent failures")
         }
 
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository should not persist terminal failures")
+        }
+
         async fn clear_active_fire(
             &self,
             _request: ClearActiveFireRequest,
         ) -> Result<Option<TriggerRecord>, TriggerError> {
             unreachable!("accepted-missing repository should not clear active fires")
+        }
+    }
+
+    struct DueErrorThenSuccessRepository {
+        failed_record: TriggerRecord,
+        success_record: TriggerRecord,
+        fire_slot: Timestamp,
+    }
+
+    #[async_trait]
+    impl TriggerRepository for DueErrorThenSuccessRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("due-error repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(vec![
+                self.failed_record.clone(),
+                self.success_record.clone(),
+            ])
+        }
+
+        async fn list_active_triggers(
+            &self,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn claim_due_fire(
+            &self,
+            request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            if request.trigger_id == self.failed_record.trigger_id {
+                return Err(TriggerError::Backend {
+                    reason: "claim failed".to_string(),
+                });
+            }
+            Ok(ClaimDueFireOutcome::Claimed(ClaimedTriggerFire {
+                record: self.success_record.clone(),
+                fire_slot: self.fire_slot,
+            }))
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            Ok(Some(self.success_record.clone()))
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository should not persist permanent failures")
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository should not persist terminal failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("due-error repository should not clear active fires")
         }
     }
 
@@ -1631,6 +1950,13 @@ mod tests {
             _request: FirePermanentFailedRequest,
         ) -> Result<Option<TriggerRecord>, TriggerError> {
             unreachable!("claim-race repository should not persist permanent failures")
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository should not persist terminal failures")
         }
 
         async fn clear_active_fire(

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -1,3 +1,5 @@
+// arch-exempt: large_file, deterministic tick core + ports + reports + tests co-located for PR15, plan #4303
+
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -128,6 +128,8 @@ impl TriggerPollerWorker {
                 continue;
             };
             let Some(run_id) = record.active_run_ref else {
+                // Keep claim-only rows blocked until recovery has lease or age
+                // evidence that clearing cannot double-submit after a crash.
                 report.results.push(TriggerPollerFireReport {
                     tenant_id: record.tenant_id,
                     trigger_id: record.trigger_id,
@@ -194,6 +196,8 @@ impl TriggerPollerWorker {
                     }
                 }
                 TriggerActiveRunState::Missing | TriggerActiveRunState::Nonterminal => {
+                    // Missing remains conservative until recovery can prove the
+                    // active run lookup is not merely stale or temporarily empty.
                     report.results.push(TriggerPollerFireReport {
                         tenant_id: record.tenant_id,
                         trigger_id: record.trigger_id,
@@ -260,7 +264,7 @@ impl TriggerPollerWorker {
                         fire_slot,
                         SubmitFailureKind::Permanent,
                         error.to_string(),
-                        None,
+                        PermanentFailureDestination::Terminal,
                     )
                     .await;
             }
@@ -274,7 +278,7 @@ impl TriggerPollerWorker {
                         fire_slot,
                         SubmitFailureKind::Permanent,
                         "claimed trigger did not produce a fire".to_string(),
-                        Some(next_run_at),
+                        PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
             }
@@ -285,7 +289,7 @@ impl TriggerPollerWorker {
                         fire_slot,
                         classify_error(&error),
                         error.to_string(),
-                        Some(next_run_at),
+                        PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
             }
@@ -304,7 +308,7 @@ impl TriggerPollerWorker {
                         fire_slot,
                         classify_error(&error),
                         error.to_string(),
-                        Some(next_run_at),
+                        PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
             }
@@ -373,7 +377,7 @@ impl TriggerPollerWorker {
                     fire_slot,
                     SubmitFailureKind::Retryable,
                     reason,
-                    Some(next_run_at),
+                    PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
             }
@@ -383,7 +387,7 @@ impl TriggerPollerWorker {
                     fire_slot,
                     SubmitFailureKind::Permanent,
                     reason,
-                    Some(next_run_at),
+                    PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
             }
@@ -393,7 +397,7 @@ impl TriggerPollerWorker {
                     fire_slot,
                     classify_error(&error),
                     error.to_string(),
-                    Some(next_run_at),
+                    PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
             }
@@ -406,7 +410,7 @@ impl TriggerPollerWorker {
         fire_slot: Timestamp,
         kind: SubmitFailureKind,
         reason: String,
-        next_run_at: Option<Timestamp>,
+        permanent_destination: PermanentFailureDestination,
     ) -> Result<TriggerPollerFireOutcome, TriggerError> {
         match kind {
             SubmitFailureKind::Retryable => {
@@ -421,26 +425,29 @@ impl TriggerPollerWorker {
                 Ok(TriggerPollerFireOutcome::RetryableFailed { reason })
             }
             SubmitFailureKind::Permanent => {
-                let Some(next_run_at) = next_run_at else {
-                    self.deps
-                        .repository
-                        .mark_fire_terminally_failed(FireTerminalFailedRequest {
-                            tenant_id: record.tenant_id,
-                            trigger_id: record.trigger_id,
-                            fire_slot,
-                        })
-                        .await?;
-                    return Ok(TriggerPollerFireOutcome::PermanentFailed { reason });
-                };
-                self.deps
-                    .repository
-                    .mark_fire_permanently_failed(FirePermanentFailedRequest {
-                        tenant_id: record.tenant_id,
-                        trigger_id: record.trigger_id,
-                        fire_slot,
-                        next_run_at,
-                    })
-                    .await?;
+                match permanent_destination {
+                    PermanentFailureDestination::Terminal => {
+                        self.deps
+                            .repository
+                            .mark_fire_terminally_failed(FireTerminalFailedRequest {
+                                tenant_id: record.tenant_id,
+                                trigger_id: record.trigger_id,
+                                fire_slot,
+                            })
+                            .await?;
+                    }
+                    PermanentFailureDestination::Reschedule(next_run_at) => {
+                        self.deps
+                            .repository
+                            .mark_fire_permanently_failed(FirePermanentFailedRequest {
+                                tenant_id: record.tenant_id,
+                                trigger_id: record.trigger_id,
+                                fire_slot,
+                                next_run_at,
+                            })
+                            .await?;
+                    }
+                }
                 Ok(TriggerPollerFireOutcome::PermanentFailed { reason })
             }
         }
@@ -571,6 +578,12 @@ enum SubmitFailureKind {
     Permanent,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PermanentFailureDestination {
+    Reschedule(Timestamp),
+    Terminal,
+}
+
 fn classify_error(error: &TriggerError) -> SubmitFailureKind {
     match error {
         TriggerError::Backend { .. } => SubmitFailureKind::Retryable,
@@ -680,6 +693,29 @@ mod tests {
         };
         assert!(matches!(
             config.validate(),
+            Err(TriggerError::InvalidPollerConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn worker_new_rejects_invalid_config() {
+        let config = TriggerPollerWorkerConfig {
+            fires_per_tick: 0,
+            ..TriggerPollerWorkerConfig::default()
+        };
+        let result = TriggerPollerWorker::new(
+            config,
+            TriggerPollerWorkerDeps {
+                repository: Arc::new(InMemoryTriggerRepository::default()),
+                source_provider: Arc::new(crate::ScheduleTriggerSourceProvider),
+                materializer: Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+                trusted_submitter: Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+                active_run_lookup: Arc::new(RecordingActiveRunLookup::default()),
+            },
+        );
+
+        assert!(matches!(
+            result,
             Err(TriggerError::InvalidPollerConfig { .. })
         ));
     }
@@ -1450,6 +1486,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tick_source_provider_not_found_persists_permanent_failure_with_next_slot() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        let expected_next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next run")
+            .expect("future run");
+        repo.upsert_trigger(record).await.expect("insert");
+        let worker = worker_with_source_provider(
+            repo.clone(),
+            Arc::new(NotFoundSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+        ));
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(persisted.next_run_at, expected_next_run_at);
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
     async fn tick_permanent_failure_without_next_slot_completes_trigger() {
         let repo = Arc::new(InMemoryTriggerRepository::default());
         let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
@@ -1488,6 +1561,8 @@ mod tests {
 
     struct NullSourceProvider;
 
+    struct NotFoundSourceProvider;
+
     #[async_trait]
     impl TriggerSourceProvider for NullSourceProvider {
         async fn evaluate(
@@ -1496,6 +1571,17 @@ mod tests {
             _now: Timestamp,
         ) -> Result<Option<TriggerFire>, TriggerError> {
             Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl TriggerSourceProvider for NotFoundSourceProvider {
+        async fn evaluate(
+            &self,
+            _record: &TriggerRecord,
+            _now: Timestamp,
+        ) -> Result<Option<TriggerFire>, TriggerError> {
+            Err(TriggerError::NotFound)
         }
     }
 

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -136,7 +136,7 @@ impl TriggerPollerWorker {
                     trigger_id: record.trigger_id,
                     fire_slot,
                     outcome: TriggerPollerFireOutcome::SkippedAlreadyActive {
-                        active_fire_slot: Some(fire_slot),
+                        active_fire_slot: fire_slot,
                         active_run_ref: None,
                     },
                 });
@@ -204,7 +204,7 @@ impl TriggerPollerWorker {
                         trigger_id: record.trigger_id,
                         fire_slot,
                         outcome: TriggerPollerFireOutcome::SkippedAlreadyActive {
-                            active_fire_slot: Some(fire_slot),
+                            active_fire_slot: fire_slot,
                             active_run_ref: record.active_run_ref,
                         },
                     });
@@ -241,7 +241,8 @@ impl TriggerPollerWorker {
                 active_fire_slot,
                 active_run_ref,
             } => TriggerPollerFireOutcome::SkippedAlreadyActive {
-                active_fire_slot,
+                active_fire_slot: active_fire_slot
+                    .expect("AlreadyActive claim outcome must include active_fire_slot"),
                 active_run_ref,
             },
             ClaimDueFireOutcome::NotDue { .. } => TriggerPollerFireOutcome::SkippedNotDue,
@@ -264,9 +265,8 @@ impl TriggerPollerWorker {
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        classification.kind,
+                        FireFailureDisposition::PermanentTerminal,
                         classification.reason,
-                        PermanentFailureDestination::Terminal,
                     )
                     .await;
             }
@@ -278,9 +278,8 @@ impl TriggerPollerWorker {
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        SubmitFailureKind::Permanent,
+                        FireFailureDisposition::PermanentReschedule(next_run_at),
                         TriggerPollerFailureReason::SourceNoFire,
-                        PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
             }
@@ -290,9 +289,8 @@ impl TriggerPollerWorker {
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        classification.kind,
+                        FireFailureDisposition::from_kind(classification.kind, next_run_at),
                         classification.reason,
-                        PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
             }
@@ -310,9 +308,8 @@ impl TriggerPollerWorker {
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        classification.kind,
+                        FireFailureDisposition::from_kind(classification.kind, next_run_at),
                         classification.reason,
-                        PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
             }
@@ -379,9 +376,8 @@ impl TriggerPollerWorker {
                 self.persist_failed_fire(
                     record,
                     fire_slot,
-                    SubmitFailureKind::Retryable,
+                    FireFailureDisposition::Retryable,
                     TriggerPollerFailureReason::from_trusted_submit_failure(reason),
-                    PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
             }
@@ -389,9 +385,8 @@ impl TriggerPollerWorker {
                 self.persist_failed_fire(
                     record,
                     fire_slot,
-                    SubmitFailureKind::Permanent,
+                    FireFailureDisposition::PermanentReschedule(next_run_at),
                     TriggerPollerFailureReason::from_trusted_submit_failure(reason),
-                    PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
             }
@@ -400,9 +395,8 @@ impl TriggerPollerWorker {
                 self.persist_failed_fire(
                     record,
                     fire_slot,
-                    classification.kind,
+                    FireFailureDisposition::from_kind(classification.kind, next_run_at),
                     classification.reason,
-                    PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
             }
@@ -413,12 +407,11 @@ impl TriggerPollerWorker {
         &self,
         record: TriggerRecord,
         fire_slot: Timestamp,
-        kind: SubmitFailureKind,
+        disposition: FireFailureDisposition,
         reason: TriggerPollerFailureReason,
-        permanent_destination: PermanentFailureDestination,
     ) -> Result<TriggerPollerFireOutcome, TriggerError> {
-        match kind {
-            SubmitFailureKind::Retryable => {
+        match disposition {
+            FireFailureDisposition::Retryable => {
                 self.deps
                     .repository
                     .mark_fire_retryable_failed(FireRetryableFailedRequest {
@@ -429,30 +422,27 @@ impl TriggerPollerWorker {
                     .await?;
                 Ok(TriggerPollerFireOutcome::RetryableFailed { reason })
             }
-            SubmitFailureKind::Permanent => {
-                match permanent_destination {
-                    PermanentFailureDestination::Terminal => {
-                        self.deps
-                            .repository
-                            .mark_fire_terminally_failed(FireTerminalFailedRequest {
-                                tenant_id: record.tenant_id,
-                                trigger_id: record.trigger_id,
-                                fire_slot,
-                            })
-                            .await?;
-                    }
-                    PermanentFailureDestination::Reschedule(next_run_at) => {
-                        self.deps
-                            .repository
-                            .mark_fire_permanently_failed(FirePermanentFailedRequest {
-                                tenant_id: record.tenant_id,
-                                trigger_id: record.trigger_id,
-                                fire_slot,
-                                next_run_at,
-                            })
-                            .await?;
-                    }
-                }
+            FireFailureDisposition::PermanentTerminal => {
+                self.deps
+                    .repository
+                    .mark_fire_terminally_failed(FireTerminalFailedRequest {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                    })
+                    .await?;
+                Ok(TriggerPollerFireOutcome::PermanentFailed { reason })
+            }
+            FireFailureDisposition::PermanentReschedule(next_run_at) => {
+                self.deps
+                    .repository
+                    .mark_fire_permanently_failed(FirePermanentFailedRequest {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                        next_run_at,
+                    })
+                    .await?;
                 Ok(TriggerPollerFireOutcome::PermanentFailed { reason })
             }
         }
@@ -511,7 +501,7 @@ pub enum TriggerPollerFireOutcome {
         run_id: TurnRunId,
     },
     SkippedAlreadyActive {
-        active_fire_slot: Option<Timestamp>,
+        active_fire_slot: Timestamp,
         active_run_ref: Option<TurnRunId>,
     },
     DueFireFailed {
@@ -525,7 +515,7 @@ pub enum TriggerPollerFireOutcome {
 pub enum TriggerPollerFailureReason {
     Backend,
     InvalidTriggerId,
-    InvalidFireIdentity,
+    InvalidFireIdentityComponent,
     InvalidRecord,
     InvalidPollerConfig,
     InvalidSchedule,
@@ -615,9 +605,19 @@ enum SubmitFailureKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PermanentFailureDestination {
-    Reschedule(Timestamp),
-    Terminal,
+enum FireFailureDisposition {
+    Retryable,
+    PermanentReschedule(Timestamp),
+    PermanentTerminal,
+}
+
+impl FireFailureDisposition {
+    fn from_kind(kind: SubmitFailureKind, next_run_at: Timestamp) -> Self {
+        match kind {
+            SubmitFailureKind::Retryable => Self::Retryable,
+            SubmitFailureKind::Permanent => Self::PermanentReschedule(next_run_at),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -638,7 +638,7 @@ fn classify_failure(error: &TriggerError) -> FailureClassification {
         ),
         TriggerError::InvalidFireIdentityComponent { .. } => (
             SubmitFailureKind::Permanent,
-            TriggerPollerFailureReason::InvalidFireIdentity,
+            TriggerPollerFailureReason::InvalidFireIdentityComponent,
         ),
         TriggerError::InvalidRecord { .. } => (
             SubmitFailureKind::Permanent,
@@ -950,7 +950,7 @@ mod tests {
         assert_eq!(
             report.results.last().map(|result| &result.outcome),
             Some(&TriggerPollerFireOutcome::SkippedAlreadyActive {
-                active_fire_slot: Some(fire_slot),
+                active_fire_slot: fire_slot,
                 active_run_ref: Some(active_run_ref)
             })
         );
@@ -1263,7 +1263,7 @@ mod tests {
         assert!(matches!(
             report.results.first().map(|result| &result.outcome),
             Some(TriggerPollerFireOutcome::SkippedAlreadyActive {
-                active_fire_slot: Some(_),
+                active_fire_slot: _,
                 active_run_ref: None
             })
         ));
@@ -1349,6 +1349,58 @@ mod tests {
                         if *reason == TriggerPollerFailureReason::Backend
                 )
         }));
+    }
+
+    #[tokio::test]
+    async fn tick_replayed_mark_fire_missing_reports_due_failure() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let mut claimed_record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        claimed_record.active_fire_slot = Some(fire_slot);
+        let original_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let worker = worker(
+            Arc::new(ReplayedMissingRepository {
+                claimed_record,
+                fire_slot,
+            }),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Replayed {
+                    original_run_id,
+                    replayed_at: fire_slot,
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(report.results.iter().any(|result| {
+            result.trigger_id == trigger_id
+                && matches!(
+                    &result.outcome,
+                    TriggerPollerFireOutcome::DueFireFailed { reason }
+                        if *reason == TriggerPollerFailureReason::Backend
+                )
+        }));
+    }
+
+    #[tokio::test]
+    async fn tick_fails_when_active_trigger_list_returns_backend_error() {
+        let worker = worker(
+            Arc::new(ActiveListErrorRepository),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let error = worker
+            .tick_once(ts(1_704_067_200))
+            .await
+            .expect_err("active list failure should abort tick");
+
+        assert!(matches!(error, TriggerError::Backend { .. }));
     }
 
     #[tokio::test]
@@ -1619,7 +1671,7 @@ mod tests {
                     label: "fire_slot".to_string(),
                     reason: "bad component".to_string(),
                 },
-                TriggerPollerFailureReason::InvalidFireIdentity,
+                TriggerPollerFailureReason::InvalidFireIdentityComponent,
             ),
             (
                 TriggerError::InvalidRecord {
@@ -1855,11 +1907,107 @@ mod tests {
             request: TriggerActiveRunStateRequest,
         ) -> Result<TriggerActiveRunState, TriggerError> {
             self.requests.lock().expect("requests lock").push(request);
-            self.results
-                .lock()
-                .expect("results lock")
-                .pop()
-                .unwrap_or(Ok(TriggerActiveRunState::Nonterminal))
+            self.results.lock().expect("results lock").pop().expect(
+                "RecordingActiveRunLookup: more active_run_state calls than configured outcomes",
+            )
+        }
+    }
+
+    struct ActiveListErrorRepository;
+
+    #[async_trait]
+    impl TriggerRepository for ActiveListErrorRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("active-list-error repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error should abort before due scan")
+        }
+
+        async fn list_active_triggers(
+            &self,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Err(TriggerError::Backend {
+                reason: "active list unavailable".to_string(),
+            })
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            unreachable!("active-list-error repository should not claim fires")
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository should not persist accepted fires")
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository should not persist permanent failures")
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository should not persist terminal failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-list-error repository should not clear active fires")
         }
     }
 
@@ -2060,6 +2208,108 @@ mod tests {
             _request: ClearActiveFireRequest,
         ) -> Result<Option<TriggerRecord>, TriggerError> {
             unreachable!("accepted-missing repository should not clear active fires")
+        }
+    }
+
+    struct ReplayedMissingRepository {
+        claimed_record: TriggerRecord,
+        fire_slot: Timestamp,
+    }
+
+    #[async_trait]
+    impl TriggerRepository for ReplayedMissingRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("replayed-missing repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(vec![self.claimed_record.clone()])
+        }
+
+        async fn list_active_triggers(
+            &self,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            Ok(ClaimDueFireOutcome::Claimed(ClaimedTriggerFire {
+                record: self.claimed_record.clone(),
+                fire_slot: self.fire_slot,
+            }))
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository should not persist accepted fires")
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            Ok(None)
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository should not persist permanent failures")
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository should not persist terminal failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("replayed-missing repository should not clear active fires")
         }
     }
 

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -106,15 +106,10 @@ impl TriggerPollerWorker {
         report.active_records = active_records.len();
         for record in active_records {
             let Some(fire_slot) = record.active_fire_slot else {
-                report.results.push(TriggerPollerFireReport {
-                    tenant_id: record.tenant_id,
-                    trigger_id: record.trigger_id,
-                    fire_slot: record.next_run_at,
-                    outcome: TriggerPollerFireOutcome::SkippedAlreadyActive {
-                        active_fire_slot: None,
-                        active_run_ref: record.active_run_ref,
-                    },
-                });
+                debug_assert!(
+                    record.active_fire_slot.is_some(),
+                    "list_active_triggers returned a record without active_fire_slot"
+                );
                 continue;
             };
             let Some(run_id) = record.active_run_ref else {
@@ -158,6 +153,13 @@ impl TriggerPollerWorker {
                             trigger_id: record.trigger_id,
                             fire_slot,
                             outcome: TriggerPollerFireOutcome::ClearedTerminalActive { run_id },
+                        });
+                    } else {
+                        report.results.push(TriggerPollerFireReport {
+                            tenant_id: record.tenant_id,
+                            trigger_id: record.trigger_id,
+                            fire_slot,
+                            outcome: TriggerPollerFireOutcome::SkippedAlreadyCleared { run_id },
                         });
                     }
                 }
@@ -223,7 +225,13 @@ impl TriggerPollerWorker {
             Ok(next_run_at) => next_run_at,
             Err(error) => {
                 return self
-                    .persist_failed_fire(record, fire_slot, SubmitFailureKind::Permanent, error)
+                    .persist_failed_fire(
+                        record,
+                        fire_slot,
+                        SubmitFailureKind::Permanent,
+                        error.to_string(),
+                        None,
+                    )
                     .await;
             }
         };
@@ -235,15 +243,20 @@ impl TriggerPollerWorker {
                         record,
                         fire_slot,
                         SubmitFailureKind::Permanent,
-                        TriggerError::InvalidRecord {
-                            reason: "claimed trigger did not produce a fire".to_string(),
-                        },
+                        "claimed trigger did not produce a fire".to_string(),
+                        Some(next_run_at),
                     )
                     .await;
             }
             Err(error) => {
                 return self
-                    .persist_failed_fire(record, fire_slot, classify_error(&error), error)
+                    .persist_failed_fire(
+                        record,
+                        fire_slot,
+                        classify_error(&error),
+                        error.to_string(),
+                        Some(next_run_at),
+                    )
                     .await;
             }
         };
@@ -256,7 +269,13 @@ impl TriggerPollerWorker {
             Ok(content_ref) => content_ref,
             Err(error) => {
                 return self
-                    .persist_failed_fire(record, fire_slot, classify_error(&error), error)
+                    .persist_failed_fire(
+                        record,
+                        fire_slot,
+                        classify_error(&error),
+                        error.to_string(),
+                        Some(next_run_at),
+                    )
                     .await;
             }
         };
@@ -319,7 +338,7 @@ impl TriggerPollerWorker {
                 Ok(TriggerPollerFireOutcome::Replayed { original_run_id })
             }
             Ok(TrustedTriggerFireSubmitOutcome::RetryableFailed { reason }) => {
-                self.persist_failed_fire_with_reason(
+                self.persist_failed_fire(
                     record,
                     fire_slot,
                     SubmitFailureKind::Retryable,
@@ -329,7 +348,7 @@ impl TriggerPollerWorker {
                 .await
             }
             Ok(TrustedTriggerFireSubmitOutcome::PermanentFailed { reason }) => {
-                self.persist_failed_fire_with_reason(
+                self.persist_failed_fire(
                     record,
                     fire_slot,
                     SubmitFailureKind::Permanent,
@@ -339,31 +358,19 @@ impl TriggerPollerWorker {
                 .await
             }
             Err(error) => {
-                self.persist_failed_fire(record, fire_slot, classify_error(&error), error)
-                    .await
+                self.persist_failed_fire(
+                    record,
+                    fire_slot,
+                    classify_error(&error),
+                    error.to_string(),
+                    Some(next_run_at),
+                )
+                .await
             }
         }
     }
 
     async fn persist_failed_fire(
-        &self,
-        record: TriggerRecord,
-        fire_slot: Timestamp,
-        kind: SubmitFailureKind,
-        error: TriggerError,
-    ) -> Result<TriggerPollerFireOutcome, TriggerError> {
-        let next_run_at = next_run_at_after_fire(&record, fire_slot).ok();
-        self.persist_failed_fire_with_reason(
-            record,
-            fire_slot,
-            kind,
-            error.to_string(),
-            next_run_at,
-        )
-        .await
-    }
-
-    async fn persist_failed_fire_with_reason(
         &self,
         record: TriggerRecord,
         fire_slot: Timestamp,
@@ -445,6 +452,9 @@ pub enum TriggerPollerFireOutcome {
         reason: String,
     },
     ClearedTerminalActive {
+        run_id: TurnRunId,
+    },
+    SkippedAlreadyCleared {
         run_id: TurnRunId,
     },
     SkippedAlreadyActive {
@@ -551,8 +561,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        InMemoryTriggerRepository, TriggerCompletionPolicy, TriggerRunStatus, TriggerSchedule,
-        TriggerSourceKind, TriggerState,
+        ClaimedTriggerFire, InMemoryTriggerRepository, TriggerCompletionPolicy, TriggerRunStatus,
+        TriggerSchedule, TriggerSourceKind, TriggerState,
     };
 
     fn ts(seconds: i64) -> Timestamp {
@@ -882,6 +892,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tick_reports_terminal_active_clear_race() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), ts(1_704_067_260));
+        record.active_fire_slot = Some(fire_slot);
+        record.active_run_ref = Some(run_id);
+        let worker = worker(
+            Arc::new(ActiveClearRaceRepository {
+                active_record: record,
+            }),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::with_state(
+                TriggerActiveRunState::Terminal,
+            )),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert_eq!(report.active_records, 1);
+        assert_eq!(
+            report.results.last().map(|result| &result.outcome),
+            Some(&TriggerPollerFireOutcome::SkippedAlreadyCleared { run_id })
+        );
+    }
+
+    #[tokio::test]
     async fn tick_clears_terminal_active_and_processes_due_trigger() {
         let repo = Arc::new(InMemoryTriggerRepository::default());
         let active_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
@@ -1050,6 +1088,38 @@ mod tests {
         assert_eq!(persisted.next_run_at, fire_slot);
         assert_eq!(persisted.active_fire_slot, None);
         assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_accepted_mark_fire_missing_propagates_backend_error() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let mut claimed_record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        claimed_record.active_fire_slot = Some(fire_slot);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let worker = worker(
+            Arc::new(AcceptedMissingRepository {
+                claimed_record,
+                fire_slot,
+            }),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Accepted {
+                    run_id,
+                    submitted_at: fire_slot,
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let error = worker
+            .tick_once(fire_slot)
+            .await
+            .expect_err("missing claimed row after accepted submit must fail");
+
+        assert!(
+            matches!(error, TriggerError::Backend { ref reason } if reason.contains("persisting accepted submit result"))
+        );
     }
 
     #[tokio::test]
@@ -1276,6 +1346,192 @@ mod tests {
                 .lock()
                 .expect("state lock")
                 .unwrap_or(TriggerActiveRunState::Nonterminal))
+        }
+    }
+
+    struct ActiveClearRaceRepository {
+        active_record: TriggerRecord,
+    }
+
+    #[async_trait]
+    impl TriggerRepository for ActiveClearRaceRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("active-clear-race repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_active_triggers(
+            &self,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(vec![self.active_record.clone()])
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            unreachable!("active-clear-race repository should not claim fires")
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository should not persist accepted fires")
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-race repository should not persist permanent failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            Ok(None)
+        }
+    }
+
+    struct AcceptedMissingRepository {
+        claimed_record: TriggerRecord,
+        fire_slot: Timestamp,
+    }
+
+    #[async_trait]
+    impl TriggerRepository for AcceptedMissingRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("accepted-missing repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(vec![self.claimed_record.clone()])
+        }
+
+        async fn list_active_triggers(
+            &self,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            Ok(ClaimDueFireOutcome::Claimed(ClaimedTriggerFire {
+                record: self.claimed_record.clone(),
+                fire_slot: self.fire_slot,
+            }))
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            Ok(None)
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository should not persist permanent failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("accepted-missing repository should not clear active fires")
         }
     }
 

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -1,0 +1,1387 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use ironclaw_host_api::{TenantId, Timestamp};
+use ironclaw_turns::TurnRunId;
+
+use crate::{
+    ClaimDueFireOutcome, ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest,
+    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest, TriggerError,
+    TriggerFire, TriggerId, TriggerInboundContentRef, TriggerPromptMaterializer, TriggerRecord,
+    TriggerRepository, TriggerSourceProvider,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerPollerWorkerConfig {
+    pub poll_interval: Duration,
+    pub fires_per_tick: usize,
+    pub max_concurrent_fires_per_trigger: usize,
+}
+
+impl Default for TriggerPollerWorkerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(30),
+            fires_per_tick: 32,
+            max_concurrent_fires_per_trigger: 1,
+        }
+    }
+}
+
+impl TriggerPollerWorkerConfig {
+    pub fn validate(&self) -> Result<(), TriggerError> {
+        if self.poll_interval.is_zero() {
+            return Err(TriggerError::InvalidPollerConfig {
+                reason: "poll_interval must be non-zero".to_string(),
+            });
+        }
+        if self.fires_per_tick == 0 {
+            return Err(TriggerError::InvalidPollerConfig {
+                reason: "fires_per_tick must be non-zero".to_string(),
+            });
+        }
+        if self.max_concurrent_fires_per_trigger != 1 {
+            return Err(TriggerError::InvalidPollerConfig {
+                reason: "V1 supports exactly one concurrent fire per trigger".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct TriggerPollerWorkerDeps {
+    pub repository: Arc<dyn TriggerRepository>,
+    pub source_provider: Arc<dyn TriggerSourceProvider>,
+    pub materializer: Arc<dyn TriggerPromptMaterializer>,
+    pub trusted_submitter: Arc<dyn TrustedTriggerFireSubmitter>,
+    pub active_run_lookup: Arc<dyn TriggerActiveRunLookup>,
+}
+
+pub struct TriggerPollerWorker {
+    config: TriggerPollerWorkerConfig,
+    deps: TriggerPollerWorkerDeps,
+}
+
+impl TriggerPollerWorker {
+    pub fn new(
+        config: TriggerPollerWorkerConfig,
+        deps: TriggerPollerWorkerDeps,
+    ) -> Result<Self, TriggerError> {
+        config.validate()?;
+        Ok(Self { config, deps })
+    }
+
+    pub async fn tick_once(&self, now: Timestamp) -> Result<TriggerPollerTickReport, TriggerError> {
+        let mut report = TriggerPollerTickReport::new(now);
+        self.clear_terminal_active_fires(&mut report).await?;
+        let due_records = self
+            .deps
+            .repository
+            .list_due_triggers(now, self.config.fires_per_tick)
+            .await?;
+        report.due_records = due_records.len();
+        for record in due_records {
+            let fire_slot = record.next_run_at;
+            let outcome = self.process_due_record(record, now).await?;
+            report.results.push(TriggerPollerFireReport {
+                tenant_id: outcome.0,
+                trigger_id: outcome.1,
+                fire_slot,
+                outcome: outcome.2,
+            });
+        }
+        Ok(report)
+    }
+
+    async fn clear_terminal_active_fires(
+        &self,
+        report: &mut TriggerPollerTickReport,
+    ) -> Result<(), TriggerError> {
+        let active_records = self
+            .deps
+            .repository
+            .list_active_triggers(self.config.fires_per_tick)
+            .await?;
+        report.active_records = active_records.len();
+        for record in active_records {
+            let Some(fire_slot) = record.active_fire_slot else {
+                report.results.push(TriggerPollerFireReport {
+                    tenant_id: record.tenant_id,
+                    trigger_id: record.trigger_id,
+                    fire_slot: record.next_run_at,
+                    outcome: TriggerPollerFireOutcome::SkippedAlreadyActive {
+                        active_fire_slot: None,
+                        active_run_ref: record.active_run_ref,
+                    },
+                });
+                continue;
+            };
+            let Some(run_id) = record.active_run_ref else {
+                report.results.push(TriggerPollerFireReport {
+                    tenant_id: record.tenant_id,
+                    trigger_id: record.trigger_id,
+                    fire_slot,
+                    outcome: TriggerPollerFireOutcome::SkippedAlreadyActive {
+                        active_fire_slot: Some(fire_slot),
+                        active_run_ref: None,
+                    },
+                });
+                continue;
+            };
+            let state = self
+                .deps
+                .active_run_lookup
+                .active_run_state(TriggerActiveRunStateRequest {
+                    tenant_id: record.tenant_id.clone(),
+                    trigger_id: record.trigger_id,
+                    fire_slot,
+                    run_id,
+                })
+                .await?;
+            match state {
+                TriggerActiveRunState::Terminal => {
+                    if self
+                        .deps
+                        .repository
+                        .clear_active_fire(ClearActiveFireRequest {
+                            tenant_id: record.tenant_id.clone(),
+                            trigger_id: record.trigger_id,
+                            fire_slot,
+                            run_id,
+                        })
+                        .await?
+                        .is_some()
+                    {
+                        report.results.push(TriggerPollerFireReport {
+                            tenant_id: record.tenant_id,
+                            trigger_id: record.trigger_id,
+                            fire_slot,
+                            outcome: TriggerPollerFireOutcome::ClearedTerminalActive { run_id },
+                        });
+                    }
+                }
+                TriggerActiveRunState::Missing | TriggerActiveRunState::Nonterminal => {
+                    report.results.push(TriggerPollerFireReport {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                        outcome: TriggerPollerFireOutcome::SkippedAlreadyActive {
+                            active_fire_slot: Some(fire_slot),
+                            active_run_ref: record.active_run_ref,
+                        },
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn process_due_record(
+        &self,
+        record: TriggerRecord,
+        now: Timestamp,
+    ) -> Result<(TenantId, TriggerId, TriggerPollerFireOutcome), TriggerError> {
+        let tenant_id = record.tenant_id.clone();
+        let trigger_id = record.trigger_id;
+        let fire_slot = record.next_run_at;
+        let claimed = self
+            .deps
+            .repository
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: tenant_id.clone(),
+                trigger_id,
+                fire_slot,
+                now,
+            })
+            .await?;
+        let outcome = match claimed {
+            ClaimDueFireOutcome::Claimed(claimed) => {
+                self.process_claimed_fire(claimed.record, claimed.fire_slot, now)
+                    .await?
+            }
+            ClaimDueFireOutcome::AlreadyActive {
+                active_fire_slot,
+                active_run_ref,
+            } => TriggerPollerFireOutcome::SkippedAlreadyActive {
+                active_fire_slot,
+                active_run_ref,
+            },
+            ClaimDueFireOutcome::NotDue { .. } => TriggerPollerFireOutcome::SkippedNotDue,
+            ClaimDueFireOutcome::NotFound => TriggerPollerFireOutcome::SkippedNotFound,
+        };
+        Ok((tenant_id, trigger_id, outcome))
+    }
+
+    async fn process_claimed_fire(
+        &self,
+        record: TriggerRecord,
+        fire_slot: Timestamp,
+        now: Timestamp,
+    ) -> Result<TriggerPollerFireOutcome, TriggerError> {
+        let next_run_at = match next_run_at_after_fire(&record, fire_slot) {
+            Ok(next_run_at) => next_run_at,
+            Err(error) => {
+                return self
+                    .persist_failed_fire(record, fire_slot, SubmitFailureKind::Permanent, error)
+                    .await;
+            }
+        };
+        let fire = match self.deps.source_provider.evaluate(&record, now).await {
+            Ok(Some(fire)) => fire,
+            Ok(None) => {
+                return self
+                    .persist_failed_fire(
+                        record,
+                        fire_slot,
+                        SubmitFailureKind::Permanent,
+                        TriggerError::InvalidRecord {
+                            reason: "claimed trigger did not produce a fire".to_string(),
+                        },
+                    )
+                    .await;
+            }
+            Err(error) => {
+                return self
+                    .persist_failed_fire(record, fire_slot, classify_error(&error), error)
+                    .await;
+            }
+        };
+        let content_ref = match self
+            .deps
+            .materializer
+            .materialize_prompt(fire.clone())
+            .await
+        {
+            Ok(content_ref) => content_ref,
+            Err(error) => {
+                return self
+                    .persist_failed_fire(record, fire_slot, classify_error(&error), error)
+                    .await;
+            }
+        };
+        match self
+            .deps
+            .trusted_submitter
+            .submit_trusted_trigger_fire(TrustedTriggerSubmitRequest {
+                fire,
+                content_ref,
+                received_at: now,
+            })
+            .await
+        {
+            Ok(TrustedTriggerFireSubmitOutcome::Accepted {
+                run_id,
+                submitted_at,
+            }) => {
+                let updated = self
+                    .deps
+                    .repository
+                    .mark_fire_accepted(FireAcceptedRequest {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                        run_id,
+                        submitted_at,
+                        next_run_at,
+                    })
+                    .await?;
+                if updated.is_none() {
+                    return Err(TriggerError::Backend {
+                        reason: "claimed trigger fire was not present when persisting accepted submit result"
+                            .to_string(),
+                    });
+                }
+                Ok(TriggerPollerFireOutcome::Submitted { run_id })
+            }
+            Ok(TrustedTriggerFireSubmitOutcome::Replayed {
+                original_run_id,
+                replayed_at,
+            }) => {
+                let updated = self
+                    .deps
+                    .repository
+                    .mark_fire_replayed(FireReplayedRequest {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                        original_run_id,
+                        replayed_at,
+                        next_run_at,
+                    })
+                    .await?;
+                if updated.is_none() {
+                    return Err(TriggerError::Backend {
+                        reason: "claimed trigger fire was not present when persisting replayed submit result"
+                            .to_string(),
+                    });
+                }
+                Ok(TriggerPollerFireOutcome::Replayed { original_run_id })
+            }
+            Ok(TrustedTriggerFireSubmitOutcome::RetryableFailed { reason }) => {
+                self.persist_failed_fire_with_reason(
+                    record,
+                    fire_slot,
+                    SubmitFailureKind::Retryable,
+                    reason,
+                    Some(next_run_at),
+                )
+                .await
+            }
+            Ok(TrustedTriggerFireSubmitOutcome::PermanentFailed { reason }) => {
+                self.persist_failed_fire_with_reason(
+                    record,
+                    fire_slot,
+                    SubmitFailureKind::Permanent,
+                    reason,
+                    Some(next_run_at),
+                )
+                .await
+            }
+            Err(error) => {
+                self.persist_failed_fire(record, fire_slot, classify_error(&error), error)
+                    .await
+            }
+        }
+    }
+
+    async fn persist_failed_fire(
+        &self,
+        record: TriggerRecord,
+        fire_slot: Timestamp,
+        kind: SubmitFailureKind,
+        error: TriggerError,
+    ) -> Result<TriggerPollerFireOutcome, TriggerError> {
+        let next_run_at = next_run_at_after_fire(&record, fire_slot).ok();
+        self.persist_failed_fire_with_reason(
+            record,
+            fire_slot,
+            kind,
+            error.to_string(),
+            next_run_at,
+        )
+        .await
+    }
+
+    async fn persist_failed_fire_with_reason(
+        &self,
+        record: TriggerRecord,
+        fire_slot: Timestamp,
+        kind: SubmitFailureKind,
+        reason: String,
+        next_run_at: Option<Timestamp>,
+    ) -> Result<TriggerPollerFireOutcome, TriggerError> {
+        match kind {
+            SubmitFailureKind::Retryable => {
+                self.deps
+                    .repository
+                    .mark_fire_retryable_failed(FireRetryableFailedRequest {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                    })
+                    .await?;
+                Ok(TriggerPollerFireOutcome::RetryableFailed { reason })
+            }
+            SubmitFailureKind::Permanent => {
+                let next_run_at = next_run_at.ok_or_else(|| TriggerError::InvalidSchedule {
+                    reason: "permanent trigger fire failure requires a future next_run_at"
+                        .to_string(),
+                })?;
+                self.deps
+                    .repository
+                    .mark_fire_permanently_failed(FirePermanentFailedRequest {
+                        tenant_id: record.tenant_id,
+                        trigger_id: record.trigger_id,
+                        fire_slot,
+                        next_run_at,
+                    })
+                    .await?;
+                Ok(TriggerPollerFireOutcome::PermanentFailed { reason })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerPollerTickReport {
+    pub now: Timestamp,
+    pub active_records: usize,
+    pub due_records: usize,
+    pub results: Vec<TriggerPollerFireReport>,
+}
+
+impl TriggerPollerTickReport {
+    fn new(now: Timestamp) -> Self {
+        Self {
+            now,
+            active_records: 0,
+            due_records: 0,
+            results: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerPollerFireReport {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub outcome: TriggerPollerFireOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TriggerPollerFireOutcome {
+    Submitted {
+        run_id: TurnRunId,
+    },
+    Replayed {
+        original_run_id: TurnRunId,
+    },
+    RetryableFailed {
+        reason: String,
+    },
+    PermanentFailed {
+        reason: String,
+    },
+    ClearedTerminalActive {
+        run_id: TurnRunId,
+    },
+    SkippedAlreadyActive {
+        active_fire_slot: Option<Timestamp>,
+        active_run_ref: Option<TurnRunId>,
+    },
+    SkippedNotDue,
+    SkippedNotFound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedTriggerSubmitRequest {
+    pub fire: TriggerFire,
+    pub content_ref: TriggerInboundContentRef,
+    pub received_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustedTriggerFireSubmitOutcome {
+    Accepted {
+        run_id: TurnRunId,
+        submitted_at: Timestamp,
+    },
+    Replayed {
+        original_run_id: TurnRunId,
+        replayed_at: Timestamp,
+    },
+    RetryableFailed {
+        reason: String,
+    },
+    PermanentFailed {
+        reason: String,
+    },
+}
+
+#[async_trait]
+pub trait TrustedTriggerFireSubmitter: Send + Sync {
+    async fn submit_trusted_trigger_fire(
+        &self,
+        request: TrustedTriggerSubmitRequest,
+    ) -> Result<TrustedTriggerFireSubmitOutcome, TriggerError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerActiveRunStateRequest {
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+    pub fire_slot: Timestamp,
+    pub run_id: TurnRunId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerActiveRunState {
+    Missing,
+    Nonterminal,
+    Terminal,
+}
+
+#[async_trait]
+pub trait TriggerActiveRunLookup: Send + Sync {
+    async fn active_run_state(
+        &self,
+        request: TriggerActiveRunStateRequest,
+    ) -> Result<TriggerActiveRunState, TriggerError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitFailureKind {
+    Retryable,
+    Permanent,
+}
+
+fn classify_error(error: &TriggerError) -> SubmitFailureKind {
+    match error {
+        TriggerError::Backend { .. } => SubmitFailureKind::Retryable,
+        TriggerError::InvalidTriggerId { .. }
+        | TriggerError::InvalidFireIdentityComponent { .. }
+        | TriggerError::InvalidRecord { .. }
+        | TriggerError::InvalidPollerConfig { .. }
+        | TriggerError::InvalidSchedule { .. }
+        | TriggerError::InvalidMaterialization { .. }
+        | TriggerError::NotFound => SubmitFailureKind::Permanent,
+    }
+}
+
+fn next_run_at_after_fire(
+    record: &TriggerRecord,
+    fire_slot: Timestamp,
+) -> Result<Timestamp, TriggerError> {
+    record
+        .schedule
+        .next_slot_after(fire_slot)?
+        .ok_or_else(|| TriggerError::InvalidSchedule {
+            reason: "schedule has no next fire slot after claimed fire".to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use chrono::{TimeZone, Utc};
+    use ironclaw_host_api::{AgentId, ProjectId, UserId};
+
+    use super::*;
+    use crate::{
+        InMemoryTriggerRepository, TriggerCompletionPolicy, TriggerRunStatus, TriggerSchedule,
+        TriggerSourceKind, TriggerState,
+    };
+
+    fn ts(seconds: i64) -> Timestamp {
+        Utc.timestamp_opt(seconds, 0).single().expect("valid ts")
+    }
+
+    fn tenant(value: &str) -> TenantId {
+        TenantId::new(value).expect("valid tenant")
+    }
+
+    fn user(value: &str) -> UserId {
+        UserId::new(value).expect("valid user")
+    }
+
+    fn sample_record(
+        trigger_id: TriggerId,
+        tenant_id: TenantId,
+        next_run_at: Timestamp,
+    ) -> TriggerRecord {
+        TriggerRecord {
+            trigger_id,
+            tenant_id,
+            creator_user_id: user("user-a"),
+            agent_id: Some(AgentId::new("agent-a").expect("valid agent")),
+            project_id: Some(ProjectId::new("project-a").expect("valid project")),
+            name: "daily summary".to_string(),
+            source: TriggerSourceKind::Schedule,
+            schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),
+            completion_policy: TriggerCompletionPolicy::Recurring,
+            prompt: "summarize unread mail".to_string(),
+            state: TriggerState::Scheduled,
+            next_run_at,
+            last_run_at: None,
+            last_fired_slot: None,
+            last_status: None,
+            active_fire_slot: None,
+            active_run_ref: None,
+            created_at: ts(1_704_067_000),
+        }
+    }
+
+    #[test]
+    fn worker_config_rejects_noop_or_unsupported_settings() {
+        let config = TriggerPollerWorkerConfig {
+            poll_interval: Duration::ZERO,
+            ..TriggerPollerWorkerConfig::default()
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(TriggerError::InvalidPollerConfig { .. })
+        ));
+
+        let config = TriggerPollerWorkerConfig {
+            fires_per_tick: 0,
+            ..TriggerPollerWorkerConfig::default()
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(TriggerError::InvalidPollerConfig { .. })
+        ));
+
+        let config = TriggerPollerWorkerConfig {
+            max_concurrent_fires_per_trigger: 2,
+            ..TriggerPollerWorkerConfig::default()
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(TriggerError::InvalidPollerConfig { .. })
+        ));
+    }
+
+    fn worker(
+        repo: Arc<dyn TriggerRepository>,
+        materializer: Arc<RecordingMaterializer>,
+        submitter: Arc<RecordingSubmitter>,
+        active_lookup: Arc<RecordingActiveRunLookup>,
+    ) -> TriggerPollerWorker {
+        TriggerPollerWorker::new(
+            TriggerPollerWorkerConfig::default(),
+            TriggerPollerWorkerDeps {
+                repository: repo,
+                source_provider: Arc::new(crate::ScheduleTriggerSourceProvider),
+                materializer,
+                trusted_submitter: submitter,
+                active_run_lookup: active_lookup,
+            },
+        )
+        .expect("valid worker")
+    }
+
+    #[tokio::test]
+    async fn tick_processes_one_due_trigger_happy_path() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        let expected_next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next run")
+            .expect("future run");
+        repo.upsert_trigger(record.clone()).await.expect("insert");
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let submitter = Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+            TrustedTriggerFireSubmitOutcome::Accepted {
+                run_id,
+                submitted_at: ts(1_704_067_205),
+            },
+        )]));
+        let materializer = Arc::new(RecordingMaterializer::success("content:trigger-fire"));
+        let worker = worker(
+            repo.clone(),
+            materializer.clone(),
+            submitter.clone(),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert_eq!(report.due_records, 1);
+        assert_eq!(
+            report.results.last().map(|result| &result.outcome),
+            Some(&TriggerPollerFireOutcome::Submitted { run_id })
+        );
+        assert_eq!(materializer.fires().len(), 1);
+        assert_eq!(submitter.requests().len(), 1);
+        let request = submitter.requests().pop().expect("submit request");
+        assert_eq!(request.fire.identity.trigger_id, trigger_id);
+        assert_eq!(request.fire.identity.fire_slot, fire_slot);
+        assert_eq!(request.fire.creator_user_id, record.creator_user_id);
+        assert_eq!(request.fire.agent_id, record.agent_id);
+        assert_eq!(request.fire.project_id, record.project_id);
+        assert_eq!(request.content_ref.as_str(), "content:trigger-fire");
+
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Ok));
+        assert_eq!(persisted.last_fired_slot, Some(fire_slot));
+        assert_eq!(persisted.active_fire_slot, Some(fire_slot));
+        assert_eq!(persisted.active_run_ref, Some(run_id));
+        assert_eq!(persisted.next_run_at, expected_next_run_at);
+    }
+
+    #[tokio::test]
+    async fn tick_persists_replayed_submit_with_original_run_ref() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        let expected_next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next run")
+            .expect("future run");
+        repo.upsert_trigger(record).await.expect("insert");
+        let original_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Replayed {
+                    original_run_id,
+                    replayed_at: ts(1_704_067_205),
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert_eq!(
+            report.results.last().map(|result| &result.outcome),
+            Some(&TriggerPollerFireOutcome::Replayed { original_run_id })
+        );
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Ok));
+        assert_eq!(persisted.last_fired_slot, Some(fire_slot));
+        assert_eq!(persisted.active_fire_slot, Some(fire_slot));
+        assert_eq!(persisted.active_run_ref, Some(original_run_id));
+        assert_eq!(persisted.next_run_at, expected_next_run_at);
+    }
+
+    #[tokio::test]
+    async fn tick_skips_claim_race_already_active_without_materializing() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let active_run_ref =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let repository = Arc::new(ClaimRaceRepository::new(
+            sample_record(trigger_id, tenant("tenant-a"), fire_slot),
+            ClaimDueFireOutcome::AlreadyActive {
+                active_fire_slot: Some(fire_slot),
+                active_run_ref: Some(active_run_ref),
+            },
+        ));
+        let materializer = Arc::new(RecordingMaterializer::success("content:trigger-fire"));
+        let submitter = Arc::new(RecordingSubmitter::with_outcomes(Vec::new()));
+        let worker = worker(
+            repository,
+            materializer.clone(),
+            submitter.clone(),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert_eq!(report.due_records, 1);
+        assert_eq!(
+            report.results.last().map(|result| &result.outcome),
+            Some(&TriggerPollerFireOutcome::SkippedAlreadyActive {
+                active_fire_slot: Some(fire_slot),
+                active_run_ref: Some(active_run_ref)
+            })
+        );
+        assert_eq!(materializer.fires().len(), 0);
+        assert_eq!(submitter.requests().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn tick_skips_active_trigger_but_processes_other_due_trigger() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let fire_slot = ts(1_704_067_200);
+        let active_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let due_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let active_run_ref =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut active = sample_record(active_id, tenant("tenant-a"), fire_slot);
+        active.active_fire_slot = Some(fire_slot);
+        active.active_run_ref = Some(active_run_ref);
+        let due = sample_record(due_id, tenant("tenant-a"), fire_slot);
+        repo.upsert_trigger(active).await.expect("insert active");
+        repo.upsert_trigger(due).await.expect("insert due");
+        let due_run_ref = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+        let submitter = Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+            TrustedTriggerFireSubmitOutcome::Accepted {
+                run_id: due_run_ref,
+                submitted_at: fire_slot,
+            },
+        )]));
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_state(
+            TriggerActiveRunState::Nonterminal,
+        ));
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            submitter,
+            active_lookup,
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert_eq!(report.active_records, 1);
+        assert_eq!(report.due_records, 1);
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == active_id
+                    && matches!(
+                        result.outcome,
+                        TriggerPollerFireOutcome::SkippedAlreadyActive { .. }
+                    ))
+        );
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == due_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::Submitted {
+                            run_id: due_run_ref
+                        })
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_clears_terminal_active_run() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), ts(1_704_067_260));
+        record.active_fire_slot = Some(fire_slot);
+        record.active_run_ref = Some(run_id);
+        repo.upsert_trigger(record).await.expect("insert active");
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_state(
+            TriggerActiveRunState::Terminal,
+        ));
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            active_lookup.clone(),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert_eq!(report.active_records, 1);
+        assert_eq!(
+            report.results.last().map(|result| &result.outcome),
+            Some(&TriggerPollerFireOutcome::ClearedTerminalActive { run_id })
+        );
+        assert_eq!(
+            active_lookup.requests(),
+            vec![TriggerActiveRunStateRequest {
+                tenant_id: tenant("tenant-a"),
+                trigger_id,
+                fire_slot,
+                run_id,
+            }]
+        );
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_clears_terminal_active_and_processes_due_trigger() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let active_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let due_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut active = sample_record(active_id, tenant("tenant-a"), ts(1_704_067_260));
+        active.active_fire_slot = Some(fire_slot);
+        active.active_run_ref = Some(run_id);
+        repo.upsert_trigger(active).await.expect("insert active");
+        repo.upsert_trigger(sample_record(due_id, tenant("tenant-a"), fire_slot))
+            .await
+            .expect("insert due");
+        let due_run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Accepted {
+                    run_id: due_run_id,
+                    submitted_at: fire_slot,
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::with_state(
+                TriggerActiveRunState::Terminal,
+            )),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == active_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::ClearedTerminalActive { run_id })
+        );
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == due_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::Submitted { run_id: due_run_id })
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_keeps_missing_active_run_blocked() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        record.active_fire_slot = Some(fire_slot);
+        record.active_run_ref = Some(run_id);
+        repo.upsert_trigger(record).await.expect("insert active");
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_state(
+            TriggerActiveRunState::Missing,
+        ));
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            active_lookup.clone(),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::SkippedAlreadyActive { .. })
+        ));
+        assert_eq!(
+            active_lookup.requests(),
+            vec![TriggerActiveRunStateRequest {
+                tenant_id: tenant("tenant-a"),
+                trigger_id,
+                fire_slot,
+                run_id,
+            }]
+        );
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.active_fire_slot, Some(fire_slot));
+        assert_eq!(persisted.active_run_ref, Some(run_id));
+    }
+
+    #[tokio::test]
+    async fn tick_keeps_claim_only_active_fire_blocked() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        record.active_fire_slot = Some(fire_slot);
+        record.active_run_ref = None;
+        repo.upsert_trigger(record).await.expect("insert active");
+        let materializer = Arc::new(RecordingMaterializer::success("content:trigger-fire"));
+        let submitter = Arc::new(RecordingSubmitter::with_outcomes(Vec::new()));
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_state(
+            TriggerActiveRunState::Terminal,
+        ));
+        let worker = worker(
+            repo.clone(),
+            materializer.clone(),
+            submitter.clone(),
+            active_lookup.clone(),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.first().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::SkippedAlreadyActive {
+                active_fire_slot: Some(_),
+                active_run_ref: None
+            })
+        ));
+        assert_eq!(materializer.fires().len(), 0);
+        assert_eq!(submitter.requests().len(), 0);
+        assert_eq!(active_lookup.requests().len(), 0);
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.active_fire_slot, Some(fire_slot));
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_retryable_submit_failure_clears_active_and_keeps_slot_retryable() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        repo.upsert_trigger(sample_record(trigger_id, tenant("tenant-a"), fire_slot))
+            .await
+            .expect("insert");
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::RetryableFailed {
+                    reason: "turn service unavailable".to_string(),
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::RetryableFailed { .. })
+        ));
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(persisted.next_run_at, fire_slot);
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_submitter_backend_error_clears_active_and_keeps_slot_retryable() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        repo.upsert_trigger(sample_record(trigger_id, tenant("tenant-a"), fire_slot))
+            .await
+            .expect("insert");
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Err(
+                TriggerError::Backend {
+                    reason: "turn submit unavailable".to_string(),
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::RetryableFailed { .. })
+        ));
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(persisted.next_run_at, fire_slot);
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_permanent_submit_failure_advances_next_slot() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        let expected_next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next run")
+            .expect("future run");
+        repo.upsert_trigger(record).await.expect("insert");
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::PermanentFailed {
+                    reason: "trusted inbound rejected scope".to_string(),
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+        ));
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(persisted.next_run_at, expected_next_run_at);
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_permanent_materialization_failure_advances_next_slot() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        let expected_next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next run")
+            .expect("future run");
+        repo.upsert_trigger(record).await.expect("insert");
+        let worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::failure(
+                TriggerError::InvalidMaterialization {
+                    reason: "bad prompt content ref".to_string(),
+                },
+            )),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+        ));
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(persisted.next_run_at, expected_next_run_at);
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    struct RecordingMaterializer {
+        result: Mutex<Option<Result<TriggerInboundContentRef, TriggerError>>>,
+        fires: Mutex<Vec<TriggerFire>>,
+    }
+
+    impl RecordingMaterializer {
+        fn success(content_ref: &str) -> Self {
+            Self {
+                result: Mutex::new(Some(
+                    Ok(TriggerInboundContentRef::new(content_ref).unwrap()),
+                )),
+                fires: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn failure(error: TriggerError) -> Self {
+            Self {
+                result: Mutex::new(Some(Err(error))),
+                fires: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn fires(&self) -> Vec<TriggerFire> {
+            self.fires.lock().expect("fires lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl TriggerPromptMaterializer for RecordingMaterializer {
+        async fn materialize_prompt(
+            &self,
+            fire: TriggerFire,
+        ) -> Result<TriggerInboundContentRef, TriggerError> {
+            self.fires.lock().expect("fires lock").push(fire);
+            self.result
+                .lock()
+                .expect("result lock")
+                .take()
+                .expect("materializer result configured")
+        }
+    }
+
+    struct RecordingSubmitter {
+        outcomes: Mutex<Vec<Result<TrustedTriggerFireSubmitOutcome, TriggerError>>>,
+        requests: Mutex<Vec<TrustedTriggerSubmitRequest>>,
+    }
+
+    impl RecordingSubmitter {
+        fn with_outcomes(
+            outcomes: Vec<Result<TrustedTriggerFireSubmitOutcome, TriggerError>>,
+        ) -> Self {
+            Self {
+                outcomes: Mutex::new(outcomes.into_iter().rev().collect()),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn requests(&self) -> Vec<TrustedTriggerSubmitRequest> {
+            self.requests.lock().expect("requests lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl TrustedTriggerFireSubmitter for RecordingSubmitter {
+        async fn submit_trusted_trigger_fire(
+            &self,
+            request: TrustedTriggerSubmitRequest,
+        ) -> Result<TrustedTriggerFireSubmitOutcome, TriggerError> {
+            self.requests.lock().expect("requests lock").push(request);
+            self.outcomes
+                .lock()
+                .expect("outcomes lock")
+                .pop()
+                .expect("submit outcome configured")
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingActiveRunLookup {
+        state: Mutex<Option<TriggerActiveRunState>>,
+        requests: Mutex<Vec<TriggerActiveRunStateRequest>>,
+    }
+
+    impl RecordingActiveRunLookup {
+        fn with_state(state: TriggerActiveRunState) -> Self {
+            Self {
+                state: Mutex::new(Some(state)),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn requests(&self) -> Vec<TriggerActiveRunStateRequest> {
+            self.requests.lock().expect("requests lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl TriggerActiveRunLookup for RecordingActiveRunLookup {
+        async fn active_run_state(
+            &self,
+            request: TriggerActiveRunStateRequest,
+        ) -> Result<TriggerActiveRunState, TriggerError> {
+            self.requests.lock().expect("requests lock").push(request);
+            Ok(self
+                .state
+                .lock()
+                .expect("state lock")
+                .unwrap_or(TriggerActiveRunState::Nonterminal))
+        }
+    }
+
+    struct ClaimRaceRepository {
+        due_record: TriggerRecord,
+        claim_outcome: Mutex<Option<ClaimDueFireOutcome>>,
+    }
+
+    impl ClaimRaceRepository {
+        fn new(due_record: TriggerRecord, claim_outcome: ClaimDueFireOutcome) -> Self {
+            Self {
+                due_record,
+                claim_outcome: Mutex::new(Some(claim_outcome)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TriggerRepository for ClaimRaceRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("claim-race repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(vec![self.due_record.clone()])
+        }
+
+        async fn list_active_triggers(
+            &self,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            Ok(self
+                .claim_outcome
+                .lock()
+                .expect("claim outcome lock")
+                .take()
+                .expect("claim outcome configured"))
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository should not persist accepted fires")
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository should not persist permanent failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("claim-race repository should not clear active fires")
+        }
+    }
+}

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -242,11 +242,18 @@ impl TriggerPollerWorker {
             ClaimDueFireOutcome::AlreadyActive {
                 active_fire_slot,
                 active_run_ref,
-            } => TriggerPollerFireOutcome::SkippedAlreadyActive {
-                active_fire_slot: active_fire_slot
-                    .expect("AlreadyActive claim outcome must include active_fire_slot"),
-                active_run_ref,
-            },
+            } => {
+                let Some(active_fire_slot) = active_fire_slot else {
+                    return Err(TriggerError::Backend {
+                        reason: "AlreadyActive claim outcome did not include active_fire_slot"
+                            .to_string(),
+                    });
+                };
+                TriggerPollerFireOutcome::SkippedAlreadyActive {
+                    active_fire_slot,
+                    active_run_ref,
+                }
+            }
             ClaimDueFireOutcome::NotDue { .. } => TriggerPollerFireOutcome::SkippedNotDue,
             ClaimDueFireOutcome::NotFound => TriggerPollerFireOutcome::SkippedNotFound,
         };

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -100,10 +100,10 @@ impl TriggerPollerWorker {
                 }
             };
             report.results.push(TriggerPollerFireReport {
-                tenant_id: outcome.0,
-                trigger_id: outcome.1,
+                tenant_id,
+                trigger_id,
                 fire_slot,
-                outcome: outcome.2,
+                outcome,
             });
         }
         Ok(report)
@@ -120,11 +120,11 @@ impl TriggerPollerWorker {
             .await?;
         report.active_records = active_records.len();
         for record in active_records {
+            debug_assert!(
+                record.active_fire_slot.is_some(),
+                "list_active_triggers returned a record without active_fire_slot"
+            );
             let Some(fire_slot) = record.active_fire_slot else {
-                debug_assert!(
-                    record.active_fire_slot.is_some(),
-                    "list_active_triggers returned a record without active_fire_slot"
-                );
                 continue;
             };
             let Some(run_id) = record.active_run_ref else {
@@ -213,7 +213,7 @@ impl TriggerPollerWorker {
         &self,
         record: TriggerRecord,
         now: Timestamp,
-    ) -> Result<(TenantId, TriggerId, TriggerPollerFireOutcome), TriggerError> {
+    ) -> Result<TriggerPollerFireOutcome, TriggerError> {
         let tenant_id = record.tenant_id.clone();
         let trigger_id = record.trigger_id;
         let fire_slot = record.next_run_at;
@@ -242,7 +242,7 @@ impl TriggerPollerWorker {
             ClaimDueFireOutcome::NotDue { .. } => TriggerPollerFireOutcome::SkippedNotDue,
             ClaimDueFireOutcome::NotFound => TriggerPollerFireOutcome::SkippedNotFound,
         };
-        Ok((tenant_id, trigger_id, outcome))
+        Ok(outcome)
     }
 
     async fn process_claimed_fire(
@@ -690,11 +690,27 @@ mod tests {
         submitter: Arc<RecordingSubmitter>,
         active_lookup: Arc<RecordingActiveRunLookup>,
     ) -> TriggerPollerWorker {
+        worker_with_source_provider(
+            repo,
+            Arc::new(crate::ScheduleTriggerSourceProvider),
+            materializer,
+            submitter,
+            active_lookup,
+        )
+    }
+
+    fn worker_with_source_provider(
+        repo: Arc<dyn TriggerRepository>,
+        source_provider: Arc<dyn TriggerSourceProvider>,
+        materializer: Arc<RecordingMaterializer>,
+        submitter: Arc<RecordingSubmitter>,
+        active_lookup: Arc<RecordingActiveRunLookup>,
+    ) -> TriggerPollerWorker {
         TriggerPollerWorker::new(
             TriggerPollerWorkerConfig::default(),
             TriggerPollerWorkerDeps {
                 repository: repo,
-                source_provider: Arc::new(crate::ScheduleTriggerSourceProvider),
+                source_provider,
                 materializer,
                 trusted_submitter: submitter,
                 active_run_lookup: active_lookup,
@@ -1397,6 +1413,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tick_source_provider_none_persists_permanent_failure_with_next_slot() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let record = sample_record(trigger_id, tenant("tenant-a"), fire_slot);
+        let expected_next_run_at = record
+            .schedule
+            .next_slot_after(fire_slot)
+            .expect("next run")
+            .expect("future run");
+        repo.upsert_trigger(record).await.expect("insert");
+        let worker = worker_with_source_provider(
+            repo.clone(),
+            Arc::new(NullSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+        assert!(matches!(
+            report.results.last().map(|result| &result.outcome),
+            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+        ));
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("load")
+            .expect("record present");
+        assert_eq!(persisted.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(persisted.next_run_at, expected_next_run_at);
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
     async fn tick_permanent_failure_without_next_slot_completes_trigger() {
         let repo = Arc::new(InMemoryTriggerRepository::default());
         let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
@@ -1431,6 +1484,19 @@ mod tests {
     struct RecordingMaterializer {
         result: Mutex<Option<Result<TriggerInboundContentRef, TriggerError>>>,
         fires: Mutex<Vec<TriggerFire>>,
+    }
+
+    struct NullSourceProvider;
+
+    #[async_trait]
+    impl TriggerSourceProvider for NullSourceProvider {
+        async fn evaluate(
+            &self,
+            _record: &TriggerRecord,
+            _now: Timestamp,
+        ) -> Result<Option<TriggerFire>, TriggerError> {
+            Ok(None)
+        }
     }
 
     impl RecordingMaterializer {

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -88,12 +88,13 @@ impl TriggerPollerWorker {
             let outcome = match self.process_due_record(record, now).await {
                 Ok(outcome) => outcome,
                 Err(error) => {
+                    let classification = classify_failure(&error);
                     report.results.push(TriggerPollerFireReport {
                         tenant_id,
                         trigger_id,
                         fire_slot,
                         outcome: TriggerPollerFireOutcome::DueFireFailed {
-                            reason: error.to_string(),
+                            reason: classification.reason,
                         },
                     });
                     continue;
@@ -153,14 +154,14 @@ impl TriggerPollerWorker {
                 .await
             {
                 Ok(state) => state,
-                Err(error) => {
+                Err(_error) => {
                     report.results.push(TriggerPollerFireReport {
                         tenant_id: record.tenant_id,
                         trigger_id: record.trigger_id,
                         fire_slot,
                         outcome: TriggerPollerFireOutcome::ActiveRunLookupFailed {
                             run_id,
-                            reason: error.to_string(),
+                            reason: TriggerPollerFailureReason::ActiveRunLookup,
                         },
                     });
                     continue;
@@ -258,12 +259,13 @@ impl TriggerPollerWorker {
         let next_run_at = match next_run_at_after_fire(&record, fire_slot) {
             Ok(next_run_at) => next_run_at,
             Err(error) => {
+                let classification = classify_failure(&error);
                 return self
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        SubmitFailureKind::Permanent,
-                        error.to_string(),
+                        classification.kind,
+                        classification.reason,
                         PermanentFailureDestination::Terminal,
                     )
                     .await;
@@ -277,18 +279,19 @@ impl TriggerPollerWorker {
                         record,
                         fire_slot,
                         SubmitFailureKind::Permanent,
-                        "claimed trigger did not produce a fire".to_string(),
+                        TriggerPollerFailureReason::SourceNoFire,
                         PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
             }
             Err(error) => {
+                let classification = classify_failure(&error);
                 return self
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        classify_error(&error),
-                        error.to_string(),
+                        classification.kind,
+                        classification.reason,
                         PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
@@ -302,12 +305,13 @@ impl TriggerPollerWorker {
         {
             Ok(content_ref) => content_ref,
             Err(error) => {
+                let classification = classify_failure(&error);
                 return self
                     .persist_failed_fire(
                         record,
                         fire_slot,
-                        classify_error(&error),
-                        error.to_string(),
+                        classification.kind,
+                        classification.reason,
                         PermanentFailureDestination::Reschedule(next_run_at),
                     )
                     .await;
@@ -376,7 +380,7 @@ impl TriggerPollerWorker {
                     record,
                     fire_slot,
                     SubmitFailureKind::Retryable,
-                    reason,
+                    TriggerPollerFailureReason::from_trusted_submit_failure(reason),
                     PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
@@ -386,17 +390,18 @@ impl TriggerPollerWorker {
                     record,
                     fire_slot,
                     SubmitFailureKind::Permanent,
-                    reason,
+                    TriggerPollerFailureReason::from_trusted_submit_failure(reason),
                     PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
             }
             Err(error) => {
+                let classification = classify_failure(&error);
                 self.persist_failed_fire(
                     record,
                     fire_slot,
-                    classify_error(&error),
-                    error.to_string(),
+                    classification.kind,
+                    classification.reason,
                     PermanentFailureDestination::Reschedule(next_run_at),
                 )
                 .await
@@ -409,7 +414,7 @@ impl TriggerPollerWorker {
         record: TriggerRecord,
         fire_slot: Timestamp,
         kind: SubmitFailureKind,
-        reason: String,
+        reason: TriggerPollerFailureReason,
         permanent_destination: PermanentFailureDestination,
     ) -> Result<TriggerPollerFireOutcome, TriggerError> {
         match kind {
@@ -490,17 +495,17 @@ pub enum TriggerPollerFireOutcome {
         original_run_id: TurnRunId,
     },
     RetryableFailed {
-        reason: String,
+        reason: TriggerPollerFailureReason,
     },
     PermanentFailed {
-        reason: String,
+        reason: TriggerPollerFailureReason,
     },
     ClearedTerminalActive {
         run_id: TurnRunId,
     },
     ActiveRunLookupFailed {
         run_id: TurnRunId,
-        reason: String,
+        reason: TriggerPollerFailureReason,
     },
     SkippedAlreadyCleared {
         run_id: TurnRunId,
@@ -510,10 +515,35 @@ pub enum TriggerPollerFireOutcome {
         active_run_ref: Option<TurnRunId>,
     },
     DueFireFailed {
-        reason: String,
+        reason: TriggerPollerFailureReason,
     },
     SkippedNotDue,
     SkippedNotFound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerPollerFailureReason {
+    Backend,
+    InvalidTriggerId,
+    InvalidFireIdentity,
+    InvalidRecord,
+    InvalidPollerConfig,
+    InvalidSchedule,
+    InvalidMaterialization,
+    NotFound,
+    SourceNoFire,
+    TrustedSubmitRetryable,
+    TrustedSubmitPermanent,
+    ActiveRunLookup,
+}
+
+impl TriggerPollerFailureReason {
+    fn from_trusted_submit_failure(reason: TrustedTriggerSubmitFailureReason) -> Self {
+        match reason {
+            TrustedTriggerSubmitFailureReason::Retryable => Self::TrustedSubmitRetryable,
+            TrustedTriggerSubmitFailureReason::Permanent => Self::TrustedSubmitPermanent,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -521,6 +551,12 @@ pub struct TrustedTriggerSubmitRequest {
     pub fire: TriggerFire,
     pub content_ref: TriggerInboundContentRef,
     pub received_at: Timestamp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustedTriggerSubmitFailureReason {
+    Retryable,
+    Permanent,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -534,10 +570,10 @@ pub enum TrustedTriggerFireSubmitOutcome {
         replayed_at: Timestamp,
     },
     RetryableFailed {
-        reason: String,
+        reason: TrustedTriggerSubmitFailureReason,
     },
     PermanentFailed {
-        reason: String,
+        reason: TrustedTriggerSubmitFailureReason,
     },
 }
 
@@ -584,17 +620,48 @@ enum PermanentFailureDestination {
     Terminal,
 }
 
-fn classify_error(error: &TriggerError) -> SubmitFailureKind {
-    match error {
-        TriggerError::Backend { .. } => SubmitFailureKind::Retryable,
-        TriggerError::InvalidTriggerId { .. }
-        | TriggerError::InvalidFireIdentityComponent { .. }
-        | TriggerError::InvalidRecord { .. }
-        | TriggerError::InvalidPollerConfig { .. }
-        | TriggerError::InvalidSchedule { .. }
-        | TriggerError::InvalidMaterialization { .. }
-        | TriggerError::NotFound => SubmitFailureKind::Permanent,
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FailureClassification {
+    kind: SubmitFailureKind,
+    reason: TriggerPollerFailureReason,
+}
+
+fn classify_failure(error: &TriggerError) -> FailureClassification {
+    let (kind, reason) = match error {
+        TriggerError::Backend { .. } => (
+            SubmitFailureKind::Retryable,
+            TriggerPollerFailureReason::Backend,
+        ),
+        TriggerError::InvalidTriggerId { .. } => (
+            SubmitFailureKind::Permanent,
+            TriggerPollerFailureReason::InvalidTriggerId,
+        ),
+        TriggerError::InvalidFireIdentityComponent { .. } => (
+            SubmitFailureKind::Permanent,
+            TriggerPollerFailureReason::InvalidFireIdentity,
+        ),
+        TriggerError::InvalidRecord { .. } => (
+            SubmitFailureKind::Permanent,
+            TriggerPollerFailureReason::InvalidRecord,
+        ),
+        TriggerError::InvalidPollerConfig { .. } => (
+            SubmitFailureKind::Permanent,
+            TriggerPollerFailureReason::InvalidPollerConfig,
+        ),
+        TriggerError::InvalidSchedule { .. } => (
+            SubmitFailureKind::Permanent,
+            TriggerPollerFailureReason::InvalidSchedule,
+        ),
+        TriggerError::InvalidMaterialization { .. } => (
+            SubmitFailureKind::Permanent,
+            TriggerPollerFailureReason::InvalidMaterialization,
+        ),
+        TriggerError::NotFound => (
+            SubmitFailureKind::Permanent,
+            TriggerPollerFailureReason::NotFound,
+        ),
+    };
+    FailureClassification { kind, reason }
 }
 
 fn next_run_at_after_fire(
@@ -1110,8 +1177,10 @@ mod tests {
                 .any(|result| result.trigger_id == active_id
                     && matches!(
                         result.outcome,
-                        TriggerPollerFireOutcome::ActiveRunLookupFailed { run_id: actual_run_id, .. }
-                        if actual_run_id == run_id
+                        TriggerPollerFireOutcome::ActiveRunLookupFailed {
+                            run_id: actual_run_id,
+                            reason: TriggerPollerFailureReason::ActiveRunLookup,
+                        } if actual_run_id == run_id
                     ))
         );
         assert!(
@@ -1223,7 +1292,7 @@ mod tests {
             Arc::new(RecordingMaterializer::success("content:trigger-fire")),
             Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
                 TrustedTriggerFireSubmitOutcome::RetryableFailed {
-                    reason: "turn service unavailable".to_string(),
+                    reason: TrustedTriggerSubmitFailureReason::Retryable,
                 },
             )])),
             Arc::new(RecordingActiveRunLookup::default()),
@@ -1233,7 +1302,9 @@ mod tests {
 
         assert!(matches!(
             report.results.last().map(|result| &result.outcome),
-            Some(TriggerPollerFireOutcome::RetryableFailed { .. })
+            Some(TriggerPollerFireOutcome::RetryableFailed {
+                reason: TriggerPollerFailureReason::TrustedSubmitRetryable,
+            })
         ));
         let persisted = repo
             .get_trigger(tenant("tenant-a"), trigger_id)
@@ -1275,7 +1346,7 @@ mod tests {
                 && matches!(
                     &result.outcome,
                     TriggerPollerFireOutcome::DueFireFailed { reason }
-                        if reason.contains("persisting accepted submit result")
+                        if *reason == TriggerPollerFailureReason::Backend
                 )
         }));
     }
@@ -1317,7 +1388,9 @@ mod tests {
                 .any(|result| result.trigger_id == failed_id
                     && matches!(
                         result.outcome,
-                        TriggerPollerFireOutcome::DueFireFailed { .. }
+                        TriggerPollerFireOutcome::DueFireFailed {
+                            reason: TriggerPollerFailureReason::Backend,
+                        }
                     ))
         );
         assert!(
@@ -1355,7 +1428,9 @@ mod tests {
 
         assert!(matches!(
             report.results.last().map(|result| &result.outcome),
-            Some(TriggerPollerFireOutcome::RetryableFailed { .. })
+            Some(TriggerPollerFireOutcome::RetryableFailed {
+                reason: TriggerPollerFailureReason::Backend,
+            })
         ));
         let persisted = repo
             .get_trigger(tenant("tenant-a"), trigger_id)
@@ -1385,7 +1460,7 @@ mod tests {
             Arc::new(RecordingMaterializer::success("content:trigger-fire")),
             Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
                 TrustedTriggerFireSubmitOutcome::PermanentFailed {
-                    reason: "trusted inbound rejected scope".to_string(),
+                    reason: TrustedTriggerSubmitFailureReason::Permanent,
                 },
             )])),
             Arc::new(RecordingActiveRunLookup::default()),
@@ -1395,7 +1470,9 @@ mod tests {
 
         assert!(matches!(
             report.results.last().map(|result| &result.outcome),
-            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+            Some(TriggerPollerFireOutcome::PermanentFailed {
+                reason: TriggerPollerFailureReason::TrustedSubmitPermanent,
+            })
         ));
         let persisted = repo
             .get_trigger(tenant("tenant-a"), trigger_id)
@@ -1435,7 +1512,9 @@ mod tests {
 
         assert!(matches!(
             report.results.last().map(|result| &result.outcome),
-            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+            Some(TriggerPollerFireOutcome::PermanentFailed {
+                reason: TriggerPollerFailureReason::InvalidMaterialization,
+            })
         ));
         let persisted = repo
             .get_trigger(tenant("tenant-a"), trigger_id)
@@ -1472,7 +1551,9 @@ mod tests {
 
         assert!(matches!(
             report.results.last().map(|result| &result.outcome),
-            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+            Some(TriggerPollerFireOutcome::PermanentFailed {
+                reason: TriggerPollerFailureReason::SourceNoFire,
+            })
         ));
         let persisted = repo
             .get_trigger(tenant("tenant-a"), trigger_id)
@@ -1509,7 +1590,9 @@ mod tests {
 
         assert!(matches!(
             report.results.last().map(|result| &result.outcome),
-            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+            Some(TriggerPollerFireOutcome::PermanentFailed {
+                reason: TriggerPollerFailureReason::NotFound,
+            })
         ));
         let persisted = repo
             .get_trigger(tenant("tenant-a"), trigger_id)
@@ -1520,6 +1603,61 @@ mod tests {
         assert_eq!(persisted.next_run_at, expected_next_run_at);
         assert_eq!(persisted.active_fire_slot, None);
         assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_source_provider_errors_report_bounded_permanent_reasons() {
+        let cases = vec![
+            (
+                TriggerError::InvalidTriggerId {
+                    reason: "bad trigger".to_string(),
+                },
+                TriggerPollerFailureReason::InvalidTriggerId,
+            ),
+            (
+                TriggerError::InvalidFireIdentityComponent {
+                    label: "fire_slot".to_string(),
+                    reason: "bad component".to_string(),
+                },
+                TriggerPollerFailureReason::InvalidFireIdentity,
+            ),
+            (
+                TriggerError::InvalidRecord {
+                    reason: "bad record".to_string(),
+                },
+                TriggerPollerFailureReason::InvalidRecord,
+            ),
+            (
+                TriggerError::InvalidPollerConfig {
+                    reason: "bad config".to_string(),
+                },
+                TriggerPollerFailureReason::InvalidPollerConfig,
+            ),
+        ];
+
+        for (error, expected_reason) in cases {
+            let repo = Arc::new(InMemoryTriggerRepository::default());
+            let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+            let fire_slot = ts(1_704_067_200);
+            repo.upsert_trigger(sample_record(trigger_id, tenant("tenant-a"), fire_slot))
+                .await
+                .expect("insert");
+            let worker = worker_with_source_provider(
+                repo,
+                Arc::new(ErrorSourceProvider::new(error)),
+                Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+                Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+                Arc::new(RecordingActiveRunLookup::default()),
+            );
+
+            let report = worker.tick_once(fire_slot).await.expect("tick succeeds");
+
+            assert!(matches!(
+                report.results.last().map(|result| &result.outcome),
+                Some(TriggerPollerFireOutcome::PermanentFailed { reason })
+                    if *reason == expected_reason
+            ));
+        }
     }
 
     #[tokio::test]
@@ -1541,7 +1679,9 @@ mod tests {
 
         assert!(matches!(
             report.results.last().map(|result| &result.outcome),
-            Some(TriggerPollerFireOutcome::PermanentFailed { .. })
+            Some(TriggerPollerFireOutcome::PermanentFailed {
+                reason: TriggerPollerFailureReason::InvalidSchedule,
+            })
         ));
         let persisted = repo
             .get_trigger(tenant("tenant-a"), trigger_id)
@@ -1563,6 +1703,18 @@ mod tests {
 
     struct NotFoundSourceProvider;
 
+    struct ErrorSourceProvider {
+        error: Mutex<Option<TriggerError>>,
+    }
+
+    impl ErrorSourceProvider {
+        fn new(error: TriggerError) -> Self {
+            Self {
+                error: Mutex::new(Some(error)),
+            }
+        }
+    }
+
     #[async_trait]
     impl TriggerSourceProvider for NullSourceProvider {
         async fn evaluate(
@@ -1582,6 +1734,22 @@ mod tests {
             _now: Timestamp,
         ) -> Result<Option<TriggerFire>, TriggerError> {
             Err(TriggerError::NotFound)
+        }
+    }
+
+    #[async_trait]
+    impl TriggerSourceProvider for ErrorSourceProvider {
+        async fn evaluate(
+            &self,
+            _record: &TriggerRecord,
+            _now: Timestamp,
+        ) -> Result<Option<TriggerFire>, TriggerError> {
+            Err(self
+                .error
+                .lock()
+                .expect("error lock")
+                .take()
+                .expect("source provider error configured"))
         }
     }
 

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -263,6 +263,7 @@ async fn assert_due_query_clamps_limit_and_respects_state_gate(repo: &impl Trigg
             tenant("tenant-active-run"),
             due_slot,
         );
+        record.active_fire_slot = Some(due_slot);
         record.active_run_ref =
             Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("valid run"));
         record
@@ -401,6 +402,122 @@ async fn assert_due_query_clamps_limit_and_respects_state_gate(repo: &impl Trigg
     );
 }
 
+async fn assert_active_query_lists_active_records_in_deterministic_order(
+    repo: &impl TriggerRepository,
+) {
+    let early_slot = ts(1_704_067_200);
+    let later_slot = ts(1_704_067_260);
+    let inactive = sample_record(
+        TriggerId::parse("01J00000000000000000000001").expect("ulid"),
+        tenant("tenant-inactive"),
+        early_slot,
+    );
+    let inactive_trigger_id = inactive.trigger_id;
+    let active_later = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000002").expect("ulid"),
+            tenant("tenant-active-later"),
+            later_slot,
+        );
+        record.active_fire_slot = Some(later_slot);
+        record
+    };
+    let active_early_a = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000003").expect("ulid"),
+            tenant("tenant-active-a"),
+            later_slot,
+        );
+        record.active_fire_slot = Some(early_slot);
+        record.active_run_ref =
+            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("valid run"));
+        record
+    };
+    let active_early_b = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000004").expect("ulid"),
+            tenant("tenant-active-b"),
+            later_slot,
+        );
+        record.active_fire_slot = Some(early_slot);
+        record.active_run_ref =
+            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("valid run"));
+        record
+    };
+    let mut overflow_records = Vec::new();
+    for index in 0..130 {
+        let mut record = sample_record(
+            TriggerId::new(),
+            tenant(&format!("tenant-overflow-{index:03}")),
+            later_slot,
+        );
+        record.active_fire_slot = Some(later_slot);
+        overflow_records.push(record);
+    }
+
+    repo.upsert_trigger(inactive)
+        .await
+        .expect("insert inactive");
+    repo.upsert_trigger(active_later.clone())
+        .await
+        .expect("insert active later");
+    repo.upsert_trigger(active_early_b.clone())
+        .await
+        .expect("insert active early b");
+    repo.upsert_trigger(active_early_a.clone())
+        .await
+        .expect("insert active early a");
+    for record in &overflow_records {
+        repo.upsert_trigger(record.clone())
+            .await
+            .expect("insert overflow active");
+    }
+
+    assert!(
+        repo.list_active_triggers(0)
+            .await
+            .expect("zero active limit")
+            .is_empty()
+    );
+
+    let active = repo
+        .list_active_triggers(128 + 10)
+        .await
+        .expect("list active triggers");
+    assert_eq!(active.len(), 128);
+    assert!(
+        active
+            .iter()
+            .all(|record| record.active_fire_slot.is_some()),
+        "active query must only return rows with an active fire slot"
+    );
+    assert!(
+        active
+            .iter()
+            .all(|record| record.trigger_id != inactive_trigger_id),
+        "inactive rows must not appear in the active cleanup query"
+    );
+    assert_eq!(
+        active
+            .iter()
+            .take(3)
+            .map(|record| (record.tenant_id.clone(), record.trigger_id))
+            .collect::<Vec<_>>(),
+        vec![
+            (active_early_a.tenant_id.clone(), active_early_a.trigger_id),
+            (active_early_b.tenant_id.clone(), active_early_b.trigger_id),
+            (active_later.tenant_id.clone(), active_later.trigger_id),
+        ]
+    );
+
+    let limited = repo
+        .list_active_triggers(1)
+        .await
+        .expect("list active limited");
+    assert_eq!(limited.len(), 1);
+    assert_eq!(limited[0].trigger_id, active_early_a.trigger_id);
+}
+
 async fn assert_rejects_validation_failures_before_persistence(repo: &impl TriggerRepository) {
     let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
     let tenant_id = tenant("tenant-a");
@@ -518,6 +635,9 @@ async fn libsql_repository_contract_parity() {
     assert_due_query_clamps_limit_and_respects_state_gate(&repo).await;
 
     let (_dir, repo) = build_libsql_repo().await;
+    assert_active_query_lists_active_records_in_deterministic_order(&repo).await;
+
+    let (_dir, repo) = build_libsql_repo().await;
     assert_rejects_validation_failures_before_persistence(&repo).await;
 
     let (_dir, repo) = build_libsql_repo().await;
@@ -605,6 +725,9 @@ async fn postgres_repository_contract_parity() {
 
     clear_postgres_triggers(&pool).await;
     assert_due_query_clamps_limit_and_respects_state_gate(&repo).await;
+
+    clear_postgres_triggers(&pool).await;
+    assert_active_query_lists_active_records_in_deterministic_order(&repo).await;
 
     clear_postgres_triggers(&pool).await;
     assert_rejects_validation_failures_before_persistence(&repo).await;
@@ -710,6 +833,12 @@ fn malformed_row_cases() -> Vec<(&'static str, &'static str, &'static str, ReadM
             Get,
         ),
         ("active_run_ref", "not-a-uuid", "active_run_ref", Get),
+        (
+            "active_run_ref",
+            "01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a",
+            "active_run_ref",
+            Get,
+        ),
         ("last_status", "timed_out", "last_status", Get),
         ("created_at", "not-a-timestamp", "created_at", Get),
     ]
@@ -1642,21 +1771,18 @@ mod fire_claim_contract {
         run_only.active_run_ref =
             Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5e").expect("valid run"));
         assert!(run_only.has_active_fire());
-        let expected_run_only_ref = run_only.active_run_ref;
-        repo.upsert_trigger(run_only)
+        let error = repo
+            .upsert_trigger(run_only)
             .await
-            .expect("persist active row with run ref only");
+            .expect_err("active_run_ref without fire slot must be rejected");
+        assert_error_contains(error, "active_run_ref requires active_fire_slot");
+
         assert!(
-            repo.claim_due_fire(ClaimDueFireRequest {
-                tenant_id: run_only_tenant_id,
-                trigger_id: run_only_trigger_id,
-                fire_slot,
-                now: fire_slot,
-            })
-            .await
-            .expect("active run-ref-only claim")
-            .matches_already_active(None, expected_run_only_ref),
-            "active run ref without fire slot must block a second claim"
+            repo.get_trigger(run_only_tenant_id, run_only_trigger_id)
+                .await
+                .expect("run-only row lookup")
+                .is_none(),
+            "invalid run-ref-only row must not be persisted"
         );
 
         let mut status_only = sample_record(

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -978,7 +978,7 @@ mod fire_claim_contract {
 
     use ironclaw_triggers::{
         ClaimDueFireOutcome, ClaimDueFireRequest, FireAcceptedRequest, FirePermanentFailedRequest,
-        FireReplayedRequest, FireRetryableFailedRequest,
+        FireReplayedRequest, FireRetryableFailedRequest, FireTerminalFailedRequest,
     };
 
     async fn assert_fire_claim_and_update_contract(repo: &impl TriggerRepository) {
@@ -1240,6 +1240,43 @@ mod fire_claim_contract {
         assert_eq!(permanent_failed.active_fire_slot, None);
         assert_eq!(permanent_failed.active_run_ref, None);
         assert!(permanent_failed.next_run_at > fire_slot);
+
+        let terminal_trigger_id = TriggerId::parse("01J00000000000000000000006").expect("ulid");
+        let terminal_tenant_id = tenant("tenant-terminal");
+        let mut terminal_record =
+            sample_record(terminal_trigger_id, terminal_tenant_id.clone(), fire_slot);
+        terminal_record.last_run_at = Some(failure_previous_run_at);
+        terminal_record.last_fired_slot = Some(failure_previous_slot);
+        repo.upsert_trigger(terminal_record)
+            .await
+            .expect("insert terminal-failure record");
+        let terminal_claim = repo
+            .claim_due_fire(ClaimDueFireRequest {
+                tenant_id: terminal_tenant_id.clone(),
+                trigger_id: terminal_trigger_id,
+                fire_slot,
+                now: fire_slot,
+            })
+            .await
+            .expect("claim terminal-failure record");
+        assert!(matches!(terminal_claim, ClaimDueFireOutcome::Claimed(_)));
+
+        let terminal_failed = repo
+            .mark_fire_terminally_failed(FireTerminalFailedRequest {
+                tenant_id: terminal_tenant_id,
+                trigger_id: terminal_trigger_id,
+                fire_slot,
+            })
+            .await
+            .expect("mark terminally failed")
+            .expect("terminal failure should persist");
+        assert_eq!(terminal_failed.last_run_at, Some(failure_previous_run_at));
+        assert_eq!(terminal_failed.last_fired_slot, Some(failure_previous_slot));
+        assert_eq!(terminal_failed.last_status, Some(TriggerRunStatus::Error));
+        assert_eq!(terminal_failed.state, TriggerState::Completed);
+        assert_eq!(terminal_failed.active_fire_slot, None);
+        assert_eq!(terminal_failed.active_run_ref, None);
+        assert_eq!(terminal_failed.next_run_at, fire_slot);
     }
 
     async fn assert_fire_result_rejects_invalid_next_run_at(repo: &impl TriggerRepository) {

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -1430,6 +1430,35 @@ mod fire_claim_contract {
             .expect("record present");
         assert_eq!(reloaded, stale_permanent_record);
 
+        let stale_terminal_trigger_id =
+            TriggerId::parse("01J00000000000000000000014").expect("ulid");
+        let stale_terminal_tenant_id = tenant("tenant-stale-terminal");
+        let mut stale_terminal_record = sample_record(
+            stale_terminal_trigger_id,
+            stale_terminal_tenant_id.clone(),
+            fire_slot,
+        );
+        stale_terminal_record.active_fire_slot = Some(fire_slot);
+        repo.upsert_trigger(stale_terminal_record.clone())
+            .await
+            .expect("insert stale terminal record");
+        assert!(
+            repo.mark_fire_terminally_failed(FireTerminalFailedRequest {
+                tenant_id: stale_terminal_tenant_id.clone(),
+                trigger_id: stale_terminal_trigger_id,
+                fire_slot: stale_fire_slot,
+            })
+            .await
+            .expect("stale terminal update")
+            .is_none()
+        );
+        let reloaded = repo
+            .get_trigger(stale_terminal_tenant_id, stale_terminal_trigger_id)
+            .await
+            .expect("reload stale terminal")
+            .expect("record present");
+        assert_eq!(reloaded, stale_terminal_record);
+
         let accepted_trigger_id = TriggerId::parse("01J0000000000000000000000E").expect("ulid");
         let accepted_tenant_id = tenant("tenant-invalid-accepted");
         let mut accepted_record =

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -570,6 +570,11 @@ Implement `TriggerPollerWorker` core logic:
 - call `handle_inbound_turn_with_trusted_scope`
 - persist synchronous submit status and next-run bookkeeping
 - preserve replay safety across crash retry or dual poller attempts
+- treat per-record due-fire processing failures and active-run lookup failures
+  as structured tick report outcomes so later due records can still be handled;
+  keep batch-level repository list failures fail-fast
+- for permanent failures with no future schedule slot, mark the trigger
+  `Completed` rather than writing a sentinel `next_run_at`
 
 Keep post-run async statuses fast-follow.
 
@@ -630,6 +635,13 @@ Wire the trigger poller into Reborn composition:
 - background trigger poller lifecycle should apply bounded startup and per-tick
   wake jitter to reduce replica stampedes, but it must not jitter trigger
   schedule calculation, fire identity, `fire_slot`, or `next_run_at`.
+- lifecycle/notification wiring should define how trigger submit failures are
+  surfaced to users or admins. Permanent failures should produce a durable,
+  throttled notification; retryable failures should avoid per-tick spam and use
+  thresholded or summarized reporting.
+- approval waits continue to belong to the turn pipeline. Composition should
+  define durable approval TTL/reminder behavior, fail-closed expiry, and stale
+  approval rejection while preserving trigger `active_run_ref` back-pressure.
 - readiness semantics for whether a disabled trigger poller is allowed and
   whether a failed trigger worker marks Reborn runtime readiness degraded.
 - architecture tests for `ironclaw_triggers` dependency edges

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -587,6 +587,9 @@ Add the heavier caller-level tests separately from the worker core:
 - proof that a second due fire is skipped while one fire for the same trigger
   is active
 - concurrent poller claim attempts cannot both submit the same trigger/slot
+- claim-only active-fire recovery must require a composition-owned lease or
+  age signal before retrying, so a freshly claimed slot is never misclassified
+  as abandoned and submitted twice
 - retryable submit failure leaves `next_run_at` retryable
 - terminal run failure for an already accepted/submitted slot does not mint a
   second V1 turn for the same fire identity
@@ -624,6 +627,9 @@ Wire the trigger poller into Reborn composition:
 - background task bundle or worker-supervisor type that owns both turn-runner
   and trigger-poller handles, cancellation, await/shutdown ordering, and panic
   or early-exit reporting.
+- background trigger poller lifecycle should apply bounded startup and per-tick
+  wake jitter to reduce replica stampedes, but it must not jitter trigger
+  schedule calculation, fire identity, `fire_slot`, or `next_run_at`.
 - readiness semantics for whether a disabled trigger poller is allowed and
   whether a failed trigger worker marks Reborn runtime readiness degraded.
 - architecture tests for `ironclaw_triggers` dependency edges

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -591,6 +591,12 @@ Add the heavier caller-level tests separately from the worker core:
 - active-run back-pressure behavior
 - proof that a second due fire is skipped while one fire for the same trigger
   is active
+- trusted-poller authority guard coverage: global poller-only repository
+  queries such as `list_active_triggers` must remain unreachable from
+  user/API/capability paths. Add an architecture or caller-level test that
+  proves only the trusted poller path can exercise the cross-tenant active
+  scan, and carry this into PR 18 if the final token is constructed by
+  composition.
 - active-cleanup fairness coverage: when the earliest active rows are
   long-running, nonterminal, or claim-only, later terminal active rows must
   still be reached eventually instead of being starved by the same ordered
@@ -638,9 +644,21 @@ Wire the trigger poller into Reborn composition:
 - a dedicated `TriggerPollerWorkerConfig` or equivalent composition-owned type
   for poll interval, fires per tick, and per-trigger active-run cap. Do not
   reuse `RebornRuntimeInput::PollSettings`, which is request-completion polling.
+- add a sealed `TrustedTriggerPollerScope` or equivalent host-owned token before
+  exposing the real background poller lifecycle. Global trigger scans should
+  require that token or return a wrapper type such as `GlobalActiveTriggerRecord`
+  so product adapters, first-party capabilities, and tenant-scoped APIs cannot
+  accidentally treat cross-tenant poller rows as ordinary caller-scoped lists.
+  Keep tenant-scoped `list_triggers(tenant_id)` as the only user/API listing
+  path.
 - background task bundle or worker-supervisor type that owns both turn-runner
   and trigger-poller handles, cancellation, await/shutdown ordering, and panic
   or early-exit reporting.
+- decide whether the PR 15 `worker.rs` file is split into
+  `worker::{config,ports,report,mod}` or receives a tracked architecture
+  exemption. The current large-file shape is acceptable for landing the core
+  slice only if the follow-up is explicit before lifecycle and harness code add
+  more responsibilities.
 - background trigger poller lifecycle should apply bounded startup and per-tick
   wake jitter to reduce replica stampedes, but it must not jitter trigger
   schedule calculation, fire identity, `fire_slot`, or `next_run_at`.
@@ -656,6 +674,11 @@ Wire the trigger poller into Reborn composition:
   surfaced to users or admins. Permanent failures should produce a durable,
   throttled notification; retryable failures should avoid per-tick spam and use
   thresholded or summarized reporting.
+- any failure reason that leaves the in-process tick report must be bounded and
+  redacted. Do not persist, log broadly, or send raw
+  `TriggerSourceProvider`/`TriggerPromptMaterializer` error strings to users;
+  map them to typed failure categories or sanitized summaries at the lifecycle,
+  logging, or notification boundary.
 - approval waits continue to belong to the turn pipeline. Composition should
   define durable approval TTL/reminder behavior, fail-closed expiry, and stale
   approval rejection while preserving trigger `active_run_ref` back-pressure.

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -600,7 +600,10 @@ Add the heavier caller-level tests separately from the worker core:
 - active-cleanup fairness coverage: when the earliest active rows are
   long-running, nonterminal, or claim-only, later terminal active rows must
   still be reached eventually instead of being starved by the same ordered
-  first page on every tick
+  first page on every tick. Treat this as a PR 16 caller-level harness
+  requirement, not a best-effort unit test: the harness should run multiple
+  ticks with more active rows than the cleanup page size and prove terminal
+  rows outside the first page are eventually cleared.
 - if the fairness test exposes starvation, add cursor/rotation, widened cleanup
   scanning, or an equivalent repository/worker policy. If this touches
   in-memory `list_active_triggers`, consider replacing sort-then-truncate with
@@ -674,11 +677,11 @@ Wire the trigger poller into Reborn composition:
   surfaced to users or admins. Permanent failures should produce a durable,
   throttled notification; retryable failures should avoid per-tick spam and use
   thresholded or summarized reporting.
-- any failure reason that leaves the in-process tick report must be bounded and
-  redacted. Do not persist, log broadly, or send raw
-  `TriggerSourceProvider`/`TriggerPromptMaterializer` error strings to users;
-  map them to typed failure categories or sanitized summaries at the lifecycle,
-  logging, or notification boundary.
+- preserve the PR 15 bounded tick-report failure categories when lifecycle,
+  logging, and notification wiring are added. Do not reintroduce persisted,
+  broadly logged, or user-visible raw `TriggerSourceProvider`,
+  `TriggerPromptMaterializer`, backend, or submitter error strings; map typed
+  categories to sanitized summaries at the lifecycle/notification boundary.
 - approval waits continue to belong to the turn pipeline. Composition should
   define durable approval TTL/reminder behavior, fail-closed expiry, and stale
   approval rejection while preserving trigger `active_run_ref` back-pressure.

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -591,6 +591,15 @@ Add the heavier caller-level tests separately from the worker core:
 - active-run back-pressure behavior
 - proof that a second due fire is skipped while one fire for the same trigger
   is active
+- active-cleanup fairness coverage: when the earliest active rows are
+  long-running, nonterminal, or claim-only, later terminal active rows must
+  still be reached eventually instead of being starved by the same ordered
+  first page on every tick
+- if the fairness test exposes starvation, add cursor/rotation, widened cleanup
+  scanning, or an equivalent repository/worker policy. If this touches
+  in-memory `list_active_triggers`, consider replacing sort-then-truncate with
+  a bounded selection approach in the same pass; otherwise keep that as a
+  low-priority test-helper optimization.
 - concurrent poller claim attempts cannot both submit the same trigger/slot
 - claim-only active-fire recovery must require a composition-owned lease or
   age signal before retrying, so a freshly claimed slot is never misclassified
@@ -635,6 +644,14 @@ Wire the trigger poller into Reborn composition:
 - background trigger poller lifecycle should apply bounded startup and per-tick
   wake jitter to reduce replica stampedes, but it must not jitter trigger
   schedule calculation, fire identity, `fire_slot`, or `next_run_at`.
+- consider bounded active-run lookup concurrency at the lifecycle/config layer
+  once caller-level fairness coverage exists. Keep the default conservative
+  until the concrete turn-state backend and shutdown/cancellation behavior are
+  wired.
+- do not parallelize active-fire cleanup and the due-trigger query with a raw
+  `tokio::join!` unless the design preserves cleanup-before-due semantics:
+  clearing a terminal active fire before `list_due_triggers` can make that same
+  trigger eligible in the current tick.
 - lifecycle/notification wiring should define how trigger submit failures are
   surfaced to users or admins. Permanent failures should produce a durable,
   throttled notification; retryable failures should avoid per-tick spam and use

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -251,7 +251,11 @@ Slot bookkeeping is tied to acceptance, not merely polling:
 - permanent validation or authorization failures write `last_status = Error`,
   clear `active_fire_slot` and `active_run_ref`, leave `last_fired_slot` and
   `last_run_at` unchanged, and advance `next_run_at` beyond the failed
-  fire_slot.
+  fire_slot;
+- permanent failures on a schedule with no future fire slot mark the trigger
+  `Completed`, write `last_status = Error`, clear active-fire fields, and leave
+  `next_run_at` at the failed fire slot. The `Completed` state, not a sentinel
+  timestamp, removes the trigger from future due queries.
 
 Turn terminal lookup and clearing are a narrow seam layered above fire-claim
 and submit-result bookkeeping:
@@ -262,6 +266,18 @@ and submit-result bookkeeping:
   `TriggerRepository::clear_active_fire` clears only the exact matching
   `(tenant_id, trigger_id, active_fire_slot, active_run_ref)` after the caller
   has observed a terminal turn outcome.
+
+The poller treats per-record due-fire processing and active-run terminal lookup
+errors as structured tick report outcomes so one bad record does not block other
+eligible triggers in the same tick. Batch-level repository list failures remain
+fail-fast because the worker cannot know which records were safely observed.
+
+Approval waits are owned by the normal turn pipeline. While a submitted trigger
+turn is waiting for approval, the trigger remains active through
+`active_run_ref` back-pressure. Later lifecycle/notification work must define
+durable approval expiry, stale approval rejection, reminder throttling, and
+user/admin notification paths without making the trigger poller deliver outbound
+messages directly.
 
 ---
 


### PR DESCRIPTION
## Summary

PR15 adds the backend-agnostic trigger poller core for Reborn scheduled triggers.

This introduces `TriggerPollerWorker::tick_once(now)` in `ironclaw_triggers`, with injected trigger-domain ports for:

- prompt materialization into a trusted inbound content reference;
- trusted trigger fire submission;
- active run terminal-state lookup.

The worker owns deterministic core behavior only. It does not add background lifecycle wiring, startup/shutdown supervision, jitter scheduling, product ingress wiring, outbound delivery, or first-party trigger capabilities.

## What Changed

- Added `TriggerPollerWorker`, config, dependency bundle, tick report types, and trusted submit/active-run lookup ports.
- Added active-fire cleanup before each due scan:
  - active rows with terminal submitted runs are cleared through exact `fire_slot + run_id` matching;
  - nonterminal or missing submitted runs remain blocked;
  - claim-only active rows remain blocked in PR15 because safe recovery requires a later composition-owned lease/age signal.
- Added due fire processing:
  - list due records with repository limit;
  - atomically claim the due slot through the PR12/13 repository seam;
  - materialize the prompt;
  - submit through the trusted trigger-fire port;
  - persist accepted, replayed, retryable failed, and permanent failed submit outcomes.
- Added `TriggerRepository::list_active_triggers(limit)` for trusted poller cleanup across in-memory, libSQL, and PostgreSQL backends.
- Tightened `TriggerRecord` validation so `active_run_ref` requires `active_fire_slot`; a submitted run without a fire slot cannot be safely cleared.
- Expanded parity coverage for active-fire listing, malformed row hydration, replay behavior, claim-race behavior, and submit failure branches.
- Updated the trigger loop plan:
  - PR16 must handle lease/age-gated claim-only recovery in caller-level harness work;
  - PR18 lifecycle wiring should add bounded poller wake jitter without changing schedule calculation, fire identity, `fire_slot`, or `next_run_at`.

## Boundary Notes

- `ironclaw_triggers` still owns trigger records, fire identity, repository contracts, source evaluation, and deterministic poller core logic.
- Composition still owns concrete backend construction and will later adapt these ports to `InboundTurnService::handle_inbound_turn_with_trusted_scope` and turn persistence.
- PR15 does not wire a background loop. `poll_interval` is validated config carried for PR18 lifecycle ownership; `tick_once` remains deterministic and caller-driven.
- PR15 does not add outbound delivery or product-workflow ingress.

## Verification

- `cargo test -p ironclaw_triggers`
- `cargo test -p ironclaw_triggers --features libsql --test repository_contract libsql_repository_contract_parity`
- `cargo test -p ironclaw_triggers --features postgres --test repository_contract postgres_repository_contract_parity`
- `cargo clippy -p ironclaw_triggers --all-targets -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold -- --exact --nocapture`

## Review Notes

- Two rounds of 5.4-mini review were run for correctness/concurrency, tests/contracts, and Reborn ownership boundaries.
- Straightforward findings were fixed:
  - replay and submit failure branches now have direct worker coverage;
  - claim-race `AlreadyActive` avoids materialization/submit;
  - active-list parity covers same-slot ordering, max poll cap, and inactive exclusion;
  - active-run lookup request payloads are asserted;
  - `active_run_ref` without `active_fire_slot` is now rejected instead of becoming an un-clearable active row.
