### PR TITLE
Accept memory_search query aliases

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/memory.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/memory.rs
@@ -332,7 +332,7 @@ async fn dispatch_search(
     services: &MemoryServices,
     input: &Value,
 ) -> Result<Value, FirstPartyCapabilityError> {
-    let query = required_str(input, "query")?;
+    let query = search_query(input)?;
     let limit = optional_u64(input, "limit").unwrap_or(5).clamp(1, 20) as usize;
     let request = MemorySearchRequest::new(query)
         .map_err(|_| input_error())?
@@ -361,6 +361,18 @@ async fn dispatch_search(
         "results": result_values,
         "result_count": result_count,
     }))
+}
+
+fn search_query(input: &Value) -> Result<&str, FirstPartyCapabilityError> {
+    for key in ["query", "q", "text", "pattern"] {
+        if let Some(value) = input.get(key).and_then(Value::as_str) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed);
+            }
+        }
+    }
+    Err(input_error())
 }
 
 async fn dispatch_write(

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -49,7 +49,19 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Natural language search query for persistent memory"
+                    "description": "Preferred natural language search query for persistent memory"
+                },
+                "q": {
+                    "type": "string",
+                    "description": "Alias for query"
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Alias for query"
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": "Alias for query"
                 },
                 "limit": {
                     "type": "integer",

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -1055,6 +1055,48 @@ async fn memory_capabilities_write_read_tree_and_search_native_reborn_memory() {
 }
 
 #[tokio::test]
+async fn memory_search_accepts_common_query_aliases_from_model_tool_calls() {
+    let runtime = runtime_with_filesystem(InMemoryBackend::new());
+    let context = execution_context_with_mounts(
+        [MEMORY_WRITE_CAPABILITY_ID, MEMORY_SEARCH_CAPABILITY_ID],
+        memory_mounts(MountPermissions::read_write_list_delete()),
+    );
+
+    invoke_with_context(
+        &runtime,
+        MEMORY_WRITE_CAPABILITY_ID,
+        json!({
+            "target": "projects/alpha/search-alias.md",
+            "content": "Search alias marker from model tool call.",
+            "append": false
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    for input in [
+        json!({"q": "alias marker", "limit": 5}),
+        json!({"text": "alias marker", "limit": 5}),
+        json!({"pattern": "alias marker", "limit": 5}),
+    ] {
+        let search = invoke_with_context(
+            &runtime,
+            MEMORY_SEARCH_CAPABILITY_ID,
+            input,
+            context.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(search["result_count"], json!(1));
+        assert_eq!(
+            search["results"][0]["path"],
+            json!("projects/alpha/search-alias.md")
+        );
+    }
+}
+
+#[tokio::test]
 async fn memory_write_metadata_overlay_can_skip_search_indexing() {
     let runtime = runtime_with_filesystem(InMemoryBackend::new());
     let context = execution_context_with_mounts(


### PR DESCRIPTION
## Summary
- accept common model/provider aliases (`q`, `text`, `pattern`) for `builtin.memory_search` queries while preserving the canonical `query` field
- expose those aliases in the built-in input schema so the visible tool surface matches the runtime parser
- add a first-party runtime regression test that writes memory and searches it via alias inputs

## Root cause
`memory_tree` worked because its inputs are optional/defaulted, but `memory_search` required a non-empty `query` string exactly. Native provider tool calls are not guaranteed to strictly obey the advertised schema, so model-emitted search aliases such as `q` reached the first-party handler as missing `query` and were classified as `invalid_input`.

## Verification
- `cargo test -p ironclaw_host_runtime memory_search_accepts_common_query_aliases_from_model_tool_calls --test first_party_builtin_tools`
- `cargo test -p ironclaw_host_runtime memory_capabilities_write_read_tree_and_search_native_reborn_memory --test first_party_builtin_tools`
- `cargo test -p ironclaw_host_runtime visible_surface_resolves_builtin_first_party_input_schema_refs --test tool_surface_contract`
- `cargo fmt --check`
- `git diff --check`

Note: initial verification hit local disk exhaustion (`No space left on device`) while compiling `wasmtime`; I cleared this worktree generated `target/` artifacts and reran the checks successfully.