### PR TITLE
Fix Reborn Gmail OAuth auth gate scopes

### DIFF
--- a/crates/ironclaw_first_party_extensions/assets/gmail/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/gmail/manifest.toml
@@ -16,7 +16,7 @@ effects = ["dispatch_capability", "network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
 runtime_credentials = [
-  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/gmail.readonly"], audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/gmail/list_messages.input.v1.json"
 output_schema_ref = "schemas/gmail/list_messages.output.v1.json"
@@ -29,7 +29,7 @@ effects = ["dispatch_capability", "network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
 runtime_credentials = [
-  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/gmail.readonly"], audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/gmail/get_message.input.v1.json"
 output_schema_ref = "schemas/gmail/get_message.output.v1.json"
@@ -42,7 +42,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.send"] } }, provider_scopes = ["https://www.googleapis.com/auth/gmail.send"], audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/gmail/send_message.input.v1.json"
 output_schema_ref = "schemas/gmail/send_message.output.v1.json"
@@ -55,7 +55,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, provider_scopes = ["https://www.googleapis.com/auth/gmail.modify"], audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/gmail/create_draft.input.v1.json"
 output_schema_ref = "schemas/gmail/create_draft.output.v1.json"
@@ -68,7 +68,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.send"] } }, provider_scopes = ["https://www.googleapis.com/auth/gmail.send"], audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/gmail/reply_to_message.input.v1.json"
 output_schema_ref = "schemas/gmail/reply_to_message.output.v1.json"
@@ -81,7 +81,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "gmail_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/gmail.modify"] } }, provider_scopes = ["https://www.googleapis.com/auth/gmail.modify"], audience = { scheme = "https", host_pattern = "gmail.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/gmail/trash_message.input.v1.json"
 output_schema_ref = "schemas/gmail/trash_message.output.v1.json"

--- a/crates/ironclaw_first_party_extensions/assets/google-calendar/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-calendar/manifest.toml
@@ -16,7 +16,7 @@ effects = ["dispatch_capability", "network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/list_calendars.input.v1.json"
 output_schema_ref = "schemas/google-calendar/list_calendars.output.v1.json"
@@ -29,7 +29,7 @@ effects = ["dispatch_capability", "network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/list_events.input.v1.json"
 output_schema_ref = "schemas/google-calendar/list_events.output.v1.json"
@@ -42,7 +42,7 @@ effects = ["dispatch_capability", "network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/get_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/get_event.output.v1.json"
@@ -55,7 +55,7 @@ effects = ["dispatch_capability", "network", "use_secret"]
 default_permission = "allow"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/find_free_slots.input.v1.json"
 output_schema_ref = "schemas/google-calendar/find_free_slots.output.v1.json"
@@ -68,7 +68,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.events"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/create_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/create_event.output.v1.json"
@@ -81,7 +81,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.events"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/update_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/update_event.output.v1.json"
@@ -94,7 +94,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.events"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/delete_event.input.v1.json"
 output_schema_ref = "schemas/google-calendar/delete_event.output.v1.json"
@@ -107,7 +107,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.events"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/add_attendees.input.v1.json"
 output_schema_ref = "schemas/google-calendar/add_attendees.output.v1.json"
@@ -120,7 +120,7 @@ effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 default_permission = "ask"
 visibility = "model"
 runtime_credentials = [
-  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_calendar_account", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/calendar.events"] } }, provider_scopes = ["https://www.googleapis.com/auth/calendar.events"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 input_schema_ref = "schemas/google-calendar/set_reminder.input.v1.json"
 output_schema_ref = "schemas/google-calendar/set_reminder.output.v1.json"

--- a/crates/ironclaw_first_party_extensions/src/gsuite/manifest.rs
+++ b/crates/ironclaw_first_party_extensions/src/gsuite/manifest.rs
@@ -19,6 +19,8 @@ pub struct GsuitePackageSpec {
     pub description: &'static str,
     pub service: &'static str,
     pub schema_prefix: &'static str,
+    pub credential_handle: &'static str,
+    pub credential_host_pattern: &'static str,
     pub capabilities: &'static [GsuiteCapabilitySpec],
 }
 
@@ -236,6 +238,8 @@ pub const fn calendar_package_spec() -> GsuitePackageSpec {
         description: "First-party Google Calendar capabilities for Reborn.",
         service: "google-calendar",
         schema_prefix: "google-calendar",
+        credential_handle: "google_calendar_account",
+        credential_host_pattern: "www.googleapis.com",
         capabilities: CALENDAR_CAPABILITIES,
     }
 }
@@ -247,6 +251,8 @@ pub const fn gmail_package_spec() -> GsuitePackageSpec {
         description: "First-party Gmail capabilities for Reborn.",
         service: "gmail",
         schema_prefix: "gmail",
+        credential_handle: "gmail_account",
+        credential_host_pattern: "gmail.googleapis.com",
         capabilities: GMAIL_CAPABILITIES,
     }
 }

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -158,23 +158,16 @@ fn runtime_credentials(
     capability: &GsuiteCapabilitySpec,
     spec: &GsuitePackageSpec,
 ) -> Result<Vec<RuntimeCredentialRequirement>, ExtensionError> {
+    let provider_scopes = required_provider_scopes(capability);
     Ok(vec![RuntimeCredentialRequirement {
         handle: SecretHandle::new(spec.credential_handle)?,
         source: RuntimeCredentialRequirementSource::ProductAuthAccount {
             provider: RuntimeCredentialAccountProviderId::new(ironclaw_auth::GOOGLE_PROVIDER_ID)?,
             setup: RuntimeCredentialAccountSetup::OAuth {
-                scopes: capability
-                    .required_scopes
-                    .iter()
-                    .map(|scope| (*scope).to_string())
-                    .collect(),
+                scopes: provider_scopes.clone(),
             },
         },
-        provider_scopes: capability
-            .required_scopes
-            .iter()
-            .map(|scope| (*scope).to_string())
-            .collect(),
+        provider_scopes,
         audience: NetworkTargetPattern {
             scheme: Some(NetworkScheme::Https),
             host_pattern: spec.credential_host_pattern.to_string(),
@@ -186,6 +179,14 @@ fn runtime_credentials(
         },
         required: true,
     }])
+}
+
+fn required_provider_scopes(capability: &GsuiteCapabilitySpec) -> Vec<String> {
+    capability
+        .required_scopes
+        .iter()
+        .map(|scope| (*scope).to_string())
+        .collect()
 }
 
 /// Convert a [`GsuiteDispatchError`] into the neutral [`FirstPartyCapabilityError`].
@@ -224,11 +225,7 @@ fn gsuite_credential_requirements(
     Ok(vec![RuntimeCredentialAuthRequirement {
         provider,
         requester_extension,
-        provider_scopes: capability
-            .required_scopes
-            .iter()
-            .map(|scope| (*scope).to_string())
-            .collect(),
+        provider_scopes: required_provider_scopes(capability),
     }])
 }
 

--- a/crates/ironclaw_reborn_composition/src/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/src/gsuite.rs
@@ -12,9 +12,11 @@ use ironclaw_first_party_extensions::{
     GsuitePackageSpec, find_gsuite_capability, gsuite_package_specs, gsuite_resource_profile,
 };
 use ironclaw_host_api::{
-    CapabilityId, CapabilityProfileSchemaRef, ExtensionId, HostApiError, RequestedTrustClass,
-    RuntimeCredentialAccountProviderId, RuntimeCredentialAuthRequirement, RuntimeDispatchErrorKind,
-    TrustClass, VirtualPath,
+    CapabilityId, CapabilityProfileSchemaRef, ExtensionId, HostApiError, NetworkScheme,
+    NetworkTargetPattern, RequestedTrustClass, RuntimeCredentialAccountProviderId,
+    RuntimeCredentialAccountSetup, RuntimeCredentialAuthRequirement, RuntimeCredentialRequirement,
+    RuntimeCredentialRequirementSource, RuntimeCredentialTarget, RuntimeDispatchErrorKind,
+    SecretHandle, TrustClass, VirtualPath,
 };
 use ironclaw_host_runtime::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
@@ -101,7 +103,7 @@ fn package_from_spec(spec: &GsuitePackageSpec) -> Result<ExtensionPackage, Exten
     let capabilities = spec
         .capabilities
         .iter()
-        .map(|capability| capability_manifest(capability, spec.schema_prefix))
+        .map(|capability| capability_manifest(capability, spec))
         .collect::<Result<Vec<_>, _>>()?;
     ExtensionPackage::from_manifest(
         ExtensionManifest {
@@ -125,7 +127,7 @@ fn package_from_spec(spec: &GsuitePackageSpec) -> Result<ExtensionPackage, Exten
 
 fn capability_manifest(
     capability: &GsuiteCapabilitySpec,
-    schema_prefix: &str,
+    spec: &GsuitePackageSpec,
 ) -> Result<CapabilityManifest, ExtensionError> {
     Ok(CapabilityManifest {
         id: CapabilityId::new(capability.id)?,
@@ -136,20 +138,54 @@ fn capability_manifest(
         visibility: CapabilityVisibility::Model,
         input_schema_ref: CapabilityProfileSchemaRef::new(format!(
             "schemas/{}/{}.input.v1.json",
-            schema_prefix, capability.short_name
+            spec.schema_prefix, capability.short_name
         ))?,
         output_schema_ref: CapabilityProfileSchemaRef::new(format!(
             "schemas/{}/{}.output.v1.json",
-            schema_prefix, capability.short_name
+            spec.schema_prefix, capability.short_name
         ))?,
         prompt_doc_ref: Some(CapabilityProfileSchemaRef::new(format!(
             "prompts/{}/{}.md",
-            schema_prefix, capability.short_name
+            spec.schema_prefix, capability.short_name
         ))?),
         required_host_ports: Vec::new(),
-        runtime_credentials: Vec::new(),
+        runtime_credentials: runtime_credentials(capability, spec)?,
         resource_profile: Some(gsuite_resource_profile()),
     })
+}
+
+fn runtime_credentials(
+    capability: &GsuiteCapabilitySpec,
+    spec: &GsuitePackageSpec,
+) -> Result<Vec<RuntimeCredentialRequirement>, ExtensionError> {
+    Ok(vec![RuntimeCredentialRequirement {
+        handle: SecretHandle::new(spec.credential_handle)?,
+        source: RuntimeCredentialRequirementSource::ProductAuthAccount {
+            provider: RuntimeCredentialAccountProviderId::new(ironclaw_auth::GOOGLE_PROVIDER_ID)?,
+            setup: RuntimeCredentialAccountSetup::OAuth {
+                scopes: capability
+                    .required_scopes
+                    .iter()
+                    .map(|scope| (*scope).to_string())
+                    .collect(),
+            },
+        },
+        provider_scopes: capability
+            .required_scopes
+            .iter()
+            .map(|scope| (*scope).to_string())
+            .collect(),
+        audience: NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: spec.credential_host_pattern.to_string(),
+            port: None,
+        },
+        target: RuntimeCredentialTarget::Header {
+            name: "authorization".to_string(),
+            prefix: Some("Bearer ".to_string()),
+        },
+        required: true,
+    }])
 }
 
 /// Convert a [`GsuiteDispatchError`] into the neutral [`FirstPartyCapabilityError`].

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1679,6 +1679,7 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use ironclaw_auth::GOOGLE_CALENDAR_READONLY_SCOPE;
 
     /// Wiring guard: the `regex_skill_activation_enabled` flag from
     /// [`RebornRuntimeInput`] must reach
@@ -3493,7 +3494,7 @@ mod tests {
             RebornExtensionCredentialSetup::OAuth {
                 scopes,
                 ..
-            } if scopes == &vec!["https://www.googleapis.com/auth/calendar.events".to_string()]
+            } if scopes == &vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()]
         ));
         let google_setup_json =
             serde_json::to_value(&google_setup.secrets[0]).expect("serialize setup secret");

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -59,18 +59,25 @@ mod tests {
         )
     }
 
-    fn provider_tool_call(arguments: serde_json::Value) -> ProviderToolCall {
+    fn provider_tool_call_with_name(
+        name: impl Into<String>,
+        arguments: serde_json::Value,
+    ) -> ProviderToolCall {
         ProviderToolCall {
             provider_id: "test-provider".to_string(),
             provider_model_id: "test-model".to_string(),
             turn_id: Some("provider-turn-1".to_string()),
             id: "call-1".to_string(),
-            name: "builtin_echo".to_string(),
+            name: name.into(),
             arguments,
             response_reasoning: None,
             reasoning: None,
             signature: None,
         }
+    }
+
+    fn provider_tool_call(arguments: serde_json::Value) -> ProviderToolCall {
+        provider_tool_call_with_name("builtin_echo", arguments)
     }
 
     fn skill_md(name: &str, description: &str, prompt: &str) -> String {
@@ -1581,17 +1588,10 @@ mod tests {
         assert_eq!(tool_definition.name, "gmail__list_messages");
 
         let candidate = port
-            .register_provider_tool_call(ProviderToolCall {
-                provider_id: "test-provider".to_string(),
-                provider_model_id: "test-model".to_string(),
-                turn_id: Some("provider-turn-gmail-auth".to_string()),
-                id: "call-gmail-list-messages".to_string(),
-                name: tool_definition.name,
-                arguments: serde_json::json!({}),
-                response_reasoning: None,
-                reasoning: None,
-                signature: None,
-            })
+            .register_provider_tool_call(provider_tool_call_with_name(
+                tool_definition.name,
+                serde_json::json!({}),
+            ))
             .await
             .expect("gmail provider tool call stages");
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -1555,6 +1555,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn activated_gmail_provider_tool_call_without_account_returns_oauth_gate() {
+        let harness = gsuite_surface_harness(
+            "local-dev-gmail-auth-owner",
+            "gmail-auth-gate",
+            "local-dev-gmail-auth-user",
+            GsuiteExtensionState::Activated,
+        )
+        .await;
+        let port = harness
+            .wiring
+            .capability_factory
+            .create_capability_port(&harness.run_context)
+            .await
+            .expect("capability port");
+        port.visible_capabilities(VisibleCapabilityRequest {})
+            .await
+            .expect("visible surface");
+        let tool_definition = port
+            .tool_definitions()
+            .expect("tool definitions")
+            .into_iter()
+            .find(|definition| definition.capability_id.as_str() == "gmail.list_messages")
+            .expect("gmail.list_messages tool definition");
+        assert_eq!(tool_definition.name, "gmail__list_messages");
+
+        let candidate = port
+            .register_provider_tool_call(ProviderToolCall {
+                provider_id: "test-provider".to_string(),
+                provider_model_id: "test-model".to_string(),
+                turn_id: Some("provider-turn-gmail-auth".to_string()),
+                id: "call-gmail-list-messages".to_string(),
+                name: tool_definition.name,
+                arguments: serde_json::json!({}),
+                response_reasoning: None,
+                reasoning: None,
+                signature: None,
+            })
+            .await
+            .expect("gmail provider tool call stages");
+
+        let outcome = port
+            .invoke_capability(CapabilityInvocation {
+                surface_version: candidate.surface_version,
+                capability_id: candidate.capability_id,
+                input_ref: candidate.input_ref,
+            })
+            .await
+            .expect("gmail provider tool call invokes");
+
+        let CapabilityOutcome::AuthRequired {
+            credential_requirements,
+            ..
+        } = outcome
+        else {
+            panic!("expected Gmail provider tool call to return AuthRequired, got {outcome:?}");
+        };
+        assert_eq!(credential_requirements.len(), 1);
+        let requirement = &credential_requirements[0];
+        assert_eq!(
+            requirement.provider.as_str(),
+            ironclaw_auth::GOOGLE_PROVIDER_ID
+        );
+        assert_eq!(requirement.requester_extension.as_str(), "gmail");
+        assert_eq!(
+            requirement.provider_scopes,
+            vec![ironclaw_auth::GOOGLE_GMAIL_READONLY_SCOPE.to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn deactivated_gsuite_extension_capabilities_not_exposed_to_model() {
         let harness = gsuite_surface_harness(
             "local-dev-gsuite-inactive-surface-owner",

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -12,7 +12,8 @@ use ironclaw_first_party_extensions::{
     google_provider_id, gsuite_package_specs,
 };
 use ironclaw_host_api::{
-    CapabilityId, InvocationId, ResourceScope, RuntimeCredentialSource, RuntimeDispatchErrorKind,
+    CapabilityId, InvocationId, ResourceScope, RuntimeCredentialAccountSetup,
+    RuntimeCredentialRequirementSource, RuntimeCredentialSource, RuntimeDispatchErrorKind,
     RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
     SecretHandle, TrustClass, UserId,
 };
@@ -230,6 +231,32 @@ async fn bundled_gsuite_asset_manifests_match_package_specs() {
                         .prompt_doc_ref
                         .as_ref()
                         .map(|prompt| prompt.as_str().to_string()),
+                    capability
+                        .runtime_credentials
+                        .iter()
+                        .map(|credential| {
+                            let RuntimeCredentialRequirementSource::ProductAuthAccount {
+                                provider,
+                                setup:
+                                    RuntimeCredentialAccountSetup::OAuth {
+                                        scopes: setup_scopes,
+                                    },
+                            } = &credential.source
+                            else {
+                                panic!(
+                                    "GSuite capability {} must use product-auth OAuth credentials",
+                                    capability.id.as_str()
+                                );
+                            };
+                            (
+                                credential.handle.as_str().to_string(),
+                                provider.as_str().to_string(),
+                                setup_scopes.clone(),
+                                credential.provider_scopes.clone(),
+                                credential.audience.host_pattern.clone(),
+                            )
+                        })
+                        .collect::<Vec<_>>(),
                 )
             })
             .collect::<Vec<_>>();
@@ -253,6 +280,21 @@ async fn bundled_gsuite_asset_manifests_match_package_specs() {
                         "prompts/{}/{}.md",
                         spec.schema_prefix, capability.short_name
                     )),
+                    vec![(
+                        spec.credential_handle.to_string(),
+                        ironclaw_auth::GOOGLE_PROVIDER_ID.to_string(),
+                        capability
+                            .required_scopes
+                            .iter()
+                            .map(|scope| (*scope).to_string())
+                            .collect::<Vec<_>>(),
+                        capability
+                            .required_scopes
+                            .iter()
+                            .map(|scope| (*scope).to_string())
+                            .collect::<Vec<_>>(),
+                        spec.credential_host_pattern.to_string(),
+                    )],
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/ironclaw_reborn_composition/tests/gsuite.rs
+++ b/crates/ironclaw_reborn_composition/tests/gsuite.rs
@@ -264,6 +264,11 @@ async fn bundled_gsuite_asset_manifests_match_package_specs() {
             .capabilities
             .iter()
             .map(|capability| {
+                let required_scopes = capability
+                    .required_scopes
+                    .iter()
+                    .map(|scope| (*scope).to_string())
+                    .collect::<Vec<_>>();
                 (
                     capability.id.to_string(),
                     capability.effects.to_vec(),
@@ -283,16 +288,8 @@ async fn bundled_gsuite_asset_manifests_match_package_specs() {
                     vec![(
                         spec.credential_handle.to_string(),
                         ironclaw_auth::GOOGLE_PROVIDER_ID.to_string(),
-                        capability
-                            .required_scopes
-                            .iter()
-                            .map(|scope| (*scope).to_string())
-                            .collect::<Vec<_>>(),
-                        capability
-                            .required_scopes
-                            .iter()
-                            .map(|scope| (*scope).to_string())
-                            .collect::<Vec<_>>(),
+                        required_scopes.clone(),
+                        required_scopes,
                         spec.credential_host_pattern.to_string(),
                     )],
                 )


### PR DESCRIPTION
## Summary
- add explicit least-privilege Google provider scopes to bundled Gmail OAuth runtime credentials so Reborn auth gates can start the correct OAuth flow
- align Google Calendar manifests with the same runtime credential contract because it had the same missing provider_scopes shape
- move GSuite credential handle/audience metadata into the canonical package spec and generate runtime credentials from it
- add caller-facing regression coverage for a provider gmail__list_messages call with no account returning AuthRequired with gmail.readonly

## Root cause
The Reborn authorization gate reads top-level runtime credential provider_scopes before first-party dispatch. Gmail manifests only had OAuth setup scopes, and every capability used gmail.modify there. When connect gmail led the model to gmail__list_messages, the auth gate produced an empty-scope OAuth requirement instead of the required gmail.readonly requirement.

## Thermo review
- Removed the brittle schema_prefix -> credential-handle/host matching from Reborn composition.
- Promoted credential handle and Google API audience host to GSuitePackageSpec so generated packages, deployed manifests, and tests all use the canonical package contract.
- Added asset/spec regression coverage for OAuth setup scopes and provider_scopes to prevent future drift.

## Verification
- cargo fmt
- cargo test -p ironclaw_first_party_extensions gsuite --tests
- cargo test -p ironclaw_reborn_composition activated_gmail_provider_tool_call_without_account_returns_oauth_gate --lib
- cargo test -p ironclaw_reborn_composition gsuite --tests
- cargo test -p ironclaw_reborn_composition local_dev_gsuite --lib
- git diff --check

Note: ironclaw_reborn_composition still emits existing dead-code warnings in these targeted test runs.