### PR TITLE
[codex] Enable WebUI v2 DCR extension setup

### DIFF
--- a/crates/ironclaw_auth/src/error.rs
+++ b/crates/ironclaw_auth/src/error.rs
@@ -21,6 +21,8 @@ pub enum AuthErrorCode {
     AccountSelectionRequired,
     #[error("backend_unavailable")]
     BackendUnavailable,
+    #[error("malformed_config")]
+    MalformedConfig,
     #[error("malformed_callback")]
     MalformedCallback,
     #[error("canceled")]
@@ -53,6 +55,8 @@ pub enum AuthProductError {
     AccountSelectionRequired,
     #[error("backend unavailable")]
     BackendUnavailable,
+    #[error("auth backend configuration is malformed")]
+    MalformedConfig,
     /// A compare-and-swap precondition failed; the caller should re-read and
     /// retry if the operation is safe to retry.
     #[error("backend conflict (CAS precondition failed)")]
@@ -83,6 +87,7 @@ impl AuthProductError {
             Self::CredentialMissing => AuthErrorCode::CredentialMissing,
             Self::AccountSelectionRequired => AuthErrorCode::AccountSelectionRequired,
             Self::BackendUnavailable => AuthErrorCode::BackendUnavailable,
+            Self::MalformedConfig => AuthErrorCode::MalformedConfig,
             // CAS conflicts are an infrastructure detail; surface as BackendUnavailable
             // at all stable product boundaries.
             Self::BackendConflict => AuthErrorCode::BackendUnavailable,

--- a/crates/ironclaw_first_party_extensions/assets/notion-mcp/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/notion-mcp/manifest.toml
@@ -15,7 +15,7 @@ id = "notion.notion-search"
 description = "Search Notion workspace content and connected sources through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -29,7 +29,7 @@ id = "notion.notion-fetch"
 description = "Fetch a Notion page, database, or data source by URL or ID through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -43,7 +43,7 @@ id = "notion.notion-create-pages"
 description = "Create one or more Notion pages with properties, content, templates, icons, or covers through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -57,7 +57,7 @@ id = "notion.notion-update-page"
 description = "Update a Notion page's properties, content, icon, cover, or template through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -71,7 +71,7 @@ id = "notion.notion-move-pages"
 description = "Move one or more Notion pages or databases to a new parent through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -85,7 +85,7 @@ id = "notion.notion-duplicate-page"
 description = "Duplicate a Notion page within the connected workspace through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -99,7 +99,7 @@ id = "notion.notion-create-database"
 description = "Create a Notion database, initial data source, and initial view through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -113,7 +113,7 @@ id = "notion.notion-update-data-source"
 description = "Update a Notion data source's properties, name, description, or other attributes through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -127,7 +127,7 @@ id = "notion.notion-create-view"
 description = "Create a Notion database view with filters, sorts, grouping, or display configuration through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -141,7 +141,7 @@ id = "notion.notion-update-view"
 description = "Update a Notion database view's name, filters, sorts, grouping, or display configuration through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -155,7 +155,7 @@ id = "notion.notion-query-data-sources"
 description = "Query across multiple Notion data sources with structured summaries, grouping, and filters through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -169,7 +169,7 @@ id = "notion.notion-query-database-view"
 description = "Query data from a Notion database using a predefined view's filters and sorts through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -183,7 +183,7 @@ id = "notion.notion-create-comment"
 description = "Add a page-level, block-level, inline, or reply comment through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -197,7 +197,7 @@ id = "notion.notion-get-comments"
 description = "List comments and discussions on a Notion page through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -211,7 +211,7 @@ id = "notion.notion-get-teams"
 description = "Retrieve teams and teamspaces in the connected Notion workspace through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -225,7 +225,7 @@ id = "notion.notion-get-users"
 description = "List users in the connected Notion workspace through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -239,7 +239,7 @@ id = "notion.notion-get-user"
 description = "Retrieve Notion user information by ID through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -253,7 +253,7 @@ id = "notion.notion-get-self"
 description = "Retrieve the connected bot user and workspace information through Notion MCP."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion" }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "mcp_notion_access_token", source = { type = "product_auth_account", provider = "notion", setup = { kind = "oauth", scopes = [] } }, audience = { scheme = "https", host_pattern = "mcp.notion.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"

--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -384,7 +384,9 @@ fn map_auth_product_error(error: AuthProductError) -> ProductWorkflowError {
         AuthProductError::CrossScopeDenied => {
             auth_rejected(AuthInteractionRejectionKind::CrossScopeDenied)
         }
-        AuthProductError::BackendUnavailable | AuthProductError::BackendConflict => {
+        AuthProductError::BackendUnavailable
+        | AuthProductError::BackendConflict
+        | AuthProductError::MalformedConfig => {
             auth_rejected(AuthInteractionRejectionKind::FlowUnavailable)
         }
         AuthProductError::Canceled
@@ -409,7 +411,9 @@ fn map_credential_selection_error(error: AuthProductError) -> ProductWorkflowErr
         AuthProductError::CrossScopeDenied => {
             auth_rejected(AuthInteractionRejectionKind::CrossScopeDenied)
         }
-        AuthProductError::BackendUnavailable | AuthProductError::BackendConflict => {
+        AuthProductError::BackendUnavailable
+        | AuthProductError::BackendConflict
+        | AuthProductError::MalformedConfig => {
             auth_rejected(AuthInteractionRejectionKind::FlowUnavailable)
         }
         AuthProductError::CredentialMissing

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -15,9 +15,9 @@ use ironclaw_auth::{
     InMemoryAuthProductServices, ManualTokenSetupRequest, NewAuthFlow, OAuthAuthorizationUrl,
     OAuthCallbackClaimRequest, OAuthCallbackFailureInput, OAuthCallbackInput,
     OAuthProviderCallbackRequest, OAuthProviderExchangeContext, OpaqueStateHash, PkceVerifierHash,
-    ProviderBackedCredentialAccountService, ProviderCallbackOutcome, SecretCleanupReport,
-    SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest, SecretSubmitResult, Timestamp,
-    TurnGateAuthFlowQuery, TurnRunRef, scope_matches,
+    ProviderBackedCredentialAccountService, ProviderCallbackOutcome, ProviderScope,
+    SecretCleanupReport, SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest,
+    SecretSubmitResult, Timestamp, TurnGateAuthFlowQuery, TurnRunRef, scope_matches,
 };
 use ironclaw_product_adapters::AuthPromptChallengeKind;
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
@@ -107,6 +107,15 @@ pub(crate) struct RebornOAuthStartFlowRequest {
     pub(crate) authorization_url: OAuthAuthorizationUrl,
     pub(crate) opaque_state_hash: OpaqueStateHash,
     pub(crate) pkce_verifier_hash: PkceVerifierHash,
+    pub(crate) update_binding: Option<CredentialAccountUpdateBinding>,
+    pub(crate) expires_at: ironclaw_auth::Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RebornDcrOAuthStartFlowRequest {
+    pub(crate) scope: AuthProductScope,
+    pub(crate) provider: AuthProviderId,
+    pub(crate) provider_scopes: Vec<ProviderScope>,
     pub(crate) update_binding: Option<CredentialAccountUpdateBinding>,
     pub(crate) expires_at: ironclaw_auth::Timestamp,
 }
@@ -958,6 +967,25 @@ impl RebornProductAuthServices {
                 pkce_verifier_hash: Some(request.pkce_verifier_hash),
                 expires_at: request.expires_at,
             })
+            .await
+    }
+
+    pub(crate) async fn start_dcr_setup_oauth_flow(
+        &self,
+        request: RebornDcrOAuthStartFlowRequest,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        let Some(registry) = &self.dcr_oauth_registry else {
+            return Ok(None);
+        };
+        registry
+            .start_setup_flow(
+                &self.flow_manager,
+                request.scope,
+                &request.provider,
+                &request.provider_scopes,
+                request.update_binding,
+                request.expires_at,
+            )
             .await
     }
 

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -28,7 +28,7 @@ use ironclaw_host_api::UserId;
 use ironclaw_turns::{TurnRunId, TurnScope};
 
 use crate::manual_token_flow::{PortBackedManualTokenFlowService, RebornManualTokenFlowService};
-use crate::oauth_dcr::{DcrGateChallengeRequest, OAuthDcrProviderRegistry};
+use crate::oauth_dcr::{DcrGateChallengeRequest, DcrSetupFlowRequest, OAuthDcrProviderRegistry};
 use crate::product_auth_runtime_credentials::{
     ProductAuthRuntimeCredentialAccountSelector, RuntimeCredentialAccountSelectionService,
 };
@@ -115,6 +115,7 @@ pub(crate) struct RebornOAuthStartFlowRequest {
 pub(crate) struct RebornDcrOAuthStartFlowRequest {
     pub(crate) scope: AuthProductScope,
     pub(crate) provider: AuthProviderId,
+    pub(crate) account_label: CredentialAccountLabel,
     pub(crate) provider_scopes: Vec<ProviderScope>,
     pub(crate) update_binding: Option<CredentialAccountUpdateBinding>,
     pub(crate) expires_at: ironclaw_auth::Timestamp,
@@ -980,11 +981,14 @@ impl RebornProductAuthServices {
         registry
             .start_setup_flow(
                 &self.flow_manager,
-                request.scope,
-                &request.provider,
-                &request.provider_scopes,
-                request.update_binding,
-                request.expires_at,
+                DcrSetupFlowRequest {
+                    scope: request.scope,
+                    provider: request.provider,
+                    account_label: request.account_label,
+                    provider_scopes: request.provider_scopes,
+                    update_binding: request.update_binding,
+                    expires_at: request.expires_at,
+                },
             )
             .await
     }

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -110,12 +110,10 @@ fn onboarding(package_id: &str) -> Option<LifecycleExtensionOnboarding> {
             "After authorization completes, activate Google Calendar to publish its tools.",
         )),
         "notion" => Some(onboarding_message(
-            "Notion needs a workspace access token before MCP tools can run.",
-            Some(
-                "Create or copy a Notion integration token for the workspace IronClaw should access, then paste it here.",
-            ),
-            Some("https://www.notion.so/profile/integrations"),
-            "After saving the token, activate Notion to publish its MCP tools.",
+            "Notion needs OAuth authorization before MCP tools can run.",
+            Some("Authorize the Notion workspace that IronClaw should access for MCP requests."),
+            None,
+            "After authorization completes, activate Notion to publish its MCP tools.",
         )),
         "nearai" => Some(onboarding_message(
             "NEAR AI needs an API key before its MCP tools can run.",
@@ -1458,7 +1456,7 @@ mod tests {
                 "google-calendar",
                 "Google Calendar needs Google OAuth authorization",
             ),
-            ("notion", "Notion needs a workspace access token"),
+            ("notion", "Notion needs OAuth authorization"),
             ("nearai", "NEAR AI needs an API key"),
             ("web-access", "Web Access does not need credentials"),
         ] {
@@ -1480,6 +1478,22 @@ mod tests {
                 "{extension_id} must include the next user step"
             );
         }
+    }
+
+    #[test]
+    fn bundled_notion_projects_oauth_credential_setup() {
+        let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
+        let package_ref =
+            LifecyclePackageRef::new(LifecyclePackageKind::Extension, "notion").unwrap();
+        let summary = catalog.resolve(&package_ref).unwrap().summary();
+
+        assert_eq!(summary.credential_requirements.len(), 1);
+        let requirement = &summary.credential_requirements[0];
+        assert_eq!(requirement.provider, "notion");
+        assert!(matches!(
+            &requirement.setup,
+            LifecycleExtensionCredentialSetup::OAuth { scopes } if scopes.is_empty()
+        ));
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
@@ -8,10 +8,11 @@ use chrono::{Duration as ChronoDuration, Utc};
 use ironclaw_auth::{
     AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowKind, AuthFlowManager,
     AuthFlowOwnerScope, AuthFlowRecordSource, AuthGateRef, AuthProductError, AuthProductScope,
-    AuthProviderId, CredentialAccountLabel, NewAuthFlow, OAuthAuthorizationEndpoint,
-    OAuthAuthorizeUrlRequest, OAuthClientId, OAuthExtraParam, OAuthRedirectUri, OAuthState,
-    PkceVerifierSecret, ProviderScope, TurnGateAuthFlowQuery, TurnRunRef, build_authorization_url,
-    opaque_state_hash, pkce_s256_challenge, pkce_verifier_hash,
+    AuthProviderId, CredentialAccountLabel, CredentialAccountUpdateBinding, NewAuthFlow,
+    OAuthAuthorizationEndpoint, OAuthAuthorizeUrlRequest, OAuthClientId, OAuthExtraParam,
+    OAuthRedirectUri, OAuthState, PkceVerifierSecret, ProviderScope, TurnGateAuthFlowQuery,
+    TurnRunRef, build_authorization_url, opaque_state_hash, pkce_s256_challenge,
+    pkce_verifier_hash,
 };
 use ironclaw_capabilities::CapabilityObligationHandler;
 use ironclaw_host_api::{
@@ -129,7 +130,14 @@ impl OAuthDcrProvider {
 
         let flow_id = AuthFlowId::new();
         let material = self
-            .prepare_flow_material(&auth_scope, flow_id, &turn_run_ref, gate_ref)
+            .prepare_flow_material(
+                &auth_scope,
+                flow_id,
+                DcrFlowContext::BlockedGate {
+                    turn_run_ref: &turn_run_ref,
+                    gate_ref,
+                },
+            )
             .await?;
         let expires_at = Utc::now() + ChronoDuration::seconds(DCR_FLOW_TTL_SECONDS);
         let request = NewAuthFlow {
@@ -172,6 +180,8 @@ impl OAuthDcrProvider {
                 )
                 .await
         {
+            self.cleanup_registered_client(&flow.scope.resource, &material.registration)
+                .await;
             if self
                 .cleanup_flow_material(&flow.scope.resource, flow_id)
                 .await
@@ -201,6 +211,85 @@ impl OAuthDcrProvider {
         challenge_view_from_flow(&flow)
     }
 
+    pub(crate) async fn start_setup_flow(
+        &self,
+        flow_manager: &Arc<dyn AuthFlowManager>,
+        scope: AuthProductScope,
+        provider_scopes: &[ProviderScope],
+        update_binding: Option<CredentialAccountUpdateBinding>,
+        expires_at: ironclaw_auth::Timestamp,
+    ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+        if provider_scopes != self.scopes.as_slice() {
+            return Err(AuthProductError::BackendUnavailable);
+        }
+        let _setup_guard = self.setup_lock.lock().await;
+        let flow_id = AuthFlowId::new();
+        let material = self
+            .prepare_flow_material(&scope, flow_id, DcrFlowContext::Setup)
+            .await?;
+        let request = NewAuthFlow {
+            id: Some(flow_id),
+            scope: scope.clone(),
+            kind: AuthFlowKind::IntegrationCredential,
+            provider: AuthProviderId::new(self.spec.provider_id)?,
+            challenge: AuthChallenge::OAuthUrl {
+                authorization_url: material.authorization_url,
+                expires_at,
+            },
+            continuation: AuthContinuationRef::SetupOnly,
+            update_binding,
+            opaque_state_hash: Some(material.opaque_state_hash),
+            pkce_verifier_hash: Some(material.pkce_verifier_hash),
+            expires_at,
+        };
+        let flow = match flow_manager.create_flow(request).await {
+            Ok(flow) => flow,
+            Err(error) => {
+                self.cleanup_registered_client(&scope.resource, &material.registration)
+                    .await;
+                return Err(error);
+            }
+        };
+        if let Err(error) = self
+            .store_flow_material(
+                &flow.scope,
+                flow_id,
+                material.pkce_verifier,
+                &material.client_material,
+            )
+            .await
+        {
+            self.cleanup_registered_client(&flow.scope.resource, &material.registration)
+                .await;
+            if self
+                .cleanup_flow_material(&flow.scope.resource, flow_id)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    provider = self.spec.provider_id,
+                    flow_id = %flow_id,
+                    cleanup_kind = "flow_material",
+                    "failed to clean up DCR setup flow material after storage failure"
+                );
+            }
+            if flow_manager
+                .cancel_flow(&flow.scope, flow_id)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    provider = self.spec.provider_id,
+                    flow_id = %flow_id,
+                    cleanup_kind = "cancel_flow",
+                    "failed to cancel DCR setup flow after storage failure"
+                );
+            }
+            return Err(error);
+        }
+        Ok(flow)
+    }
+
     #[allow(
         dead_code,
         reason = "used by the webui-v2-beta OAuth callback route through RebornProductAuthServices"
@@ -222,8 +311,7 @@ impl OAuthDcrProvider {
         &self,
         scope: &AuthProductScope,
         flow_id: AuthFlowId,
-        turn_run_ref: &TurnRunRef,
-        gate_ref: &AuthGateRef,
+        context: DcrFlowContext<'_>,
     ) -> Result<PreparedDcrFlow, AuthProductError> {
         let metadata = self.discover_authorization_server(&scope.resource).await?;
         let pkce_verifier = SecretString::from(ironclaw_common::pkce::generate_code_verifier());
@@ -260,13 +348,27 @@ impl OAuthDcrProvider {
             redirect_uri: redirect_uri.as_str().to_string(),
             token_endpoint: metadata.token_endpoint,
         };
-        tracing::debug!(
-            provider = self.spec.provider_id,
-            flow_id = %flow_id,
-            turn_run_ref = %turn_run_ref,
-            gate_ref = %gate_ref,
-            "prepared DCR OAuth material for blocked auth gate"
-        );
+        match context {
+            DcrFlowContext::BlockedGate {
+                turn_run_ref,
+                gate_ref,
+            } => {
+                tracing::debug!(
+                    provider = self.spec.provider_id,
+                    flow_id = %flow_id,
+                    turn_run_ref = %turn_run_ref,
+                    gate_ref = %gate_ref,
+                    "prepared DCR OAuth material for blocked auth gate"
+                );
+            }
+            DcrFlowContext::Setup => {
+                tracing::debug!(
+                    provider = self.spec.provider_id,
+                    flow_id = %flow_id,
+                    "prepared DCR OAuth material for setup flow"
+                );
+            }
+        }
         Ok(PreparedDcrFlow {
             authorization_url,
             opaque_state_hash: opaque_state_hash(&state)?,
@@ -779,6 +881,30 @@ impl OAuthDcrProviderRegistry {
         };
         dcr_provider.pkce_verifier_for_flow(scope, flow_id).await
     }
+
+    pub(crate) async fn start_setup_flow(
+        &self,
+        flow_manager: &Arc<dyn AuthFlowManager>,
+        scope: AuthProductScope,
+        provider: &AuthProviderId,
+        provider_scopes: &[ProviderScope],
+        update_binding: Option<CredentialAccountUpdateBinding>,
+        expires_at: ironclaw_auth::Timestamp,
+    ) -> Result<Option<ironclaw_auth::AuthFlowRecord>, AuthProductError> {
+        let Some(dcr_provider) = self.providers.get(provider.as_str()) else {
+            return Ok(None);
+        };
+        dcr_provider
+            .start_setup_flow(
+                flow_manager,
+                scope,
+                provider_scopes,
+                update_binding,
+                expires_at,
+            )
+            .await
+            .map(Some)
+    }
 }
 
 impl fmt::Debug for OAuthDcrProviderRegistry {
@@ -788,6 +914,14 @@ impl fmt::Debug for OAuthDcrProviderRegistry {
             .field("providers", &self.providers.keys().collect::<Vec<_>>())
             .finish()
     }
+}
+
+enum DcrFlowContext<'a> {
+    BlockedGate {
+        turn_run_ref: &'a TurnRunRef,
+        gate_ref: &'a AuthGateRef,
+    },
+    Setup,
 }
 
 #[derive(Debug)]
@@ -935,6 +1069,44 @@ mod tests {
             .unwrap()
             .expect("flow");
 
+        let pkce = provider
+            .pkce_verifier_for_flow(&flow.scope, flow.id)
+            .await
+            .unwrap();
+        assert!(pkce.is_some());
+    }
+
+    #[tokio::test]
+    async fn dcr_provider_creates_setup_only_flow_and_stores_pkce_material() {
+        let provider = test_provider(Arc::new(DcrSetupEgress));
+        let auth = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let flow_manager: Arc<dyn AuthFlowManager> = auth.clone();
+
+        let flow = provider
+            .start_setup_flow(
+                &flow_manager,
+                sample_auth_scope(),
+                &[],
+                None,
+                Utc::now() + ChronoDuration::seconds(DCR_FLOW_TTL_SECONDS),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(flow.provider.as_str(), "notion");
+        assert!(matches!(flow.continuation, AuthContinuationRef::SetupOnly));
+        let Some(AuthChallenge::OAuthUrl {
+            authorization_url, ..
+        }) = &flow.challenge
+        else {
+            panic!("setup flow should render an OAuth URL challenge");
+        };
+        assert!(authorization_url.as_str().contains("client_id=dcr-client"));
+        assert!(
+            authorization_url
+                .as_str()
+                .contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A3000")
+        );
         let pkce = provider
             .pkce_verifier_for_flow(&flow.scope, flow.id)
             .await

--- a/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
@@ -168,7 +168,11 @@ impl OAuthDcrProvider {
                     .await?
                     .ok_or(AuthProductError::BackendConflict)?
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                self.cleanup_registered_client(&auth_scope.resource, &material.registration)
+                    .await;
+                return Err(error);
+            }
         };
         if flow.id == flow_id
             && let Err(error) = self
@@ -215,6 +219,7 @@ impl OAuthDcrProvider {
         &self,
         flow_manager: &Arc<dyn AuthFlowManager>,
         scope: AuthProductScope,
+        account_label: CredentialAccountLabel,
         provider_scopes: &[ProviderScope],
         update_binding: Option<CredentialAccountUpdateBinding>,
         expires_at: ironclaw_auth::Timestamp,
@@ -222,10 +227,15 @@ impl OAuthDcrProvider {
         if provider_scopes != self.scopes.as_slice() {
             return Err(AuthProductError::BackendUnavailable);
         }
-        let _setup_guard = self.setup_lock.lock().await;
         let flow_id = AuthFlowId::new();
         let material = self
-            .prepare_flow_material(&scope, flow_id, DcrFlowContext::Setup)
+            .prepare_flow_material(
+                &scope,
+                flow_id,
+                DcrFlowContext::Setup {
+                    account_label: &account_label,
+                },
+            )
             .await?;
         let request = NewAuthFlow {
             id: Some(flow_id),
@@ -316,7 +326,11 @@ impl OAuthDcrProvider {
         let metadata = self.discover_authorization_server(&scope.resource).await?;
         let pkce_verifier = SecretString::from(ironclaw_common::pkce::generate_code_verifier());
         let state = ironclaw_common::pkce::generate_code_verifier();
-        let redirect_uri = self.callback_redirect_uri(scope, flow_id)?;
+        let account_label = match context {
+            DcrFlowContext::BlockedGate { .. } => &self.account_label,
+            DcrFlowContext::Setup { account_label } => account_label,
+        };
+        let redirect_uri = self.callback_redirect_uri(scope, flow_id, account_label)?;
         let registration = self
             .register_client(
                 &scope.resource,
@@ -361,7 +375,7 @@ impl OAuthDcrProvider {
                     "prepared DCR OAuth material for blocked auth gate"
                 );
             }
-            DcrFlowContext::Setup => {
+            DcrFlowContext::Setup { .. } => {
                 tracing::debug!(
                     provider = self.spec.provider_id,
                     flow_id = %flow_id,
@@ -571,7 +585,7 @@ impl OAuthDcrProvider {
             tracing::warn!(
                 provider = self.spec.provider_id,
                 cleanup_kind = "dcr_registration",
-                "failed to deregister orphaned DCR client after flow conflict"
+                "failed to deregister orphaned DCR client after flow failure"
             );
         }
     }
@@ -580,6 +594,7 @@ impl OAuthDcrProvider {
         &self,
         scope: &AuthProductScope,
         flow_id: AuthFlowId,
+        account_label: &CredentialAccountLabel,
     ) -> Result<OAuthRedirectUri, AuthProductError> {
         let mut url = callback_base_url(&self.callback_origin, flow_id)?;
         {
@@ -587,7 +602,7 @@ impl OAuthDcrProvider {
             query.append_pair("user_id", scope.resource.user_id.as_str());
             query.append_pair("invocation_id", &scope.resource.invocation_id.to_string());
             query.append_pair("provider", self.spec.provider_id);
-            query.append_pair("account_label", self.account_label.as_str());
+            query.append_pair("account_label", account_label.as_str());
             query.append_pair("scope", &scope_text(&self.scopes));
             if let Some(agent_id) = &scope.resource.agent_id {
                 query.append_pair("agent_id", agent_id.as_str());
@@ -885,12 +900,16 @@ impl OAuthDcrProviderRegistry {
     pub(crate) async fn start_setup_flow(
         &self,
         flow_manager: &Arc<dyn AuthFlowManager>,
-        scope: AuthProductScope,
-        provider: &AuthProviderId,
-        provider_scopes: &[ProviderScope],
-        update_binding: Option<CredentialAccountUpdateBinding>,
-        expires_at: ironclaw_auth::Timestamp,
+        request: DcrSetupFlowRequest,
     ) -> Result<Option<ironclaw_auth::AuthFlowRecord>, AuthProductError> {
+        let DcrSetupFlowRequest {
+            scope,
+            provider,
+            account_label,
+            provider_scopes,
+            update_binding,
+            expires_at,
+        } = request;
         let Some(dcr_provider) = self.providers.get(provider.as_str()) else {
             return Ok(None);
         };
@@ -898,7 +917,8 @@ impl OAuthDcrProviderRegistry {
             .start_setup_flow(
                 flow_manager,
                 scope,
-                provider_scopes,
+                account_label,
+                &provider_scopes,
                 update_binding,
                 expires_at,
             )
@@ -921,7 +941,9 @@ enum DcrFlowContext<'a> {
         turn_run_ref: &'a TurnRunRef,
         gate_ref: &'a AuthGateRef,
     },
-    Setup,
+    Setup {
+        account_label: &'a CredentialAccountLabel,
+    },
 }
 
 #[derive(Debug)]
@@ -948,6 +970,15 @@ pub(crate) struct DcrGateChallengeRequest<'a> {
     pub(crate) owner_user_id: &'a ironclaw_host_api::UserId,
     pub(crate) run_id: TurnRunId,
     pub(crate) gate_ref: &'a AuthGateRef,
+}
+
+pub(crate) struct DcrSetupFlowRequest {
+    pub(crate) scope: AuthProductScope,
+    pub(crate) provider: AuthProviderId,
+    pub(crate) account_label: CredentialAccountLabel,
+    pub(crate) provider_scopes: Vec<ProviderScope>,
+    pub(crate) update_binding: Option<CredentialAccountUpdateBinding>,
+    pub(crate) expires_at: ironclaw_auth::Timestamp,
 }
 
 fn auth_scope_for_blocked_turn(
@@ -1086,6 +1117,7 @@ mod tests {
             .start_setup_flow(
                 &flow_manager,
                 sample_auth_scope(),
+                CredentialAccountLabel::new("work notion").unwrap(),
                 &[],
                 None,
                 Utc::now() + ChronoDuration::seconds(DCR_FLOW_TTL_SECONDS),
@@ -1102,6 +1134,18 @@ mod tests {
             panic!("setup flow should render an OAuth URL challenge");
         };
         assert!(authorization_url.as_str().contains("client_id=dcr-client"));
+        let parsed = url::Url::parse(authorization_url.as_str()).unwrap();
+        let redirect_uri = parsed
+            .query_pairs()
+            .find_map(|(name, value)| (name == "redirect_uri").then(|| value.into_owned()))
+            .expect("redirect uri");
+        let redirect = url::Url::parse(&redirect_uri).unwrap();
+        assert_eq!(
+            redirect
+                .query_pairs()
+                .find_map(|(name, value)| (name == "account_label").then(|| value.into_owned())),
+            Some("work notion".to_string())
+        );
         assert!(
             authorization_url
                 .as_str()
@@ -1112,6 +1156,37 @@ mod tests {
             .await
             .unwrap();
         assert!(pkce.is_some());
+    }
+
+    #[tokio::test]
+    async fn dcr_provider_setup_flow_rejects_scope_mismatch() {
+        let provider = test_provider(Arc::new(DcrSetupEgress));
+        let auth = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let flow_manager: Arc<dyn AuthFlowManager> = auth.clone();
+
+        let error = provider
+            .start_setup_flow(
+                &flow_manager,
+                sample_auth_scope(),
+                CredentialAccountLabel::new("work notion").unwrap(),
+                &[ProviderScope::new("read").unwrap()],
+                None,
+                Utc::now() + ChronoDuration::seconds(DCR_FLOW_TTL_SECONDS),
+            )
+            .await
+            .expect_err("scope mismatch should be rejected before registration");
+
+        assert_eq!(
+            error.code(),
+            ironclaw_auth::AuthErrorCode::BackendUnavailable
+        );
+        assert!(
+            auth.flows_for_owner(sample_flow_owner())
+                .await
+                .unwrap()
+                .is_empty(),
+            "scope mismatch must not create a setup flow"
+        );
     }
 
     #[tokio::test]
@@ -1236,6 +1311,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dcr_provider_setup_flow_cleans_up_material_and_cancels_flow_when_client_material_write_fails()
+     {
+        let secret_store = Arc::new(SecondPutFailingSecretStore::new());
+        let provider = OAuthDcrProvider::new(
+            test_config(),
+            Arc::new(DcrSetupEgress),
+            secret_store.clone(),
+            Arc::new(TestObligationHandler),
+        )
+        .unwrap();
+        let auth = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let flow_manager: Arc<dyn AuthFlowManager> = auth.clone();
+        let scope = sample_auth_scope();
+
+        let error = provider
+            .start_setup_flow(
+                &flow_manager,
+                scope.clone(),
+                CredentialAccountLabel::new("work notion").unwrap(),
+                &[],
+                None,
+                Utc::now() + ChronoDuration::seconds(DCR_FLOW_TTL_SECONDS),
+            )
+            .await
+            .expect_err("second secret write fails");
+
+        assert_eq!(
+            error.code(),
+            ironclaw_auth::AuthErrorCode::BackendUnavailable
+        );
+        let put_handles = secret_store.put_handles();
+        assert_eq!(
+            put_handles.len(),
+            2,
+            "PKCE and client material put attempted"
+        );
+        let deleted_handles = secret_store.deleted_handles();
+        assert_eq!(
+            deleted_handles, put_handles,
+            "rollback must delete both setup flow handles"
+        );
+        let flows = auth.flows_for_owner(sample_flow_owner()).await.unwrap();
+        assert_eq!(flows.len(), 1, "rollback should leave one terminal flow");
+        assert_eq!(
+            flows[0].status,
+            ironclaw_auth::AuthFlowStatus::Canceled,
+            "failed DCR setup storage must cancel the newly created flow"
+        );
+        assert!(
+            secret_store
+                .metadata(&scope.resource, &put_handles[0])
+                .await
+                .unwrap()
+                .is_none(),
+            "PKCE material written before client failure must be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn dcr_provider_cleans_up_registered_client_when_blocked_gate_create_flow_fails() {
+        let egress = Arc::new(RecordingDcrSetupEgress::new());
+        let provider = OAuthDcrProvider::new(
+            test_config(),
+            egress.clone(),
+            Arc::new(ironclaw_secrets::InMemorySecretStore::new()),
+            Arc::new(TestObligationHandler),
+        )
+        .unwrap();
+        let flow_manager: Arc<dyn AuthFlowManager> = Arc::new(BackendUnavailableFlowManager);
+        let auth = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let flow_source: Arc<dyn AuthFlowRecordSource> = auth;
+        let scope = sample_turn_scope();
+        let owner = ironclaw_host_api::UserId::new("user").unwrap();
+        let run_id = TurnRunId::new();
+        let gate_ref =
+            AuthGateRef::new("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string()).unwrap();
+
+        let error = provider
+            .challenge_for_blocked_gate(
+                &flow_manager,
+                &flow_source,
+                &scope,
+                &owner,
+                run_id,
+                &gate_ref,
+            )
+            .await
+            .expect_err("create_flow should fail");
+
+        assert_eq!(
+            error.code(),
+            ironclaw_auth::AuthErrorCode::BackendUnavailable
+        );
+        assert!(
+            egress
+                .requests()
+                .iter()
+                .any(|(method, url)| *method == NetworkMethod::Delete
+                    && url == "https://oauth.notion.com/register/dcr-client"),
+            "create_flow failures must deregister the DCR client"
+        );
+    }
+
+    #[tokio::test]
     async fn pkce_verifier_for_flow_returns_none_when_secret_not_found() {
         let provider = test_provider(Arc::new(TestEgress));
 
@@ -1284,7 +1463,11 @@ mod tests {
         );
 
         let redirect = provider
-            .callback_redirect_uri(&scope, AuthFlowId::from_uuid(uuid::Uuid::nil()))
+            .callback_redirect_uri(
+                &scope,
+                AuthFlowId::from_uuid(uuid::Uuid::nil()),
+                &CredentialAccountLabel::new("notion").unwrap(),
+            )
             .unwrap();
 
         assert!(
@@ -1351,6 +1534,17 @@ mod tests {
             Some(ironclaw_host_api::ProjectId::new("project").unwrap()),
             ironclaw_host_api::ThreadId::new("thread").unwrap(),
         )
+    }
+
+    fn sample_flow_owner() -> AuthFlowOwnerScope {
+        let scope = sample_auth_scope();
+        AuthFlowOwnerScope {
+            tenant_id: scope.resource.tenant_id,
+            user_id: scope.resource.user_id,
+            agent_id: scope.resource.agent_id,
+            project_id: scope.resource.project_id,
+            thread_id: scope.resource.thread_id.unwrap(),
+        }
     }
 
     #[derive(Debug, Clone, Copy)]
@@ -1564,7 +1758,12 @@ mod tests {
                 "https://oauth.notion.com/.well-known/oauth-authorization-server" => {
                     br#"{"authorization_endpoint":"https://oauth.notion.com/authorize","token_endpoint":"https://oauth.notion.com/token","registration_endpoint":"https://oauth.notion.com/register"}"#.to_vec()
                 }
-                "https://oauth.notion.com/register" => br#"{"client_id":"dcr-client"}"#.to_vec(),
+                "https://oauth.notion.com/register" => br#"{"client_id":"dcr-client","registration_client_uri":"https://oauth.notion.com/register/dcr-client","registration_access_token":"registration-token"}"#.to_vec(),
+                "https://oauth.notion.com/register/dcr-client"
+                    if request.method == NetworkMethod::Delete =>
+                {
+                    br#"{}"#.to_vec()
+                }
                 other => panic!("unexpected DCR egress URL: {other}"),
             };
             Ok(ironclaw_host_api::RuntimeHttpEgressResponse {
@@ -1576,6 +1775,129 @@ mod tests {
                 saved_body: None,
                 redaction_applied: false,
             })
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingDcrSetupEgress {
+        requests: Mutex<Vec<(NetworkMethod, String)>>,
+    }
+
+    impl RecordingDcrSetupEgress {
+        fn new() -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn requests(&self) -> Vec<(NetworkMethod, String)> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl RuntimeHttpEgress for RecordingDcrSetupEgress {
+        async fn execute(
+            &self,
+            request: RuntimeHttpEgressRequest,
+        ) -> Result<
+            ironclaw_host_api::RuntimeHttpEgressResponse,
+            ironclaw_host_api::RuntimeHttpEgressError,
+        > {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push((request.method, request.url.clone()));
+            DcrSetupEgress.execute(request).await
+        }
+    }
+
+    #[derive(Debug)]
+    struct BackendUnavailableFlowManager;
+
+    #[async_trait]
+    impl AuthFlowManager for BackendUnavailableFlowManager {
+        async fn create_flow(
+            &self,
+            _request: NewAuthFlow,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            Err(AuthProductError::BackendUnavailable)
+        }
+
+        async fn get_flow(
+            &self,
+            _scope: &AuthProductScope,
+            _flow_id: AuthFlowId,
+        ) -> Result<Option<ironclaw_auth::AuthFlowRecord>, AuthProductError> {
+            unreachable!("create-flow failure test does not read flows")
+        }
+
+        async fn claim_oauth_callback(
+            &self,
+            _scope: &AuthProductScope,
+            _request: ironclaw_auth::OAuthCallbackClaimRequest,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            unreachable!("create-flow failure test does not claim callbacks")
+        }
+
+        async fn complete_oauth_callback(
+            &self,
+            _scope: &AuthProductScope,
+            _input: ironclaw_auth::OAuthCallbackInput,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            unreachable!("create-flow failure test does not complete callbacks")
+        }
+
+        async fn complete_credential_selection(
+            &self,
+            _scope: &AuthProductScope,
+            _input: ironclaw_auth::CredentialSelectionInput,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            unreachable!("create-flow failure test does not complete selection")
+        }
+
+        async fn complete_manual_token(
+            &self,
+            _scope: &AuthProductScope,
+            _input: ironclaw_auth::ManualTokenCompletionInput,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            unreachable!("create-flow failure test does not complete manual tokens")
+        }
+
+        async fn cancel_manual_token(
+            &self,
+            _scope: &AuthProductScope,
+            _interaction_id: ironclaw_auth::AuthInteractionId,
+        ) -> Result<Option<ironclaw_auth::AuthFlowRecord>, AuthProductError> {
+            unreachable!("create-flow failure test does not cancel manual tokens")
+        }
+
+        async fn fail_oauth_callback(
+            &self,
+            _scope: &AuthProductScope,
+            _input: ironclaw_auth::OAuthCallbackFailureInput,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            unreachable!("create-flow failure test does not fail callbacks")
+        }
+
+        async fn mark_continuation_dispatched(
+            &self,
+            _scope: &AuthProductScope,
+            _flow_id: AuthFlowId,
+            _emitted_at: ironclaw_auth::Timestamp,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            unreachable!("create-flow failure test does not mark continuations")
+        }
+
+        async fn cancel_flow(
+            &self,
+            _scope: &AuthProductScope,
+            _flow_id: AuthFlowId,
+        ) -> Result<ironclaw_auth::AuthFlowRecord, AuthProductError> {
+            unreachable!("create-flow failure test does not cancel flows")
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -26,9 +26,9 @@ use axum::{
 };
 use chrono::{Duration as ChronoDuration, Utc};
 use ironclaw_auth::{
-    AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowStatus, AuthGateRef, AuthInteractionId,
-    AuthProductError, AuthProductScope, AuthProviderId, AuthSessionId, AuthSurface,
-    AuthorizationCodeHash, CredentialAccountChoiceRequest, CredentialAccountId,
+    AuthChallenge, AuthContinuationRef, AuthErrorCode, AuthFlowId, AuthFlowStatus, AuthGateRef,
+    AuthInteractionId, AuthProductError, AuthProductScope, AuthProviderId, AuthSessionId,
+    AuthSurface, AuthorizationCodeHash, CredentialAccountChoiceRequest, CredentialAccountId,
     CredentialAccountLabel, CredentialAccountListPage, CredentialAccountListRequest,
     CredentialAccountProjection, CredentialAccountSelectionRequest, CredentialAccountStatus,
     CredentialAccountUpdateBinding, CredentialRecoveryProjection, CredentialRecoveryRequest,
@@ -55,7 +55,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 use uuid::Uuid;
 
-use crate::auth::RebornOAuthStartFlowRequest;
+use crate::auth::{RebornDcrOAuthStartFlowRequest, RebornOAuthStartFlowRequest};
 use crate::{
     RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest, RebornManualTokenSubmitResponse,
     RebornOAuthCallbackError, RebornOAuthCallbackOutcome, RebornOAuthCallbackRequest,

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -542,7 +542,7 @@ pub(crate) struct OAuthStartResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct GoogleOAuthStartResponse {
+pub(crate) struct ProductOAuthStartResponse {
     pub(crate) flow_id: AuthFlowId,
     pub(crate) status: AuthFlowStatus,
     pub(crate) provider: AuthProviderId,
@@ -725,6 +725,13 @@ impl ProductAuthRouteFailure {
         )
     }
 
+    fn malformed_config() -> Self {
+        Self::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            AuthErrorCode::MalformedConfig,
+        )
+    }
+
     fn backend_timeout() -> Self {
         Self::new(
             StatusCode::GATEWAY_TIMEOUT,
@@ -760,7 +767,9 @@ pub(super) fn route_failure_from_callback_error(
         AuthErrorCode::CrossScopeDenied => StatusCode::FORBIDDEN,
         AuthErrorCode::ProviderDenied | AuthErrorCode::Canceled => StatusCode::BAD_REQUEST,
         AuthErrorCode::FlowAlreadyTerminal => StatusCode::CONFLICT,
-        AuthErrorCode::BackendUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+        AuthErrorCode::BackendUnavailable | AuthErrorCode::MalformedConfig => {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
         AuthErrorCode::TokenExchangeFailed | AuthErrorCode::RefreshFailed => {
             StatusCode::BAD_GATEWAY
         }
@@ -1282,11 +1291,14 @@ mod tests {
     use crate::oauth_dcr_protocol::flow_secret_handle;
     use crate::{RebornAuthContinuationDispatcher, notion_oauth::notion_provider_spec};
     use async_trait::async_trait;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Method, Request, header};
     use ironclaw_capabilities::{CapabilityObligationHandler, CapabilityObligationRequest};
     use ironclaw_host_api::{
-        RuntimeHttpEgress, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+        NetworkMethod, RuntimeHttpEgress, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
     };
     use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
+    use tower::ServiceExt;
 
     struct NoopDispatcher;
 
@@ -1321,6 +1333,15 @@ mod tests {
             thread_id: None,
             invocation_id: InvocationId::new(),
         }
+    }
+
+    fn test_caller() -> WebUiAuthenticatedCaller {
+        WebUiAuthenticatedCaller::new(
+            TenantId::new("tenant-alpha").expect("tenant"),
+            UserId::new("user-alpha").expect("user"),
+            None,
+            None,
+        )
     }
 
     #[test]
@@ -1360,6 +1381,125 @@ mod tests {
 
         assert_eq!(error.status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(error.body.code, AuthErrorCode::BackendUnavailable);
+    }
+
+    #[tokio::test]
+    async fn extension_oauth_start_handler_starts_dcr_setup_flow_for_notion() {
+        let secret_store = Arc::new(InMemorySecretStore::new());
+        let dcr_provider = Arc::new(
+            OAuthDcrProvider::new(
+                OAuthDcrProviderConfig {
+                    spec: notion_provider_spec(),
+                    callback_origin: "http://127.0.0.1:3000".to_string(),
+                    client_name: "Ironclaw".to_string(),
+                    account_label: CredentialAccountLabel::new("notion").expect("label"),
+                    scopes: Vec::new(),
+                },
+                Arc::new(RouteDcrSetupEgress),
+                secret_store,
+                Arc::new(NoopObligationHandler),
+            )
+            .expect("DCR provider"),
+        );
+        let product_auth = RebornProductAuthServices::local_dev_in_memory(Arc::new(NoopDispatcher))
+            .with_dcr_oauth_registry(Arc::new(OAuthDcrProviderRegistry::new(vec![dcr_provider])));
+        let state = ProductAuthRouteState::new(
+            Arc::new(product_auth),
+            TenantId::new("tenant-alpha").expect("tenant"),
+            None,
+            None,
+        );
+        let app = product_auth_route_mount(state)
+            .protected
+            .layer(axum::Extension(test_caller()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/webchat/v2/extensions/notion/setup/oauth/start")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "provider": "notion",
+                            "account_label": "work notion",
+                            "scopes": [],
+                            "expires_at": (Utc::now() + ChronoDuration::minutes(5)).to_rfc3339(),
+                            "invocation_id": InvocationId::new().to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("route response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("start json");
+        assert_eq!(json["provider"], "notion");
+        assert_eq!(json["continuation"]["type"], "setup_only");
+        let authorization_url = json["authorization_url"]
+            .as_str()
+            .expect("authorization url");
+        let parsed = url::Url::parse(authorization_url).expect("authorization URL");
+        assert_eq!(parsed.host_str(), Some("oauth.notion.com"));
+        let redirect_uri = parsed
+            .query_pairs()
+            .find_map(|(name, value)| (name == "redirect_uri").then(|| value.into_owned()))
+            .expect("redirect uri");
+        let redirect = url::Url::parse(&redirect_uri).expect("callback redirect URL");
+        assert_eq!(
+            redirect
+                .query_pairs()
+                .find_map(|(name, value)| (name == "account_label").then(|| value.into_owned())),
+            Some("work notion".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn extension_oauth_start_handler_returns_config_error_when_dcr_registry_is_missing() {
+        let state = ProductAuthRouteState::new(
+            Arc::new(RebornProductAuthServices::local_dev_in_memory(Arc::new(
+                NoopDispatcher,
+            ))),
+            TenantId::new("tenant-alpha").expect("tenant"),
+            None,
+            None,
+        );
+        let app = product_auth_route_mount(state)
+            .protected
+            .layer(axum::Extension(test_caller()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/webchat/v2/extensions/notion/setup/oauth/start")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "provider": "notion",
+                            "account_label": "work notion",
+                            "scopes": [],
+                            "expires_at": (Utc::now() + ChronoDuration::minutes(5)).to_rfc3339(),
+                            "invocation_id": InvocationId::new().to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("route response");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("error json");
+        assert_eq!(json["code"], "malformed_config");
     }
 
     #[tokio::test]
@@ -1442,6 +1582,42 @@ mod tests {
             _request: RuntimeHttpEgressRequest,
         ) -> Result<RuntimeHttpEgressResponse, ironclaw_host_api::RuntimeHttpEgressError> {
             panic!("callback PKCE fallback test must not perform DCR HTTP egress")
+        }
+    }
+
+    #[derive(Debug)]
+    struct RouteDcrSetupEgress;
+
+    #[async_trait]
+    impl RuntimeHttpEgress for RouteDcrSetupEgress {
+        async fn execute(
+            &self,
+            request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, ironclaw_host_api::RuntimeHttpEgressError> {
+            let body = match request.url.as_str() {
+                "https://mcp.notion.com/mcp/.well-known/oauth-protected-resource" => {
+                    br#"{"authorization_servers":["https://oauth.notion.com"]}"#.to_vec()
+                }
+                "https://oauth.notion.com/.well-known/oauth-authorization-server" => {
+                    br#"{"authorization_endpoint":"https://oauth.notion.com/authorize","token_endpoint":"https://oauth.notion.com/token","registration_endpoint":"https://oauth.notion.com/register"}"#.to_vec()
+                }
+                "https://oauth.notion.com/register" => br#"{"client_id":"dcr-client","registration_client_uri":"https://oauth.notion.com/register/dcr-client","registration_access_token":"registration-token"}"#.to_vec(),
+                "https://oauth.notion.com/register/dcr-client"
+                    if request.method == NetworkMethod::Delete =>
+                {
+                    br#"{}"#.to_vec()
+                }
+                other => panic!("unexpected DCR route egress URL: {other}"),
+            };
+            Ok(RuntimeHttpEgressResponse {
+                status: 200,
+                headers: Vec::new(),
+                request_bytes: request.body.len() as u64,
+                response_bytes: body.len() as u64,
+                body,
+                saved_body: None,
+                redaction_applied: false,
+            })
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
@@ -75,11 +75,11 @@ pub(super) async fn extension_oauth_start_handler(
     Path(package_id): Path<String>,
     Json(request): Json<ExtensionOAuthStartRequest>,
 ) -> Result<Json<GoogleOAuthStartResponse>, ProductAuthRouteFailure> {
-    if request.provider != GOOGLE_PROVIDER_ID {
-        return Err(ProductAuthRouteFailure::invalid_request());
-    }
     let requester_extension =
         ExtensionId::new(package_id).map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    if request.provider != GOOGLE_PROVIDER_ID {
+        return start_dcr_extension_oauth_flow(state, caller, request, requester_extension).await;
+    }
     start_google_oauth_flow(
         state,
         caller,
@@ -95,6 +95,70 @@ pub(super) async fn extension_oauth_start_handler(
         true,
     )
     .await
+}
+
+async fn start_dcr_extension_oauth_flow(
+    state: ProductAuthRouteState,
+    caller: WebUiAuthenticatedCaller,
+    request: ExtensionOAuthStartRequest,
+    requester_extension: ExtensionId,
+) -> Result<Json<GoogleOAuthStartResponse>, ProductAuthRouteFailure> {
+    let now = Utc::now();
+    if request.expires_at <= now
+        || request.expires_at > now + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS)
+    {
+        return Err(ProductAuthRouteFailure::invalid_request());
+    }
+
+    let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let requested_scopes = request
+        .scopes
+        .into_iter()
+        .map(ProviderScope::new)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let fields = ScopeFields {
+        session_id: None,
+        thread_id: None,
+        invocation_id: request.invocation_id,
+    };
+    let scope = scope_from_authenticated_caller_parts_requiring_invocation(&caller, &fields)?;
+    let update_binding = scoped_update_binding_for_requester(
+        &state,
+        scope.clone(),
+        provider.clone(),
+        requested_scopes.clone(),
+        Some(&requester_extension),
+    )
+    .await?;
+    let flow = run_with_backend_timeout(state.product_auth.start_dcr_setup_oauth_flow(
+        RebornDcrOAuthStartFlowRequest {
+            scope: scope.clone(),
+            provider: provider.clone(),
+            provider_scopes: requested_scopes,
+            update_binding,
+            expires_at: request.expires_at,
+        },
+    ))
+    .await?
+    .ok_or_else(ProductAuthRouteFailure::invalid_request)?;
+    let Some(AuthChallenge::OAuthUrl {
+        authorization_url, ..
+    }) = &flow.challenge
+    else {
+        return Err(ProductAuthRouteFailure::backend_unavailable());
+    };
+
+    Ok(Json(GoogleOAuthStartResponse {
+        flow_id: flow.id,
+        status: flow.status,
+        provider,
+        authorization_url: authorization_url.clone(),
+        expires_at: flow.expires_at,
+        continuation: flow.continuation,
+        callback_scope: scope_hint(&scope),
+    }))
 }
 
 async fn start_google_oauth_flow(

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
@@ -65,7 +65,7 @@ pub(super) async fn google_oauth_start_handler(
     State(state): State<ProductAuthRouteState>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Json(request): Json<GoogleOAuthStartRequest>,
-) -> Result<Json<GoogleOAuthStartResponse>, ProductAuthRouteFailure> {
+) -> Result<Json<ProductOAuthStartResponse>, ProductAuthRouteFailure> {
     start_google_oauth_flow(state, caller, request, None, false).await
 }
 
@@ -74,7 +74,7 @@ pub(super) async fn extension_oauth_start_handler(
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
     Path(package_id): Path<String>,
     Json(request): Json<ExtensionOAuthStartRequest>,
-) -> Result<Json<GoogleOAuthStartResponse>, ProductAuthRouteFailure> {
+) -> Result<Json<ProductOAuthStartResponse>, ProductAuthRouteFailure> {
     let requester_extension =
         ExtensionId::new(package_id).map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     if request.provider != GOOGLE_PROVIDER_ID {
@@ -102,7 +102,7 @@ async fn start_dcr_extension_oauth_flow(
     caller: WebUiAuthenticatedCaller,
     request: ExtensionOAuthStartRequest,
     requester_extension: ExtensionId,
-) -> Result<Json<GoogleOAuthStartResponse>, ProductAuthRouteFailure> {
+) -> Result<Json<ProductOAuthStartResponse>, ProductAuthRouteFailure> {
     let now = Utc::now();
     if request.expires_at <= now
         || request.expires_at > now + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS)
@@ -111,6 +111,8 @@ async fn start_dcr_extension_oauth_flow(
     }
 
     let provider = AuthProviderId::new(request.provider)
+        .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
+    let account_label = CredentialAccountLabel::new(request.account_label)
         .map_err(|_| ProductAuthRouteFailure::invalid_request())?;
     let requested_scopes = request
         .scopes
@@ -136,13 +138,14 @@ async fn start_dcr_extension_oauth_flow(
         RebornDcrOAuthStartFlowRequest {
             scope: scope.clone(),
             provider: provider.clone(),
+            account_label,
             provider_scopes: requested_scopes,
             update_binding,
             expires_at: request.expires_at,
         },
     ))
     .await?
-    .ok_or_else(ProductAuthRouteFailure::invalid_request)?;
+    .ok_or_else(ProductAuthRouteFailure::malformed_config)?;
     let Some(AuthChallenge::OAuthUrl {
         authorization_url, ..
     }) = &flow.challenge
@@ -150,7 +153,7 @@ async fn start_dcr_extension_oauth_flow(
         return Err(ProductAuthRouteFailure::backend_unavailable());
     };
 
-    Ok(Json(GoogleOAuthStartResponse {
+    Ok(Json(ProductOAuthStartResponse {
         flow_id: flow.id,
         status: flow.status,
         provider,
@@ -167,7 +170,7 @@ async fn start_google_oauth_flow(
     request: GoogleOAuthStartRequest,
     requester_extension: Option<ExtensionId>,
     require_invocation_id: bool,
-) -> Result<Json<GoogleOAuthStartResponse>, ProductAuthRouteFailure> {
+) -> Result<Json<ProductOAuthStartResponse>, ProductAuthRouteFailure> {
     let now = Utc::now();
     if request.expires_at <= now
         || request.expires_at > now + ChronoDuration::seconds(PRODUCT_AUTH_FLOW_MAX_TTL_SECONDS)
@@ -241,7 +244,7 @@ async fn start_google_oauth_flow(
     .await?;
     state.store_pkce_verifier(flow.id, pkce_verifier_secret, flow.expires_at)?;
 
-    Ok(Json(GoogleOAuthStartResponse {
+    Ok(Json(ProductOAuthStartResponse {
         flow_id: flow.id,
         status: flow.status,
         provider,

--- a/crates/ironclaw_reborn_composition/src/webui_extension_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/webui_extension_credentials.rs
@@ -107,7 +107,7 @@ fn map_auth_error(error: crate::RebornAuthProductError) -> RebornServicesError {
             403,
             false,
         ),
-        AuthErrorCode::BackendUnavailable => services_error(
+        AuthErrorCode::BackendUnavailable | AuthErrorCode::MalformedConfig => services_error(
             RebornServicesErrorCode::Unavailable,
             RebornServicesErrorKind::ServiceUnavailable,
             503,


### PR DESCRIPTION
## Summary

- Marks the bundled Notion MCP runtime credentials as OAuth setup requirements so WebUI v2 projects an OAuth Configure flow instead of manual token input.
- Adds ProductAuth/DCR setup-flow wiring so extension OAuth setup can start DCR-backed providers while preserving the existing static Google OAuth path.
- Updates Notion onboarding copy and adds regression coverage for the DCR setup flow and Notion OAuth projection.

## Why

WebUI v2 extension setup already had a generic OAuth start route, but non-Google providers were rejected before reaching ProductAuth. Notion DCR should stay in the backend provider layer and expose the same setup response shape to the frontend, avoiding provider-specific WebUI logic.

## Validation

- `CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition dcr_provider_creates_setup_only_flow_and_stores_pkce_material -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition --features webui-v2-beta bundled_notion_projects_oauth_credential_setup -- --nocapture`
