### PR TITLE
Fix Google OAuth prompts for runtime auth gates

### DIFF
--- a/crates/ironclaw_reborn_cli/src/runtime.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime.rs
@@ -409,8 +409,11 @@ fn resolve_google_oauth_config(
         );
     }
     let hosted_domain_hint = reborn_hosted_domain_hint.or(legacy_hosted_domain_hint);
-    let client = OAuthClientConfig::new(client_id, redirect_uri, client_secret)
+    let mut client = OAuthClientConfig::new(client_id, redirect_uri, client_secret)
         .context("invalid Google OAuth client configuration")?;
+    if let Some(hosted_domain_hint) = hosted_domain_hint.clone() {
+        client = client.with_hosted_domain_hint(hosted_domain_hint);
+    }
 
     Ok(Some(ResolvedGoogleOAuthConfig {
         client,

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -29,6 +29,7 @@ use ironclaw_turns::{TurnRunId, TurnScope};
 
 use crate::manual_token_flow::{PortBackedManualTokenFlowService, RebornManualTokenFlowService};
 use crate::oauth_dcr::{DcrGateChallengeRequest, OAuthDcrProviderRegistry};
+use crate::oauth_gate::{OAuthGateChallengeRequest, OAuthGateProviderRegistry};
 use crate::product_auth_runtime_credentials::{
     ProductAuthRuntimeCredentialAccountSelector, RuntimeCredentialAccountSelectionService,
 };
@@ -437,6 +438,7 @@ pub struct RebornProductAuthServices {
     cleanup_service: Arc<dyn SecretCleanupService>,
     continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
     dcr_oauth_registry: Option<Arc<OAuthDcrProviderRegistry>>,
+    oauth_gate_registry: Option<Arc<OAuthGateProviderRegistry>>,
     /// Optional read projection for WebUI/local-dev auth interactions.
     ///
     /// `RebornProductAuthServices` may still support OAuth callbacks,
@@ -481,6 +483,7 @@ impl std::fmt::Debug for RebornProductAuthServices {
             )
             .field("flow_record_source", &self.flow_record_source.is_some())
             .field("dcr_oauth_registry", &self.dcr_oauth_registry.is_some())
+            .field("oauth_gate_registry", &self.oauth_gate_registry.is_some())
             .finish()
     }
 }
@@ -511,6 +514,7 @@ impl RebornProductAuthServices {
             cleanup_service,
             continuation_dispatcher,
             dcr_oauth_registry: None,
+            oauth_gate_registry: None,
             flow_record_source: None,
         }
     }
@@ -637,6 +641,14 @@ impl RebornProductAuthServices {
         registry: Arc<OAuthDcrProviderRegistry>,
     ) -> Self {
         self.dcr_oauth_registry = Some(registry);
+        self
+    }
+
+    pub(crate) fn with_oauth_gate_registry(
+        mut self,
+        registry: Arc<OAuthGateProviderRegistry>,
+    ) -> Self {
+        self.oauth_gate_registry = Some(registry);
         self
     }
 
@@ -928,6 +940,14 @@ impl RebornProductAuthServices {
         provider: &AuthProviderId,
         flow_id: AuthFlowId,
     ) -> Result<Option<SecretString>, RebornOAuthCallbackError> {
+        if let Some(registry) = &self.oauth_gate_registry
+            && let Some(pkce) = registry
+                .pkce_verifier_for_flow(scope, provider, flow_id)
+                .await
+                .map_err(RebornOAuthCallbackError::from)?
+        {
+            return Ok(Some(pkce));
+        }
         let Some(registry) = &self.dcr_oauth_registry else {
             return Ok(None);
         };
@@ -1206,6 +1226,21 @@ impl AuthChallengeProvider for RebornProductAuthServices {
         let Some(source) = self.flow_record_source.as_ref() else {
             return Ok(None);
         };
+        if let Some(registry) = &self.oauth_gate_registry
+            && let Some(view) = registry
+                .challenge_for_blocked_gate(OAuthGateChallengeRequest {
+                    flow_manager: &self.flow_manager,
+                    flow_source: source,
+                    requirements: credential_requirements,
+                    scope,
+                    owner_user_id,
+                    run_id,
+                    gate_ref: &gate_ref,
+                })
+                .await?
+        {
+            return Ok(Some(view));
+        }
         if let Some(registry) = &self.dcr_oauth_registry
             && let Some(view) = registry
                 .challenge_for_blocked_gate(DcrGateChallengeRequest {

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -29,7 +29,7 @@ use ironclaw_turns::{TurnRunId, TurnScope};
 
 use crate::manual_token_flow::{PortBackedManualTokenFlowService, RebornManualTokenFlowService};
 use crate::oauth_dcr::{DcrGateChallengeRequest, OAuthDcrProviderRegistry};
-use crate::oauth_gate::{OAuthGateChallengeRequest, OAuthGateProviderRegistry};
+use crate::oauth_gate::{GoogleOAuthGateProviderRegistry, OAuthGateChallengeRequest};
 use crate::product_auth_runtime_credentials::{
     ProductAuthRuntimeCredentialAccountSelector, RuntimeCredentialAccountSelectionService,
 };
@@ -438,7 +438,7 @@ pub struct RebornProductAuthServices {
     cleanup_service: Arc<dyn SecretCleanupService>,
     continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
     dcr_oauth_registry: Option<Arc<OAuthDcrProviderRegistry>>,
-    oauth_gate_registry: Option<Arc<OAuthGateProviderRegistry>>,
+    oauth_gate_registry: Option<Arc<GoogleOAuthGateProviderRegistry>>,
     /// Optional read projection for WebUI/local-dev auth interactions.
     ///
     /// `RebornProductAuthServices` may still support OAuth callbacks,
@@ -646,7 +646,7 @@ impl RebornProductAuthServices {
 
     pub(crate) fn with_oauth_gate_registry(
         mut self,
-        registry: Arc<OAuthGateProviderRegistry>,
+        registry: Arc<GoogleOAuthGateProviderRegistry>,
     ) -> Self {
         self.oauth_gate_registry = Some(registry);
         self

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -430,6 +430,9 @@ fn compose_product_auth_services(
     if let Some(registry) = provider_composition.dcr_registry {
         services = services.with_dcr_oauth_registry(registry);
     }
+    if let Some(registry) = provider_composition.gate_registry {
+        services = services.with_oauth_gate_registry(registry);
+    }
     Arc::new(services)
 }
 
@@ -623,6 +626,10 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
                     Some(registry) => services.with_dcr_oauth_registry(registry),
                     None => services,
                 };
+                let services = match provider_composition.gate_registry.clone() {
+                    Some(registry) => services.with_oauth_gate_registry(registry),
+                    None => services,
+                };
                 Arc::new(services)
             }
             #[cfg(not(any(feature = "libsql", feature = "postgres")))]
@@ -634,8 +641,12 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
                     Some(provider_client) => services.with_provider_client(provider_client),
                     None => services,
                 };
-                Arc::new(match provider_composition.dcr_registry.clone() {
+                let services = match provider_composition.dcr_registry.clone() {
                     Some(registry) => services.with_dcr_oauth_registry(registry),
+                    None => services,
+                };
+                Arc::new(match provider_composition.gate_registry.clone() {
+                    Some(registry) => services.with_oauth_gate_registry(registry),
                     None => services,
                 })
             }

--- a/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
@@ -276,6 +276,7 @@ async fn local_dev_google_oauth_backend_builds_with_host_provider_config() {
                 client_secret: None,
                 redirect_uri: OAuthRedirectUri::new("https://app.example/oauth/google/callback")
                     .expect("redirect uri"),
+                hosted_domain_hint: None,
             }),
     )
     .await
@@ -293,12 +294,14 @@ async fn local_dev_notion_oauth_backend_builds_with_host_provider_config() {
                 client_secret: None,
                 redirect_uri: OAuthRedirectUri::new("https://app.example/oauth/google/callback")
                     .expect("redirect uri"),
+                hosted_domain_hint: None,
             })
             .with_notion_oauth_backend(OAuthClientConfig {
                 client_id: OAuthClientId::new("notion-client-123").expect("client id"),
                 client_secret: None,
                 redirect_uri: OAuthRedirectUri::new("https://app.example/oauth/notion/callback")
                     .expect("redirect uri"),
+                hosted_domain_hint: None,
             }),
     )
     .await
@@ -394,6 +397,7 @@ async fn local_dev_google_oauth_backend_accepts_optional_client_secret_config() 
             client_secret: Some(SecretString::from("raw-client-secret".to_string())),
             redirect_uri: OAuthRedirectUri::new("https://app.example/oauth/google/callback")
                 .expect("redirect uri"),
+            hosted_domain_hint: None,
         }),
     )
     .await

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -26,6 +26,7 @@ pub struct OAuthClientConfig {
     pub client_id: OAuthClientId,
     pub client_secret: Option<SecretString>,
     pub redirect_uri: OAuthRedirectUri,
+    pub hosted_domain_hint: Option<String>,
 }
 
 impl OAuthClientConfig {
@@ -38,7 +39,13 @@ impl OAuthClientConfig {
             client_id: OAuthClientId::new(client_id)?,
             client_secret,
             redirect_uri: OAuthRedirectUri::new(redirect_uri)?,
+            hosted_domain_hint: None,
         })
+    }
+
+    pub fn with_hosted_domain_hint(mut self, hosted_domain_hint: impl Into<String>) -> Self {
+        self.hosted_domain_hint = Some(hosted_domain_hint.into());
+        self
     }
 }
 
@@ -52,6 +59,10 @@ impl std::fmt::Debug for OAuthClientConfig {
                 &self.client_secret.as_ref().map(|_| "[REDACTED]"),
             )
             .field("redirect_uri", &self.redirect_uri)
+            .field(
+                "hosted_domain_hint",
+                &self.hosted_domain_hint.as_ref().map(|_| "[REDACTED]"),
+            )
             .finish()
     }
 }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -50,6 +50,7 @@ mod nearai_mcp;
 mod notion_oauth;
 mod oauth_dcr;
 mod oauth_dcr_protocol;
+mod oauth_gate;
 mod oauth_provider_client;
 mod product_auth_durable;
 mod product_auth_providers;

--- a/crates/ironclaw_reborn_composition/src/oauth_gate.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_gate.rs
@@ -26,11 +26,11 @@ use crate::projection::AuthChallengeView;
 const GATE_FLOW_TTL_SECONDS: i64 = 600;
 
 #[derive(Clone)]
-pub(crate) struct OAuthGateProviderRegistry {
+pub(crate) struct GoogleOAuthGateProviderRegistry {
     providers: BTreeMap<String, Arc<GoogleOAuthGateProvider>>,
 }
 
-impl OAuthGateProviderRegistry {
+impl GoogleOAuthGateProviderRegistry {
     pub(crate) fn new(providers: Vec<Arc<GoogleOAuthGateProvider>>) -> Self {
         Self {
             providers: providers
@@ -69,10 +69,10 @@ impl OAuthGateProviderRegistry {
     }
 }
 
-impl fmt::Debug for OAuthGateProviderRegistry {
+impl fmt::Debug for GoogleOAuthGateProviderRegistry {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("OAuthGateProviderRegistry")
+            .debug_struct("GoogleOAuthGateProviderRegistry")
             .field("providers", &self.providers.keys().collect::<Vec<_>>())
             .finish()
     }

--- a/crates/ironclaw_reborn_composition/src/oauth_gate.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_gate.rs
@@ -116,18 +116,10 @@ impl GoogleOAuthGateProvider {
         let auth_scope = auth_scope_for_blocked_turn(request.scope, request.owner_user_id);
         let turn_run_ref = TurnRunRef::new(request.run_id.to_string())?;
         let query = turn_gate_query(&auth_scope, request.scope, &turn_run_ref, request.gate_ref);
-        if let Some(existing) = request
-            .flow_source
-            .flow_for_turn_gate(query.clone())
-            .await?
-        {
-            return challenge_view_from_flow(&existing);
-        }
 
         let _setup_guard = self.setup_lock.lock().await;
-        if let Some(existing) = request
-            .flow_source
-            .flow_for_turn_gate(query.clone())
+        if let Some(existing) = self
+            .reusable_flow_for_query(request.flow_manager, request.flow_source, query.clone())
             .await?
         {
             return challenge_view_from_flow(&existing);
@@ -137,6 +129,12 @@ impl GoogleOAuthGateProvider {
         let scopes = provider_scopes(&requirement.provider_scopes)?;
         let prepared = self.prepare_flow(&auth_scope, flow_id, scopes).await?;
         let expires_at = Utc::now() + ChronoDuration::seconds(GATE_FLOW_TTL_SECONDS);
+        self.store_pkce_verifier(
+            &auth_scope.resource,
+            flow_id,
+            prepared.pkce_verifier.clone(),
+        )
+        .await?;
         let flow = match request
             .flow_manager
             .create_flow(NewAuthFlow {
@@ -160,35 +158,39 @@ impl GoogleOAuthGateProvider {
             .await
         {
             Ok(flow) => flow,
-            Err(AuthProductError::BackendConflict) => request
-                .flow_source
-                .flow_for_turn_gate(query)
-                .await?
-                .ok_or(AuthProductError::BackendConflict)?,
-            Err(error) => return Err(error),
+            Err(AuthProductError::BackendConflict) => {
+                self.cleanup_pkce_verifier(&auth_scope.resource, flow_id)
+                    .await;
+                self.reusable_flow_for_query(request.flow_manager, request.flow_source, query)
+                    .await?
+                    .ok_or(AuthProductError::BackendConflict)?
+            }
+            Err(error) => {
+                self.cleanup_pkce_verifier(&auth_scope.resource, flow_id)
+                    .await;
+                return Err(error);
+            }
         };
 
-        if flow.id == flow_id
-            && let Err(error) = self
-                .store_pkce_verifier(&flow.scope.resource, flow_id, prepared.pkce_verifier)
-                .await
-        {
-            if request
-                .flow_manager
-                .cancel_flow(&flow.scope, flow_id)
-                .await
-                .is_err()
-            {
-                tracing::warn!(
-                    provider = self.provider_id(),
-                    flow_id = %flow_id,
-                    "failed to cancel OAuth gate flow after PKCE storage failure"
-                );
-            }
-            return Err(error);
-        }
-
         challenge_view_from_flow(&flow)
+    }
+
+    async fn reusable_flow_for_query(
+        &self,
+        flow_manager: &Arc<dyn AuthFlowManager>,
+        flow_source: &Arc<dyn AuthFlowRecordSource>,
+        query: TurnGateAuthFlowQuery,
+    ) -> Result<Option<AuthFlowRecord>, AuthProductError> {
+        let Some(existing) = flow_source.flow_for_turn_gate(query).await? else {
+            return Ok(None);
+        };
+        if existing.expires_at > Utc::now() {
+            return Ok(Some(existing));
+        }
+        flow_manager
+            .cancel_flow(&existing.scope, existing.id)
+            .await
+            .map(|_| None)
     }
 
     async fn prepare_flow(
@@ -212,7 +214,7 @@ impl GoogleOAuthGateProvider {
             state.as_str(),
             &pkce_challenge,
             &scopes,
-            None,
+            self.client.hosted_domain_hint.as_deref(),
         )?;
         Ok(PreparedOAuthGateFlow {
             authorization_url,
@@ -233,6 +235,19 @@ impl GoogleOAuthGateProvider {
             .await
             .map(|_| ())
             .map_err(|_| AuthProductError::BackendUnavailable)
+    }
+
+    async fn cleanup_pkce_verifier(&self, scope: &ResourceScope, flow_id: AuthFlowId) {
+        let Ok(handle) = pkce_secret_handle(flow_id) else {
+            return;
+        };
+        if self.secret_store.delete(scope, &handle).await.is_err() {
+            tracing::warn!(
+                provider = self.provider_id(),
+                flow_id = %flow_id,
+                "failed to clean up OAuth gate PKCE verifier after flow creation failure"
+            );
+        }
     }
 
     async fn pkce_verifier_for_flow(
@@ -336,4 +351,184 @@ fn challenge_view_from_flow(flow: &AuthFlowRecord) -> Result<AuthChallengeView, 
 fn pkce_secret_handle(flow_id: AuthFlowId) -> Result<SecretHandle, AuthProductError> {
     SecretHandle::new(format!("google-oauth-gate-flow-pkce-{flow_id}"))
         .map_err(|_| AuthProductError::BackendUnavailable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_auth::{
+        AuthFlowStatus, GOOGLE_CALENDAR_READONLY_SCOPE, InMemoryAuthProductServices,
+        OAuthAuthorizationUrl,
+    };
+    use ironclaw_host_api::{
+        AgentId, ExtensionId, RuntimeCredentialAccountProviderId, TenantId, ThreadId, UserId,
+    };
+    use ironclaw_secrets::InMemorySecretStore;
+
+    #[tokio::test]
+    async fn google_oauth_gate_replaces_expired_turn_gate_flow() {
+        let fixture = GateFixture::new(None);
+        let expired_flow_id = AuthFlowId::new();
+        let expired_scope = fixture.auth_scope();
+        fixture
+            .flow_manager
+            .create_flow(NewAuthFlow {
+                id: Some(expired_flow_id),
+                scope: expired_scope.clone(),
+                kind: AuthFlowKind::IntegrationCredential,
+                provider: AuthProviderId::new(ironclaw_auth::GOOGLE_PROVIDER_ID).unwrap(),
+                challenge: AuthChallenge::OAuthUrl {
+                    authorization_url: OAuthAuthorizationUrl::new(
+                        "https://accounts.google.com/o/oauth2/v2/auth?state=expired".to_string(),
+                    )
+                    .unwrap(),
+                    expires_at: Utc::now() - ChronoDuration::seconds(1),
+                },
+                continuation: AuthContinuationRef::TurnGateResume {
+                    turn_run_ref: TurnRunRef::new(fixture.run_id.to_string()).unwrap(),
+                    gate_ref: fixture.gate_ref.clone(),
+                },
+                update_binding: None,
+                opaque_state_hash: None,
+                pkce_verifier_hash: None,
+                expires_at: Utc::now() - ChronoDuration::seconds(1),
+            })
+            .await
+            .unwrap();
+
+        let challenge = fixture.challenge().await;
+
+        assert_ne!(
+            challenge.authorization_url.unwrap().as_str(),
+            "https://accounts.google.com/o/oauth2/v2/auth?state=expired"
+        );
+        let expired = fixture
+            .shared
+            .get_flow(&expired_scope, expired_flow_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(expired.status, AuthFlowStatus::Canceled);
+        assert_eq!(fixture.active_gate_flows().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn google_oauth_gate_reuses_one_flow_under_concurrent_challenges() {
+        let fixture = GateFixture::new(None);
+
+        let (left, right) = tokio::join!(fixture.challenge(), fixture.challenge());
+        let left = left.authorization_url.unwrap();
+        let right = right.authorization_url.unwrap();
+
+        assert_eq!(left, right);
+        assert_eq!(fixture.active_gate_flows().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn google_oauth_gate_authorization_url_keeps_hosted_domain_hint() {
+        let fixture = GateFixture::new(Some("example.com"));
+
+        let challenge = fixture.challenge().await;
+        let authorization_url = challenge.authorization_url.unwrap();
+        let parsed = url::Url::parse(authorization_url.as_str()).unwrap();
+
+        assert!(
+            parsed
+                .query_pairs()
+                .any(|(name, value)| name == "hd" && value == "example.com")
+        );
+    }
+
+    struct GateFixture {
+        shared: Arc<InMemoryAuthProductServices>,
+        flow_manager: Arc<dyn AuthFlowManager>,
+        flow_source: Arc<dyn AuthFlowRecordSource>,
+        provider: GoogleOAuthGateProvider,
+        scope: TurnScope,
+        owner_user_id: UserId,
+        run_id: TurnRunId,
+        gate_ref: AuthGateRef,
+        requirement: RuntimeCredentialAuthRequirement,
+    }
+
+    impl GateFixture {
+        fn new(hosted_domain_hint: Option<&str>) -> Self {
+            let shared = Arc::new(InMemoryAuthProductServices::new());
+            let flow_manager: Arc<dyn AuthFlowManager> = shared.clone();
+            let flow_source: Arc<dyn AuthFlowRecordSource> = shared.clone();
+            let mut client = OAuthClientConfig::new(
+                "google-client.apps.googleusercontent.com",
+                "http://127.0.0.1:3000/api/reborn/product-auth/oauth/google/callback",
+                None,
+            )
+            .unwrap();
+            if let Some(hosted_domain_hint) = hosted_domain_hint {
+                client = client.with_hosted_domain_hint(hosted_domain_hint);
+            }
+            Self {
+                shared,
+                flow_manager,
+                flow_source,
+                provider: GoogleOAuthGateProvider::new(
+                    client,
+                    Arc::new(InMemorySecretStore::new()),
+                ),
+                scope: TurnScope::new(
+                    TenantId::new("tenant-alpha").unwrap(),
+                    Some(AgentId::new("agent-alpha").unwrap()),
+                    None,
+                    ThreadId::new("thread-alpha").unwrap(),
+                ),
+                owner_user_id: UserId::new("user-alpha").unwrap(),
+                run_id: TurnRunId::new(),
+                gate_ref: AuthGateRef::new("gate:google-auth").unwrap(),
+                requirement: RuntimeCredentialAuthRequirement {
+                    provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                    requester_extension: ExtensionId::new("google-calendar").unwrap(),
+                    provider_scopes: vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()],
+                },
+            }
+        }
+
+        async fn challenge(&self) -> AuthChallengeView {
+            self.provider
+                .challenge_for_blocked_gate(
+                    OAuthGateChallengeRequest {
+                        flow_manager: &self.flow_manager,
+                        flow_source: &self.flow_source,
+                        requirements: std::slice::from_ref(&self.requirement),
+                        scope: &self.scope,
+                        owner_user_id: &self.owner_user_id,
+                        run_id: self.run_id,
+                        gate_ref: &self.gate_ref,
+                    },
+                    &self.requirement,
+                )
+                .await
+                .unwrap()
+        }
+
+        fn auth_scope(&self) -> AuthProductScope {
+            auth_scope_for_blocked_turn(&self.scope, &self.owner_user_id)
+        }
+
+        async fn active_gate_flows(&self) -> Vec<AuthFlowRecord> {
+            let auth_scope = self.auth_scope();
+            let turn_run_ref = TurnRunRef::new(self.run_id.to_string()).unwrap();
+            let query = turn_gate_query(&auth_scope, &self.scope, &turn_run_ref, &self.gate_ref);
+            self.shared
+                .flows_for_owner(query.owner)
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|flow| {
+                    flow.status == AuthFlowStatus::AwaitingUser
+                        && matches!(
+                            flow.continuation,
+                            AuthContinuationRef::TurnGateResume { .. }
+                        )
+                })
+                .collect()
+        }
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/oauth_gate.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_gate.rs
@@ -1,0 +1,339 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use ironclaw_auth::{
+    AuthChallenge, AuthContinuationRef, AuthFlowId, AuthFlowKind, AuthFlowManager,
+    AuthFlowOwnerScope, AuthFlowRecord, AuthFlowRecordSource, AuthGateRef, AuthProductError,
+    AuthProductScope, AuthProviderId, AuthSurface, CredentialAccountLabel,
+    GoogleOAuthCallbackState, NewAuthFlow, PkceVerifierSecret, ProviderScope,
+    TurnGateAuthFlowQuery, TurnRunRef, build_google_authorization_url, opaque_state_hash,
+    pkce_s256_challenge, pkce_verifier_hash,
+};
+use ironclaw_host_api::{
+    InvocationId, ResourceScope, RuntimeCredentialAuthRequirement, SecretHandle,
+};
+use ironclaw_product_adapters::AuthPromptChallengeKind;
+use ironclaw_secrets::{SecretMaterial, SecretStore};
+use ironclaw_turns::{TurnRunId, TurnScope};
+use secrecy::SecretString;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::input::OAuthClientConfig;
+use crate::projection::AuthChallengeView;
+
+const GATE_FLOW_TTL_SECONDS: i64 = 600;
+
+#[derive(Clone)]
+pub(crate) struct OAuthGateProviderRegistry {
+    providers: BTreeMap<String, Arc<GoogleOAuthGateProvider>>,
+}
+
+impl OAuthGateProviderRegistry {
+    pub(crate) fn new(providers: Vec<Arc<GoogleOAuthGateProvider>>) -> Self {
+        Self {
+            providers: providers
+                .into_iter()
+                .map(|provider| (provider.provider_id().to_string(), provider))
+                .collect(),
+        }
+    }
+
+    pub(crate) async fn challenge_for_blocked_gate(
+        &self,
+        request: OAuthGateChallengeRequest<'_>,
+    ) -> Result<Option<AuthChallengeView>, AuthProductError> {
+        let [requirement] = request.requirements else {
+            return Ok(None);
+        };
+        let Some(provider) = self.providers.get(requirement.provider.as_str()) else {
+            return Ok(None);
+        };
+        provider
+            .challenge_for_blocked_gate(request, requirement)
+            .await
+            .map(Some)
+    }
+
+    pub(crate) async fn pkce_verifier_for_flow(
+        &self,
+        scope: &AuthProductScope,
+        provider: &AuthProviderId,
+        flow_id: AuthFlowId,
+    ) -> Result<Option<SecretString>, AuthProductError> {
+        let Some(provider) = self.providers.get(provider.as_str()) else {
+            return Ok(None);
+        };
+        provider.pkce_verifier_for_flow(scope, flow_id).await
+    }
+}
+
+impl fmt::Debug for OAuthGateProviderRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OAuthGateProviderRegistry")
+            .field("providers", &self.providers.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+pub(crate) struct OAuthGateChallengeRequest<'a> {
+    pub(crate) flow_manager: &'a Arc<dyn AuthFlowManager>,
+    pub(crate) flow_source: &'a Arc<dyn AuthFlowRecordSource>,
+    pub(crate) requirements: &'a [RuntimeCredentialAuthRequirement],
+    pub(crate) scope: &'a TurnScope,
+    pub(crate) owner_user_id: &'a ironclaw_host_api::UserId,
+    pub(crate) run_id: TurnRunId,
+    pub(crate) gate_ref: &'a AuthGateRef,
+}
+
+#[derive(Clone)]
+pub(crate) struct GoogleOAuthGateProvider {
+    client: OAuthClientConfig,
+    secret_store: Arc<dyn SecretStore>,
+    setup_lock: Arc<AsyncMutex<()>>,
+}
+
+impl GoogleOAuthGateProvider {
+    pub(crate) fn new(client: OAuthClientConfig, secret_store: Arc<dyn SecretStore>) -> Self {
+        Self {
+            client,
+            secret_store,
+            setup_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    fn provider_id(&self) -> &'static str {
+        ironclaw_auth::GOOGLE_PROVIDER_ID
+    }
+
+    async fn challenge_for_blocked_gate(
+        &self,
+        request: OAuthGateChallengeRequest<'_>,
+        requirement: &RuntimeCredentialAuthRequirement,
+    ) -> Result<AuthChallengeView, AuthProductError> {
+        let auth_scope = auth_scope_for_blocked_turn(request.scope, request.owner_user_id);
+        let turn_run_ref = TurnRunRef::new(request.run_id.to_string())?;
+        let query = turn_gate_query(&auth_scope, request.scope, &turn_run_ref, request.gate_ref);
+        if let Some(existing) = request
+            .flow_source
+            .flow_for_turn_gate(query.clone())
+            .await?
+        {
+            return challenge_view_from_flow(&existing);
+        }
+
+        let _setup_guard = self.setup_lock.lock().await;
+        if let Some(existing) = request
+            .flow_source
+            .flow_for_turn_gate(query.clone())
+            .await?
+        {
+            return challenge_view_from_flow(&existing);
+        }
+
+        let flow_id = AuthFlowId::new();
+        let scopes = provider_scopes(&requirement.provider_scopes)?;
+        let prepared = self.prepare_flow(&auth_scope, flow_id, scopes).await?;
+        let expires_at = Utc::now() + ChronoDuration::seconds(GATE_FLOW_TTL_SECONDS);
+        let flow = match request
+            .flow_manager
+            .create_flow(NewAuthFlow {
+                id: Some(flow_id),
+                scope: auth_scope.clone(),
+                kind: AuthFlowKind::IntegrationCredential,
+                provider: AuthProviderId::new(self.provider_id())?,
+                challenge: AuthChallenge::OAuthUrl {
+                    authorization_url: prepared.authorization_url,
+                    expires_at,
+                },
+                continuation: AuthContinuationRef::TurnGateResume {
+                    turn_run_ref,
+                    gate_ref: request.gate_ref.clone(),
+                },
+                update_binding: None,
+                opaque_state_hash: Some(prepared.opaque_state_hash),
+                pkce_verifier_hash: Some(prepared.pkce_verifier_hash),
+                expires_at,
+            })
+            .await
+        {
+            Ok(flow) => flow,
+            Err(AuthProductError::BackendConflict) => request
+                .flow_source
+                .flow_for_turn_gate(query)
+                .await?
+                .ok_or(AuthProductError::BackendConflict)?,
+            Err(error) => return Err(error),
+        };
+
+        if flow.id == flow_id
+            && let Err(error) = self
+                .store_pkce_verifier(&flow.scope.resource, flow_id, prepared.pkce_verifier)
+                .await
+        {
+            if request
+                .flow_manager
+                .cancel_flow(&flow.scope, flow_id)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    provider = self.provider_id(),
+                    flow_id = %flow_id,
+                    "failed to cancel OAuth gate flow after PKCE storage failure"
+                );
+            }
+            return Err(error);
+        }
+
+        challenge_view_from_flow(&flow)
+    }
+
+    async fn prepare_flow(
+        &self,
+        scope: &AuthProductScope,
+        flow_id: AuthFlowId,
+        scopes: Vec<ProviderScope>,
+    ) -> Result<PreparedOAuthGateFlow, AuthProductError> {
+        let account_label = CredentialAccountLabel::new("google")?;
+        let state =
+            GoogleOAuthCallbackState::new(flow_id, scope.clone(), account_label, scopes.clone())?
+                .encode()?;
+        let opaque_state_hash = opaque_state_hash(state.as_str())?;
+        let pkce_verifier = SecretString::from(ironclaw_common::pkce::generate_code_verifier());
+        let pkce_secret = PkceVerifierSecret::new(pkce_verifier.clone())?;
+        let pkce_verifier_hash = pkce_verifier_hash(&pkce_secret)?;
+        let pkce_challenge = pkce_s256_challenge(&pkce_secret);
+        let authorization_url = build_google_authorization_url(
+            self.client.client_id.as_str(),
+            self.client.redirect_uri.as_str(),
+            state.as_str(),
+            &pkce_challenge,
+            &scopes,
+            None,
+        )?;
+        Ok(PreparedOAuthGateFlow {
+            authorization_url,
+            opaque_state_hash,
+            pkce_verifier_hash,
+            pkce_verifier,
+        })
+    }
+
+    async fn store_pkce_verifier(
+        &self,
+        scope: &ResourceScope,
+        flow_id: AuthFlowId,
+        material: SecretMaterial,
+    ) -> Result<(), AuthProductError> {
+        self.secret_store
+            .put(scope.clone(), pkce_secret_handle(flow_id)?, material)
+            .await
+            .map(|_| ())
+            .map_err(|_| AuthProductError::BackendUnavailable)
+    }
+
+    async fn pkce_verifier_for_flow(
+        &self,
+        scope: &AuthProductScope,
+        flow_id: AuthFlowId,
+    ) -> Result<Option<SecretString>, AuthProductError> {
+        let handle = pkce_secret_handle(flow_id)?;
+        let lease = match self.secret_store.lease_once(&scope.resource, &handle).await {
+            Ok(lease) => lease,
+            Err(error) if error.is_unknown_secret() => return Ok(None),
+            Err(_) => return Err(AuthProductError::BackendUnavailable),
+        };
+        self.secret_store
+            .consume(&scope.resource, lease.id)
+            .await
+            .map(Some)
+            .map_err(|_| AuthProductError::BackendUnavailable)
+    }
+}
+
+impl fmt::Debug for GoogleOAuthGateProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GoogleOAuthGateProvider")
+            .field("client_id", &self.client.client_id.as_str())
+            .field("redirect_uri", &self.client.redirect_uri)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+struct PreparedOAuthGateFlow {
+    authorization_url: ironclaw_auth::OAuthAuthorizationUrl,
+    opaque_state_hash: ironclaw_auth::OpaqueStateHash,
+    pkce_verifier_hash: ironclaw_auth::PkceVerifierHash,
+    pkce_verifier: SecretString,
+}
+
+fn auth_scope_for_blocked_turn(
+    scope: &TurnScope,
+    owner_user_id: &ironclaw_host_api::UserId,
+) -> AuthProductScope {
+    AuthProductScope::new(
+        ResourceScope {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: owner_user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            mission_id: None,
+            thread_id: Some(scope.thread_id.clone()),
+            invocation_id: InvocationId::new(),
+        },
+        AuthSurface::Callback,
+    )
+}
+
+fn turn_gate_query(
+    auth_scope: &AuthProductScope,
+    turn_scope: &TurnScope,
+    turn_run_ref: &TurnRunRef,
+    gate_ref: &AuthGateRef,
+) -> TurnGateAuthFlowQuery {
+    TurnGateAuthFlowQuery {
+        owner: AuthFlowOwnerScope {
+            tenant_id: auth_scope.resource.tenant_id.clone(),
+            user_id: auth_scope.resource.user_id.clone(),
+            agent_id: auth_scope.resource.agent_id.clone(),
+            project_id: auth_scope.resource.project_id.clone(),
+            thread_id: turn_scope.thread_id.clone(),
+        },
+        turn_run_ref: turn_run_ref.clone(),
+        gate_ref: gate_ref.clone(),
+        include_terminal: false,
+    }
+}
+
+fn provider_scopes(raw_scopes: &[String]) -> Result<Vec<ProviderScope>, AuthProductError> {
+    raw_scopes
+        .iter()
+        .map(|scope| ProviderScope::new(scope.clone()))
+        .collect()
+}
+
+fn challenge_view_from_flow(flow: &AuthFlowRecord) -> Result<AuthChallengeView, AuthProductError> {
+    match flow.challenge.as_ref() {
+        Some(AuthChallenge::OAuthUrl {
+            authorization_url,
+            expires_at,
+        }) => Ok(AuthChallengeView {
+            kind: AuthPromptChallengeKind::OAuthUrl,
+            provider: flow.provider.clone(),
+            account_label: None,
+            authorization_url: Some(authorization_url.clone()),
+            expires_at: Some(*expires_at),
+        }),
+        Some(_) | None => Err(AuthProductError::BackendUnavailable),
+    }
+}
+
+fn pkce_secret_handle(flow_id: AuthFlowId) -> Result<SecretHandle, AuthProductError> {
+    SecretHandle::new(format!("google-oauth-gate-flow-pkce-{flow_id}"))
+        .map_err(|_| AuthProductError::BackendUnavailable)
+}

--- a/crates/ironclaw_reborn_composition/src/oauth_gate.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_gate.rs
@@ -44,16 +44,16 @@ impl GoogleOAuthGateProviderRegistry {
         &self,
         request: OAuthGateChallengeRequest<'_>,
     ) -> Result<Option<AuthChallengeView>, AuthProductError> {
-        let [requirement] = request.requirements else {
-            return Ok(None);
-        };
-        let Some(provider) = self.providers.get(requirement.provider.as_str()) else {
-            return Ok(None);
-        };
-        provider
-            .challenge_for_blocked_gate(request, requirement)
-            .await
-            .map(Some)
+        for requirement in request.requirements {
+            let Some(provider) = self.providers.get(requirement.provider.as_str()) else {
+                continue;
+            };
+            return provider
+                .challenge_for_blocked_gate(request, requirement)
+                .await
+                .map(Some);
+        }
+        Ok(None)
     }
 
     pub(crate) async fn pkce_verifier_for_flow(
@@ -437,6 +437,36 @@ mod tests {
                 .query_pairs()
                 .any(|(name, value)| name == "hd" && value == "example.com")
         );
+    }
+
+    #[tokio::test]
+    async fn google_oauth_gate_registry_uses_registered_requirement_when_multiple_present() {
+        let fixture = GateFixture::new(None);
+        let registry =
+            GoogleOAuthGateProviderRegistry::new(vec![Arc::new(fixture.provider.clone())]);
+        let unsupported_requirement = RuntimeCredentialAuthRequirement {
+            provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+            requester_extension: ExtensionId::new("github").unwrap(),
+            provider_scopes: Vec::new(),
+        };
+        let requirements = vec![unsupported_requirement, fixture.requirement.clone()];
+
+        let challenge = registry
+            .challenge_for_blocked_gate(OAuthGateChallengeRequest {
+                flow_manager: &fixture.flow_manager,
+                flow_source: &fixture.flow_source,
+                requirements: &requirements,
+                scope: &fixture.scope,
+                owner_user_id: &fixture.owner_user_id,
+                run_id: fixture.run_id,
+                gate_ref: &fixture.gate_ref,
+            })
+            .await
+            .unwrap()
+            .expect("google requirement should produce a challenge");
+
+        assert_eq!(challenge.kind, AuthPromptChallengeKind::OAuthUrl);
+        assert_eq!(fixture.active_gate_flows().await.len(), 1);
     }
 
     struct GateFixture {

--- a/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
@@ -16,14 +16,14 @@ use ironclaw_secrets::SecretStore;
 use crate::RebornBuildError;
 use crate::input::{OAuthDcrProviderBackendConfig, OAuthProviderBackendConfig};
 use crate::oauth_dcr::{OAuthDcrProvider, OAuthDcrProviderRegistry};
-use crate::oauth_gate::{GoogleOAuthGateProvider, OAuthGateProviderRegistry};
+use crate::oauth_gate::{GoogleOAuthGateProvider, GoogleOAuthGateProviderRegistry};
 use crate::oauth_provider_client::HostOAuthProviderClient;
 
 #[derive(Clone)]
 pub(crate) struct OAuthProviderComposition {
     pub(crate) client: Option<Arc<dyn AuthProviderClient>>,
     pub(crate) dcr_registry: Option<Arc<OAuthDcrProviderRegistry>>,
-    pub(crate) gate_registry: Option<Arc<OAuthGateProviderRegistry>>,
+    pub(crate) gate_registry: Option<Arc<GoogleOAuthGateProviderRegistry>>,
 }
 
 pub(crate) fn compose_provider_client(
@@ -108,7 +108,7 @@ fn compose_provider_client_with_runtime(
     let dcr_registry =
         (!dcr_providers.is_empty()).then(|| Arc::new(OAuthDcrProviderRegistry::new(dcr_providers)));
     let gate_registry = (!gate_providers.is_empty())
-        .then(|| Arc::new(OAuthGateProviderRegistry::new(gate_providers)));
+        .then(|| Arc::new(GoogleOAuthGateProviderRegistry::new(gate_providers)));
     Ok(OAuthProviderComposition {
         client: compose_provider_clients(clients),
         dcr_registry,

--- a/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
@@ -229,17 +229,22 @@ mod tests {
     use crate::OAuthClientConfig;
     use crate::google_oauth::google_provider_spec;
     use crate::notion_oauth::{NOTION_PROVIDER_ID, notion_provider_spec};
+    use crate::oauth_gate::OAuthGateChallengeRequest;
     use ironclaw_auth::{
-        AuthProductScope, AuthProviderId, AuthSurface, AuthorizationCodeHash,
-        CredentialAccountLabel, OAuthAuthorizationCode, OAuthClientId, OAuthRedirectUri,
+        AuthFlowManager, AuthFlowRecordSource, AuthGateRef, AuthProductScope, AuthProviderId,
+        AuthSurface, AuthorizationCodeHash, CredentialAccountLabel, GOOGLE_CALENDAR_READONLY_SCOPE,
+        InMemoryAuthProductServices, OAuthAuthorizationCode, OAuthClientId, OAuthRedirectUri,
         PkceVerifierHash, PkceVerifierSecret, ProviderScope,
     };
     use ironclaw_capabilities::{CapabilityObligationError, CapabilityObligationRequest};
     use ironclaw_host_api::{
-        InvocationId, ResourceScope, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
-        RuntimeHttpEgressResponse, TenantId, UserId,
+        AgentId, ExtensionId, InvocationId, ResourceScope, RuntimeCredentialAccountProviderId,
+        RuntimeCredentialAuthRequirement, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+        RuntimeHttpEgressResponse, TenantId, ThreadId, UserId,
     };
+    use ironclaw_product_adapters::AuthPromptChallengeKind;
     use ironclaw_secrets::InMemorySecretStore;
+    use ironclaw_turns::{TurnRunId, TurnScope};
     use secrecy::SecretString;
     use std::sync::Mutex;
 
@@ -315,11 +320,69 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn compose_provider_client_registers_google_oauth_gate_provider() {
+        let composition = compose_provider_client_with_runtime(
+            vec![OAuthProviderBackendConfig {
+                spec: google_provider_spec(),
+                client: oauth_client("google-client", "https://app.example/oauth/google"),
+            }],
+            Vec::new(),
+            Arc::new(InMemorySecretStore::new()),
+            OAuthProviderRuntimePorts::new(
+                Arc::new(RecordingEgress::ok(Vec::new())),
+                Arc::new(NoopObligationHandler),
+            ),
+        )
+        .expect("provider composition");
+        let registry = composition.gate_registry.expect("google gate registry");
+        let shared = Arc::new(InMemoryAuthProductServices::new());
+        let flow_manager: Arc<dyn AuthFlowManager> = shared.clone();
+        let flow_source: Arc<dyn AuthFlowRecordSource> = shared;
+        let scope = TurnScope::new(
+            TenantId::new("tenant-a").unwrap(),
+            Some(AgentId::new("agent-a").unwrap()),
+            None,
+            ThreadId::new("thread-a").unwrap(),
+        );
+        let owner_user_id = UserId::new("user-a").unwrap();
+        let run_id = TurnRunId::new();
+        let gate_ref = AuthGateRef::new("gate:google-auth").unwrap();
+        let requirements = vec![RuntimeCredentialAuthRequirement {
+            provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+            requester_extension: ExtensionId::new("google-calendar").unwrap(),
+            provider_scopes: vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()],
+        }];
+
+        let view = registry
+            .challenge_for_blocked_gate(OAuthGateChallengeRequest {
+                flow_manager: &flow_manager,
+                flow_source: &flow_source,
+                requirements: &requirements,
+                scope: &scope,
+                owner_user_id: &owner_user_id,
+                run_id,
+                gate_ref: &gate_ref,
+            })
+            .await
+            .expect("gate challenge")
+            .expect("google oauth challenge");
+
+        assert_eq!(view.kind, AuthPromptChallengeKind::OAuthUrl);
+        assert_eq!(view.provider.as_str(), "google");
+        assert!(
+            view.authorization_url
+                .as_ref()
+                .is_some_and(|url| url.as_str().starts_with("https://accounts.google.com/"))
+        );
+    }
+
     fn oauth_client(client_id: &str, redirect_uri: &str) -> OAuthClientConfig {
         OAuthClientConfig {
             client_id: OAuthClientId::new(client_id).unwrap(),
             client_secret: None,
             redirect_uri: OAuthRedirectUri::new(redirect_uri).unwrap(),
+            hosted_domain_hint: None,
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_providers.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_auth::{
-    AuthProductError, AuthProviderClient, OAuthProviderCallbackRequest, OAuthProviderExchange,
-    OAuthProviderExchangeContext, OAuthProviderRefresh, OAuthProviderRefreshRequest,
+    AuthProductError, AuthProviderClient, GOOGLE_PROVIDER_ID, OAuthProviderCallbackRequest,
+    OAuthProviderExchange, OAuthProviderExchangeContext, OAuthProviderRefresh,
+    OAuthProviderRefreshRequest,
 };
 use ironclaw_capabilities::CapabilityObligationHandler;
 use ironclaw_host_api::RuntimeHttpEgress;
@@ -15,12 +16,14 @@ use ironclaw_secrets::SecretStore;
 use crate::RebornBuildError;
 use crate::input::{OAuthDcrProviderBackendConfig, OAuthProviderBackendConfig};
 use crate::oauth_dcr::{OAuthDcrProvider, OAuthDcrProviderRegistry};
+use crate::oauth_gate::{GoogleOAuthGateProvider, OAuthGateProviderRegistry};
 use crate::oauth_provider_client::HostOAuthProviderClient;
 
 #[derive(Clone)]
 pub(crate) struct OAuthProviderComposition {
     pub(crate) client: Option<Arc<dyn AuthProviderClient>>,
     pub(crate) dcr_registry: Option<Arc<OAuthDcrProviderRegistry>>,
+    pub(crate) gate_registry: Option<Arc<OAuthGateProviderRegistry>>,
 }
 
 pub(crate) fn compose_provider_client(
@@ -44,8 +47,15 @@ fn compose_provider_client_with_runtime(
     runtime_ports: OAuthProviderRuntimePorts,
 ) -> Result<OAuthProviderComposition, RebornBuildError> {
     let mut clients = Vec::new();
+    let mut gate_providers = Vec::new();
     for config in configs {
         let provider_id = config.spec.provider_id;
+        if provider_id == GOOGLE_PROVIDER_ID {
+            gate_providers.push(Arc::new(GoogleOAuthGateProvider::new(
+                config.client.clone(),
+                Arc::clone(&secret_store),
+            )));
+        }
         let mut client = HostOAuthProviderClient::new(
             config.spec,
             runtime_ports.runtime_http_egress(),
@@ -97,9 +107,12 @@ fn compose_provider_client_with_runtime(
     }
     let dcr_registry =
         (!dcr_providers.is_empty()).then(|| Arc::new(OAuthDcrProviderRegistry::new(dcr_providers)));
+    let gate_registry = (!gate_providers.is_empty())
+        .then(|| Arc::new(OAuthGateProviderRegistry::new(gate_providers)));
     Ok(OAuthProviderComposition {
         client: compose_provider_clients(clients),
         dcr_registry,
+        gate_registry,
     })
 }
 

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
@@ -308,22 +308,16 @@ pub(super) async fn google_oauth_callback_handler(
         state.remove_pkce_verifier(flow_id);
         return Err(ProductAuthRouteFailure::malformed_callback());
     };
-    let pkce_verifier = match state.pkce_verifier_for_callback(flow_id) {
-        Ok(pkce_verifier) => pkce_verifier,
-        Err(_) => match run_with_backend_timeout(state.product_auth.oauth_pkce_verifier_for_flow(
-            callback_scope,
-            &provider,
-            flow_id,
-        ))
-        .await?
+    let pkce_verifier =
+        match pkce_verifier_for_known_callback_flow(&state, callback_scope, &provider, flow_id)
+            .await
         {
-            Some(pkce_verifier) => pkce_verifier,
-            None => {
+            Ok(pkce_verifier) => pkce_verifier,
+            Err(error) => {
                 state.remove_pkce_verifier(flow_id);
-                return Err(ProductAuthRouteFailure::unknown_or_expired_flow());
+                return Err(error);
             }
-        },
-    };
+        };
     let callback_scopes = match parse_google_callback_scopes(query.scopes.as_deref()) {
         Ok(callback_scopes) => {
             callback_scopes.unwrap_or_else(|| callback_state.requested_scopes().to_vec())
@@ -406,14 +400,13 @@ pub(super) async fn callback_outcome_from_query(
         .code
         .as_ref()
         .ok_or_else(ProductAuthRouteFailure::malformed_callback)?;
-    let pkce_verifier = match state.pkce_verifier_for_callback(flow_id) {
-        Ok(verifier) => verifier,
-        Err(cache_error) => state
-            .product_auth
-            .oauth_pkce_verifier_for_flow(scope, flow_provider.unwrap_or(&provider), flow_id)
-            .await?
-            .ok_or(cache_error)?,
-    };
+    let pkce_verifier = pkce_verifier_for_known_callback_flow(
+        state,
+        scope,
+        flow_provider.unwrap_or(&provider),
+        flow_id,
+    )
+    .await?;
     let scopes = parse_provider_scopes(query.scopes.as_deref())?;
     let authorization_code_hash = authorization_code_hash(code.expose_secret())?;
     let pkce_verifier_hash = pkce_verifier_hash(pkce_verifier.expose_secret())?;
@@ -432,6 +425,25 @@ pub(super) async fn callback_outcome_from_query(
             scopes,
         },
     })
+}
+
+async fn pkce_verifier_for_known_callback_flow(
+    state: &ProductAuthRouteState,
+    scope: &AuthProductScope,
+    provider: &AuthProviderId,
+    flow_id: AuthFlowId,
+) -> Result<SecretString, ProductAuthRouteFailure> {
+    let cache_error = match state.pkce_verifier_for_callback(flow_id) {
+        Ok(verifier) => return Ok(verifier),
+        Err(error) => error,
+    };
+    run_with_backend_timeout(
+        state
+            .product_auth
+            .oauth_pkce_verifier_for_flow(scope, provider, flow_id),
+    )
+    .await?
+    .ok_or(cache_error)
 }
 
 fn validate_google_callback_query_fields(
@@ -481,7 +493,7 @@ mod tests {
     use super::*;
     use crate::RebornAuthContinuationDispatcher;
     use crate::input::OAuthClientConfig;
-    use crate::oauth_gate::{GoogleOAuthGateProvider, OAuthGateProviderRegistry};
+    use crate::oauth_gate::{GoogleOAuthGateProvider, GoogleOAuthGateProviderRegistry};
     use crate::projection::AuthChallengeProvider;
     use async_trait::async_trait;
     use ironclaw_auth::{GOOGLE_CALENDAR_READONLY_SCOPE, InMemoryAuthProductServices};
@@ -508,7 +520,7 @@ mod tests {
         let product_auth = Arc::new(
             RebornProductAuthServices::from_shared(shared.clone(), dispatcher.clone())
                 .with_flow_record_source(shared)
-                .with_oauth_gate_registry(Arc::new(OAuthGateProviderRegistry::new(vec![
+                .with_oauth_gate_registry(Arc::new(GoogleOAuthGateProviderRegistry::new(vec![
                     google_gate,
                 ]))),
         );

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
@@ -475,3 +475,132 @@ pub(super) fn should_forget_pkce_verifier(code: AuthErrorCode) -> bool {
             | AuthErrorCode::AccountSelectionRequired
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RebornAuthContinuationDispatcher;
+    use crate::input::OAuthClientConfig;
+    use crate::oauth_gate::{GoogleOAuthGateProvider, OAuthGateProviderRegistry};
+    use crate::projection::AuthChallengeProvider;
+    use async_trait::async_trait;
+    use ironclaw_auth::{GOOGLE_CALENDAR_READONLY_SCOPE, InMemoryAuthProductServices};
+    use ironclaw_host_api::{RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement};
+    use ironclaw_secrets::{InMemorySecretStore, SecretStore};
+    use ironclaw_turns::{TurnRunId, TurnScope};
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn google_oauth_callback_uses_gate_pkce_store_when_route_cache_misses() {
+        let shared = Arc::new(InMemoryAuthProductServices::new());
+        let secret_store = Arc::new(InMemorySecretStore::new());
+        let secret_store_for_provider: Arc<dyn SecretStore> = secret_store.clone();
+        let dispatcher = Arc::new(RecordingDispatcher::default());
+        let google_gate = Arc::new(GoogleOAuthGateProvider::new(
+            OAuthClientConfig::new(
+                "google-client.apps.googleusercontent.com",
+                "http://127.0.0.1:3000/api/reborn/product-auth/oauth/google/callback",
+                None,
+            )
+            .expect("google oauth client"),
+            secret_store_for_provider,
+        ));
+        let product_auth = Arc::new(
+            RebornProductAuthServices::from_shared(shared.clone(), dispatcher.clone())
+                .with_flow_record_source(shared)
+                .with_oauth_gate_registry(Arc::new(OAuthGateProviderRegistry::new(vec![
+                    google_gate,
+                ]))),
+        );
+        let state = ProductAuthRouteState::new(
+            product_auth.clone(),
+            TenantId::new("tenant-alpha").expect("tenant"),
+            None,
+            None,
+        );
+        let turn_scope = TurnScope::new(
+            TenantId::new("tenant-alpha").expect("tenant"),
+            None,
+            None,
+            ThreadId::new("thread-alpha").expect("thread"),
+        );
+        let owner_user_id = UserId::new("user-alpha").expect("user");
+        let run_id = TurnRunId::new();
+        let gate_ref = "gate:google-auth";
+        let requirements = vec![RuntimeCredentialAuthRequirement {
+            provider: RuntimeCredentialAccountProviderId::new("google").expect("provider"),
+            requester_extension: ExtensionId::new("google-calendar").expect("extension"),
+            provider_scopes: vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()],
+        }];
+
+        let challenge = product_auth
+            .challenge_for_gate(&turn_scope, &owner_user_id, run_id, gate_ref, &requirements)
+            .await
+            .expect("challenge lookup")
+            .expect("google oauth challenge");
+        let authorization_url = challenge.authorization_url.expect("authorization url");
+        let state_value = Url::parse(authorization_url.as_str())
+            .expect("authorization url")
+            .query_pairs()
+            .find_map(|(name, value)| (name == "state").then(|| value.into_owned()))
+            .expect("oauth state");
+        let encoded_state =
+            url::form_urlencoded::byte_serialize(state_value.as_bytes()).collect::<String>();
+        let encoded_scope =
+            url::form_urlencoded::byte_serialize(GOOGLE_CALENDAR_READONLY_SCOPE.as_bytes())
+                .collect::<String>();
+        let uri = format!(
+            "{GOOGLE_OAUTH_CALLBACK_PATH}?state={encoded_state}&code=google-auth-code&scope={encoded_scope}"
+        )
+        .parse::<Uri>()
+        .expect("callback uri");
+
+        let response = google_oauth_callback_handler(
+            State(state),
+            RawQuery(uri.query().map(str::to_string)),
+            uri,
+        )
+        .await
+        .expect("google callback")
+        .0;
+
+        assert_eq!(response.status, AuthFlowStatus::Completed);
+        let events = dispatcher.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].continuation,
+            AuthContinuationRef::TurnGateResume {
+                turn_run_ref: TurnRunRef::new(run_id.to_string()).expect("run ref"),
+                gate_ref: AuthGateRef::new(gate_ref).expect("gate ref"),
+            }
+        );
+    }
+
+    #[derive(Default)]
+    struct RecordingDispatcher {
+        events: Mutex<Vec<ironclaw_auth::AuthContinuationEvent>>,
+    }
+
+    impl RecordingDispatcher {
+        fn events(&self) -> Vec<ironclaw_auth::AuthContinuationEvent> {
+            self.events
+                .lock()
+                .expect("recording dispatcher lock")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl RebornAuthContinuationDispatcher for RecordingDispatcher {
+        async fn dispatch_auth_continuation(
+            &self,
+            event: ironclaw_auth::AuthContinuationEvent,
+        ) -> Result<(), AuthProductError> {
+            self.events
+                .lock()
+                .expect("recording dispatcher lock")
+                .push(event);
+            Ok(())
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
@@ -291,26 +291,38 @@ pub(super) async fn google_oauth_callback_handler(
         return response.map(Json);
     }
 
-    if let Err(error) = run_with_backend_timeout(
+    let provider = match run_with_backend_timeout(
         state
             .product_auth
             .ensure_oauth_callback_flow_known(callback_scope, flow_id),
     )
     .await
     {
-        state.remove_pkce_verifier(flow_id);
-        return Err(error);
-    }
+        Ok(provider) => provider,
+        Err(error) => {
+            state.remove_pkce_verifier(flow_id);
+            return Err(error);
+        }
+    };
     let Some(code) = query.code.as_ref() else {
         state.remove_pkce_verifier(flow_id);
         return Err(ProductAuthRouteFailure::malformed_callback());
     };
     let pkce_verifier = match state.pkce_verifier_for_callback(flow_id) {
         Ok(pkce_verifier) => pkce_verifier,
-        Err(error) => {
-            state.remove_pkce_verifier(flow_id);
-            return Err(error);
-        }
+        Err(_) => match run_with_backend_timeout(state.product_auth.oauth_pkce_verifier_for_flow(
+            callback_scope,
+            &provider,
+            flow_id,
+        ))
+        .await?
+        {
+            Some(pkce_verifier) => pkce_verifier,
+            None => {
+                state.remove_pkce_verifier(flow_id);
+                return Err(ProductAuthRouteFailure::unknown_or_expired_flow());
+            }
+        },
     };
     let callback_scopes = match parse_google_callback_scopes(query.scopes.as_deref()) {
         Ok(callback_scopes) => {

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -293,7 +293,7 @@ async fn webui_event_stream_uses_credential_requirement_for_manual_token_auth_pr
 async fn webui_event_stream_creates_google_oauth_prompt_for_runtime_credential_gate() {
     use crate::OAuthClientConfig;
     use crate::auth::{RebornAuthContinuationDispatcher, RebornProductAuthServices};
-    use crate::oauth_gate::{GoogleOAuthGateProvider, OAuthGateProviderRegistry};
+    use crate::oauth_gate::{GoogleOAuthGateProvider, GoogleOAuthGateProviderRegistry};
     use async_trait::async_trait;
     use ironclaw_auth::{AuthContinuationEvent, InMemoryAuthProductServices};
     use ironclaw_secrets::InMemorySecretStore;
@@ -342,7 +342,9 @@ async fn webui_event_stream_creates_google_oauth_prompt_for_runtime_credential_g
     let product_auth = Arc::new(
         RebornProductAuthServices::from_shared(shared.clone(), Arc::new(NoopDispatcher))
             .with_flow_record_source(shared)
-            .with_oauth_gate_registry(Arc::new(OAuthGateProviderRegistry::new(vec![google_gate]))),
+            .with_oauth_gate_registry(Arc::new(GoogleOAuthGateProviderRegistry::new(vec![
+                google_gate,
+            ]))),
     );
 
     let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -290,6 +290,119 @@ async fn webui_event_stream_uses_credential_requirement_for_manual_token_auth_pr
 }
 
 #[tokio::test]
+async fn webui_event_stream_creates_google_oauth_prompt_for_runtime_credential_gate() {
+    use crate::OAuthClientConfig;
+    use crate::auth::{RebornAuthContinuationDispatcher, RebornProductAuthServices};
+    use crate::oauth_gate::{GoogleOAuthGateProvider, OAuthGateProviderRegistry};
+    use async_trait::async_trait;
+    use ironclaw_auth::{AuthContinuationEvent, InMemoryAuthProductServices};
+    use ironclaw_secrets::InMemorySecretStore;
+
+    #[derive(Debug)]
+    struct NoopDispatcher;
+
+    #[async_trait]
+    impl RebornAuthContinuationDispatcher for NoopDispatcher {
+        async fn dispatch_auth_continuation(
+            &self,
+            _event: AuthContinuationEvent,
+        ) -> Result<(), ironclaw_auth::AuthProductError> {
+            Ok(())
+        }
+    }
+
+    let tenant_id = TenantId::new("webui-events-tenant").unwrap();
+    let user_id = UserId::new("webui-events-user").unwrap();
+    let agent_id = AgentId::new("webui-events-agent").unwrap();
+    let thread_id = ThreadId::new("webui-events-google-auth-thread").unwrap();
+    let turn_run = TurnRunId::new();
+    let gate_ref = "gate:auth-required";
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+    let credential_requirements = vec![RuntimeCredentialAuthRequirement {
+        provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+        requester_extension: ExtensionId::new("google-calendar").unwrap(),
+        provider_scopes: vec!["https://www.googleapis.com/auth/calendar.readonly".to_string()],
+    }];
+
+    let shared = Arc::new(InMemoryAuthProductServices::new());
+    let google_gate = Arc::new(GoogleOAuthGateProvider::new(
+        OAuthClientConfig::new(
+            "google-client.apps.googleusercontent.com",
+            "http://127.0.0.1:3000/api/reborn/product-auth/oauth/google/callback",
+            None,
+        )
+        .unwrap(),
+        Arc::new(InMemorySecretStore::new()),
+    ));
+    let product_auth = Arc::new(
+        RebornProductAuthServices::from_shared(shared.clone(), Arc::new(NoopDispatcher))
+            .with_flow_record_source(shared)
+            .with_oauth_gate_registry(Arc::new(OAuthGateProviderRegistry::new(vec![google_gate]))),
+    );
+
+    let event_log_dyn: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let services = build_reborn_projection_services(
+        event_log_dyn,
+        ReplyTargetBindingRef::new("webui-events-reply").unwrap(),
+    )
+    .with_turn_events(
+        Arc::new(FakeTurnEventSource {
+            events: vec![TurnLifecycleEvent {
+                cursor: TurnEventCursor(1),
+                scope: scope.clone(),
+                occurred_at: Some(chrono::Utc::now()),
+                owner_user_id: Some(user_id.clone()),
+                run_id: turn_run,
+                status: TurnStatus::BlockedAuth,
+                kind: TurnEventKind::Blocked,
+                blocked_gate: Some(TurnBlockedGateMetadata {
+                    gate_ref: GateRef::new(gate_ref).unwrap(),
+                    gate_kind: TurnBlockedGateKind::Auth,
+                    credential_requirements: credential_requirements.clone(),
+                }),
+                sanitized_reason: Some("Google authentication required".to_string()),
+            }],
+        }),
+        Arc::new(FakeTurnCoordinator {
+            state: TurnRunState {
+                credential_requirements,
+                ..turn_run_state(&scope, &user_id, turn_run, TurnEventCursor(1))
+            },
+        }),
+    )
+    .with_auth_challenges(product_auth);
+
+    let events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: TurnActor::new(user_id),
+            scope,
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        event.payload(),
+        ProductOutboundPayload::AuthPrompt(prompt)
+            if prompt.turn_run_id == turn_run
+                && prompt.auth_request_ref == gate_ref
+                && prompt.challenge_kind == Some(AuthPromptChallengeKind::OAuthUrl)
+                && prompt.provider.as_deref() == Some("google")
+                && prompt.authorization_url.as_deref().is_some_and(|url|
+                    url.starts_with("https://accounts.google.com/")
+                        && url.contains("https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.readonly")
+                )
+                && prompt.account_label.is_none()
+    )), "events: {events:#?}");
+}
+
+#[tokio::test]
 async fn webui_event_stream_projects_blocked_dependent_run_status() {
     let tenant_id = TenantId::new("webui-events-tenant").unwrap();
     let user_id = UserId::new("webui-events-user").unwrap();

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -581,6 +581,7 @@ async fn production_google_oauth_config_uses_factory_built_product_auth_ports() 
             client_id: OAuthClientId::new("google-client-123").unwrap(),
             client_secret: None,
             redirect_uri: OAuthRedirectUri::new("https://app.example/oauth/callback").unwrap(),
+            hosted_domain_hint: None,
         })
         .with_production_trust_policy(production_trust_policy())
         .with_runtime_policy(production_runtime_policy())


### PR DESCRIPTION
## Summary
- add a static Google OAuth gate provider for runtime credential auth gates
- create/reuse TurnGateResume OAuth flows from Google credential requirements instead of falling back to manual-token prompts
- let Google callback load PKCE from the scoped secret-store fallback for gate-created flows
- add a WebUI projection regression test for Google runtime auth gates rendering oauth_url prompts

## Tests
- cargo fmt --check
- cargo check -p ironclaw_reborn_composition --features webui-v2-beta
- cargo test -p ironclaw_reborn_composition webui_event_stream_creates_google_oauth_prompt_for_runtime_credential_gate --features webui-v2-beta -- --nocapture
- cargo test -p ironclaw_reborn_composition product_auth_google_oauth_callback_completes_setup_flow --features webui-v2-beta -- --nocapture
- cargo clippy -p ironclaw_reborn_composition --features webui-v2-beta --all-targets -- -D warnings