### PR TITLE
Keep auth gate visible during projection text updates

### DIFF
--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -96,6 +96,26 @@ mod tests {
     }
 
     #[test]
+    fn chat_projection_text_preserves_pending_gate() {
+        let events = asset_text("js/pages/chat/lib/useChatEvents.js");
+        let text_branch = events
+            .split("if (item.text)")
+            .nth(1)
+            .expect("text projection branch exists")
+            .split("if (item.thinking)")
+            .next()
+            .expect("thinking branch follows text branch");
+        assert!(
+            text_branch.contains("terminal run_status is the only"),
+            "text branch should document that run_status owns gate clearing"
+        );
+        assert!(
+            !text_branch.contains("setPendingGate(null);"),
+            "projection text must not hide a still-blocked auth gate"
+        );
+    }
+
+    #[test]
     fn extensions_onboarding_messages_render_in_cards() {
         let extension_card = asset_text("js/pages/extensions/components/extension-card.js");
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/auth-oauth-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/auth-oauth-card.js
@@ -8,8 +8,8 @@
  * click. The OAuth callback is handled server-side
  * (`/api/reborn/product-auth/oauth/callback/{flow_id}`), which resumes the
  * paused run. The WebUI observes the resume via the next projection_update
- * (run_status flip) which causes `setPendingGate(null)` via the `item.text`
- * path in useChatEvents.js — so this card unmounts automatically.
+ * (terminal run_status flip), so this card unmounts automatically only after
+ * the run leaves the blocked auth state.
  *
  * Security invariants (issue #4112):
  * - No raw token, PKCE verifier, opaque state, or auth code is ever handled

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -288,7 +288,9 @@ function applyProjectionItems({
       // ProductProjectionItem::Text { id, body } — the body is the
       // assistant-visible reply text accumulated through projection.
       // Dedup by item id so repeated snapshots don't duplicate the
-      // same bubble.
+      // same bubble. Text can arrive in the same projection snapshot
+      // as a still-blocked gate, so terminal run_status is the only
+      // projection item that clears pendingGate.
       const messageId = `text-${item.text.id}`;
       setMessages((prev) => {
         const existing = prev.findIndex((m) => m.id === messageId);
@@ -306,7 +308,6 @@ function applyProjectionItems({
         return [...prev, next];
       });
       setIsProcessing(false);
-      setPendingGate(null);
     }
 
     if (item.thinking) {


### PR DESCRIPTION
## Summary
- keep WebUI v2 pending auth gates visible when projection text items arrive
- rely on terminal run_status events to clear pending gates
- add a static asset regression guard for the text projection branch

## Tests
- cargo fmt --check -p ironclaw_webui_v2_static
- cargo test -p ironclaw_webui_v2_static
- node --check crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
- node --check crates/ironclaw_webui_v2_static/static/js/pages/chat/components/auth-oauth-card.js