### PR TITLE
[codex] Validate provider capability inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,6 +4580,7 @@ dependencies = [
  "ironclaw_threads",
  "ironclaw_trust",
  "ironclaw_turns",
+ "jsonschema",
  "parking_lot",
  "rust_decimal",
  "rust_decimal_macros",

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/comment_issue.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/comment_issue.md
@@ -1,5 +1,5 @@
 Use `github.comment_issue` to add an issue or pull request comment.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_branch.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_branch.md
@@ -1,5 +1,5 @@
 Use `github.create_branch` to create a branch from another branch or tag ref.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_issue.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_issue.md
@@ -1,5 +1,5 @@
 Use `github.create_issue` to create an issue.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_issue_comment.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_issue_comment.md
@@ -1,5 +1,5 @@
 Use `github.create_issue_comment` to add an issue or pull request comment.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_or_update_file.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_or_update_file.md
@@ -1,5 +1,5 @@
 Use `github.create_or_update_file` to create or update a repository file.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_pr_review.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_pr_review.md
@@ -1,5 +1,5 @@
 Use `github.create_pr_review` to create a pull request review.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_pull_request.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_pull_request.md
@@ -1,5 +1,5 @@
 Use `github.create_pull_request` to create a pull request.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_release.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_release.md
@@ -1,5 +1,5 @@
 Use `github.create_release` to create a repository release.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_repo.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/create_repo.md
@@ -1,5 +1,5 @@
 Use `github.create_repo` to create a GitHub repository.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/delete_file.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/delete_file.md
@@ -1,5 +1,5 @@
 Use `github.delete_file` to delete a repository file.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/fork_repo.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/fork_repo.md
@@ -1,5 +1,5 @@
 Use `github.fork_repo` to fork a repository.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_combined_status.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_combined_status.md
@@ -1,5 +1,5 @@
 Use `github.get_combined_status` to fetch combined commit status for a ref.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_file_content.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_file_content.md
@@ -1,5 +1,5 @@
 Use `github.get_file_content` to fetch repository file content metadata/content.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_issue.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_issue.md
@@ -1,5 +1,5 @@
 Use `github.get_issue` to fetch one issue or pull request by issue number.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_pull_request.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_pull_request.md
@@ -1,5 +1,5 @@
 Use `github.get_pull_request` to fetch one pull request.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_pull_request_files.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_pull_request_files.md
@@ -1,5 +1,5 @@
 Use `github.get_pull_request_files` to list files changed in a pull request.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_pull_request_reviews.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_pull_request_reviews.md
@@ -1,5 +1,5 @@
 Use `github.get_pull_request_reviews` to list pull request reviews.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_repo.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_repo.md
@@ -1,5 +1,5 @@
 Use `github.get_repo` to get a GitHub repository.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_workflow_runs.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/get_workflow_runs.md
@@ -1,5 +1,5 @@
 Use `github.get_workflow_runs` to list GitHub Actions workflow runs.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/handle_webhook.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/handle_webhook.md
@@ -1,5 +1,5 @@
 Use `github.handle_webhook` to normalize a GitHub webhook payload into system event intents.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability does not call GitHub; it normalizes a webhook payload already verified and supplied by the host.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_branches.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_branches.md
@@ -1,5 +1,5 @@
 Use `github.list_branches` to list repository branches.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_issue_comments.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_issue_comments.md
@@ -1,5 +1,5 @@
 Use `github.list_issue_comments` to list issue or pull request timeline comments.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_issues.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_issues.md
@@ -1,5 +1,5 @@
 Use `github.list_issues` to list issues in one repository.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_pull_request_comments.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_pull_request_comments.md
@@ -1,5 +1,5 @@
 Use `github.list_pull_request_comments` to list pull request review comments.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_pull_requests.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_pull_requests.md
@@ -1,5 +1,5 @@
 Use `github.list_pull_requests` to list pull requests in one repository.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_releases.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_releases.md
@@ -1,5 +1,5 @@
 Use `github.list_releases` to list repository releases.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_repos.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/list_repos.md
@@ -1,5 +1,5 @@
 Use `github.list_repos` to list public repositories for a user.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/merge_pull_request.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/merge_pull_request.md
@@ -1,5 +1,5 @@
 Use `github.merge_pull_request` to merge a pull request.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/reply_pull_request_comment.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/reply_pull_request_comment.md
@@ -1,5 +1,5 @@
 Use `github.reply_pull_request_comment` to reply to a pull request review comment. Include the pull request number and review comment id.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/search_code.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/search_code.md
@@ -1,5 +1,5 @@
 Use `github.search_code` to search code.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/search_issues_pull_requests.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/search_issues_pull_requests.md
@@ -1,5 +1,5 @@
 Use `github.search_issues_pull_requests` to search GitHub issues and pull requests.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/search_repositories.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/search_repositories.md
@@ -1,5 +1,5 @@
 Use `github.search_repositories` to search repositories.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability reads from the GitHub API through host HTTP egress and requires a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/prompts/github/trigger_workflow.md
+++ b/crates/ironclaw_first_party_extensions/assets/github/prompts/github/trigger_workflow.md
@@ -1,5 +1,5 @@
 Use `github.trigger_workflow` to dispatch a GitHub Actions workflow.
 
-Pass the required fields exactly as requested by the user. If the user provides a GitHub URL, extract the owner, repository, and number/path/ref fields before calling this capability.
+Use the exact JSON field names from this capability schema. If the user provides a GitHub URL, extract the owner and repo fields plus the schema-specific number, path, or ref key; for pull-request tools, use `pr_number`; for issue tools, use `issue_number`.
 
 This capability performs an external write through the GitHub API using host HTTP egress. It requires approval and a configured GitHub product-auth account.

--- a/crates/ironclaw_first_party_extensions/assets/github/wasm-src/src/lib.rs
+++ b/crates/ironclaw_first_party_extensions/assets/github/wasm-src/src/lib.rs
@@ -99,7 +99,7 @@ mod tests {
     use crate::dispatch::{action_from_context, execute_inner};
     use crate::exports::near::agent::tool::Guest;
     use crate::request::sanitize_host_error;
-    use crate::types::GitHubWebhookRequest;
+    use crate::types::{GitHubAction, GitHubWebhookRequest};
     use crate::validation::{normalize_ref_lookup, validate_repo_path};
     use crate::webhook::handle_webhook;
     use serde_json::json;
@@ -139,6 +139,39 @@ mod tests {
             .unwrap_err(),
             "invalid_parameters"
         );
+    }
+
+    #[test]
+    fn serde_accepts_common_pr_number_aliases() {
+        let action: GitHubAction = serde_json::from_value(json!({
+            "action": "get_pull_request",
+            "owner": "nearai",
+            "repo": "ironclaw",
+            "number": 4286
+        }))
+        .expect("number should be accepted as a pull request number alias");
+        assert!(matches!(
+            action,
+            GitHubAction::GetPullRequest {
+                pr_number: 4286,
+                ..
+            }
+        ));
+
+        let action: GitHubAction = serde_json::from_value(json!({
+            "action": "get_pull_request_files",
+            "owner": "nearai",
+            "repo": "ironclaw",
+            "pull_number": 4286
+        }))
+        .expect("pull_number should be accepted as a pull request number alias");
+        assert!(matches!(
+            action,
+            GitHubAction::GetPullRequestFiles {
+                pr_number: 4286,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/ironclaw_first_party_extensions/assets/github/wasm-src/src/types.rs
+++ b/crates/ironclaw_first_party_extensions/assets/github/wasm-src/src/types.rs
@@ -82,18 +82,21 @@ pub(crate) enum GitHubAction {
     GetPullRequest {
         owner: String,
         repo: String,
+        #[serde(alias = "number", alias = "pull_number")]
         pr_number: u32,
     },
     #[serde(rename = "get_pull_request_files")]
     GetPullRequestFiles {
         owner: String,
         repo: String,
+        #[serde(alias = "number", alias = "pull_number")]
         pr_number: u32,
     },
     #[serde(rename = "create_pr_review")]
     CreatePrReview {
         owner: String,
         repo: String,
+        #[serde(alias = "number", alias = "pull_number")]
         pr_number: u32,
         body: String,
         event: PrReviewEvent,
@@ -102,6 +105,7 @@ pub(crate) enum GitHubAction {
     ListPullRequestComments {
         owner: String,
         repo: String,
+        #[serde(alias = "number", alias = "pull_number")]
         pr_number: u32,
         page: Option<u32>,
         limit: Option<u32>,
@@ -110,6 +114,7 @@ pub(crate) enum GitHubAction {
     ReplyPullRequestComment {
         owner: String,
         repo: String,
+        #[serde(alias = "number", alias = "pull_number")]
         pr_number: u32,
         comment_id: u64,
         body: String,
@@ -118,6 +123,7 @@ pub(crate) enum GitHubAction {
     GetPullRequestReviews {
         owner: String,
         repo: String,
+        #[serde(alias = "number", alias = "pull_number")]
         pr_number: u32,
         page: Option<u32>,
         limit: Option<u32>,
@@ -132,6 +138,7 @@ pub(crate) enum GitHubAction {
     MergePullRequest {
         owner: String,
         repo: String,
+        #[serde(alias = "number", alias = "pull_number")]
         pr_number: u32,
         commit_title: Option<String>,
         commit_message: Option<String>,

--- a/crates/ironclaw_host_runtime/src/capability_catalog.rs
+++ b/crates/ironclaw_host_runtime/src/capability_catalog.rs
@@ -115,14 +115,14 @@ where
     Ok(())
 }
 
-async fn read_json_ref<F>(
+pub(crate) async fn read_json_ref<F>(
     fs: &F,
     root: &VirtualPath,
     reference: &CapabilityProfileSchemaRef,
     field: &'static str,
 ) -> Result<Value, HostRuntimeError>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + ?Sized,
 {
     let path = resolve_under_root(root, reference)?;
     let bytes = read_bounded(fs, &path, MAX_HOT_SCHEMA_BYTES, field).await?;
@@ -147,7 +147,7 @@ async fn read_text_ref<F>(
     reference: &CapabilityProfileSchemaRef,
 ) -> Result<String, HostRuntimeError>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + ?Sized,
 {
     let path = resolve_under_root(root, reference)?;
     let bytes = read_bounded(fs, &path, MAX_HOT_PROMPT_BYTES, "prompt_doc_ref").await?;
@@ -166,7 +166,7 @@ async fn read_bounded<F>(
     field: &'static str,
 ) -> Result<Vec<u8>, HostRuntimeError>
 where
-    F: RootFilesystem,
+    F: RootFilesystem + ?Sized,
 {
     let bytes = fs
         .read_file_bounded(path, max_bytes)

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -23,6 +23,7 @@ use ironclaw_capabilities::{
     CapabilitySpawnRequest, CapabilitySpawnResult,
 };
 use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry, SharedExtensionRegistry};
+use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     ApprovalRequestId, CapabilityDispatcher, CapabilityId, DispatchFailureKind, InvocationId,
     PackageSource, ResourceScope, RuntimeDispatchErrorKind, RuntimeKind, SecretHandle,
@@ -65,6 +66,7 @@ pub struct DefaultHostRuntime {
     process_store: Option<Arc<dyn ProcessStore>>,
     process_result_store: Option<Arc<dyn ProcessResultStore>>,
     process_cancellation_registry: Option<Arc<ProcessCancellationRegistry>>,
+    surface_filesystem: Option<Arc<dyn RootFilesystem>>,
     runtime_health: Option<Arc<dyn RuntimeBackendHealth>>,
     obligation_handler: Option<Arc<dyn CapabilityObligationHandler>>,
     surface_version: CapabilitySurfaceVersion,
@@ -128,6 +130,7 @@ impl DefaultHostRuntime {
             process_store: None,
             process_result_store: None,
             process_cancellation_registry: None,
+            surface_filesystem: None,
             runtime_health: None,
             obligation_handler: None,
             surface_version,
@@ -155,6 +158,11 @@ impl DefaultHostRuntime {
     /// capability invocation and visible-capability projection.
     pub fn with_runtime_policy(mut self, policy: EffectiveRuntimePolicy) -> Self {
         self.runtime_policy = policy;
+        self
+    }
+
+    pub fn with_surface_filesystem(mut self, filesystem: Arc<dyn RootFilesystem>) -> Self {
+        self.surface_filesystem = Some(filesystem);
         self
     }
 
@@ -654,14 +662,17 @@ impl HostRuntime for DefaultHostRuntime {
         request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, HostRuntimeError> {
         let registry = self.registry.snapshot();
-        CapabilityCatalog::new(
+        let catalog = CapabilityCatalog::new(
             &registry,
             self.authorizer.as_ref(),
             &self.surface_version,
             &self.runtime_policy,
-        )
-        .visible_capabilities(request)
-        .await
+        );
+        let catalog = match self.surface_filesystem.as_deref() {
+            Some(filesystem) => catalog.with_filesystem(filesystem),
+            None => catalog,
+        };
+        catalog.visible_capabilities(request).await
     }
 
     /// Best-effort cancellation fanout for active work in one scope.

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -495,6 +495,7 @@ where
             .runtime_policy
             .clone()
             .unwrap_or_else(local_testing_runtime_policy);
+        let surface_filesystem: Arc<dyn RootFilesystem> = self.filesystem.clone();
 
         let mut runtime = DefaultHostRuntime::from_shared_registry(
             Arc::clone(&self.registry),
@@ -503,6 +504,7 @@ where
             self.surface_version.clone(),
             runtime_policy,
         )
+        .with_surface_filesystem(surface_filesystem)
         .with_trust_policy_dyn(Arc::clone(&self.trust_policy))
         .with_process_manager(process_manager)
         .with_process_store(process_store)

--- a/crates/ironclaw_host_runtime/src/surface.rs
+++ b/crates/ironclaw_host_runtime/src/surface.rs
@@ -1,5 +1,6 @@
 use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
-use ironclaw_extensions::{CapabilityVisibility, ExtensionRegistry};
+use ironclaw_extensions::{CapabilityVisibility, ExtensionPackage, ExtensionRegistry};
+use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityGrant, Decision, EffectKind, ResourceEstimate, RuntimeKind,
     canonical_json_v1, runtime_policy::EffectiveRuntimePolicy, sha256_digest_token,
@@ -9,6 +10,7 @@ use serde_json::{Value, json};
 
 use crate::{
     CapabilitySurfaceVersion, HostRuntimeError, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    capability_catalog::read_json_ref,
     first_party_tools::{BUILTIN_FIRST_PARTY_PROVIDER, resolve_builtin_input_schema_ref},
     plan_capability,
 };
@@ -118,6 +120,7 @@ pub(crate) struct CapabilityCatalog<'a> {
     authorizer: &'a dyn TrustAwareCapabilityDispatchAuthorizer,
     base_version: &'a CapabilitySurfaceVersion,
     runtime_policy: &'a EffectiveRuntimePolicy,
+    filesystem: Option<&'a dyn RootFilesystem>,
 }
 
 impl<'a> CapabilityCatalog<'a> {
@@ -132,7 +135,13 @@ impl<'a> CapabilityCatalog<'a> {
             authorizer,
             base_version,
             runtime_policy,
+            filesystem: None,
         }
+    }
+
+    pub(crate) fn with_filesystem(mut self, filesystem: &'a dyn RootFilesystem) -> Self {
+        self.filesystem = Some(filesystem);
+        self
     }
 
     pub(crate) async fn visible_capabilities(
@@ -182,7 +191,7 @@ impl<'a> CapabilityCatalog<'a> {
             };
 
             capabilities.push(VisibleCapability {
-                descriptor: surface_descriptor(descriptor)?,
+                descriptor: self.surface_descriptor(descriptor).await?,
                 access,
                 estimated_resources: estimate,
             });
@@ -206,34 +215,80 @@ impl<'a> CapabilityCatalog<'a> {
             .unwrap_or(CapabilityVisibility::Model)
             == CapabilityVisibility::Model
     }
+
+    async fn surface_descriptor(
+        &self,
+        descriptor: &CapabilityDescriptor,
+    ) -> Result<CapabilityDescriptor, HostRuntimeError> {
+        let mut descriptor = descriptor.clone();
+        let reference = descriptor
+            .parameters_schema
+            .get("$ref")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
+        if descriptor.provider.as_str() == BUILTIN_FIRST_PARTY_PROVIDER {
+            let Some(reference) = reference else {
+                return Err(HostRuntimeError::invalid_request(format!(
+                    "built-in capability {} must publish from an input schema ref",
+                    descriptor.id
+                )));
+            };
+            descriptor.parameters_schema = resolve_builtin_input_schema_ref(&reference)
+                .ok_or_else(|| {
+                    HostRuntimeError::invalid_request(format!(
+                        "built-in capability {} references unknown input schema {}",
+                        descriptor.id, reference
+                    ))
+                })?;
+            return Ok(descriptor);
+        }
+
+        let Some(reference) = reference else {
+            return Ok(descriptor);
+        };
+        let Some(filesystem) = self.filesystem else {
+            return Ok(descriptor);
+        };
+        let Some(package) = self.registry.get_extension(&descriptor.provider) else {
+            return Ok(descriptor);
+        };
+        descriptor.parameters_schema =
+            resolve_package_input_schema_ref(filesystem, package, &descriptor.id, &reference)
+                .await?;
+        Ok(descriptor)
+    }
 }
 
-fn surface_descriptor(
-    descriptor: &CapabilityDescriptor,
-) -> Result<CapabilityDescriptor, HostRuntimeError> {
-    let mut descriptor = descriptor.clone();
-    if descriptor.provider.as_str() != BUILTIN_FIRST_PARTY_PROVIDER {
-        return Ok(descriptor);
-    }
-    let Some(reference) = descriptor
-        .parameters_schema
-        .get("$ref")
-        .and_then(Value::as_str)
-        .map(str::to_string)
+async fn resolve_package_input_schema_ref(
+    filesystem: &dyn RootFilesystem,
+    package: &ExtensionPackage,
+    capability_id: &ironclaw_host_api::CapabilityId,
+    reference: &str,
+) -> Result<Value, HostRuntimeError> {
+    let Some(declaration) = package
+        .manifest
+        .capabilities
+        .iter()
+        .find(|capability| &capability.id == capability_id)
     else {
         return Err(HostRuntimeError::invalid_request(format!(
-            "built-in capability {} must publish from an input schema ref",
-            descriptor.id
+            "capability {capability_id} is missing manifest declaration"
         )));
     };
-    descriptor.parameters_schema =
-        resolve_builtin_input_schema_ref(&reference).ok_or_else(|| {
-            HostRuntimeError::invalid_request(format!(
-                "built-in capability {} references unknown input schema {}",
-                descriptor.id, reference
-            ))
-        })?;
-    Ok(descriptor)
+    if declaration.input_schema_ref.as_str() != reference {
+        return Err(HostRuntimeError::invalid_request(format!(
+            "capability {capability_id} descriptor schema ref {reference} does not match manifest input schema ref {}",
+            declaration.input_schema_ref.as_str()
+        )));
+    }
+    read_json_ref(
+        filesystem,
+        &package.root,
+        &declaration.input_schema_ref,
+        "input_schema_ref",
+    )
+    .await
 }
 
 fn surface_version(
@@ -422,10 +477,31 @@ fn host_api_error(error: ironclaw_host_api::HostApiError) -> HostRuntimeError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironclaw_host_api::{CapabilityId, ExtensionId, PermissionMode, TrustClass};
+    use ironclaw_authorization::GrantAuthorizer;
+    use ironclaw_host_api::{
+        CapabilityId, ExtensionId, PermissionMode, TrustClass,
+        runtime_policy::{
+            ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy,
+            FilesystemBackendKind, NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+        },
+    };
 
-    #[test]
-    fn builtin_surface_descriptor_requires_input_schema_ref() {
+    fn test_runtime_policy() -> EffectiveRuntimePolicy {
+        EffectiveRuntimePolicy {
+            deployment: DeploymentMode::LocalSingleUser,
+            requested_profile: RuntimeProfile::SecureDefault,
+            resolved_profile: RuntimeProfile::SecureDefault,
+            filesystem_backend: FilesystemBackendKind::ScopedVirtual,
+            process_backend: ProcessBackendKind::None,
+            network_mode: NetworkMode::Deny,
+            secret_mode: SecretMode::Deny,
+            approval_policy: ApprovalPolicy::AskAlways,
+            audit_mode: AuditMode::LocalMinimal,
+        }
+    }
+
+    #[tokio::test]
+    async fn builtin_surface_descriptor_requires_input_schema_ref() {
         let descriptor = CapabilityDescriptor {
             id: CapabilityId::new("builtin.bad").unwrap(),
             provider: ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER).unwrap(),
@@ -438,8 +514,17 @@ mod tests {
             runtime_credentials: Vec::new(),
             resource_profile: None,
         };
+        let registry = ExtensionRegistry::new();
+        let runtime_policy = test_runtime_policy();
+        let surface_version = CapabilitySurfaceVersion::new("surface-v1").unwrap();
+        let authorizer = GrantAuthorizer;
+        let catalog =
+            CapabilityCatalog::new(&registry, &authorizer, &surface_version, &runtime_policy);
 
-        let error = surface_descriptor(&descriptor).expect_err("built-in schema refs are required");
+        let error = catalog
+            .surface_descriptor(&descriptor)
+            .await
+            .expect_err("built-in schema refs are required");
 
         assert!(
             matches!(error, HostRuntimeError::InvalidRequest { ref reason }

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -619,6 +619,44 @@ async fn visible_surface_resolves_builtin_first_party_input_schema_refs() {
 }
 
 #[tokio::test]
+async fn visible_surface_resolves_extension_package_input_schema_refs() {
+    let (_storage, fs, registry) = hot_catalog_fixture(
+        Some(
+            r#"{"type":"object","properties":{"message":{"type":"string"}},"required":["message"],"additionalProperties":false}"#,
+        ),
+        r#"{"type":"object"}"#,
+        "Prompt docs exist.",
+    );
+    let runtime =
+        runtime_with(registry, Arc::new(GrantAuthorizer)).with_surface_filesystem(Arc::new(fs));
+
+    let surface = runtime
+        .visible_capabilities(visible_request(context_with_grants([(
+            capability_id("echo.say"),
+            vec![EffectKind::DispatchCapability],
+        )])))
+        .await
+        .unwrap();
+
+    assert_eq!(visible_ids(&surface), vec![capability_id("echo.say")]);
+    let schema = &surface.capabilities[0].descriptor.parameters_schema;
+    assert!(
+        schema.get("$ref").is_none(),
+        "extension capabilities should expose concrete input schemas, got {schema:?}"
+    );
+    assert_eq!(schema["properties"]["message"]["type"], "string");
+
+    let validator = jsonschema::validator_for(schema).expect("resolved extension schema is valid");
+    validator
+        .validate(&json!({"message": "hello"}))
+        .expect("resolved schema should accept valid inputs");
+    assert!(
+        validator.validate(&json!({"body": "hello"})).is_err(),
+        "resolved schema should reject fields outside the capability input contract"
+    );
+}
+
+#[tokio::test]
 async fn visible_surface_filters_by_grants_provider_trust_and_preserves_registry_order() {
     let registry = registry_from_manifests([
         (ECHO_MANIFEST, "/system/extensions/echo"),

--- a/crates/ironclaw_loop_support/Cargo.toml
+++ b/crates/ironclaw_loop_support/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dashmap = "6"
 futures = "0.3"
 hex = "0.4.3"
+jsonschema = { version = "0.45", default-features = false }
 parking_lot = "0.12"
 tracing = "0.1"
 tokio = { version = "1", features = ["rt", "sync", "time"] }

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -30,9 +30,11 @@ use ironclaw_turns::{
 };
 use tokio::sync::Notify;
 
+mod provider_input;
 mod provider_validation;
 mod surface_snapshot;
 
+use self::provider_input::{normalize_provider_arguments, prepare_provider_arguments};
 use self::provider_validation::{
     PROVIDER_TOOL_NAME_MAX_BYTES, validate_provider_arguments, validate_provider_tool_call,
 };
@@ -1053,6 +1055,8 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
             .input_resolver
             .resolve_capability_input(&self.run_context, &request.input_ref)
             .await?;
+        let input =
+            prepare_provider_arguments(&input, &capability.parameters_schema, "capability input")?;
         let input = host_runtime_input_for_capability(&request.capability_id, input)?;
         let invocation_context = invocation_context_from_visible(
             &self.visible_request.context,
@@ -1203,226 +1207,6 @@ fn provider_schema_is_usable(schema: &serde_json::Value) -> bool {
     ) && object
         .get("properties")
         .is_none_or(serde_json::Value::is_object)
-}
-
-fn normalize_provider_arguments(
-    arguments: &serde_json::Value,
-    schema: &serde_json::Value,
-    label: &'static str,
-) -> Result<serde_json::Value, AgentLoopHostError> {
-    normalize_provider_value(arguments, schema, label)
-}
-
-fn normalize_provider_value(
-    value: &serde_json::Value,
-    schema: &serde_json::Value,
-    label: &'static str,
-) -> Result<serde_json::Value, AgentLoopHostError> {
-    // `oneOf` / `anyOf`: pick the variant whose declared `type` matches the
-    // value's shape, after attempting to coerce stringified containers. This
-    // lets schemas like `{ oneOf: [{type:object}, {type:array}] }` accept both
-    // a real array and a stringified array (e.g. an LLM that double-encoded
-    // the argument). Without this, the variant-less top-level schema slips
-    // through the type-matched branches below as a no-op and the stringified
-    // container is forwarded raw to the tool.
-    if let Some(variants) = schema_variants(schema) {
-        return normalize_one_of_variants(value, variants, label);
-    }
-
-    if schema_type_matches(schema, "object") {
-        let object_value = coerce_json_string(value, label)?;
-        let Some(object) = object_value.as_object() else {
-            if is_json_container_string(value) {
-                return Err(provider_coercion_error(label, "object"));
-            }
-            return Ok(object_value);
-        };
-        let Some(properties) = schema
-            .get("properties")
-            .and_then(serde_json::Value::as_object)
-        else {
-            return Ok(object_value);
-        };
-        let mut normalized = object.clone();
-        for (property, property_schema) in properties {
-            if let Some(property_value) = normalized.get(property).cloned() {
-                normalized.insert(
-                    property.clone(),
-                    normalize_provider_value(&property_value, property_schema, label)?,
-                );
-            }
-        }
-        return Ok(serde_json::Value::Object(normalized));
-    }
-
-    if schema_type_matches(schema, "array") {
-        let array_value = coerce_json_string(value, label)?;
-        let Some(array) = array_value.as_array() else {
-            if is_json_container_string(value) {
-                return Err(provider_coercion_error(label, "array"));
-            }
-            return Ok(array_value);
-        };
-        let Some(items) = schema.get("items") else {
-            return Ok(array_value);
-        };
-        return array
-            .iter()
-            .map(|item| normalize_provider_value(item, items, label))
-            .collect::<Result<Vec<_>, _>>()
-            .map(serde_json::Value::Array);
-    }
-
-    if schema_type_matches(schema, "integer") {
-        return coerce_integer_string(value, label);
-    }
-
-    if schema_type_matches(schema, "number") {
-        return coerce_number_string(value, label);
-    }
-
-    if schema_type_matches(schema, "boolean") {
-        return coerce_boolean_string(value, label);
-    }
-
-    Ok(value.clone())
-}
-
-fn schema_variants(schema: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
-    schema
-        .get("oneOf")
-        .or_else(|| schema.get("anyOf"))
-        .and_then(serde_json::Value::as_array)
-}
-
-fn normalize_one_of_variants(
-    value: &serde_json::Value,
-    variants: &[serde_json::Value],
-    label: &'static str,
-) -> Result<serde_json::Value, AgentLoopHostError> {
-    // Coerce stringified containers up front so we match by parsed shape.
-    // Coerce stringified containers up front so we match by parsed shape.
-    // Use `unwrap_or_else` rather than `?` so that an unparseable string
-    // (e.g. a plain string that starts with `{` or `[` but is not valid
-    // JSON) can still fall through to a `string` variant in the schema
-    // instead of producing a false-positive `InvalidInvocation` error.
-    let candidate = coerce_json_string(value, label).unwrap_or_else(|_| value.clone());
-    let shape = value_shape(&candidate);
-    for variant in variants {
-        // In JSON Schema every `integer` is also a valid `number`, so allow
-        // integer-shaped values to match `number` variants as well.
-        if schema_type_matches(variant, shape)
-            || (shape == "integer" && schema_type_matches(variant, "number"))
-        {
-            return normalize_provider_value(&candidate, variant, label);
-        }
-    }
-    // No declared variant matches the value's shape; leave the original value
-    // alone so the tool's own input validation can produce a precise error.
-    Ok(value.clone())
-}
-
-fn value_shape(value: &serde_json::Value) -> &'static str {
-    match value {
-        serde_json::Value::Object(_) => "object",
-        serde_json::Value::Array(_) => "array",
-        serde_json::Value::String(_) => "string",
-        serde_json::Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
-        serde_json::Value::Number(_) => "number",
-        serde_json::Value::Bool(_) => "boolean",
-        serde_json::Value::Null => "null",
-    }
-}
-
-fn schema_type_matches(schema: &serde_json::Value, expected: &str) -> bool {
-    match schema.get("type") {
-        Some(serde_json::Value::String(actual)) => actual == expected,
-        Some(serde_json::Value::Array(types)) => {
-            types.iter().any(|actual| actual.as_str() == Some(expected))
-        }
-        _ => false,
-    }
-}
-
-fn is_json_container_string(value: &serde_json::Value) -> bool {
-    value
-        .as_str()
-        .map(str::trim)
-        .is_some_and(|text| text.starts_with('{') || text.starts_with('['))
-}
-
-fn coerce_json_string(
-    value: &serde_json::Value,
-    label: &'static str,
-) -> Result<serde_json::Value, AgentLoopHostError> {
-    let Some(text) = value.as_str() else {
-        return Ok(value.clone());
-    };
-    let trimmed = text.trim();
-    if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
-        return Ok(value.clone());
-    }
-    serde_json::from_str(trimmed).map_err(|_| {
-        AgentLoopHostError::new(
-            AgentLoopHostErrorKind::InvalidInvocation,
-            format!("{label} could not be parsed as schema-declared JSON"),
-        )
-    })
-}
-
-fn coerce_integer_string(
-    value: &serde_json::Value,
-    label: &'static str,
-) -> Result<serde_json::Value, AgentLoopHostError> {
-    let Some(text) = value.as_str() else {
-        return Ok(value.clone());
-    };
-    let trimmed = text.trim();
-    if trimmed.is_empty() || trimmed.contains('.') || trimmed.contains('e') || trimmed.contains('E')
-    {
-        return Err(provider_coercion_error(label, "integer"));
-    }
-    let parsed = trimmed
-        .parse::<i64>()
-        .map_err(|_| provider_coercion_error(label, "integer"))?;
-    Ok(serde_json::Value::Number(parsed.into()))
-}
-
-fn coerce_number_string(
-    value: &serde_json::Value,
-    label: &'static str,
-) -> Result<serde_json::Value, AgentLoopHostError> {
-    let Some(text) = value.as_str() else {
-        return Ok(value.clone());
-    };
-    let parsed = text
-        .trim()
-        .parse::<f64>()
-        .map_err(|_| provider_coercion_error(label, "number"))?;
-    let number = serde_json::Number::from_f64(parsed)
-        .ok_or_else(|| provider_coercion_error(label, "number"))?;
-    Ok(serde_json::Value::Number(number))
-}
-
-fn coerce_boolean_string(
-    value: &serde_json::Value,
-    label: &'static str,
-) -> Result<serde_json::Value, AgentLoopHostError> {
-    let Some(text) = value.as_str() else {
-        return Ok(value.clone());
-    };
-    match text.trim().to_ascii_lowercase().as_str() {
-        "true" => Ok(serde_json::Value::Bool(true)),
-        "false" => Ok(serde_json::Value::Bool(false)),
-        _ => Err(provider_coercion_error(label, "boolean")),
-    }
-}
-
-fn provider_coercion_error(label: &'static str, expected: &'static str) -> AgentLoopHostError {
-    AgentLoopHostError::new(
-        AgentLoopHostErrorKind::InvalidInvocation,
-        format!("{label} could not be coerced to schema-declared {expected}"),
-    )
 }
 
 fn provider_tool_name(
@@ -2609,6 +2393,102 @@ mod tests {
         .expect("anyOf array variant should accept stringified array");
 
         assert_eq!(normalized, serde_json::json!({ "payload": ["a", "b"] }));
+    }
+
+    #[test]
+    fn provider_argument_preparation_validates_required_fields_before_dispatch() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "pr_number": { "type": "integer", "minimum": 1 }
+            },
+            "required": ["owner", "repo", "pr_number"]
+        });
+
+        let error = prepare_provider_arguments(
+            &serde_json::json!({ "owner": "nearai", "repo": "ironclaw" }),
+            &schema,
+            "provider arguments",
+        )
+        .expect_err("missing required fields should fail before dispatch");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        assert!(error.safe_summary.contains("schema validation"));
+    }
+
+    #[test]
+    fn provider_argument_preparation_rejects_unknown_fields_before_dispatch() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "pr_number": { "type": "integer" }
+            },
+            "required": ["owner", "repo", "pr_number"]
+        });
+
+        let error = prepare_provider_arguments(
+            &serde_json::json!({
+                "owner": "nearai",
+                "repo": "ironclaw",
+                "pr_number": 4286,
+                "number": 4286
+            }),
+            &schema,
+            "provider arguments",
+        )
+        .expect_err("additional properties should fail before dispatch");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        assert!(error.safe_summary.contains("schema validation"));
+    }
+
+    #[test]
+    fn provider_argument_preparation_validates_composed_object_schema_after_normalization() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "query": { "type": "string" },
+                "page": { "type": "integer", "minimum": 1 },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" }
+            },
+            "allOf": [
+                {
+                    "if": { "required": ["owner"] },
+                    "then": { "required": ["repo"] }
+                }
+            ],
+            "anyOf": [
+                { "required": ["query"] },
+                { "required": ["owner", "repo"] }
+            ]
+        });
+
+        let normalized = prepare_provider_arguments(
+            &serde_json::json!({ "query": "repo:nearai/ironclaw", "page": "2" }),
+            &schema,
+            "provider arguments",
+        )
+        .expect("top-level anyOf object schema should still normalize properties");
+        assert_eq!(
+            normalized,
+            serde_json::json!({ "query": "repo:nearai/ironclaw", "page": 2 })
+        );
+
+        let error = prepare_provider_arguments(
+            &serde_json::json!({ "owner": "nearai" }),
+            &schema,
+            "provider arguments",
+        )
+        .expect_err("composed schema constraints should fail before dispatch");
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
     }
 
     /// Regression for Gemini review comment: a plain string that starts with
@@ -3852,6 +3732,112 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runtime_capability_invocation_validates_schema_before_dispatch() {
+        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+        let provider_id = ExtensionId::new("demo").expect("valid provider id");
+        let mut visible = visible_capability(capability_id.clone(), provider_id.clone());
+        visible.descriptor.parameters_schema = serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "message": { "type": "string" }
+            },
+            "required": ["message"]
+        });
+        let runtime = Arc::new(RecordingHostRuntime::new(vec![visible]));
+        let mut context = execution_context("thread-runtime-schema-validation");
+        let run_context = loop_run_context(&context).await;
+        let loop_driver_extension =
+            loop_driver_execution_extension_id(&run_context).expect("valid extension id");
+        context.grants.grants.push(dispatch_capability_grant(
+            &capability_id,
+            &loop_driver_extension,
+        ));
+        let port = HostRuntimeLoopCapabilityPortFactory::new(
+            runtime.clone(),
+            visible_request(context).with_provider_trust(std::collections::BTreeMap::from([(
+                provider_id.clone(),
+                dispatch_trust_decision(),
+            )])),
+            Arc::new(JsonInputResolver(serde_json::json!({"number": 4286}))),
+            Arc::new(RecordingResultWriter::default()),
+            dummy_milestone_sink(),
+        )
+        .port_for_run_context(run_context);
+        let surface = port
+            .visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible capabilities load");
+
+        let error = port
+            .invoke_capability(CapabilityInvocation {
+                surface_version: surface.version,
+                capability_id,
+                input_ref: CapabilityInputRef::new("input:direct-invalid")
+                    .expect("valid input ref"),
+            })
+            .await
+            .expect_err("invalid direct input should fail before runtime dispatch");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        assert!(error.safe_summary.contains("schema validation"));
+        assert!(
+            runtime.take_requests().is_empty(),
+            "invalid direct input must not reach the runtime"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_capability_invocation_normalizes_input_before_dispatch() {
+        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+        let provider_id = ExtensionId::new("demo").expect("valid provider id");
+        let mut visible = visible_capability(capability_id.clone(), provider_id.clone());
+        visible.descriptor.parameters_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "limit": { "type": "integer" }
+            },
+            "required": ["limit"]
+        });
+        let runtime = Arc::new(RecordingHostRuntime::new(vec![visible]));
+        let mut context = execution_context("thread-runtime-input-normalization");
+        let run_context = loop_run_context(&context).await;
+        let loop_driver_extension =
+            loop_driver_execution_extension_id(&run_context).expect("valid extension id");
+        context.grants.grants.push(dispatch_capability_grant(
+            &capability_id,
+            &loop_driver_extension,
+        ));
+        let port = HostRuntimeLoopCapabilityPortFactory::new(
+            runtime.clone(),
+            visible_request(context).with_provider_trust(std::collections::BTreeMap::from([(
+                provider_id.clone(),
+                dispatch_trust_decision(),
+            )])),
+            Arc::new(JsonInputResolver(serde_json::json!({"limit": "10"}))),
+            Arc::new(RecordingResultWriter::default()),
+            dummy_milestone_sink(),
+        )
+        .port_for_run_context(run_context);
+        let surface = port
+            .visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible capabilities load");
+
+        port.invoke_capability(CapabilityInvocation {
+            surface_version: surface.version,
+            capability_id,
+            input_ref: CapabilityInputRef::new("input:direct-normalized").expect("valid input ref"),
+        })
+        .await
+        .expect("valid direct input should dispatch");
+
+        let requests = runtime.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].input, serde_json::json!({"limit": 10}));
+    }
+
+    #[tokio::test]
     async fn process_sandbox_capability_rejects_invalid_plan_before_runtime_spawn() {
         let capability_id =
             CapabilityId::new(ironclaw_process_sandbox::PROCESS_SANDBOX_CAPABILITY_ID)
@@ -4637,6 +4623,19 @@ mod tests {
             _input_ref: &CapabilityInputRef,
         ) -> Result<serde_json::Value, AgentLoopHostError> {
             Ok(serde_json::json!({"ok": true}))
+        }
+    }
+
+    struct JsonInputResolver(serde_json::Value);
+
+    #[async_trait]
+    impl LoopCapabilityInputResolver for JsonInputResolver {
+        async fn resolve_capability_input(
+            &self,
+            _run_context: &LoopRunContext,
+            _input_ref: &CapabilityInputRef,
+        ) -> Result<serde_json::Value, AgentLoopHostError> {
+            Ok(self.0.clone())
         }
     }
 

--- a/crates/ironclaw_loop_support/src/capability_port/provider_input.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/provider_input.rs
@@ -1,0 +1,264 @@
+use ironclaw_turns::run_profile::{AgentLoopHostError, AgentLoopHostErrorKind};
+
+pub(super) fn prepare_provider_arguments(
+    arguments: &serde_json::Value,
+    schema: &serde_json::Value,
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    let normalized = normalize_provider_arguments(arguments, schema, label)?;
+    validate_provider_arguments_schema(&normalized, schema, label)?;
+    Ok(normalized)
+}
+
+pub(super) fn normalize_provider_arguments(
+    arguments: &serde_json::Value,
+    schema: &serde_json::Value,
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    normalize_provider_value(arguments, schema, label)
+}
+
+fn normalize_provider_value(
+    value: &serde_json::Value,
+    schema: &serde_json::Value,
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    if schema_type_matches(schema, "object") {
+        let object_value = coerce_json_string(value, label)?;
+        let Some(object) = object_value.as_object() else {
+            if is_json_container_string(value) {
+                return Err(provider_coercion_error(label, "object"));
+            }
+            return Ok(object_value);
+        };
+        let Some(properties) = schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+        else {
+            return Ok(object_value);
+        };
+        let mut normalized = object.clone();
+        for (property, property_schema) in properties {
+            if let Some(property_value) = normalized.get(property).cloned() {
+                normalized.insert(
+                    property.clone(),
+                    normalize_provider_value(&property_value, property_schema, label)?,
+                );
+            }
+        }
+        return Ok(serde_json::Value::Object(normalized));
+    }
+
+    if schema_type_matches(schema, "array") {
+        let array_value = coerce_json_string(value, label)?;
+        let Some(array) = array_value.as_array() else {
+            if is_json_container_string(value) {
+                return Err(provider_coercion_error(label, "array"));
+            }
+            return Ok(array_value);
+        };
+        let Some(items) = schema.get("items") else {
+            return Ok(array_value);
+        };
+        return array
+            .iter()
+            .map(|item| normalize_provider_value(item, items, label))
+            .collect::<Result<Vec<_>, _>>()
+            .map(serde_json::Value::Array);
+    }
+
+    if schema_type_matches(schema, "integer") {
+        return coerce_integer_string(value, label);
+    }
+
+    if schema_type_matches(schema, "number") {
+        return coerce_number_string(value, label);
+    }
+
+    if schema_type_matches(schema, "boolean") {
+        return coerce_boolean_string(value, label);
+    }
+
+    // `oneOf` / `anyOf`: pick the variant whose declared `type` matches the
+    // value's shape, after attempting to coerce stringified containers. This
+    // covers variant schemas such as `{ oneOf: [{type:object}, {type:array}] }`.
+    // Object schemas that also carry `anyOf`/`allOf` are handled by the object
+    // branch above so declared properties are still normalized before full
+    // JSON Schema validation enforces the composed constraints.
+    if let Some(variants) = schema_variants(schema) {
+        return normalize_one_of_variants(value, variants, label);
+    }
+
+    Ok(value.clone())
+}
+
+fn validate_provider_arguments_schema(
+    arguments: &serde_json::Value,
+    schema: &serde_json::Value,
+    label: &'static str,
+) -> Result<(), AgentLoopHostError> {
+    if schema_is_unresolved_ref(schema) {
+        return Ok(());
+    }
+    let validator = jsonschema::validator_for(schema).map_err(|error| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::StaleSurface,
+            format!("{label} schema is invalid: {error}"),
+        )
+    })?;
+    if let Some(error) = validator.iter_errors(arguments).next() {
+        let instance_path = error.instance_path().as_str().to_string();
+        let schema_path = error.schema_path().as_str().to_string();
+        return Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidInvocation,
+            format!(
+                "{label} failed schema validation at instance path {instance_path} against schema path {schema_path}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn schema_is_unresolved_ref(schema: &serde_json::Value) -> bool {
+    schema.as_object().is_some_and(|object| {
+        object
+            .get("$ref")
+            .and_then(serde_json::Value::as_str)
+            .is_some()
+    })
+}
+
+fn schema_variants(schema: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    schema
+        .get("oneOf")
+        .or_else(|| schema.get("anyOf"))
+        .and_then(serde_json::Value::as_array)
+}
+
+fn normalize_one_of_variants(
+    value: &serde_json::Value,
+    variants: &[serde_json::Value],
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    // Use `unwrap_or_else` rather than `?` so that an unparseable string
+    // (e.g. a plain string that starts with `{` or `[` but is not valid
+    // JSON) can still fall through to a `string` variant in the schema
+    // instead of producing a false-positive `InvalidInvocation` error.
+    let candidate = coerce_json_string(value, label).unwrap_or_else(|_| value.clone());
+    let shape = value_shape(&candidate);
+    for variant in variants {
+        // In JSON Schema every `integer` is also a valid `number`, so allow
+        // integer-shaped values to match `number` variants as well.
+        if schema_type_matches(variant, shape)
+            || (shape == "integer" && schema_type_matches(variant, "number"))
+        {
+            return normalize_provider_value(&candidate, variant, label);
+        }
+    }
+    // No declared variant matches the value's shape; leave the original value
+    // alone so full schema validation can produce the authoritative error.
+    Ok(value.clone())
+}
+
+fn value_shape(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Object(_) => "object",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Null => "null",
+    }
+}
+
+fn schema_type_matches(schema: &serde_json::Value, expected: &str) -> bool {
+    match schema.get("type") {
+        Some(serde_json::Value::String(actual)) => actual == expected,
+        Some(serde_json::Value::Array(types)) => {
+            types.iter().any(|actual| actual.as_str() == Some(expected))
+        }
+        _ => false,
+    }
+}
+
+fn is_json_container_string(value: &serde_json::Value) -> bool {
+    value
+        .as_str()
+        .map(str::trim)
+        .is_some_and(|text| text.starts_with('{') || text.starts_with('['))
+}
+
+fn coerce_json_string(
+    value: &serde_json::Value,
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    let Some(text) = value.as_str() else {
+        return Ok(value.clone());
+    };
+    let trimmed = text.trim();
+    if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
+        return Ok(value.clone());
+    }
+    serde_json::from_str(trimmed).map_err(|_| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidInvocation,
+            format!("{label} could not be parsed as schema-declared JSON"),
+        )
+    })
+}
+
+fn coerce_integer_string(
+    value: &serde_json::Value,
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    let Some(text) = value.as_str() else {
+        return Ok(value.clone());
+    };
+    let trimmed = text.trim();
+    if trimmed.is_empty() || trimmed.contains('.') || trimmed.contains('e') || trimmed.contains('E')
+    {
+        return Err(provider_coercion_error(label, "integer"));
+    }
+    let parsed = trimmed
+        .parse::<i64>()
+        .map_err(|_| provider_coercion_error(label, "integer"))?;
+    Ok(serde_json::Value::Number(parsed.into()))
+}
+
+fn coerce_number_string(
+    value: &serde_json::Value,
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    let Some(text) = value.as_str() else {
+        return Ok(value.clone());
+    };
+    let parsed = text
+        .trim()
+        .parse::<f64>()
+        .map_err(|_| provider_coercion_error(label, "number"))?;
+    let number = serde_json::Number::from_f64(parsed)
+        .ok_or_else(|| provider_coercion_error(label, "number"))?;
+    Ok(serde_json::Value::Number(number))
+}
+
+fn coerce_boolean_string(
+    value: &serde_json::Value,
+    label: &'static str,
+) -> Result<serde_json::Value, AgentLoopHostError> {
+    let Some(text) = value.as_str() else {
+        return Ok(value.clone());
+    };
+    match text.trim().to_ascii_lowercase().as_str() {
+        "true" => Ok(serde_json::Value::Bool(true)),
+        "false" => Ok(serde_json::Value::Bool(false)),
+        _ => Err(provider_coercion_error(label, "boolean")),
+    }
+}
+
+fn provider_coercion_error(label: &'static str, expected: &'static str) -> AgentLoopHostError {
+    AgentLoopHostError::new(
+        AgentLoopHostErrorKind::InvalidInvocation,
+        format!("{label} could not be coerced to schema-declared {expected}"),
+    )
+}

--- a/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
+++ b/crates/ironclaw_loop_support/src/capability_port/surface_snapshot.rs
@@ -210,7 +210,7 @@ impl RuntimeSurfaceCapabilitySnapshot {
                 "provider tool call was not advertised to the model",
             ));
         }
-        let normalized_arguments = super::normalize_provider_arguments(
+        let normalized_arguments = super::prepare_provider_arguments(
             &tool_call.arguments,
             &self.parameters_schema,
             "provider arguments",

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -307,62 +307,103 @@ fn bundled_extension_package(
 }
 
 fn github_assets() -> Vec<AvailableExtensionAsset> {
+    macro_rules! github_schema_asset {
+        ($path:literal) => {
+            bytes_asset(
+                concat!("schemas/github/", $path),
+                include_bytes!(concat!(
+                    "../../ironclaw_first_party_extensions/assets/github/schemas/github/",
+                    $path
+                )),
+            )
+        };
+    }
+    macro_rules! github_prompt_asset {
+        ($path:literal) => {
+            bytes_asset(
+                concat!("prompts/github/", $path),
+                include_bytes!(concat!(
+                    "../../ironclaw_first_party_extensions/assets/github/prompts/github/",
+                    $path
+                )),
+            )
+        };
+    }
+
     vec![
         bytes_asset("manifest.toml", GITHUB_MANIFEST.as_bytes()),
-        bytes_asset(
-            "schemas/github/search_issues.input.v1.json",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/schemas/github/search_issues.input.v1.json"
-            ),
-        ),
-        bytes_asset(
-            "schemas/github/search_issues.output.v1.json",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/schemas/github/search_issues.output.v1.json"
-            ),
-        ),
-        bytes_asset(
-            "schemas/github/get_issue.input.v1.json",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/schemas/github/get_issue.input.v1.json"
-            ),
-        ),
-        bytes_asset(
-            "schemas/github/get_issue.output.v1.json",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/schemas/github/get_issue.output.v1.json"
-            ),
-        ),
-        bytes_asset(
-            "schemas/github/comment_issue.input.v1.json",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/schemas/github/comment_issue.input.v1.json"
-            ),
-        ),
-        bytes_asset(
-            "schemas/github/comment_issue.output.v1.json",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/schemas/github/comment_issue.output.v1.json"
-            ),
-        ),
-        bytes_asset(
-            "prompts/github/search_issues.md",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/prompts/github/search_issues.md"
-            ),
-        ),
-        bytes_asset(
-            "prompts/github/get_issue.md",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/prompts/github/get_issue.md"
-            ),
-        ),
-        bytes_asset(
-            "prompts/github/comment_issue.md",
-            include_bytes!(
-                "../../ironclaw_first_party_extensions/assets/github/prompts/github/comment_issue.md"
-            ),
-        ),
+        github_schema_asset!("comment_issue.input.v1.json"),
+        github_schema_asset!("comment_issue.output.v1.json"),
+        github_schema_asset!("create_branch.input.v1.json"),
+        github_schema_asset!("create_issue.input.v1.json"),
+        github_schema_asset!("create_issue_comment.input.v1.json"),
+        github_schema_asset!("create_or_update_file.input.v1.json"),
+        github_schema_asset!("create_pr_review.input.v1.json"),
+        github_schema_asset!("create_pull_request.input.v1.json"),
+        github_schema_asset!("create_release.input.v1.json"),
+        github_schema_asset!("create_repo.input.v1.json"),
+        github_schema_asset!("delete_file.input.v1.json"),
+        github_schema_asset!("fork_repo.input.v1.json"),
+        github_schema_asset!("get_combined_status.input.v1.json"),
+        github_schema_asset!("get_file_content.input.v1.json"),
+        github_schema_asset!("get_issue.input.v1.json"),
+        github_schema_asset!("get_issue.output.v1.json"),
+        github_schema_asset!("get_pull_request.input.v1.json"),
+        github_schema_asset!("get_pull_request_files.input.v1.json"),
+        github_schema_asset!("get_pull_request_reviews.input.v1.json"),
+        github_schema_asset!("get_repo.input.v1.json"),
+        github_schema_asset!("get_workflow_runs.input.v1.json"),
+        github_schema_asset!("handle_webhook.input.v1.json"),
+        github_schema_asset!("list_branches.input.v1.json"),
+        github_schema_asset!("list_issue_comments.input.v1.json"),
+        github_schema_asset!("list_issues.input.v1.json"),
+        github_schema_asset!("list_pull_request_comments.input.v1.json"),
+        github_schema_asset!("list_pull_requests.input.v1.json"),
+        github_schema_asset!("list_releases.input.v1.json"),
+        github_schema_asset!("list_repos.input.v1.json"),
+        github_schema_asset!("merge_pull_request.input.v1.json"),
+        github_schema_asset!("raw_output.v1.json"),
+        github_schema_asset!("reply_pull_request_comment.input.v1.json"),
+        github_schema_asset!("search_code.input.v1.json"),
+        github_schema_asset!("search_issues.input.v1.json"),
+        github_schema_asset!("search_issues.output.v1.json"),
+        github_schema_asset!("search_issues_pull_requests.input.v1.json"),
+        github_schema_asset!("search_repositories.input.v1.json"),
+        github_schema_asset!("trigger_workflow.input.v1.json"),
+        github_prompt_asset!("comment_issue.md"),
+        github_prompt_asset!("create_branch.md"),
+        github_prompt_asset!("create_issue.md"),
+        github_prompt_asset!("create_issue_comment.md"),
+        github_prompt_asset!("create_or_update_file.md"),
+        github_prompt_asset!("create_pr_review.md"),
+        github_prompt_asset!("create_pull_request.md"),
+        github_prompt_asset!("create_release.md"),
+        github_prompt_asset!("create_repo.md"),
+        github_prompt_asset!("delete_file.md"),
+        github_prompt_asset!("fork_repo.md"),
+        github_prompt_asset!("get_combined_status.md"),
+        github_prompt_asset!("get_file_content.md"),
+        github_prompt_asset!("get_issue.md"),
+        github_prompt_asset!("get_pull_request.md"),
+        github_prompt_asset!("get_pull_request_files.md"),
+        github_prompt_asset!("get_pull_request_reviews.md"),
+        github_prompt_asset!("get_repo.md"),
+        github_prompt_asset!("get_workflow_runs.md"),
+        github_prompt_asset!("handle_webhook.md"),
+        github_prompt_asset!("list_branches.md"),
+        github_prompt_asset!("list_issue_comments.md"),
+        github_prompt_asset!("list_issues.md"),
+        github_prompt_asset!("list_pull_request_comments.md"),
+        github_prompt_asset!("list_pull_requests.md"),
+        github_prompt_asset!("list_releases.md"),
+        github_prompt_asset!("list_repos.md"),
+        github_prompt_asset!("merge_pull_request.md"),
+        github_prompt_asset!("reply_pull_request_comment.md"),
+        github_prompt_asset!("search_code.md"),
+        github_prompt_asset!("search_issues.md"),
+        github_prompt_asset!("search_issues_pull_requests.md"),
+        github_prompt_asset!("search_repositories.md"),
+        github_prompt_asset!("trigger_workflow.md"),
         bytes_asset("wasm/github_tool.wasm", GITHUB_WASM_MODULE),
     ]
 }
@@ -1027,7 +1068,14 @@ mod tests {
     fn bundled_first_party_manifest_asset_refs_are_packaged() {
         let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
 
-        for extension_id in ["notion", "web-access", "nearai", "google-calendar", "gmail"] {
+        for extension_id in [
+            "github",
+            "notion",
+            "web-access",
+            "nearai",
+            "google-calendar",
+            "gmail",
+        ] {
             let package_ref =
                 LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id).unwrap();
             let package = catalog.resolve(&package_ref).unwrap();
@@ -1060,6 +1108,37 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[tokio::test]
+    async fn materialize_bundled_github_writes_manifest_schema_refs() {
+        let fs = InMemoryBackend::default();
+        let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
+        let package_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, "github").unwrap();
+        let github = catalog.resolve(&package_ref).unwrap();
+
+        materialize_available_extension(&fs, github).await.unwrap();
+
+        let get_repo_schema = fs
+            .read_file(
+                &VirtualPath::new(
+                    "/system/extensions/github/schemas/github/get_repo.input.v1.json",
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            std::str::from_utf8(&get_repo_schema)
+                .unwrap()
+                .contains("GitHub get_repo input")
+        );
+        fs.read_file(
+            &VirtualPath::new("/system/extensions/github/prompts/github/get_repo.md").unwrap(),
+        )
+        .await
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Validate runtime provider tool-call arguments against their JSON Schema after existing schema-guided coercion, before dispatching to capability runtimes.
- Validate direct/replayed runtime capability invocations against the same schema before WASM dispatch, closing the bypass shown by the repeated `invoke_json` logs.
- Resolve first-party extension input-schema `$ref`s when building production visible capability surfaces, so GitHub capabilities expose concrete fields instead of opaque schema pointers.
- Package all bundled GitHub manifest-declared schema and prompt assets so `/system/extensions/github/...` contains files like `schemas/github/get_repo.input.v1.json` after materialization.
- Extract provider argument preparation into a focused loop-support module instead of growing capability_port.rs.
- Accept common GitHub PR number aliases (`number`, `pull_number`) at the WASM deserialization boundary while keeping schemas canonical.
- Tighten GitHub prompt docs to tell models to use exact schema field names such as `pr_number` and `issue_number`.

## Root cause

There were three related schema gaps.

First, provider argument preparation normalized scalar/container shapes but did not enforce advertised schema constraints like `required`, `additionalProperties`, `anyOf`, `allOf`, or conditionals before runtime dispatch. Provider tool calls were fixed first; direct/replayed capability invocations also needed the same validation because they resolve an `input_ref` immediately before dispatch. Without that second gate, invalid GitHub PR calls could still reach the guest and collapse into a generic `InputEncode` failure.

Second, the visible capability surface only expanded `$ref` input schemas for the built-in provider. Installed first-party extension packages such as GitHub still exposed `parameters_schema` as `{"$ref": ...}`. That meant the model saw only a pointer rather than concrete fields, and loop-support intentionally skipped validation for unresolved top-level refs because it had no schema registry. Production host-runtime composition now provides the filesystem-backed package resolver, so extension surfaces publish concrete schemas before model tool definitions are built.

Third, the bundled GitHub available-extension asset list only materialized the older issue/search schemas and prompts. The manifest now declares many more capabilities, including `github.get_repo`, but files such as `/system/extensions/github/schemas/github/get_repo.input.v1.json` were never written. Once visible-surface `$ref` resolution became active, any turn, even `hello`, failed during surface preparation before user input mattered. The bundled GitHub asset list now includes every manifest-declared schema and prompt ref, and tests cover both asset-list completeness and materialization of the exact `get_repo` schema path.

## Validation

- `cargo test --manifest-path crates/ironclaw_first_party_extensions/assets/github/wasm-src/Cargo.toml --lib`
- `cargo test -p ironclaw_first_party_extensions`
- `cargo test -p ironclaw_reborn_composition bundled_first_party_manifest_asset_refs_are_packaged -- --nocapture`
- `cargo test -p ironclaw_reborn_composition materialize_bundled_github_writes_manifest_schema_refs -- --nocapture`
- `cargo test -p ironclaw_host_runtime builtin_surface_descriptor_requires_input_schema_ref -- --nocapture`
- `cargo test -p ironclaw_host_runtime --test tool_surface_contract`
- `cargo test -p ironclaw_loop_support`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `git diff --check`

Note: the focused `ironclaw_reborn_composition` test commands currently emit pre-existing dead-code warnings from `product_auth_durable`; the targeted tests pass.
