### PR TITLE
Fix Codex ChatGPT Reborn empty responses

### DIFF
--- a/crates/ironclaw_llm/src/codex_chatgpt.rs
+++ b/crates/ironclaw_llm/src/codex_chatgpt.rs
@@ -20,6 +20,7 @@ use reqwest::Client;
 use rust_decimal::Decimal;
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
+use std::borrow::Cow;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
@@ -558,13 +559,17 @@ impl CodexChatGptProvider {
                     if data.is_empty() {
                         continue;
                     }
+                    if data == "[DONE]" {
+                        return Ok(result);
+                    }
 
                     let parsed: Value = match serde_json::from_str(data) {
                         Ok(v) => v,
                         Err(_) => continue,
                     };
 
-                    if Self::handle_sse_event(&mut result, event.event.as_str(), &parsed) {
+                    let event_type = Self::resolve_sse_event_type(event.event.as_str(), &parsed);
+                    if Self::handle_sse_event(&mut result, event_type.as_ref(), &parsed) {
                         return Ok(result);
                     }
                 }
@@ -605,13 +610,17 @@ impl CodexChatGptProvider {
                 if data.is_empty() {
                     continue;
                 }
+                if data == "[DONE]" {
+                    return Ok(result);
+                }
 
                 let parsed: Value = match serde_json::from_str(data) {
                     Ok(v) => v,
                     Err(_) => continue,
                 };
 
-                if Self::handle_sse_event(&mut result, current_event_type.as_str(), &parsed) {
+                let event_type = Self::resolve_sse_event_type(current_event_type.as_str(), &parsed);
+                if Self::handle_sse_event(&mut result, event_type.as_ref(), &parsed) {
                     return Ok(result);
                 }
             }
@@ -620,11 +629,29 @@ impl CodexChatGptProvider {
         Ok(result)
     }
 
+    fn resolve_sse_event_type<'a>(event_type: &'a str, parsed: &'a Value) -> Cow<'a, str> {
+        if !event_type.is_empty() && event_type != "message" {
+            return Cow::Borrowed(event_type);
+        }
+        parsed
+            .get("type")
+            .and_then(|value| value.as_str())
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Borrowed(event_type))
+    }
+
     fn handle_sse_event(result: &mut ResponsesResult, event_type: &str, parsed: &Value) -> bool {
         match event_type {
             "response.output_text.delta" => {
                 if let Some(delta) = parsed.get("delta").and_then(|d| d.as_str()) {
                     result.text.push_str(delta);
+                }
+            }
+            "response.output_text.done" => {
+                if result.text.is_empty()
+                    && let Some(text) = parsed.get("text").and_then(|d| d.as_str())
+                {
+                    result.text.push_str(text);
                 }
             }
             event_type
@@ -673,6 +700,19 @@ impl CodexChatGptProvider {
                     entry.arguments.push_str(delta);
                 }
             }
+            "response.function_call_arguments.done" => {
+                if let Some(item_id) = parsed.get("item_id").and_then(|v| v.as_str())
+                    && let Some(entry) = result.pending_tool_calls.get_mut(item_id)
+                    && let Some(arguments) = parsed.get("arguments").and_then(|d| d.as_str())
+                {
+                    entry.arguments = arguments.to_string();
+                }
+            }
+            "response.output_item.done" => {
+                if let Some(item) = parsed.get("item").or_else(|| parsed.get("output")) {
+                    Self::merge_completed_output_item(result, item, result.text.is_empty());
+                }
+            }
             "response.completed" => {
                 if let Some(response) = parsed.get("response")
                     && let Some(usage) = response.get("usage")
@@ -686,12 +726,110 @@ impl CodexChatGptProvider {
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0) as u32;
                 }
+                if let Some(response) = parsed.get("response") {
+                    Self::merge_completed_response_output(result, response);
+                }
+                tracing::debug!(
+                    content_bytes = result.text.len(),
+                    tool_call_count = result.pending_tool_calls.len(),
+                    input_tokens = result.input_tokens,
+                    output_tokens = result.output_tokens,
+                    "Codex ChatGPT: parsed completed response"
+                );
                 return true;
             }
             _ => {}
         }
 
         false
+    }
+
+    fn merge_completed_response_output(result: &mut ResponsesResult, response: &Value) {
+        if result.text.is_empty()
+            && let Some(output_text) = response.get("output_text").and_then(|value| value.as_str())
+        {
+            result.text.push_str(output_text);
+        }
+
+        let allow_text_fallback = result.text.is_empty();
+        if let Some(output) = response.get("output").and_then(|value| value.as_array()) {
+            for item in output {
+                Self::merge_completed_output_item(result, item, allow_text_fallback);
+            }
+        }
+    }
+
+    fn merge_completed_output_item(
+        result: &mut ResponsesResult,
+        item: &Value,
+        allow_text_fallback: bool,
+    ) {
+        match item.get("type").and_then(|value| value.as_str()) {
+            Some("message") => {
+                if allow_text_fallback {
+                    Self::append_output_message_text(&mut result.text, item);
+                }
+            }
+            Some("function_call") => {
+                let item_id = item
+                    .get("id")
+                    .and_then(|value| value.as_str())
+                    .or_else(|| item.get("call_id").and_then(|value| value.as_str()))
+                    .unwrap_or("")
+                    .to_string();
+                if item_id.is_empty() {
+                    return;
+                }
+                let call_id = item
+                    .get("call_id")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or(&item_id)
+                    .to_string();
+                let name = item
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let arguments = item
+                    .get("arguments")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                result
+                    .pending_tool_calls
+                    .entry(item_id)
+                    .and_modify(|existing| {
+                        if !call_id.is_empty() {
+                            existing.call_id = call_id.clone();
+                        }
+                        if !name.is_empty() {
+                            existing.name = name.clone();
+                        }
+                        if !arguments.is_empty() {
+                            existing.arguments = arguments.clone();
+                        }
+                    })
+                    .or_insert_with(|| PendingToolCall {
+                        call_id,
+                        name,
+                        arguments,
+                    });
+            }
+            _ => {}
+        }
+    }
+
+    fn append_output_message_text(output: &mut String, item: &Value) {
+        let Some(content) = item.get("content").and_then(|value| value.as_array()) else {
+            return;
+        };
+        for part in content {
+            if part.get("type").and_then(|value| value.as_str()) == Some("output_text")
+                && let Some(text) = part.get("text").and_then(|value| value.as_str())
+            {
+                output.push_str(text);
+            }
+        }
     }
 
     /// Remove keys with empty-string values from a JSON object.
@@ -988,6 +1126,48 @@ data: {"response":{"usage":{"input_tokens":10,"output_tokens":5}}}
     }
 
     #[test]
+    fn test_parse_sse_data_only_type_field_text_response() {
+        let sse = r#"data: {"type":"response.output_text.delta","delta":"Hello"}
+
+data: {"type":"response.output_text.delta","delta":" world!"}
+
+data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":5}}}
+
+"#;
+        let result = CodexChatGptProvider::parse_sse_response(sse).unwrap();
+        assert_eq!(result.text, "Hello world!");
+        assert_eq!(result.input_tokens, 10);
+        assert_eq!(result.output_tokens, 5);
+        assert!(result.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn test_parse_sse_output_text_done_without_delta() {
+        let sse = r#"data: {"type":"response.output_text.done","text":"Hello from done."}
+
+data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":5}}}
+
+"#;
+        let result = CodexChatGptProvider::parse_sse_response(sse).unwrap();
+        assert_eq!(result.text, "Hello from done.");
+        assert_eq!(result.input_tokens, 10);
+        assert_eq!(result.output_tokens, 5);
+        assert!(result.pending_tool_calls.is_empty());
+    }
+
+    #[test]
+    fn test_parse_sse_completed_response_output_text_without_deltas() {
+        let sse = r#"data: {"type":"response.completed","response":{"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello from final output."}]}],"usage":{"input_tokens":10,"output_tokens":5}}}
+
+"#;
+        let result = CodexChatGptProvider::parse_sse_response(sse).unwrap();
+        assert_eq!(result.text, "Hello from final output.");
+        assert_eq!(result.input_tokens, 10);
+        assert_eq!(result.output_tokens, 5);
+        assert!(result.pending_tool_calls.is_empty());
+    }
+
+    #[test]
     fn test_parse_sse_reasoning_summary_response() {
         let sse = r#"event: response.reasoning_summary_text.delta
 data: {"delta":"Thinking Steps\n"}
@@ -1036,6 +1216,20 @@ data: {"response":{"usage":{"input_tokens":20,"output_tokens":15}}}
         assert_eq!(tc.arguments, "{\"query\":\"rust\"}");
     }
 
+    #[test]
+    fn test_parse_sse_completed_response_output_tool_call_without_deltas() {
+        let sse = r#"data: {"type":"response.completed","response":{"output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"search","arguments":"{\"query\":\"rust\"}"}],"usage":{"input_tokens":20,"output_tokens":15}}}
+
+"#;
+        let result = CodexChatGptProvider::parse_sse_response(sse).unwrap();
+        assert!(result.text.is_empty());
+        assert_eq!(result.pending_tool_calls.len(), 1);
+        let tc = result.pending_tool_calls.get("fc_1").unwrap();
+        assert_eq!(tc.call_id, "call_1");
+        assert_eq!(tc.name, "search");
+        assert_eq!(tc.arguments, "{\"query\":\"rust\"}");
+    }
+
     #[tokio::test]
     async fn test_parse_sse_stream_response() {
         let stream = stream::iter(vec![
@@ -1047,6 +1241,28 @@ data: {"response":{"usage":{"input_tokens":20,"output_tokens":15}}}
             )),
             Ok(Bytes::from_static(
                 b"event: response.completed\ndata: {\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n\n",
+            )),
+        ]);
+
+        let result = CodexChatGptProvider::parse_sse_stream(stream, Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(result.text, "Hello world");
+        assert_eq!(result.input_tokens, 3);
+        assert_eq!(result.output_tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn test_parse_sse_stream_data_only_type_field_response() {
+        let stream = stream::iter(vec![
+            Ok(Bytes::from_static(
+                b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\n",
+            )),
+            Ok(Bytes::from_static(
+                b"data: {\"type\":\"response.output_text.delta\",\"delta\":\" world\"}\n\n",
+            )),
+            Ok(Bytes::from_static(
+                b"data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n\n",
             )),
         ]);
 
@@ -1099,6 +1315,39 @@ data: {"response":{"usage":{"input_tokens":3,"output_tokens":2}}}
             response.tool_calls[0].arguments,
             json!({"message": "hello"})
         );
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_accepts_data_only_text_response() {
+        let base_url = responses_api_test_server::spawn(
+            r#"data: {"type":"response.output_text.delta","delta":"Hello from data-only SSE."}
+
+data: {"type":"response.completed","response":{"usage":{"input_tokens":3,"output_tokens":2}}}
+
+"#,
+        )
+        .await;
+        let provider = CodexChatGptProvider::new(&base_url, "test-key", "gpt-4o");
+        let request = ToolCompletionRequest::new(
+            vec![ChatMessage::user("hello")],
+            vec![ToolDefinition {
+                name: "builtin.echo".to_string(),
+                description: "Echo input".to_string(),
+                parameters: json!({"type": "object"}),
+            }],
+        );
+
+        let response = provider
+            .complete_with_tools(request)
+            .await
+            .expect("tool-capable completion succeeds");
+
+        assert_eq!(
+            response.content.as_deref(),
+            Some("Hello from data-only SSE.")
+        );
+        assert!(response.tool_calls.is_empty());
+        assert_eq!(response.finish_reason, FinishReason::Stop);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_llm/src/codex_chatgpt.rs
+++ b/crates/ironclaw_llm/src/codex_chatgpt.rs
@@ -1217,6 +1217,30 @@ data: {"response":{"usage":{"input_tokens":20,"output_tokens":15}}}
     }
 
     #[test]
+    fn test_parse_sse_tool_call_done_events() {
+        let sse = r#"event: response.output_item.added
+data: {"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"search"}}
+
+event: response.function_call_arguments.done
+data: {"item_id":"fc_1","arguments":"{\"query\":\"rust\"}"}
+
+event: response.output_item.done
+data: {"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"search"}}
+
+event: response.completed
+data: {"response":{"usage":{"input_tokens":20,"output_tokens":15}}}
+
+"#;
+        let result = CodexChatGptProvider::parse_sse_response(sse).unwrap();
+        assert!(result.text.is_empty());
+        assert_eq!(result.pending_tool_calls.len(), 1);
+        let tc = result.pending_tool_calls.get("fc_1").unwrap();
+        assert_eq!(tc.call_id, "call_1");
+        assert_eq!(tc.name, "search");
+        assert_eq!(tc.arguments, "{\"query\":\"rust\"}");
+    }
+
+    #[test]
     fn test_parse_sse_completed_response_output_tool_call_without_deltas() {
         let sse = r#"data: {"type":"response.completed","response":{"output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"search","arguments":"{\"query\":\"rust\"}"}],"usage":{"input_tokens":20,"output_tokens":15}}}
 
@@ -1272,6 +1296,33 @@ data: {"response":{"usage":{"input_tokens":20,"output_tokens":15}}}
         assert_eq!(result.text, "Hello world");
         assert_eq!(result.input_tokens, 3);
         assert_eq!(result.output_tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn test_parse_sse_done_marker_stops_parsing() {
+        let sse = r#"data: {"type":"response.output_text.delta","delta":"hello"}
+
+data: [DONE]
+
+data: {"type":"response.output_text.delta","delta":" ignored"}
+
+"#;
+        let result = CodexChatGptProvider::parse_sse_response(sse).unwrap();
+        assert_eq!(result.text, "hello");
+
+        let stream = stream::iter(vec![
+            Ok(Bytes::from_static(
+                b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
+            )),
+            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
+            Ok(Bytes::from_static(
+                b"data: {\"type\":\"response.output_text.delta\",\"delta\":\" ignored\"}\n\n",
+            )),
+        ]);
+        let result = CodexChatGptProvider::parse_sse_stream(stream, Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(result.text, "hello");
     }
 
     #[tokio::test]

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -84,7 +84,10 @@ pub use reasoning::{
     TokenUsage, ToolSelection, is_silent_reply, llm_signals_tool_intent,
     user_signals_execution_intent,
 };
-pub use reasoning::{clean_response, recover_tool_calls_from_content};
+pub use reasoning::{
+    clean_response, contains_codex_text_tool_call_syntax,
+    recover_codex_text_tool_calls_from_content, recover_tool_calls_from_content,
+};
 pub use recording::{MemorySnapshotEntry, RecordingLlm};
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 #[cfg(feature = "registry-provider-factory")]

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -86,7 +86,8 @@ pub use reasoning::{
 };
 pub use reasoning::{
     clean_response, contains_codex_text_tool_call_syntax,
-    recover_codex_text_tool_calls_from_content, recover_tool_calls_from_content,
+    recover_codex_text_tool_calls_from_content, recover_codex_text_tool_calls_from_tool_names,
+    recover_tool_calls_from_content,
 };
 pub use recording::{MemorySnapshotEntry, RecordingLlm};
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};

--- a/crates/ironclaw_llm/src/reasoning.rs
+++ b/crates/ironclaw_llm/src/reasoning.rs
@@ -1842,7 +1842,90 @@ pub fn recover_tool_calls_from_content(
         }
     }
 
+    recover_codex_text_tool_calls(content, &tool_names, &mut calls);
+
     calls
+}
+
+/// Recover Codex textual tool-call syntax such as
+/// `to=tool.name json\n{...}` when the tool name is present in the
+/// advertised tool surface.
+pub fn recover_codex_text_tool_calls_from_content(
+    content: &str,
+    available_tools: &[ToolDefinition],
+) -> Vec<ToolCall> {
+    let tool_names: std::collections::HashSet<&str> =
+        available_tools.iter().map(|t| t.name.as_str()).collect();
+    let mut calls = Vec::new();
+    recover_codex_text_tool_calls(content, &tool_names, &mut calls);
+    calls
+}
+
+fn recover_codex_text_tool_calls(
+    content: &str,
+    tool_names: &std::collections::HashSet<&str>,
+    calls: &mut Vec<ToolCall>,
+) {
+    let mut search_from = 0;
+    while let Some(offset) = content[search_from..].find("to=") {
+        let start = search_from + offset;
+        let Some((name, arguments, end)) = parse_codex_text_tool_call_at(content, start) else {
+            search_from = start + "to=".len();
+            continue;
+        };
+        search_from = end.max(start + 1);
+
+        if !tool_names.contains(name.as_str()) {
+            continue;
+        }
+
+        calls.push(ToolCall {
+            id: super::provider::generate_tool_call_id(calls.len(), RECOVERED_TOOL_CALL_SEED),
+            name,
+            arguments,
+            reasoning: None,
+            signature: None,
+        });
+    }
+}
+
+pub fn contains_codex_text_tool_call_syntax(content: &str) -> bool {
+    let mut search_from = 0;
+    while let Some(offset) = content[search_from..].find("to=") {
+        let start = search_from + offset;
+        if parse_codex_text_tool_call_at(content, start).is_some() {
+            return true;
+        }
+        search_from = start + "to=".len();
+    }
+    false
+}
+
+fn parse_codex_text_tool_call_at(
+    content: &str,
+    start: usize,
+) -> Option<(String, serde_json::Value, usize)> {
+    let after_prefix = content.get(start..)?.strip_prefix("to=")?;
+    let name_start = start + "to=".len();
+    let name_end = after_prefix
+        .find(|ch: char| ch.is_whitespace() || ch == '{')
+        .map(|relative| name_start + relative)
+        .unwrap_or(content.len());
+    let name = &content[name_start..name_end];
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return None;
+    }
+
+    let brace_start = name_end + content[name_end..].find('{')?;
+    let mut json_stream = serde_json::Deserializer::from_str(&content[brace_start..])
+        .into_iter::<serde_json::Value>();
+    let arguments = json_stream.next()?.ok()?;
+    let consumed = json_stream.byte_offset();
+    Some((name.to_string(), arguments, brace_start + consumed.max(1)))
 }
 
 /// `<tool_call>tool_list</tool_call>` or `<|tool_call|>` in the content field
@@ -1901,8 +1984,40 @@ pub fn clean_response(text: &str) -> String {
         result = strip_markdown_fence_block(&result, tag);
     }
 
+    // 6d. Strip Codex textual tool-call syntax emitted by fallback model
+    // paths, e.g. `to=tool.name ...json\n{...}`. Recovery handles valid
+    // advertised tools before cleanup; this prevents residual call syntax
+    // from becoming user-visible prose.
+    result = strip_codex_text_tool_calls(&result);
+
     // 7. Collapse triple+ newlines, trim
     collapse_newlines(&result)
+}
+
+fn strip_codex_text_tool_calls(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut cursor = 0;
+    while let Some(offset) = text[cursor..].find("to=") {
+        let start = cursor + offset;
+        if let Some((_, _, end)) = parse_codex_text_tool_call_at(text, start) {
+            result.push_str(&text[cursor..start]);
+            if result.chars().last().is_some_and(|ch| !ch.is_whitespace())
+                && text[end..]
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| !ch.is_whitespace())
+            {
+                result.push(' ');
+            }
+            cursor = end;
+        } else {
+            let consumed = start + "to=".len();
+            result.push_str(&text[cursor..consumed]);
+            cursor = consumed;
+        }
+    }
+    result.push_str(&text[cursor..]);
+    result
 }
 
 /// Strip markdown-fenced tool-call blocks like ` ```tool_call\n{...}\n``` `.
@@ -3094,12 +3209,54 @@ That's my plan."#;
     }
 
     #[test]
+    fn test_recover_codex_text_tool_call() {
+        let tools = make_tools(&["notion.notion-search"]);
+        let content = "Searching now.to=notion.notion-search weirdjson\n{\"query\":\"\",\"query_type\":\"internal\"}";
+        let calls = recover_tool_calls_from_content(content, &tools);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "notion.notion-search");
+        assert_eq!(
+            calls[0].arguments,
+            serde_json::json!({"query":"","query_type":"internal"})
+        );
+    }
+
+    #[test]
+    fn test_recover_multiple_codex_text_tool_calls() {
+        let tools = make_tools(&["demo__echo"]);
+        let content =
+            "to=demo__echo json\n{\"message\":\"one\"}to=demo__echo json\n{\"message\":\"two\"}";
+        let calls = recover_tool_calls_from_content(content, &tools);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].arguments, serde_json::json!({"message":"one"}));
+        assert_eq!(calls[1].arguments, serde_json::json!({"message":"two"}));
+    }
+
+    #[test]
+    fn test_recover_codex_text_unknown_tool_ignored() {
+        let tools = make_tools(&["http"]);
+        let content = "to=hidden.tool json\n{}";
+        let calls = recover_tool_calls_from_content(content, &tools);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
     fn test_clean_response_strips_bracket_tool_calls() {
         let input = "Let me fetch that.\n[Called tool `http` with arguments: {\"method\":\"GET\",\"url\":\"https://example.com\"}]\nHere are the results.";
         let cleaned = clean_response(input);
         assert!(!cleaned.contains("[Called tool"));
         assert!(cleaned.contains("Let me fetch that."));
         assert!(cleaned.contains("Here are the results."));
+    }
+
+    #[test]
+    fn test_clean_response_strips_codex_text_tool_calls() {
+        let input = "Searching now.to=notion.notion-search weirdjson\n{\"query\":\"\",\"query_type\":\"internal\"}I am waiting for results.";
+        let cleaned = clean_response(input);
+        assert!(!cleaned.contains("to=notion.notion-search"));
+        assert!(!cleaned.contains("\"query_type\""));
+        assert!(cleaned.contains("Searching now."));
+        assert!(cleaned.contains("I am waiting for results."));
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/reasoning.rs
+++ b/crates/ironclaw_llm/src/reasoning.rs
@@ -1854,10 +1854,30 @@ pub fn recover_codex_text_tool_calls_from_content(
     content: &str,
     available_tools: &[ToolDefinition],
 ) -> Vec<ToolCall> {
-    let tool_names: std::collections::HashSet<&str> =
-        available_tools.iter().map(|t| t.name.as_str()).collect();
+    let tool_names = available_tools
+        .iter()
+        .map(|tool| tool.name.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    recover_codex_text_tool_calls_from_name_set(content, &tool_names)
+}
+
+pub fn recover_codex_text_tool_calls_from_tool_names(
+    content: &str,
+    tool_names: &[String],
+) -> Vec<ToolCall> {
+    let tool_names = tool_names
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::HashSet<_>>();
+    recover_codex_text_tool_calls_from_name_set(content, &tool_names)
+}
+
+fn recover_codex_text_tool_calls_from_name_set(
+    content: &str,
+    tool_names: &std::collections::HashSet<&str>,
+) -> Vec<ToolCall> {
     let mut calls = Vec::new();
-    recover_codex_text_tool_calls(content, &tool_names, &mut calls);
+    recover_codex_text_tool_calls(content, tool_names, &mut calls);
     calls
 }
 
@@ -1866,6 +1886,7 @@ fn recover_codex_text_tool_calls(
     tool_names: &std::collections::HashSet<&str>,
     calls: &mut Vec<ToolCall>,
 ) {
+    let code_regions = find_code_regions(content);
     let mut search_from = 0;
     while let Some(offset) = content[search_from..].find("to=") {
         let start = search_from + offset;
@@ -1874,6 +1895,10 @@ fn recover_codex_text_tool_calls(
             continue;
         };
         search_from = end.max(start + 1);
+
+        if !is_recoverable_tool_call_segment(content, start, end, &code_regions) {
+            continue;
+        }
 
         if !tool_names.contains(name.as_str()) {
             continue;
@@ -1890,10 +1915,13 @@ fn recover_codex_text_tool_calls(
 }
 
 pub fn contains_codex_text_tool_call_syntax(content: &str) -> bool {
+    let code_regions = find_code_regions(content);
     let mut search_from = 0;
     while let Some(offset) = content[search_from..].find("to=") {
         let start = search_from + offset;
-        if parse_codex_text_tool_call_at(content, start).is_some() {
+        if let Some((_, _, end)) = parse_codex_text_tool_call_at(content, start)
+            && is_recoverable_tool_call_segment(content, start, end, &code_regions)
+        {
             return true;
         }
         search_from = start + "to=".len();
@@ -1920,7 +1948,12 @@ fn parse_codex_text_tool_call_at(
         return None;
     }
 
-    let brace_start = name_end + content[name_end..].find('{')?;
+    let separator = &content[name_end..];
+    let brace_relative = separator.find('{')?;
+    if !separator[..brace_relative].trim_end().ends_with("json") {
+        return None;
+    }
+    let brace_start = name_end + brace_relative;
     let mut json_stream = serde_json::Deserializer::from_str(&content[brace_start..])
         .into_iter::<serde_json::Value>();
     let arguments = json_stream.next()?.ok()?;
@@ -1995,11 +2028,14 @@ pub fn clean_response(text: &str) -> String {
 }
 
 fn strip_codex_text_tool_calls(text: &str) -> String {
+    let code_regions = find_code_regions(text);
     let mut result = String::with_capacity(text.len());
     let mut cursor = 0;
     while let Some(offset) = text[cursor..].find("to=") {
         let start = cursor + offset;
-        if let Some((_, _, end)) = parse_codex_text_tool_call_at(text, start) {
+        if let Some((_, _, end)) = parse_codex_text_tool_call_at(text, start)
+            && is_recoverable_tool_call_segment(text, start, end, &code_regions)
+        {
             result.push_str(&text[cursor..start]);
             if result.chars().last().is_some_and(|ch| !ch.is_whitespace())
                 && text[end..]
@@ -3211,7 +3247,8 @@ That's my plan."#;
     #[test]
     fn test_recover_codex_text_tool_call() {
         let tools = make_tools(&["notion.notion-search"]);
-        let content = "Searching now.to=notion.notion-search weirdjson\n{\"query\":\"\",\"query_type\":\"internal\"}";
+        let content =
+            "to=notion.notion-search weirdjson\n{\"query\":\"\",\"query_type\":\"internal\"}";
         let calls = recover_tool_calls_from_content(content, &tools);
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "notion.notion-search");
@@ -3225,7 +3262,7 @@ That's my plan."#;
     fn test_recover_multiple_codex_text_tool_calls() {
         let tools = make_tools(&["demo__echo"]);
         let content =
-            "to=demo__echo json\n{\"message\":\"one\"}to=demo__echo json\n{\"message\":\"two\"}";
+            "to=demo__echo json\n{\"message\":\"one\"}\nto=demo__echo json\n{\"message\":\"two\"}";
         let calls = recover_tool_calls_from_content(content, &tools);
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].arguments, serde_json::json!({"message":"one"}));
@@ -3241,6 +3278,22 @@ That's my plan."#;
     }
 
     #[test]
+    fn test_recover_codex_text_inline_prose_ignored() {
+        let tools = make_tools(&["demo__echo"]);
+        let content = "Here is an example: to=demo__echo json\n{\"message\":\"hello\"}";
+        let calls = recover_tool_calls_from_content(content, &tools);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn test_recover_codex_text_in_fenced_code_ignored() {
+        let tools = make_tools(&["demo__echo"]);
+        let content = "```text\nto=demo__echo json\n{\"message\":\"hello\"}\n```";
+        let calls = recover_tool_calls_from_content(content, &tools);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
     fn test_clean_response_strips_bracket_tool_calls() {
         let input = "Let me fetch that.\n[Called tool `http` with arguments: {\"method\":\"GET\",\"url\":\"https://example.com\"}]\nHere are the results.";
         let cleaned = clean_response(input);
@@ -3251,7 +3304,7 @@ That's my plan."#;
 
     #[test]
     fn test_clean_response_strips_codex_text_tool_calls() {
-        let input = "Searching now.to=notion.notion-search weirdjson\n{\"query\":\"\",\"query_type\":\"internal\"}I am waiting for results.";
+        let input = "Searching now.\nto=notion.notion-search weirdjson\n{\"query\":\"\",\"query_type\":\"internal\"}\nI am waiting for results.";
         let cleaned = clean_response(input);
         assert!(!cleaned.contains("to=notion.notion-search"));
         assert!(!cleaned.contains("\"query_type\""));

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -17,7 +17,9 @@ use ironclaw_host_api::sha256_digest_token;
 use ironclaw_llm::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider, Role,
     ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition, clean_response,
+    contains_codex_text_tool_call_syntax,
     costs::{default_cost, model_cost},
+    recover_codex_text_tool_calls_from_content,
 };
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
@@ -782,18 +784,22 @@ where
             );
         }
         if !tool_definitions.is_empty() {
-            let tool_request = ToolCompletionRequest::from_completion_request(
-                completion,
-                tool_definitions
-                    .into_iter()
-                    .map(provider_tool_definition_to_llm)
-                    .collect(),
-            );
+            let llm_tool_definitions = tool_definitions
+                .into_iter()
+                .map(provider_tool_definition_to_llm)
+                .collect::<Vec<_>>();
+            let recovery_tool_definitions = llm_tool_definitions.clone();
+            let tool_request =
+                ToolCompletionRequest::from_completion_request(completion, llm_tool_definitions);
             debug!("reborn model gateway dispatching tool-capable provider request");
             let response = provider
                 .complete_with_tools(tool_request)
                 .await
                 .map_err(map_provider_error)?;
+            let response = recover_textual_tool_calls_from_tool_response(
+                response,
+                &recovery_tool_definitions,
+            )?;
             return tool_response_to_host(
                 response,
                 capabilities,
@@ -823,6 +829,45 @@ where
         "reborn model gateway received text-only provider response"
     );
     response_to_host_reply(response)
+}
+
+fn recover_textual_tool_calls_from_tool_response(
+    response: ToolCompletionResponse,
+    tool_definitions: &[ToolDefinition],
+) -> Result<ToolCompletionResponse, HostManagedModelError> {
+    if !response.tool_calls.is_empty() {
+        return Ok(response);
+    }
+    let Some(content) = response.content.as_deref() else {
+        return Ok(response);
+    };
+    let recovered_tool_calls =
+        recover_codex_text_tool_calls_from_content(content, tool_definitions);
+    if recovered_tool_calls.is_empty() {
+        if contains_codex_text_tool_call_syntax(content) {
+            debug!("reborn model gateway rejected unrecovered textual provider tool-call syntax");
+            return Err(HostManagedModelError::safe(
+                HostManagedModelErrorKind::InvalidOutput,
+                "model returned textual tool-call syntax instead of structured tool calls",
+            ));
+        }
+        return Ok(response);
+    }
+
+    debug!(
+        recovered_tool_call_count = recovered_tool_calls.len(),
+        "reborn model gateway recovered capability calls from textual provider response"
+    );
+    Ok(ToolCompletionResponse {
+        content: Some(clean_response(content)),
+        tool_calls: recovered_tool_calls,
+        input_tokens: response.input_tokens,
+        output_tokens: response.output_tokens,
+        finish_reason: FinishReason::ToolUse,
+        cache_read_input_tokens: response.cache_read_input_tokens,
+        cache_creation_input_tokens: response.cache_creation_input_tokens,
+        reasoning: response.reasoning,
+    })
 }
 
 fn provider_tool_definition_to_llm(definition: ProviderToolDefinition) -> ToolDefinition {
@@ -929,6 +974,12 @@ async fn tool_response_to_host(
     match response.finish_reason {
         FinishReason::Stop => {
             let content = clean_response(&response.content.unwrap_or_default());
+            if content.trim().is_empty() {
+                return Err(HostManagedModelError::safe(
+                    HostManagedModelErrorKind::InvalidOutput,
+                    "model returned an empty assistant response",
+                ));
+            }
             debug!(
                 content_bytes = content.len(),
                 "reborn model gateway classified tool-capable provider response as assistant reply"

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -19,7 +19,7 @@ use ironclaw_llm::{
     ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition, clean_response,
     contains_codex_text_tool_call_syntax,
     costs::{default_cost, model_cost},
-    recover_codex_text_tool_calls_from_content,
+    recover_codex_text_tool_calls_from_tool_names,
 };
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
@@ -784,11 +784,14 @@ where
             );
         }
         if !tool_definitions.is_empty() {
+            let mut recovery_tool_names = Vec::with_capacity(tool_definitions.len());
             let llm_tool_definitions = tool_definitions
                 .into_iter()
-                .map(provider_tool_definition_to_llm)
+                .map(|definition| {
+                    recovery_tool_names.push(definition.name.clone());
+                    provider_tool_definition_to_llm(definition)
+                })
                 .collect::<Vec<_>>();
-            let recovery_tool_definitions = llm_tool_definitions.clone();
             let tool_request =
                 ToolCompletionRequest::from_completion_request(completion, llm_tool_definitions);
             debug!("reborn model gateway dispatching tool-capable provider request");
@@ -796,10 +799,8 @@ where
                 .complete_with_tools(tool_request)
                 .await
                 .map_err(map_provider_error)?;
-            let response = recover_textual_tool_calls_from_tool_response(
-                response,
-                &recovery_tool_definitions,
-            )?;
+            let response =
+                recover_textual_tool_calls_from_tool_response(response, &recovery_tool_names)?;
             return tool_response_to_host(
                 response,
                 capabilities,
@@ -833,7 +834,7 @@ where
 
 fn recover_textual_tool_calls_from_tool_response(
     response: ToolCompletionResponse,
-    tool_definitions: &[ToolDefinition],
+    tool_names: &[String],
 ) -> Result<ToolCompletionResponse, HostManagedModelError> {
     if !response.tool_calls.is_empty() {
         return Ok(response);
@@ -841,8 +842,7 @@ fn recover_textual_tool_calls_from_tool_response(
     let Some(content) = response.content.as_deref() else {
         return Ok(response);
     };
-    let recovered_tool_calls =
-        recover_codex_text_tool_calls_from_content(content, tool_definitions);
+    let recovered_tool_calls = recover_codex_text_tool_calls_from_tool_names(content, tool_names);
     if recovered_tool_calls.is_empty() {
         if contains_codex_text_tool_call_syntax(content) {
             debug!("reborn model gateway rejected unrecovered textual provider tool-call syntax");

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -342,6 +342,99 @@ async fn gateway_with_tool_surface_calls_complete_with_tools_and_returns_capabil
 }
 
 #[tokio::test]
+async fn gateway_rejects_empty_tool_capable_stop_response_without_text_only_retry() {
+    let provider = Arc::new(ToolAwareProvider::tool_response(ToolCompletionResponse {
+        content: None,
+        tool_calls: Vec::new(),
+        input_tokens: 1,
+        output_tokens: 1,
+        finish_reason: FinishReason::Stop,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning: None,
+    }));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let error = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
+    assert!(capabilities.registered.lock().unwrap().is_empty());
+    assert_eq!(provider.tool_requests.lock().unwrap().len(), 1);
+    assert!(provider.complete_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn gateway_recovers_capability_calls_from_textual_tool_syntax() {
+    let provider = Arc::new(ToolAwareProvider::tool_stop_reply(
+        "Searching now.to=demo__echo weirdjson\n{\"message\":\"hello\"}",
+    ));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let response = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
+        .await
+        .unwrap();
+
+    let ParentLoopOutput::CapabilityCalls(calls) = response.output else {
+        panic!("expected capability calls");
+    };
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0].capability_id,
+        CapabilityId::new("demo.echo").unwrap()
+    );
+    assert_eq!(provider.tool_requests.lock().unwrap().len(), 1);
+    assert!(provider.complete_requests.lock().unwrap().is_empty());
+
+    let registered = capabilities.registered.lock().unwrap();
+    assert_eq!(registered.len(), 1);
+    assert_eq!(registered[0].name, "demo__echo");
+    assert_eq!(
+        registered[0].arguments,
+        serde_json::json!({"message":"hello"})
+    );
+}
+
+#[tokio::test]
+async fn gateway_rejects_unrecovered_textual_tool_syntax() {
+    let provider = Arc::new(ToolAwareProvider::tool_stop_reply(
+        "Searching now.to=hidden.tool weirdjson\n{\"message\":\"hello\"}",
+    ));
+    let gateway = LlmProviderModelGateway::with_provider_identity(
+        STATIC_PROVIDER_ID,
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    );
+    let capabilities = Arc::new(GatewayCapabilityPort::with_tool_surface());
+
+    let error = gateway
+        .stream_model_with_capabilities(model_request(interactive_model()), capabilities.clone())
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, HostManagedModelErrorKind::InvalidOutput);
+    assert!(capabilities.registered.lock().unwrap().is_empty());
+    assert_eq!(provider.tool_requests.lock().unwrap().len(), 1);
+    assert!(provider.complete_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn gateway_preserves_structured_tool_calls_when_content_has_legacy_marker() {
     let provider = Arc::new(ToolAwareProvider::tool_response(ToolCompletionResponse {
         content: Some(

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -375,7 +375,7 @@ async fn gateway_rejects_empty_tool_capable_stop_response_without_text_only_retr
 #[tokio::test]
 async fn gateway_recovers_capability_calls_from_textual_tool_syntax() {
     let provider = Arc::new(ToolAwareProvider::tool_stop_reply(
-        "Searching now.to=demo__echo weirdjson\n{\"message\":\"hello\"}",
+        "Searching now.\nto=demo__echo weirdjson\n{\"message\":\"hello\"}",
     ));
     let gateway = LlmProviderModelGateway::with_provider_identity(
         STATIC_PROVIDER_ID,
@@ -413,7 +413,7 @@ async fn gateway_recovers_capability_calls_from_textual_tool_syntax() {
 #[tokio::test]
 async fn gateway_rejects_unrecovered_textual_tool_syntax() {
     let provider = Arc::new(ToolAwareProvider::tool_stop_reply(
-        "Searching now.to=hidden.tool weirdjson\n{\"message\":\"hello\"}",
+        "Searching now.\nto=hidden.tool weirdjson\n{\"message\":\"hello\"}",
     ));
     let gateway = LlmProviderModelGateway::with_provider_identity(
         STATIC_PROVIDER_ID,


### PR DESCRIPTION
## Summary
- harden Codex ChatGPT SSE parsing for data-only `type` events, `[DONE]`, `response.output_text.done`, `response.output_item.done`, and completed-response output fallbacks
- recover Codex textual `to=<tool>` call syntax through a canonical `ironclaw_llm` helper, while stripping it from visible assistant text
- make the Reborn gateway fail fast on genuinely empty tool-capable responses instead of doing a slow second text-only provider call

## Thermo review notes
- Removed the text-only fallback round trip from the gateway; it was the main latency regression and added incidental orchestration complexity.
- Moved textual tool-call parsing out of `ironclaw_reborn::model_gateway` and into `ironclaw_llm::reasoning` so the gateway does not carry a bespoke duplicate parser.
- Kept Reborn’s responsibility narrow: recover/reject a provider response, then dispatch through the existing capability path.

## Validation
- `cargo test -p ironclaw_llm codex_chatgpt -- --nocapture`
- `cargo test -p ironclaw_llm codex_text -- --nocapture`
- `cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway -- --nocapture`
- `git diff --check`
