### PR TITLE
[codex] fix(webuiv2): keep assistant replies last

### DIFF
--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -116,6 +116,24 @@ mod tests {
     }
 
     #[test]
+    fn chat_message_grouping_hoists_only_final_replies() {
+        let groups = asset_text("js/pages/chat/lib/message-groups.js");
+        assert!(groups.contains("function isFinalAssistantReply"));
+        assert!(groups.contains("msg.isFinalReply === true"));
+        assert!(groups.contains("msg.status === \"finalized\""));
+        assert!(groups.contains("appendGroupedMessages(items, reordered.before);"));
+        assert!(groups.contains("appendGroupedMessages(items, reordered.activity);"));
+        assert!(!groups.contains("lastAssistantReplyIndex"));
+
+        let history = asset_text("js/pages/chat/lib/history-messages.js");
+        assert!(history.contains("isFinalReply: isFinalAssistantRecord(record)"));
+        assert!(history.contains("record.status === \"finalized\""));
+
+        let events = asset_text("js/pages/chat/lib/useChatEvents.js");
+        assert!(events.contains("isFinalReply: true"));
+    }
+
+    #[test]
     fn extensions_onboarding_messages_render_in_cards() {
         let extension_card = asset_text("js/pages/extensions/components/extension-card.js");
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
@@ -43,6 +43,7 @@ export function messagesFromTimeline(records, pendingMessages = []) {
       timestamp: timestampForRecord(record),
       kind: record.kind,
       status: record.status,
+      isFinalReply: isFinalAssistantRecord(record),
       sequence: record.sequence,
       turnRunId: record.turn_run_id || null,
     });
@@ -54,6 +55,13 @@ export function messagesFromTimeline(records, pendingMessages = []) {
   }
 
   return messages;
+}
+
+function isFinalAssistantRecord(record) {
+  return (
+    (record.kind === "assistant" || record.kind === "assistant_message") &&
+    record.status === "finalized"
+  );
 }
 
 function roleForRecord(record) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { messagesFromTimeline } from "./history-messages.js";
+
+test("messagesFromTimeline: finalized assistant records are marked as final replies", () => {
+  const messages = messagesFromTimeline([
+    {
+      message_id: "final",
+      kind: "assistant",
+      status: "finalized",
+      content: "Done.",
+    },
+    {
+      message_id: "draft",
+      kind: "assistant",
+      status: "draft",
+      content: "I will check.",
+    },
+  ]);
+
+  assert.equal(messages[0].id, "msg-final");
+  assert.equal(messages[0].isFinalReply, true);
+  assert.equal(messages[1].id, "msg-draft");
+  assert.equal(messages[1].isFinalReply, false);
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
@@ -1,12 +1,14 @@
 /* Collapse consecutive single tool_activity messages into runs for rendering.
-   Messages that already carry toolCalls are full message bubbles and break a
-   run; non-tool messages also break a run. */
+   If the persisted timeline puts trailing reasoning/tool activity after the
+   final assistant reply, render that activity before the reply so the answer
+   stays last. Earlier assistant messages keep their original position because
+   they are middle-of-turn narration. */
 export function groupMessages(messages) {
+  const ordered = assistantLastForTrailingActivity(messages);
   const items = [];
   let run = null;
-  for (const msg of messages) {
-    const isToolActivity =
-      msg.role === "tool_activity" && !(msg.toolCalls && msg.toolCalls.length > 0);
+  for (const msg of ordered) {
+    const isToolActivity = isCollapsibleToolActivity(msg);
     if (isToolActivity) {
       if (!run) {
         run = { type: "tool-run", id: `tool-run-${msg.id}`, tools: [] };
@@ -19,4 +21,41 @@ export function groupMessages(messages) {
     }
   }
   return items;
+}
+
+function assistantLastForTrailingActivity(messages) {
+  const lastAssistant = lastAssistantReplyIndex(messages);
+  if (lastAssistant < 0 || lastAssistant === messages.length - 1) return messages;
+
+  const trailing = messages.slice(lastAssistant + 1);
+  if (!trailing.every(isAuxiliaryActivity)) return messages;
+
+  return [
+    ...messages.slice(0, lastAssistant),
+    ...trailing,
+    messages[lastAssistant],
+  ];
+}
+
+function lastAssistantReplyIndex(messages) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (isAssistantReply(messages[i])) return i;
+  }
+  return -1;
+}
+
+function isAssistantReply(msg) {
+  return msg.role === "assistant" && !(msg.toolCalls && msg.toolCalls.length > 0);
+}
+
+function isAuxiliaryActivity(msg) {
+  return msg.role === "thinking" || msg.role === "tool_activity" || hasToolCalls(msg);
+}
+
+function isCollapsibleToolActivity(msg) {
+  return msg.role === "tool_activity" && !hasToolCalls(msg);
+}
+
+function hasToolCalls(msg) {
+  return msg.toolCalls && msg.toolCalls.length > 0;
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
@@ -4,10 +4,22 @@
    stays last. Earlier assistant messages keep their original position because
    they are middle-of-turn narration. */
 export function groupMessages(messages) {
-  const ordered = assistantLastForTrailingActivity(messages);
   const items = [];
+  const reordered = trailingActivityBeforeFinalReply(messages);
+  if (reordered) {
+    appendGroupedMessages(items, reordered.before);
+    appendGroupedMessages(items, reordered.activity);
+    appendGroupedMessages(items, [reordered.reply]);
+    return items;
+  }
+
+  appendGroupedMessages(items, messages);
+  return items;
+}
+
+function appendGroupedMessages(items, messages) {
   let run = null;
-  for (const msg of ordered) {
+  for (const msg of messages) {
     const isToolActivity = isCollapsibleToolActivity(msg);
     if (isToolActivity) {
       if (!run) {
@@ -20,32 +32,37 @@ export function groupMessages(messages) {
       items.push({ type: "message", id: msg.id, message: msg });
     }
   }
-  return items;
 }
 
-function assistantLastForTrailingActivity(messages) {
-  const lastAssistant = lastAssistantReplyIndex(messages);
-  if (lastAssistant < 0 || lastAssistant === messages.length - 1) return messages;
+function trailingActivityBeforeFinalReply(messages) {
+  const lastAssistant = lastFinalAssistantReplyIndex(messages);
+  if (lastAssistant < 0 || lastAssistant === messages.length - 1) return null;
 
   const trailing = messages.slice(lastAssistant + 1);
-  if (!trailing.every(isAuxiliaryActivity)) return messages;
+  if (!trailing.every(isAuxiliaryActivity)) return null;
 
-  return [
-    ...messages.slice(0, lastAssistant),
-    ...trailing,
-    messages[lastAssistant],
-  ];
+  return {
+    before: messages.slice(0, lastAssistant),
+    activity: trailing,
+    reply: messages[lastAssistant],
+  };
 }
 
-function lastAssistantReplyIndex(messages) {
+function lastFinalAssistantReplyIndex(messages) {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (isAssistantReply(messages[i])) return i;
+    if (isFinalAssistantReply(messages[i])) return i;
   }
   return -1;
 }
 
-function isAssistantReply(msg) {
-  return msg.role === "assistant" && !(msg.toolCalls && msg.toolCalls.length > 0);
+function isFinalAssistantReply(msg) {
+  return (
+    msg.role === "assistant" &&
+    !(msg.toolCalls && msg.toolCalls.length > 0) &&
+    (msg.isFinalReply === true ||
+      ((msg.kind === "assistant" || msg.kind === "assistant_message") &&
+        msg.status === "finalized"))
+  );
 }
 
 function isAuxiliaryActivity(msg) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
@@ -14,10 +14,10 @@ test("groupMessages: consecutive tool_activity messages collapse into one run", 
   assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a", "b"]);
 });
 
-test("groupMessages: non-tool messages break tool runs", () => {
+test("groupMessages: non-auxiliary messages break tool runs", () => {
   const grouped = groupMessages([
     { id: "a", role: "tool_activity" },
-    { id: "m", role: "assistant", content: "done" },
+    { id: "m", role: "system", content: "paused" },
     { id: "b", role: "tool_activity" },
   ]);
 
@@ -38,4 +38,52 @@ test("groupMessages: toolCalls-bearing messages are not grouped and break runs",
   assert.equal(grouped[0].type, "tool-run");
   assert.equal(grouped[1].type, "message");
   assert.equal(grouped[2].type, "tool-run");
+});
+
+test("groupMessages: final assistant renders after trailing activity", () => {
+  const grouped = groupMessages([
+    { id: "u", role: "user", content: "connect notion" },
+    { id: "m", role: "assistant", content: "I cannot connect Notion." },
+    { id: "a", role: "tool_activity", toolName: "notion-get-self" },
+    { id: "r", role: "thinking", content: "Need to check the integration." },
+  ]);
+
+  assert.equal(grouped.length, 4);
+  assert.equal(grouped[0].type, "message");
+  assert.equal(grouped[0].message.id, "u");
+  assert.equal(grouped[1].type, "tool-run");
+  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["a"]);
+  assert.equal(grouped[2].type, "message");
+  assert.equal(grouped[2].message.id, "r");
+  assert.equal(grouped[3].type, "message");
+  assert.equal(grouped[3].message.id, "m");
+});
+
+test("groupMessages: final assistant remains last after earlier and trailing activity", () => {
+  const grouped = groupMessages([
+    { id: "a", role: "tool_activity", toolName: "read" },
+    { id: "m", role: "assistant", content: "Done." },
+    { id: "b", role: "tool_activity", toolName: "grep" },
+  ]);
+
+  assert.equal(grouped.length, 2);
+  assert.equal(grouped[0].type, "tool-run");
+  assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a", "b"]);
+  assert.equal(grouped[1].type, "message");
+  assert.equal(grouped[1].message.id, "m");
+});
+
+test("groupMessages: middle assistant stays before its following activity", () => {
+  const grouped = groupMessages([
+    { id: "m1", role: "assistant", content: "I will check." },
+    { id: "a", role: "tool_activity", toolName: "read" },
+    { id: "m2", role: "assistant", content: "Done." },
+  ]);
+
+  assert.equal(grouped.length, 3);
+  assert.equal(grouped[0].type, "message");
+  assert.equal(grouped[0].message.id, "m1");
+  assert.equal(grouped[1].type, "tool-run");
+  assert.equal(grouped[2].type, "message");
+  assert.equal(grouped[2].message.id, "m2");
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
@@ -43,7 +43,12 @@ test("groupMessages: toolCalls-bearing messages are not grouped and break runs",
 test("groupMessages: final assistant renders after trailing activity", () => {
   const grouped = groupMessages([
     { id: "u", role: "user", content: "connect notion" },
-    { id: "m", role: "assistant", content: "I cannot connect Notion." },
+    {
+      id: "m",
+      role: "assistant",
+      content: "I cannot connect Notion.",
+      isFinalReply: true,
+    },
     { id: "a", role: "tool_activity", toolName: "notion-get-self" },
     { id: "r", role: "thinking", content: "Need to check the integration." },
   ]);
@@ -59,18 +64,20 @@ test("groupMessages: final assistant renders after trailing activity", () => {
   assert.equal(grouped[3].message.id, "m");
 });
 
-test("groupMessages: final assistant remains last after earlier and trailing activity", () => {
+test("groupMessages: trailing activity stays separate from earlier tool runs", () => {
   const grouped = groupMessages([
     { id: "a", role: "tool_activity", toolName: "read" },
-    { id: "m", role: "assistant", content: "Done." },
+    { id: "m", role: "assistant", content: "Done.", isFinalReply: true },
     { id: "b", role: "tool_activity", toolName: "grep" },
   ]);
 
-  assert.equal(grouped.length, 2);
+  assert.equal(grouped.length, 3);
   assert.equal(grouped[0].type, "tool-run");
-  assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a", "b"]);
-  assert.equal(grouped[1].type, "message");
-  assert.equal(grouped[1].message.id, "m");
+  assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a"]);
+  assert.equal(grouped[1].type, "tool-run");
+  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["b"]);
+  assert.equal(grouped[2].type, "message");
+  assert.equal(grouped[2].message.id, "m");
 });
 
 test("groupMessages: middle assistant stays before its following activity", () => {
@@ -86,4 +93,63 @@ test("groupMessages: middle assistant stays before its following activity", () =
   assert.equal(grouped[1].type, "tool-run");
   assert.equal(grouped[2].type, "message");
   assert.equal(grouped[2].message.id, "m2");
+});
+
+test("groupMessages: middle assistant is not hoisted before final reply arrives", () => {
+  const grouped = groupMessages([
+    { id: "m", role: "assistant", content: "I will check." },
+    { id: "a", role: "tool_activity", toolName: "read" },
+    { id: "b", role: "tool_activity", toolName: "grep" },
+  ]);
+
+  assert.equal(grouped.length, 2);
+  assert.equal(grouped[0].type, "message");
+  assert.equal(grouped[0].message.id, "m");
+  assert.equal(grouped[1].type, "tool-run");
+  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["a", "b"]);
+});
+
+test("groupMessages: assistant is not hoisted when non-auxiliary message trails", () => {
+  const grouped = groupMessages([
+    { id: "m", role: "assistant", content: "answer", isFinalReply: true },
+    { id: "a", role: "tool_activity", toolName: "read" },
+    { id: "s", role: "system", content: "later note" },
+  ]);
+
+  assert.equal(grouped.length, 3);
+  assert.equal(grouped[0].type, "message");
+  assert.equal(grouped[0].message.id, "m");
+  assert.equal(grouped[1].type, "tool-run");
+  assert.equal(grouped[2].type, "message");
+  assert.equal(grouped[2].message.id, "s");
+});
+
+test("groupMessages: toolCalls assistant is not the hoist target", () => {
+  const grouped = groupMessages([
+    { id: "m", role: "assistant", content: "answer", isFinalReply: true },
+    { id: "a", role: "tool_activity", toolName: "read" },
+    { id: "g", role: "assistant", toolCalls: [{ toolName: "read" }] },
+  ]);
+
+  assert.equal(grouped.length, 3);
+  assert.equal(grouped[0].type, "tool-run");
+  assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a"]);
+  assert.equal(grouped[1].type, "message");
+  assert.equal(grouped[1].message.id, "g");
+  assert.equal(grouped[2].type, "message");
+  assert.equal(grouped[2].message.id, "m");
+});
+
+test("groupMessages: no reordering when timeline has no assistant reply", () => {
+  const grouped = groupMessages([
+    { id: "u", role: "user", content: "run checks" },
+    { id: "a", role: "tool_activity", toolName: "read" },
+    { id: "b", role: "tool_activity", toolName: "grep" },
+  ]);
+
+  assert.equal(grouped.length, 2);
+  assert.equal(grouped[0].type, "message");
+  assert.equal(grouped[0].message.id, "u");
+  assert.equal(grouped[1].type, "tool-run");
+  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["a", "b"]);
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -130,6 +130,7 @@ export function useChatEvents({
               content: reply.text || "",
               timestamp: reply.generated_at || new Date().toISOString(),
               turnRunId: reply.turn_run_id,
+              isFinalReply: true,
             },
           ]);
           setPendingGate(null);
@@ -299,6 +300,7 @@ function applyProjectionItems({
           role: "assistant",
           content: item.text.body || "",
           timestamp: new Date().toISOString(),
+          isFinalReply: true,
         };
         if (existing >= 0) {
           const copy = [...prev];


### PR DESCRIPTION
## Summary
- Keep the final assistant reply visually last when trailing reasoning/tool activity arrives after it in WebUI v2 timelines.
- Preserve middle assistant narration ordering when another assistant message follows later.
- Add message grouping regressions for both cases.

## Validation
- node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
- cargo test -p ironclaw_webui_v2_static
- git diff --check
