### PR TITLE
[codex] Allow cancelling parked auth without flow record

### DIFF
--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -223,6 +223,14 @@ impl DefaultAuthInteractionService {
                 return Err(auth_rejected(AuthInteractionRejectionKind::StaleAuth));
             }
         }
+        self.cancel_auth_run(request, run_id).await
+    }
+
+    async fn cancel_auth_run(
+        &self,
+        request: ResolveAuthInteractionRequest,
+        run_id: TurnRunId,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
         let response = self
             .turn_coordinator
             .cancel_run(CancelRunRequest {
@@ -235,6 +243,20 @@ impl DefaultAuthInteractionService {
             .await
             .map_err(map_auth_resume_error)?;
         Ok(ResolveAuthInteractionResponse::Canceled(response))
+    }
+
+    async fn cancel_parked_auth_without_flow(
+        &self,
+        request: ResolveAuthInteractionRequest,
+        run_id: TurnRunId,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        match self.turn_gate_state(&request, run_id).await? {
+            BlockedGateState::ParkedOnGate => {}
+            BlockedGateState::NotParkedOnGate => {
+                return Err(auth_rejected(AuthInteractionRejectionKind::MissingAuth));
+            }
+        }
+        self.cancel_auth_run(request, run_id).await
     }
 }
 
@@ -273,9 +295,21 @@ impl AuthInteractionService for DefaultAuthInteractionService {
         request: ResolveAuthInteractionRequest,
     ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
         let scope = AuthInteractionScope::from_turn(&request.scope, &request.actor);
-        let gate = self
+        let gate = match self
             .find_gate(&scope, request.run_id_hint, &request.gate_ref)
-            .await?;
+            .await
+        {
+            Ok(gate) => gate,
+            Err(ProductWorkflowError::AuthInteractionRejected {
+                kind: AuthInteractionRejectionKind::MissingAuth,
+            }) if matches!(request.decision, AuthInteractionDecision::Deny) => {
+                let Some(run_id) = request.run_id_hint else {
+                    return Err(auth_rejected(AuthInteractionRejectionKind::MissingAuth));
+                };
+                return self.cancel_parked_auth_without_flow(request, run_id).await;
+            }
+            Err(error) => return Err(error),
+        };
         let run_id = request.run_id_hint.unwrap_or_else(|| gate.run_id());
         match (
             self.turn_gate_state(&request, run_id).await?,

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -744,6 +744,89 @@ async fn denied_auth_cancels_flow_and_run() {
 }
 
 #[tokio::test]
+async fn denied_auth_without_flow_record_cancels_parked_auth_run() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-deny-no-flow");
+    let flow = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, flow_manager, coordinator) =
+        service_parts(flow, Vec::new(), actor.clone(), gate_ref.clone());
+
+    let response = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("auth-action-deny-no-flow").unwrap(),
+        })
+        .await
+        .expect("deny parked auth without flow record");
+
+    assert!(matches!(
+        response,
+        ResolveAuthInteractionResponse::Canceled(_)
+    ));
+    assert!(
+        flow_manager.cancellations().is_empty(),
+        "no auth flow record should mean there is no flow to cancel"
+    );
+    assert_eq!(coordinator.cancellations().len(), 1);
+    assert!(coordinator.resumes().is_empty());
+}
+
+#[tokio::test]
+async fn denied_auth_without_flow_record_requires_current_parked_auth_gate() {
+    let actor = TurnActor::new(UserId::new("alice").unwrap());
+    let scope = turn_scope("alice", "thread-a");
+    let run_id = TurnRunId::new();
+    let gate_ref = make_gate_ref("gate:auth-deny-no-flow-stale");
+    let flow = auth_flow(
+        AuthFlowStatus::AwaitingUser,
+        &scope,
+        &actor,
+        run_id,
+        &gate_ref,
+        None,
+        setup_challenge(),
+    );
+    let (service, _flow_manager, coordinator) =
+        service_parts(flow, Vec::new(), actor.clone(), gate_ref.clone());
+    coordinator.set_status(TurnStatus::Queued);
+
+    let error = service
+        .resolve(ResolveAuthInteractionRequest {
+            scope,
+            actor,
+            run_id_hint: Some(run_id),
+            gate_ref,
+            decision: AuthInteractionDecision::Deny,
+            idempotency_key: IdempotencyKey::new("auth-action-deny-no-flow-stale").unwrap(),
+        })
+        .await
+        .expect_err("missing auth flow must not cancel a non-parked run");
+
+    assert!(matches!(
+        error,
+        ProductWorkflowError::AuthInteractionRejected {
+            kind: AuthInteractionRejectionKind::MissingAuth
+        }
+    ));
+    assert!(coordinator.cancellations().is_empty());
+    assert!(coordinator.resumes().is_empty());
+}
+
+#[tokio::test]
 async fn duplicate_completed_auth_resolution_replays_through_turn_coordinator() {
     let actor = TurnActor::new(UserId::new("alice").unwrap());
     let scope = turn_scope("alice", "thread-a");


### PR DESCRIPTION
## Summary

- Allow auth-gate cancellation to cancel a still-parked blocked-auth run even when no product-auth flow record exists.
- Keep the fallback gated by the typed auth interaction freshness check so stale or non-parked gates still fail closed.
- Add regression coverage for missing-flow cancellation and stale missing-flow rejection.

## Root Cause

WebUI v2 can render an auth card from blocked turn state plus credential requirements without a matching product-auth flow record. The cancel path previously required the auth flow record before it would reach turn cancellation, so the browser received `404 blocked_authentication` and the card stayed stuck.

## Validation

- `cargo fmt --check -p ironclaw_product_workflow`
- `cargo test -p ironclaw_product_workflow --test auth_interaction_contract`
- `cargo test -p ironclaw_product_workflow`

Note: cargo emitted unrelated dead-code warnings from `ironclaw_reborn_composition` during the product workflow tests.