### PR TITLE
Slack Reborn multi-tenant ingress resolver

### DIFF
--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -151,8 +151,11 @@ pub use runtime_input::{
 pub use skill_listing::{RebornSkillListError, list_reborn_local_skills};
 #[cfg(feature = "slack-v2-host-beta")]
 pub use slack_serve::{
-    SLACK_EVENTS_PATH, SlackEventsRouteState, SlackEventsWebhookDispatcher,
-    slack_events_route_descriptors, slack_events_route_mount,
+    ResolvedSlackInstallation, SLACK_EVENTS_PATH, SlackEnvelopeMetadata, SlackEventsRouteState,
+    SlackEventsWebhookDispatcher, SlackIngressError, SlackIngressService,
+    SlackInstallationRateLimitConfig, SlackInstallationRecord, SlackInstallationResolver,
+    SlackInstallationSelector, StaticSlackInstallationResolver, slack_events_route_descriptors,
+    slack_events_route_mount,
 };
 pub use webui::{RebornWebuiBundle, build_webui_services};
 #[cfg(feature = "webui-v2-beta")]

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -66,7 +66,7 @@ mod runtime;
 mod runtime_input;
 mod skill_listing;
 #[cfg(feature = "slack-v2-host-beta")]
-mod slack_serve;
+pub mod slack_serve;
 #[cfg(feature = "test-support")]
 pub mod test_support;
 mod web_access;
@@ -151,11 +151,8 @@ pub use runtime_input::{
 pub use skill_listing::{RebornSkillListError, list_reborn_local_skills};
 #[cfg(feature = "slack-v2-host-beta")]
 pub use slack_serve::{
-    ResolvedSlackInstallation, SLACK_EVENTS_PATH, SlackEnvelopeMetadata, SlackEventsRouteState,
-    SlackEventsWebhookDispatcher, SlackIngressError, SlackIngressService,
-    SlackInstallationRateLimitConfig, SlackInstallationRecord, SlackInstallationResolver,
-    SlackInstallationSelector, StaticSlackInstallationResolver, slack_events_route_descriptors,
-    slack_events_route_mount,
+    SLACK_EVENTS_PATH, SlackEventsRouteState, SlackEventsWebhookDispatcher,
+    slack_events_route_descriptors, slack_events_route_mount,
 };
 pub use webui::{RebornWebuiBundle, build_webui_services};
 #[cfg(feature = "webui-v2-beta")]

--- a/crates/ironclaw_reborn_composition/src/slack_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve.rs
@@ -26,13 +26,19 @@ use ironclaw_host_api::ingress::{
     WebSocketOriginPolicy,
 };
 use ironclaw_product_adapters::ProtocolAuthEvidence;
-use ironclaw_slack_v2_adapter::parse_slack_url_verification_challenge;
 use ironclaw_wasm_product_adapters::{
     NativeProductAdapterRunner, RunnerError, WebhookProcessOutcome,
 };
 use serde::Serialize;
 
 use crate::webui_serve::{PublicRouteDrain, PublicRouteMount};
+
+mod installation;
+pub use installation::{
+    ResolvedSlackInstallation, SlackEnvelopeMetadata, SlackIngressError, SlackIngressService,
+    SlackInstallationRateLimitConfig, SlackInstallationRecord, SlackInstallationResolver,
+    SlackInstallationSelector, StaticSlackInstallationResolver,
+};
 
 pub const SLACK_EVENTS_PATH: &str = "/webhooks/slack/events";
 const SLACK_EVENTS_ROUTE_ID: &str = "slack.events";
@@ -84,16 +90,20 @@ impl SlackEventsWebhookDispatcher for NativeProductAdapterRunner {
 
 #[derive(Clone)]
 pub struct SlackEventsRouteState {
-    dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
+    ingress: SlackIngressService,
 }
 
 impl SlackEventsRouteState {
-    pub fn new(dispatcher: Arc<dyn SlackEventsWebhookDispatcher>) -> Self {
-        Self { dispatcher }
+    pub fn new(ingress: SlackIngressService) -> Self {
+        Self { ingress }
+    }
+
+    pub fn from_resolver(resolver: Arc<dyn SlackInstallationResolver>) -> Self {
+        Self::new(SlackIngressService::new(resolver))
     }
 
     pub async fn drain_immediate_ack_tasks(&self) {
-        self.dispatcher.drain_immediate_ack_tasks().await;
+        self.ingress.drain_installations().await;
     }
 }
 
@@ -107,7 +117,7 @@ impl std::fmt::Debug for SlackEventsRouteState {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("SlackEventsRouteState")
-            .field("dispatcher", &"Arc<dyn SlackEventsWebhookDispatcher>")
+            .field("ingress", &self.ingress)
             .finish()
     }
 }
@@ -144,13 +154,11 @@ fn slack_events_policy() -> IngressPolicy {
             max_bytes: SLACK_EVENTS_BODY_LIMIT_BYTES,
         },
         rate_limit: RateLimitPolicy::Limited {
-            // Interim pre-auth guard. The descriptor-driven limiter runs before
-            // Slack signature verification, so it cannot yet bucket by verified
-            // installation/workspace. `PerIp` is also not a safe substitute for
-            // Slack because events arrive from shared Slack egress pools. A
-            // verified-installation limiter belongs in a follow-up extension to
-            // the ingress rate-limit model or a post-verification Slack-specific
-            // limiter.
+            // Coarse pre-auth abuse guard. The route-level service adds a
+            // second post-verification bucket keyed by the resolved Slack
+            // tenant/installation, because Slack events can arrive from shared
+            // Slack egress pools and one workspace must not consume the budget
+            // for every tenant.
             scope: RateLimitScope::Global,
             max_requests: SLACK_EVENTS_MAX_REQUESTS,
             window_seconds: SLACK_EVENTS_RATE_WINDOW_SECONDS,
@@ -169,37 +177,60 @@ async fn slack_events_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
-    let evidence = match state
-        .dispatcher
-        .verify_webhook_auth(&headers, body.as_ref())
-    {
-        Ok(evidence) => evidence,
-        Err(error) => return runner_error_response(error),
-    };
+    state.ingress.handle_events(headers, body).await
+}
 
-    match parse_slack_url_verification_challenge(body.as_ref(), &evidence) {
-        Ok(Some(challenge)) => return (StatusCode::OK, challenge.challenge).into_response(),
-        Ok(None) => {}
-        Err(error) => {
+fn ingress_error_response(error: SlackIngressError) -> Response {
+    match error {
+        SlackIngressError::Runner(error) => runner_error_response(error),
+        SlackIngressError::Envelope(error) => {
             tracing::debug!(
                 target = "ironclaw::reborn::slack_events",
                 error = %error,
-                "Slack URL verification parse failed"
+                "Slack Events API envelope metadata parse failed"
             );
-            return error_response(
+            error_response(
                 StatusCode::BAD_REQUEST,
                 SlackWebhookErrorCategory::MalformedPayload,
-            );
+            )
         }
-    }
-
-    match state
-        .dispatcher
-        .process_verified_webhook_immediate_ack(body.as_ref(), &evidence)
-        .await
-    {
-        Ok(_) => (StatusCode::OK, "ok").into_response(),
-        Err(error) => runner_error_response(error),
+        SlackIngressError::InstallationNotFound => {
+            tracing::debug!(
+                target = "ironclaw::reborn::slack_events",
+                reason = "not_found",
+                "Slack Events API installation resolution failed"
+            );
+            error_response(
+                StatusCode::UNAUTHORIZED,
+                SlackWebhookErrorCategory::Authentication,
+            )
+        }
+        SlackIngressError::AmbiguousInstallation => {
+            tracing::debug!(
+                target = "ironclaw::reborn::slack_events",
+                reason = "ambiguous",
+                "Slack Events API installation resolution failed"
+            );
+            error_response(
+                StatusCode::UNAUTHORIZED,
+                SlackWebhookErrorCategory::Authentication,
+            )
+        }
+        SlackIngressError::InstallationRateLimited {
+            tenant_id,
+            adapter_installation_id,
+        } => {
+            tracing::debug!(
+                target = "ironclaw::reborn::slack_events",
+                tenant_id = %tenant_id,
+                adapter_installation_id = %adapter_installation_id,
+                "Slack Events API installation rate limit exceeded"
+            );
+            error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                SlackWebhookErrorCategory::Capacity,
+            )
+        }
     }
 }
 
@@ -264,9 +295,12 @@ mod tests {
 
     use async_trait::async_trait;
     use axum::body::Body;
-    use axum::http::Request;
+    use axum::http::{HeaderValue, Request};
     use http_body_util::BodyExt;
-    use ironclaw_product_adapters::auth::mark_request_signature_verified;
+    use ironclaw_host_api::TenantId;
+    use ironclaw_product_adapters::auth::{
+        mark_request_signature_verified, mark_shared_secret_header_verified,
+    };
     use ironclaw_product_adapters::capabilities::ProductAdapterCapabilities;
     use ironclaw_product_adapters::external::{
         ExternalActorRef, ExternalConversationRef, ExternalEventId,
@@ -340,6 +374,115 @@ mod tests {
                 ..Self::verified()
             }
         }
+    }
+
+    struct FakeSlackResolver {
+        dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
+    }
+
+    impl FakeSlackResolver {
+        fn new(dispatcher: Arc<dyn SlackEventsWebhookDispatcher>) -> Self {
+            Self { dispatcher }
+        }
+    }
+
+    impl SlackInstallationResolver for FakeSlackResolver {
+        fn resolve_installation<'a>(
+            &'a self,
+            headers: &'a HeaderMap,
+            body: &'a [u8],
+        ) -> Pin<
+            Box<
+                dyn Future<Output = Result<ResolvedSlackInstallation, SlackIngressError>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                let evidence = self.dispatcher.verify_webhook_auth(headers, body)?;
+                Ok(ResolvedSlackInstallation::new(
+                    tenant_id("tenant-alpha"),
+                    installation_id("install-alpha"),
+                    SlackEnvelopeMetadata {
+                        team_id: Some("T-alpha".to_string()),
+                        enterprise_id: None,
+                        api_app_id: Some("A-alpha".to_string()),
+                        event_user_id: Some("U123".to_string()),
+                        event_channel_id: Some("D123".to_string()),
+                    },
+                    evidence,
+                    Arc::clone(&self.dispatcher),
+                ))
+            })
+        }
+
+        fn drain_installations<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async move {
+                self.dispatcher.drain_immediate_ack_tasks().await;
+            })
+        }
+    }
+
+    struct HeaderSecretDispatcher {
+        expected_secret: &'static str,
+        subject: &'static str,
+        dispatch_calls: Arc<AtomicUsize>,
+    }
+
+    impl HeaderSecretDispatcher {
+        fn new(expected_secret: &'static str, subject: &'static str) -> Self {
+            Self {
+                expected_secret,
+                subject,
+                dispatch_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl SlackEventsWebhookDispatcher for HeaderSecretDispatcher {
+        fn verify_webhook_auth(
+            &self,
+            headers: &HeaderMap,
+            _body: &[u8],
+        ) -> Result<ProtocolAuthEvidence, RunnerError> {
+            if headers
+                .get("X-Test-Secret")
+                .and_then(|value| value.to_str().ok())
+                == Some(self.expected_secret)
+            {
+                return Ok(mark_shared_secret_header_verified(
+                    "X-Test-Secret",
+                    self.subject,
+                ));
+            }
+            Err(RunnerError::AuthenticationFailed {
+                failure: ProtocolAuthFailure::SignatureMismatch,
+            })
+        }
+
+        fn process_verified_webhook_immediate_ack<'a>(
+            &'a self,
+            _body: &'a [u8],
+            _evidence: &'a ProtocolAuthEvidence,
+        ) -> Pin<Box<dyn Future<Output = Result<WebhookProcessOutcome, RunnerError>> + Send + 'a>>
+        {
+            self.dispatch_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(WebhookProcessOutcome::AcceptedForAsyncDispatch) })
+        }
+
+        fn drain_immediate_ack_tasks<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async {})
+        }
+    }
+
+    fn tenant_id(value: &str) -> TenantId {
+        TenantId::new(value).expect("valid tenant")
+    }
+
+    fn installation_id(value: &str) -> AdapterInstallationId {
+        AdapterInstallationId::new(value).expect("valid installation")
     }
 
     struct StaticAdapter {
@@ -470,18 +613,115 @@ mod tests {
     }
 
     async fn post_slack_events(dispatcher: FakeSlackDispatcher, body: &'static str) -> Response {
-        let mount = slack_events_route_mount(SlackEventsRouteState::new(Arc::new(dispatcher)));
+        post_slack_events_with_headers(Arc::new(dispatcher), body, Vec::new()).await
+    }
+
+    async fn post_slack_events_with_headers(
+        dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
+        body: &'static str,
+        headers: Vec<(&'static str, &'static str)>,
+    ) -> Response {
+        let resolver = Arc::new(FakeSlackResolver::new(dispatcher));
+        let mount = slack_events_route_mount(SlackEventsRouteState::from_resolver(resolver));
+        post_to_mount(&mount, body, headers).await
+    }
+
+    async fn post_to_mount(
+        mount: &PublicRouteMount,
+        body: &'static str,
+        headers: Vec<(&'static str, &'static str)>,
+    ) -> Response {
+        let mut builder = Request::builder().method("POST").uri(SLACK_EVENTS_PATH);
+        for (name, value) in headers {
+            builder = builder.header(name, value);
+        }
         mount
             .router
+            .clone()
             .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(SLACK_EVENTS_PATH)
+                builder
                     .body(Body::from(body))
                     .expect("request should build"),
             )
             .await
             .expect("router should respond")
+    }
+
+    const TEAM_A_BODY: &str = r#"{
+        "type": "event_callback",
+        "team_id": "T-A",
+        "api_app_id": "A-slack",
+        "event_id": "Ev-A",
+        "event": {
+            "type": "message",
+            "channel_type": "im",
+            "user": "U123",
+            "channel": "D-A",
+            "text": "hello from A",
+            "ts": "1710000000.000001"
+        }
+    }"#;
+
+    const TEAM_B_BODY: &str = r#"{
+        "type": "event_callback",
+        "team_id": "T-B",
+        "api_app_id": "A-slack",
+        "event_id": "Ev-B",
+        "event": {
+            "type": "message",
+            "channel_type": "im",
+            "user": "U123",
+            "channel": "D-B",
+            "text": "hello from B",
+            "ts": "1710000000.000002"
+        }
+    }"#;
+
+    fn secret_headers(secret: &'static str) -> Vec<(&'static str, &'static str)> {
+        vec![("X-Test-Secret", secret)]
+    }
+
+    fn header_map(secret: &'static str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Test-Secret", HeaderValue::from_static(secret));
+        headers
+    }
+
+    fn static_resolver_fixture() -> (
+        StaticSlackInstallationResolver,
+        Arc<HeaderSecretDispatcher>,
+        Arc<HeaderSecretDispatcher>,
+    ) {
+        let dispatcher_a = Arc::new(HeaderSecretDispatcher::new("secret-a", "install-a"));
+        let dispatcher_b = Arc::new(HeaderSecretDispatcher::new("secret-b", "install-b"));
+        let resolver = StaticSlackInstallationResolver::new(vec![
+            SlackInstallationRecord::new(
+                tenant_id("tenant-a"),
+                installation_id("install-a"),
+                SlackInstallationSelector::team("T-A"),
+                dispatcher_a.clone(),
+            ),
+            SlackInstallationRecord::new(
+                tenant_id("tenant-b"),
+                installation_id("install-b"),
+                SlackInstallationSelector::team("T-B"),
+                dispatcher_b.clone(),
+            ),
+        ]);
+        (resolver, dispatcher_a, dispatcher_b)
+    }
+
+    fn static_resolver_mount(
+        rate_limit: SlackInstallationRateLimitConfig,
+    ) -> (
+        PublicRouteMount,
+        Arc<HeaderSecretDispatcher>,
+        Arc<HeaderSecretDispatcher>,
+    ) {
+        let (resolver, dispatcher_a, dispatcher_b) = static_resolver_fixture();
+        let service = SlackIngressService::with_rate_limit_config(Arc::new(resolver), rate_limit);
+        let mount = slack_events_route_mount(SlackEventsRouteState::new(service));
+        (mount, dispatcher_a, dispatcher_b)
     }
 
     async fn assert_error_body(response: Response, expected: &str) {
@@ -588,6 +828,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn static_resolver_routes_same_slack_user_by_verified_workspace_installation() {
+        let (resolver, _, _) = static_resolver_fixture();
+
+        let install_a = resolver
+            .resolve_installation(&header_map("secret-a"), TEAM_A_BODY.as_bytes())
+            .await
+            .expect("team A resolves");
+        let install_b = resolver
+            .resolve_installation(&header_map("secret-b"), TEAM_B_BODY.as_bytes())
+            .await
+            .expect("team B resolves");
+
+        assert_eq!(install_a.tenant_id().as_str(), "tenant-a");
+        assert_eq!(install_a.adapter_installation_id().as_str(), "install-a");
+        assert_eq!(install_a.metadata().event_user_id.as_deref(), Some("U123"));
+        assert_eq!(install_b.tenant_id().as_str(), "tenant-b");
+        assert_eq!(install_b.adapter_installation_id().as_str(), "install-b");
+        assert_eq!(install_b.metadata().event_user_id.as_deref(), Some("U123"));
+    }
+
+    #[tokio::test]
+    async fn slack_events_handler_dispatches_workspace_b_to_install_b_runner() {
+        let (mount, dispatcher_a, dispatcher_b) =
+            static_resolver_mount(SlackInstallationRateLimitConfig::default());
+        let response = post_to_mount(&mount, TEAM_B_BODY, secret_headers("secret-b")).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(dispatcher_a.dispatch_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(dispatcher_b.dispatch_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn slack_events_handler_rejects_workspace_b_with_install_a_secret_context() {
+        let (mount, dispatcher_a, dispatcher_b) =
+            static_resolver_mount(SlackInstallationRateLimitConfig::default());
+        let response = post_to_mount(&mount, TEAM_B_BODY, secret_headers("secret-a")).await;
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_error_body(response, "authentication").await;
+        assert_eq!(dispatcher_a.dispatch_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(dispatcher_b.dispatch_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn slack_events_handler_rate_limits_after_auth_by_installation() {
+        let rate_limit = SlackInstallationRateLimitConfig::new(
+            NonZeroU32::new(1).expect("nonzero"),
+            Duration::from_secs(60),
+        );
+        let (mount, dispatcher_a, dispatcher_b) = static_resolver_mount(rate_limit);
+
+        let first_a = post_to_mount(&mount, TEAM_A_BODY, secret_headers("secret-a")).await;
+        let second_a = post_to_mount(&mount, TEAM_A_BODY, secret_headers("secret-a")).await;
+        let first_b = post_to_mount(&mount, TEAM_B_BODY, secret_headers("secret-b")).await;
+
+        assert_eq!(first_a.status(), StatusCode::OK);
+        assert_eq!(second_a.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_error_body(second_a, "capacity").await;
+        assert_eq!(first_b.status(), StatusCode::OK);
+        assert_eq!(dispatcher_a.dispatch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(dispatcher_b.dispatch_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn slack_events_handler_dispatches_through_native_runner() {
         let parse_count = Arc::new(AtomicUsize::new(0));
         let accepted_count = Arc::new(AtomicUsize::new(0));
@@ -606,7 +910,9 @@ mod tests {
                 std::num::NonZeroUsize::new(1).expect("nonzero"),
             ),
         );
-        let state = SlackEventsRouteState::new(Arc::new(runner));
+        let state = SlackEventsRouteState::from_resolver(Arc::new(FakeSlackResolver::new(
+            Arc::new(runner),
+        )));
         let mount = slack_events_route_mount(state.clone());
         let response = mount
             .router

--- a/crates/ironclaw_reborn_composition/src/slack_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve.rs
@@ -43,7 +43,7 @@ pub use installation::{
 pub const SLACK_EVENTS_PATH: &str = "/webhooks/slack/events";
 const SLACK_EVENTS_ROUTE_ID: &str = "slack.events";
 const SLACK_EVENTS_BODY_LIMIT_BYTES: NonZeroU64 = NonZeroU64::new(1024 * 1024).unwrap(); // safety: 1 MiB is a non-zero literal.
-const SLACK_EVENTS_MAX_REQUESTS: NonZeroU32 = NonZeroU32::new(120).unwrap(); // safety: 120 requests is a non-zero literal.
+const SLACK_EVENTS_MAX_REQUESTS: NonZeroU32 = NonZeroU32::new(12_000).unwrap(); // safety: 12,000 requests is a non-zero literal.
 const SLACK_EVENTS_RATE_WINDOW_SECONDS: NonZeroU32 = NonZeroU32::new(60).unwrap(); // safety: 60 seconds is a non-zero literal.
 
 pub trait SlackEventsWebhookDispatcher: Send + Sync {
@@ -154,7 +154,8 @@ fn slack_events_policy() -> IngressPolicy {
             max_bytes: SLACK_EVENTS_BODY_LIMIT_BYTES,
         },
         rate_limit: RateLimitPolicy::Limited {
-            // Coarse pre-auth abuse guard. The route-level service adds a
+            // Coarse pre-auth abuse guard. Keep this well above the
+            // per-installation quota below: the route-level service adds a
             // second post-verification bucket keyed by the resolved Slack
             // tenant/installation, because Slack events can arrive from shared
             // Slack egress pools and one workspace must not consume the budget
@@ -407,6 +408,7 @@ mod tests {
                         team_id: Some("T-alpha".to_string()),
                         enterprise_id: None,
                         api_app_id: Some("A-alpha".to_string()),
+                        install_user_id: Some("U-install-alpha".to_string()),
                         event_user_id: Some("U123".to_string()),
                         event_channel_id: Some("D123".to_string()),
                     },

--- a/crates/ironclaw_reborn_composition/src/slack_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve.rs
@@ -35,10 +35,14 @@ use crate::webui_serve::{PublicRouteDrain, PublicRouteMount};
 
 mod installation;
 pub use installation::{
-    ResolvedSlackInstallation, SlackEnvelopeMetadata, SlackIngressError, SlackIngressService,
-    SlackInstallationRateLimitConfig, SlackInstallationRecord, SlackInstallationResolver,
-    SlackInstallationSelector, StaticSlackInstallationResolver,
+    ResolvedSlackIngress, ResolvedSlackInstallation, SlackApiAppId, SlackChannelId,
+    SlackEnterpriseId, SlackEnvelopeMetadata, SlackIngressError, SlackInstallationRateLimitConfig,
+    SlackInstallationRateLimiter, SlackInstallationRecord, SlackInstallationResolver,
+    SlackInstallationSelector, SlackTeamId, SlackUserId, StaticSlackInstallationResolver,
 };
+
+#[cfg(test)]
+mod handler_tests;
 
 pub const SLACK_EVENTS_PATH: &str = "/webhooks/slack/events";
 const SLACK_EVENTS_ROUTE_ID: &str = "slack.events";
@@ -85,6 +89,66 @@ impl SlackEventsWebhookDispatcher for NativeProductAdapterRunner {
 
     fn drain_immediate_ack_tasks<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(NativeProductAdapterRunner::drain_immediate_ack_tasks(self))
+    }
+}
+
+#[derive(Clone)]
+pub struct SlackIngressService {
+    resolver: Arc<dyn SlackInstallationResolver>,
+    installation_rate_limiter: SlackInstallationRateLimiter,
+}
+
+impl SlackIngressService {
+    pub fn new(resolver: Arc<dyn SlackInstallationResolver>) -> Self {
+        Self::with_rate_limit_config(resolver, SlackInstallationRateLimitConfig::default())
+    }
+
+    pub fn with_rate_limit_config(
+        resolver: Arc<dyn SlackInstallationResolver>,
+        rate_limit: SlackInstallationRateLimitConfig,
+    ) -> Self {
+        Self {
+            resolver,
+            installation_rate_limiter: SlackInstallationRateLimiter::new(rate_limit),
+        }
+    }
+
+    async fn handle_events(&self, headers: HeaderMap, body: Bytes) -> Response {
+        let ingress = match self.resolver.resolve_ingress(&headers, body.as_ref()).await {
+            Ok(ingress) => ingress,
+            Err(error) => return ingress_error_response(error),
+        };
+        if let Err(error) = self.installation_rate_limiter.check(ingress.installation()) {
+            return ingress_error_response(error);
+        }
+
+        match ingress {
+            ResolvedSlackIngress::UrlVerification { challenge, .. } => {
+                (StatusCode::OK, challenge).into_response()
+            }
+            ResolvedSlackIngress::Event { installation, .. } => match installation
+                .dispatcher()
+                .process_verified_webhook_immediate_ack(body.as_ref(), installation.evidence())
+                .await
+            {
+                Ok(_) => (StatusCode::OK, "ok").into_response(),
+                Err(error) => runner_error_response(error),
+            },
+        }
+    }
+
+    pub async fn drain_installations(&self) {
+        self.resolver.drain_installations().await;
+    }
+}
+
+impl std::fmt::Debug for SlackIngressService {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SlackIngressService")
+            .field("resolver", &"Arc<dyn SlackInstallationResolver>")
+            .field("installation_rate_limiter", &self.installation_rate_limiter)
+            .finish()
     }
 }
 
@@ -296,12 +360,10 @@ mod tests {
 
     use async_trait::async_trait;
     use axum::body::Body;
-    use axum::http::{HeaderValue, Request};
+    use axum::http::Request;
     use http_body_util::BodyExt;
     use ironclaw_host_api::TenantId;
-    use ironclaw_product_adapters::auth::{
-        mark_request_signature_verified, mark_shared_secret_header_verified,
-    };
+    use ironclaw_product_adapters::auth::mark_request_signature_verified;
     use ironclaw_product_adapters::capabilities::ProductAdapterCapabilities;
     use ironclaw_product_adapters::external::{
         ExternalActorRef, ExternalConversationRef, ExternalEventId,
@@ -316,6 +378,7 @@ mod tests {
         ProjectionSubscriptionRequest, ProtocolAuthEvidence, ProtocolAuthFailure,
         ProtocolHttpEgress, UserMessagePayload,
     };
+    use ironclaw_slack_v2_adapter::SlackPayloadParseError;
     use ironclaw_wasm_product_adapters::{
         NativeProductAdapterRunnerConfig, SharedSecretHeaderAuth, WebhookAuth,
     };
@@ -388,33 +451,51 @@ mod tests {
     }
 
     impl SlackInstallationResolver for FakeSlackResolver {
-        fn resolve_installation<'a>(
+        fn resolve_ingress<'a>(
             &'a self,
             headers: &'a HeaderMap,
             body: &'a [u8],
         ) -> Pin<
-            Box<
-                dyn Future<Output = Result<ResolvedSlackInstallation, SlackIngressError>>
-                    + Send
-                    + 'a,
-            >,
+            Box<dyn Future<Output = Result<ResolvedSlackIngress, SlackIngressError>> + Send + 'a>,
         > {
             Box::pin(async move {
                 let evidence = self.dispatcher.verify_webhook_auth(headers, body)?;
-                Ok(ResolvedSlackInstallation::new(
+                let installation = ResolvedSlackInstallation::new(
                     tenant_id("tenant-alpha"),
                     installation_id("install-alpha"),
-                    SlackEnvelopeMetadata {
-                        team_id: Some("T-alpha".to_string()),
-                        enterprise_id: None,
-                        api_app_id: Some("A-alpha".to_string()),
-                        install_user_id: Some("U-install-alpha".to_string()),
-                        event_user_id: Some("U123".to_string()),
-                        event_channel_id: Some("D123".to_string()),
-                    },
                     evidence,
                     Arc::clone(&self.dispatcher),
-                ))
+                );
+                let value: serde_json::Value = serde_json::from_slice(body).map_err(|err| {
+                    SlackIngressError::Envelope(SlackPayloadParseError::InvalidJson {
+                        reason: err.to_string(),
+                    })
+                })?;
+                if value.get("type").and_then(|kind| kind.as_str()) == Some("url_verification") {
+                    let challenge = value
+                        .get("challenge")
+                        .and_then(|challenge| challenge.as_str())
+                        .ok_or_else(|| {
+                            SlackIngressError::Envelope(SlackPayloadParseError::InvalidJson {
+                                reason: "missing challenge".into(),
+                            })
+                        })?;
+                    return Ok(ResolvedSlackIngress::UrlVerification {
+                        installation,
+                        challenge: challenge.to_string(),
+                    });
+                }
+                Ok(ResolvedSlackIngress::Event {
+                    installation,
+                    metadata: SlackEnvelopeMetadata::new(
+                        Some(SlackTeamId::new("T-alpha")),
+                        None,
+                        Some(SlackApiAppId::new("A-alpha")),
+                        Some(SlackUserId::new("U-install-alpha")),
+                        Some(SlackUserId::new("U123")),
+                        Some(SlackChannelId::new("D123")),
+                    ),
+                })
             })
         }
 
@@ -422,60 +503,6 @@ mod tests {
             Box::pin(async move {
                 self.dispatcher.drain_immediate_ack_tasks().await;
             })
-        }
-    }
-
-    struct HeaderSecretDispatcher {
-        expected_secret: &'static str,
-        subject: &'static str,
-        dispatch_calls: Arc<AtomicUsize>,
-    }
-
-    impl HeaderSecretDispatcher {
-        fn new(expected_secret: &'static str, subject: &'static str) -> Self {
-            Self {
-                expected_secret,
-                subject,
-                dispatch_calls: Arc::new(AtomicUsize::new(0)),
-            }
-        }
-    }
-
-    impl SlackEventsWebhookDispatcher for HeaderSecretDispatcher {
-        fn verify_webhook_auth(
-            &self,
-            headers: &HeaderMap,
-            _body: &[u8],
-        ) -> Result<ProtocolAuthEvidence, RunnerError> {
-            if headers
-                .get("X-Test-Secret")
-                .and_then(|value| value.to_str().ok())
-                == Some(self.expected_secret)
-            {
-                return Ok(mark_shared_secret_header_verified(
-                    "X-Test-Secret",
-                    self.subject,
-                ));
-            }
-            Err(RunnerError::AuthenticationFailed {
-                failure: ProtocolAuthFailure::SignatureMismatch,
-            })
-        }
-
-        fn process_verified_webhook_immediate_ack<'a>(
-            &'a self,
-            _body: &'a [u8],
-            _evidence: &'a ProtocolAuthEvidence,
-        ) -> Pin<Box<dyn Future<Output = Result<WebhookProcessOutcome, RunnerError>> + Send + 'a>>
-        {
-            self.dispatch_calls.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Ok(WebhookProcessOutcome::AcceptedForAsyncDispatch) })
-        }
-
-        fn drain_immediate_ack_tasks<'a>(
-            &'a self,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
-            Box::pin(async {})
         }
     }
 
@@ -649,83 +676,6 @@ mod tests {
             .expect("router should respond")
     }
 
-    const TEAM_A_BODY: &str = r#"{
-        "type": "event_callback",
-        "team_id": "T-A",
-        "api_app_id": "A-slack",
-        "event_id": "Ev-A",
-        "event": {
-            "type": "message",
-            "channel_type": "im",
-            "user": "U123",
-            "channel": "D-A",
-            "text": "hello from A",
-            "ts": "1710000000.000001"
-        }
-    }"#;
-
-    const TEAM_B_BODY: &str = r#"{
-        "type": "event_callback",
-        "team_id": "T-B",
-        "api_app_id": "A-slack",
-        "event_id": "Ev-B",
-        "event": {
-            "type": "message",
-            "channel_type": "im",
-            "user": "U123",
-            "channel": "D-B",
-            "text": "hello from B",
-            "ts": "1710000000.000002"
-        }
-    }"#;
-
-    fn secret_headers(secret: &'static str) -> Vec<(&'static str, &'static str)> {
-        vec![("X-Test-Secret", secret)]
-    }
-
-    fn header_map(secret: &'static str) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        headers.insert("X-Test-Secret", HeaderValue::from_static(secret));
-        headers
-    }
-
-    fn static_resolver_fixture() -> (
-        StaticSlackInstallationResolver,
-        Arc<HeaderSecretDispatcher>,
-        Arc<HeaderSecretDispatcher>,
-    ) {
-        let dispatcher_a = Arc::new(HeaderSecretDispatcher::new("secret-a", "install-a"));
-        let dispatcher_b = Arc::new(HeaderSecretDispatcher::new("secret-b", "install-b"));
-        let resolver = StaticSlackInstallationResolver::new(vec![
-            SlackInstallationRecord::new(
-                tenant_id("tenant-a"),
-                installation_id("install-a"),
-                SlackInstallationSelector::team("T-A"),
-                dispatcher_a.clone(),
-            ),
-            SlackInstallationRecord::new(
-                tenant_id("tenant-b"),
-                installation_id("install-b"),
-                SlackInstallationSelector::team("T-B"),
-                dispatcher_b.clone(),
-            ),
-        ]);
-        (resolver, dispatcher_a, dispatcher_b)
-    }
-
-    fn static_resolver_mount(
-        rate_limit: SlackInstallationRateLimitConfig,
-    ) -> (
-        PublicRouteMount,
-        Arc<HeaderSecretDispatcher>,
-        Arc<HeaderSecretDispatcher>,
-    ) {
-        let (resolver, dispatcher_a, dispatcher_b) = static_resolver_fixture();
-        let service = SlackIngressService::with_rate_limit_config(Arc::new(resolver), rate_limit);
-        let mount = slack_events_route_mount(SlackEventsRouteState::new(service));
-        (mount, dispatcher_a, dispatcher_b)
-    }
-
     async fn assert_error_body(response: Response, expected: &str) {
         let bytes = response
             .into_body()
@@ -827,70 +777,6 @@ mod tests {
             .to_bytes();
         assert_eq!(&bytes[..], b"ok");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn static_resolver_routes_same_slack_user_by_verified_workspace_installation() {
-        let (resolver, _, _) = static_resolver_fixture();
-
-        let install_a = resolver
-            .resolve_installation(&header_map("secret-a"), TEAM_A_BODY.as_bytes())
-            .await
-            .expect("team A resolves");
-        let install_b = resolver
-            .resolve_installation(&header_map("secret-b"), TEAM_B_BODY.as_bytes())
-            .await
-            .expect("team B resolves");
-
-        assert_eq!(install_a.tenant_id().as_str(), "tenant-a");
-        assert_eq!(install_a.adapter_installation_id().as_str(), "install-a");
-        assert_eq!(install_a.metadata().event_user_id.as_deref(), Some("U123"));
-        assert_eq!(install_b.tenant_id().as_str(), "tenant-b");
-        assert_eq!(install_b.adapter_installation_id().as_str(), "install-b");
-        assert_eq!(install_b.metadata().event_user_id.as_deref(), Some("U123"));
-    }
-
-    #[tokio::test]
-    async fn slack_events_handler_dispatches_workspace_b_to_install_b_runner() {
-        let (mount, dispatcher_a, dispatcher_b) =
-            static_resolver_mount(SlackInstallationRateLimitConfig::default());
-        let response = post_to_mount(&mount, TEAM_B_BODY, secret_headers("secret-b")).await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(dispatcher_a.dispatch_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(dispatcher_b.dispatch_calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn slack_events_handler_rejects_workspace_b_with_install_a_secret_context() {
-        let (mount, dispatcher_a, dispatcher_b) =
-            static_resolver_mount(SlackInstallationRateLimitConfig::default());
-        let response = post_to_mount(&mount, TEAM_B_BODY, secret_headers("secret-a")).await;
-
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-        assert_error_body(response, "authentication").await;
-        assert_eq!(dispatcher_a.dispatch_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(dispatcher_b.dispatch_calls.load(Ordering::SeqCst), 0);
-    }
-
-    #[tokio::test]
-    async fn slack_events_handler_rate_limits_after_auth_by_installation() {
-        let rate_limit = SlackInstallationRateLimitConfig::new(
-            NonZeroU32::new(1).expect("nonzero"),
-            Duration::from_secs(60),
-        );
-        let (mount, dispatcher_a, dispatcher_b) = static_resolver_mount(rate_limit);
-
-        let first_a = post_to_mount(&mount, TEAM_A_BODY, secret_headers("secret-a")).await;
-        let second_a = post_to_mount(&mount, TEAM_A_BODY, secret_headers("secret-a")).await;
-        let first_b = post_to_mount(&mount, TEAM_B_BODY, secret_headers("secret-b")).await;
-
-        assert_eq!(first_a.status(), StatusCode::OK);
-        assert_eq!(second_a.status(), StatusCode::TOO_MANY_REQUESTS);
-        assert_error_body(second_a, "capacity").await;
-        assert_eq!(first_b.status(), StatusCode::OK);
-        assert_eq!(dispatcher_a.dispatch_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(dispatcher_b.dispatch_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_serve/handler_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/handler_tests.rs
@@ -1,0 +1,224 @@
+use std::future::Future;
+use std::num::NonZeroU32;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{HeaderMap, Request, StatusCode};
+use http_body_util::BodyExt;
+use ironclaw_host_api::TenantId;
+use ironclaw_product_adapters::auth::mark_shared_secret_header_verified;
+use ironclaw_product_adapters::identity::AdapterInstallationId;
+use ironclaw_product_adapters::{ProtocolAuthEvidence, ProtocolAuthFailure};
+use ironclaw_wasm_product_adapters::{RunnerError, WebhookProcessOutcome};
+use tower::ServiceExt;
+
+use super::*;
+
+struct HeaderSecretDispatcher {
+    expected_secret: &'static str,
+    subject: &'static str,
+    dispatch_calls: Arc<AtomicUsize>,
+}
+
+impl HeaderSecretDispatcher {
+    fn new(expected_secret: &'static str, subject: &'static str) -> Self {
+        Self {
+            expected_secret,
+            subject,
+            dispatch_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl SlackEventsWebhookDispatcher for HeaderSecretDispatcher {
+    fn verify_webhook_auth(
+        &self,
+        headers: &HeaderMap,
+        _body: &[u8],
+    ) -> Result<ProtocolAuthEvidence, RunnerError> {
+        if headers
+            .get("X-Test-Secret")
+            .and_then(|value| value.to_str().ok())
+            == Some(self.expected_secret)
+        {
+            return Ok(mark_shared_secret_header_verified(
+                "X-Test-Secret",
+                self.subject,
+            ));
+        }
+        Err(RunnerError::AuthenticationFailed {
+            failure: ProtocolAuthFailure::SignatureMismatch,
+        })
+    }
+
+    fn process_verified_webhook_immediate_ack<'a>(
+        &'a self,
+        _body: &'a [u8],
+        _evidence: &'a ProtocolAuthEvidence,
+    ) -> Pin<Box<dyn Future<Output = Result<WebhookProcessOutcome, RunnerError>> + Send + 'a>> {
+        self.dispatch_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(WebhookProcessOutcome::AcceptedForAsyncDispatch) })
+    }
+
+    fn drain_immediate_ack_tasks<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+}
+
+fn tenant_id(value: &str) -> TenantId {
+    TenantId::new(value).expect("valid tenant")
+}
+
+fn installation_id(value: &str) -> AdapterInstallationId {
+    AdapterInstallationId::new(value).expect("valid installation")
+}
+
+async fn post_to_mount(
+    mount: &PublicRouteMount,
+    body: &'static str,
+    secret: &'static str,
+) -> Response {
+    mount
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SLACK_EVENTS_PATH)
+                .header("X-Test-Secret", secret)
+                .body(Body::from(body))
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should respond")
+}
+
+async fn assert_error_body(response: Response, expected: &str) {
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body should collect")
+        .to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json error body");
+    assert_eq!(body["error"], expected);
+}
+
+const TEAM_A_BODY: &str = r#"{
+    "type": "event_callback",
+    "team_id": "T-A",
+    "api_app_id": "A-slack",
+    "event_id": "Ev-A",
+    "event": {
+        "type": "message",
+        "channel_type": "im",
+        "user": "U123",
+        "channel": "D-A",
+        "text": "hello from A",
+        "ts": "1710000000.000001"
+    }
+}"#;
+
+#[tokio::test]
+async fn slack_events_handler_rejects_malformed_event_envelope_before_dispatch() {
+    let dispatcher = Arc::new(HeaderSecretDispatcher::new("secret-a", "install-a"));
+    let resolver = StaticSlackInstallationResolver::new(vec![SlackInstallationRecord::new(
+        tenant_id("tenant-a"),
+        installation_id("install-a"),
+        SlackInstallationSelector::team("T-A"),
+        dispatcher.clone(),
+    )]);
+    let mount = slack_events_route_mount(SlackEventsRouteState::new(SlackIngressService::new(
+        Arc::new(resolver),
+    )));
+
+    let response = post_to_mount(&mount, "{", "secret-a").await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_error_body(response, "malformed_payload").await;
+    assert_eq!(dispatcher.dispatch_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn slack_events_handler_rejects_missing_installation_without_dispatch() {
+    let dispatcher = Arc::new(HeaderSecretDispatcher::new("secret-a", "install-a"));
+    let resolver = StaticSlackInstallationResolver::new(vec![SlackInstallationRecord::new(
+        tenant_id("tenant-a"),
+        installation_id("install-a"),
+        SlackInstallationSelector::team("T-A"),
+        dispatcher.clone(),
+    )]);
+    let mount = slack_events_route_mount(SlackEventsRouteState::new(SlackIngressService::new(
+        Arc::new(resolver),
+    )));
+    let unknown_team_body =
+        r#"{"type":"event_callback","team_id":"T-unknown","event":{"type":"message"}}"#;
+
+    let response = post_to_mount(&mount, unknown_team_body, "secret-a").await;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_error_body(response, "authentication").await;
+    assert_eq!(dispatcher.dispatch_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn slack_events_handler_rejects_ambiguous_installation_without_dispatch() {
+    let dispatcher_a = Arc::new(HeaderSecretDispatcher::new("shared-secret", "install-a"));
+    let dispatcher_b = Arc::new(HeaderSecretDispatcher::new("shared-secret", "install-b"));
+    let resolver = StaticSlackInstallationResolver::new(vec![
+        SlackInstallationRecord::new(
+            tenant_id("tenant-a"),
+            installation_id("install-a"),
+            SlackInstallationSelector::team("T-A"),
+            dispatcher_a.clone(),
+        ),
+        SlackInstallationRecord::new(
+            tenant_id("tenant-b"),
+            installation_id("install-b"),
+            SlackInstallationSelector::team("T-A"),
+            dispatcher_b.clone(),
+        ),
+    ]);
+    let mount = slack_events_route_mount(SlackEventsRouteState::new(SlackIngressService::new(
+        Arc::new(resolver),
+    )));
+
+    let response = post_to_mount(&mount, TEAM_A_BODY, "shared-secret").await;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_error_body(response, "authentication").await;
+    assert_eq!(dispatcher_a.dispatch_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(dispatcher_b.dispatch_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn slack_events_handler_rate_limit_refills_after_window() {
+    let dispatcher = Arc::new(HeaderSecretDispatcher::new("secret-a", "install-a"));
+    let resolver = StaticSlackInstallationResolver::new(vec![SlackInstallationRecord::new(
+        tenant_id("tenant-a"),
+        installation_id("install-a"),
+        SlackInstallationSelector::team("T-A"),
+        dispatcher.clone(),
+    )]);
+    let rate_limit = SlackInstallationRateLimitConfig::new(
+        NonZeroU32::new(1).expect("nonzero"),
+        Duration::from_millis(1),
+    );
+    let mount = slack_events_route_mount(SlackEventsRouteState::new(
+        SlackIngressService::with_rate_limit_config(Arc::new(resolver), rate_limit),
+    ));
+
+    let first = post_to_mount(&mount, TEAM_A_BODY, "secret-a").await;
+    let second = post_to_mount(&mount, TEAM_A_BODY, "secret-a").await;
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    let third = post_to_mount(&mount, TEAM_A_BODY, "secret-a").await;
+
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_error_body(second, "capacity").await;
+    assert_eq!(third.status(), StatusCode::OK);
+    assert_eq!(dispatcher.dispatch_calls.load(Ordering::SeqCst), 2);
+}

--- a/crates/ironclaw_reborn_composition/src/slack_serve/handler_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/handler_tests.rs
@@ -69,11 +69,11 @@ impl SlackEventsWebhookDispatcher for HeaderSecretDispatcher {
 }
 
 fn tenant_id(value: &str) -> TenantId {
-    TenantId::new(value).expect("valid tenant")
+    TenantId::new(value).expect("valid tenant") // safety: test helper only passes hard-coded valid tenant identifiers.
 }
 
 fn installation_id(value: &str) -> AdapterInstallationId {
-    AdapterInstallationId::new(value).expect("valid installation")
+    AdapterInstallationId::new(value).expect("valid installation") // safety: test helper only passes hard-coded valid installation identifiers.
 }
 
 async fn post_to_mount(
@@ -90,10 +90,10 @@ async fn post_to_mount(
                 .uri(SLACK_EVENTS_PATH)
                 .header("X-Test-Secret", secret)
                 .body(Body::from(body))
-                .expect("request should build"),
+                .expect("request should build"), // safety: test builds a valid fixed POST request.
         )
         .await
-        .expect("router should respond")
+        .expect("router should respond") // safety: axum test router should produce a response for fixed route input.
 }
 
 async fn assert_error_body(response: Response, expected: &str) {
@@ -101,10 +101,10 @@ async fn assert_error_body(response: Response, expected: &str) {
         .into_body()
         .collect()
         .await
-        .expect("body should collect")
+        .expect("body should collect") // safety: test response bodies are small and fully buffered.
         .to_bytes();
-    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json error body");
-    assert_eq!(body["error"], expected);
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json error body"); // safety: error responses are generated as JSON by this route.
+    assert_eq!(body["error"], expected); // safety: assertion is in a test-only helper.
 }
 
 const TEAM_A_BODY: &str = r#"{

--- a/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
@@ -1,0 +1,500 @@
+//! Slack installation resolution and post-auth installation-scoped ingress policy.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::num::NonZeroU32;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::body::Bytes;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use ironclaw_host_api::TenantId;
+use ironclaw_product_adapters::{AdapterInstallationId, ProtocolAuthEvidence};
+use ironclaw_slack_v2_adapter::{SlackPayloadParseError, parse_slack_url_verification_challenge};
+use ironclaw_wasm_product_adapters::RunnerError;
+use serde::Deserialize;
+use thiserror::Error;
+
+use super::{
+    SlackEventsWebhookDispatcher, SlackWebhookErrorCategory, error_response,
+    ingress_error_response, runner_error_response,
+};
+
+const SLACK_INSTALLATION_MAX_REQUESTS: NonZeroU32 = NonZeroU32::new(120).unwrap(); // safety: 120 requests is a non-zero literal.
+const SLACK_INSTALLATION_RATE_WINDOW: Duration = Duration::from_secs(60);
+const MAX_SLACK_METADATA_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlackEnvelopeMetadata {
+    pub team_id: Option<String>,
+    pub enterprise_id: Option<String>,
+    pub api_app_id: Option<String>,
+    pub event_user_id: Option<String>,
+    pub event_channel_id: Option<String>,
+}
+
+fn parse_slack_envelope_metadata(
+    raw_payload: &[u8],
+    auth_evidence: &ProtocolAuthEvidence,
+) -> Result<SlackEnvelopeMetadata, SlackPayloadParseError> {
+    if !auth_evidence.is_verified() {
+        return Err(SlackPayloadParseError::UnauthenticatedPayload);
+    }
+    if raw_payload.len() > MAX_SLACK_METADATA_PAYLOAD_BYTES {
+        return Err(SlackPayloadParseError::InvalidJson {
+            reason: "payload exceeds size limit".into(),
+        });
+    }
+    let wrapper: SlackEnvelopeMetadataWrapper =
+        serde_json::from_slice(raw_payload).map_err(|err| SlackPayloadParseError::InvalidJson {
+            reason: err.to_string(),
+        })?;
+    Ok(wrapper.into_metadata())
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackEnvelopeMetadataWrapper {
+    team_id: Option<String>,
+    enterprise_id: Option<String>,
+    api_app_id: Option<String>,
+    event: Option<SlackEnvelopeEventMetadata>,
+    #[serde(default)]
+    authorizations: Vec<SlackAuthorizationMetadata>,
+}
+
+impl SlackEnvelopeMetadataWrapper {
+    fn into_metadata(self) -> SlackEnvelopeMetadata {
+        let authorization = self.authorizations.into_iter().next();
+        SlackEnvelopeMetadata {
+            team_id: self
+                .team_id
+                .or_else(|| authorization.as_ref().and_then(|auth| auth.team_id.clone())),
+            enterprise_id: self.enterprise_id.or_else(|| {
+                authorization
+                    .as_ref()
+                    .and_then(|auth| auth.enterprise_id.clone())
+            }),
+            api_app_id: self.api_app_id,
+            event_user_id: self.event.as_ref().and_then(|event| event.user.clone()),
+            event_channel_id: self.event.and_then(|event| event.channel),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackEnvelopeEventMetadata {
+    user: Option<String>,
+    channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackAuthorizationMetadata {
+    team_id: Option<String>,
+    enterprise_id: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct ResolvedSlackInstallation {
+    tenant_id: TenantId,
+    adapter_installation_id: AdapterInstallationId,
+    metadata: SlackEnvelopeMetadata,
+    evidence: ProtocolAuthEvidence,
+    dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
+}
+
+impl ResolvedSlackInstallation {
+    pub fn new(
+        tenant_id: TenantId,
+        adapter_installation_id: AdapterInstallationId,
+        metadata: SlackEnvelopeMetadata,
+        evidence: ProtocolAuthEvidence,
+        dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            adapter_installation_id,
+            metadata,
+            evidence,
+            dispatcher,
+        }
+    }
+
+    pub fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+
+    pub fn adapter_installation_id(&self) -> &AdapterInstallationId {
+        &self.adapter_installation_id
+    }
+
+    pub fn metadata(&self) -> &SlackEnvelopeMetadata {
+        &self.metadata
+    }
+
+    pub fn evidence(&self) -> &ProtocolAuthEvidence {
+        &self.evidence
+    }
+
+    pub fn dispatcher(&self) -> Arc<dyn SlackEventsWebhookDispatcher> {
+        Arc::clone(&self.dispatcher)
+    }
+}
+
+impl std::fmt::Debug for ResolvedSlackInstallation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResolvedSlackInstallation")
+            .field("tenant_id", &self.tenant_id)
+            .field("adapter_installation_id", &self.adapter_installation_id)
+            .field("metadata", &self.metadata)
+            .field("dispatcher", &"Arc<dyn SlackEventsWebhookDispatcher>")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SlackIngressError {
+    #[error(transparent)]
+    Runner(#[from] RunnerError),
+    #[error(transparent)]
+    Envelope(#[from] SlackPayloadParseError),
+    #[error("no verified Slack installation matched the signed envelope")]
+    InstallationNotFound,
+    #[error("multiple verified Slack installations matched the signed envelope")]
+    AmbiguousInstallation,
+    #[error(
+        "Slack installation rate limit exceeded for tenant {tenant_id} installation {adapter_installation_id}"
+    )]
+    InstallationRateLimited {
+        tenant_id: TenantId,
+        adapter_installation_id: AdapterInstallationId,
+    },
+}
+
+pub trait SlackInstallationResolver: Send + Sync {
+    fn resolve_installation<'a>(
+        &'a self,
+        headers: &'a HeaderMap,
+        body: &'a [u8],
+    ) -> Pin<
+        Box<dyn Future<Output = Result<ResolvedSlackInstallation, SlackIngressError>> + Send + 'a>,
+    >;
+
+    fn drain_installations<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+}
+
+#[derive(Clone)]
+pub struct SlackInstallationRecord {
+    tenant_id: TenantId,
+    adapter_installation_id: AdapterInstallationId,
+    selector: SlackInstallationSelector,
+    dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
+}
+
+impl SlackInstallationRecord {
+    pub fn new(
+        tenant_id: TenantId,
+        adapter_installation_id: AdapterInstallationId,
+        selector: SlackInstallationSelector,
+        dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            adapter_installation_id,
+            selector,
+            dispatcher,
+        }
+    }
+}
+
+impl std::fmt::Debug for SlackInstallationRecord {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SlackInstallationRecord")
+            .field("tenant_id", &self.tenant_id)
+            .field("adapter_installation_id", &self.adapter_installation_id)
+            .field("selector", &self.selector)
+            .field("dispatcher", &"Arc<dyn SlackEventsWebhookDispatcher>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlackInstallationSelector {
+    team_id: Option<String>,
+    enterprise_id: Option<String>,
+    api_app_id: Option<String>,
+}
+
+impl SlackInstallationSelector {
+    pub fn new(
+        team_id: Option<String>,
+        enterprise_id: Option<String>,
+        api_app_id: Option<String>,
+    ) -> Self {
+        Self {
+            team_id,
+            enterprise_id,
+            api_app_id,
+        }
+    }
+
+    pub fn team(team_id: impl Into<String>) -> Self {
+        Self::new(Some(team_id.into()), None, None)
+    }
+
+    fn matches(&self, metadata: &SlackEnvelopeMetadata) -> bool {
+        selector_part_matches(self.team_id.as_deref(), metadata.team_id.as_deref())
+            && selector_part_matches(
+                self.enterprise_id.as_deref(),
+                metadata.enterprise_id.as_deref(),
+            )
+            && selector_part_matches(self.api_app_id.as_deref(), metadata.api_app_id.as_deref())
+            && (self.team_id.is_some() || self.enterprise_id.is_some() || self.api_app_id.is_some())
+    }
+}
+
+fn selector_part_matches(configured: Option<&str>, observed: Option<&str>) -> bool {
+    match configured {
+        Some(configured) => observed == Some(configured),
+        None => true,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticSlackInstallationResolver {
+    installations: Vec<SlackInstallationRecord>,
+}
+
+impl StaticSlackInstallationResolver {
+    pub fn new(installations: impl IntoIterator<Item = SlackInstallationRecord>) -> Self {
+        Self {
+            installations: installations.into_iter().collect(),
+        }
+    }
+
+    fn resolve_sync(
+        &self,
+        headers: &HeaderMap,
+        body: &[u8],
+    ) -> Result<ResolvedSlackInstallation, SlackIngressError> {
+        let mut auth_failure: Option<RunnerError> = None;
+        let mut verified = Vec::new();
+        for installation in &self.installations {
+            match installation.dispatcher.verify_webhook_auth(headers, body) {
+                Ok(evidence) => verified.push((installation, evidence)),
+                Err(error) => {
+                    auth_failure.get_or_insert(error);
+                }
+            };
+        }
+
+        if verified.is_empty() {
+            return Err(auth_failure
+                .unwrap_or(RunnerError::AuthenticationFailed {
+                    failure: ironclaw_product_adapters::ProtocolAuthFailure::Missing,
+                })
+                .into());
+        }
+
+        let metadata = parse_slack_envelope_metadata(body, &verified[0].1)?;
+        let mut matches = verified
+            .into_iter()
+            .filter(|(installation, _)| installation.selector.matches(&metadata));
+        let Some((installation, evidence)) = matches.next() else {
+            return Err(SlackIngressError::InstallationNotFound);
+        };
+        if matches.next().is_some() {
+            return Err(SlackIngressError::AmbiguousInstallation);
+        }
+
+        Ok(ResolvedSlackInstallation::new(
+            installation.tenant_id.clone(),
+            installation.adapter_installation_id.clone(),
+            metadata,
+            evidence,
+            Arc::clone(&installation.dispatcher),
+        ))
+    }
+}
+
+impl SlackInstallationResolver for StaticSlackInstallationResolver {
+    fn resolve_installation<'a>(
+        &'a self,
+        headers: &'a HeaderMap,
+        body: &'a [u8],
+    ) -> Pin<
+        Box<dyn Future<Output = Result<ResolvedSlackInstallation, SlackIngressError>> + Send + 'a>,
+    > {
+        Box::pin(async move { self.resolve_sync(headers, body) })
+    }
+
+    fn drain_installations<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            for installation in &self.installations {
+                installation.dispatcher.drain_immediate_ack_tasks().await;
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlackInstallationRateLimitConfig {
+    pub max_requests: NonZeroU32,
+    pub window: Duration,
+}
+
+impl SlackInstallationRateLimitConfig {
+    pub fn new(max_requests: NonZeroU32, window: Duration) -> Self {
+        Self {
+            max_requests,
+            window,
+        }
+    }
+}
+
+impl Default for SlackInstallationRateLimitConfig {
+    fn default() -> Self {
+        Self {
+            max_requests: SLACK_INSTALLATION_MAX_REQUESTS,
+            window: SLACK_INSTALLATION_RATE_WINDOW,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SlackInstallationRateLimiter {
+    config: SlackInstallationRateLimitConfig,
+    buckets: Arc<tokio::sync::Mutex<HashMap<SlackInstallationRateLimitKey, SlackRateLimitBucket>>>,
+}
+
+impl SlackInstallationRateLimiter {
+    fn new(config: SlackInstallationRateLimitConfig) -> Self {
+        Self {
+            config,
+            buckets: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        }
+    }
+
+    async fn check(
+        &self,
+        installation: &ResolvedSlackInstallation,
+    ) -> Result<(), SlackIngressError> {
+        let now = Instant::now();
+        let key = SlackInstallationRateLimitKey {
+            tenant_id: installation.tenant_id.clone(),
+            adapter_installation_id: installation.adapter_installation_id.clone(),
+        };
+        let mut buckets = self.buckets.lock().await;
+        let bucket = buckets.entry(key).or_insert(SlackRateLimitBucket {
+            window_started_at: now,
+            requests: 0,
+        });
+        if now.duration_since(bucket.window_started_at) >= self.config.window {
+            bucket.window_started_at = now;
+            bucket.requests = 0;
+        }
+        if bucket.requests >= self.config.max_requests.get() {
+            return Err(SlackIngressError::InstallationRateLimited {
+                tenant_id: installation.tenant_id.clone(),
+                adapter_installation_id: installation.adapter_installation_id.clone(),
+            });
+        }
+        bucket.requests += 1;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SlackInstallationRateLimitKey {
+    tenant_id: TenantId,
+    adapter_installation_id: AdapterInstallationId,
+}
+
+#[derive(Debug, Clone)]
+struct SlackRateLimitBucket {
+    window_started_at: Instant,
+    requests: u32,
+}
+
+#[derive(Clone)]
+pub struct SlackIngressService {
+    resolver: Arc<dyn SlackInstallationResolver>,
+    installation_rate_limiter: SlackInstallationRateLimiter,
+}
+
+impl SlackIngressService {
+    pub fn new(resolver: Arc<dyn SlackInstallationResolver>) -> Self {
+        Self::with_rate_limit_config(resolver, SlackInstallationRateLimitConfig::default())
+    }
+
+    pub fn with_rate_limit_config(
+        resolver: Arc<dyn SlackInstallationResolver>,
+        rate_limit: SlackInstallationRateLimitConfig,
+    ) -> Self {
+        Self {
+            resolver,
+            installation_rate_limiter: SlackInstallationRateLimiter::new(rate_limit),
+        }
+    }
+
+    pub(super) async fn handle_events(&self, headers: HeaderMap, body: Bytes) -> Response {
+        let installation = match self
+            .resolver
+            .resolve_installation(&headers, body.as_ref())
+            .await
+        {
+            Ok(installation) => installation,
+            Err(error) => return ingress_error_response(error),
+        };
+        if let Err(error) = self.installation_rate_limiter.check(&installation).await {
+            return ingress_error_response(error);
+        }
+
+        match parse_slack_url_verification_challenge(body.as_ref(), installation.evidence()) {
+            Ok(Some(challenge)) => return (StatusCode::OK, challenge.challenge).into_response(),
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!(
+                    target = "ironclaw::reborn::slack_events",
+                    tenant_id = %installation.tenant_id(),
+                    adapter_installation_id = %installation.adapter_installation_id(),
+                    error = %error,
+                    "Slack URL verification parse failed"
+                );
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    SlackWebhookErrorCategory::MalformedPayload,
+                );
+            }
+        }
+
+        match installation
+            .dispatcher()
+            .process_verified_webhook_immediate_ack(body.as_ref(), installation.evidence())
+            .await
+        {
+            Ok(_) => (StatusCode::OK, "ok").into_response(),
+            Err(error) => runner_error_response(error),
+        }
+    }
+
+    pub async fn drain_installations(&self) {
+        self.resolver.drain_installations().await;
+    }
+}
+
+impl std::fmt::Debug for SlackIngressService {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SlackIngressService")
+            .field("resolver", &"Arc<dyn SlackInstallationResolver>")
+            .field(
+                "installation_rate_limiter",
+                &self.installation_rate_limiter.config,
+            )
+            .finish()
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
@@ -7,69 +7,173 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use axum::body::Bytes;
-use axum::http::{HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::http::HeaderMap;
+use futures::future::join_all;
 use ironclaw_host_api::TenantId;
 use ironclaw_product_adapters::{AdapterInstallationId, ProtocolAuthEvidence};
-use ironclaw_slack_v2_adapter::{SlackPayloadParseError, parse_slack_url_verification_challenge};
+use ironclaw_slack_v2_adapter::SlackPayloadParseError;
 use ironclaw_wasm_product_adapters::RunnerError;
 use serde::Deserialize;
 use thiserror::Error;
 
-use super::{
-    SlackEventsWebhookDispatcher, SlackWebhookErrorCategory, error_response,
-    ingress_error_response, runner_error_response,
-};
+use super::SlackEventsWebhookDispatcher;
 
 const SLACK_INSTALLATION_MAX_REQUESTS: NonZeroU32 = NonZeroU32::new(120).unwrap(); // safety: 120 requests is a non-zero literal.
 const SLACK_INSTALLATION_RATE_WINDOW: Duration = Duration::from_secs(60);
 const MAX_SLACK_METADATA_PAYLOAD_BYTES: usize = 1024 * 1024;
+const MAX_SLACK_VERIFICATION_CANDIDATES: usize = 8;
+
+macro_rules! slack_id_type {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::ops::Deref for $name {
+            type Target = str;
+
+            fn deref(&self) -> &Self::Target {
+                self.as_str()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(self.as_str())
+            }
+        }
+    };
+}
+
+slack_id_type!(SlackTeamId);
+slack_id_type!(SlackEnterpriseId);
+slack_id_type!(SlackApiAppId);
+slack_id_type!(SlackUserId);
+slack_id_type!(SlackChannelId);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SlackEnvelopeMetadata {
-    pub team_id: Option<String>,
-    pub enterprise_id: Option<String>,
-    pub api_app_id: Option<String>,
-    pub install_user_id: Option<String>,
-    pub event_user_id: Option<String>,
-    pub event_channel_id: Option<String>,
+    pub team_id: Option<SlackTeamId>,
+    pub enterprise_id: Option<SlackEnterpriseId>,
+    pub api_app_id: Option<SlackApiAppId>,
+    pub install_user_id: Option<SlackUserId>,
+    pub event_user_id: Option<SlackUserId>,
+    pub event_channel_id: Option<SlackChannelId>,
+    install_contexts: Vec<SlackInstallContext>,
 }
 
 impl SlackEnvelopeMetadata {
-    fn empty() -> Self {
+    pub fn new(
+        team_id: Option<SlackTeamId>,
+        enterprise_id: Option<SlackEnterpriseId>,
+        api_app_id: Option<SlackApiAppId>,
+        install_user_id: Option<SlackUserId>,
+        event_user_id: Option<SlackUserId>,
+        event_channel_id: Option<SlackChannelId>,
+    ) -> Self {
         Self {
-            team_id: None,
-            enterprise_id: None,
-            api_app_id: None,
-            install_user_id: None,
-            event_user_id: None,
-            event_channel_id: None,
+            team_id: team_id.clone(),
+            enterprise_id: enterprise_id.clone(),
+            api_app_id,
+            install_user_id: install_user_id.clone(),
+            event_user_id,
+            event_channel_id,
+            install_contexts: vec![SlackInstallContext {
+                team_id,
+                enterprise_id,
+                install_user_id,
+            }],
+        }
+    }
+
+    fn from_wrapper(wrapper: SlackEnvelopeMetadataWrapper) -> Self {
+        let event = wrapper.event;
+        let mut install_contexts: Vec<_> = wrapper
+            .authorizations
+            .into_iter()
+            .map(SlackInstallContext::from_authorization)
+            .collect();
+
+        if install_contexts.is_empty() {
+            install_contexts.push(SlackInstallContext {
+                team_id: wrapper
+                    .context_team_id
+                    .or(wrapper.team_id)
+                    .map(SlackTeamId::new),
+                enterprise_id: wrapper
+                    .context_enterprise_id
+                    .or(wrapper.enterprise_id)
+                    .map(SlackEnterpriseId::new),
+                install_user_id: None,
+            });
+        }
+
+        let primary_context = install_contexts.first().cloned().unwrap_or_default();
+        Self {
+            team_id: primary_context.team_id.clone(),
+            enterprise_id: primary_context.enterprise_id.clone(),
+            api_app_id: wrapper.api_app_id.map(SlackApiAppId::new),
+            install_user_id: primary_context.install_user_id.clone(),
+            event_user_id: event
+                .as_ref()
+                .and_then(|event| event.user.clone())
+                .map(SlackUserId::new),
+            event_channel_id: event
+                .and_then(|event| event.channel)
+                .map(SlackChannelId::new),
+            install_contexts,
+        }
+    }
+
+    fn install_contexts(&self) -> impl Iterator<Item = &SlackInstallContext> {
+        self.install_contexts.iter()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct SlackInstallContext {
+    team_id: Option<SlackTeamId>,
+    enterprise_id: Option<SlackEnterpriseId>,
+    install_user_id: Option<SlackUserId>,
+}
+
+impl SlackInstallContext {
+    fn from_authorization(authorization: SlackAuthorizationMetadata) -> Self {
+        Self {
+            team_id: authorization.team_id.map(SlackTeamId::new),
+            enterprise_id: authorization.enterprise_id.map(SlackEnterpriseId::new),
+            install_user_id: authorization.user_id.map(SlackUserId::new),
         }
     }
 }
 
-fn parse_slack_envelope_metadata(
+fn parse_slack_envelope(
     raw_payload: &[u8],
-    auth_evidence: &ProtocolAuthEvidence,
-) -> Result<SlackEnvelopeMetadata, SlackPayloadParseError> {
-    if !auth_evidence.is_verified() {
-        return Err(SlackPayloadParseError::UnauthenticatedPayload);
-    }
+) -> Result<SlackEnvelopeMetadataWrapper, SlackPayloadParseError> {
     if raw_payload.len() > MAX_SLACK_METADATA_PAYLOAD_BYTES {
         return Err(SlackPayloadParseError::InvalidJson {
             reason: "payload exceeds size limit".into(),
         });
     }
-    let wrapper: SlackEnvelopeMetadataWrapper =
-        serde_json::from_slice(raw_payload).map_err(|err| SlackPayloadParseError::InvalidJson {
-            reason: err.to_string(),
-        })?;
-    Ok(wrapper.into_metadata())
+    serde_json::from_slice(raw_payload).map_err(|err| SlackPayloadParseError::InvalidJson {
+        reason: err.to_string(),
+    })
 }
 
 #[derive(Debug, Clone, Deserialize)]
 struct SlackEnvelopeMetadataWrapper {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    challenge: Option<String>,
     team_id: Option<String>,
     enterprise_id: Option<String>,
     context_team_id: Option<String>,
@@ -81,24 +185,15 @@ struct SlackEnvelopeMetadataWrapper {
 }
 
 impl SlackEnvelopeMetadataWrapper {
-    fn into_metadata(self) -> SlackEnvelopeMetadata {
-        let authorization = self.authorizations.into_iter().next();
-        SlackEnvelopeMetadata {
-            team_id: authorization
-                .as_ref()
-                .and_then(|auth| auth.team_id.clone())
-                .or(self.context_team_id)
-                .or(self.team_id),
-            enterprise_id: authorization
-                .as_ref()
-                .and_then(|auth| auth.enterprise_id.clone())
-                .or(self.context_enterprise_id)
-                .or(self.enterprise_id),
-            api_app_id: self.api_app_id,
-            install_user_id: authorization.as_ref().and_then(|auth| auth.user_id.clone()),
-            event_user_id: self.event.as_ref().and_then(|event| event.user.clone()),
-            event_channel_id: self.event.and_then(|event| event.channel),
-        }
+    fn is_url_verification(&self) -> bool {
+        self.kind.as_deref() == Some("url_verification")
+    }
+
+    fn into_challenge(self) -> Result<String, SlackPayloadParseError> {
+        self.challenge
+            .ok_or_else(|| SlackPayloadParseError::InvalidJson {
+                reason: "missing challenge".into(),
+            })
     }
 }
 
@@ -119,7 +214,6 @@ struct SlackAuthorizationMetadata {
 pub struct ResolvedSlackInstallation {
     tenant_id: TenantId,
     adapter_installation_id: AdapterInstallationId,
-    metadata: SlackEnvelopeMetadata,
     evidence: ProtocolAuthEvidence,
     dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
 }
@@ -128,14 +222,12 @@ impl ResolvedSlackInstallation {
     pub fn new(
         tenant_id: TenantId,
         adapter_installation_id: AdapterInstallationId,
-        metadata: SlackEnvelopeMetadata,
         evidence: ProtocolAuthEvidence,
         dispatcher: Arc<dyn SlackEventsWebhookDispatcher>,
     ) -> Self {
         Self {
             tenant_id,
             adapter_installation_id,
-            metadata,
             evidence,
             dispatcher,
         }
@@ -147,10 +239,6 @@ impl ResolvedSlackInstallation {
 
     pub fn adapter_installation_id(&self) -> &AdapterInstallationId {
         &self.adapter_installation_id
-    }
-
-    pub fn metadata(&self) -> &SlackEnvelopeMetadata {
-        &self.metadata
     }
 
     pub fn evidence(&self) -> &ProtocolAuthEvidence {
@@ -168,9 +256,49 @@ impl std::fmt::Debug for ResolvedSlackInstallation {
             .debug_struct("ResolvedSlackInstallation")
             .field("tenant_id", &self.tenant_id)
             .field("adapter_installation_id", &self.adapter_installation_id)
-            .field("metadata", &self.metadata)
             .field("dispatcher", &"Arc<dyn SlackEventsWebhookDispatcher>")
             .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone)]
+pub enum ResolvedSlackIngress {
+    UrlVerification {
+        installation: ResolvedSlackInstallation,
+        challenge: String,
+    },
+    Event {
+        installation: ResolvedSlackInstallation,
+        metadata: SlackEnvelopeMetadata,
+    },
+}
+
+impl ResolvedSlackIngress {
+    pub fn installation(&self) -> &ResolvedSlackInstallation {
+        match self {
+            Self::UrlVerification { installation, .. } | Self::Event { installation, .. } => {
+                installation
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for ResolvedSlackIngress {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UrlVerification { installation, .. } => formatter
+                .debug_struct("ResolvedSlackIngress::UrlVerification")
+                .field("installation", installation)
+                .finish(),
+            Self::Event {
+                installation,
+                metadata,
+            } => formatter
+                .debug_struct("ResolvedSlackIngress::Event")
+                .field("installation", installation)
+                .field("metadata", metadata)
+                .finish(),
+        }
     }
 }
 
@@ -194,13 +322,11 @@ pub enum SlackIngressError {
 }
 
 pub trait SlackInstallationResolver: Send + Sync {
-    fn resolve_installation<'a>(
+    fn resolve_ingress<'a>(
         &'a self,
         headers: &'a HeaderMap,
         body: &'a [u8],
-    ) -> Pin<
-        Box<dyn Future<Output = Result<ResolvedSlackInstallation, SlackIngressError>> + Send + 'a>,
-    >;
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedSlackIngress, SlackIngressError>> + Send + 'a>>;
 
     fn drain_installations<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 }
@@ -242,58 +368,151 @@ impl std::fmt::Debug for SlackInstallationRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SlackInstallationSelector {
-    team_id: Option<String>,
-    enterprise_id: Option<String>,
-    api_app_id: Option<String>,
-    install_user_id: Option<String>,
+pub enum SlackInstallationSelector {
+    Team {
+        team_id: SlackTeamId,
+    },
+    AppTeam {
+        api_app_id: SlackApiAppId,
+        team_id: SlackTeamId,
+    },
+    EnterpriseTeam {
+        enterprise_id: SlackEnterpriseId,
+        team_id: SlackTeamId,
+    },
+    InstallUser {
+        team_id: SlackTeamId,
+        install_user_id: SlackUserId,
+    },
+    EnterpriseInstallUser {
+        enterprise_id: SlackEnterpriseId,
+        team_id: SlackTeamId,
+        install_user_id: SlackUserId,
+    },
+    AppInstallUser {
+        api_app_id: SlackApiAppId,
+        team_id: SlackTeamId,
+        install_user_id: SlackUserId,
+    },
 }
 
 impl SlackInstallationSelector {
-    pub fn new(
-        team_id: Option<String>,
-        enterprise_id: Option<String>,
-        api_app_id: Option<String>,
-    ) -> Self {
-        Self {
-            team_id,
-            enterprise_id,
-            api_app_id,
-            install_user_id: None,
+    pub fn team(team_id: impl Into<String>) -> Self {
+        Self::Team {
+            team_id: SlackTeamId::new(team_id),
         }
     }
 
-    pub fn team(team_id: impl Into<String>) -> Self {
-        Self::new(Some(team_id.into()), None, None)
+    pub fn app_team(api_app_id: impl Into<String>, team_id: impl Into<String>) -> Self {
+        Self::AppTeam {
+            api_app_id: SlackApiAppId::new(api_app_id),
+            team_id: SlackTeamId::new(team_id),
+        }
     }
 
-    pub fn with_install_user_id(mut self, install_user_id: impl Into<String>) -> Self {
-        self.install_user_id = Some(install_user_id.into());
-        self
+    pub fn enterprise_team(enterprise_id: impl Into<String>, team_id: impl Into<String>) -> Self {
+        Self::EnterpriseTeam {
+            enterprise_id: SlackEnterpriseId::new(enterprise_id),
+            team_id: SlackTeamId::new(team_id),
+        }
+    }
+
+    pub fn with_install_user_id(self, install_user_id: impl Into<String>) -> Self {
+        match self {
+            Self::Team { team_id } => Self::InstallUser {
+                team_id,
+                install_user_id: SlackUserId::new(install_user_id),
+            },
+            Self::AppTeam {
+                api_app_id,
+                team_id,
+            } => Self::AppInstallUser {
+                api_app_id,
+                team_id,
+                install_user_id: SlackUserId::new(install_user_id),
+            },
+            Self::EnterpriseTeam {
+                enterprise_id,
+                team_id,
+            } => Self::EnterpriseInstallUser {
+                enterprise_id,
+                team_id,
+                install_user_id: SlackUserId::new(install_user_id),
+            },
+            Self::InstallUser { team_id, .. } => Self::InstallUser {
+                team_id,
+                install_user_id: SlackUserId::new(install_user_id),
+            },
+            Self::EnterpriseInstallUser {
+                enterprise_id,
+                team_id,
+                ..
+            } => Self::EnterpriseInstallUser {
+                enterprise_id,
+                team_id,
+                install_user_id: SlackUserId::new(install_user_id),
+            },
+            Self::AppInstallUser {
+                api_app_id,
+                team_id,
+                ..
+            } => Self::AppInstallUser {
+                api_app_id,
+                team_id,
+                install_user_id: SlackUserId::new(install_user_id),
+            },
+        }
     }
 
     fn matches(&self, metadata: &SlackEnvelopeMetadata) -> bool {
-        selector_part_matches(self.team_id.as_deref(), metadata.team_id.as_deref())
-            && selector_part_matches(
-                self.enterprise_id.as_deref(),
-                metadata.enterprise_id.as_deref(),
-            )
-            && selector_part_matches(self.api_app_id.as_deref(), metadata.api_app_id.as_deref())
-            && selector_part_matches(
-                self.install_user_id.as_deref(),
-                metadata.install_user_id.as_deref(),
-            )
-            && (self.team_id.is_some()
-                || self.enterprise_id.is_some()
-                || self.api_app_id.is_some()
-                || self.install_user_id.is_some())
-    }
-}
-
-fn selector_part_matches(configured: Option<&str>, observed: Option<&str>) -> bool {
-    match configured {
-        Some(configured) => observed == Some(configured),
-        None => true,
+        match self {
+            Self::Team { team_id } => metadata
+                .install_contexts()
+                .any(|context| context.team_id.as_ref() == Some(team_id)),
+            Self::AppTeam {
+                api_app_id,
+                team_id,
+            } => {
+                metadata.api_app_id.as_ref() == Some(api_app_id)
+                    && metadata
+                        .install_contexts()
+                        .any(|context| context.team_id.as_ref() == Some(team_id))
+            }
+            Self::EnterpriseTeam {
+                enterprise_id,
+                team_id,
+            } => metadata.install_contexts().any(|context| {
+                context.enterprise_id.as_ref() == Some(enterprise_id)
+                    && context.team_id.as_ref() == Some(team_id)
+            }),
+            Self::InstallUser {
+                team_id,
+                install_user_id,
+            } => metadata.install_contexts().any(|context| {
+                context.team_id.as_ref() == Some(team_id)
+                    && context.install_user_id.as_ref() == Some(install_user_id)
+            }),
+            Self::EnterpriseInstallUser {
+                enterprise_id,
+                team_id,
+                install_user_id,
+            } => metadata.install_contexts().any(|context| {
+                context.enterprise_id.as_ref() == Some(enterprise_id)
+                    && context.team_id.as_ref() == Some(team_id)
+                    && context.install_user_id.as_ref() == Some(install_user_id)
+            }),
+            Self::AppInstallUser {
+                api_app_id,
+                team_id,
+                install_user_id,
+            } => {
+                metadata.api_app_id.as_ref() == Some(api_app_id)
+                    && metadata.install_contexts().any(|context| {
+                        context.team_id.as_ref() == Some(team_id)
+                            && context.install_user_id.as_ref() == Some(install_user_id)
+                    })
+            }
+        }
     }
 }
 
@@ -313,10 +532,82 @@ impl StaticSlackInstallationResolver {
         &self,
         headers: &HeaderMap,
         body: &[u8],
-    ) -> Result<ResolvedSlackInstallation, SlackIngressError> {
+    ) -> Result<ResolvedSlackIngress, SlackIngressError> {
+        match parse_slack_envelope(body) {
+            Ok(envelope) if envelope.is_url_verification() => {
+                self.resolve_url_verification(headers, body, envelope)
+            }
+            Ok(envelope) => self.resolve_event(headers, body, envelope),
+            Err(error) => self.resolve_unparseable(headers, body, error),
+        }
+    }
+
+    fn resolve_url_verification(
+        &self,
+        headers: &HeaderMap,
+        body: &[u8],
+        envelope: SlackEnvelopeMetadataWrapper,
+    ) -> Result<ResolvedSlackIngress, SlackIngressError> {
+        self.ensure_candidate_budget(self.installations.len())?;
+        let mut verified = self.verify_candidates(self.installations.iter(), headers, body)?;
+        if verified.len() > 1 {
+            return Err(SlackIngressError::AmbiguousInstallation);
+        }
+        let (installation, evidence) = verified.remove(0);
+        Ok(ResolvedSlackIngress::UrlVerification {
+            installation: Self::resolved_installation(installation, evidence),
+            challenge: envelope.into_challenge()?,
+        })
+    }
+
+    fn resolve_event(
+        &self,
+        headers: &HeaderMap,
+        body: &[u8],
+        envelope: SlackEnvelopeMetadataWrapper,
+    ) -> Result<ResolvedSlackIngress, SlackIngressError> {
+        let metadata = SlackEnvelopeMetadata::from_wrapper(envelope);
+        let candidates: Vec<_> = self
+            .installations
+            .iter()
+            .filter(|installation| installation.selector.matches(&metadata))
+            .collect();
+        if candidates.is_empty() {
+            return Err(SlackIngressError::InstallationNotFound);
+        }
+        self.ensure_candidate_budget(candidates.len())?;
+
+        let mut verified = self.verify_candidates(candidates, headers, body)?;
+        if verified.len() > 1 {
+            return Err(SlackIngressError::AmbiguousInstallation);
+        }
+        let (installation, evidence) = verified.remove(0);
+        Ok(ResolvedSlackIngress::Event {
+            installation: Self::resolved_installation(installation, evidence),
+            metadata,
+        })
+    }
+
+    fn resolve_unparseable(
+        &self,
+        headers: &HeaderMap,
+        body: &[u8],
+        error: SlackPayloadParseError,
+    ) -> Result<ResolvedSlackIngress, SlackIngressError> {
+        self.ensure_candidate_budget(self.installations.len())?;
+        self.verify_candidates(self.installations.iter(), headers, body)?;
+        Err(error.into())
+    }
+
+    fn verify_candidates<'a>(
+        &self,
+        candidates: impl IntoIterator<Item = &'a SlackInstallationRecord>,
+        headers: &HeaderMap,
+        body: &[u8],
+    ) -> Result<Vec<(&'a SlackInstallationRecord, ProtocolAuthEvidence)>, SlackIngressError> {
         let mut auth_failure: Option<RunnerError> = None;
         let mut verified = Vec::new();
-        for installation in &self.installations {
+        for installation in candidates {
             match installation.dispatcher.verify_webhook_auth(headers, body) {
                 Ok(evidence) => verified.push((installation, evidence)),
                 Err(error) => {
@@ -332,55 +623,46 @@ impl StaticSlackInstallationResolver {
                 })
                 .into());
         }
+        Ok(verified)
+    }
 
-        if parse_slack_url_verification_challenge(body, &verified[0].1)?.is_some() {
-            let (installation, evidence) = verified.remove(0);
-            return Ok(ResolvedSlackInstallation::new(
-                installation.tenant_id.clone(),
-                installation.adapter_installation_id.clone(),
-                SlackEnvelopeMetadata::empty(),
-                evidence,
-                Arc::clone(&installation.dispatcher),
-            ));
-        }
-
-        let metadata = parse_slack_envelope_metadata(body, &verified[0].1)?;
-        let mut matches = verified
-            .into_iter()
-            .filter(|(installation, _)| installation.selector.matches(&metadata));
-        let Some((installation, evidence)) = matches.next() else {
-            return Err(SlackIngressError::InstallationNotFound);
-        };
-        if matches.next().is_some() {
+    fn ensure_candidate_budget(&self, candidate_count: usize) -> Result<(), SlackIngressError> {
+        if candidate_count > MAX_SLACK_VERIFICATION_CANDIDATES {
             return Err(SlackIngressError::AmbiguousInstallation);
         }
+        Ok(())
+    }
 
-        Ok(ResolvedSlackInstallation::new(
+    fn resolved_installation(
+        installation: &SlackInstallationRecord,
+        evidence: ProtocolAuthEvidence,
+    ) -> ResolvedSlackInstallation {
+        ResolvedSlackInstallation::new(
             installation.tenant_id.clone(),
             installation.adapter_installation_id.clone(),
-            metadata,
             evidence,
             Arc::clone(&installation.dispatcher),
-        ))
+        )
     }
 }
 
 impl SlackInstallationResolver for StaticSlackInstallationResolver {
-    fn resolve_installation<'a>(
+    fn resolve_ingress<'a>(
         &'a self,
         headers: &'a HeaderMap,
         body: &'a [u8],
-    ) -> Pin<
-        Box<dyn Future<Output = Result<ResolvedSlackInstallation, SlackIngressError>> + Send + 'a>,
-    > {
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedSlackIngress, SlackIngressError>> + Send + 'a>>
+    {
         Box::pin(async move { self.resolve_sync(headers, body) })
     }
 
     fn drain_installations<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
-            for installation in &self.installations {
-                installation.dispatcher.drain_immediate_ack_tasks().await;
-            }
+            let drains = self
+                .installations
+                .iter()
+                .map(|installation| installation.dispatcher.drain_immediate_ack_tasks());
+            join_all(drains).await;
         })
     }
 }
@@ -410,20 +692,20 @@ impl Default for SlackInstallationRateLimitConfig {
 }
 
 #[derive(Clone)]
-struct SlackInstallationRateLimiter {
+pub struct SlackInstallationRateLimiter {
     config: SlackInstallationRateLimitConfig,
     buckets: Arc<Mutex<HashMap<SlackInstallationRateLimitKey, SlackRateLimitBucket>>>,
 }
 
 impl SlackInstallationRateLimiter {
-    fn new(config: SlackInstallationRateLimitConfig) -> Self {
+    pub fn new(config: SlackInstallationRateLimitConfig) -> Self {
         Self {
             config,
             buckets: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    fn check(&self, installation: &ResolvedSlackInstallation) -> Result<(), SlackIngressError> {
+    pub fn check(&self, installation: &ResolvedSlackInstallation) -> Result<(), SlackIngressError> {
         let now = Instant::now();
         let key = SlackInstallationRateLimitKey {
             tenant_id: installation.tenant_id.clone(),
@@ -433,22 +715,39 @@ impl SlackInstallationRateLimiter {
             Ok(buckets) => buckets,
             Err(poisoned) => poisoned.into_inner(),
         };
-        let bucket = buckets.entry(key).or_insert(SlackRateLimitBucket {
-            window_started_at: now,
-            requests: 0,
-        });
-        if now.duration_since(bucket.window_started_at) >= self.config.window {
-            bucket.window_started_at = now;
-            bucket.requests = 0;
-        }
-        if bucket.requests >= self.config.max_requests.get() {
+        self.prune_stale_buckets(&mut buckets, now);
+        let bucket = buckets
+            .entry(key)
+            .or_insert_with(|| SlackRateLimitBucket::full(now, &self.config));
+        bucket.refill(now, &self.config);
+        if !bucket.try_consume() {
             return Err(SlackIngressError::InstallationRateLimited {
                 tenant_id: installation.tenant_id.clone(),
                 adapter_installation_id: installation.adapter_installation_id.clone(),
             });
         }
-        bucket.requests += 1;
         Ok(())
+    }
+
+    fn prune_stale_buckets(
+        &self,
+        buckets: &mut HashMap<SlackInstallationRateLimitKey, SlackRateLimitBucket>,
+        now: Instant,
+    ) {
+        let ttl = self.config.window.saturating_mul(2);
+        let capacity = self.config.max_requests.get() as f64;
+        buckets.retain(|_, bucket| {
+            now.duration_since(bucket.last_refilled_at) < ttl || bucket.tokens < capacity
+        });
+    }
+}
+
+impl std::fmt::Debug for SlackInstallationRateLimiter {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SlackInstallationRateLimiter")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 
@@ -460,87 +759,39 @@ struct SlackInstallationRateLimitKey {
 
 #[derive(Debug, Clone)]
 struct SlackRateLimitBucket {
-    window_started_at: Instant,
-    requests: u32,
+    last_refilled_at: Instant,
+    tokens: f64,
 }
 
-#[derive(Clone)]
-pub struct SlackIngressService {
-    resolver: Arc<dyn SlackInstallationResolver>,
-    installation_rate_limiter: SlackInstallationRateLimiter,
-}
-
-impl SlackIngressService {
-    pub fn new(resolver: Arc<dyn SlackInstallationResolver>) -> Self {
-        Self::with_rate_limit_config(resolver, SlackInstallationRateLimitConfig::default())
-    }
-
-    pub fn with_rate_limit_config(
-        resolver: Arc<dyn SlackInstallationResolver>,
-        rate_limit: SlackInstallationRateLimitConfig,
-    ) -> Self {
+impl SlackRateLimitBucket {
+    fn full(now: Instant, config: &SlackInstallationRateLimitConfig) -> Self {
         Self {
-            resolver,
-            installation_rate_limiter: SlackInstallationRateLimiter::new(rate_limit),
+            last_refilled_at: now,
+            tokens: config.max_requests.get() as f64,
         }
     }
 
-    pub(super) async fn handle_events(&self, headers: HeaderMap, body: Bytes) -> Response {
-        let installation = match self
-            .resolver
-            .resolve_installation(&headers, body.as_ref())
-            .await
-        {
-            Ok(installation) => installation,
-            Err(error) => return ingress_error_response(error),
+    fn refill(&mut self, now: Instant, config: &SlackInstallationRateLimitConfig) {
+        let elapsed = now.duration_since(self.last_refilled_at);
+        if elapsed.is_zero() {
+            return;
+        }
+        let capacity = config.max_requests.get() as f64;
+        let refill_ratio = if config.window.is_zero() {
+            1.0
+        } else {
+            elapsed.as_secs_f64() / config.window.as_secs_f64()
         };
-        if let Err(error) = self.installation_rate_limiter.check(&installation) {
-            return ingress_error_response(error);
-        }
-
-        match parse_slack_url_verification_challenge(body.as_ref(), installation.evidence()) {
-            Ok(Some(challenge)) => return (StatusCode::OK, challenge.challenge).into_response(),
-            Ok(None) => {}
-            Err(error) => {
-                tracing::debug!(
-                    target = "ironclaw::reborn::slack_events",
-                    tenant_id = %installation.tenant_id(),
-                    adapter_installation_id = %installation.adapter_installation_id(),
-                    error = %error,
-                    "Slack URL verification parse failed"
-                );
-                return error_response(
-                    StatusCode::BAD_REQUEST,
-                    SlackWebhookErrorCategory::MalformedPayload,
-                );
-            }
-        }
-
-        match installation
-            .dispatcher()
-            .process_verified_webhook_immediate_ack(body.as_ref(), installation.evidence())
-            .await
-        {
-            Ok(_) => (StatusCode::OK, "ok").into_response(),
-            Err(error) => runner_error_response(error),
-        }
+        self.tokens = capacity.min(self.tokens + refill_ratio * capacity);
+        self.last_refilled_at = now;
     }
 
-    pub async fn drain_installations(&self) {
-        self.resolver.drain_installations().await;
-    }
-}
-
-impl std::fmt::Debug for SlackIngressService {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("SlackIngressService")
-            .field("resolver", &"Arc<dyn SlackInstallationResolver>")
-            .field(
-                "installation_rate_limiter",
-                &self.installation_rate_limiter.config,
-            )
-            .finish()
+    fn try_consume(&mut self) -> bool {
+        if self.tokens < 1.0 {
+            return false;
+        }
+        self.tokens -= 1.0;
+        true
     }
 }
 
@@ -589,14 +840,6 @@ mod tests {
         }
     }
 
-    fn verified() -> ProtocolAuthEvidence {
-        mark_request_signature_verified(
-            "X-Slack-Signature",
-            Some("X-Slack-Request-Timestamp".to_string()),
-            "slack-install",
-        )
-    }
-
     fn tenant_id(value: &str) -> TenantId {
         TenantId::new(value).expect("valid tenant")
     }
@@ -611,27 +854,52 @@ mod tests {
 
     #[test]
     fn envelope_metadata_prefers_authorization_context_for_slack_connect() {
-        let metadata = parse_slack_envelope_metadata(
-            br#"{
-                "type": "event_callback",
-                "team_id": "T-external",
-                "context_team_id": "T-context",
-                "api_app_id": "A-slack",
-                "authorizations": [{
-                    "team_id": "T-install",
-                    "enterprise_id": "E-install",
-                    "user_id": "U-install"
-                }],
-                "event": {"type": "message", "user": "U-external", "channel": "C-shared"}
-            }"#,
-            &verified(),
-        )
-        .expect("metadata parses");
+        let metadata = SlackEnvelopeMetadata::from_wrapper(
+            parse_slack_envelope(
+                br#"{
+                    "type": "event_callback",
+                    "team_id": "T-external",
+                    "context_team_id": "T-context",
+                    "api_app_id": "A-slack",
+                    "authorizations": [{
+                        "team_id": "T-install",
+                        "enterprise_id": "E-install",
+                        "user_id": "U-install"
+                    }],
+                    "event": {"type": "message", "user": "U-external", "channel": "C-shared"}
+                }"#,
+            )
+            .expect("envelope parses"),
+        );
 
         assert_eq!(metadata.team_id.as_deref(), Some("T-install"));
         assert_eq!(metadata.enterprise_id.as_deref(), Some("E-install"));
         assert_eq!(metadata.install_user_id.as_deref(), Some("U-install"));
         assert_eq!(metadata.event_user_id.as_deref(), Some("U-external"));
+    }
+
+    #[test]
+    fn envelope_metadata_matches_all_authorization_contexts() {
+        let metadata = SlackEnvelopeMetadata::from_wrapper(
+            parse_slack_envelope(
+                br#"{
+                    "type": "event_callback",
+                    "api_app_id": "A-slack",
+                    "authorizations": [
+                        {"team_id": "T-shared", "user_id": "U-install-a"},
+                        {"team_id": "T-shared", "user_id": "U-install-b"}
+                    ],
+                    "event": {"type": "message", "user": "U-event", "channel": "D123"}
+                }"#,
+            )
+            .expect("envelope parses"),
+        );
+
+        assert!(
+            SlackInstallationSelector::team("T-shared")
+                .with_install_user_id("U-install-b")
+                .matches(&metadata)
+        );
     }
 
     #[tokio::test]
@@ -643,17 +911,25 @@ mod tests {
             dispatcher("install-a"),
         )]);
 
-        let installation = resolver
-            .resolve_installation(
+        let ingress = resolver
+            .resolve_ingress(
                 &HeaderMap::new(),
                 br#"{"type":"url_verification","challenge":"challenge-token"}"#,
             )
             .await
             .expect("url verification resolves before selector matching");
 
-        assert_eq!(installation.tenant_id().as_str(), "tenant-a");
-        assert_eq!(installation.adapter_installation_id().as_str(), "install-a");
-        assert_eq!(installation.metadata().team_id, None);
+        match ingress {
+            ResolvedSlackIngress::UrlVerification {
+                installation,
+                challenge,
+            } => {
+                assert_eq!(installation.tenant_id().as_str(), "tenant-a");
+                assert_eq!(installation.adapter_installation_id().as_str(), "install-a");
+                assert_eq!(challenge, "challenge-token");
+            }
+            ResolvedSlackIngress::Event { .. } => panic!("expected url verification"),
+        }
     }
 
     #[tokio::test]
@@ -673,8 +949,8 @@ mod tests {
             ),
         ]);
 
-        let installation = resolver
-            .resolve_installation(
+        let ingress = resolver
+            .resolve_ingress(
                 &HeaderMap::new(),
                 br#"{
                     "type":"event_callback",
@@ -687,11 +963,16 @@ mod tests {
             .await
             .expect("authorization user disambiguates install");
 
-        assert_eq!(installation.tenant_id().as_str(), "tenant-b");
-        assert_eq!(installation.adapter_installation_id().as_str(), "install-b");
-        assert_eq!(
-            installation.metadata().install_user_id.as_deref(),
-            Some("U-install-b")
-        );
+        match ingress {
+            ResolvedSlackIngress::Event {
+                installation,
+                metadata,
+            } => {
+                assert_eq!(installation.tenant_id().as_str(), "tenant-b");
+                assert_eq!(installation.adapter_installation_id().as_str(), "install-b");
+                assert_eq!(metadata.install_user_id.as_deref(), Some("U-install-b"));
+            }
+            ResolvedSlackIngress::UrlVerification { .. } => panic!("expected event"),
+        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
@@ -903,7 +903,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn static_resolver_allows_url_verification_before_selector_matching() {
+    async fn static_resolver_allows_url_verification_before_selector_matching() -> Result<(), String>
+    {
         let resolver = StaticSlackInstallationResolver::new(vec![SlackInstallationRecord::new(
             tenant_id("tenant-a"),
             installation_id("install-a"),
@@ -919,21 +920,22 @@ mod tests {
             .await
             .expect("url verification resolves before selector matching");
 
-        match ingress {
-            ResolvedSlackIngress::UrlVerification {
-                installation,
-                challenge,
-            } => {
-                assert_eq!(installation.tenant_id().as_str(), "tenant-a");
-                assert_eq!(installation.adapter_installation_id().as_str(), "install-a");
-                assert_eq!(challenge, "challenge-token");
-            }
-            ResolvedSlackIngress::Event { .. } => panic!("expected url verification"),
-        }
+        let ResolvedSlackIngress::UrlVerification {
+            installation,
+            challenge,
+        } = ingress
+        else {
+            return Err("expected url verification".to_string());
+        };
+        assert_eq!(installation.tenant_id().as_str(), "tenant-a");
+        assert_eq!(installation.adapter_installation_id().as_str(), "install-a");
+        assert_eq!(challenge, "challenge-token");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn static_resolver_disambiguates_same_workspace_by_authorization_user() {
+    async fn static_resolver_disambiguates_same_workspace_by_authorization_user()
+    -> Result<(), String> {
         let resolver = StaticSlackInstallationResolver::new(vec![
             SlackInstallationRecord::new(
                 tenant_id("tenant-a"),
@@ -963,16 +965,16 @@ mod tests {
             .await
             .expect("authorization user disambiguates install");
 
-        match ingress {
-            ResolvedSlackIngress::Event {
-                installation,
-                metadata,
-            } => {
-                assert_eq!(installation.tenant_id().as_str(), "tenant-b");
-                assert_eq!(installation.adapter_installation_id().as_str(), "install-b");
-                assert_eq!(metadata.install_user_id.as_deref(), Some("U-install-b"));
-            }
-            ResolvedSlackIngress::UrlVerification { .. } => panic!("expected event"),
-        }
+        let ResolvedSlackIngress::Event {
+            installation,
+            metadata,
+        } = ingress
+        else {
+            return Err("expected event".to_string());
+        };
+        assert_eq!(installation.tenant_id().as_str(), "tenant-b");
+        assert_eq!(installation.adapter_installation_id().as_str(), "install-b");
+        assert_eq!(metadata.install_user_id.as_deref(), Some("U-install-b"));
+        Ok(())
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::num::NonZeroU32;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use axum::body::Bytes;
@@ -31,8 +31,22 @@ pub struct SlackEnvelopeMetadata {
     pub team_id: Option<String>,
     pub enterprise_id: Option<String>,
     pub api_app_id: Option<String>,
+    pub install_user_id: Option<String>,
     pub event_user_id: Option<String>,
     pub event_channel_id: Option<String>,
+}
+
+impl SlackEnvelopeMetadata {
+    fn empty() -> Self {
+        Self {
+            team_id: None,
+            enterprise_id: None,
+            api_app_id: None,
+            install_user_id: None,
+            event_user_id: None,
+            event_channel_id: None,
+        }
+    }
 }
 
 fn parse_slack_envelope_metadata(
@@ -58,6 +72,8 @@ fn parse_slack_envelope_metadata(
 struct SlackEnvelopeMetadataWrapper {
     team_id: Option<String>,
     enterprise_id: Option<String>,
+    context_team_id: Option<String>,
+    context_enterprise_id: Option<String>,
     api_app_id: Option<String>,
     event: Option<SlackEnvelopeEventMetadata>,
     #[serde(default)]
@@ -68,15 +84,18 @@ impl SlackEnvelopeMetadataWrapper {
     fn into_metadata(self) -> SlackEnvelopeMetadata {
         let authorization = self.authorizations.into_iter().next();
         SlackEnvelopeMetadata {
-            team_id: self
-                .team_id
-                .or_else(|| authorization.as_ref().and_then(|auth| auth.team_id.clone())),
-            enterprise_id: self.enterprise_id.or_else(|| {
-                authorization
-                    .as_ref()
-                    .and_then(|auth| auth.enterprise_id.clone())
-            }),
+            team_id: authorization
+                .as_ref()
+                .and_then(|auth| auth.team_id.clone())
+                .or(self.context_team_id)
+                .or(self.team_id),
+            enterprise_id: authorization
+                .as_ref()
+                .and_then(|auth| auth.enterprise_id.clone())
+                .or(self.context_enterprise_id)
+                .or(self.enterprise_id),
             api_app_id: self.api_app_id,
+            install_user_id: authorization.as_ref().and_then(|auth| auth.user_id.clone()),
             event_user_id: self.event.as_ref().and_then(|event| event.user.clone()),
             event_channel_id: self.event.and_then(|event| event.channel),
         }
@@ -93,6 +112,7 @@ struct SlackEnvelopeEventMetadata {
 struct SlackAuthorizationMetadata {
     team_id: Option<String>,
     enterprise_id: Option<String>,
+    user_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -226,6 +246,7 @@ pub struct SlackInstallationSelector {
     team_id: Option<String>,
     enterprise_id: Option<String>,
     api_app_id: Option<String>,
+    install_user_id: Option<String>,
 }
 
 impl SlackInstallationSelector {
@@ -238,11 +259,17 @@ impl SlackInstallationSelector {
             team_id,
             enterprise_id,
             api_app_id,
+            install_user_id: None,
         }
     }
 
     pub fn team(team_id: impl Into<String>) -> Self {
         Self::new(Some(team_id.into()), None, None)
+    }
+
+    pub fn with_install_user_id(mut self, install_user_id: impl Into<String>) -> Self {
+        self.install_user_id = Some(install_user_id.into());
+        self
     }
 
     fn matches(&self, metadata: &SlackEnvelopeMetadata) -> bool {
@@ -252,7 +279,14 @@ impl SlackInstallationSelector {
                 metadata.enterprise_id.as_deref(),
             )
             && selector_part_matches(self.api_app_id.as_deref(), metadata.api_app_id.as_deref())
-            && (self.team_id.is_some() || self.enterprise_id.is_some() || self.api_app_id.is_some())
+            && selector_part_matches(
+                self.install_user_id.as_deref(),
+                metadata.install_user_id.as_deref(),
+            )
+            && (self.team_id.is_some()
+                || self.enterprise_id.is_some()
+                || self.api_app_id.is_some()
+                || self.install_user_id.is_some())
     }
 }
 
@@ -297,6 +331,17 @@ impl StaticSlackInstallationResolver {
                     failure: ironclaw_product_adapters::ProtocolAuthFailure::Missing,
                 })
                 .into());
+        }
+
+        if parse_slack_url_verification_challenge(body, &verified[0].1)?.is_some() {
+            let (installation, evidence) = verified.remove(0);
+            return Ok(ResolvedSlackInstallation::new(
+                installation.tenant_id.clone(),
+                installation.adapter_installation_id.clone(),
+                SlackEnvelopeMetadata::empty(),
+                evidence,
+                Arc::clone(&installation.dispatcher),
+            ));
         }
 
         let metadata = parse_slack_envelope_metadata(body, &verified[0].1)?;
@@ -367,27 +412,27 @@ impl Default for SlackInstallationRateLimitConfig {
 #[derive(Clone)]
 struct SlackInstallationRateLimiter {
     config: SlackInstallationRateLimitConfig,
-    buckets: Arc<tokio::sync::Mutex<HashMap<SlackInstallationRateLimitKey, SlackRateLimitBucket>>>,
+    buckets: Arc<Mutex<HashMap<SlackInstallationRateLimitKey, SlackRateLimitBucket>>>,
 }
 
 impl SlackInstallationRateLimiter {
     fn new(config: SlackInstallationRateLimitConfig) -> Self {
         Self {
             config,
-            buckets: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            buckets: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    async fn check(
-        &self,
-        installation: &ResolvedSlackInstallation,
-    ) -> Result<(), SlackIngressError> {
+    fn check(&self, installation: &ResolvedSlackInstallation) -> Result<(), SlackIngressError> {
         let now = Instant::now();
         let key = SlackInstallationRateLimitKey {
             tenant_id: installation.tenant_id.clone(),
             adapter_installation_id: installation.adapter_installation_id.clone(),
         };
-        let mut buckets = self.buckets.lock().await;
+        let mut buckets = match self.buckets.lock() {
+            Ok(buckets) => buckets,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         let bucket = buckets.entry(key).or_insert(SlackRateLimitBucket {
             window_started_at: now,
             requests: 0,
@@ -449,7 +494,7 @@ impl SlackIngressService {
             Ok(installation) => installation,
             Err(error) => return ingress_error_response(error),
         };
-        if let Err(error) = self.installation_rate_limiter.check(&installation).await {
+        if let Err(error) = self.installation_rate_limiter.check(&installation) {
             return ingress_error_response(error);
         }
 
@@ -496,5 +541,157 @@ impl std::fmt::Debug for SlackIngressService {
                 &self.installation_rate_limiter.config,
             )
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use axum::http::HeaderMap;
+    use ironclaw_product_adapters::auth::mark_request_signature_verified;
+    use ironclaw_wasm_product_adapters::WebhookProcessOutcome;
+
+    use super::*;
+
+    struct AlwaysVerifiedDispatcher {
+        subject: &'static str,
+    }
+
+    impl SlackEventsWebhookDispatcher for AlwaysVerifiedDispatcher {
+        fn verify_webhook_auth(
+            &self,
+            _headers: &HeaderMap,
+            _body: &[u8],
+        ) -> Result<ProtocolAuthEvidence, RunnerError> {
+            Ok(mark_request_signature_verified(
+                "X-Slack-Signature",
+                Some("X-Slack-Request-Timestamp".to_string()),
+                self.subject,
+            ))
+        }
+
+        fn process_verified_webhook_immediate_ack<'a>(
+            &'a self,
+            _body: &'a [u8],
+            _evidence: &'a ProtocolAuthEvidence,
+        ) -> Pin<Box<dyn Future<Output = Result<WebhookProcessOutcome, RunnerError>> + Send + 'a>>
+        {
+            Box::pin(async { Ok(WebhookProcessOutcome::AcceptedForAsyncDispatch) })
+        }
+
+        fn drain_immediate_ack_tasks<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async {})
+        }
+    }
+
+    fn verified() -> ProtocolAuthEvidence {
+        mark_request_signature_verified(
+            "X-Slack-Signature",
+            Some("X-Slack-Request-Timestamp".to_string()),
+            "slack-install",
+        )
+    }
+
+    fn tenant_id(value: &str) -> TenantId {
+        TenantId::new(value).expect("valid tenant")
+    }
+
+    fn installation_id(value: &str) -> AdapterInstallationId {
+        AdapterInstallationId::new(value).expect("valid installation")
+    }
+
+    fn dispatcher(subject: &'static str) -> Arc<dyn SlackEventsWebhookDispatcher> {
+        Arc::new(AlwaysVerifiedDispatcher { subject })
+    }
+
+    #[test]
+    fn envelope_metadata_prefers_authorization_context_for_slack_connect() {
+        let metadata = parse_slack_envelope_metadata(
+            br#"{
+                "type": "event_callback",
+                "team_id": "T-external",
+                "context_team_id": "T-context",
+                "api_app_id": "A-slack",
+                "authorizations": [{
+                    "team_id": "T-install",
+                    "enterprise_id": "E-install",
+                    "user_id": "U-install"
+                }],
+                "event": {"type": "message", "user": "U-external", "channel": "C-shared"}
+            }"#,
+            &verified(),
+        )
+        .expect("metadata parses");
+
+        assert_eq!(metadata.team_id.as_deref(), Some("T-install"));
+        assert_eq!(metadata.enterprise_id.as_deref(), Some("E-install"));
+        assert_eq!(metadata.install_user_id.as_deref(), Some("U-install"));
+        assert_eq!(metadata.event_user_id.as_deref(), Some("U-external"));
+    }
+
+    #[tokio::test]
+    async fn static_resolver_allows_url_verification_before_selector_matching() {
+        let resolver = StaticSlackInstallationResolver::new(vec![SlackInstallationRecord::new(
+            tenant_id("tenant-a"),
+            installation_id("install-a"),
+            SlackInstallationSelector::team("T-A"),
+            dispatcher("install-a"),
+        )]);
+
+        let installation = resolver
+            .resolve_installation(
+                &HeaderMap::new(),
+                br#"{"type":"url_verification","challenge":"challenge-token"}"#,
+            )
+            .await
+            .expect("url verification resolves before selector matching");
+
+        assert_eq!(installation.tenant_id().as_str(), "tenant-a");
+        assert_eq!(installation.adapter_installation_id().as_str(), "install-a");
+        assert_eq!(installation.metadata().team_id, None);
+    }
+
+    #[tokio::test]
+    async fn static_resolver_disambiguates_same_workspace_by_authorization_user() {
+        let resolver = StaticSlackInstallationResolver::new(vec![
+            SlackInstallationRecord::new(
+                tenant_id("tenant-a"),
+                installation_id("install-a"),
+                SlackInstallationSelector::team("T-shared").with_install_user_id("U-install-a"),
+                dispatcher("install-a"),
+            ),
+            SlackInstallationRecord::new(
+                tenant_id("tenant-b"),
+                installation_id("install-b"),
+                SlackInstallationSelector::team("T-shared").with_install_user_id("U-install-b"),
+                dispatcher("install-b"),
+            ),
+        ]);
+
+        let installation = resolver
+            .resolve_installation(
+                &HeaderMap::new(),
+                br#"{
+                    "type":"event_callback",
+                    "team_id":"T-shared",
+                    "api_app_id":"A-slack",
+                    "authorizations":[{"team_id":"T-shared","user_id":"U-install-b"}],
+                    "event":{"type":"message","user":"U-event","channel":"D123"}
+                }"#,
+            )
+            .await
+            .expect("authorization user disambiguates install");
+
+        assert_eq!(installation.tenant_id().as_str(), "tenant-b");
+        assert_eq!(installation.adapter_installation_id().as_str(), "install-b");
+        assert_eq!(
+            installation.metadata().install_user_id.as_deref(),
+            Some("U-install-b")
+        );
     }
 }


### PR DESCRIPTION
Follow-up to [#4272](https://github.com/nearai/ironclaw/pull/4272).

This adds the explicit Slack installation-resolution seam before Events API dispatch:

- introduces `SlackInstallationResolver` / `SlackIngressService`
- resolves verified Slack envelope metadata to `tenant_id` + `adapter_installation_id` + installation-scoped dispatcher
- keeps Slack user resolution out of the adapter; the adapter still emits external Slack refs and ProductWorkflow/ConversationBindingService owns user binding
- adds post-auth rate limiting keyed by resolved `(tenant_id, adapter_installation_id)` while keeping the route descriptor's coarse pre-auth global guard
- adds caller-facing coverage for cross-workspace same-user routing, install-context isolation, and per-installation rate limiting

Validation:
- `cargo fmt`
- `cargo clippy -p ironclaw_reborn_composition --tests --features slack-v2-host-beta -- -D warnings`
