### PR TITLE
Fix reusable product auth credential lookup

### DIFF
--- a/crates/ironclaw_auth/src/credential.rs
+++ b/crates/ironclaw_auth/src/credential.rs
@@ -529,9 +529,9 @@ pub trait CredentialAccountService: Send + Sync {
 }
 
 /// Stable credential-account owner fields used by read models that need to
-/// find accounts across transient invocation ids or product surfaces. A
-/// missing session id matches both global and session-scoped accounts for the
-/// owner; a present session id matches only that exact session.
+/// find accounts across transient invocation ids, product surfaces, or runtime
+/// sub-scopes. Missing mission/thread/session ids match both global and
+/// scoped accounts for the owner; present ids match only that exact scope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CredentialAccountOwnerScope {
     pub tenant_id: TenantId,
@@ -562,8 +562,14 @@ impl CredentialAccountOwnerScope {
             && resource.user_id == self.user_id
             && resource.agent_id == self.agent_id
             && resource.project_id == self.project_id
-            && resource.mission_id == self.mission_id
-            && resource.thread_id == self.thread_id
+            && self
+                .mission_id
+                .as_ref()
+                .is_none_or(|mission_id| resource.mission_id.as_ref() == Some(mission_id))
+            && self
+                .thread_id
+                .as_ref()
+                .is_none_or(|thread_id| resource.thread_id.as_ref() == Some(thread_id))
             && self
                 .session_id
                 .as_ref()

--- a/crates/ironclaw_auth/tests/auth_product_contract/credential_account_contract.rs
+++ b/crates/ironclaw_auth/tests/auth_product_contract/credential_account_contract.rs
@@ -1,4 +1,6 @@
 use crate::common::*;
+use ironclaw_auth::CredentialAccountRecordSource;
+use ironclaw_host_api::ThreadId;
 
 #[tokio::test]
 async fn credential_setup_updates_only_explicit_authorized_account() {
@@ -490,6 +492,38 @@ async fn credential_account_selection_filters_by_requester_authority() {
         .await
         .expect("granted requester can select shared account");
     assert_eq!(selected_shared.id, shared.id);
+}
+
+#[tokio::test]
+async fn owner_record_source_can_find_reusable_accounts_from_any_thread() {
+    let services = InMemoryAuthProductServices::new();
+    let mut setup_owner = scope("alice-thread-reuse");
+    setup_owner.resource.thread_id = Some(ThreadId::new("thread-auth-1").unwrap());
+    let account = services
+        .create_account(NewCredentialAccount {
+            scope: setup_owner.clone(),
+            provider: provider(),
+            label: label("work"),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(SecretHandle::new("github-work").unwrap()),
+            refresh_secret: None,
+            scopes: Vec::new(),
+        })
+        .await
+        .expect("create reusable account");
+
+    let mut runtime_owner = setup_owner;
+    runtime_owner.resource.thread_id = None;
+    runtime_owner.session_id = None;
+    let accounts = services
+        .accounts_for_owner(&runtime_owner)
+        .await
+        .expect("owner accounts");
+
+    assert!(accounts.iter().any(|candidate| candidate.id == account.id));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -15,7 +15,7 @@ use tokio::task::JoinSet;
 use super::*;
 use crate::product_auth_runtime_credentials::{
     ProductAuthRuntimeCredentialAccountSelector, ProductAuthRuntimeCredentialResolver,
-    RuntimeCredentialAccountSelectionService,
+    RuntimeCredentialAccountSelectionRequest, RuntimeCredentialAccountSelectionService,
 };
 use ironclaw_auth::{
     AuthChallenge, AuthContinuationRef, AuthFlowKind, AuthFlowManager, AuthFlowOwnerScope,
@@ -205,9 +205,9 @@ async fn filesystem_runtime_account_selection_matches_setup_invocation_account()
 
     let selector = ProductAuthRuntimeCredentialAccountSelector::new(service.clone());
     let selected = selector
-        .select_unique_configured_runtime_account(CredentialAccountSelectionRequest::new(
+        .select_unique_configured_runtime_account(RuntimeCredentialAccountSelectionRequest::new(
+            CredentialAccountSelectionRequest::new(runtime_scope.clone(), google_provider()),
             runtime_scope,
-            google_provider(),
         ))
         .await
         .unwrap();

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -3,16 +3,19 @@ use std::sync::Arc;
 use chrono::{Duration, Utc};
 use ironclaw_filesystem::{InMemoryBackend, ScopedFilesystem};
 use ironclaw_host_api::{
-    InvocationId, MountAlias, MountGrant, MountPermissions, SecretHandle, ThreadId, UserId,
-    VirtualPath,
+    ExtensionId, InvocationId, MountAlias, MountGrant, MountPermissions,
+    RuntimeCredentialAccountProviderId, SecretHandle, ThreadId, UserId, VirtualPath,
 };
+use ironclaw_host_runtime::RuntimeCredentialAccountRequest;
+use ironclaw_host_runtime::RuntimeCredentialAccountResolver;
 use ironclaw_secrets::{InMemorySecretStore, SecretStore};
 use secrecy::SecretString;
 use tokio::task::JoinSet;
 
 use super::*;
 use crate::product_auth_runtime_credentials::{
-    ProductAuthRuntimeCredentialAccountSelector, RuntimeCredentialAccountSelectionService,
+    ProductAuthRuntimeCredentialAccountSelector, ProductAuthRuntimeCredentialResolver,
+    RuntimeCredentialAccountSelectionService,
 };
 use ironclaw_auth::{
     AuthChallenge, AuthContinuationRef, AuthFlowKind, AuthFlowManager, AuthFlowOwnerScope,
@@ -211,6 +214,51 @@ async fn filesystem_runtime_account_selection_matches_setup_invocation_account()
 
     assert_eq!(selected.id, created.id);
     assert_eq!(selected.access_secret, Some(access_secret));
+}
+
+#[tokio::test]
+async fn filesystem_runtime_account_selection_matches_new_thread_reusable_account() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let mut setup_scope = test_scope();
+    setup_scope.surface = AuthSurface::Callback;
+    setup_scope.resource.thread_id = Some(ThreadId::new("thread-auth-1").unwrap());
+    let mut runtime_scope = AuthProductScope::new(setup_scope.resource.clone(), AuthSurface::Api);
+    runtime_scope.resource.thread_id = Some(ThreadId::new("thread-auth-2").unwrap());
+    runtime_scope.resource.invocation_id = InvocationId::new();
+    let service = Arc::new(test_service(filesystem, secret_store));
+    let access_secret = SecretHandle::new("google-access").unwrap();
+
+    let created = service
+        .create_account(NewCredentialAccount {
+            scope: setup_scope,
+            provider: google_provider(),
+            label: account_label(),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(access_secret.clone()),
+            refresh_secret: None,
+            scopes: vec![ProviderScope::new("gmail.readonly").unwrap()],
+        })
+        .await
+        .unwrap();
+
+    let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+        ProductAuthRuntimeCredentialAccountSelector::new(service),
+    ));
+    let resolved = resolver
+        .resolve_access_secret(RuntimeCredentialAccountRequest {
+            scope: &runtime_scope.resource,
+            provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+            requester_extension: &ExtensionId::new("google-calendar").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(created.access_secret, Some(resolved.clone()));
+    assert_eq!(resolved, access_secret);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use ironclaw_auth::{
     AuthProductError, AuthProductScope, AuthProviderId, AuthSurface, CredentialAccount,
     CredentialAccountRecordSource, CredentialAccountSelectionRequest, CredentialAccountStatus,
+    CredentialOwnership,
 };
 use ironclaw_host_api::{CredentialStageError, SecretHandle};
 use ironclaw_host_runtime::{RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver};
@@ -23,8 +24,25 @@ impl ProductAuthRuntimeCredentialResolver {
 pub(crate) trait RuntimeCredentialAccountSelectionService: Send + Sync {
     async fn select_unique_configured_runtime_account(
         &self,
-        request: CredentialAccountSelectionRequest,
+        request: RuntimeCredentialAccountSelectionRequest,
     ) -> Result<CredentialAccount, AuthProductError>;
+}
+
+pub(crate) struct RuntimeCredentialAccountSelectionRequest {
+    lookup: CredentialAccountSelectionRequest,
+    runtime_scope: AuthProductScope,
+}
+
+impl RuntimeCredentialAccountSelectionRequest {
+    pub(crate) fn new(
+        lookup: CredentialAccountSelectionRequest,
+        runtime_scope: AuthProductScope,
+    ) -> Self {
+        Self {
+            lookup,
+            runtime_scope,
+        }
+    }
 }
 
 pub(crate) struct ProductAuthRuntimeCredentialAccountSelector {
@@ -50,11 +68,33 @@ impl std::fmt::Debug for ProductAuthRuntimeCredentialAccountSelector {
 impl RuntimeCredentialAccountSelectionService for ProductAuthRuntimeCredentialAccountSelector {
     async fn select_unique_configured_runtime_account(
         &self,
-        request: CredentialAccountSelectionRequest,
+        request: RuntimeCredentialAccountSelectionRequest,
     ) -> Result<CredentialAccount, AuthProductError> {
-        self.accounts
-            .select_unique_configured_account_for_owner(request)
-            .await
+        let configured = self
+            .accounts
+            .accounts_for_owner(&request.lookup.scope)
+            .await?
+            .into_iter()
+            .filter(|account| {
+                account.provider == request.lookup.provider
+                    && account.status == CredentialAccountStatus::Configured
+                    && account_visible_from_runtime_scope(account, &request.runtime_scope)
+            })
+            .collect::<Vec<_>>();
+        if configured.is_empty() {
+            return Err(AuthProductError::CredentialMissing);
+        }
+        let selectable = configured
+            .into_iter()
+            .filter(|account| {
+                account.is_authorized_for_requester(request.lookup.requester_extension.as_ref())
+            })
+            .collect::<Vec<_>>();
+        match selectable.as_slice() {
+            [] => Err(AuthProductError::CrossScopeDenied),
+            [account] => Ok(account.clone()),
+            _ => Err(AuthProductError::AccountSelectionRequired),
+        }
     }
 }
 
@@ -86,8 +126,11 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
         let account = self
             .accounts
             .select_unique_configured_runtime_account(
-                CredentialAccountSelectionRequest::new(auth_scope, provider)
-                    .for_extension(request.requester_extension.clone()),
+                RuntimeCredentialAccountSelectionRequest::new(
+                    CredentialAccountSelectionRequest::new(auth_scope, provider)
+                        .for_extension(request.requester_extension.clone()),
+                    AuthProductScope::new(request.scope.clone(), AuthSurface::Api),
+                ),
             )
             .await
             .map_err(map_account_error)?;
@@ -102,6 +145,24 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
         // Backend so the caller does not loop through re-auth.
         account.access_secret.ok_or(CredentialStageError::Backend)
     }
+}
+
+fn account_visible_from_runtime_scope(
+    account: &CredentialAccount,
+    runtime_scope: &AuthProductScope,
+) -> bool {
+    if account.ownership == CredentialOwnership::UserReusable {
+        return true;
+    }
+    let account_resource = &account.scope.resource;
+    let runtime_resource = &runtime_scope.resource;
+    account_resource.tenant_id == runtime_resource.tenant_id
+        && account_resource.user_id == runtime_resource.user_id
+        && account_resource.agent_id == runtime_resource.agent_id
+        && account_resource.project_id == runtime_resource.project_id
+        && account_resource.mission_id == runtime_resource.mission_id
+        && account_resource.thread_id == runtime_resource.thread_id
+        && account.scope.session_id == runtime_scope.session_id
 }
 
 fn runtime_account_owner_scope(
@@ -129,8 +190,8 @@ mod tests {
         InMemoryAuthProductServices, NewCredentialAccount,
     };
     use ironclaw_host_api::{
-        ExtensionId, InvocationId, ResourceScope, RuntimeCredentialAccountProviderId, ThreadId,
-        UserId,
+        ExtensionId, InvocationId, MissionId, ResourceScope, RuntimeCredentialAccountProviderId,
+        ThreadId, UserId,
     };
 
     use super::*;
@@ -255,6 +316,89 @@ mod tests {
             .unwrap();
 
         assert_eq!(resolved, access_secret);
+    }
+
+    #[tokio::test]
+    async fn resolver_matches_reusable_setup_account_from_new_mission() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let mut setup_scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        setup_scope.mission_id = Some(MissionId::new("mission-auth-1").unwrap());
+        let mut runtime_scope = setup_scope.clone();
+        runtime_scope.mission_id = Some(MissionId::new("mission-auth-2").unwrap());
+        runtime_scope.invocation_id = InvocationId::new();
+        let access_secret = SecretHandle::new("github_manual_access").unwrap();
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: AuthProductScope::new(setup_scope, AuthSurface::Callback),
+                provider: AuthProviderId::new("github").unwrap(),
+                label: CredentialAccountLabel::new("work github").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(access_secret.clone()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+
+        let resolved = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &runtime_scope,
+                provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                requester_extension: &ExtensionId::new("github").unwrap(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, access_secret);
+    }
+
+    #[tokio::test]
+    async fn resolver_rejects_extension_owned_account_from_new_thread() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let mut setup_scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        setup_scope.thread_id = Some(ThreadId::new("thread-auth-1").unwrap());
+        let mut runtime_scope = setup_scope.clone();
+        runtime_scope.thread_id = Some(ThreadId::new("thread-auth-2").unwrap());
+        runtime_scope.invocation_id = InvocationId::new();
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: AuthProductScope::new(setup_scope, AuthSurface::Callback),
+                provider: AuthProviderId::new("github").unwrap(),
+                label: CredentialAccountLabel::new("work github").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::ExtensionOwned,
+                owner_extension: Some(ExtensionId::new("github").unwrap()),
+                granted_extensions: Vec::new(),
+                access_secret: Some(SecretHandle::new("github_manual_access").unwrap()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+
+        let error = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &runtime_scope,
+                provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                requester_extension: &ExtensionId::new("github").unwrap(),
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, CredentialStageError::AuthRequired);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -73,7 +73,8 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
         &self,
         request: RuntimeCredentialAccountRequest<'_>,
     ) -> Result<SecretHandle, CredentialStageError> {
-        let auth_scope = AuthProductScope::new(request.scope.clone(), AuthSurface::Api);
+        let auth_scope =
+            AuthProductScope::new(runtime_account_owner_scope(request.scope), AuthSurface::Api);
         let provider = AuthProviderId::new(request.provider.as_str()).map_err(|e| {
             tracing::debug!(
                 provider = %request.provider.as_str(),
@@ -101,6 +102,15 @@ impl RuntimeCredentialAccountResolver for ProductAuthRuntimeCredentialResolver {
         // Backend so the caller does not loop through re-auth.
         account.access_secret.ok_or(CredentialStageError::Backend)
     }
+}
+
+fn runtime_account_owner_scope(
+    scope: &ironclaw_host_api::ResourceScope,
+) -> ironclaw_host_api::ResourceScope {
+    let mut owner = scope.clone();
+    owner.mission_id = None;
+    owner.thread_id = None;
+    owner
 }
 
 fn map_account_error(error: AuthProductError) -> CredentialStageError {
@@ -172,6 +182,48 @@ mod tests {
                 .unwrap();
         setup_scope.thread_id = Some(ThreadId::new("thread-auth-1").unwrap());
         let mut runtime_scope = setup_scope.clone();
+        runtime_scope.invocation_id = InvocationId::new();
+        let access_secret = SecretHandle::new("github_manual_access").unwrap();
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: AuthProductScope::new(setup_scope, AuthSurface::Callback),
+                provider: AuthProviderId::new("github").unwrap(),
+                label: CredentialAccountLabel::new("work github").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(access_secret.clone()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+
+        let resolved = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &runtime_scope,
+                provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                requester_extension: &ExtensionId::new("github").unwrap(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, access_secret);
+    }
+
+    #[tokio::test]
+    async fn resolver_matches_reusable_setup_account_from_new_thread() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let mut setup_scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        setup_scope.thread_id = Some(ThreadId::new("thread-auth-1").unwrap());
+        let mut runtime_scope = setup_scope.clone();
+        runtime_scope.thread_id = Some(ThreadId::new("thread-auth-2").unwrap());
         runtime_scope.invocation_id = InvocationId::new();
         let access_secret = SecretHandle::new("github_manual_access").unwrap();
         accounts


### PR DESCRIPTION
## Summary
- normalize runtime product-auth account lookup to stable owner scope so reusable credentials survive new thread/session contexts
- allow owner record matching to find scoped accounts when runtime lookup omits transient mission/thread/session ids
- add auth, resolver, and durable filesystem regressions for new-thread credential reuse

## Thermo Review
- reviewed for structural regressions and spaghetti growth
- no new file crosses the 1k-line threshold; `credential.rs` was already over 1k at base
- kept behavior in the runtime credential resolver path with caller-level regression coverage

## Tests
- `cargo fmt --check`
- `cargo test -p ironclaw_auth owner_record_source_can_find_reusable_accounts_from_any_thread`
- `cargo test -p ironclaw_reborn_composition resolver_matches_reusable_setup_account_from_new_thread`
- `cargo test -p ironclaw_reborn_composition filesystem_runtime_account_selection_matches_new_thread_reusable_account`