### PR TITLE
[codex] Zeroize HTTP credential carriers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,6 +4521,7 @@ dependencies = [
  "wat",
  "wit-component 0.245.1",
  "wit-parser 0.245.1",
+ "zeroize",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.18",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -4641,6 +4642,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/ironclaw_host_api/Cargo.toml
+++ b/crates/ironclaw_host_api/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
+zeroize = "1"
 
 [dev-dependencies]
 rust_decimal_macros = "1"

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -64,6 +64,10 @@ impl Drop for RuntimeHttpEgressRequest {
 
 impl RuntimeHttpEgressRequest {
     fn scrub_sensitive_url_and_headers(&mut self) {
+        // Host credential injection currently writes secrets into URL components
+        // and header values. Header names and body payloads are separate
+        // caller-controlled data and need an explicit threat-model decision
+        // before broadening this carrier scrub scope.
         self.url.zeroize();
         for (_, value) in &mut self.headers {
             value.zeroize();

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -8,12 +8,19 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
     CapabilityId, HostApiError, MountGrant, NetworkMethod, NetworkPolicy, ResourceScope,
     RuntimeKind, ScopedPath, SecretHandle,
 };
 
+/// Runtime HTTP request accepted by the host-owned egress service.
+///
+/// URL and header values may contain host-injected credential material after
+/// the service resolves approved credential injections. Those buffers are
+/// zeroized when the request is dropped; transport code may still need
+/// plaintext while dispatching the request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeHttpEgressRequest {
     pub runtime: RuntimeKind,
@@ -48,6 +55,28 @@ pub struct RuntimeHttpEgressRequest {
     /// runtime to its remaining execution deadline when applicable.
     pub timeout_ms: Option<u32>,
 }
+
+impl Drop for RuntimeHttpEgressRequest {
+    fn drop(&mut self) {
+        self.scrub_sensitive_url_and_headers();
+    }
+}
+
+impl RuntimeHttpEgressRequest {
+    fn scrub_sensitive_url_and_headers(&mut self) {
+        self.url.zeroize();
+        for (_, value) in &mut self.headers {
+            value.zeroize();
+        }
+    }
+}
+
+impl ZeroizeOnDrop for RuntimeHttpEgressRequest {}
+
+const _: fn(&RuntimeHttpEgressRequest) = |request| {
+    fn require_zeroize_on_drop<T: ?Sized + ZeroizeOnDrop>(_: &T) {}
+    require_zeroize_on_drop(request);
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeHttpSaveTarget {
@@ -393,5 +422,43 @@ where
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         self.as_ref().execute(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{InvocationId, UserId};
+
+    #[test]
+    fn runtime_http_egress_request_scrubs_url_and_header_values() {
+        let mut request = RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::Script,
+            scope: ResourceScope::local_default(UserId::new("user1").unwrap(), InvocationId::new())
+                .unwrap(),
+            capability_id: CapabilityId::new("runtime.http").unwrap(),
+            method: NetworkMethod::Post,
+            url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
+            headers: vec![(
+                "authorization".to_string(),
+                "Bearer sk-header-secret".to_string(),
+            )],
+            body: b"hello".to_vec(),
+            network_policy: NetworkPolicy {
+                allowed_targets: vec![],
+                deny_private_ip_ranges: true,
+                max_egress_bytes: Some(4096),
+            },
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            save_body_to: None,
+            timeout_ms: None,
+        };
+
+        request.scrub_sensitive_url_and_headers();
+
+        assert!(request.url.is_empty());
+        assert_eq!(request.headers[0].0, "authorization");
+        assert!(request.headers[0].1.is_empty());
     }
 }

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -68,6 +68,7 @@ ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-postgres = "0.7"
+zeroize = "1"
 wat = "1.245.1"
 wit-component = "0.245.1"
 wit-parser = "0.245.1"

--- a/crates/ironclaw_host_runtime/src/egress/pipeline.rs
+++ b/crates/ironclaw_host_runtime/src/egress/pipeline.rs
@@ -95,7 +95,7 @@ fn authorize_body_store<N, S>(
 
 async fn dispatch_network<N, S>(
     service: &HostHttpEgressService<N, S>,
-    request: RuntimeHttpEgressRequest,
+    mut request: RuntimeHttpEgressRequest,
     network_policy: NetworkPolicy,
 ) -> Result<ironclaw_network::NetworkHttpResponse, PipelineError>
 where
@@ -104,11 +104,11 @@ where
     service
         .network()
         .execute(NetworkHttpRequest {
-            scope: request.scope,
+            scope: request.scope.clone(),
             method: request.method,
-            url: request.url,
-            headers: request.headers,
-            body: request.body,
+            url: std::mem::take(&mut request.url),
+            headers: std::mem::take(&mut request.headers),
+            body: std::mem::take(&mut request.body),
             policy: network_policy,
             response_body_limit: request.response_body_limit,
             timeout_ms: request.timeout_ms,

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -883,20 +883,17 @@ fn request_with_staged_credential(
     capability_id: CapabilityId,
     handle: SecretHandle,
 ) -> RuntimeHttpEgressRequest {
-    RuntimeHttpEgressRequest {
-        credential_injections: vec![RuntimeCredentialInjection {
-            handle,
-            source: RuntimeCredentialSource::StagedObligation {
-                capability_id: capability_id.clone(),
-            },
-            target: RuntimeCredentialTarget::Header {
-                name: "authorization".to_string(),
-                prefix: Some("Bearer ".to_string()),
-            },
-            required: true,
-        }],
-        ..request_without_credentials(scope, capability_id)
-    }
+    let mut request = request_without_credentials(scope, capability_id.clone());
+    request.credential_injections = vec![RuntimeCredentialInjection {
+        handle,
+        source: RuntimeCredentialSource::StagedObligation { capability_id },
+        target: RuntimeCredentialTarget::Header {
+            name: "authorization".to_string(),
+            prefix: Some("Bearer ".to_string()),
+        },
+        required: true,
+    }];
+    request
 }
 
 fn sample_scope() -> ResourceScope {

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -185,7 +185,7 @@ fn host_http_egress_records_injected_credentials_in_zeroizing_network_request() 
     );
 }
 
-fn require_zeroize_on_drop<T: ?Sized + secrecy::zeroize::ZeroizeOnDrop>(_: &T) {}
+fn require_zeroize_on_drop<T: ?Sized + zeroize::ZeroizeOnDrop>(_: &T) {}
 
 #[tokio::test]
 async fn host_http_egress_consumes_secret_staged_by_builtin_obligation_handler() {

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -119,6 +119,74 @@ async fn host_http_egress_consumes_staged_obligation_secret_once() {
     assert_eq!(network_recorder.lock().unwrap().len(), 1);
 }
 
+#[test]
+fn host_http_egress_records_injected_credentials_in_zeroizing_network_request() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: br#"{"ok":true}"#.to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 11,
+            resolved_ip: None,
+        },
+    });
+    let network_recorder = network.requests.clone();
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    let handle = SecretHandle::new("api-token").unwrap();
+    let services = test_obligation_services();
+    stage_policy_sync(&services, &scope, &capability_id, sample_policy());
+    stage_secret_sync(
+        &services,
+        &scope,
+        &capability_id,
+        &handle,
+        "sk-staged-secret",
+    );
+    let service = services.host_http_egress(network);
+
+    block_on_test(service.execute(RuntimeHttpEgressRequest {
+        runtime: RuntimeKind::Script,
+        scope,
+        capability_id: capability_id.clone(),
+        method: NetworkMethod::Post,
+        url: "https://api.example.test/v1/run".to_string(),
+        headers: vec![],
+        body: b"hello".to_vec(),
+        network_policy: sample_policy(),
+        credential_injections: vec![RuntimeCredentialInjection {
+            handle,
+            source: RuntimeCredentialSource::StagedObligation { capability_id },
+            target: RuntimeCredentialTarget::Header {
+                name: "authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            required: true,
+        }],
+        response_body_limit: Some(4096),
+        save_body_to: None,
+        timeout_ms: None,
+    }))
+    .expect("staged secret should be injected through host egress");
+
+    let requests = network_recorder.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    require_zeroize_on_drop(&requests[0]);
+    assert_eq!(
+        requests[0]
+            .headers
+            .iter()
+            .find(|(name, _)| name == "authorization"),
+        Some(&(
+            "authorization".to_string(),
+            "Bearer sk-staged-secret".to_string()
+        ))
+    );
+}
+
+fn require_zeroize_on_drop<T: ?Sized + secrecy::zeroize::ZeroizeOnDrop>(_: &T) {}
+
 #[tokio::test]
 async fn host_http_egress_consumes_secret_staged_by_builtin_obligation_handler() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {

--- a/crates/ironclaw_network/Cargo.toml
+++ b/crates/ironclaw_network/Cargo.toml
@@ -12,6 +12,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-
 thiserror = "2"
 tokio = { version = "1", features = ["rt"] }
 url = "2"
+zeroize = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "time"] }

--- a/crates/ironclaw_network/src/egress.rs
+++ b/crates/ironclaw_network/src/egress.rs
@@ -74,6 +74,8 @@ where
         let target = network_target_for_http_url(&request.url, estimated_request_bytes)?;
         let permit = StaticNetworkPolicyEnforcer::new(request.policy.clone())
             .authorize_blocking(NetworkRequest {
+                // This clone only carries scoped identity metadata; the sensitive
+                // URL/header/body buffers are still moved out below with `mem::take`.
                 scope: request.scope.clone(),
                 target: target.clone(),
                 method: request.method,

--- a/crates/ironclaw_network/src/egress.rs
+++ b/crates/ironclaw_network/src/egress.rs
@@ -62,7 +62,7 @@ where
 {
     async fn execute(
         &self,
-        request: NetworkHttpRequest,
+        mut request: NetworkHttpRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
         let estimated_request_bytes = estimate_http_request_bytes(
             request.method,
@@ -74,7 +74,7 @@ where
         let target = network_target_for_http_url(&request.url, estimated_request_bytes)?;
         let permit = StaticNetworkPolicyEnforcer::new(request.policy.clone())
             .authorize_blocking(NetworkRequest {
-                scope: request.scope,
+                scope: request.scope.clone(),
                 target: target.clone(),
                 method: request.method,
                 estimated_bytes: Some(estimated_request_bytes),
@@ -97,9 +97,9 @@ where
         })??;
         let transport_request = NetworkTransportRequest {
             method: permit.method,
-            url: request.url,
-            headers: request.headers,
-            body: request.body,
+            url: std::mem::take(&mut request.url),
+            headers: std::mem::take(&mut request.headers),
+            body: std::mem::take(&mut request.body),
             resolved_ips,
             response_body_limit: request.response_body_limit,
             timeout_ms: request.timeout_ms,

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -380,8 +380,14 @@ mod tests {
         let client = reqwest::Client::new();
         let req = client.request(Method::GET, "http://example.com");
         let mut headers = vec![
-            ("authorization".to_string(), "Bearer sk-header-secret".to_string()),
-            ("x-api-key".to_string(), "sk-second-header-secret".to_string()),
+            (
+                "authorization".to_string(),
+                "Bearer sk-header-secret".to_string(),
+            ),
+            (
+                "x-api-key".to_string(),
+                "sk-second-header-secret".to_string(),
+            ),
         ];
 
         let req = apply_request_headers(req, &mut headers);

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -114,6 +114,22 @@ fn build_reqwest_client(key: &ReqwestClientKey) -> Result<reqwest::Client, reqwe
     builder.build()
 }
 
+fn parse_request_url(
+    request: &mut NetworkTransportRequest,
+    request_bytes: u64,
+) -> Result<url::Url, NetworkHttpError> {
+    // Taking empties the request carrier before reqwest sees the URL. The
+    // parsed Url and reqwest internals still retain plaintext while dispatching.
+    let mut raw_url = std::mem::take(&mut request.url);
+    let parsed = url::Url::parse(&raw_url).map_err(|error| NetworkHttpError::InvalidUrl {
+        reason: error.to_string(),
+        request_bytes,
+        response_bytes: 0,
+    });
+    raw_url.zeroize();
+    parsed
+}
+
 #[async_trait]
 impl NetworkHttpTransport for ReqwestNetworkTransport {
     async fn execute(
@@ -122,11 +138,7 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
         let request_bytes = request.body.len() as u64;
         reject_caller_host_header(&request.headers)?;
-        let url = url::Url::parse(&request.url).map_err(|error| NetworkHttpError::InvalidUrl {
-            reason: error.to_string(),
-            request_bytes,
-            response_bytes: 0,
-        })?;
+        let url = parse_request_url(&mut request, request_bytes)?;
         let host = url
             .host_str()
             .ok_or_else(|| NetworkHttpError::InvalidUrl {
@@ -142,7 +154,6 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
                 request_bytes,
                 response_bytes: 0,
             })?;
-        request.url.zeroize();
 
         let resolved_addrs = request
             .resolved_ips
@@ -277,6 +288,24 @@ mod tests {
     use std::net::IpAddr;
 
     use super::*;
+
+    #[test]
+    fn parse_request_url_takes_the_source_string_carrier() {
+        let mut request = NetworkTransportRequest {
+            method: NetworkMethod::Get,
+            url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
+            headers: Vec::new(),
+            body: Vec::new(),
+            resolved_ips: Vec::new(),
+            response_body_limit: None,
+            timeout_ms: None,
+        };
+
+        let parsed = parse_request_url(&mut request, 0).unwrap();
+
+        assert_eq!(parsed.host_str(), Some("api.example.test"));
+        assert!(request.url.is_empty());
+    }
 
     #[test]
     fn effective_request_timeout_clamps_requested_timeout_to_transport_default() {

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -7,6 +7,7 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_host_api::NetworkMethod;
+use zeroize::Zeroize;
 
 use crate::{
     egress::NetworkHttpTransport,
@@ -117,7 +118,7 @@ fn build_reqwest_client(key: &ReqwestClientKey) -> Result<reqwest::Client, reqwe
 impl NetworkHttpTransport for ReqwestNetworkTransport {
     async fn execute(
         &self,
-        request: NetworkTransportRequest,
+        mut request: NetworkTransportRequest,
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
         let request_bytes = request.body.len() as u64;
         reject_caller_host_header(&request.headers)?;
@@ -141,6 +142,7 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
                 request_bytes,
                 response_bytes: 0,
             })?;
+        request.url.zeroize();
 
         let resolved_addrs = request
             .resolved_ips
@@ -162,8 +164,8 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
 
         let mut req = client
             .request(reqwest_method(request.method), url)
-            .body(request.body);
-        for (name, value) in request.headers {
+            .body(std::mem::take(&mut request.body));
+        for (name, value) in std::mem::take(&mut request.headers) {
             req = req.header(name, value);
         }
         let mut response = req

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -114,12 +114,14 @@ fn build_reqwest_client(key: &ReqwestClientKey) -> Result<reqwest::Client, reqwe
     builder.build()
 }
 
-fn parse_request_url(
+/// Parses the URL while scrubbing only the source request carrier copy.
+///
+/// The returned `url::Url` and reqwest internals still retain plaintext while
+/// the request is dispatched.
+fn parse_request_url_scrubbing_source_carrier(
     request: &mut NetworkTransportRequest,
     request_bytes: u64,
 ) -> Result<url::Url, NetworkHttpError> {
-    // Taking empties the request carrier before reqwest sees the URL. The
-    // parsed Url and reqwest internals still retain plaintext while dispatching.
     let mut raw_url = std::mem::take(&mut request.url);
     let parsed = url::Url::parse(&raw_url).map_err(|error| NetworkHttpError::InvalidUrl {
         reason: error.to_string(),
@@ -138,7 +140,7 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
         let request_bytes = request.body.len() as u64;
         reject_caller_host_header(&request.headers)?;
-        let url = parse_request_url(&mut request, request_bytes)?;
+        let url = parse_request_url_scrubbing_source_carrier(&mut request, request_bytes)?;
         let host = url
             .host_str()
             .ok_or_else(|| NetworkHttpError::InvalidUrl {
@@ -290,7 +292,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_request_url_takes_the_source_string_carrier() {
+    fn parse_request_url_scrubs_only_source_carrier_copy() {
         let mut request = NetworkTransportRequest {
             method: NetworkMethod::Get,
             url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
@@ -301,9 +303,13 @@ mod tests {
             timeout_ms: None,
         };
 
-        let parsed = parse_request_url(&mut request, 0).unwrap();
+        let parsed = parse_request_url_scrubbing_source_carrier(&mut request, 0).unwrap();
 
         assert_eq!(parsed.host_str(), Some("api.example.test"));
+        assert_eq!(
+            parsed.as_str(),
+            "https://api.example.test/v1?token=sk-query-secret"
+        );
         assert!(request.url.is_empty());
     }
 

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -124,7 +124,7 @@ fn parse_request_url_scrubbing_source_carrier(
 ) -> Result<url::Url, NetworkHttpError> {
     let mut raw_url = std::mem::take(&mut request.url);
     let parsed = url::Url::parse(&raw_url).map_err(|error| NetworkHttpError::InvalidUrl {
-        reason: error.to_string(),
+        reason: format!("URL parse error: {error:?}"),
         request_bytes,
         response_bytes: 0,
     });
@@ -310,6 +310,29 @@ mod tests {
             parsed.as_str(),
             "https://api.example.test/v1?token=sk-query-secret"
         );
+        assert!(request.url.is_empty());
+    }
+
+    #[test]
+    fn parse_request_url_error_does_not_include_source_url() {
+        let mut request = NetworkTransportRequest {
+            method: NetworkMethod::Get,
+            url: "https://api.example.test:bad-port/v1?token=sk-query-secret".to_string(),
+            headers: Vec::new(),
+            body: Vec::new(),
+            resolved_ips: Vec::new(),
+            response_body_limit: None,
+            timeout_ms: None,
+        };
+
+        let error = parse_request_url_scrubbing_source_carrier(&mut request, 0).unwrap_err();
+
+        let NetworkHttpError::InvalidUrl { reason, .. } = error else {
+            panic!("expected invalid URL error");
+        };
+        assert!(reason.starts_with("URL parse error: "));
+        assert!(!reason.contains("api.example.test"));
+        assert!(!reason.contains("sk-query-secret"));
         assert!(request.url.is_empty());
     }
 

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -117,14 +117,16 @@ fn build_reqwest_client(key: &ReqwestClientKey) -> Result<reqwest::Client, reqwe
 /// Parses the URL while scrubbing only the source request carrier copy.
 ///
 /// The returned `url::Url` and reqwest internals still retain plaintext while
-/// the request is dispatched.
+/// the request is dispatched. Parse failures use a fixed diagnostic rather
+/// than `url::ParseError` formatting because those diagnostics may include
+/// raw input that contains injected credentials.
 fn parse_request_url_scrubbing_source_carrier(
     request: &mut NetworkTransportRequest,
     request_bytes: u64,
 ) -> Result<url::Url, NetworkHttpError> {
     let mut raw_url = std::mem::take(&mut request.url);
-    let parsed = url::Url::parse(&raw_url).map_err(|error| NetworkHttpError::InvalidUrl {
-        reason: format!("URL parse error: {error:?}"),
+    let parsed = url::Url::parse(&raw_url).map_err(|_| NetworkHttpError::InvalidUrl {
+        reason: "URL parse error: invalid format".to_string(),
         request_bytes,
         response_bytes: 0,
     });
@@ -330,8 +332,31 @@ mod tests {
         let NetworkHttpError::InvalidUrl { reason, .. } = error else {
             panic!("expected invalid URL error");
         };
-        assert!(reason.starts_with("URL parse error: "));
+        assert_eq!(reason, "URL parse error: invalid format");
         assert!(!reason.contains("api.example.test"));
+        assert!(!reason.contains("sk-query-secret"));
+        assert!(request.url.is_empty());
+    }
+
+    #[test]
+    fn parse_request_url_relative_error_does_not_include_source_url() {
+        let mut request = NetworkTransportRequest {
+            method: NetworkMethod::Get,
+            url: "/relative/path?token=sk-query-secret".to_string(),
+            headers: Vec::new(),
+            body: Vec::new(),
+            resolved_ips: Vec::new(),
+            response_body_limit: None,
+            timeout_ms: None,
+        };
+
+        let error = parse_request_url_scrubbing_source_carrier(&mut request, 0).unwrap_err();
+
+        let NetworkHttpError::InvalidUrl { reason, .. } = error else {
+            panic!("expected invalid URL error");
+        };
+        assert_eq!(reason, "URL parse error: invalid format");
+        assert!(!reason.contains("/relative/path"));
         assert!(!reason.contains("sk-query-secret"));
         assert!(request.url.is_empty());
     }

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -120,7 +120,7 @@ fn build_reqwest_client(key: &ReqwestClientKey) -> Result<reqwest::Client, reqwe
 /// the request is dispatched. Parse failures use a fixed diagnostic rather
 /// than `url::ParseError` formatting because those diagnostics may include
 /// raw input that contains injected credentials.
-fn parse_request_url_scrubbing_source_carrier(
+fn take_request_url(
     request: &mut NetworkTransportRequest,
     request_bytes: u64,
 ) -> Result<url::Url, NetworkHttpError> {
@@ -134,6 +134,20 @@ fn parse_request_url_scrubbing_source_carrier(
     parsed
 }
 
+fn apply_request_headers(
+    mut req: reqwest::RequestBuilder,
+    headers: &mut [(String, String)],
+) -> reqwest::RequestBuilder {
+    for (name, value) in headers.iter() {
+        req = req.header(name.as_str(), value.as_str());
+    }
+    for (name, value) in headers.iter_mut() {
+        name.zeroize();
+        value.zeroize();
+    }
+    req
+}
+
 #[async_trait]
 impl NetworkHttpTransport for ReqwestNetworkTransport {
     async fn execute(
@@ -142,7 +156,7 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
     ) -> Result<NetworkHttpResponse, NetworkHttpError> {
         let request_bytes = request.body.len() as u64;
         reject_caller_host_header(&request.headers)?;
-        let url = parse_request_url_scrubbing_source_carrier(&mut request, request_bytes)?;
+        let url = take_request_url(&mut request, request_bytes)?;
         let host = url
             .host_str()
             .ok_or_else(|| NetworkHttpError::InvalidUrl {
@@ -177,12 +191,11 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
             )
             .await?;
 
+        let mut headers = std::mem::take(&mut request.headers);
         let mut req = client
             .request(reqwest_method(request.method), url)
             .body(std::mem::take(&mut request.body));
-        for (name, value) in &request.headers {
-            req = req.header(name.as_str(), value.as_str());
-        }
+        req = apply_request_headers(req, &mut headers);
         let mut response = req
             .send()
             .await
@@ -292,9 +305,10 @@ mod tests {
     use std::net::IpAddr;
 
     use super::*;
+    use reqwest::Method;
 
     #[test]
-    fn parse_request_url_scrubs_only_source_carrier_copy() {
+    fn take_request_url_scrubs_only_source_carrier_copy() {
         let mut request = NetworkTransportRequest {
             method: NetworkMethod::Get,
             url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
@@ -305,7 +319,7 @@ mod tests {
             timeout_ms: None,
         };
 
-        let parsed = parse_request_url_scrubbing_source_carrier(&mut request, 0).unwrap();
+        let parsed = take_request_url(&mut request, 0).unwrap();
 
         assert_eq!(parsed.host_str(), Some("api.example.test"));
         assert_eq!(
@@ -316,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_request_url_error_does_not_include_source_url() {
+    fn take_request_url_error_does_not_include_source_url() {
         let mut request = NetworkTransportRequest {
             method: NetworkMethod::Get,
             url: "https://api.example.test:bad-port/v1?token=sk-query-secret".to_string(),
@@ -327,7 +341,7 @@ mod tests {
             timeout_ms: None,
         };
 
-        let error = parse_request_url_scrubbing_source_carrier(&mut request, 0).unwrap_err();
+        let error = take_request_url(&mut request, 0).unwrap_err();
 
         let NetworkHttpError::InvalidUrl { reason, .. } = error else {
             panic!("expected invalid URL error");
@@ -339,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_request_url_relative_error_does_not_include_source_url() {
+    fn take_request_url_relative_error_does_not_include_source_url() {
         let mut request = NetworkTransportRequest {
             method: NetworkMethod::Get,
             url: "/relative/path?token=sk-query-secret".to_string(),
@@ -350,7 +364,7 @@ mod tests {
             timeout_ms: None,
         };
 
-        let error = parse_request_url_scrubbing_source_carrier(&mut request, 0).unwrap_err();
+        let error = take_request_url(&mut request, 0).unwrap_err();
 
         let NetworkHttpError::InvalidUrl { reason, .. } = error else {
             panic!("expected invalid URL error");
@@ -359,6 +373,22 @@ mod tests {
         assert!(!reason.contains("/relative/path"));
         assert!(!reason.contains("sk-query-secret"));
         assert!(request.url.is_empty());
+    }
+
+    #[test]
+    fn apply_request_headers_zeroizes_source_carrier_copy_after_reqwest_build() {
+        let client = reqwest::Client::new();
+        let req = client.request(Method::GET, "http://example.com");
+        let mut headers = vec![
+            ("authorization".to_string(), "Bearer sk-header-secret".to_string()),
+            ("x-api-key".to_string(), "sk-second-header-secret".to_string()),
+        ];
+
+        let req = apply_request_headers(req, &mut headers);
+
+        assert_eq!(headers[0], (String::new(), String::new()));
+        assert_eq!(headers[1], (String::new(), String::new()));
+        let _ = req;
     }
 
     #[test]

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -176,8 +176,8 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
         let mut req = client
             .request(reqwest_method(request.method), url)
             .body(std::mem::take(&mut request.body));
-        for (name, value) in std::mem::take(&mut request.headers) {
-            req = req.header(name, value);
+        for (name, value) in &request.headers {
+            req = req.header(name.as_str(), value.as_str());
         }
         let mut response = req
             .send()

--- a/crates/ironclaw_network/src/transport.rs
+++ b/crates/ironclaw_network/src/transport.rs
@@ -7,7 +7,7 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_host_api::NetworkMethod;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
     egress::NetworkHttpTransport,
@@ -120,6 +120,8 @@ fn build_reqwest_client(key: &ReqwestClientKey) -> Result<reqwest::Client, reqwe
 /// the request is dispatched. Parse failures use a fixed diagnostic rather
 /// than `url::ParseError` formatting because those diagnostics may include
 /// raw input that contains injected credentials.
+/// The source request URL is consumed even on parse failure so callers cannot
+/// later inspect a credential-bearing raw URL for diagnostics.
 fn take_request_url(
     request: &mut NetworkTransportRequest,
     request_bytes: u64,
@@ -145,6 +147,8 @@ fn apply_request_headers(
         name.zeroize();
         value.zeroize();
     }
+    // reqwest's internal HeaderMap retains its copied values until the request
+    // builder is consumed and the response future completes.
     req
 }
 
@@ -191,11 +195,11 @@ impl NetworkHttpTransport for ReqwestNetworkTransport {
             )
             .await?;
 
-        let mut headers = std::mem::take(&mut request.headers);
+        let mut headers = Zeroizing::new(std::mem::take(&mut request.headers));
         let mut req = client
             .request(reqwest_method(request.method), url)
             .body(std::mem::take(&mut request.body));
-        req = apply_request_headers(req, &mut headers);
+        req = apply_request_headers(req, &mut headers[..]);
         let mut response = req
             .send()
             .await

--- a/crates/ironclaw_network/src/types.rs
+++ b/crates/ironclaw_network/src/types.rs
@@ -48,6 +48,10 @@ impl Drop for NetworkHttpRequest {
 
 impl NetworkHttpRequest {
     fn scrub_sensitive_url_and_headers(&mut self) {
+        // Host credential injection currently writes secrets into URL components
+        // and header values. Header names and body payloads are separate
+        // caller-controlled data and need an explicit threat-model decision
+        // before broadening this carrier scrub scope.
         self.url.zeroize();
         for (_, value) in &mut self.headers {
             value.zeroize();
@@ -85,6 +89,10 @@ impl Drop for NetworkTransportRequest {
 
 impl NetworkTransportRequest {
     fn scrub_sensitive_url_and_headers(&mut self) {
+        // Host credential injection currently writes secrets into URL components
+        // and header values. Header names and body payloads are separate
+        // caller-controlled data and need an explicit threat-model decision
+        // before broadening this carrier scrub scope.
         self.url.zeroize();
         for (_, value) in &mut self.headers {
             value.zeroize();
@@ -141,6 +149,25 @@ mod tests {
         assert!(request.url.is_empty());
         assert_eq!(request.headers[0].0, "authorization");
         assert!(request.headers[0].1.is_empty());
+    }
+
+    #[test]
+    fn network_http_request_scrubs_url_with_empty_headers() {
+        let mut request = NetworkHttpRequest {
+            scope: sample_scope(),
+            method: NetworkMethod::Get,
+            url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
+            headers: Vec::new(),
+            body: Vec::new(),
+            policy: sample_policy(),
+            response_body_limit: Some(4096),
+            timeout_ms: None,
+        };
+
+        request.scrub_sensitive_url_and_headers();
+
+        assert!(request.url.is_empty());
+        assert!(request.headers.is_empty());
     }
 
     #[test]

--- a/crates/ironclaw_network/src/types.rs
+++ b/crates/ironclaw_network/src/types.rs
@@ -1,6 +1,7 @@
 use std::net::IpAddr;
 
 use ironclaw_host_api::{NetworkMethod, NetworkPolicy, NetworkTarget, ResourceScope};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub const DEFAULT_RESPONSE_BODY_LIMIT: u64 = 10 * 1024 * 1024;
 pub(crate) const MAX_RESPONSE_BODY_LIMIT: u64 = DEFAULT_RESPONSE_BODY_LIMIT;
@@ -24,6 +25,9 @@ pub struct NetworkPermit {
 }
 
 /// Full host-mediated HTTP request handled by the network boundary.
+///
+/// URL and header values may contain host-injected credential material. The
+/// carrier keeps the public field shape stable but scrubs those buffers on drop.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetworkHttpRequest {
     pub scope: ResourceScope,
@@ -36,7 +40,32 @@ pub struct NetworkHttpRequest {
     pub timeout_ms: Option<u32>,
 }
 
+impl Drop for NetworkHttpRequest {
+    fn drop(&mut self) {
+        self.scrub_sensitive_url_and_headers();
+    }
+}
+
+impl NetworkHttpRequest {
+    fn scrub_sensitive_url_and_headers(&mut self) {
+        self.url.zeroize();
+        for (_, value) in &mut self.headers {
+            value.zeroize();
+        }
+    }
+}
+
+impl ZeroizeOnDrop for NetworkHttpRequest {}
+
+const _: fn(&NetworkHttpRequest) = |request| {
+    fn require_zeroize_on_drop<T: ?Sized + ZeroizeOnDrop>(_: &T) {}
+    require_zeroize_on_drop(request);
+};
+
 /// Transport request after policy, URL, DNS, and private-IP checks succeed.
+///
+/// URL/header buffers are scrubbed when this carrier drops. Transport code must
+/// still hand plaintext to URL parsing and the HTTP client while dispatching.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetworkTransportRequest {
     pub method: NetworkMethod,
@@ -47,6 +76,28 @@ pub struct NetworkTransportRequest {
     pub response_body_limit: Option<u64>,
     pub timeout_ms: Option<u32>,
 }
+
+impl Drop for NetworkTransportRequest {
+    fn drop(&mut self) {
+        self.scrub_sensitive_url_and_headers();
+    }
+}
+
+impl NetworkTransportRequest {
+    fn scrub_sensitive_url_and_headers(&mut self) {
+        self.url.zeroize();
+        for (_, value) in &mut self.headers {
+            value.zeroize();
+        }
+    }
+}
+
+impl ZeroizeOnDrop for NetworkTransportRequest {}
+
+const _: fn(&NetworkTransportRequest) = |request| {
+    fn require_zeroize_on_drop<T: ?Sized + ZeroizeOnDrop>(_: &T) {}
+    require_zeroize_on_drop(request);
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetworkHttpResponse {
@@ -62,4 +113,79 @@ pub struct NetworkUsage {
     pub request_bytes: u64,
     pub response_bytes: u64,
     pub resolved_ip: Option<IpAddr>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_host_api::{InvocationId, NetworkScheme, NetworkTargetPattern, TenantId, UserId};
+
+    #[test]
+    fn network_http_request_scrubs_url_and_header_values() {
+        let mut request = NetworkHttpRequest {
+            scope: sample_scope(),
+            method: NetworkMethod::Get,
+            url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
+            headers: vec![(
+                "authorization".to_string(),
+                "Bearer sk-header-secret".to_string(),
+            )],
+            body: Vec::new(),
+            policy: sample_policy(),
+            response_body_limit: Some(4096),
+            timeout_ms: None,
+        };
+
+        request.scrub_sensitive_url_and_headers();
+
+        assert!(request.url.is_empty());
+        assert_eq!(request.headers[0].0, "authorization");
+        assert!(request.headers[0].1.is_empty());
+    }
+
+    #[test]
+    fn network_transport_request_scrubs_url_and_header_values() {
+        let mut request = NetworkTransportRequest {
+            method: NetworkMethod::Post,
+            url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
+            headers: vec![(
+                "authorization".to_string(),
+                "Bearer sk-header-secret".to_string(),
+            )],
+            body: b"hello".to_vec(),
+            resolved_ips: vec![],
+            response_body_limit: Some(4096),
+            timeout_ms: None,
+        };
+
+        request.scrub_sensitive_url_and_headers();
+
+        assert!(request.url.is_empty());
+        assert_eq!(request.headers[0].0, "authorization");
+        assert!(request.headers[0].1.is_empty());
+    }
+
+    fn sample_scope() -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant1").unwrap(),
+            user_id: UserId::new("user1").unwrap(),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    fn sample_policy() -> NetworkPolicy {
+        NetworkPolicy {
+            allowed_targets: vec![NetworkTargetPattern {
+                scheme: Some(NetworkScheme::Https),
+                host_pattern: "api.example.test".to_string(),
+                port: Some(443),
+            }],
+            deny_private_ip_ranges: true,
+            max_egress_bytes: Some(4096),
+        }
+    }
 }

--- a/crates/ironclaw_network/tests/network_http_egress_contract.rs
+++ b/crates/ironclaw_network/tests/network_http_egress_contract.rs
@@ -94,6 +94,60 @@ async fn http_egress_forwards_timeout_to_transport() {
 }
 
 #[tokio::test]
+async fn http_egress_forwards_sensitive_headers_in_zeroizing_transport_carrier() {
+    let transport = RecordingTransport::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: b"ok".to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 0,
+            response_bytes: 2,
+            resolved_ip: None,
+        },
+    });
+    let requests = transport.requests.clone();
+    let egress = PolicyNetworkHttpEgress::new_with_resolver(
+        transport,
+        StaticResolver::new(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))]),
+    );
+
+    egress
+        .execute(NetworkHttpRequest {
+            scope: sample_scope(),
+            method: NetworkMethod::Get,
+            url: "https://api.example.test/v1?token=sk-query-secret".to_string(),
+            headers: vec![(
+                "authorization".to_string(),
+                "Bearer sk-header-secret".to_string(),
+            )],
+            body: vec![],
+            policy: policy("api.example.test", Some(443), true, None),
+            response_body_limit: Some(1024),
+            timeout_ms: None,
+        })
+        .await
+        .expect("network response should be returned");
+
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    require_zeroize_on_drop(&requests[0]);
+    assert_eq!(
+        requests[0].url,
+        "https://api.example.test/v1?token=sk-query-secret"
+    );
+    assert_eq!(
+        requests[0]
+            .headers
+            .iter()
+            .find(|(name, _)| name == "authorization"),
+        Some(&(
+            "authorization".to_string(),
+            "Bearer sk-header-secret".to_string()
+        ))
+    );
+}
+
+#[tokio::test]
 async fn http_egress_denies_private_resolved_host_before_transport() {
     let transport = RecordingTransport::ok(NetworkHttpResponse {
         status: 200,
@@ -495,6 +549,8 @@ impl NetworkResolver for PanickingResolver {
         panic!("resolver panic")
     }
 }
+
+fn require_zeroize_on_drop<T: ?Sized + zeroize::ZeroizeOnDrop>(_: &T) {}
 
 fn sample_request(url: &str) -> NetworkHttpRequest {
     NetworkHttpRequest {

--- a/crates/ironclaw_network/tests/network_http_egress_contract.rs
+++ b/crates/ironclaw_network/tests/network_http_egress_contract.rs
@@ -329,6 +329,41 @@ async fn reqwest_transport_does_not_follow_redirects() {
 }
 
 #[tokio::test]
+async fn reqwest_transport_forwards_all_headers_to_http_client() {
+    let (url, request_bytes, server) =
+        captured_request_server("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+    let transport = ReqwestNetworkTransport::new(Duration::from_secs(2));
+
+    let response = transport
+        .execute(NetworkTransportRequest {
+            method: NetworkMethod::Get,
+            url,
+            headers: vec![
+                (
+                    "authorization".to_string(),
+                    "Bearer sk-header-secret".to_string(),
+                ),
+                (
+                    "x-api-key".to_string(),
+                    "sk-second-header-secret".to_string(),
+                ),
+            ],
+            body: vec![],
+            resolved_ips: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))],
+            response_body_limit: Some(1024),
+            timeout_ms: None,
+        })
+        .await
+        .expect("transport should forward borrowed header values");
+    server.join().unwrap();
+
+    let raw_request = String::from_utf8(request_bytes.lock().unwrap().clone()).unwrap();
+    assert_eq!(response.status, 200);
+    assert!(raw_request.contains("\r\nauthorization: Bearer sk-header-secret\r\n"));
+    assert!(raw_request.contains("\r\nx-api-key: sk-second-header-secret\r\n"));
+}
+
+#[tokio::test]
 async fn reqwest_transport_uses_all_resolved_addresses_for_connection_fallback() {
     let (url, server) = single_response_server_for_host(
         "fallback.example.test",
@@ -567,6 +602,30 @@ fn sample_request(url: &str) -> NetworkHttpRequest {
 
 fn single_response_server(response: &'static str) -> (String, std::thread::JoinHandle<()>) {
     single_response_server_for_host("127.0.0.1", response)
+}
+
+fn captured_request_server(
+    response: &'static str,
+) -> (String, Arc<Mutex<Vec<u8>>>, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let request_bytes = Arc::new(Mutex::new(Vec::new()));
+    let captured = request_bytes.clone();
+    let handle = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 2048];
+        let bytes_read = stream.read(&mut request).unwrap();
+        captured
+            .lock()
+            .unwrap()
+            .extend_from_slice(&request[..bytes_read]);
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+    (
+        format!("http://127.0.0.1:{port}/test"),
+        request_bytes,
+        handle,
+    )
 }
 
 fn single_response_server_for_host(


### PR DESCRIPTION
## Summary

Fixes #4222 by zeroizing HTTP request carrier buffers that may contain host-injected credential material.

This keeps the public request field shape stable while adding drop-time scrubbing for:

- `RuntimeHttpEgressRequest` URL/header values
- `NetworkHttpRequest` URL/header values
- `NetworkTransportRequest` URL/header values

The runtime and network handoffs now move URL/header/body buffers forward with `std::mem::take` so credential-bearing allocations are not cloned across carriers.

## Root cause

Runtime HTTP credential injection kept leased/staged secret material in zeroizing `SecretMaterial`, but then copied plaintext credentials into ordinary request carrier `String`s for URL/header transport fields. Those carrier values could be retained by host/network request objects without scrub-on-drop behavior.

## Notes

- Public `RuntimeHttpEgressRequest` serde/field shape is unchanged.
- URL/header buffers are scrubbed on drop; transport dispatch still necessarily hands plaintext to URL parsing and the HTTP client while sending.
- Review feedback considered splitting the DTO from a sensitive payload or adding a conversion helper. This PR intentionally keeps the narrower explicit handoff to stay scoped to issue #4222.

## Validation

- `cargo test -p ironclaw_host_api --test host_api_contract`
- `cargo test -p ironclaw_network --test network_http_egress_contract`
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract host_http_egress_records_injected_credentials_in_zeroizing_network_request -- --nocapture`
- `cargo test -p ironclaw_host_api runtime_http_egress_request_scrubs_url_and_header_values -- --nocapture`
- `cargo test -p ironclaw_network scrubs_url_and_header_values -- --nocapture`
- `cargo clippy -p ironclaw_host_api -p ironclaw_network -p ironclaw_host_runtime --all-targets -- -D warnings`
- `git diff --check`
