### PR TITLE
PR16: Add trigger poller harness coverage

### DIFF
--- a/crates/ironclaw_triggers/Cargo.toml
+++ b/crates/ironclaw_triggers/Cargo.toml
@@ -24,6 +24,7 @@ tokio-postgres = { version = "0.7", optional = true }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "2"
+tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 ulid = { version = "1", features = ["serde"] }
 

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -677,18 +677,15 @@ pub trait TriggerRepository: Send + Sync {
     /// This has the same trusted-poller-only authorization constraints as
     /// [`TriggerRepository::list_active_triggers`]. The cursor must be derived
     /// from a previous trusted active scan result, not from user input.
+    ///
+    /// Cursor pagination is required for every repository implementation so the
+    /// poller cannot advance successfully on the first tick and then fail when
+    /// it resumes from a stored cursor.
     async fn list_active_triggers_after(
         &self,
         after: Option<ActiveTriggerScanCursor>,
         limit: usize,
-    ) -> Result<Vec<TriggerRecord>, TriggerError> {
-        if after.is_some() {
-            return Err(TriggerError::Backend {
-                reason: "trigger repository does not support active scan cursors".to_string(),
-            });
-        }
-        self.list_active_triggers(limit).await
-    }
+    ) -> Result<Vec<TriggerRecord>, TriggerError>;
 
     async fn claim_due_fire(
         &self,

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1,7 +1,7 @@
 //! Scheduled trigger domain contracts for IronClaw Reborn.
 //!
 //! This crate owns trigger records, source-provider evaluation, deterministic
-//! fire identity, and in-memory test behavior. Durable persistence, poller
+//! fire identity, trusted poller scope, and in-memory test behavior. Poller
 //! lifecycle wiring, first-party capabilities, and outbound delivery are owned
 //! by later slices.
 
@@ -33,6 +33,63 @@ const MAX_DUE_TRIGGER_POLL_LIMIT: usize = 128;
 const IDENTITY_VERSION_LABEL: &str = "ironclaw.trigger-fire.v1";
 const ROUTE_THREAD_DOMAIN: &str = "route-thread";
 const EXTERNAL_EVENT_DOMAIN: &str = "external-event";
+
+mod trusted_poller {
+    use core::marker::PhantomData;
+
+    use super::private;
+
+    /// Sealed host-only token proving the caller already crossed the trusted
+    /// trigger poller boundary.
+    ///
+    /// The witness is crate-local, zero-sized, and unconstructible by
+    /// capability or adapter code. Trigger-owned poller code can mint it
+    /// without adding lifecycle wiring or a separate composition hook.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct TrustedTriggerPollerWitness(PhantomData<private::TrustedTriggerPollerSeal>);
+
+    pub(crate) fn mint() -> TrustedTriggerPollerWitness {
+        TrustedTriggerPollerWitness(PhantomData)
+    }
+}
+
+#[allow(dead_code)]
+mod private {
+    pub(crate) struct TrustedTriggerPollerSeal;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TrustedTriggerPollerScope(trusted_poller::TrustedTriggerPollerWitness);
+
+impl TrustedTriggerPollerScope {
+    pub(crate) fn mint() -> Self {
+        Self(trusted_poller::mint())
+    }
+}
+
+#[async_trait]
+trait TrustedTriggerPollerRepository: TriggerRepository {
+    async fn list_due_triggers_trusted(
+        &self,
+        _scope: TrustedTriggerPollerScope,
+        now: Timestamp,
+        limit: usize,
+    ) -> Result<Vec<TriggerRecord>, TriggerError> {
+        self.list_due_triggers(now, limit).await
+    }
+
+    async fn list_active_triggers_after_trusted(
+        &self,
+        _scope: TrustedTriggerPollerScope,
+        after: Option<ActiveTriggerScanCursor>,
+        limit: usize,
+    ) -> Result<Vec<TriggerRecord>, TriggerError> {
+        self.list_active_triggers_after(after, limit).await
+    }
+}
+
+#[async_trait]
+impl<T> TrustedTriggerPollerRepository for T where T: TriggerRepository + ?Sized {}
 
 #[derive(Debug, Error)]
 pub enum TriggerError {
@@ -500,6 +557,13 @@ pub struct ClearActiveFireRequest {
     pub run_id: TurnRunId,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveTriggerScanCursor {
+    pub active_fire_slot: Timestamp,
+    pub tenant_id: TenantId,
+    pub trigger_id: TriggerId,
+}
+
 #[async_trait]
 pub trait TriggerSourceProvider: Send + Sync {
     async fn evaluate(
@@ -564,9 +628,10 @@ pub trait TriggerRepository: Send + Sync {
     ///
     /// # Safety / Authorization
     ///
-    /// This is a global query and must not be used for tenant-scoped or
-    /// user-facing list operations. Callers must preserve each returned
-    /// record's tenant/user authority when materializing a fire.
+    /// This is a global repository query and must not be surfaced as a
+    /// tenant-scoped or user-facing capability. Host-owned poller code should
+    /// prefer the sealed trusted poller scope helper so the call site stays
+    /// explicit about crossing the boundary.
     async fn list_due_triggers(
         &self,
         now: Timestamp,
@@ -577,12 +642,31 @@ pub trait TriggerRepository: Send + Sync {
     ///
     /// # Safety / Authorization
     ///
-    /// This is a global query and must not be used for tenant-scoped or
-    /// user-facing list operations. It exists so the poller can clear completed
-    /// active fires before future schedule slots become eligible. Callers must
-    /// preserve each returned record's tenant authority when checking or
-    /// clearing active fire state.
+    /// This is a global repository query and must not be surfaced as a
+    /// tenant-scoped or user-facing capability. Host-owned poller code should
+    /// prefer the sealed trusted poller scope helper so the call site stays
+    /// explicit about crossing the boundary.
     async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError>;
+
+    /// Lists active trigger fires after a previous scan cursor.
+    ///
+    /// # Safety / Authorization
+    ///
+    /// This has the same trusted-poller-only authorization constraints as
+    /// [`TriggerRepository::list_active_triggers`]. The cursor must be derived
+    /// from a previous trusted active scan result, not from user input.
+    async fn list_active_triggers_after(
+        &self,
+        after: Option<ActiveTriggerScanCursor>,
+        limit: usize,
+    ) -> Result<Vec<TriggerRecord>, TriggerError> {
+        if after.is_some() {
+            return Err(TriggerError::Backend {
+                reason: "trigger repository does not support active scan cursors".to_string(),
+            });
+        }
+        self.list_active_triggers(limit).await
+    }
 
     async fn claim_due_fire(
         &self,
@@ -745,6 +829,14 @@ impl TriggerRepository for InMemoryTriggerRepository {
     }
 
     async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError> {
+        self.list_active_triggers_after(None, limit).await
+    }
+
+    async fn list_active_triggers_after(
+        &self,
+        after: Option<ActiveTriggerScanCursor>,
+        limit: usize,
+    ) -> Result<Vec<TriggerRecord>, TriggerError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
@@ -761,6 +853,19 @@ impl TriggerRepository for InMemoryTriggerRepository {
                     key.clone(),
                 ))
             })
+            .filter(
+                |(active_fire_slot, tenant_id, trigger_id, _)| match after.as_ref() {
+                    Some(cursor) => {
+                        (*active_fire_slot, tenant_id, *trigger_id)
+                            > (
+                                cursor.active_fire_slot,
+                                &cursor.tenant_id,
+                                cursor.trigger_id,
+                            )
+                    }
+                    None => true,
+                },
+            )
             .collect::<Vec<_>>();
         selected_keys.sort_by_key(|(active_fire_slot, tenant_id, trigger_id, _)| {
             (*active_fire_slot, tenant_id.clone(), *trigger_id)
@@ -1263,6 +1368,12 @@ mod tests {
             TriggerExternalEventId::new("event-1"),
             Err(TriggerError::InvalidFireIdentityComponent { .. })
         ));
+    }
+
+    #[test]
+    fn trusted_trigger_poller_scope_is_host_minted_and_zero_sized() {
+        let scope = TrustedTriggerPollerScope::mint();
+        assert_eq!(core::mem::size_of_val(&scope), 0);
     }
 
     #[test]

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -559,9 +559,31 @@ pub struct ClearActiveFireRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActiveTriggerScanCursor {
-    pub active_fire_slot: Timestamp,
-    pub tenant_id: TenantId,
-    pub trigger_id: TriggerId,
+    active_fire_slot: Timestamp,
+    tenant_id: TenantId,
+    trigger_id: TriggerId,
+}
+
+impl ActiveTriggerScanCursor {
+    pub fn from_active_record(record: &TriggerRecord) -> Option<Self> {
+        Some(Self {
+            active_fire_slot: record.active_fire_slot?,
+            tenant_id: record.tenant_id.clone(),
+            trigger_id: record.trigger_id,
+        })
+    }
+
+    pub fn active_fire_slot(&self) -> Timestamp {
+        self.active_fire_slot
+    }
+
+    pub fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+
+    pub fn trigger_id(&self) -> TriggerId {
+        self.trigger_id
+    }
 }
 
 #[async_trait]
@@ -858,9 +880,9 @@ impl TriggerRepository for InMemoryTriggerRepository {
                     Some(cursor) => {
                         (*active_fire_slot, tenant_id, *trigger_id)
                             > (
-                                cursor.active_fire_slot,
-                                &cursor.tenant_id,
-                                cursor.trigger_id,
+                                cursor.active_fire_slot(),
+                                cursor.tenant_id(),
+                                cursor.trigger_id(),
                             )
                     }
                     None => true,

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -1,7 +1,7 @@
 //! Scheduled trigger domain contracts for IronClaw Reborn.
 //!
 //! This crate owns trigger records, source-provider evaluation, deterministic
-//! fire identity, trusted poller scope, and in-memory test behavior. Poller
+//! fire identity, trusted poller call sites, and in-memory test behavior. Poller
 //! lifecycle wiring, first-party capabilities, and outbound delivery are owned
 //! by later slices.
 
@@ -33,63 +33,6 @@ const MAX_DUE_TRIGGER_POLL_LIMIT: usize = 128;
 const IDENTITY_VERSION_LABEL: &str = "ironclaw.trigger-fire.v1";
 const ROUTE_THREAD_DOMAIN: &str = "route-thread";
 const EXTERNAL_EVENT_DOMAIN: &str = "external-event";
-
-mod trusted_poller {
-    use core::marker::PhantomData;
-
-    use super::private;
-
-    /// Sealed host-only token proving the caller already crossed the trusted
-    /// trigger poller boundary.
-    ///
-    /// The witness is crate-local, zero-sized, and unconstructible by
-    /// capability or adapter code. Trigger-owned poller code can mint it
-    /// without adding lifecycle wiring or a separate composition hook.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub(crate) struct TrustedTriggerPollerWitness(PhantomData<private::TrustedTriggerPollerSeal>);
-
-    pub(crate) fn mint() -> TrustedTriggerPollerWitness {
-        TrustedTriggerPollerWitness(PhantomData)
-    }
-}
-
-#[allow(dead_code)]
-mod private {
-    pub(crate) struct TrustedTriggerPollerSeal;
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TrustedTriggerPollerScope(trusted_poller::TrustedTriggerPollerWitness);
-
-impl TrustedTriggerPollerScope {
-    pub(crate) fn mint() -> Self {
-        Self(trusted_poller::mint())
-    }
-}
-
-#[async_trait]
-trait TrustedTriggerPollerRepository: TriggerRepository {
-    async fn list_due_triggers_trusted(
-        &self,
-        _scope: TrustedTriggerPollerScope,
-        now: Timestamp,
-        limit: usize,
-    ) -> Result<Vec<TriggerRecord>, TriggerError> {
-        self.list_due_triggers(now, limit).await
-    }
-
-    async fn list_active_triggers_after_trusted(
-        &self,
-        _scope: TrustedTriggerPollerScope,
-        after: Option<ActiveTriggerScanCursor>,
-        limit: usize,
-    ) -> Result<Vec<TriggerRecord>, TriggerError> {
-        self.list_active_triggers_after(after, limit).await
-    }
-}
-
-#[async_trait]
-impl<T> TrustedTriggerPollerRepository for T where T: TriggerRepository + ?Sized {}
 
 #[derive(Debug, Error)]
 pub enum TriggerError {
@@ -652,8 +595,8 @@ pub trait TriggerRepository: Send + Sync {
     ///
     /// This is a global repository query and must not be surfaced as a
     /// tenant-scoped or user-facing capability. Host-owned poller code should
-    /// prefer the sealed trusted poller scope helper so the call site stays
-    /// explicit about crossing the boundary.
+    /// keep this call on explicit worker-local trusted poller call sites so the
+    /// trust boundary remains visible.
     async fn list_due_triggers(
         &self,
         now: Timestamp,
@@ -666,8 +609,8 @@ pub trait TriggerRepository: Send + Sync {
     ///
     /// This is a global repository query and must not be surfaced as a
     /// tenant-scoped or user-facing capability. Host-owned poller code should
-    /// prefer the sealed trusted poller scope helper so the call site stays
-    /// explicit about crossing the boundary.
+    /// keep this call on explicit worker-local trusted poller call sites so the
+    /// trust boundary remains visible.
     async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError>;
 
     /// Lists active trigger fires after a previous scan cursor.
@@ -860,39 +803,41 @@ impl TriggerRepository for InMemoryTriggerRepository {
             return Ok(Vec::new());
         }
         let limit = limit.min(MAX_DUE_TRIGGER_POLL_LIMIT);
-        let state = self.lock_state()?;
-        let mut selected_keys = state
-            .iter()
-            .filter_map(|(key, record)| {
-                let active_fire_slot = record.active_fire_slot?;
-                Some((
-                    active_fire_slot,
-                    record.tenant_id.clone(),
-                    record.trigger_id,
-                    key.clone(),
-                ))
-            })
-            .filter(
-                |(active_fire_slot, tenant_id, trigger_id, _)| match after.as_ref() {
-                    Some(cursor) => {
-                        (*active_fire_slot, tenant_id, *trigger_id)
-                            > (
-                                cursor.active_fire_slot(),
-                                cursor.tenant_id(),
-                                cursor.trigger_id(),
-                            )
-                    }
-                    None => true,
-                },
-            )
-            .collect::<Vec<_>>();
-        selected_keys.sort_by_key(|(active_fire_slot, tenant_id, trigger_id, _)| {
+        let mut selected_records = {
+            let state = self.lock_state()?;
+            state
+                .values()
+                .filter_map(|record| {
+                    let active_fire_slot = record.active_fire_slot?;
+                    Some((
+                        active_fire_slot,
+                        record.tenant_id.clone(),
+                        record.trigger_id,
+                        record.clone(),
+                    ))
+                })
+                .filter(
+                    |(active_fire_slot, tenant_id, trigger_id, _record)| match after.as_ref() {
+                        Some(cursor) => {
+                            (*active_fire_slot, tenant_id, *trigger_id)
+                                > (
+                                    cursor.active_fire_slot(),
+                                    cursor.tenant_id(),
+                                    cursor.trigger_id(),
+                                )
+                        }
+                        None => true,
+                    },
+                )
+                .collect::<Vec<_>>()
+        };
+        selected_records.sort_by_key(|(active_fire_slot, tenant_id, trigger_id, _record)| {
             (*active_fire_slot, tenant_id.clone(), *trigger_id)
         });
-        selected_keys.truncate(limit);
-        Ok(selected_keys
+        selected_records.truncate(limit);
+        Ok(selected_records
             .into_iter()
-            .filter_map(|(_, _, _, key)| state.get(&key).cloned())
+            .map(|(_, _, _, record)| record)
             .collect())
     }
 
@@ -1387,12 +1332,6 @@ mod tests {
             TriggerExternalEventId::new("event-1"),
             Err(TriggerError::InvalidFireIdentityComponent { .. })
         ));
-    }
-
-    #[test]
-    fn trusted_trigger_poller_scope_is_host_minted_and_zero_sized() {
-        let scope = TrustedTriggerPollerScope::mint();
-        assert_eq!(core::mem::size_of_val(&scope), 0);
     }
 
     #[test]

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -134,6 +134,16 @@ impl LibSqlTriggerRepository {
             )
             .await
             .map_err(|error| backend_error("create trigger tenant list index", error))?;
+            conn.execute(
+                &format!(
+                    "CREATE INDEX IF NOT EXISTS trigger_records_active_fire_slot_idx
+                     ON {TRIGGER_TABLE} (active_fire_slot, tenant_id, trigger_id)
+                     WHERE active_fire_slot IS NOT NULL"
+                ),
+                (),
+            )
+            .await
+            .map_err(|error| backend_error("create trigger active scan index", error))?;
             Ok::<(), TriggerError>(())
         }
         .await;
@@ -324,9 +334,9 @@ impl TriggerRepository for LibSqlTriggerRepository {
                          LIMIT ?4"
                     ),
                     params![
-                        fmt_ts(&cursor.active_fire_slot),
-                        cursor.tenant_id.as_str(),
-                        cursor.trigger_id.to_string(),
+                        fmt_ts(&cursor.active_fire_slot()),
+                        cursor.tenant_id().as_str(),
+                        cursor.trigger_id().to_string(),
                         limit as i64,
                     ],
                 )

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -14,8 +14,8 @@ use libsql::params;
 
 #[cfg(feature = "libsql")]
 use crate::{
-    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, ClearActiveFireRequest,
-    FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
+    ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire,
+    ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
     FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerCompletionPolicy, TriggerError,
     TriggerId, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
     TriggerSourceKind, TriggerState, reject_failed_result_after_active_run,
@@ -295,24 +295,58 @@ impl TriggerRepository for LibSqlTriggerRepository {
     }
 
     async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError> {
+        self.list_active_triggers_after(None, limit).await
+    }
+
+    async fn list_active_triggers_after(
+        &self,
+        after: Option<ActiveTriggerScanCursor>,
+        limit: usize,
+    ) -> Result<Vec<TriggerRecord>, TriggerError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
         let limit = limit.min(super::MAX_DUE_TRIGGER_POLL_LIMIT);
         let conn = self.connect().await?;
-        let mut rows = conn
-            .query(
-                &format!(
-                    "SELECT {TRIGGER_COLUMNS}
-                     FROM {TRIGGER_TABLE}
-                     WHERE active_fire_slot IS NOT NULL
-                     ORDER BY active_fire_slot, tenant_id, trigger_id
-                     LIMIT ?1"
-                ),
-                params![limit as i64],
-            )
-            .await
-            .map_err(|error| backend_error("query active trigger records", error))?;
+        let mut rows = match after {
+            Some(cursor) => {
+                conn.query(
+                    &format!(
+                        "SELECT {TRIGGER_COLUMNS}
+                         FROM {TRIGGER_TABLE}
+                         WHERE active_fire_slot IS NOT NULL
+                           AND (
+                             active_fire_slot > ?1
+                             OR (active_fire_slot = ?1 AND tenant_id > ?2)
+                             OR (active_fire_slot = ?1 AND tenant_id = ?2 AND trigger_id > ?3)
+                           )
+                         ORDER BY active_fire_slot, tenant_id, trigger_id
+                         LIMIT ?4"
+                    ),
+                    params![
+                        fmt_ts(&cursor.active_fire_slot),
+                        cursor.tenant_id.as_str(),
+                        cursor.trigger_id.to_string(),
+                        limit as i64,
+                    ],
+                )
+                .await
+            }
+            None => {
+                conn.query(
+                    &format!(
+                        "SELECT {TRIGGER_COLUMNS}
+                         FROM {TRIGGER_TABLE}
+                         WHERE active_fire_slot IS NOT NULL
+                         ORDER BY active_fire_slot, tenant_id, trigger_id
+                         LIMIT ?1"
+                    ),
+                    params![limit as i64],
+                )
+                .await
+            }
+        }
+        .map_err(|error| backend_error("query active trigger records", error))?;
         let mut records = Vec::new();
         loop {
             match rows.next().await {

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -250,8 +250,8 @@ impl TriggerRepository for PostgresTriggerRepository {
         let client = self.connect().await?;
         let rows = match after {
             Some(cursor) => {
-                let active_fire_slot = fmt_ts(&cursor.active_fire_slot);
-                let trigger_id = cursor.trigger_id.to_string();
+                let active_fire_slot = fmt_ts(&cursor.active_fire_slot());
+                let trigger_id = cursor.trigger_id().to_string();
                 client
                     .query(
                         &format!(
@@ -268,7 +268,7 @@ impl TriggerRepository for PostgresTriggerRepository {
                         ),
                         &[
                             &active_fire_slot,
-                            &cursor.tenant_id.as_str(),
+                            &cursor.tenant_id().as_str(),
                             &trigger_id,
                             &limit,
                         ],
@@ -913,4 +913,8 @@ CREATE INDEX IF NOT EXISTS trigger_records_state_next_run_at_idx
 
 CREATE INDEX IF NOT EXISTS trigger_records_tenant_created_at_idx
     ON trigger_records (tenant_id, created_at, trigger_id);
+
+CREATE INDEX IF NOT EXISTS trigger_records_active_fire_slot_idx
+    ON trigger_records (active_fire_slot, tenant_id, trigger_id)
+    WHERE active_fire_slot IS NOT NULL;
 "#;

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -5,8 +5,8 @@ use ironclaw_turns::TurnRunId;
 use tokio_postgres::Row;
 
 use crate::{
-    ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire, ClearActiveFireRequest,
-    FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
+    ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire,
+    ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
     FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerCompletionPolicy, TriggerError,
     TriggerId, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
     TriggerSourceKind, TriggerState, reject_failed_result_after_active_run,
@@ -235,24 +235,62 @@ impl TriggerRepository for PostgresTriggerRepository {
     }
 
     async fn list_active_triggers(&self, limit: usize) -> Result<Vec<TriggerRecord>, TriggerError> {
+        self.list_active_triggers_after(None, limit).await
+    }
+
+    async fn list_active_triggers_after(
+        &self,
+        after: Option<ActiveTriggerScanCursor>,
+        limit: usize,
+    ) -> Result<Vec<TriggerRecord>, TriggerError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
         let limit = limit.min(super::MAX_DUE_TRIGGER_POLL_LIMIT) as i64;
         let client = self.connect().await?;
-        let rows = client
-            .query(
-                &format!(
-                    "SELECT {TRIGGER_COLUMNS}
-                     FROM {TRIGGER_TABLE}
-                     WHERE active_fire_slot IS NOT NULL
-                     ORDER BY active_fire_slot, tenant_id, trigger_id
-                     LIMIT $1"
-                ),
-                &[&limit],
-            )
-            .await
-            .map_err(|error| backend_error("query active trigger records", error))?;
+        let rows = match after {
+            Some(cursor) => {
+                let active_fire_slot = fmt_ts(&cursor.active_fire_slot);
+                let trigger_id = cursor.trigger_id.to_string();
+                client
+                    .query(
+                        &format!(
+                            "SELECT {TRIGGER_COLUMNS}
+                             FROM {TRIGGER_TABLE}
+                             WHERE active_fire_slot IS NOT NULL
+                               AND (
+                                 active_fire_slot > $1
+                                 OR (active_fire_slot = $1 AND tenant_id > $2)
+                                 OR (active_fire_slot = $1 AND tenant_id = $2 AND trigger_id > $3)
+                               )
+                             ORDER BY active_fire_slot, tenant_id, trigger_id
+                             LIMIT $4"
+                        ),
+                        &[
+                            &active_fire_slot,
+                            &cursor.tenant_id.as_str(),
+                            &trigger_id,
+                            &limit,
+                        ],
+                    )
+                    .await
+            }
+            None => {
+                client
+                    .query(
+                        &format!(
+                            "SELECT {TRIGGER_COLUMNS}
+                             FROM {TRIGGER_TABLE}
+                             WHERE active_fire_slot IS NOT NULL
+                             ORDER BY active_fire_slot, tenant_id, trigger_id
+                             LIMIT $1"
+                        ),
+                        &[&limit],
+                    )
+                    .await
+            }
+        }
+        .map_err(|error| backend_error("query active trigger records", error))?;
         rows.into_iter().map(|row| row_to_record(&row)).collect()
     }
 

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -1,16 +1,20 @@
 // arch-exempt: large_file, deterministic tick core + ports + reports + tests co-located for PR15, plan #4303
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use ironclaw_host_api::{TenantId, Timestamp};
 use ironclaw_turns::TurnRunId;
 
 use crate::{
-    ClaimDueFireOutcome, ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest,
-    FirePermanentFailedRequest, FireReplayedRequest, FireRetryableFailedRequest,
-    FireTerminalFailedRequest, TriggerError, TriggerFire, TriggerId, TriggerInboundContentRef,
-    TriggerPromptMaterializer, TriggerRecord, TriggerRepository, TriggerSourceProvider,
+    ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClearActiveFireRequest,
+    FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
+    FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerError, TriggerFire, TriggerId,
+    TriggerInboundContentRef, TriggerPromptMaterializer, TriggerRecord, TriggerRepository,
+    TriggerSourceProvider, TrustedTriggerPollerRepository, TrustedTriggerPollerScope,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,6 +67,7 @@ pub struct TriggerPollerWorkerDeps {
 pub struct TriggerPollerWorker {
     config: TriggerPollerWorkerConfig,
     deps: TriggerPollerWorkerDeps,
+    active_scan_cursor: Mutex<Option<ActiveTriggerScanCursor>>,
 }
 
 impl TriggerPollerWorker {
@@ -71,7 +76,11 @@ impl TriggerPollerWorker {
         deps: TriggerPollerWorkerDeps,
     ) -> Result<Self, TriggerError> {
         config.validate()?;
-        Ok(Self { config, deps })
+        Ok(Self {
+            config,
+            deps,
+            active_scan_cursor: Mutex::new(None),
+        })
     }
 
     pub async fn tick_once(&self, now: Timestamp) -> Result<TriggerPollerTickReport, TriggerError> {
@@ -80,7 +89,12 @@ impl TriggerPollerWorker {
         let due_records = self
             .deps
             .repository
-            .list_due_triggers(now, self.config.fires_per_tick)
+            .as_ref()
+            .list_due_triggers_trusted(
+                TrustedTriggerPollerScope::mint(),
+                now,
+                self.config.fires_per_tick,
+            )
             .await?;
         report.due_records = due_records.len();
         for record in due_records {
@@ -116,12 +130,33 @@ impl TriggerPollerWorker {
         &self,
         report: &mut TriggerPollerTickReport,
     ) -> Result<(), TriggerError> {
-        let active_records = self
+        let mut cursor = self.active_scan_cursor()?;
+        let mut active_records = self
             .deps
             .repository
-            .list_active_triggers(self.config.fires_per_tick)
+            .as_ref()
+            .list_active_triggers_after_trusted(
+                TrustedTriggerPollerScope::mint(),
+                cursor.clone(),
+                self.config.fires_per_tick,
+            )
             .await?;
+        if active_records.is_empty() && cursor.is_some() {
+            cursor = None;
+            active_records = self
+                .deps
+                .repository
+                .as_ref()
+                .list_active_triggers_after_trusted(
+                    TrustedTriggerPollerScope::mint(),
+                    cursor.clone(),
+                    self.config.fires_per_tick,
+                )
+                .await?;
+        }
         report.active_records = active_records.len();
+        let mut next_cursor = cursor;
+        let mut advance_cursor = true;
         for record in active_records {
             debug_assert!(
                 record.active_fire_slot.is_some(),
@@ -129,6 +164,11 @@ impl TriggerPollerWorker {
             );
             let Some(fire_slot) = record.active_fire_slot else {
                 continue;
+            };
+            let record_cursor = ActiveTriggerScanCursor {
+                active_fire_slot: fire_slot,
+                tenant_id: record.tenant_id.clone(),
+                trigger_id: record.trigger_id,
             };
             let Some(run_id) = record.active_run_ref else {
                 // Keep claim-only rows blocked until recovery has lease or age
@@ -142,6 +182,9 @@ impl TriggerPollerWorker {
                         active_run_ref: None,
                     },
                 });
+                if advance_cursor {
+                    next_cursor = Some(record_cursor);
+                }
                 continue;
             };
             let state = match self
@@ -166,6 +209,7 @@ impl TriggerPollerWorker {
                             reason: TriggerPollerFailureReason::ActiveRunLookup,
                         },
                     });
+                    advance_cursor = false;
                     continue;
                 }
             };
@@ -212,7 +256,33 @@ impl TriggerPollerWorker {
                     });
                 }
             }
+            if advance_cursor {
+                next_cursor = Some(record_cursor);
+            }
         }
+        self.set_active_scan_cursor(next_cursor)?;
+        Ok(())
+    }
+
+    fn active_scan_cursor(&self) -> Result<Option<ActiveTriggerScanCursor>, TriggerError> {
+        self.active_scan_cursor
+            .lock()
+            .map(|cursor| cursor.clone())
+            .map_err(|_| TriggerError::Backend {
+                reason: "trigger poller active scan cursor mutex poisoned".to_string(),
+            })
+    }
+
+    fn set_active_scan_cursor(
+        &self,
+        cursor: Option<ActiveTriggerScanCursor>,
+    ) -> Result<(), TriggerError> {
+        *self
+            .active_scan_cursor
+            .lock()
+            .map_err(|_| TriggerError::Backend {
+                reason: "trigger poller active scan cursor mutex poisoned".to_string(),
+            })? = cursor;
         Ok(())
     }
 
@@ -818,8 +888,26 @@ mod tests {
         submitter: Arc<RecordingSubmitter>,
         active_lookup: Arc<RecordingActiveRunLookup>,
     ) -> TriggerPollerWorker {
-        TriggerPollerWorker::new(
+        worker_with_config(
+            repo,
+            source_provider,
+            materializer,
+            submitter,
+            active_lookup,
             TriggerPollerWorkerConfig::default(),
+        )
+    }
+
+    fn worker_with_config(
+        repo: Arc<dyn TriggerRepository>,
+        source_provider: Arc<dyn TriggerSourceProvider>,
+        materializer: Arc<RecordingMaterializer>,
+        submitter: Arc<RecordingSubmitter>,
+        active_lookup: Arc<RecordingActiveRunLookup>,
+        config: TriggerPollerWorkerConfig,
+    ) -> TriggerPollerWorker {
+        TriggerPollerWorker::new(
+            config,
             TriggerPollerWorkerDeps {
                 repository: repo,
                 source_provider,
@@ -1070,6 +1158,180 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tick_active_cleanup_cursor_reaches_terminal_rows_after_blocked_page() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let first_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let second_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let third_id = TriggerId::parse("01J00000000000000000000001").expect("ulid");
+        let fourth_id = TriggerId::parse("01J00000000000000000000002").expect("ulid");
+        let terminal_id = TriggerId::parse("01J00000000000000000000003").expect("ulid");
+        let first_slot = ts(1_704_067_200);
+        let second_slot = ts(1_704_067_260);
+        let third_slot = ts(1_704_067_320);
+        let fourth_slot = ts(1_704_067_380);
+        let terminal_slot = ts(1_704_067_440);
+        let first_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let second_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+        let third_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5c").expect("run id");
+        let fourth_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5d").expect("run id");
+        let terminal_run =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5e").expect("run id");
+
+        let mut first = sample_record(first_id, tenant("tenant-a"), ts(1_704_067_800));
+        first.active_fire_slot = Some(first_slot);
+        first.active_run_ref = Some(first_run);
+        let mut second = sample_record(second_id, tenant("tenant-a"), ts(1_704_067_800));
+        second.active_fire_slot = Some(second_slot);
+        second.active_run_ref = Some(second_run);
+        let mut third = sample_record(third_id, tenant("tenant-a"), ts(1_704_067_800));
+        third.active_fire_slot = Some(third_slot);
+        third.active_run_ref = Some(third_run);
+        let mut fourth = sample_record(fourth_id, tenant("tenant-a"), ts(1_704_067_800));
+        fourth.active_fire_slot = Some(fourth_slot);
+        fourth.active_run_ref = Some(fourth_run);
+        let mut terminal = sample_record(terminal_id, tenant("tenant-a"), ts(1_704_067_800));
+        terminal.active_fire_slot = Some(terminal_slot);
+        terminal.active_run_ref = Some(terminal_run);
+        repo.upsert_trigger(first).await.expect("insert first");
+        repo.upsert_trigger(second).await.expect("insert second");
+        repo.upsert_trigger(third).await.expect("insert third");
+        repo.upsert_trigger(fourth).await.expect("insert fourth");
+        repo.upsert_trigger(terminal)
+            .await
+            .expect("insert terminal");
+
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_results(vec![
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Terminal),
+        ]));
+        let worker = worker_with_config(
+            repo.clone(),
+            Arc::new(crate::ScheduleTriggerSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            active_lookup.clone(),
+            TriggerPollerWorkerConfig {
+                fires_per_tick: 2,
+                ..TriggerPollerWorkerConfig::default()
+            },
+        );
+
+        let first_report = worker.tick_once(first_slot).await.expect("first tick");
+        assert_eq!(first_report.active_records, 2);
+        assert!(
+            first_report
+                .results
+                .iter()
+                .all(|result| result.trigger_id != terminal_id)
+        );
+
+        let second_report = worker.tick_once(second_slot).await.expect("second tick");
+        assert_eq!(second_report.active_records, 2);
+        assert!(
+            second_report
+                .results
+                .iter()
+                .all(|result| result.trigger_id != terminal_id)
+        );
+
+        let third_report = worker.tick_once(third_slot).await.expect("third tick");
+        assert_eq!(third_report.active_records, 1);
+        assert!(
+            third_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == terminal_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::ClearedTerminalActive {
+                            run_id: terminal_run
+                        })
+        );
+        assert_eq!(active_lookup.requests().len(), 5);
+        let persisted = repo
+            .get_trigger(tenant("tenant-a"), terminal_id)
+            .await
+            .expect("load terminal")
+            .expect("terminal record");
+        assert_eq!(persisted.active_fire_slot, None);
+        assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_retries_active_page_when_clear_fails_before_advancing_cursor() {
+        let first_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let second_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let third_id = TriggerId::parse("01J00000000000000000000001").expect("ulid");
+        let first_slot = ts(1_704_067_200);
+        let second_slot = ts(1_704_067_260);
+        let third_slot = ts(1_704_067_320);
+        let first_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let second_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+        let third_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5c").expect("run id");
+
+        let mut first = sample_record(first_id, tenant("tenant-a"), ts(1_704_067_800));
+        first.active_fire_slot = Some(first_slot);
+        first.active_run_ref = Some(first_run);
+        let mut second = sample_record(second_id, tenant("tenant-a"), ts(1_704_067_800));
+        second.active_fire_slot = Some(second_slot);
+        second.active_run_ref = Some(second_run);
+        let mut third = sample_record(third_id, tenant("tenant-a"), ts(1_704_067_800));
+        third.active_fire_slot = Some(third_slot);
+        third.active_run_ref = Some(third_run);
+
+        let repo = Arc::new(ActiveClearFailsOnceRepository::new(
+            vec![first, second, third],
+            second_id,
+        ));
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_results(vec![
+            Ok(TriggerActiveRunState::Terminal),
+            Ok(TriggerActiveRunState::Terminal),
+            Ok(TriggerActiveRunState::Terminal),
+            Ok(TriggerActiveRunState::Terminal),
+        ]));
+        let worker = worker_with_config(
+            repo.clone(),
+            Arc::new(crate::ScheduleTriggerSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            active_lookup,
+            TriggerPollerWorkerConfig {
+                fires_per_tick: 2,
+                ..TriggerPollerWorkerConfig::default()
+            },
+        );
+
+        let first_error = worker.tick_once(first_slot).await.expect_err("clear fails");
+        assert!(matches!(first_error, TriggerError::Backend { .. }));
+
+        let second_report = worker.tick_once(second_slot).await.expect("retry tick");
+
+        assert_eq!(second_report.active_records, 2);
+        assert_eq!(
+            repo.clear_requests(),
+            vec![first_id, second_id, second_id, third_id]
+        );
+        assert!(
+            second_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == second_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::ClearedTerminalActive { run_id: second_run })
+        );
+        assert!(
+            second_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == third_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::ClearedTerminalActive { run_id: third_run })
+        );
+    }
+
+    #[tokio::test]
     async fn tick_reports_terminal_active_clear_race() {
         let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
         let fire_slot = ts(1_704_067_200);
@@ -1199,6 +1461,191 @@ mod tests {
                 .any(|result| result.trigger_id == due_id
                     && result.outcome
                         == TriggerPollerFireOutcome::Submitted { run_id: due_run_id })
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_retries_active_lookup_error_before_advancing_cursor() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let failed_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let terminal_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let failed_slot = ts(1_704_067_200);
+        let terminal_slot = ts(1_704_067_260);
+        let failed_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let terminal_run =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+        let mut failed = sample_record(failed_id, tenant("tenant-a"), ts(1_704_067_800));
+        failed.active_fire_slot = Some(failed_slot);
+        failed.active_run_ref = Some(failed_run);
+        let mut terminal = sample_record(terminal_id, tenant("tenant-a"), ts(1_704_067_800));
+        terminal.active_fire_slot = Some(terminal_slot);
+        terminal.active_run_ref = Some(terminal_run);
+        repo.upsert_trigger(failed).await.expect("insert failed");
+        repo.upsert_trigger(terminal)
+            .await
+            .expect("insert terminal");
+
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_results(vec![
+            Err(TriggerError::Backend {
+                reason: "turn state unavailable".to_string(),
+            }),
+            Ok(TriggerActiveRunState::Terminal),
+            Ok(TriggerActiveRunState::Terminal),
+        ]));
+        let worker = worker_with_config(
+            repo.clone(),
+            Arc::new(crate::ScheduleTriggerSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            active_lookup.clone(),
+            TriggerPollerWorkerConfig {
+                fires_per_tick: 2,
+                ..TriggerPollerWorkerConfig::default()
+            },
+        );
+
+        let first_report = worker.tick_once(failed_slot).await.expect("first tick");
+        assert!(
+            first_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == failed_id
+                    && matches!(
+                        result.outcome,
+                        TriggerPollerFireOutcome::ActiveRunLookupFailed { .. }
+                    ))
+        );
+        assert!(
+            first_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == terminal_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::ClearedTerminalActive {
+                            run_id: terminal_run
+                        })
+        );
+
+        let second_report = worker.tick_once(terminal_slot).await.expect("second tick");
+        assert_eq!(second_report.active_records, 1);
+        assert!(
+            second_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == failed_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::ClearedTerminalActive { run_id: failed_run })
+        );
+        assert_eq!(
+            active_lookup
+                .requests()
+                .into_iter()
+                .map(|request| request.trigger_id)
+                .collect::<Vec<_>>(),
+            vec![failed_id, terminal_id, failed_id]
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_replayed_submit_can_be_cleared_on_a_later_tick_without_stopping_due_work() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let replayed_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let due_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let replayed_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        repo.upsert_trigger(sample_record(replayed_id, tenant("tenant-a"), fire_slot))
+            .await
+            .expect("insert replayed candidate");
+        let first_worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Replayed {
+                    original_run_id: replayed_run_id,
+                    replayed_at: ts(1_704_067_205),
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::default()),
+        );
+
+        let first_report = first_worker.tick_once(fire_slot).await.expect("first tick");
+        assert_eq!(
+            first_report.results.last().map(|result| &result.outcome),
+            Some(&TriggerPollerFireOutcome::Replayed {
+                original_run_id: replayed_run_id
+            })
+        );
+        let persisted_after_replay = repo
+            .get_trigger(tenant("tenant-a"), replayed_id)
+            .await
+            .expect("reload replayed")
+            .expect("replayed record");
+        assert_eq!(persisted_after_replay.active_fire_slot, Some(fire_slot));
+        assert_eq!(persisted_after_replay.active_run_ref, Some(replayed_run_id));
+
+        repo.upsert_trigger(sample_record(due_id, tenant("tenant-a"), fire_slot))
+            .await
+            .expect("insert later due");
+
+        let second_due_run_id =
+            TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5c").expect("run id");
+        let second_worker = worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(vec![Ok(
+                TrustedTriggerFireSubmitOutcome::Accepted {
+                    run_id: second_due_run_id,
+                    submitted_at: fire_slot,
+                },
+            )])),
+            Arc::new(RecordingActiveRunLookup::with_results(vec![Ok(
+                TriggerActiveRunState::Terminal,
+            )])),
+        );
+
+        let second_report = second_worker
+            .tick_once(fire_slot)
+            .await
+            .expect("second tick");
+
+        assert_eq!(second_report.active_records, 1);
+        assert_eq!(second_report.due_records, 1);
+        assert!(
+            second_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == replayed_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::ClearedTerminalActive {
+                            run_id: replayed_run_id,
+                        })
+        );
+        assert!(
+            second_report
+                .results
+                .iter()
+                .any(|result| result.trigger_id == due_id
+                    && result.outcome
+                        == TriggerPollerFireOutcome::Submitted {
+                            run_id: second_due_run_id
+                        })
+        );
+        assert_eq!(
+            repo.get_trigger(tenant("tenant-a"), replayed_id)
+                .await
+                .expect("reload replayed after cleanup")
+                .expect("replayed record after cleanup")
+                .active_fire_slot,
+            None
+        );
+        assert_eq!(
+            repo.get_trigger(tenant("tenant-a"), replayed_id)
+                .await
+                .expect("reload replayed after cleanup")
+                .expect("replayed record after cleanup")
+                .active_run_ref,
+            None
         );
     }
 
@@ -2115,6 +2562,191 @@ mod tests {
             _request: ClearActiveFireRequest,
         ) -> Result<Option<TriggerRecord>, TriggerError> {
             Ok(None)
+        }
+    }
+
+    struct ActiveClearFailsOnceRepository {
+        records: Mutex<Vec<TriggerRecord>>,
+        clear_requests: Mutex<Vec<TriggerId>>,
+        fail_once_trigger_id: TriggerId,
+        failed_once: Mutex<bool>,
+    }
+
+    impl ActiveClearFailsOnceRepository {
+        fn new(records: Vec<TriggerRecord>, fail_once_trigger_id: TriggerId) -> Self {
+            Self {
+                records: Mutex::new(records),
+                clear_requests: Mutex::new(Vec::new()),
+                fail_once_trigger_id,
+                failed_once: Mutex::new(false),
+            }
+        }
+
+        fn clear_requests(&self) -> Vec<TriggerId> {
+            self.clear_requests
+                .lock()
+                .expect("clear requests lock")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl TriggerRepository for ActiveClearFailsOnceRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("active-clear-fails-once repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_active_triggers(
+            &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            after: Option<ActiveTriggerScanCursor>,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            let mut records = self
+                .records
+                .lock()
+                .expect("active records lock")
+                .iter()
+                .filter_map(|record| {
+                    let active_fire_slot = record.active_fire_slot?;
+                    Some((
+                        active_fire_slot,
+                        record.tenant_id.clone(),
+                        record.trigger_id,
+                        record.clone(),
+                    ))
+                })
+                .filter(
+                    |(active_fire_slot, tenant_id, trigger_id, _)| match after.as_ref() {
+                        Some(cursor) => {
+                            (*active_fire_slot, tenant_id, *trigger_id)
+                                > (
+                                    cursor.active_fire_slot,
+                                    &cursor.tenant_id,
+                                    cursor.trigger_id,
+                                )
+                        }
+                        None => true,
+                    },
+                )
+                .collect::<Vec<_>>();
+            records.sort_by_key(|(active_fire_slot, tenant_id, trigger_id, _)| {
+                (*active_fire_slot, tenant_id.clone(), *trigger_id)
+            });
+            records.truncate(limit);
+            Ok(records
+                .into_iter()
+                .map(|(_, _, _, record)| record)
+                .collect())
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            unreachable!("active-clear-fails-once repository should not claim fires")
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository should not persist accepted fires")
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository should not persist permanent failures")
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-clear-fails-once repository should not persist terminal failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            self.clear_requests
+                .lock()
+                .expect("clear requests lock")
+                .push(request.trigger_id);
+            if request.trigger_id == self.fail_once_trigger_id {
+                let mut failed_once = self.failed_once.lock().expect("failed-once lock");
+                if !*failed_once {
+                    *failed_once = true;
+                    return Err(TriggerError::Backend {
+                        reason: "clear failed once".to_string(),
+                    });
+                }
+            }
+
+            let mut records = self.records.lock().expect("active records lock");
+            let Some(record) = records.iter_mut().find(|record| {
+                record.tenant_id == request.tenant_id && record.trigger_id == request.trigger_id
+            }) else {
+                return Ok(None);
+            };
+            let updated = record.clone();
+            record.active_fire_slot = None;
+            record.active_run_ref = None;
+            Ok(Some(updated))
         }
     }
 

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -156,7 +156,7 @@ impl TriggerPollerWorker {
         }
         report.active_records = active_records.len();
         let mut next_cursor = cursor;
-        let mut advance_cursor = true;
+        let mut first_unadvanced_cursor: Option<ActiveTriggerScanCursor> = None;
         for record in active_records {
             debug_assert!(
                 record.active_fire_slot.is_some(),
@@ -165,10 +165,8 @@ impl TriggerPollerWorker {
             let Some(fire_slot) = record.active_fire_slot else {
                 continue;
             };
-            let record_cursor = ActiveTriggerScanCursor {
-                active_fire_slot: fire_slot,
-                tenant_id: record.tenant_id.clone(),
-                trigger_id: record.trigger_id,
+            let Some(record_cursor) = ActiveTriggerScanCursor::from_active_record(&record) else {
+                continue;
             };
             let Some(run_id) = record.active_run_ref else {
                 // Keep claim-only rows blocked until recovery has lease or age
@@ -182,7 +180,7 @@ impl TriggerPollerWorker {
                         active_run_ref: None,
                     },
                 });
-                if advance_cursor {
+                if first_unadvanced_cursor.is_none() {
                     next_cursor = Some(record_cursor);
                 }
                 continue;
@@ -209,7 +207,7 @@ impl TriggerPollerWorker {
                             reason: TriggerPollerFailureReason::ActiveRunLookup,
                         },
                     });
-                    advance_cursor = false;
+                    first_unadvanced_cursor.get_or_insert(record_cursor);
                     continue;
                 }
             };
@@ -256,7 +254,7 @@ impl TriggerPollerWorker {
                     });
                 }
             }
-            if advance_cursor {
+            if first_unadvanced_cursor.is_none() {
                 next_cursor = Some(record_cursor);
             }
         }
@@ -1257,6 +1255,110 @@ mod tests {
             .expect("terminal record");
         assert_eq!(persisted.active_fire_slot, None);
         assert_eq!(persisted.active_run_ref, None);
+    }
+
+    #[tokio::test]
+    async fn tick_active_cleanup_cursor_wraps_to_start_when_page_is_empty() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let first_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let second_id = TriggerId::parse("01J00000000000000000000000").expect("ulid");
+        let third_id = TriggerId::parse("01J00000000000000000000001").expect("ulid");
+        let first_slot = ts(1_704_067_200);
+        let second_slot = ts(1_704_067_260);
+        let third_slot = ts(1_704_067_320);
+        let first_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let second_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("run id");
+        let third_run = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5c").expect("run id");
+
+        let mut first = sample_record(first_id, tenant("tenant-a"), ts(1_704_067_800));
+        first.active_fire_slot = Some(first_slot);
+        first.active_run_ref = Some(first_run);
+        let mut second = sample_record(second_id, tenant("tenant-a"), ts(1_704_067_800));
+        second.active_fire_slot = Some(second_slot);
+        second.active_run_ref = Some(second_run);
+        let mut third = sample_record(third_id, tenant("tenant-a"), ts(1_704_067_800));
+        third.active_fire_slot = Some(third_slot);
+        third.active_run_ref = Some(third_run);
+        repo.upsert_trigger(first).await.expect("insert first");
+        repo.upsert_trigger(second).await.expect("insert second");
+        repo.upsert_trigger(third).await.expect("insert third");
+
+        let active_lookup = Arc::new(RecordingActiveRunLookup::with_results(vec![
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Nonterminal),
+            Ok(TriggerActiveRunState::Nonterminal),
+        ]));
+        let worker = worker_with_config(
+            repo,
+            Arc::new(crate::ScheduleTriggerSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            active_lookup.clone(),
+            TriggerPollerWorkerConfig {
+                fires_per_tick: 2,
+                ..TriggerPollerWorkerConfig::default()
+            },
+        );
+
+        let first_report = worker.tick_once(first_slot).await.expect("first tick");
+        assert_eq!(first_report.active_records, 2);
+        let second_report = worker.tick_once(second_slot).await.expect("second tick");
+        assert_eq!(second_report.active_records, 1);
+
+        let third_report = worker.tick_once(third_slot).await.expect("third tick");
+        assert_eq!(third_report.active_records, 2);
+        assert_eq!(
+            third_report
+                .results
+                .iter()
+                .map(|result| result.trigger_id)
+                .collect::<Vec<_>>(),
+            vec![first_id, second_id]
+        );
+        assert_eq!(
+            active_lookup
+                .requests()
+                .into_iter()
+                .map(|request| request.trigger_id)
+                .collect::<Vec<_>>(),
+            vec![first_id, second_id, third_id, first_id, second_id]
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_fails_when_wrap_refetch_returns_backend_error() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), ts(1_704_067_800));
+        record.active_fire_slot = Some(fire_slot);
+        record.active_run_ref = Some(run_id);
+        let repo = Arc::new(ActiveWrapRefetchErrorRepository::new(record));
+        let worker = worker_with_config(
+            repo.clone(),
+            Arc::new(crate::ScheduleTriggerSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::with_state(
+                TriggerActiveRunState::Nonterminal,
+            )),
+            TriggerPollerWorkerConfig {
+                fires_per_tick: 1,
+                ..TriggerPollerWorkerConfig::default()
+            },
+        );
+
+        let first_report = worker.tick_once(fire_slot).await.expect("first tick");
+        assert_eq!(first_report.active_records, 1);
+
+        let error = worker
+            .tick_once(fire_slot)
+            .await
+            .expect_err("wrap refetch fails");
+        assert!(matches!(error, TriggerError::Backend { .. }));
+        assert_eq!(repo.active_scan_call_shapes(), vec![false, true, false]);
     }
 
     #[tokio::test]
@@ -2467,6 +2569,147 @@ mod tests {
         }
     }
 
+    struct ActiveWrapRefetchErrorRepository {
+        record: TriggerRecord,
+        active_scan_calls: Mutex<Vec<bool>>,
+    }
+
+    impl ActiveWrapRefetchErrorRepository {
+        fn new(record: TriggerRecord) -> Self {
+            Self {
+                record,
+                active_scan_calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn active_scan_call_shapes(&self) -> Vec<bool> {
+            self.active_scan_calls
+                .lock()
+                .expect("active scan calls lock")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl TriggerRepository for ActiveWrapRefetchErrorRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("active-wrap-refetch-error repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-wrap-refetch-error repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("active-wrap-refetch-error repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-wrap-refetch-error repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_active_triggers(
+            &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            after: Option<ActiveTriggerScanCursor>,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            let mut calls = self
+                .active_scan_calls
+                .lock()
+                .expect("active scan calls lock");
+            calls.push(after.is_some());
+            match calls.len() {
+                1 => Ok(vec![self.record.clone()]),
+                2 => Ok(Vec::new()),
+                3 => Err(TriggerError::Backend {
+                    reason: "wrap refetch unavailable".to_string(),
+                }),
+                _ => unreachable!("unexpected active scan call"),
+            }
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            unreachable!("active-wrap-refetch-error repository should not claim fires")
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-wrap-refetch-error repository should not persist accepted fires")
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-wrap-refetch-error repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!(
+                "active-wrap-refetch-error repository should not persist retryable failures"
+            )
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!(
+                "active-wrap-refetch-error repository should not persist permanent failures"
+            )
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!(
+                "active-wrap-refetch-error repository should not persist terminal failures"
+            )
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("active-wrap-refetch-error repository should not clear active fires")
+        }
+    }
+
     struct ActiveClearRaceRepository {
         active_record: TriggerRecord,
     }
@@ -2658,9 +2901,9 @@ mod tests {
                         Some(cursor) => {
                             (*active_fire_slot, tenant_id, *trigger_id)
                                 > (
-                                    cursor.active_fire_slot,
-                                    &cursor.tenant_id,
-                                    cursor.trigger_id,
+                                    cursor.active_fire_slot(),
+                                    cursor.tenant_id(),
+                                    cursor.trigger_id(),
                                 )
                         }
                         None => true,

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -67,6 +67,8 @@ pub struct TriggerPollerWorkerDeps {
 pub struct TriggerPollerWorker {
     config: TriggerPollerWorkerConfig,
     deps: TriggerPollerWorkerDeps,
+    // This guard is held only around synchronous cursor clone/set operations,
+    // never across repository, materialization, submit, or lookup awaits.
     active_scan_cursor: Mutex<Option<ActiveTriggerScanCursor>>,
 }
 
@@ -83,6 +85,11 @@ impl TriggerPollerWorker {
         })
     }
 
+    /// Executes one serialized poller tick.
+    ///
+    /// Production lifecycle wiring must not run overlapping ticks for the same
+    /// worker instance. The active-scan cursor is a per-worker progress marker
+    /// and is advanced by the single supervisor-owned tick loop.
     pub async fn tick_once(&self, now: Timestamp) -> Result<TriggerPollerTickReport, TriggerError> {
         let mut report = TriggerPollerTickReport::new(now);
         self.clear_terminal_active_fires(&mut report).await?;
@@ -2512,6 +2519,14 @@ mod tests {
 
         async fn list_active_triggers(
             &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            _after: Option<ActiveTriggerScanCursor>,
             _limit: usize,
         ) -> Result<Vec<TriggerRecord>, TriggerError> {
             Err(TriggerError::Backend {
@@ -2753,8 +2768,19 @@ mod tests {
 
         async fn list_active_triggers(
             &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            after: Option<ActiveTriggerScanCursor>,
             _limit: usize,
         ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            if after.is_some() {
+                return Ok(Vec::new());
+            }
             Ok(vec![self.active_record.clone()])
         }
 
@@ -3037,6 +3063,14 @@ mod tests {
 
         async fn list_active_triggers(
             &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            _after: Option<ActiveTriggerScanCursor>,
             _limit: usize,
         ) -> Result<Vec<TriggerRecord>, TriggerError> {
             Ok(Vec::new())
@@ -3139,6 +3173,14 @@ mod tests {
 
         async fn list_active_triggers(
             &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            _after: Option<ActiveTriggerScanCursor>,
             _limit: usize,
         ) -> Result<Vec<TriggerRecord>, TriggerError> {
             Ok(Vec::new())
@@ -3245,6 +3287,14 @@ mod tests {
 
         async fn list_active_triggers(
             &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            _after: Option<ActiveTriggerScanCursor>,
             _limit: usize,
         ) -> Result<Vec<TriggerRecord>, TriggerError> {
             Ok(Vec::new())
@@ -3361,6 +3411,14 @@ mod tests {
 
         async fn list_active_triggers(
             &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            _after: Option<ActiveTriggerScanCursor>,
             _limit: usize,
         ) -> Result<Vec<TriggerRecord>, TriggerError> {
             Ok(Vec::new())

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -67,6 +67,7 @@ pub struct TriggerPollerWorkerDeps {
 pub struct TriggerPollerWorker {
     config: TriggerPollerWorkerConfig,
     deps: TriggerPollerWorkerDeps,
+    tick_guard: tokio::sync::Mutex<()>,
     // This guard is held only around synchronous cursor clone/set operations,
     // never across repository, materialization, submit, or lookup awaits.
     active_scan_cursor: Mutex<Option<ActiveTriggerScanCursor>>,
@@ -81,6 +82,7 @@ impl TriggerPollerWorker {
         Ok(Self {
             config,
             deps,
+            tick_guard: tokio::sync::Mutex::new(()),
             active_scan_cursor: Mutex::new(None),
         })
     }
@@ -91,6 +93,7 @@ impl TriggerPollerWorker {
     /// worker instance. The active-scan cursor is a per-worker progress marker
     /// and is advanced by the single supervisor-owned tick loop.
     pub async fn tick_once(&self, now: Timestamp) -> Result<TriggerPollerTickReport, TriggerError> {
+        let _tick_guard = self.tick_guard.lock().await;
         let mut report = TriggerPollerTickReport::new(now);
         self.clear_terminal_active_fires(&mut report).await?;
         let due_records = self
@@ -137,30 +140,7 @@ impl TriggerPollerWorker {
         &self,
         report: &mut TriggerPollerTickReport,
     ) -> Result<(), TriggerError> {
-        let mut cursor = self.active_scan_cursor()?;
-        let mut active_records = self
-            .deps
-            .repository
-            .as_ref()
-            .list_active_triggers_after_trusted(
-                TrustedTriggerPollerScope::mint(),
-                cursor.clone(),
-                self.config.fires_per_tick,
-            )
-            .await?;
-        if active_records.is_empty() && cursor.is_some() {
-            cursor = None;
-            active_records = self
-                .deps
-                .repository
-                .as_ref()
-                .list_active_triggers_after_trusted(
-                    TrustedTriggerPollerScope::mint(),
-                    cursor.clone(),
-                    self.config.fires_per_tick,
-                )
-                .await?;
-        }
+        let (cursor, active_records) = self.list_active_cleanup_page().await?;
         report.active_records = active_records.len();
         let mut next_cursor = cursor;
         let mut first_unadvanced_cursor: Option<ActiveTriggerScanCursor> = None;
@@ -267,6 +247,36 @@ impl TriggerPollerWorker {
         }
         self.set_active_scan_cursor(next_cursor)?;
         Ok(())
+    }
+
+    async fn list_active_cleanup_page(
+        &self,
+    ) -> Result<(Option<ActiveTriggerScanCursor>, Vec<TriggerRecord>), TriggerError> {
+        let mut cursor = self.active_scan_cursor()?;
+        let mut active_records = self
+            .deps
+            .repository
+            .as_ref()
+            .list_active_triggers_after_trusted(
+                TrustedTriggerPollerScope::mint(),
+                cursor.clone(),
+                self.config.fires_per_tick,
+            )
+            .await?;
+        if active_records.is_empty() && cursor.is_some() {
+            cursor = None;
+            active_records = self
+                .deps
+                .repository
+                .as_ref()
+                .list_active_triggers_after_trusted(
+                    TrustedTriggerPollerScope::mint(),
+                    cursor.clone(),
+                    self.config.fires_per_tick,
+                )
+                .await?;
+        }
+        Ok((cursor, active_records))
     }
 
     fn active_scan_cursor(&self) -> Result<Option<ActiveTriggerScanCursor>, TriggerError> {
@@ -922,6 +932,28 @@ mod tests {
             },
         )
         .expect("valid worker")
+    }
+
+    #[tokio::test]
+    async fn tick_once_serializes_overlapping_calls_for_one_worker() {
+        let repo = Arc::new(TickConcurrencyRepository::default());
+        let worker = Arc::new(worker(
+            repo.clone(),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::default()),
+        ));
+        let first = worker.clone();
+        let second = worker;
+
+        let (first_result, second_result) = tokio::join!(
+            async move { first.tick_once(ts(1_704_067_200)).await },
+            async move { second.tick_once(ts(1_704_067_260)).await },
+        );
+
+        first_result.expect("first tick");
+        second_result.expect("second tick");
+        assert_eq!(repo.max_concurrent_due_scans(), 1);
     }
 
     #[tokio::test]
@@ -2475,6 +2507,140 @@ mod tests {
             self.results.lock().expect("results lock").pop().expect(
                 "RecordingActiveRunLookup: more active_run_state calls than configured outcomes",
             )
+        }
+    }
+
+    #[derive(Default)]
+    struct TickConcurrencyRepository {
+        current_due_scans: Mutex<usize>,
+        max_concurrent_due_scans: Mutex<usize>,
+    }
+
+    impl TickConcurrencyRepository {
+        fn max_concurrent_due_scans(&self) -> usize {
+            *self
+                .max_concurrent_due_scans
+                .lock()
+                .expect("max concurrent due scans lock")
+        }
+    }
+
+    #[async_trait]
+    impl TriggerRepository for TickConcurrencyRepository {
+        async fn upsert_trigger(&self, _record: TriggerRecord) -> Result<(), TriggerError> {
+            unreachable!("tick-concurrency repository is read-only")
+        }
+
+        async fn get_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository does not load records")
+        }
+
+        async fn list_triggers(
+            &self,
+            _tenant_id: TenantId,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository does not list tenant records")
+        }
+
+        async fn remove_trigger(
+            &self,
+            _tenant_id: TenantId,
+            _trigger_id: TriggerId,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository does not remove records")
+        }
+
+        async fn list_due_triggers(
+            &self,
+            _now: Timestamp,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            {
+                let mut current = self
+                    .current_due_scans
+                    .lock()
+                    .expect("current due scans lock");
+                *current += 1;
+                let mut max = self
+                    .max_concurrent_due_scans
+                    .lock()
+                    .expect("max concurrent due scans lock");
+                *max = (*max).max(*current);
+            }
+            tokio::task::yield_now().await;
+            *self
+                .current_due_scans
+                .lock()
+                .expect("current due scans lock") -= 1;
+            Ok(Vec::new())
+        }
+
+        async fn list_active_triggers(
+            &self,
+            limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            self.list_active_triggers_after(None, limit).await
+        }
+
+        async fn list_active_triggers_after(
+            &self,
+            _after: Option<ActiveTriggerScanCursor>,
+            _limit: usize,
+        ) -> Result<Vec<TriggerRecord>, TriggerError> {
+            Ok(Vec::new())
+        }
+
+        async fn claim_due_fire(
+            &self,
+            _request: ClaimDueFireRequest,
+        ) -> Result<ClaimDueFireOutcome, TriggerError> {
+            unreachable!("tick-concurrency repository should not claim fires")
+        }
+
+        async fn mark_fire_accepted(
+            &self,
+            _request: FireAcceptedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository should not persist accepted fires")
+        }
+
+        async fn mark_fire_replayed(
+            &self,
+            _request: FireReplayedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository should not persist replayed fires")
+        }
+
+        async fn mark_fire_retryable_failed(
+            &self,
+            _request: FireRetryableFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository should not persist retryable failures")
+        }
+
+        async fn mark_fire_permanently_failed(
+            &self,
+            _request: FirePermanentFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository should not persist permanent failures")
+        }
+
+        async fn mark_fire_terminally_failed(
+            &self,
+            _request: FireTerminalFailedRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository should not persist terminal failures")
+        }
+
+        async fn clear_active_fire(
+            &self,
+            _request: ClearActiveFireRequest,
+        ) -> Result<Option<TriggerRecord>, TriggerError> {
+            unreachable!("tick-concurrency repository should not clear active fires")
         }
     }
 

--- a/crates/ironclaw_triggers/src/worker.rs
+++ b/crates/ironclaw_triggers/src/worker.rs
@@ -14,7 +14,7 @@ use crate::{
     FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
     FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerError, TriggerFire, TriggerId,
     TriggerInboundContentRef, TriggerPromptMaterializer, TriggerRecord, TriggerRepository,
-    TriggerSourceProvider, TrustedTriggerPollerRepository, TrustedTriggerPollerScope,
+    TriggerSourceProvider,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,8 +68,8 @@ pub struct TriggerPollerWorker {
     config: TriggerPollerWorkerConfig,
     deps: TriggerPollerWorkerDeps,
     tick_guard: tokio::sync::Mutex<()>,
-    // This guard is held only around synchronous cursor clone/set operations,
-    // never across repository, materialization, submit, or lookup awaits.
+    // active_scan_cursor's sync mutex is held only around cursor clone/set
+    // operations, never across repository, materialization, submit, or lookup awaits.
     active_scan_cursor: Mutex<Option<ActiveTriggerScanCursor>>,
 }
 
@@ -96,15 +96,11 @@ impl TriggerPollerWorker {
         let _tick_guard = self.tick_guard.lock().await;
         let mut report = TriggerPollerTickReport::new(now);
         self.clear_terminal_active_fires(&mut report).await?;
+        // trusted-poller: this is host-owned background work, not a tenant/API list.
         let due_records = self
             .deps
             .repository
-            .as_ref()
-            .list_due_triggers_trusted(
-                TrustedTriggerPollerScope::mint(),
-                now,
-                self.config.fires_per_tick,
-            )
+            .list_due_triggers(now, self.config.fires_per_tick)
             .await?;
         report.due_records = due_records.len();
         for record in due_records {
@@ -253,27 +249,19 @@ impl TriggerPollerWorker {
         &self,
     ) -> Result<(Option<ActiveTriggerScanCursor>, Vec<TriggerRecord>), TriggerError> {
         let mut cursor = self.active_scan_cursor()?;
+        // trusted-poller: active scan cursors are derived from previous global
+        // active scan results, not user input or tenant-scoped list paths.
         let mut active_records = self
             .deps
             .repository
-            .as_ref()
-            .list_active_triggers_after_trusted(
-                TrustedTriggerPollerScope::mint(),
-                cursor.clone(),
-                self.config.fires_per_tick,
-            )
+            .list_active_triggers_after(cursor.clone(), self.config.fires_per_tick)
             .await?;
         if active_records.is_empty() && cursor.is_some() {
             cursor = None;
             active_records = self
                 .deps
                 .repository
-                .as_ref()
-                .list_active_triggers_after_trusted(
-                    TrustedTriggerPollerScope::mint(),
-                    cursor.clone(),
-                    self.config.fires_per_tick,
-                )
+                .list_active_triggers_after(cursor.clone(), self.config.fires_per_tick)
                 .await?;
         }
         Ok((cursor, active_records))
@@ -1364,6 +1352,44 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![first_id, second_id, third_id, first_id, second_id]
         );
+    }
+
+    #[tokio::test]
+    async fn tick_active_cleanup_cursor_wraps_to_empty_page_succeeds_with_zero_active_records() {
+        let repo = Arc::new(InMemoryTriggerRepository::default());
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let fire_slot = ts(1_704_067_200);
+        let run_id = TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("run id");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), ts(1_704_067_800));
+        record.active_fire_slot = Some(fire_slot);
+        record.active_run_ref = Some(run_id);
+        repo.upsert_trigger(record).await.expect("insert active");
+
+        let worker = worker_with_config(
+            repo.clone(),
+            Arc::new(crate::ScheduleTriggerSourceProvider),
+            Arc::new(RecordingMaterializer::success("content:trigger-fire")),
+            Arc::new(RecordingSubmitter::with_outcomes(Vec::new())),
+            Arc::new(RecordingActiveRunLookup::with_state(
+                TriggerActiveRunState::Nonterminal,
+            )),
+            TriggerPollerWorkerConfig {
+                fires_per_tick: 1,
+                ..TriggerPollerWorkerConfig::default()
+            },
+        );
+
+        let first_report = worker.tick_once(fire_slot).await.expect("first tick");
+        assert_eq!(first_report.active_records, 1);
+
+        repo.remove_trigger(tenant("tenant-a"), trigger_id)
+            .await
+            .expect("remove active");
+
+        let second_report = worker.tick_once(fire_slot).await.expect("second tick");
+        assert_eq!(second_report.active_records, 0);
+        let third_report = worker.tick_once(fire_slot).await.expect("third tick");
+        assert_eq!(third_report.active_records, 0);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -529,13 +529,10 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
         ]
     );
 
-    let cursor = ActiveTriggerScanCursor {
-        active_fire_slot: first_page[2].active_fire_slot.expect("active slot"),
-        tenant_id: first_page[2].tenant_id.clone(),
-        trigger_id: first_page[2].trigger_id,
-    };
+    let cursor =
+        ActiveTriggerScanCursor::from_active_record(&first_page[2]).expect("active cursor");
     let second_page = repo
-        .list_active_triggers_after(Some(cursor), 3)
+        .list_active_triggers_after(Some(cursor.clone()), 3)
         .await
         .expect("list second active page");
     assert_eq!(
@@ -557,6 +554,16 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
                 overflow_records[0].trigger_id,
             ),
         ]
+    );
+    let cursor_at_last =
+        ActiveTriggerScanCursor::from_active_record(overflow_records.last().expect("overflow row"))
+            .expect("last active cursor");
+    assert!(
+        repo.list_active_triggers_after(Some(cursor_at_last), 3)
+            .await
+            .expect("list after last active row")
+            .is_empty(),
+        "cursor at the last active row must return an empty page"
     );
 
     let active = repo

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -3,9 +3,9 @@
 use chrono::{TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_triggers::{
-    ClearActiveFireRequest, InMemoryTriggerRepository, TriggerCompletionPolicy, TriggerError,
-    TriggerId, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
-    TriggerSourceKind, TriggerState,
+    ActiveTriggerScanCursor, ClearActiveFireRequest, InMemoryTriggerRepository,
+    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
+    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use ironclaw_turns::TurnRunId;
 
@@ -413,42 +413,60 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
         early_slot,
     );
     let inactive_trigger_id = inactive.trigger_id;
-    let active_later = {
+    let blocked_oldest_a = {
         let mut record = sample_record(
             TriggerId::parse("01J00000000000000000000002").expect("ulid"),
-            tenant("tenant-active-later"),
+            tenant("tenant-blocked-a"),
+            later_slot,
+        );
+        record.active_fire_slot = Some(early_slot);
+        record
+    };
+    let blocked_oldest_b = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000003").expect("ulid"),
+            tenant("tenant-blocked-b"),
+            later_slot,
+        );
+        record.active_fire_slot = Some(early_slot);
+        record
+    };
+    let blocked_oldest_c = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000004").expect("ulid"),
+            tenant("tenant-blocked-c"),
+            later_slot,
+        );
+        record.active_fire_slot = Some(early_slot);
+        record
+    };
+    let active_terminal_later_a = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000005").expect("ulid"),
+            tenant("tenant-terminal-a"),
             later_slot,
         );
         record.active_fire_slot = Some(later_slot);
+        record.active_run_ref =
+            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5c").expect("valid run"));
         record
     };
-    let active_early_a = {
+    let active_terminal_later_b = {
         let mut record = sample_record(
-            TriggerId::parse("01J00000000000000000000003").expect("ulid"),
-            tenant("tenant-active-a"),
+            TriggerId::parse("01J00000000000000000000006").expect("ulid"),
+            tenant("tenant-terminal-b"),
             later_slot,
         );
-        record.active_fire_slot = Some(early_slot);
+        record.active_fire_slot = Some(later_slot);
         record.active_run_ref =
-            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5a").expect("valid run"));
-        record
-    };
-    let active_early_b = {
-        let mut record = sample_record(
-            TriggerId::parse("01J00000000000000000000004").expect("ulid"),
-            tenant("tenant-active-b"),
-            later_slot,
-        );
-        record.active_fire_slot = Some(early_slot);
-        record.active_run_ref =
-            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5b").expect("valid run"));
+            Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5d").expect("valid run"));
         record
     };
     let mut overflow_records = Vec::new();
-    for index in 0..130 {
+    for index in 0..126 {
         let mut record = sample_record(
             TriggerId::new(),
-            tenant(&format!("tenant-overflow-{index:03}")),
+            tenant(&format!("tenant-z-overflow-{index:03}")),
             later_slot,
         );
         record.active_fire_slot = Some(later_slot);
@@ -458,15 +476,21 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
     repo.upsert_trigger(inactive)
         .await
         .expect("insert inactive");
-    repo.upsert_trigger(active_later.clone())
+    repo.upsert_trigger(blocked_oldest_a.clone())
         .await
-        .expect("insert active later");
-    repo.upsert_trigger(active_early_b.clone())
+        .expect("insert blocked oldest a");
+    repo.upsert_trigger(blocked_oldest_b.clone())
         .await
-        .expect("insert active early b");
-    repo.upsert_trigger(active_early_a.clone())
+        .expect("insert blocked oldest b");
+    repo.upsert_trigger(blocked_oldest_c.clone())
         .await
-        .expect("insert active early a");
+        .expect("insert blocked oldest c");
+    repo.upsert_trigger(active_terminal_later_a.clone())
+        .await
+        .expect("insert active terminal later a");
+    repo.upsert_trigger(active_terminal_later_b.clone())
+        .await
+        .expect("insert active terminal later b");
     for record in &overflow_records {
         repo.upsert_trigger(record.clone())
             .await
@@ -478,6 +502,61 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
             .await
             .expect("zero active limit")
             .is_empty()
+    );
+
+    let first_page = repo
+        .list_active_triggers(3)
+        .await
+        .expect("list first active page");
+    assert_eq!(
+        first_page
+            .iter()
+            .map(|record| (record.tenant_id.clone(), record.trigger_id))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                blocked_oldest_a.tenant_id.clone(),
+                blocked_oldest_a.trigger_id,
+            ),
+            (
+                blocked_oldest_b.tenant_id.clone(),
+                blocked_oldest_b.trigger_id,
+            ),
+            (
+                blocked_oldest_c.tenant_id.clone(),
+                blocked_oldest_c.trigger_id,
+            ),
+        ]
+    );
+
+    let cursor = ActiveTriggerScanCursor {
+        active_fire_slot: first_page[2].active_fire_slot.expect("active slot"),
+        tenant_id: first_page[2].tenant_id.clone(),
+        trigger_id: first_page[2].trigger_id,
+    };
+    let second_page = repo
+        .list_active_triggers_after(Some(cursor), 3)
+        .await
+        .expect("list second active page");
+    assert_eq!(
+        second_page
+            .iter()
+            .map(|record| (record.tenant_id.clone(), record.trigger_id))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                active_terminal_later_a.tenant_id.clone(),
+                active_terminal_later_a.trigger_id,
+            ),
+            (
+                active_terminal_later_b.tenant_id.clone(),
+                active_terminal_later_b.trigger_id,
+            ),
+            (
+                overflow_records[0].tenant_id.clone(),
+                overflow_records[0].trigger_id,
+            ),
+        ]
     );
 
     let active = repo
@@ -500,14 +579,41 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
     assert_eq!(
         active
             .iter()
-            .take(3)
+            .take(6)
             .map(|record| (record.tenant_id.clone(), record.trigger_id))
             .collect::<Vec<_>>(),
         vec![
-            (active_early_a.tenant_id.clone(), active_early_a.trigger_id),
-            (active_early_b.tenant_id.clone(), active_early_b.trigger_id),
-            (active_later.tenant_id.clone(), active_later.trigger_id),
+            (
+                blocked_oldest_a.tenant_id.clone(),
+                blocked_oldest_a.trigger_id,
+            ),
+            (
+                blocked_oldest_b.tenant_id.clone(),
+                blocked_oldest_b.trigger_id,
+            ),
+            (
+                blocked_oldest_c.tenant_id.clone(),
+                blocked_oldest_c.trigger_id,
+            ),
+            (
+                active_terminal_later_a.tenant_id.clone(),
+                active_terminal_later_a.trigger_id,
+            ),
+            (
+                active_terminal_later_b.tenant_id.clone(),
+                active_terminal_later_b.trigger_id,
+            ),
+            (
+                overflow_records[0].tenant_id.clone(),
+                overflow_records[0].trigger_id,
+            ),
         ]
+    );
+    assert!(
+        active
+            .iter()
+            .any(|record| record.trigger_id == active_terminal_later_a.trigger_id),
+        "later terminal active rows should still be reachable"
     );
 
     let limited = repo
@@ -515,7 +621,7 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
         .await
         .expect("list active limited");
     assert_eq!(limited.len(), 1);
-    assert_eq!(limited[0].trigger_id, active_early_a.trigger_id);
+    assert_eq!(limited[0].trigger_id, blocked_oldest_a.trigger_id);
 }
 
 async fn assert_rejects_validation_failures_before_persistence(repo: &impl TriggerRepository) {
@@ -1668,6 +1774,7 @@ mod fire_claim_contract {
                 fire_slot,
             );
             record.state = TriggerState::Paused;
+            record.active_fire_slot = Some(fire_slot);
             record.active_run_ref =
                 Some(TurnRunId::parse("01890f0f-9b6f-7a85-9e5b-9f21a93c4f5f").expect("valid run"));
             record

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -631,6 +631,75 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
     assert_eq!(limited[0].trigger_id, blocked_oldest_a.trigger_id);
 }
 
+async fn assert_active_query_paginates_same_slot_same_tenant_by_trigger_id(
+    repo: &impl TriggerRepository,
+) {
+    let active_slot = ts(1_704_067_260);
+    let tenant_id = tenant("tenant-tie");
+    let first = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000000").expect("ulid"),
+            tenant_id.clone(),
+            ts(1_704_067_800),
+        );
+        record.active_fire_slot = Some(active_slot);
+        record
+    };
+    let second = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000001").expect("ulid"),
+            tenant_id.clone(),
+            ts(1_704_067_800),
+        );
+        record.active_fire_slot = Some(active_slot);
+        record
+    };
+    let third = {
+        let mut record = sample_record(
+            TriggerId::parse("01J00000000000000000000002").expect("ulid"),
+            tenant_id,
+            ts(1_704_067_800),
+        );
+        record.active_fire_slot = Some(active_slot);
+        record
+    };
+
+    repo.upsert_trigger(first.clone())
+        .await
+        .expect("insert first tie row");
+    repo.upsert_trigger(second.clone())
+        .await
+        .expect("insert second tie row");
+    repo.upsert_trigger(third.clone())
+        .await
+        .expect("insert third tie row");
+
+    let first_page = repo
+        .list_active_triggers(2)
+        .await
+        .expect("list first tie page");
+    assert_eq!(
+        first_page
+            .iter()
+            .map(|record| record.trigger_id)
+            .collect::<Vec<_>>(),
+        vec![first.trigger_id, second.trigger_id]
+    );
+    let cursor =
+        ActiveTriggerScanCursor::from_active_record(&first_page[1]).expect("tie page cursor");
+    let second_page = repo
+        .list_active_triggers_after(Some(cursor), 2)
+        .await
+        .expect("list second tie page");
+    assert_eq!(
+        second_page
+            .iter()
+            .map(|record| record.trigger_id)
+            .collect::<Vec<_>>(),
+        vec![third.trigger_id]
+    );
+}
+
 async fn assert_rejects_validation_failures_before_persistence(repo: &impl TriggerRepository) {
     let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
     let tenant_id = tenant("tenant-a");
@@ -751,6 +820,9 @@ async fn libsql_repository_contract_parity() {
     assert_active_query_lists_active_records_in_deterministic_order(&repo).await;
 
     let (_dir, repo) = build_libsql_repo().await;
+    assert_active_query_paginates_same_slot_same_tenant_by_trigger_id(&repo).await;
+
+    let (_dir, repo) = build_libsql_repo().await;
     assert_rejects_validation_failures_before_persistence(&repo).await;
 
     let (_dir, repo) = build_libsql_repo().await;
@@ -841,6 +913,9 @@ async fn postgres_repository_contract_parity() {
 
     clear_postgres_triggers(&pool).await;
     assert_active_query_lists_active_records_in_deterministic_order(&repo).await;
+
+    clear_postgres_triggers(&pool).await;
+    assert_active_query_paginates_same_slot_same_tenant_by_trigger_id(&repo).await;
 
     clear_postgres_triggers(&pool).await;
     assert_rejects_validation_failures_before_persistence(&repo).await;

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -531,6 +531,12 @@ async fn assert_active_query_lists_active_records_in_deterministic_order(
 
     let cursor =
         ActiveTriggerScanCursor::from_active_record(&first_page[2]).expect("active cursor");
+    assert!(
+        repo.list_active_triggers_after(Some(cursor.clone()), 0)
+            .await
+            .expect("list active cursor with zero limit")
+            .is_empty()
+    );
     let second_page = repo
         .list_active_triggers_after(Some(cursor.clone()), 3)
         .await

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -647,13 +647,11 @@ Wire the trigger poller into Reborn composition:
 - a dedicated `TriggerPollerWorkerConfig` or equivalent composition-owned type
   for poll interval, fires per tick, and per-trigger active-run cap. Do not
   reuse `RebornRuntimeInput::PollSettings`, which is request-completion polling.
-- add a sealed `TrustedTriggerPollerScope` or equivalent host-owned token before
-  exposing the real background poller lifecycle. Global trigger scans should
-  require that token or return a wrapper type such as `GlobalActiveTriggerRecord`
-  so product adapters, first-party capabilities, and tenant-scoped APIs cannot
-  accidentally treat cross-tenant poller rows as ordinary caller-scoped lists.
-  Keep tenant-scoped `list_triggers(tenant_id)` as the only user/API listing
-  path.
+- preserve the sealed `TrustedTriggerPollerScope` added in PR 16 when exposing
+  the real background poller lifecycle. Product adapters, first-party
+  capabilities, and tenant-scoped APIs must not receive access to cross-tenant
+  poller scans; keep tenant-scoped `list_triggers(tenant_id)` as the only
+  user/API listing path.
 - background task bundle or worker-supervisor type that owns both turn-runner
   and trigger-poller handles, cancellation, await/shutdown ordering, and panic
   or early-exit reporting.

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -652,8 +652,8 @@ Wire the trigger poller into Reborn composition:
 - a dedicated `TriggerPollerWorkerConfig` or equivalent composition-owned type
   for poll interval, fires per tick, and per-trigger active-run cap. Do not
   reuse `RebornRuntimeInput::PollSettings`, which is request-completion polling.
-- preserve the sealed `TrustedTriggerPollerScope` added in PR 16 when exposing
-  the real background poller lifecycle. Product adapters, first-party
+- preserve PR 16's explicit worker-local trusted poller scan call sites when
+  exposing the real background poller lifecycle. Product adapters, first-party
   capabilities, and tenant-scoped APIs must not receive access to cross-tenant
   poller scans; keep tenant-scoped `list_triggers(tenant_id)` as the only
   user/API listing path.

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -585,6 +585,11 @@ Expected size: less than 1000 lines.
 Add the heavier caller-level tests separately from the worker core:
 
 - repository + provider + inbound service + turn coordinator test path
+- integration and E2E-style harnesses should intercept external infrastructure
+  and endpoints only. Use real domain classes and composition-owned ports for
+  trigger repositories, source providers, materialization, turn submission, and
+  turn-state lookup whenever those implementations exist, so tests exercise the
+  full in-process path instead of replacing internal behavior with mocks.
 - one new canonical thread per fire
 - trusted scope reaches binding resolution
 - same scheduled slot replays instead of double-submitting

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -182,12 +182,10 @@ plumbing, not capability APIs.
 
 - `list_due_triggers` and `list_active_triggers` are the raw repository
   queries used by the trusted poller path.
-- Trigger-owned poller code must cross the boundary through a sealed
-  `TrustedTriggerPollerScope` witness so the call site stays explicit about the
-  trust transition.
+- Trigger-owned poller code must keep worker-local call sites explicit about the
+  trusted poller transition without adding a user-facing capability surface.
 - Product adapters, first-party capability code, and other untrusted callers
-  must not mint that witness or treat the global list methods as a user-facing
-  surface.
+  must not treat the global list methods as a user-facing surface.
 - The poller may continue to use the raw repository methods internally, but the
   contract treats them as implementation plumbing, not a capability contract.
 

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -175,6 +175,22 @@ must not be surfaced as an active scheduled fire.
 
 The skip policy is per-trigger, not global. Other triggers may continue to fire on the same tick.
 
+### 5.1 Trusted poller scope
+
+The global due/active repository queries are intentionally host-owned poller
+plumbing, not capability APIs.
+
+- `list_due_triggers` and `list_active_triggers` are the raw repository
+  queries used by the trusted poller path.
+- Trigger-owned poller code must cross the boundary through a sealed
+  `TrustedTriggerPollerScope` witness so the call site stays explicit about the
+  trust transition.
+- Product adapters, first-party capability code, and other untrusted callers
+  must not mint that witness or treat the global list methods as a user-facing
+  surface.
+- The poller may continue to use the raw repository methods internally, but the
+  contract treats them as implementation plumbing, not a capability contract.
+
 ---
 
 ## 6. Trusted inbound and turn execution


### PR DESCRIPTION
## Summary

PR16 adds the heavier caller-level harness around the trigger poller core from PR15, with emphasis on crash/replay behavior, active-run cleanup fairness, and trusted poller boundaries.

- adds cursor-based active trigger scans across in-memory, libSQL, and PostgreSQL repositories using deterministic `(active_fire_slot, tenant_id, trigger_id)` ordering
- teaches `TriggerPollerWorker` to page active-fire cleanup across ticks, wrap when it reaches the end, and avoid consuming cursor progress on hard clear errors or active-run lookup failures
- adds caller-level worker coverage for multi-page active cleanup, replayed submit cleanup after a later/restarted tick, hard clear retry, soft active-run lookup retry, and due-work continuation
- extends repository parity contracts for active scan pagination
- documents the sealed trusted poller scope and updates the PR18 lifecycle plan to preserve it when wiring background workers

## Boundaries / Deferrals

- no new claim API semantics in this PR; PR12/PR13 semantics remain intact
- no lifecycle/background task wiring here; PR18 owns real worker supervision, config, readiness, jitter, and shutdown wiring
- active rows with no submitted run ref remain conservatively blocked until recovery has lease/age evidence that clearing is safe
- global due/active scans remain repository plumbing for trusted poller code, not first-party capability or tenant API surfaces

## Review / Verification

Used two rounds of 5.4-mini review subagents plus an extra ownership/boundary verifier. Round 1 found cursor-consumption and default-method risks; those were fixed. Round 2 found the soft active-run lookup cursor issue; that was fixed and followed by a narrow final 5.4-mini verifier with no actionable findings.

Local checks:

- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
- `cargo test -p ironclaw_triggers`
- `cargo clippy -p ironclaw_triggers --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_triggers --test repository_contract --features libsql -- --test-threads=1 --nocapture`
- `cargo test -p ironclaw_triggers --test repository_contract --features postgres -- --test-threads=1 --nocapture` (compiled and passed; live Postgres cases skipped locally because Docker socket was unavailable)
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
