### PR TITLE
fix: (auth) durable PAT reprompt loop

### DIFF
--- a/crates/ironclaw_auth/src/fakes.rs
+++ b/crates/ironclaw_auth/src/fakes.rs
@@ -1127,16 +1127,48 @@ fn create_or_update_manual_token_account(
             validate_account_update_target(account, &account_request)?;
             update_account_from_request(account, account_request, now)
         }
-        None => create_account_in_state(
-            state,
-            manual_token_account_request(
+        None => {
+            let mut account_request = manual_token_account_request(
                 &pending,
                 CredentialOwnership::UserReusable,
                 None,
                 Vec::new(),
-            )?,
-        ),
+            )?;
+            if let Some(account_id) = latest_reusable_manual_token_account_id(state, &pending) {
+                let now = Utc::now();
+                let account = state
+                    .accounts
+                    .get_mut(&account_id)
+                    .ok_or(AuthProductError::CredentialMissing)?;
+                account_request.scope = account.scope.clone();
+                validate_account_update_target(account, &account_request)?;
+                update_account_from_request(account, account_request, now)
+            } else {
+                create_account_in_state(state, account_request)
+            }
+        }
     }
+}
+
+fn latest_reusable_manual_token_account_id(
+    state: &AuthState,
+    pending: &PendingSecretInteraction,
+) -> Option<CredentialAccountId> {
+    state
+        .accounts
+        .values()
+        .filter(|account| {
+            CredentialAccountOwnerScope::from_scope(&pending.scope).matches(account)
+                && account.provider == pending.provider
+                && account.label == pending.label
+                && account.ownership == CredentialOwnership::UserReusable
+                && account.owner_extension.is_none()
+                && account.granted_extensions.is_empty()
+                && account.access_secret.is_some()
+                && account.status != CredentialAccountStatus::Revoked
+        })
+        .max_by_key(|account| (account.updated_at, account.created_at, account.id))
+        .map(|account| account.id)
 }
 
 fn manual_token_account_request(

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/interactions.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/interactions.rs
@@ -124,10 +124,15 @@ where
         pending: &StoredManualTokenInteraction,
         secret: SecretString,
     ) -> Result<CredentialAccount, AuthProductError> {
+        let reusable_account = match pending.update_binding.as_ref() {
+            Some(_) => None,
+            None => self.find_reusable_manual_token_account(pending).await?,
+        };
         let account_id = pending
             .update_binding
             .as_ref()
             .map(|binding| binding.account_id)
+            .or_else(|| reusable_account.as_ref().map(|account| account.id))
             .unwrap_or_else(|| CredentialAccountId::from_uuid(pending.id.as_uuid()));
         let access_secret = manual_token_secret_handle(account_id, pending.id)?;
 
@@ -142,8 +147,12 @@ where
                 )
             })
             .unwrap_or((CredentialOwnership::UserReusable, None, Vec::new()));
+        let request_scope = reusable_account
+            .as_ref()
+            .map(|account| account.scope.clone())
+            .unwrap_or_else(|| pending.scope.clone());
         let request = NewCredentialAccount {
-            scope: pending.scope.clone(),
+            scope: request_scope,
             provider: pending.provider.clone(),
             label: pending.label.clone(),
             status: credential_status_for_completed_flow(),
@@ -154,8 +163,8 @@ where
             refresh_secret: None,
             scopes: Vec::new(),
         };
-        match pending.update_binding.as_ref() {
-            Some(binding) => {
+        match (pending.update_binding.as_ref(), reusable_account.as_ref()) {
+            (Some(binding), _) => {
                 let lock = self.lock_for(format!("account:{}", binding.account_id));
                 let _guard = lock.lock().await;
                 let (mut account, version) = self
@@ -188,7 +197,34 @@ where
                 }
                 Ok(account)
             }
-            None => {
+            (None, Some(reusable)) => {
+                let lock = self.lock_for(format!("account:{}", reusable.id));
+                let _guard = lock.lock().await;
+                let (mut account, version) = self
+                    .read_account(&reusable.scope, reusable.id)
+                    .await?
+                    .ok_or(AuthProductError::CredentialMissing)?;
+                validate_reusable_manual_token_account(&account, pending)?;
+                validate_account_update_target(&account, &request)?;
+                let previous_access_secret = account.access_secret.clone();
+                self.store_manual_secret(pending, access_secret, secret)
+                    .await?;
+                update_account_from_request(&mut account, request, Utc::now())?;
+                if let Err(error) = self
+                    .write_account(&account, CasExpectation::Version(version))
+                    .await
+                {
+                    self.cleanup_manual_secret(&pending.scope.resource, &account.access_secret)
+                        .await;
+                    return Err(error);
+                }
+                if previous_access_secret.as_ref() != account.access_secret.as_ref() {
+                    self.cleanup_manual_secret(&account.scope.resource, &previous_access_secret)
+                        .await;
+                }
+                Ok(account)
+            }
+            (None, None) => {
                 validate_new_credential_account(&request)?;
                 self.store_manual_secret(pending, access_secret, secret)
                     .await?;
@@ -205,6 +241,21 @@ where
                 }
             }
         }
+    }
+
+    async fn find_reusable_manual_token_account(
+        &self,
+        pending: &StoredManualTokenInteraction,
+    ) -> Result<Option<CredentialAccount>, AuthProductError> {
+        let owner = ironclaw_auth::CredentialAccountOwnerScope::from_scope(&pending.scope);
+        let mut matches = self
+            .account_records_for_owner(&owner)
+            .await?
+            .into_iter()
+            .filter(|account| validate_reusable_manual_token_account(account, pending).is_ok())
+            .collect::<Vec<_>>();
+        matches.sort_by_key(|account| (account.updated_at, account.created_at, account.id));
+        Ok(matches.pop())
     }
 
     async fn store_manual_secret(
@@ -233,6 +284,23 @@ where
             let _ = self.secret_store.delete(scope, access_secret).await;
         }
     }
+}
+
+fn validate_reusable_manual_token_account(
+    account: &CredentialAccount,
+    pending: &StoredManualTokenInteraction,
+) -> Result<(), AuthProductError> {
+    if account.provider != pending.provider
+        || account.label != pending.label
+        || account.ownership != CredentialOwnership::UserReusable
+        || account.owner_extension.is_some()
+        || !account.granted_extensions.is_empty()
+        || account.access_secret.is_none()
+        || account.status == ironclaw_auth::CredentialAccountStatus::Revoked
+    {
+        return Err(AuthProductError::CredentialMissing);
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -327,6 +327,101 @@ async fn filesystem_manual_token_submit_stores_secret_and_dedupes_replay() {
 }
 
 #[tokio::test]
+async fn filesystem_manual_token_submit_rotates_existing_reusable_account() {
+    let filesystem = test_filesystem();
+    let concrete_secret_store = Arc::new(InMemorySecretStore::new());
+    let secret_store: Arc<dyn SecretStore> = concrete_secret_store.clone();
+    let scope = test_scope();
+    let service = test_service(filesystem, secret_store);
+
+    let first_challenge = service
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .unwrap();
+    let AuthChallenge::ManualTokenRequired {
+        interaction_id: first_interaction,
+        ..
+    } = first_challenge
+    else {
+        panic!("expected manual token challenge");
+    };
+    let first = service
+        .submit_manual_token(
+            &scope,
+            SecretSubmitRequest {
+                interaction_id: first_interaction,
+                secret: SecretString::from("first-manual-token"),
+            },
+        )
+        .await
+        .unwrap();
+    let first_account = service
+        .read_account(&scope, first.account_id)
+        .await
+        .unwrap()
+        .expect("first account")
+        .0;
+    let first_handle = first_account.access_secret.expect("first secret handle");
+
+    let second_challenge = service
+        .request_secret_input(ManualTokenSetupRequest {
+            scope: scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding: None,
+            expires_at: Utc::now() + Duration::minutes(5),
+        })
+        .await
+        .unwrap();
+    let AuthChallenge::ManualTokenRequired {
+        interaction_id: second_interaction,
+        ..
+    } = second_challenge
+    else {
+        panic!("expected manual token challenge");
+    };
+    let second = service
+        .submit_manual_token(
+            &scope,
+            SecretSubmitRequest {
+                interaction_id: second_interaction,
+                secret: SecretString::from("second-manual-token"),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(second.account_id, first.account_id);
+    let accounts = service.accounts_for_owner(&scope).await.unwrap();
+    assert_eq!(accounts.len(), 1);
+    let updated = accounts.into_iter().next().unwrap();
+    let second_handle = updated.access_secret.expect("second secret handle");
+    assert_ne!(second_handle, first_handle);
+    assert!(
+        concrete_secret_store
+            .metadata(&scope.resource, &second_handle)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        concrete_secret_store
+            .metadata(&scope.resource, &first_handle)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn filesystem_manual_token_completion_persists_auth_flow_account() {
     let filesystem = test_filesystem();
     let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -93,7 +93,8 @@ impl RuntimeCredentialAccountSelectionService for ProductAuthRuntimeCredentialAc
         match selectable.as_slice() {
             [] => Err(AuthProductError::CrossScopeDenied),
             [account] => Ok(account.clone()),
-            _ => Err(AuthProductError::AccountSelectionRequired),
+            _ => select_latest_duplicate_user_reusable_account(&selectable)
+                .ok_or(AuthProductError::AccountSelectionRequired),
         }
     }
 }
@@ -163,6 +164,26 @@ fn account_visible_from_runtime_scope(
         && account_resource.mission_id == runtime_resource.mission_id
         && account_resource.thread_id == runtime_resource.thread_id
         && account.scope.session_id == runtime_scope.session_id
+}
+
+fn select_latest_duplicate_user_reusable_account(
+    accounts: &[CredentialAccount],
+) -> Option<CredentialAccount> {
+    let first = accounts.first()?;
+    if !accounts.iter().all(|account| {
+        account.provider == first.provider
+            && account.label == first.label
+            && account.ownership == CredentialOwnership::UserReusable
+            && account.owner_extension.is_none()
+            && account.granted_extensions.is_empty()
+            && account.access_secret.is_some()
+    }) {
+        return None;
+    }
+    accounts
+        .iter()
+        .max_by_key(|account| (account.updated_at, account.created_at, account.id))
+        .cloned()
 }
 
 fn runtime_account_owner_scope(
@@ -542,5 +563,61 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(error, CredentialStageError::AuthRequired);
+    }
+
+    #[tokio::test]
+    async fn resolver_uses_latest_duplicate_user_reusable_account() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        let auth_scope = AuthProductScope::new(scope.clone(), AuthSurface::Api);
+        let first_secret = SecretHandle::new("old-token").unwrap();
+        let latest_secret = SecretHandle::new("new-token").unwrap();
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: auth_scope.clone(),
+                provider: AuthProviderId::new("github").unwrap(),
+                label: CredentialAccountLabel::new("GitHub").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(first_secret),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: auth_scope,
+                provider: AuthProviderId::new("github").unwrap(),
+                label: CredentialAccountLabel::new("GitHub").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(latest_secret.clone()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+
+        let resolved = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &scope,
+                provider: &RuntimeCredentialAccountProviderId::new("github").unwrap(),
+                requester_extension: &ExtensionId::new("github").unwrap(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, latest_secret);
     }
 }


### PR DESCRIPTION
## Summary
- rotate an existing matching user-reusable manual-token account instead of creating a new account for every PAT prompt
- collapse same-label duplicate user-reusable runtime accounts to the latest valid secret so old prompt-created duplicates do not block tool calls forever
- keep distinct-account ambiguity intact and add regressions for manual-token rotation plus duplicate runtime selection

## Tests
- cargo test -p ironclaw_auth manual_token
- cargo test -p ironclaw_reborn_composition product_auth_durable::tests::filesystem_manual_token
- cargo test -p ironclaw_reborn_composition product_auth_runtime_credentials

Note: filtered ironclaw_reborn_composition test builds still emit existing dead-code warnings for gated product-auth modules.