### PR TITLE
Fix Gmail OAuth auth gate requirements

### DIFF
--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -118,10 +118,11 @@ impl From<DispatchError> for CapabilityInvocationError {
             DispatchError::AuthRequired {
                 capability,
                 required_secrets,
+                credential_requirements,
             } => Self::AuthorizationRequiresAuth {
                 capability,
                 required_secrets,
-                credential_requirements: Vec::new(),
+                credential_requirements,
             },
             other => Self::Dispatch {
                 kind: dispatch_error_kind(&other),
@@ -137,7 +138,10 @@ fn dispatch_error_kind(error: &DispatchError) -> DispatchFailureKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironclaw_host_api::{ExtensionId, RuntimeDispatchErrorKind, RuntimeKind, SecretHandle};
+    use ironclaw_host_api::{
+        ExtensionId, RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement,
+        RuntimeDispatchErrorKind, RuntimeKind, SecretHandle,
+    };
 
     fn cap() -> CapabilityId {
         CapabilityId::new("test.cap").unwrap()
@@ -264,6 +268,7 @@ mod tests {
             let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
                 capability: cap(),
                 required_secrets: secrets.clone(),
+                credential_requirements: Vec::new(),
             });
             match err {
                 CapabilityInvocationError::AuthorizationRequiresAuth {
@@ -277,6 +282,33 @@ mod tests {
                 }
                 other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn from_dispatch_auth_required_round_trips_credential_requirements() {
+        let requirement = RuntimeCredentialAuthRequirement {
+            provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+            requester_extension: ExtensionId::new("gmail").unwrap(),
+            provider_scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
+        };
+        let err = CapabilityInvocationError::from(DispatchError::AuthRequired {
+            capability: cap(),
+            required_secrets: Vec::new(),
+            credential_requirements: vec![requirement.clone()],
+        });
+
+        match err {
+            CapabilityInvocationError::AuthorizationRequiresAuth {
+                capability,
+                required_secrets,
+                credential_requirements,
+            } => {
+                assert_eq!(capability, cap());
+                assert!(required_secrets.is_empty());
+                assert_eq!(credential_requirements, vec![requirement]);
+            }
+            other => panic!("expected AuthorizationRequiresAuth, got {other:?}"),
         }
     }
 }

--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -124,7 +124,15 @@ impl From<DispatchError> for CapabilityInvocationError {
                 required_secrets,
                 credential_requirements,
             },
-            other => Self::Dispatch {
+            other @ (DispatchError::UnknownCapability { .. }
+            | DispatchError::UnknownProvider { .. }
+            | DispatchError::RuntimeMismatch { .. }
+            | DispatchError::MissingRuntimeBackend { .. }
+            | DispatchError::UnsupportedRuntime { .. }
+            | DispatchError::Mcp { .. }
+            | DispatchError::Script { .. }
+            | DispatchError::Wasm { .. }
+            | DispatchError::FirstParty { .. }) => Self::Dispatch {
                 kind: dispatch_error_kind(&other),
             },
         }

--- a/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_auth_run_state_contract.rs
@@ -201,6 +201,7 @@ impl CapabilityDispatcher for AuthRequiredDispatcher {
         Err(DispatchError::AuthRequired {
             capability: request.capability_id,
             required_secrets: vec![],
+            credential_requirements: Vec::new(),
         })
     }
 }

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 use crate::{
     CapabilityId, ExtensionId, MountView, ResourceEstimate, ResourceReceipt, ResourceReservation,
-    ResourceScope, ResourceUsage, RuntimeKind, SecretHandle,
+    ResourceScope, ResourceUsage, RuntimeCredentialAuthRequirement, RuntimeKind, SecretHandle,
 };
 
 /// Request for one already-authorized declared capability dispatch.
@@ -237,6 +237,7 @@ pub enum DispatchError {
     AuthRequired {
         capability: CapabilityId,
         required_secrets: Vec<SecretHandle>,
+        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
     },
     #[error("MCP dispatch failed: {kind}")]
     Mcp { kind: RuntimeDispatchErrorKind },
@@ -290,12 +291,20 @@ impl fmt::Debug for DispatchError {
             Self::AuthRequired {
                 capability,
                 required_secrets,
+                credential_requirements,
             } => f
                 .debug_struct("AuthRequired")
                 .field("capability", capability)
                 .field(
                     "required_secrets",
                     &format!("[{} handle(s) redacted]", required_secrets.len()),
+                )
+                .field(
+                    "credential_requirements",
+                    &format!(
+                        "[{} requirement(s) redacted]",
+                        credential_requirements.len()
+                    ),
                 )
                 .finish(),
             Self::Mcp { kind } => f.debug_struct("Mcp").field("kind", kind).finish(),

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1752,4 +1752,31 @@ fn dispatch_error_auth_required_debug_redacts_required_secrets() {
         debug_empty.contains("0 handle(s) redacted"),
         "zero redaction count must appear; got: {debug_empty}"
     );
+    let requirement = RuntimeCredentialAuthRequirement {
+        provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+        requester_extension: ExtensionId::new("gmail").unwrap(),
+        provider_scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
+    };
+    let with_requirement = DispatchError::AuthRequired {
+        capability: CapabilityId::new("test.cap").unwrap(),
+        required_secrets: Vec::new(),
+        credential_requirements: vec![requirement],
+    };
+    let debug_with_requirement = format!("{with_requirement:?}");
+    assert!(
+        debug_with_requirement.contains("1 requirement(s) redacted"),
+        "credential requirement redaction count must appear; got: {debug_with_requirement}"
+    );
+    assert!(
+        !debug_with_requirement.contains("gmail"),
+        "requester extension must not appear in Debug output; got: {debug_with_requirement}"
+    );
+    assert!(
+        !debug_with_requirement.contains("gmail.readonly"),
+        "provider scope must not appear in Debug output; got: {debug_with_requirement}"
+    );
+    assert!(
+        !debug_with_requirement.contains("google"),
+        "provider id must not appear in Debug output; got: {debug_with_requirement}"
+    );
 }

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -285,6 +285,7 @@ fn dispatch_errors_preserve_typed_failure_kind() {
         DispatchError::AuthRequired {
             capability: CapabilityId::new("test.cap").unwrap(),
             required_secrets: required_secrets.clone(),
+            credential_requirements: Vec::new(),
         }
         .failure_kind(),
         DispatchFailureKind::AuthRequired
@@ -294,6 +295,7 @@ fn dispatch_errors_preserve_typed_failure_kind() {
         DispatchError::AuthRequired {
             capability: CapabilityId::new("test.cap").unwrap(),
             required_secrets: Vec::new(),
+            credential_requirements: Vec::new(),
         }
         .failure_kind(),
         DispatchFailureKind::AuthRequired
@@ -1705,6 +1707,7 @@ fn dispatch_error_event_kind_pins_auth_required_token() {
         DispatchError::AuthRequired {
             capability: cap(),
             required_secrets: vec![handle],
+            credential_requirements: Vec::new(),
         }
         .event_kind(),
         "auth_required"
@@ -1714,6 +1717,7 @@ fn dispatch_error_event_kind_pins_auth_required_token() {
         DispatchError::AuthRequired {
             capability: cap(),
             required_secrets: Vec::new(),
+            credential_requirements: Vec::new(),
         }
         .event_kind(),
         "auth_required"
@@ -1726,6 +1730,7 @@ fn dispatch_error_auth_required_debug_redacts_required_secrets() {
     let error = DispatchError::AuthRequired {
         capability: CapabilityId::new("test.cap").unwrap(),
         required_secrets: vec![handle],
+        credential_requirements: Vec::new(),
     };
     let debug = format!("{error:?}");
     assert!(
@@ -1740,6 +1745,7 @@ fn dispatch_error_auth_required_debug_redacts_required_secrets() {
     let empty = DispatchError::AuthRequired {
         capability: CapabilityId::new("test.cap").unwrap(),
         required_secrets: Vec::new(),
+        credential_requirements: Vec::new(),
     };
     let debug_empty = format!("{empty:?}");
     assert!(

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use async_trait::async_trait;
 use ironclaw_host_api::{
     CapabilityDisplayOutputPreview, CapabilityId, MountView, ResourceEstimate, ResourceScope,
-    ResourceUsage, RuntimeDispatchErrorKind, SecretHandle,
+    ResourceUsage, RuntimeCredentialAuthRequirement, RuntimeDispatchErrorKind, SecretHandle,
 };
 use serde_json::Value;
 
@@ -130,6 +130,8 @@ pub enum FirstPartyCapabilityError {
         /// Specific secret handles the runtime auth gate must prompt for.
         /// May be empty when the obligation layer does not know which handle failed.
         required_secrets: Vec<SecretHandle>,
+        /// Structured credential requirements the runtime auth gate can turn into OAuth.
+        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
         usage: Option<ResourceUsage>,
     },
 }
@@ -144,16 +146,33 @@ impl FirstPartyCapabilityError {
     pub fn auth_required() -> Self {
         Self::AuthRequired {
             required_secrets: Vec::new(),
+            credential_requirements: Vec::new(),
             usage: None,
         }
     }
 
     /// Construct an auth-required failure naming the handles to re-authorize.
     pub fn auth_required_with(required_secrets: Vec<SecretHandle>) -> Self {
+        Self::auth_required_with_context(required_secrets, Vec::new())
+    }
+
+    /// Construct an auth-required failure naming both secret handles and OAuth requirements.
+    pub fn auth_required_with_context(
+        required_secrets: Vec<SecretHandle>,
+        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+    ) -> Self {
         Self::AuthRequired {
             required_secrets,
+            credential_requirements,
             usage: None,
         }
+    }
+
+    /// Construct an auth-required failure naming the OAuth credential requirements.
+    pub fn auth_required_for_credentials(
+        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+    ) -> Self {
+        Self::auth_required_with_context(Vec::new(), credential_requirements)
     }
 
     /// Attach resource usage. Builder-style for use in handler return expressions.
@@ -164,9 +183,12 @@ impl FirstPartyCapabilityError {
                 usage: Some(usage),
             },
             Self::AuthRequired {
-                required_secrets, ..
+                required_secrets,
+                credential_requirements,
+                ..
             } => Self::AuthRequired {
                 required_secrets,
+                credential_requirements,
                 usage: Some(usage),
             },
         }
@@ -192,6 +214,17 @@ impl FirstPartyCapabilityError {
             Self::AuthRequired {
                 required_secrets, ..
             } => Some(required_secrets),
+            Self::Dispatch { .. } => None,
+        }
+    }
+
+    /// Structured credential requirements, if this is an auth failure.
+    pub fn credential_requirements(&self) -> Option<&Vec<RuntimeCredentialAuthRequirement>> {
+        match self {
+            Self::AuthRequired {
+                credential_requirements,
+                ..
+            } => Some(credential_requirements),
             Self::Dispatch { .. } => None,
         }
     }

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -333,10 +333,13 @@ where
                 }
                 return match error {
                     FirstPartyCapabilityError::AuthRequired {
-                        required_secrets, ..
+                        required_secrets,
+                        credential_requirements,
+                        ..
                     } => Err(DispatchError::AuthRequired {
                         capability: request.capability_id.clone(),
                         required_secrets,
+                        credential_requirements,
                     }),
                     FirstPartyCapabilityError::Dispatch { kind, .. } => {
                         Err(DispatchError::FirstParty { kind })
@@ -772,6 +775,7 @@ fn wasm_guest_dispatch_error(error: &str, capability: &CapabilityId) -> Dispatch
         WasmGuestErrorKind::AuthRequired => DispatchError::AuthRequired {
             capability: capability.clone(),
             required_secrets: Vec::new(),
+            credential_requirements: Vec::new(),
         },
         WasmGuestErrorKind::Runtime(kind) => DispatchError::Wasm { kind },
     }

--- a/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    DispatchError, ResourceEstimate, RuntimeDispatchErrorKind, RuntimeKind, SecretHandle,
+    DispatchError, ExtensionId, ResourceEstimate, RuntimeCredentialAccountProviderId,
+    RuntimeCredentialAuthRequirement, RuntimeDispatchErrorKind, RuntimeKind, SecretHandle,
 };
 use serde_json::json;
 
@@ -56,12 +57,14 @@ async fn first_party_adapter_maps_handler_auth_required_to_dispatch_auth_require
         Err(DispatchError::AuthRequired {
             capability,
             required_secrets,
+            credential_requirements,
         }) => {
             assert_eq!(capability, descriptor.id);
             assert!(
                 required_secrets.is_empty(),
                 "auth_required() handler yields no required handles; got {required_secrets:?}"
             );
+            assert!(credential_requirements.is_empty());
         }
         other => panic!("expected AuthRequired, got {other:?}"),
     }
@@ -176,6 +179,67 @@ async fn first_party_adapter_forwards_required_secrets_from_auth_required_handle
 }
 
 #[tokio::test]
+async fn first_party_adapter_forwards_credential_requirements_from_auth_required_handler() {
+    let requirement = RuntimeCredentialAuthRequirement {
+        provider: RuntimeCredentialAccountProviderId::new("google").unwrap(),
+        requester_extension: ExtensionId::new("gmail").unwrap(),
+        provider_scopes: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
+    };
+    let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
+    let registry = Arc::new(FirstPartyCapabilityRegistry::new().with_handler(
+        descriptor.id.clone(),
+        Arc::new(AuthRequiredWithCredentialRequirementsHandler {
+            requirement: requirement.clone(),
+        }),
+    ));
+    let adapter = FirstPartyRuntimeAdapter::from_registry(
+        registry,
+        Arc::new(LocalInvocationServicesResolver::new(
+            Arc::new(LocalFilesystem::new()),
+            None,
+            Arc::new(LocalHostProcessPort::new()),
+            None,
+        )),
+    );
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let package = test_package(WASM_MANIFEST, "test-wasm");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope,
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({}),
+        })
+        .await;
+
+    match result {
+        Err(DispatchError::AuthRequired {
+            credential_requirements,
+            ..
+        }) => {
+            assert_eq!(credential_requirements, vec![requirement]);
+        }
+        other => panic!("expected AuthRequired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn first_party_adapter_maps_panicking_handler_to_backend() {
     let descriptor = test_descriptor(RuntimeKind::FirstParty, Vec::new());
     let registry = Arc::new(
@@ -260,6 +324,24 @@ impl crate::FirstPartyCapabilityHandler for AuthRequiredWithSecretsHandler {
         Err(crate::FirstPartyCapabilityError::auth_required_with(vec![
             self.handle.clone(),
         ]))
+    }
+}
+
+struct AuthRequiredWithCredentialRequirementsHandler {
+    requirement: RuntimeCredentialAuthRequirement,
+}
+
+#[async_trait]
+impl crate::FirstPartyCapabilityHandler for AuthRequiredWithCredentialRequirementsHandler {
+    async fn dispatch(
+        &self,
+        _request: crate::FirstPartyCapabilityRequest,
+    ) -> Result<crate::FirstPartyCapabilityResult, crate::FirstPartyCapabilityError> {
+        Err(
+            crate::FirstPartyCapabilityError::auth_required_for_credentials(vec![
+                self.requirement.clone(),
+            ]),
+        )
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -9,11 +9,11 @@ use ironclaw_extensions::{
 use ironclaw_first_party_extensions::{
     GsuiteCapabilitySpec, GsuiteCredentialStageError, GsuiteCredentialStageRequest,
     GsuiteCredentialStager, GsuiteDispatchError, GsuiteDispatchRequest, GsuiteExecutor,
-    GsuitePackageSpec, gsuite_package_specs, gsuite_resource_profile,
+    GsuitePackageSpec, find_gsuite_capability, gsuite_package_specs, gsuite_resource_profile,
 };
 use ironclaw_host_api::{
     CapabilityId, CapabilityProfileSchemaRef, ExtensionId, HostApiError, RequestedTrustClass,
-    TrustClass, VirtualPath,
+    RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement, TrustClass, VirtualPath,
 };
 use ironclaw_host_runtime::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
@@ -91,7 +91,7 @@ impl FirstPartyCapabilityHandler for GsuiteFirstPartyHandler {
                 runtime_http_egress: egress,
             })
             .await
-            .map_err(gsuite_error)?;
+            .map_err(|error| gsuite_error(error, &request.capability_id))?;
         Ok(FirstPartyCapabilityResult::new(result.output, result.usage))
     }
 }
@@ -152,24 +152,46 @@ fn capability_manifest(
 }
 
 /// Convert a [`GsuiteDispatchError`] into the neutral [`FirstPartyCapabilityError`].
-///
-/// Recovery context carried by [`GsuiteCredentialDispatchReason::Recovery`] and
-/// [`GsuiteCredentialDispatchReason::MissingScopes`] (recovery kind, provider id,
-/// available accounts, missing OAuth scopes) is intentionally dropped here:
-/// [`FirstPartyCapabilityError`] has no recovery-payload field.  Upper services
-/// receive a generic `AuthRequired` gate.  To thread structured recovery hints
-/// through to the runtime, `FirstPartyCapabilityError::AuthRequired` must be
-/// extended with an opaque reason payload (tracked as a follow-up).
-fn gsuite_error(error: GsuiteDispatchError) -> FirstPartyCapabilityError {
+fn gsuite_error(
+    error: GsuiteDispatchError,
+    capability_id: &CapabilityId,
+) -> FirstPartyCapabilityError {
     let usage = error.usage().cloned();
     let base = match error.auth_requirement() {
-        Some(required_secrets) => FirstPartyCapabilityError::auth_required_with(required_secrets),
+        Some(required_secrets) => FirstPartyCapabilityError::auth_required_with_context(
+            required_secrets,
+            gsuite_credential_requirements(capability_id),
+        ),
         None => FirstPartyCapabilityError::new(error.kind()),
     };
     match usage {
         Some(u) => base.with_usage(u),
         None => base,
     }
+}
+
+fn gsuite_credential_requirements(
+    capability_id: &CapabilityId,
+) -> Vec<RuntimeCredentialAuthRequirement> {
+    let Some((package, capability)) = find_gsuite_capability(capability_id.as_str()) else {
+        return Vec::new();
+    };
+    let Ok(provider) = RuntimeCredentialAccountProviderId::new(ironclaw_auth::GOOGLE_PROVIDER_ID)
+    else {
+        return Vec::new();
+    };
+    let Ok(requester_extension) = ExtensionId::new(package.extension_id) else {
+        return Vec::new();
+    };
+    vec![RuntimeCredentialAuthRequirement {
+        provider,
+        requester_extension,
+        provider_scopes: capability
+            .required_scopes
+            .iter()
+            .map(|scope| (*scope).to_string())
+            .collect(),
+    }]
 }
 
 pub(crate) struct ProductAuthRuntimeGsuiteCredentialStager {
@@ -193,5 +215,45 @@ impl GsuiteCredentialStager for ProductAuthRuntimeGsuiteCredentialStager {
         self.runtime_ports
             .stage_secret_once(request.scope, request.capability_id, request.access_secret)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_first_party_extensions::{
+        GMAIL_LIST_MESSAGES_CAPABILITY_ID, GsuiteCredentialDispatchReason,
+    };
+    use ironclaw_host_api::RuntimeDispatchErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn gmail_auth_failure_maps_to_google_oauth_requirement() {
+        let capability_id = CapabilityId::new(GMAIL_LIST_MESSAGES_CAPABILITY_ID).unwrap();
+        let error = GsuiteDispatchError::new(RuntimeDispatchErrorKind::Client)
+            .with_reason(GsuiteCredentialDispatchReason::MissingAccessSecret);
+
+        let mapped = gsuite_error(error, &capability_id);
+
+        let FirstPartyCapabilityError::AuthRequired {
+            required_secrets,
+            credential_requirements,
+            ..
+        } = mapped
+        else {
+            panic!("expected Gmail auth failure to map to FirstParty AuthRequired");
+        };
+        assert!(required_secrets.is_empty());
+        assert_eq!(credential_requirements.len(), 1);
+        let requirement = &credential_requirements[0];
+        assert_eq!(
+            requirement.provider.as_str(),
+            ironclaw_auth::GOOGLE_PROVIDER_ID
+        );
+        assert_eq!(requirement.requester_extension.as_str(), "gmail");
+        assert_eq!(
+            requirement.provider_scopes,
+            vec![ironclaw_auth::GOOGLE_GMAIL_READONLY_SCOPE.to_string()]
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -13,7 +13,8 @@ use ironclaw_first_party_extensions::{
 };
 use ironclaw_host_api::{
     CapabilityId, CapabilityProfileSchemaRef, ExtensionId, HostApiError, RequestedTrustClass,
-    RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement, TrustClass, VirtualPath,
+    RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement, RuntimeDispatchErrorKind,
+    TrustClass, VirtualPath,
 };
 use ironclaw_host_runtime::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
@@ -158,10 +159,13 @@ fn gsuite_error(
 ) -> FirstPartyCapabilityError {
     let usage = error.usage().cloned();
     let base = match error.auth_requirement() {
-        Some(required_secrets) => FirstPartyCapabilityError::auth_required_with_context(
-            required_secrets,
-            gsuite_credential_requirements(capability_id),
-        ),
+        Some(required_secrets) => match gsuite_credential_requirements(capability_id) {
+            Ok(credential_requirements) => FirstPartyCapabilityError::auth_required_with_context(
+                required_secrets,
+                credential_requirements,
+            ),
+            Err(error) => error,
+        },
         None => FirstPartyCapabilityError::new(error.kind()),
     };
     match usage {
@@ -172,18 +176,16 @@ fn gsuite_error(
 
 fn gsuite_credential_requirements(
     capability_id: &CapabilityId,
-) -> Vec<RuntimeCredentialAuthRequirement> {
-    let Some((package, capability)) = find_gsuite_capability(capability_id.as_str()) else {
-        return Vec::new();
-    };
-    let Ok(provider) = RuntimeCredentialAccountProviderId::new(ironclaw_auth::GOOGLE_PROVIDER_ID)
-    else {
-        return Vec::new();
-    };
-    let Ok(requester_extension) = ExtensionId::new(package.extension_id) else {
-        return Vec::new();
-    };
-    vec![RuntimeCredentialAuthRequirement {
+) -> Result<Vec<RuntimeCredentialAuthRequirement>, FirstPartyCapabilityError> {
+    let (package, capability) =
+        find_gsuite_capability(capability_id.as_str()).ok_or_else(|| {
+            FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::UndeclaredCapability)
+        })?;
+    let provider = RuntimeCredentialAccountProviderId::new(ironclaw_auth::GOOGLE_PROVIDER_ID)
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend))?;
+    let requester_extension = ExtensionId::new(package.extension_id)
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend))?;
+    Ok(vec![RuntimeCredentialAuthRequirement {
         provider,
         requester_extension,
         provider_scopes: capability
@@ -191,7 +193,7 @@ fn gsuite_credential_requirements(
             .iter()
             .map(|scope| (*scope).to_string())
             .collect(),
-    }]
+    }])
 }
 
 pub(crate) struct ProductAuthRuntimeGsuiteCredentialStager {

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -463,6 +463,20 @@ async fn bundled_gsuite_handler_projects_stage_auth_required_to_first_party_auth
         None,
         "AuthRequired variant must have no dispatch kind"
     );
+    let credential_requirements = error
+        .credential_requirements()
+        .expect("stage AuthRequired should surface OAuth requirements");
+    assert_eq!(credential_requirements.len(), 1);
+    let requirement = &credential_requirements[0];
+    assert_eq!(
+        requirement.provider.as_str(),
+        ironclaw_auth::GOOGLE_PROVIDER_ID
+    );
+    assert_eq!(requirement.requester_extension.as_str(), "gmail");
+    assert_eq!(
+        requirement.provider_scopes,
+        vec![GOOGLE_GMAIL_SEND_SCOPE.to_string()]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- preserve structured credential requirements across first-party auth failures
- map Gmail auth failures to Google OAuth requirements using the declared Gmail capability scopes
- add regression coverage for Gmail mapping, first-party runtime adapter forwarding, and dispatch-to-capability auth conversion

## Tests
- cargo test -p ironclaw_reborn_composition gsuite::tests::gmail_auth_failure_maps_to_google_oauth_requirement
- cargo test -p ironclaw_host_runtime first_party_adapter_forwards_credential_requirements_from_auth_required_handler
- cargo test -p ironclaw_capabilities from_dispatch_auth_required_round_trips_credential_requirements
- cargo test -p ironclaw_host_api dispatch_error_auth_required_debug_redacts_required_secrets
- git diff --check