### PR TITLE
Fix local-dev Reborn memory mount

### DIFF
--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -689,6 +689,9 @@ mod tests {
         // (e.g. a backend without pgvector); the trait-level capability
         // declaration is what gates real backends.
         let fs = InMemoryBackend::new();
+        let capabilities = fs.capabilities();
+        assert!(capabilities.has(crate::Capability::IndexFts));
+        assert!(capabilities.has(crate::Capability::IndexVector));
         let prefix = vpath("/memory");
         let fts = IndexSpec::new(
             IndexName::new("by_chunk").unwrap(),

--- a/crates/ironclaw_filesystem/src/types.rs
+++ b/crates/ironclaw_filesystem/src/types.rs
@@ -461,9 +461,10 @@ impl BackendCapabilities {
     }
 
     /// Convenience: every capability the in-memory reference backend
-    /// implements. Includes Events on top of `sql_typical`.
+    /// implements. Includes Events, FTS, and Vector on top of
+    /// `sql_typical`.
     pub const fn in_memory_full() -> Self {
-        Self::sql_typical().with(Capability::Events)
+        Self::sql_typical_full()
     }
 
     /// Convenience: read + write + append + list + stat + delete only.

--- a/crates/ironclaw_filesystem/src/types.rs
+++ b/crates/ironclaw_filesystem/src/types.rs
@@ -517,3 +517,17 @@ impl<'de> Deserialize<'de> for BackendCapabilities {
         Ok(out)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_full_includes_fts_vector_events() {
+        let capabilities = BackendCapabilities::in_memory_full();
+
+        assert!(capabilities.has(Capability::IndexFts));
+        assert!(capabilities.has(Capability::IndexVector));
+        assert!(capabilities.has(Capability::Events));
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1018,10 +1018,13 @@ async fn build_local_dev_root_filesystem(
         workspace_root,
         host_home_root,
     )?);
-    let mut root = CompositeRootFilesystem::new();
-    mount_local_dev_memory_root(&mut root, Arc::new(InMemoryBackend::new()))?;
-    mount_local_dev_project_roots(&mut root, local)?;
-    Ok(Arc::new(root))
+    tracing::warn!(
+        "local-dev: /memory is backed by InMemoryBackend; memory documents are ephemeral and will be lost on restart"
+    );
+    let mut composite = CompositeRootFilesystem::new();
+    mount_local_dev_memory_root(&mut composite, Arc::new(InMemoryBackend::new()))?;
+    mount_local_dev_project_roots(&mut composite, local)?;
+    Ok(Arc::new(composite))
 }
 
 fn local_dev_project_filesystem(
@@ -1230,6 +1233,8 @@ fn write_local_dev_secret_master_key(path: &Path, key: &str) -> Result<(), Rebor
     }
 }
 
+// Intentionally uncfg'd: these helpers are called from both libsql and
+// no-libsql local-dev root filesystem paths.
 fn local_dev_mount_descriptor(
     virtual_root: &str,
     backend_id: &str,
@@ -2311,6 +2316,70 @@ mod tests {
         assert_eq!(
             search["results"][0]["path"],
             serde_json::json!("projects/alpha/notes.md")
+        );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn local_dev_memory_documents_persist_across_rebuilds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_dev_root = dir.path().join("local-dev");
+        let owner = "local-dev-durable-memory-owner";
+
+        let services =
+            build_reborn_services(RebornBuildInput::local_dev(owner, local_dev_root.clone()))
+                .await
+                .expect("first local-dev services build");
+        let runtime = services
+            .host_runtime
+            .as_ref()
+            .expect("host runtime composed");
+
+        invoke_json(
+            runtime.as_ref(),
+            MEMORY_WRITE_CAPABILITY_ID,
+            memory_context(MEMORY_WRITE_CAPABILITY_ID),
+            serde_json::json!({
+                "target": "projects/durable/notes.md",
+                "content": "local dev durable mounted memory root search marker",
+                "append": false
+            }),
+        )
+        .await
+        .expect("memory_write should persist through the libsql /memory root");
+        drop(services);
+
+        let rebuilt =
+            build_reborn_services(RebornBuildInput::local_dev(owner, local_dev_root.clone()))
+                .await
+                .expect("rebuilt local-dev services");
+        let runtime = rebuilt.host_runtime.as_ref().expect("rebuilt host runtime");
+
+        let tree = invoke_json(
+            runtime.as_ref(),
+            MEMORY_TREE_CAPABILITY_ID,
+            memory_context(MEMORY_TREE_CAPABILITY_ID),
+            serde_json::json!({"path": "", "depth": 3}),
+        )
+        .await
+        .expect("memory_tree should list rebuilt libsql memory documents");
+        assert!(
+            tree.to_string().contains("durable/"),
+            "memory_tree should include the persisted memory document: {tree}"
+        );
+
+        let search = invoke_json(
+            runtime.as_ref(),
+            MEMORY_SEARCH_CAPABILITY_ID,
+            memory_context(MEMORY_SEARCH_CAPABILITY_ID),
+            serde_json::json!({"query": "durable mounted memory root search marker", "limit": 5}),
+        )
+        .await
+        .expect("memory_search should query rebuilt libsql memory documents");
+        assert_eq!(search["result_count"], serde_json::json!(1));
+        assert_eq!(
+            search["results"][0]["path"],
+            serde_json::json!("projects/durable/notes.md")
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -21,11 +21,13 @@ use ironclaw_events::{
 use ironclaw_extensions::{
     ExtensionInstallationStore, ExtensionLifecycleService, ExtensionRegistry,
 };
-use ironclaw_filesystem::RootFilesystem;
+#[cfg(not(feature = "libsql"))]
+use ironclaw_filesystem::InMemoryBackend;
 #[cfg(feature = "libsql")]
+use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::{
     BackendCapabilities, BackendId, BackendKind, Capability, CompositeRootFilesystem, ContentKind,
-    IndexPolicy, LibSqlRootFilesystem, MountDescriptor, StorageClass,
+    IndexPolicy, MountDescriptor, RootFilesystem, StorageClass,
 };
 use ironclaw_filesystem::{LocalFilesystem, ScopedFilesystem};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -109,10 +111,7 @@ use crate::{
     web_access::register_bundled_web_access_first_party_handlers,
 };
 
-#[cfg(feature = "libsql")]
 pub(crate) type LocalDevRootFilesystem = CompositeRootFilesystem;
-#[cfg(not(feature = "libsql"))]
-pub(crate) type LocalDevRootFilesystem = LocalFilesystem;
 
 type LocalDevWorkspaceFilesystems = (
     Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
@@ -991,6 +990,7 @@ async fn build_local_dev_root_filesystem(
         )?,
         Arc::clone(&database),
     )?;
+    mount_local_dev_memory_root(&mut root, Arc::clone(&database))?;
     root.mount(
         local_dev_mount_descriptor(
             "/events",
@@ -1003,30 +1003,7 @@ async fn build_local_dev_root_filesystem(
         )?,
         database,
     )?;
-    root.mount(
-        local_dev_mount_descriptor(
-            "/projects",
-            "local-dev-project-files",
-            BackendKind::LocalFilesystem,
-            StorageClass::FileContent,
-            ContentKind::ProjectFile,
-            IndexPolicy::NotIndexed,
-            local_dev_bytes_capabilities(),
-        )?,
-        Arc::clone(&local),
-    )?;
-    root.mount(
-        local_dev_mount_descriptor(
-            "/system/extensions",
-            "local-dev-system-extensions",
-            BackendKind::LocalFilesystem,
-            StorageClass::FileContent,
-            ContentKind::ExtensionPackage,
-            IndexPolicy::NotIndexed,
-            local_dev_bytes_capabilities(),
-        )?,
-        Arc::clone(&local),
-    )?;
+    mount_local_dev_project_roots(&mut root, local)?;
     Ok(Arc::new(root))
 }
 
@@ -1036,11 +1013,15 @@ async fn build_local_dev_root_filesystem(
     workspace_root: &Path,
     host_home_root: Option<&LocalDevHostHomeRoot>,
 ) -> Result<Arc<LocalDevRootFilesystem>, RebornBuildError> {
-    Ok(Arc::new(local_dev_project_filesystem(
+    let local = Arc::new(local_dev_project_filesystem(
         root,
         workspace_root,
         host_home_root,
-    )?))
+    )?);
+    let mut root = CompositeRootFilesystem::new();
+    mount_local_dev_memory_root(&mut root, Arc::new(InMemoryBackend::new()))?;
+    mount_local_dev_project_roots(&mut root, local)?;
+    Ok(Arc::new(root))
 }
 
 fn local_dev_project_filesystem(
@@ -1068,6 +1049,59 @@ fn local_dev_project_filesystem(
         )?;
     }
     Ok(filesystem)
+}
+
+fn mount_local_dev_memory_root<F>(
+    root: &mut CompositeRootFilesystem,
+    backend: Arc<F>,
+) -> Result<(), RebornBuildError>
+where
+    F: RootFilesystem + 'static,
+{
+    root.mount(
+        local_dev_mount_descriptor(
+            "/memory",
+            "local-dev-memory",
+            BackendKind::MemoryDocuments,
+            StorageClass::StructuredRecords,
+            ContentKind::MemoryDocument,
+            IndexPolicy::FullTextAndVector,
+            backend.capabilities(),
+        )?,
+        backend,
+    )?;
+    Ok(())
+}
+
+fn mount_local_dev_project_roots(
+    root: &mut CompositeRootFilesystem,
+    local: Arc<LocalFilesystem>,
+) -> Result<(), RebornBuildError> {
+    root.mount(
+        local_dev_mount_descriptor(
+            "/projects",
+            "local-dev-project-files",
+            BackendKind::LocalFilesystem,
+            StorageClass::FileContent,
+            ContentKind::ProjectFile,
+            IndexPolicy::NotIndexed,
+            local_dev_bytes_capabilities(),
+        )?,
+        Arc::clone(&local),
+    )?;
+    root.mount(
+        local_dev_mount_descriptor(
+            "/system/extensions",
+            "local-dev-system-extensions",
+            BackendKind::LocalFilesystem,
+            StorageClass::FileContent,
+            ContentKind::ExtensionPackage,
+            IndexPolicy::NotIndexed,
+            local_dev_bytes_capabilities(),
+        )?,
+        local,
+    )?;
+    Ok(())
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1196,7 +1230,6 @@ fn write_local_dev_secret_master_key(path: &Path, key: &str) -> Result<(), Rebor
     }
 }
 
-#[cfg(feature = "libsql")]
 fn local_dev_mount_descriptor(
     virtual_root: &str,
     backend_id: &str,
@@ -1217,7 +1250,6 @@ fn local_dev_mount_descriptor(
     })
 }
 
-#[cfg(feature = "libsql")]
 fn local_dev_bytes_capabilities() -> BackendCapabilities {
     BackendCapabilities::empty()
         .with(Capability::Read)
@@ -2192,6 +2224,7 @@ mod tests {
         RuntimeKind, ScopedPath, SecretHandle, TrustClass, UserId, VirtualPath,
     };
     use ironclaw_host_runtime::{
+        MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID, MEMORY_WRITE_CAPABILITY_ID,
         RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind,
         SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID,
     };
@@ -2227,6 +2260,58 @@ mod tests {
                 .is_some()
         );
         assert_eq!(services.readiness.state, RebornReadinessState::DevOnly);
+    }
+
+    #[tokio::test]
+    async fn local_dev_memory_first_party_tools_use_mounted_memory_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let services = build_reborn_services(RebornBuildInput::local_dev(
+            "local-dev-memory-owner",
+            dir.path().join("local-dev"),
+        ))
+        .await
+        .expect("local-dev services build");
+        let runtime = services.host_runtime.expect("host runtime composed");
+
+        invoke_json(
+            runtime.as_ref(),
+            MEMORY_WRITE_CAPABILITY_ID,
+            memory_context(MEMORY_WRITE_CAPABILITY_ID),
+            serde_json::json!({
+                "target": "projects/alpha/notes.md",
+                "content": "local dev mounted memory root search marker",
+                "append": false
+            }),
+        )
+        .await
+        .expect("memory_write should use the mounted /memory root");
+
+        let tree = invoke_json(
+            runtime.as_ref(),
+            MEMORY_TREE_CAPABILITY_ID,
+            memory_context(MEMORY_TREE_CAPABILITY_ID),
+            serde_json::json!({"path": "", "depth": 3}),
+        )
+        .await
+        .expect("memory_tree should list the mounted /memory root");
+        assert!(
+            tree.to_string().contains("alpha/"),
+            "memory_tree should include the written memory document: {tree}"
+        );
+
+        let search = invoke_json(
+            runtime.as_ref(),
+            MEMORY_SEARCH_CAPABILITY_ID,
+            memory_context(MEMORY_SEARCH_CAPABILITY_ID),
+            serde_json::json!({"query": "mounted memory root search marker", "limit": 5}),
+        )
+        .await
+        .expect("memory_search should query the mounted /memory root");
+        assert_eq!(search["result_count"], serde_json::json!(1));
+        assert_eq!(
+            search["results"][0]["path"],
+            serde_json::json!("projects/alpha/notes.md")
+        );
     }
 
     #[cfg(feature = "libsql")]
@@ -2970,6 +3055,14 @@ mod tests {
 
     fn workspace_context(capability_id: &str) -> ExecutionContext {
         execution_context(capability_id, workspace_mounts())
+    }
+
+    fn memory_context(capability_id: &str) -> ExecutionContext {
+        execution_context(
+            capability_id,
+            memory_mount_view(MountPermissions::read_write_list_delete())
+                .expect("valid memory mounts"),
+        )
     }
 
     fn gsuite_context(capability_id: &str) -> ExecutionContext {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -26,8 +26,8 @@ use ironclaw_filesystem::InMemoryBackend;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::{
-    BackendCapabilities, BackendId, BackendKind, Capability, CompositeRootFilesystem, ContentKind,
-    IndexPolicy, MountDescriptor, RootFilesystem, StorageClass,
+    BackendCapabilities, BackendId, BackendKind, CompositeRootFilesystem, ContentKind, IndexPolicy,
+    MountDescriptor, RootFilesystem, StorageClass,
 };
 use ironclaw_filesystem::{LocalFilesystem, ScopedFilesystem};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1088,7 +1088,7 @@ fn mount_local_dev_project_roots(
             StorageClass::FileContent,
             ContentKind::ProjectFile,
             IndexPolicy::NotIndexed,
-            local_dev_bytes_capabilities(),
+            BackendCapabilities::bytes_only(),
         )?,
         Arc::clone(&local),
     )?;
@@ -1100,7 +1100,7 @@ fn mount_local_dev_project_roots(
             StorageClass::FileContent,
             ContentKind::ExtensionPackage,
             IndexPolicy::NotIndexed,
-            local_dev_bytes_capabilities(),
+            BackendCapabilities::bytes_only(),
         )?,
         local,
     )?;
@@ -1233,8 +1233,8 @@ fn write_local_dev_secret_master_key(path: &Path, key: &str) -> Result<(), Rebor
     }
 }
 
-// Intentionally uncfg'd: these helpers are called from both libsql and
-// no-libsql local-dev root filesystem paths.
+// Intentionally uncfg'd: called from both libsql and no-libsql local-dev root
+// filesystem paths.
 fn local_dev_mount_descriptor(
     virtual_root: &str,
     backend_id: &str,
@@ -1253,16 +1253,6 @@ fn local_dev_mount_descriptor(
         index_policy,
         capabilities,
     })
-}
-
-fn local_dev_bytes_capabilities() -> BackendCapabilities {
-    BackendCapabilities::empty()
-        .with(Capability::Read)
-        .with(Capability::Write)
-        .with(Capability::Append)
-        .with(Capability::List)
-        .with(Capability::Stat)
-        .with(Capability::Delete)
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -2067,7 +2067,7 @@ fn local_dev_root_filesystem(
                 StorageClass::StructuredRecords,
                 ContentKind::MemoryDocument,
                 IndexPolicy::FullTextAndVector,
-                BackendCapabilities::in_memory_full(),
+                memory.capabilities(),
             )?,
             memory,
         )?;


### PR DESCRIPTION
## Summary
- Mount /memory on the local-dev libSQL root filesystem so Reborn first-party memory tools have a real structured-record backend.
- Make local-dev use a composite root filesystem in all feature shapes, with no-libSQL /memory backed by InMemoryBackend instead of a granted but missing mount.
- Advertise FTS/vector support from the in-memory filesystem backend, matching its implemented ensure_index/query behavior.
- Add a regression test that writes memory through the composed HostRuntime, then verifies memory_tree and memory_search succeed.

## Tests
- cargo fmt --check
- git diff --check
- cargo test -p ironclaw_filesystem ensure_index_accepts_fts_and_vector_kinds
- cargo test -p ironclaw_reborn_composition local_dev_memory_first_party_tools_use_mounted_memory_root
- cargo test -p ironclaw_reborn_composition --features libsql local_dev_memory_first_party_tools_use_mounted_memory_root
