### PR TITLE
Treat invalid provider tool output as recoverable

### DIFF
--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -902,13 +902,13 @@ async fn tool_response_to_host(
         for provider_call in &provider_calls {
             capabilities
                 .validate_provider_tool_call(provider_call)
-                .map_err(map_capability_host_error)?;
+                .map_err(map_provider_tool_output_error)?;
         }
         for provider_call in provider_calls {
             let candidate = capabilities
                 .register_provider_tool_call(provider_call)
                 .await
-                .map_err(map_capability_host_error)?;
+                .map_err(map_provider_tool_output_error)?;
             candidates.push(candidate);
         }
         debug!(
@@ -1062,6 +1062,18 @@ fn map_capability_host_error(error: AgentLoopHostError) -> HostManagedModelError
         | AgentLoopHostErrorKind::Internal => HostManagedModelErrorKind::Unavailable,
     };
     HostManagedModelError::safe(kind, error.safe_summary)
+}
+
+fn map_provider_tool_output_error(error: AgentLoopHostError) -> HostManagedModelError {
+    match error.kind {
+        AgentLoopHostErrorKind::Invalid | AgentLoopHostErrorKind::InvalidInvocation => {
+            HostManagedModelError::safe(
+                HostManagedModelErrorKind::InvalidOutput,
+                error.safe_summary,
+            )
+        }
+        _ => map_capability_host_error(error),
+    }
 }
 
 fn convert_messages(

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -448,7 +448,7 @@ async fn gateway_rejects_invalid_provider_tool_batch_before_any_registration() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidRequest);
+    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
     assert!(capabilities.registered.lock().unwrap().is_empty());
 }
 


### PR DESCRIPTION
## Summary
- map provider-originated tool-call validation/registration `Invalid` and `InvalidInvocation` errors to `InvalidOutput`
- preserve existing host-error mapping for non-provider-output capability failures
- update the invalid provider tool batch regression to assert recoverable model-output classification

## Tests
- PASS: `cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway`
- PASS: `cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway gateway_rejects_invalid_provider_tool_batch_before_any_registration`
- BROADER CHECK: `cargo test -p ironclaw_reborn --features root-llm-provider` currently fails in unrelated script-capability E2E coverage: `text_only_host_e2e_invokes_script_capability_through_real_host_runtime` and `turn_runner_worker_drives_script_capability_through_real_host_runtime` report host runtime rejected capability request / host_creation_failed.