### PR TITLE
Project WebUI v2 extension onboarding messages

### DIFF
--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -101,12 +101,13 @@ pub use inbound_turn::{
 pub use ledger::{IdempotencyDecision, IdempotencyLedger};
 pub use lifecycle::{
     LifecycleBlockerRef, LifecycleCommandKind, LifecycleExtensionCredentialRequirement,
-    LifecycleExtensionCredentialSetup, LifecycleExtensionRuntimeKind, LifecycleExtensionSource,
-    LifecycleExtensionSummary, LifecycleInstalledExtensionSummary, LifecyclePackageId,
-    LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase, LifecycleProductAction,
-    LifecycleProductContext, LifecycleProductFacade, LifecycleProductPayload,
-    LifecycleProductResponse, LifecycleProductSurfaceContext, LifecycleReadinessBlocker,
-    LifecycleSkillSource, LifecycleSkillSummary, UnsupportedLifecycleProductFacade,
+    LifecycleExtensionCredentialSetup, LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind,
+    LifecycleExtensionSource, LifecycleExtensionSummary, LifecycleInstalledExtensionSummary,
+    LifecyclePackageId, LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase,
+    LifecycleProductAction, LifecycleProductContext, LifecycleProductFacade,
+    LifecycleProductPayload, LifecycleProductResponse, LifecycleProductSurfaceContext,
+    LifecycleReadinessBlocker, LifecycleSkillSource, LifecycleSkillSummary,
+    UnsupportedLifecycleProductFacade,
 };
 // Product hosts use this outbound orchestration seam to wire outbound policy
 // decisions to adapter rendering without reaching into module internals.
@@ -134,13 +135,13 @@ pub use reborn_services::{
     ExtensionCredentialSetupService, ExtensionCredentialStatusRequest,
     ExtensionCredentialSubmitRequest, RebornCancelRunResponse, RebornCreateThreadResponse,
     RebornExtensionActionResponse, RebornExtensionCredentialSetup, RebornExtensionInfo,
-    RebornExtensionListResponse, RebornExtensionRegistryEntry, RebornExtensionRegistryResponse,
-    RebornExtensionSetupField, RebornExtensionSetupSecret, RebornGetRunStateRequest,
-    RebornGetRunStateResponse, RebornListThreadsResponse, RebornResolveGateResponse,
-    RebornResumeGateResponse, RebornServices, RebornServicesApi, RebornServicesError,
-    RebornServicesErrorCode, RebornServicesErrorKind, RebornSetupExtensionResponse,
-    RebornStreamEventsRequest, RebornStreamEventsResponse, RebornSubmitTurnResponse,
-    RebornTimelineRequest, RebornTimelineResponse,
+    RebornExtensionListResponse, RebornExtensionOnboardingPayload, RebornExtensionOnboardingState,
+    RebornExtensionRegistryEntry, RebornExtensionRegistryResponse, RebornExtensionSetupField,
+    RebornExtensionSetupSecret, RebornGetRunStateRequest, RebornGetRunStateResponse,
+    RebornListThreadsResponse, RebornResolveGateResponse, RebornResumeGateResponse, RebornServices,
+    RebornServicesApi, RebornServicesError, RebornServicesErrorCode, RebornServicesErrorKind,
+    RebornSetupExtensionResponse, RebornStreamEventsRequest, RebornStreamEventsResponse,
+    RebornSubmitTurnResponse, RebornTimelineRequest, RebornTimelineResponse,
 };
 
 pub use webui_inbound::{

--- a/crates/ironclaw_product_workflow/src/lifecycle.rs
+++ b/crates/ironclaw_product_workflow/src/lifecycle.rs
@@ -342,6 +342,8 @@ pub struct LifecycleExtensionSummary {
     pub visible_read_only_capability_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub credential_requirements: Vec<LifecycleExtensionCredentialRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onboarding: Option<LifecycleExtensionOnboarding>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -356,6 +358,17 @@ pub struct LifecycleExtensionCredentialRequirement {
     pub provider: String,
     pub required: bool,
     pub setup: LifecycleExtensionCredentialSetup,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleExtensionOnboarding {
+    pub instructions: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_instructions: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_next_step: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -49,6 +49,7 @@ use crate::{
 };
 
 mod error;
+mod extension_onboarding;
 mod extension_setup_credentials;
 mod extensions;
 mod lifecycle_setup;
@@ -58,11 +59,12 @@ pub use error::{RebornServicesError, RebornServicesErrorCode, RebornServicesErro
 pub use types::{
     RebornCancelRunResponse, RebornCreateThreadResponse, RebornExtensionActionResponse,
     RebornExtensionCredentialSetup, RebornExtensionInfo, RebornExtensionListResponse,
-    RebornExtensionRegistryEntry, RebornExtensionRegistryResponse, RebornExtensionSetupField,
-    RebornExtensionSetupSecret, RebornGetRunStateRequest, RebornGetRunStateResponse,
-    RebornListThreadsResponse, RebornResolveGateResponse, RebornResumeGateResponse,
-    RebornSetupExtensionResponse, RebornStreamEventsRequest, RebornStreamEventsResponse,
-    RebornSubmitTurnResponse, RebornTimelineRequest, RebornTimelineResponse,
+    RebornExtensionOnboardingPayload, RebornExtensionOnboardingState, RebornExtensionRegistryEntry,
+    RebornExtensionRegistryResponse, RebornExtensionSetupField, RebornExtensionSetupSecret,
+    RebornGetRunStateRequest, RebornGetRunStateResponse, RebornListThreadsResponse,
+    RebornResolveGateResponse, RebornResumeGateResponse, RebornSetupExtensionResponse,
+    RebornStreamEventsRequest, RebornStreamEventsResponse, RebornSubmitTurnResponse,
+    RebornTimelineRequest, RebornTimelineResponse,
 };
 
 type SkillActivationRecorder =

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
@@ -1,0 +1,421 @@
+use crate::{
+    LifecycleExtensionCredentialSetup, LifecycleExtensionRuntimeKind, LifecycleExtensionSummary,
+    LifecycleInstalledExtensionSummary, LifecyclePhase, LifecycleProductPayload,
+    LifecycleProductResponse,
+};
+
+use super::types::{RebornExtensionOnboardingPayload, RebornExtensionOnboardingState};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ExtensionOnboarding {
+    pub(super) state: Option<RebornExtensionOnboardingState>,
+    pub(super) onboarding: Option<RebornExtensionOnboardingPayload>,
+    pub(super) instructions: Option<String>,
+    pub(super) awaiting_token: Option<bool>,
+}
+
+impl ExtensionOnboarding {
+    pub(super) fn empty() -> Self {
+        Self {
+            state: None,
+            onboarding: None,
+            instructions: None,
+            awaiting_token: None,
+        }
+    }
+}
+
+pub(super) fn for_installed(extension: &LifecycleInstalledExtensionSummary) -> ExtensionOnboarding {
+    for_summary(&extension.summary, extension.phase)
+}
+
+pub(super) fn from_lifecycle(lifecycle: &LifecycleProductResponse) -> ExtensionOnboarding {
+    let Some(LifecycleProductPayload::ExtensionList { extensions, .. }) = &lifecycle.payload else {
+        return ExtensionOnboarding::empty();
+    };
+    let extension = lifecycle
+        .package_ref
+        .as_ref()
+        .and_then(|package_ref| {
+            extensions
+                .iter()
+                .find(|extension| &extension.summary.package_ref == package_ref)
+        })
+        .or_else(|| extensions.first());
+    let Some(extension) = extension else {
+        return ExtensionOnboarding::empty();
+    };
+    for_installed(extension)
+}
+
+fn for_summary(summary: &LifecycleExtensionSummary, phase: LifecyclePhase) -> ExtensionOnboarding {
+    if phase == LifecyclePhase::Active {
+        return ExtensionOnboarding::empty();
+    }
+    if phase == LifecyclePhase::Configured || summary.credential_requirements.is_empty() {
+        return no_credential_onboarding(summary, phase);
+    }
+    credential_onboarding(summary)
+}
+
+fn credential_onboarding(summary: &LifecycleExtensionSummary) -> ExtensionOnboarding {
+    let has_oauth = summary.credential_requirements.iter().any(|requirement| {
+        matches!(
+            requirement.setup,
+            LifecycleExtensionCredentialSetup::OAuth { .. }
+        )
+    });
+    let state = if has_oauth {
+        RebornExtensionOnboardingState::AuthRequired
+    } else {
+        RebornExtensionOnboardingState::SetupRequired
+    };
+    let instructions = instructions(summary);
+    let credential_instructions = summary
+        .onboarding
+        .as_ref()
+        .and_then(|onboarding| onboarding.credential_instructions.clone())
+        .unwrap_or_else(|| format!("Configure the credentials required by {}.", summary.name));
+    let credential_next_step = credential_next_step(summary);
+    ExtensionOnboarding {
+        state: Some(state),
+        onboarding: Some(RebornExtensionOnboardingPayload {
+            credential_instructions: Some(credential_instructions),
+            setup_url: setup_url(summary),
+            credential_next_step: Some(credential_next_step),
+        }),
+        instructions: Some(instructions),
+        awaiting_token: Some(!has_oauth),
+    }
+}
+
+fn no_credential_onboarding(
+    summary: &LifecycleExtensionSummary,
+    phase: LifecyclePhase,
+) -> ExtensionOnboarding {
+    let state = match phase {
+        LifecyclePhase::Installed | LifecyclePhase::Configured => {
+            Some(RebornExtensionOnboardingState::Installed)
+        }
+        LifecyclePhase::Failed => Some(RebornExtensionOnboardingState::Failed),
+        _ => None,
+    };
+    let instructions = if phase == LifecyclePhase::Configured {
+        Some(activation_instructions(summary))
+    } else if let Some(onboarding) = &summary.onboarding {
+        Some(onboarding.instructions.clone())
+    } else if matches!(
+        summary.runtime_kind,
+        LifecycleExtensionRuntimeKind::McpServer
+    ) {
+        Some(format!(
+            "{} is installed. Activate it to make its MCP tools available.",
+            summary.name
+        ))
+    } else if phase == LifecyclePhase::Installed {
+        Some(format!(
+            "{} is installed. Activate it to make its tools available.",
+            summary.name
+        ))
+    } else {
+        None
+    };
+    ExtensionOnboarding {
+        state,
+        onboarding: instructions
+            .as_ref()
+            .map(|instructions| RebornExtensionOnboardingPayload {
+                credential_instructions: Some(instructions.clone()),
+                setup_url: None,
+                credential_next_step: Some(credential_next_step(summary)),
+            }),
+        instructions,
+        awaiting_token: None,
+    }
+}
+
+fn activation_instructions(summary: &LifecycleExtensionSummary) -> String {
+    if matches!(
+        summary.runtime_kind,
+        LifecycleExtensionRuntimeKind::McpServer
+    ) {
+        format!(
+            "{} is installed. Activate it to make its MCP tools available.",
+            summary.name
+        )
+    } else {
+        format!(
+            "{} is installed. Activate it to make its tools available.",
+            summary.name
+        )
+    }
+}
+
+fn instructions(summary: &LifecycleExtensionSummary) -> String {
+    summary
+        .onboarding
+        .as_ref()
+        .map(|onboarding| onboarding.instructions.clone())
+        .unwrap_or_else(|| {
+            format!(
+                "{} needs configuration before its tools can run.",
+                summary.name
+            )
+        })
+}
+
+fn setup_url(summary: &LifecycleExtensionSummary) -> Option<String> {
+    summary
+        .onboarding
+        .as_ref()
+        .and_then(|onboarding| onboarding.setup_url.clone())
+}
+
+fn credential_next_step(summary: &LifecycleExtensionSummary) -> String {
+    summary
+        .onboarding
+        .as_ref()
+        .and_then(|onboarding| onboarding.credential_next_step.clone())
+        .unwrap_or_else(|| {
+            format!(
+                "After configuration completes, activate {} to publish its tools.",
+                summary.name
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        LifecycleExtensionCredentialRequirement, LifecycleExtensionOnboarding,
+        LifecycleExtensionSource, LifecyclePackageKind, LifecyclePackageRef,
+    };
+
+    #[test]
+    fn github_manual_token_projects_setup_required_message() {
+        let extension = installed_extension(
+            "github",
+            "GitHub",
+            LifecyclePhase::Installed,
+            vec![manual_requirement("github_runtime_token", "github")],
+            LifecycleExtensionRuntimeKind::WasmTool,
+            Some(LifecycleExtensionOnboarding {
+                instructions: "GitHub needs a personal access token before its repository and pull request tools can run.".to_string(),
+                credential_instructions: Some("Create a GitHub personal access token with the repository permissions you want IronClaw to use, then paste it here.".to_string()),
+                setup_url: Some("https://github.com/settings/personal-access-tokens/new".to_string()),
+                credential_next_step: Some("After saving the token, activate GitHub to publish its tools.".to_string()),
+            }),
+        );
+
+        let onboarding = for_installed(&extension);
+
+        assert_eq!(
+            onboarding.state,
+            Some(RebornExtensionOnboardingState::SetupRequired)
+        );
+        assert_eq!(onboarding.awaiting_token, Some(true));
+        assert_eq!(
+            onboarding.instructions.as_deref(),
+            Some(
+                "GitHub needs a personal access token before its repository and pull request tools can run."
+            )
+        );
+        assert_eq!(
+            onboarding
+                .onboarding
+                .expect("onboarding payload")
+                .setup_url
+                .as_deref(),
+            Some("https://github.com/settings/personal-access-tokens/new")
+        );
+    }
+
+    #[test]
+    fn google_oauth_projects_auth_required_message() {
+        let extension = installed_extension(
+            "gmail",
+            "Gmail",
+            LifecyclePhase::Installed,
+            vec![oauth_requirement("gmail_account", "google")],
+            LifecycleExtensionRuntimeKind::FirstParty,
+            Some(LifecycleExtensionOnboarding {
+                instructions: "Gmail needs Google OAuth authorization before mail tools can run."
+                    .to_string(),
+                credential_instructions: Some(
+                    "Authorize the Google account that IronClaw should use for Gmail.".to_string(),
+                ),
+                setup_url: None,
+                credential_next_step: Some(
+                    "After authorization completes, activate Gmail to publish its tools."
+                        .to_string(),
+                ),
+            }),
+        );
+
+        let onboarding = for_installed(&extension);
+
+        assert_eq!(
+            onboarding.state,
+            Some(RebornExtensionOnboardingState::AuthRequired)
+        );
+        assert_eq!(onboarding.awaiting_token, Some(false));
+        assert_eq!(
+            onboarding.instructions.as_deref(),
+            Some("Gmail needs Google OAuth authorization before mail tools can run.")
+        );
+    }
+
+    #[test]
+    fn web_access_projects_activation_message_without_credentials() {
+        let extension = installed_extension(
+            "web-access",
+            "Web Access",
+            LifecyclePhase::Installed,
+            Vec::new(),
+            LifecycleExtensionRuntimeKind::FirstParty,
+            Some(LifecycleExtensionOnboarding {
+                instructions: "Web Access does not need credentials. Activate it to make web search and saved-result retrieval tools available.".to_string(),
+                credential_instructions: Some("No credentials are required for Web Access.".to_string()),
+                setup_url: None,
+                credential_next_step: Some("Activate Web Access to publish its tools.".to_string()),
+            }),
+        );
+
+        let onboarding = for_installed(&extension);
+
+        assert_eq!(
+            onboarding.state,
+            Some(RebornExtensionOnboardingState::Installed)
+        );
+        assert_eq!(onboarding.awaiting_token, None);
+        assert_eq!(
+            onboarding.instructions.as_deref(),
+            Some(
+                "Web Access does not need credentials. Activate it to make web search and saved-result retrieval tools available."
+            )
+        );
+    }
+
+    #[test]
+    fn configured_credentialed_extension_projects_activation_message() {
+        let extension = installed_extension(
+            "github",
+            "GitHub",
+            LifecyclePhase::Configured,
+            vec![manual_requirement("github_runtime_token", "github")],
+            LifecycleExtensionRuntimeKind::WasmTool,
+            Some(LifecycleExtensionOnboarding {
+                instructions: "GitHub needs a personal access token before its repository and pull request tools can run.".to_string(),
+                credential_instructions: Some("Create a GitHub personal access token with the repository permissions you want IronClaw to use, then paste it here.".to_string()),
+                setup_url: Some("https://github.com/settings/personal-access-tokens/new".to_string()),
+                credential_next_step: Some("After saving the token, activate GitHub to publish its tools.".to_string()),
+            }),
+        );
+
+        let onboarding = for_installed(&extension);
+
+        assert_eq!(
+            onboarding.state,
+            Some(RebornExtensionOnboardingState::Installed)
+        );
+        assert_eq!(onboarding.awaiting_token, None);
+        assert_eq!(
+            onboarding.instructions.as_deref(),
+            Some("GitHub is installed. Activate it to make its tools available.")
+        );
+    }
+
+    #[test]
+    fn lifecycle_projection_uses_matching_package_ref() {
+        let lifecycle = LifecycleProductResponse {
+            package_ref: Some(
+                LifecyclePackageRef::new(LifecyclePackageKind::Extension, "target")
+                    .expect("valid package ref"),
+            ),
+            phase: LifecyclePhase::Installed,
+            blockers: Vec::new(),
+            message: None,
+            payload: Some(LifecycleProductPayload::ExtensionList {
+                extensions: vec![
+                    installed_extension(
+                        "other",
+                        "Other",
+                        LifecyclePhase::Installed,
+                        Vec::new(),
+                        LifecycleExtensionRuntimeKind::FirstParty,
+                        Some(LifecycleExtensionOnboarding {
+                            instructions: "Other message".to_string(),
+                            credential_instructions: None,
+                            setup_url: None,
+                            credential_next_step: None,
+                        }),
+                    ),
+                    installed_extension(
+                        "target",
+                        "Target",
+                        LifecyclePhase::Installed,
+                        Vec::new(),
+                        LifecycleExtensionRuntimeKind::FirstParty,
+                        Some(LifecycleExtensionOnboarding {
+                            instructions: "Target message".to_string(),
+                            credential_instructions: None,
+                            setup_url: None,
+                            credential_next_step: None,
+                        }),
+                    ),
+                ],
+                count: 2,
+            }),
+        };
+
+        let onboarding = from_lifecycle(&lifecycle);
+
+        assert_eq!(onboarding.instructions.as_deref(), Some("Target message"));
+    }
+
+    fn installed_extension(
+        package_id: &str,
+        name: &str,
+        phase: LifecyclePhase,
+        credential_requirements: Vec<LifecycleExtensionCredentialRequirement>,
+        runtime_kind: LifecycleExtensionRuntimeKind,
+        onboarding: Option<LifecycleExtensionOnboarding>,
+    ) -> LifecycleInstalledExtensionSummary {
+        LifecycleInstalledExtensionSummary {
+            summary: LifecycleExtensionSummary {
+                package_ref: LifecyclePackageRef::new(LifecyclePackageKind::Extension, package_id)
+                    .expect("valid package ref"),
+                name: name.to_string(),
+                version: "1.0.0".to_string(),
+                description: "test extension".to_string(),
+                source: LifecycleExtensionSource::HostBundled,
+                runtime_kind,
+                visible_read_only_capability_ids: Vec::new(),
+                credential_requirements,
+                onboarding,
+            },
+            phase,
+        }
+    }
+
+    fn manual_requirement(name: &str, provider: &str) -> LifecycleExtensionCredentialRequirement {
+        LifecycleExtensionCredentialRequirement {
+            name: name.to_string(),
+            provider: provider.to_string(),
+            required: true,
+            setup: LifecycleExtensionCredentialSetup::ManualToken,
+        }
+    }
+
+    fn oauth_requirement(name: &str, provider: &str) -> LifecycleExtensionCredentialRequirement {
+        LifecycleExtensionCredentialRequirement {
+            name: name.to_string(),
+            provider: provider.to_string(),
+            required: true,
+            setup: LifecycleExtensionCredentialSetup::OAuth {
+                scopes: vec!["scope".to_string()],
+            },
+        }
+    }
+}

--- a/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
@@ -9,14 +9,19 @@ use crate::{
     WebUiAuthenticatedCaller,
 };
 
+use super::extension_onboarding;
 use super::lifecycle_setup::map_lifecycle_error;
 
 pub(super) async fn list_extensions(
     facade: &dyn LifecycleProductFacade,
     caller: WebUiAuthenticatedCaller,
 ) -> Result<RebornExtensionListResponse, RebornServicesError> {
-    let lifecycle =
-        execute_lifecycle(facade, caller, LifecycleProductAction::ExtensionList).await?;
+    let lifecycle = execute_lifecycle(
+        facade,
+        lifecycle_surface_context(caller),
+        LifecycleProductAction::ExtensionList,
+    )
+    .await?;
     Ok(RebornExtensionListResponse {
         extensions: lifecycle_extension_infos(&lifecycle),
     })
@@ -26,15 +31,16 @@ pub(super) async fn list_extension_registry(
     facade: &dyn LifecycleProductFacade,
     caller: WebUiAuthenticatedCaller,
 ) -> Result<RebornExtensionRegistryResponse, RebornServicesError> {
+    let context = lifecycle_surface_context(caller);
     let (installed_result, registry_result) = tokio::join!(
         execute_lifecycle(
             facade,
-            caller.clone(),
+            context.clone(),
             LifecycleProductAction::ExtensionList
         ),
         execute_lifecycle(
             facade,
-            caller,
+            context,
             LifecycleProductAction::ExtensionSearch {
                 query: String::new(),
             },
@@ -66,13 +72,15 @@ pub(super) async fn install_extension(
     caller: WebUiAuthenticatedCaller,
     package_ref: LifecyclePackageRef,
 ) -> Result<RebornExtensionActionResponse, RebornServicesError> {
+    let context = lifecycle_surface_context(caller);
     let lifecycle = execute_lifecycle(
         facade,
-        caller,
+        context.clone(),
         LifecycleProductAction::ExtensionInstall { package_ref },
     )
     .await?;
-    Ok(action_response(&lifecycle, None))
+    let projection = project_action_package_best_effort(facade, context, &lifecycle).await;
+    Ok(action_response(&lifecycle, None, projection.as_ref()))
 }
 
 pub(super) async fn activate_extension(
@@ -80,15 +88,18 @@ pub(super) async fn activate_extension(
     caller: WebUiAuthenticatedCaller,
     package_ref: LifecyclePackageRef,
 ) -> Result<RebornExtensionActionResponse, RebornServicesError> {
+    let context = lifecycle_surface_context(caller);
     let lifecycle = execute_lifecycle(
         facade,
-        caller,
+        context.clone(),
         LifecycleProductAction::ExtensionActivate { package_ref },
     )
     .await?;
+    let projection = project_action_package_best_effort(facade, context, &lifecycle).await;
     Ok(action_response(
         &lifecycle,
         Some(lifecycle.phase == LifecyclePhase::Active),
+        projection.as_ref(),
     ))
 }
 
@@ -99,22 +110,51 @@ pub(super) async fn remove_extension(
 ) -> Result<RebornExtensionActionResponse, RebornServicesError> {
     let lifecycle = execute_lifecycle(
         facade,
-        caller,
+        lifecycle_surface_context(caller),
         LifecycleProductAction::ExtensionRemove { package_ref },
     )
     .await?;
-    Ok(action_response(&lifecycle, None))
+    Ok(action_response(&lifecycle, None, None))
 }
 
 async fn execute_lifecycle(
     facade: &dyn LifecycleProductFacade,
-    caller: WebUiAuthenticatedCaller,
+    context: LifecycleProductContext,
     action: LifecycleProductAction,
 ) -> Result<LifecycleProductResponse, RebornServicesError> {
     facade
-        .execute(lifecycle_surface_context(caller), action)
+        .execute(context, action)
         .await
         .map_err(map_lifecycle_error)
+}
+
+async fn project_action_package(
+    facade: &dyn LifecycleProductFacade,
+    context: LifecycleProductContext,
+    lifecycle: &LifecycleProductResponse,
+) -> Result<Option<LifecycleProductResponse>, RebornServicesError> {
+    let Some(package_ref) = lifecycle.package_ref.clone() else {
+        return Ok(None);
+    };
+    facade
+        .project_package(context, package_ref)
+        .await
+        .map(Some)
+        .map_err(map_lifecycle_error)
+}
+
+async fn project_action_package_best_effort(
+    facade: &dyn LifecycleProductFacade,
+    context: LifecycleProductContext,
+    lifecycle: &LifecycleProductResponse,
+) -> Option<LifecycleProductResponse> {
+    // Install/activate already mutated lifecycle state. Projection only enriches
+    // the response with onboarding copy, so failure must not turn a completed
+    // action into a browser-visible mutation error.
+    project_action_package(facade, context, lifecycle)
+        .await
+        .ok()
+        .flatten()
 }
 
 fn lifecycle_surface_context(caller: WebUiAuthenticatedCaller) -> LifecycleProductContext {
@@ -161,6 +201,7 @@ fn registry_entry(
 
 fn extension_info(installed: LifecycleInstalledExtensionSummary) -> RebornExtensionInfo {
     let phase = installed.phase;
+    let onboarding = extension_onboarding::for_installed(&installed);
     let summary = installed.summary;
     RebornExtensionInfo {
         package_ref: summary.package_ref,
@@ -181,8 +222,8 @@ fn extension_info(installed: LifecycleInstalledExtensionSummary) -> RebornExtens
         activation_status: Some(phase_status(phase).to_string()),
         activation_error: None,
         version: Some(summary.version),
-        onboarding_state: None,
-        onboarding: None,
+        onboarding_state: onboarding.state,
+        onboarding: onboarding.onboarding,
     }
 }
 
@@ -206,22 +247,178 @@ fn phase_status(phase: LifecyclePhase) -> &'static str {
 fn action_response(
     lifecycle: &LifecycleProductResponse,
     activated: Option<bool>,
+    projection: Option<&LifecycleProductResponse>,
 ) -> RebornExtensionActionResponse {
     let success = !matches!(
         lifecycle.phase,
         LifecyclePhase::Failed | LifecyclePhase::UnsupportedOrLegacy
     );
+    let onboarding = projection
+        .map(extension_onboarding::from_lifecycle)
+        .unwrap_or_else(extension_onboarding::ExtensionOnboarding::empty);
     RebornExtensionActionResponse {
         success,
-        message: lifecycle
-            .message
+        message: onboarding
+            .instructions
             .clone()
+            .or_else(|| lifecycle.message.clone())
             .unwrap_or_else(|| "Extension lifecycle action completed".to_string()),
         activated,
         auth_url: None,
-        awaiting_token: None,
-        instructions: None,
-        onboarding_state: None,
-        onboarding: None,
+        awaiting_token: onboarding.awaiting_token,
+        instructions: onboarding.instructions,
+        onboarding_state: onboarding.state,
+        onboarding: onboarding.onboarding,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+
+    use super::*;
+    use crate::{
+        LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
+        LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind, LifecycleExtensionSource,
+        LifecycleInstalledExtensionSummary, LifecyclePackageKind, ProductWorkflowError,
+        RebornExtensionOnboardingState,
+    };
+
+    #[tokio::test]
+    async fn install_action_projects_lifecycle_onboarding_when_available() {
+        let facade = ActionProjectionFacade {
+            projection_error: false,
+        };
+
+        let response = install_extension(&facade, caller(), package_ref())
+            .await
+            .expect("install response");
+
+        assert!(response.success);
+        assert_eq!(
+            response.message,
+            "Fixture needs a token before its tools can run."
+        );
+        assert_eq!(
+            response.onboarding_state,
+            Some(RebornExtensionOnboardingState::SetupRequired)
+        );
+        assert_eq!(response.awaiting_token, Some(true));
+        assert_eq!(
+            response
+                .onboarding
+                .as_ref()
+                .and_then(|payload| payload.credential_instructions.as_deref()),
+            Some("Paste the fixture token.")
+        );
+    }
+
+    #[tokio::test]
+    async fn install_action_keeps_success_when_message_projection_fails() {
+        let facade = ActionProjectionFacade {
+            projection_error: true,
+        };
+
+        let response = install_extension(&facade, caller(), package_ref())
+            .await
+            .expect("install response");
+
+        assert!(response.success);
+        assert_eq!(response.message, "Fixture installed.");
+        assert!(response.onboarding_state.is_none());
+        assert!(response.onboarding.is_none());
+    }
+
+    struct ActionProjectionFacade {
+        projection_error: bool,
+    }
+
+    #[async_trait]
+    impl LifecycleProductFacade for ActionProjectionFacade {
+        async fn execute(
+            &self,
+            _context: LifecycleProductContext,
+            action: LifecycleProductAction,
+        ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+            assert!(matches!(
+                action,
+                LifecycleProductAction::ExtensionInstall { .. }
+            ));
+            Ok(LifecycleProductResponse {
+                package_ref: Some(package_ref()),
+                phase: LifecyclePhase::Installed,
+                blockers: Vec::new(),
+                message: Some("Fixture installed.".to_string()),
+                payload: Some(LifecycleProductPayload::ExtensionInstall {
+                    installed: true,
+                    visible_capability_ids: Vec::new(),
+                }),
+            })
+        }
+
+        async fn project_package(
+            &self,
+            _context: LifecycleProductContext,
+            _package_ref: LifecyclePackageRef,
+        ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+            if self.projection_error {
+                return Err(ProductWorkflowError::Transient {
+                    reason: "projection unavailable".to_string(),
+                });
+            }
+            Ok(LifecycleProductResponse {
+                package_ref: Some(package_ref()),
+                phase: LifecyclePhase::Installed,
+                blockers: Vec::new(),
+                message: None,
+                payload: Some(LifecycleProductPayload::ExtensionList {
+                    extensions: vec![LifecycleInstalledExtensionSummary {
+                        summary: summary_with_onboarding(),
+                        phase: LifecyclePhase::Installed,
+                    }],
+                    count: 1,
+                }),
+            })
+        }
+    }
+
+    fn caller() -> WebUiAuthenticatedCaller {
+        WebUiAuthenticatedCaller::new(
+            TenantId::new("tenant-alpha").expect("valid tenant"),
+            UserId::new("user-alpha").expect("valid user"),
+            Some(AgentId::new("agent-alpha").expect("valid agent")),
+            Some(ProjectId::new("project-alpha").expect("valid project")),
+        )
+    }
+
+    fn package_ref() -> LifecyclePackageRef {
+        LifecyclePackageRef::new(LifecyclePackageKind::Extension, "fixture").expect("valid ref")
+    }
+
+    fn summary_with_onboarding() -> LifecycleExtensionSummary {
+        LifecycleExtensionSummary {
+            package_ref: package_ref(),
+            name: "Fixture".to_string(),
+            version: "1.0.0".to_string(),
+            description: "test extension".to_string(),
+            source: LifecycleExtensionSource::HostBundled,
+            runtime_kind: LifecycleExtensionRuntimeKind::WasmTool,
+            visible_read_only_capability_ids: Vec::new(),
+            credential_requirements: vec![LifecycleExtensionCredentialRequirement {
+                name: "fixture_token".to_string(),
+                provider: "fixture".to_string(),
+                required: true,
+                setup: LifecycleExtensionCredentialSetup::ManualToken,
+            }],
+            onboarding: Some(LifecycleExtensionOnboarding {
+                instructions: "Fixture needs a token before its tools can run.".to_string(),
+                credential_instructions: Some("Paste the fixture token.".to_string()),
+                setup_url: None,
+                credential_next_step: Some(
+                    "After saving the token, activate Fixture to publish its tools.".to_string(),
+                ),
+            }),
+        }
     }
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
@@ -10,7 +10,7 @@ use crate::{
     WebUiInboundValidationError, WebUiSetupExtensionRequest,
 };
 
-use super::{ExtensionCredentialSetupService, extension_setup_credentials};
+use super::{ExtensionCredentialSetupService, extension_onboarding, extension_setup_credentials};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SetupAction {
@@ -96,14 +96,15 @@ async fn setup_extension_response(
         requirements,
     )
     .await?;
+    let onboarding = extension_onboarding::from_lifecycle(&lifecycle).onboarding;
     Ok(RebornSetupExtensionResponse {
         package_ref,
         phase: lifecycle.phase,
         blockers: lifecycle.blockers,
+        onboarding,
         payload: lifecycle.payload,
         secrets,
         fields: Vec::new(),
-        onboarding: None,
     })
 }
 

--- a/crates/ironclaw_product_workflow/src/reborn_services/types.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/types.rs
@@ -7,7 +7,6 @@ use ironclaw_turns::{
     SanitizedFailure, TurnCheckpointId, TurnRunId, TurnRunState, TurnStatus,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use crate::{
     LifecyclePackageRef, LifecyclePhase, LifecycleProductPayload, LifecycleReadinessBlocker,
@@ -236,9 +235,9 @@ pub struct RebornExtensionInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub onboarding_state: Option<String>,
+    pub onboarding_state: Option<RebornExtensionOnboardingState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub onboarding: Option<Value>,
+    pub onboarding: Option<RebornExtensionOnboardingPayload>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -254,9 +253,28 @@ pub struct RebornExtensionActionResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub onboarding_state: Option<String>,
+    pub onboarding_state: Option<RebornExtensionOnboardingState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub onboarding: Option<Value>,
+    pub onboarding: Option<RebornExtensionOnboardingPayload>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RebornExtensionOnboardingState {
+    AuthRequired,
+    SetupRequired,
+    Installed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RebornExtensionOnboardingPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_instructions: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_next_step: Option<String>,
 }
 
 /// WebUI v2 setup projection for extension lifecycle.
@@ -278,7 +296,7 @@ pub struct RebornSetupExtensionResponse {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<RebornExtensionSetupField>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub onboarding: Option<Value>,
+    pub onboarding: Option<RebornExtensionOnboardingPayload>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -14,15 +14,17 @@ use ironclaw_product_workflow::{
     ApprovalInteractionDecision, ApprovalInteractionService, AuthInteractionDecision,
     AuthInteractionService, ExtensionCredentialSetupService, ExtensionCredentialStatusRequest,
     ExtensionCredentialSubmitRequest, LifecycleExtensionCredentialRequirement,
-    LifecycleExtensionCredentialSetup, LifecycleExtensionRuntimeKind, LifecycleExtensionSource,
-    LifecycleExtensionSummary, LifecycleInstalledExtensionSummary, LifecyclePackageKind,
-    LifecyclePackageRef, LifecyclePhase, LifecycleProductContext, LifecycleProductFacade,
-    LifecycleProductPayload, LifecycleProductResponse, LifecycleReadinessBlocker,
-    ListPendingApprovalsRequest, ListPendingApprovalsResponse, ListPendingAuthInteractionsRequest,
-    ListPendingAuthInteractionsResponse, RebornGetRunStateRequest, RebornResolveGateResponse,
-    RebornServices, RebornServicesApi, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind, RebornStreamEventsRequest, RebornSubmitTurnResponse,
-    RebornTimelineRequest, ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
+    LifecycleExtensionCredentialSetup, LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind,
+    LifecycleExtensionSource, LifecycleExtensionSummary, LifecycleInstalledExtensionSummary,
+    LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase, LifecycleProductAction,
+    LifecycleProductContext, LifecycleProductFacade, LifecycleProductPayload,
+    LifecycleProductResponse, LifecycleReadinessBlocker, ListPendingApprovalsRequest,
+    ListPendingApprovalsResponse, ListPendingAuthInteractionsRequest,
+    ListPendingAuthInteractionsResponse, ProductWorkflowError, RebornExtensionOnboardingState,
+    RebornGetRunStateRequest, RebornResolveGateResponse, RebornServices, RebornServicesApi,
+    RebornServicesError, RebornServicesErrorCode, RebornServicesErrorKind,
+    RebornStreamEventsRequest, RebornSubmitTurnResponse, RebornTimelineRequest,
+    ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
     ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, WebUiAuthenticatedCaller,
     WebUiCancelRunRequest, WebUiCreateThreadRequest, WebUiInboundValidationCode,
     WebUiListThreadsRequest, WebUiResolveGateRequest, WebUiSendMessageRequest,
@@ -486,6 +488,7 @@ impl AuthInteractionService for RecordingAuthInteractionService {
 struct RecordingLifecycleFacade {
     package_refs: Mutex<Vec<LifecyclePackageRef>>,
     credential_requirements: Vec<LifecycleExtensionCredentialRequirement>,
+    onboarding: Option<LifecycleExtensionOnboarding>,
 }
 
 impl RecordingLifecycleFacade {
@@ -493,6 +496,7 @@ impl RecordingLifecycleFacade {
         Self {
             package_refs: Mutex::new(Vec::new()),
             credential_requirements: Vec::new(),
+            onboarding: None,
         }
     }
 
@@ -502,6 +506,18 @@ impl RecordingLifecycleFacade {
         Self {
             package_refs: Mutex::new(Vec::new()),
             credential_requirements,
+            onboarding: None,
+        }
+    }
+
+    fn with_credential_requirements_and_onboarding(
+        credential_requirements: Vec<LifecycleExtensionCredentialRequirement>,
+        onboarding: LifecycleExtensionOnboarding,
+    ) -> Self {
+        Self {
+            package_refs: Mutex::new(Vec::new()),
+            credential_requirements,
+            onboarding: Some(onboarding),
         }
     }
 
@@ -525,6 +541,7 @@ impl RecordingLifecycleFacade {
             runtime_kind: LifecycleExtensionRuntimeKind::FirstParty,
             visible_read_only_capability_ids: Vec::new(),
             credential_requirements: self.credential_requirements.clone(),
+            onboarding: self.onboarding.clone(),
         };
         Some(LifecycleProductPayload::ExtensionList {
             extensions: vec![LifecycleInstalledExtensionSummary {
@@ -555,15 +572,53 @@ impl LifecycleProductFacade for RecordingLifecycleFacade {
             .lock()
             .expect("lock")
             .push(package_ref.clone());
+        let phase = if self.credential_requirements.is_empty() {
+            LifecyclePhase::UnsupportedOrLegacy
+        } else {
+            LifecyclePhase::Configured
+        };
         let mut response = LifecycleProductResponse::projection(
             Some(package_ref),
-            LifecyclePhase::UnsupportedOrLegacy,
+            phase,
             vec![LifecycleReadinessBlocker::runtime(Some(
                 "extension_lifecycle_store_unwired".to_string(),
             ))?],
         );
         response.payload = self.extension_list_payload(response.package_ref.as_ref().expect("ref"));
         Ok(response)
+    }
+}
+
+struct ListingLifecycleFacade {
+    extension: LifecycleInstalledExtensionSummary,
+}
+
+#[async_trait]
+impl LifecycleProductFacade for ListingLifecycleFacade {
+    async fn execute(
+        &self,
+        _context: LifecycleProductContext,
+        action: LifecycleProductAction,
+    ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+        assert!(matches!(action, LifecycleProductAction::ExtensionList));
+        Ok(LifecycleProductResponse {
+            package_ref: None,
+            phase: self.extension.phase,
+            blockers: Vec::new(),
+            message: None,
+            payload: Some(LifecycleProductPayload::ExtensionList {
+                extensions: vec![self.extension.clone()],
+                count: 1,
+            }),
+        })
+    }
+
+    async fn project_package(
+        &self,
+        _context: LifecycleProductContext,
+        _package_ref: LifecyclePackageRef,
+    ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+        panic!("list_extensions should execute the list action, not project one package")
     }
 }
 
@@ -3395,6 +3450,78 @@ async fn setup_extension_projects_through_configured_lifecycle_facade() {
 }
 
 #[tokio::test]
+async fn list_extensions_projects_onboarding_payload_through_reborn_services() {
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(FakeTurnCoordinator::default()),
+    )
+    .with_lifecycle_product_facade(Arc::new(ListingLifecycleFacade {
+        extension: LifecycleInstalledExtensionSummary {
+            summary: extension_summary(
+                "github",
+                vec![manual_credential_requirement("github_runtime_token", true)],
+                Some(onboarding_fixture()),
+            ),
+            phase: LifecyclePhase::Installed,
+        },
+    }));
+
+    let response = services
+        .list_extensions(caller())
+        .await
+        .expect("extension list response");
+    let extension = response.extensions.first().expect("one extension");
+
+    assert_eq!(
+        extension.onboarding_state,
+        Some(RebornExtensionOnboardingState::SetupRequired)
+    );
+    let onboarding = extension.onboarding.as_ref().expect("onboarding payload");
+    assert_eq!(
+        onboarding.credential_instructions.as_deref(),
+        Some("Paste the GitHub token IronClaw should use.")
+    );
+    assert_eq!(
+        onboarding.credential_next_step.as_deref(),
+        Some("After saving the token, activate GitHub to publish its tools.")
+    );
+}
+
+#[tokio::test]
+async fn setup_extension_returns_post_setup_onboarding_payload() {
+    let services = RebornServices::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(FakeTurnCoordinator::default()),
+    )
+    .with_lifecycle_product_facade(Arc::new(
+        RecordingLifecycleFacade::with_credential_requirements_and_onboarding(
+            vec![manual_credential_requirement("github_runtime_token", true)],
+            onboarding_fixture(),
+        ),
+    ));
+
+    let response = services
+        .setup_extension(
+            caller(),
+            lifecycle_package_ref("github"),
+            WebUiSetupExtensionRequest::default(),
+        )
+        .await
+        .expect("setup extension response");
+
+    let onboarding = response.onboarding.as_ref().expect("onboarding payload");
+    assert_eq!(response.phase, LifecyclePhase::Configured);
+    assert_eq!(
+        onboarding.credential_instructions.as_deref(),
+        Some("github is installed. Activate it to make its tools available.")
+    );
+    assert_eq!(
+        onboarding.credential_next_step.as_deref(),
+        Some("After saving the token, activate GitHub to publish its tools.")
+    );
+}
+
+#[tokio::test]
 async fn setup_extension_rejects_blank_required_manual_secret() {
     let credentials = Arc::new(RecordingExtensionCredentialSetupService::default());
     let services =
@@ -3493,6 +3620,35 @@ fn setup_services_with_requirements(
 fn lifecycle_package_ref(package_id: &str) -> LifecyclePackageRef {
     LifecyclePackageRef::new(LifecyclePackageKind::Extension, package_id)
         .expect("valid package ref")
+}
+
+fn extension_summary(
+    package_id: &str,
+    credential_requirements: Vec<LifecycleExtensionCredentialRequirement>,
+    onboarding: Option<LifecycleExtensionOnboarding>,
+) -> LifecycleExtensionSummary {
+    LifecycleExtensionSummary {
+        package_ref: lifecycle_package_ref(package_id),
+        name: package_id.to_string(),
+        version: "1.0.0".to_string(),
+        description: "test extension".to_string(),
+        source: LifecycleExtensionSource::HostBundled,
+        runtime_kind: LifecycleExtensionRuntimeKind::FirstParty,
+        visible_read_only_capability_ids: Vec::new(),
+        credential_requirements,
+        onboarding,
+    }
+}
+
+fn onboarding_fixture() -> LifecycleExtensionOnboarding {
+    LifecycleExtensionOnboarding {
+        instructions: "GitHub needs a token before its tools can run.".to_string(),
+        credential_instructions: Some("Paste the GitHub token IronClaw should use.".to_string()),
+        setup_url: Some("https://github.com/settings/personal-access-tokens/new".to_string()),
+        credential_next_step: Some(
+            "After saving the token, activate GitHub to publish its tools.".to_string(),
+        ),
+    }
 }
 
 fn manual_credential_requirement(

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -6,8 +6,8 @@ use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{CapabilityId, ExtensionId, VirtualPath, sha256_digest_token};
 use ironclaw_product_workflow::{
     LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
-    LifecycleExtensionRuntimeKind, LifecycleExtensionSource, LifecycleExtensionSummary,
-    LifecyclePackageKind, LifecyclePackageRef, ProductWorkflowError,
+    LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind, LifecycleExtensionSource,
+    LifecycleExtensionSummary, LifecyclePackageKind, LifecyclePackageRef, ProductWorkflowError,
 };
 use toml::Value;
 
@@ -62,7 +62,68 @@ impl AvailableExtensionPackage {
             runtime_kind: runtime_kind(&self.package.manifest.runtime),
             visible_read_only_capability_ids,
             credential_requirements: credential_requirements(self),
+            onboarding: onboarding(self.package_ref.id.as_str()),
         }
+    }
+}
+
+fn onboarding(package_id: &str) -> Option<LifecycleExtensionOnboarding> {
+    match package_id {
+        "github" => Some(onboarding_message(
+            "GitHub needs a personal access token before its repository and pull request tools can run.",
+            Some(
+                "Create a GitHub personal access token with the repository permissions you want IronClaw to use, then paste it here.",
+            ),
+            Some("https://github.com/settings/personal-access-tokens/new"),
+            "After saving the token, activate GitHub to publish its tools.",
+        )),
+        "gmail" => Some(onboarding_message(
+            "Gmail needs Google OAuth authorization before mail tools can run.",
+            Some("Authorize the Google account that IronClaw should use for Gmail."),
+            None,
+            "After authorization completes, activate Gmail to publish its tools.",
+        )),
+        "google-calendar" => Some(onboarding_message(
+            "Google Calendar needs Google OAuth authorization before calendar tools can run.",
+            Some("Authorize the Google account that IronClaw should use for calendar events."),
+            None,
+            "After authorization completes, activate Google Calendar to publish its tools.",
+        )),
+        "notion" => Some(onboarding_message(
+            "Notion needs a workspace access token before MCP tools can run.",
+            Some(
+                "Create or copy a Notion integration token for the workspace IronClaw should access, then paste it here.",
+            ),
+            Some("https://www.notion.so/profile/integrations"),
+            "After saving the token, activate Notion to publish its MCP tools.",
+        )),
+        "nearai" => Some(onboarding_message(
+            "NEAR AI needs an API key before its MCP tools can run.",
+            Some("Paste the NEAR AI API key IronClaw should use for hosted MCP requests."),
+            None,
+            "After saving the API key, activate NEAR AI to publish its MCP tools.",
+        )),
+        "web-access" => Some(onboarding_message(
+            "Web Access does not need credentials. Activate it to make web search and saved-result retrieval tools available.",
+            Some("No credentials are required for Web Access."),
+            None,
+            "Activate Web Access to publish its tools.",
+        )),
+        _ => None,
+    }
+}
+
+fn onboarding_message(
+    instructions: &str,
+    credential_instructions: Option<&str>,
+    setup_url: Option<&str>,
+    credential_next_step: &str,
+) -> LifecycleExtensionOnboarding {
+    LifecycleExtensionOnboarding {
+        instructions: instructions.to_string(),
+        credential_instructions: credential_instructions.map(str::to_string),
+        setup_url: setup_url.map(str::to_string),
+        credential_next_step: Some(credential_next_step.to_string()),
     }
 }
 
@@ -1166,6 +1227,41 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn bundled_extension_summaries_include_onboarding_messages() {
+        let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
+
+        for (extension_id, expected_instructions) in [
+            ("github", "GitHub needs a personal access token"),
+            ("gmail", "Gmail needs Google OAuth authorization"),
+            (
+                "google-calendar",
+                "Google Calendar needs Google OAuth authorization",
+            ),
+            ("notion", "Notion needs a workspace access token"),
+            ("nearai", "NEAR AI needs an API key"),
+            ("web-access", "Web Access does not need credentials"),
+        ] {
+            let package_ref =
+                LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id).unwrap();
+            let summary = catalog.resolve(&package_ref).unwrap().summary();
+            let onboarding = summary
+                .onboarding
+                .as_ref()
+                .expect("bundled extension onboarding");
+
+            assert!(
+                onboarding.instructions.contains(expected_instructions),
+                "{extension_id} onboarding instructions should include `{expected_instructions}`; got `{}`",
+                onboarding.instructions,
+            );
+            assert!(
+                onboarding.credential_next_step.is_some(),
+                "{extension_id} must include the next user step"
+            );
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle_command.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle_command.rs
@@ -240,6 +240,7 @@ mod tests {
                         ironclaw_product_workflow::LifecycleExtensionRuntimeKind::WasmTool,
                     visible_read_only_capability_ids: Vec::new(),
                     credential_requirements: Vec::new(),
+                    onboarding: None,
                 }],
             }),
         };

--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -94,4 +94,30 @@ mod tests {
         assert!(events.contains("setActiveRun?.(null);"));
         assert!(events.contains("latestRunIdRef.current = null;"));
     }
+
+    #[test]
+    fn extensions_onboarding_messages_render_in_cards() {
+        let extension_card = asset_text("js/pages/extensions/components/extension-card.js");
+
+        assert!(
+            extension_card.contains("state === \"setup_required\" || state === \"auth_required\""),
+            "setup/auth states must prefer credential setup instructions"
+        );
+        assert!(
+            extension_card.contains(
+                "ext.onboarding?.credential_instructions || ext.onboarding?.credential_next_step"
+            ),
+            "setup/auth onboarding should render credential instructions before next-step copy"
+        );
+        assert!(
+            extension_card.contains(
+                "ext.onboarding?.credential_next_step || ext.onboarding?.credential_instructions"
+            ),
+            "configured/no-credential onboarding should render next-step copy before setup copy"
+        );
+        assert!(
+            extension_card.contains("${onboardingHint}"),
+            "extension cards must render the projected onboarding hint"
+        );
+    }
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/extension-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/extension-card.js
@@ -15,6 +15,12 @@ export function ExtensionCard({ ext, onActivate, onConfigure, onRemove, isBusy }
   const kindLabel = KIND_LABELS[ext.kind] || ext.kind;
   const displayName = ext.display_name || packageId(ext);
   const canManage = Boolean(ext.package_ref);
+  const setupState = state === "setup_required" || state === "auth_required";
+  const onboardingHint =
+    (setupState
+      ? ext.onboarding?.credential_instructions || ext.onboarding?.credential_next_step
+      : ext.onboarding?.credential_next_step || ext.onboarding?.credential_instructions) ||
+    null;
 
   return html`
     <div
@@ -60,6 +66,13 @@ export function ExtensionCard({ ext, onActivate, onConfigure, onRemove, isBusy }
               className="mt-2 rounded-[10px] border border-[color-mix(in_srgb,var(--v2-danger-text)_36%,var(--v2-panel-border))] bg-[var(--v2-danger-soft)] px-3 py-1.5 text-xs text-[var(--v2-danger-text)]"
             >
               ${ext.activation_error}
+            </div>
+          `}
+          ${onboardingHint && html`
+            <div
+              className="mt-2 rounded-md border border-white/12 bg-white/[0.04] px-3 py-2 text-xs leading-5 text-[var(--v2-text-muted)]"
+            >
+              ${onboardingHint}
             </div>
           `}
         </div>

--- a/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions.js
@@ -47,7 +47,13 @@ export function useExtensions() {
     mutationFn: ({ packageRef }) => installExtension(packageRef),
     onSuccess: (res, { displayName }) => {
       if (res.success) {
-        setActionResult({ type: "success", message: `${displayName || "Extension"} installed` });
+        setActionResult({
+          type: "success",
+          message:
+            res.message ||
+            res.instructions ||
+            `${displayName || "Extension"} installed`,
+        });
         if (res.auth_url) {
           window.open(res.auth_url, "_blank", "noopener,noreferrer");
         }
@@ -66,7 +72,13 @@ export function useExtensions() {
     mutationFn: ({ packageRef }) => activateExtension(packageRef),
     onSuccess: (res, { displayName }) => {
       if (res.success) {
-        setActionResult({ type: "success", message: `${displayName || "Extension"} activated` });
+        setActionResult({
+          type: "success",
+          message:
+            res.message ||
+            res.instructions ||
+            `${displayName || "Extension"} activated`,
+        });
         if (res.auth_url) {
           window.open(res.auth_url, "_blank", "noopener,noreferrer");
         }


### PR DESCRIPTION
## Summary
- Add per-extension WebUI v2 onboarding projections for the current bundled extensions: GitHub, Gmail, Google Calendar, Notion, NEAR AI, and Web Access.
- Surface onboarding state/message payloads on installed extension list responses, setup responses, and install/activate action responses when package projection is available.
- Show onboarding hints on extension cards and use backend action messages in install/activate toasts.

## Test Plan
- `node --check crates/ironclaw_webui_v2_static/static/js/pages/extensions/components/extension-card.js && node --check crates/ironclaw_webui_v2_static/static/js/pages/extensions/hooks/useExtensions.js`
- `cargo test -p ironclaw_product_workflow extension_onboarding --features test-support`
- `cargo test -p ironclaw_product_workflow --features test-support`
- `cargo test -p ironclaw_webui_v2_static --features webui-v2-beta`
- `cargo test -p ironclaw_reborn_composition extension_lifecycle --features test-support`
- `cargo test -p ironclaw_reborn_composition bundled_extension_summaries_include_onboarding_messages --features test-support`
- `cargo clippy -p ironclaw_product_workflow -p ironclaw_reborn_composition -p ironclaw_webui_v2_static --features ironclaw_reborn_composition/test-support,test-support,webui-v2-beta --tests -- -D warnings`
- `git diff --check`

Stacked on #4323 / `codex/webuiv2-extension-credentials`.
