### PR TITLE
PR18.6: enable trigger poller via config + env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -212,8 +212,8 @@ HEARTBEAT_NOTIFY_USER=default
 # OFF by default. Enable to allow the host background poller to scan due trigger
 # records and auto-fire scheduled (cron) triggers. Without this, triggers can be
 # created and listed but will never fire automatically.
-# IRONCLAW_TRIGGER_POLLER_ENABLED=true           # set to true to opt in (default: false)
-# IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=60       # how often the poller checks for due triggers
+# IRONCLAW_TRIGGER_POLLER_ENABLED=true           # accepts 1/true to enable, 0/false to disable (default: false; any other value is a fatal startup error)
+# IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=60       # how often the poller checks for due triggers (positive integer seconds)
 
 # Docker Sandbox
 # SANDBOX_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -208,6 +208,13 @@ HEARTBEAT_NOTIFY_USER=default
 # MEMORY_HYGIENE_VERSION_KEEP_COUNT=50           # max versions to keep per document
 # MEMORY_HYGIENE_CADENCE_HOURS=12                # minimum hours between cleanup passes
 
+# Trigger poller (scheduled / cron trigger firing)
+# OFF by default. Enable to allow the host background poller to scan due trigger
+# records and auto-fire scheduled (cron) triggers. Without this, triggers can be
+# created and listed but will never fire automatically.
+# IRONCLAW_TRIGGER_POLLER_ENABLED=true           # set to true to opt in (default: false)
+# IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=60       # how often the poller checks for due triggers
+
 # Docker Sandbox
 # SANDBOX_ENABLED=true
 # SANDBOX_POLICY=readonly                # readonly, workspace_write, or full_access

--- a/.env.example
+++ b/.env.example
@@ -213,7 +213,7 @@ HEARTBEAT_NOTIFY_USER=default
 # records and auto-fire scheduled (cron) triggers. Without this, triggers can be
 # created and listed but will never fire automatically.
 # IRONCLAW_TRIGGER_POLLER_ENABLED=true           # accepts 1/true to enable, 0/false to disable (default: false; any other value is a fatal startup error)
-# IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=60       # how often the poller checks for due triggers (positive integer seconds)
+# IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=60       # how often the poller checks for due triggers (integer seconds, 1..=3600)
 
 # Docker Sandbox
 # SANDBOX_ENABLED=true

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -234,9 +234,31 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
         "ironclaw_reborn_config must remain a standalone boot contract crate with no IronClaw workspace dependencies of any dependency kind",
     );
 
-    let cli_runtime_source =
-        std::fs::read_to_string(root.join("crates/ironclaw_reborn_cli/src/runtime.rs"))
-            .expect("Reborn CLI runtime.rs must be readable");
+    // The runtime entry point lives at `runtime/mod.rs`; helpers (e.g.
+    // `trigger_poller.rs`) live alongside as child modules. Boundary checks
+    // must scan every `.rs` file under the runtime module so a forbidden
+    // import cannot slip in through a child file.
+    let runtime_dir = root.join("crates/ironclaw_reborn_cli/src/runtime");
+    let mut cli_runtime_source = String::new();
+    for entry in std::fs::read_dir(&runtime_dir).unwrap_or_else(|err| {
+        panic!(
+            "Reborn CLI runtime/ directory must be readable at {}: {err}",
+            runtime_dir.display()
+        )
+    }) {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+            panic!(
+                "Reborn CLI runtime file {} unreadable: {err}",
+                path.display()
+            )
+        });
+        cli_runtime_source.push_str(&content);
+        cli_runtime_source.push('\n');
+    }
     assert!(
         cli_runtime_source.contains("build_reborn_runtime"),
         "Reborn CLI should enter the assembled runtime through ironclaw_reborn_composition::build_reborn_runtime"
@@ -251,7 +273,7 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
     ] {
         assert!(
             !cli_runtime_source.contains(forbidden),
-            "Reborn CLI runtime.rs must not wire lower-level Reborn runtime pieces directly via `{forbidden}`; keep REPL as a UX shell over ironclaw_reborn_composition."
+            "Reborn CLI runtime/ must not wire lower-level Reborn runtime pieces directly via `{forbidden}`; keep REPL as a UX shell over ironclaw_reborn_composition."
         );
     }
 }

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -235,30 +235,40 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
     );
 
     // The runtime entry point lives at `runtime/mod.rs`; helpers (e.g.
-    // `trigger_poller.rs`) live alongside as child modules. Boundary checks
-    // must scan every `.rs` file under the runtime module so a forbidden
-    // import cannot slip in through a child file.
+    // `trigger_poller.rs`) live alongside as child modules, and a future
+    // child could live in a nested directory. Boundary checks recurse so
+    // a forbidden import cannot slip in through any descendant `.rs`
+    // file. Mirrors the recursion in `collect_forbidden_*` walkers
+    // elsewhere in this file.
+    fn collect_runtime_rs(dir: &std::path::Path, out: &mut String) {
+        for entry in std::fs::read_dir(dir).unwrap_or_else(|err| {
+            panic!(
+                "Reborn CLI runtime directory must be readable at {}: {err}",
+                dir.display()
+            )
+        }) {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                collect_runtime_rs(&path, out);
+                continue;
+            }
+            if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+                continue;
+            }
+            let content = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+                panic!(
+                    "Reborn CLI runtime file {} unreadable: {err}",
+                    path.display()
+                )
+            });
+            out.push_str(&content);
+            out.push('\n');
+        }
+    }
+
     let runtime_dir = root.join("crates/ironclaw_reborn_cli/src/runtime");
     let mut cli_runtime_source = String::new();
-    for entry in std::fs::read_dir(&runtime_dir).unwrap_or_else(|err| {
-        panic!(
-            "Reborn CLI runtime/ directory must be readable at {}: {err}",
-            runtime_dir.display()
-        )
-    }) {
-        let path = entry.expect("dir entry").path();
-        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
-            continue;
-        }
-        let content = std::fs::read_to_string(&path).unwrap_or_else(|err| {
-            panic!(
-                "Reborn CLI runtime file {} unreadable: {err}",
-                path.display()
-            )
-        });
-        cli_runtime_source.push_str(&content);
-        cli_runtime_source.push('\n');
-    }
+    collect_runtime_rs(&runtime_dir, &mut cli_runtime_source);
     assert!(
         cli_runtime_source.contains("build_reborn_runtime"),
         "Reborn CLI should enter the assembled runtime through ironclaw_reborn_composition::build_reborn_runtime"

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -234,38 +234,6 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
         "ironclaw_reborn_config must remain a standalone boot contract crate with no IronClaw workspace dependencies of any dependency kind",
     );
 
-    // The runtime entry point lives at `runtime/mod.rs`; helpers (e.g.
-    // `trigger_poller.rs`) live alongside as child modules, and a future
-    // child could live in a nested directory. Boundary checks recurse so
-    // a forbidden import cannot slip in through any descendant `.rs`
-    // file. Mirrors the recursion in `collect_forbidden_*` walkers
-    // elsewhere in this file.
-    fn collect_runtime_rs(dir: &std::path::Path, out: &mut String) {
-        for entry in std::fs::read_dir(dir).unwrap_or_else(|err| {
-            panic!(
-                "Reborn CLI runtime directory must be readable at {}: {err}",
-                dir.display()
-            )
-        }) {
-            let path = entry.expect("dir entry").path();
-            if path.is_dir() {
-                collect_runtime_rs(&path, out);
-                continue;
-            }
-            if path.extension().and_then(|s| s.to_str()) != Some("rs") {
-                continue;
-            }
-            let content = std::fs::read_to_string(&path).unwrap_or_else(|err| {
-                panic!(
-                    "Reborn CLI runtime file {} unreadable: {err}",
-                    path.display()
-                )
-            });
-            out.push_str(&content);
-            out.push('\n');
-        }
-    }
-
     let runtime_dir = root.join("crates/ironclaw_reborn_cli/src/runtime");
     let mut cli_runtime_source = String::new();
     collect_runtime_rs(&runtime_dir, &mut cli_runtime_source);
@@ -2521,6 +2489,38 @@ fn assert_no_normal_workspace_deps<'a>(
             !actual.iter().any(|dependency| dependency == forbidden),
             "{crate_name} must not have a normal dependency on {forbidden}; actual normal ironclaw deps: {actual:?}"
         );
+    }
+}
+
+/// Recursively concatenate every `.rs` file under `dir` into `out`,
+/// descending into subdirectories. Matches the recursion pattern used by
+/// `collect_forbidden_*` walkers above so future boundary checks over
+/// `runtime/` can reuse the same helper. Used by
+/// `reborn_cli_binary_crate_stays_separate_from_v1_root` to scan the
+/// entire `runtime/` module tree for forbidden imports.
+fn collect_runtime_rs(dir: &std::path::Path, out: &mut String) {
+    for entry in std::fs::read_dir(dir).unwrap_or_else(|err| {
+        panic!(
+            "Reborn CLI runtime directory must be readable at {}: {err}",
+            dir.display()
+        )
+    }) {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            collect_runtime_rs(&path, out);
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+            panic!(
+                "Reborn CLI runtime file {} unreadable: {err}",
+                path.display()
+            )
+        });
+        out.push_str(&content);
+        out.push('\n');
     }
 }
 

--- a/crates/ironclaw_reborn_cli/src/runtime.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime.rs
@@ -7,7 +7,8 @@ use anyhow::Context;
 use ironclaw_reborn_composition::{
     OAuthClientConfig, PollSettings, RebornBuildInput, RebornCompositionProfile,
     RebornLocalRuntimeProfileOptions, RebornRuntimeIdentity, RebornRuntimeInput,
-    TurnRunnerSettings, build_reborn_runtime, local_runtime_build_input_with_options,
+    TriggerPollerSettings, TurnRunnerSettings, build_reborn_runtime,
+    local_runtime_build_input_with_options,
 };
 use ironclaw_reborn_config::{REBORN_PROFILE_ENV, RebornBootConfig, RebornProfile};
 use secrecy::SecretString;
@@ -256,6 +257,9 @@ pub(crate) fn build_runtime_input_with_options(
     #[allow(unused_mut)]
     let mut runtime_input = RebornRuntimeInput::from_services(runtime_services.services_input)
         .with_runner_settings(runner_settings(runtime_services.config_file.as_ref())?)
+        .with_trigger_poller_settings(trigger_poller_settings(
+            runtime_services.config_file.as_ref(),
+        )?)
         .with_poll_settings(PollSettings {
             interval: Duration::from_millis(200),
             max_total: Duration::from_secs(180),
@@ -592,6 +596,98 @@ fn runner_settings(
     Ok(settings)
 }
 
+/// Build [`TriggerPollerSettings`] by merging three layers of configuration.
+///
+/// Precedence (highest first):
+/// 1. Environment variables:
+///    - `IRONCLAW_TRIGGER_POLLER_ENABLED` — `1`/`true` → enabled, `0`/`false` → disabled
+///      (case-insensitive). Overrides any `enabled` value from the config file.
+///    - `IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS` — parse as `u64`; overrides the
+///      config-file `poll_interval_secs`.  Must be > 0.
+/// 2. Config-file `[trigger_poller]` section — all fields are optional; any field
+///    absent here falls through to the compiled default.
+/// 3. Compiled default — `TriggerPollerSettings::default()` (disabled, all limits
+///    at the `ironclaw_triggers` crate defaults).
+///
+/// V1 invariant: `max_concurrent_fires_per_trigger` must be exactly 1. Passing
+/// any other value (via config or, were an env override ever added, env) returns
+/// an error rather than silently breaking per-trigger serialisation.
+fn trigger_poller_settings(
+    config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
+) -> anyhow::Result<TriggerPollerSettings> {
+    // Layer 3: compiled default (disabled).
+    let mut settings = TriggerPollerSettings::default();
+
+    // Layer 2: config-file [trigger_poller] section.
+    if let Some(section) = config_file.and_then(|file| file.trigger_poller.as_ref()) {
+        if let Some(enabled) = section.enabled {
+            settings.enabled = enabled;
+        }
+
+        // Build a mutable worker config to apply section overrides.
+        let mut worker = settings.worker;
+
+        if let Some(secs) = section.poll_interval_secs {
+            if secs == 0 {
+                anyhow::bail!(
+                    "config file [trigger_poller].poll_interval_secs must be greater than 0"
+                );
+            }
+            worker.poll_interval = Duration::from_secs(secs);
+        }
+
+        if let Some(fires) = section.fires_per_tick {
+            worker.fires_per_tick = fires as usize;
+        }
+
+        if let Some(max_concurrent) = section.max_concurrent_fires_per_trigger {
+            // V1 invariant: per-trigger concurrency is locked at 1.
+            if max_concurrent != 1 {
+                anyhow::bail!(
+                    "config file [trigger_poller].max_concurrent_fires_per_trigger must be 1 \
+                     (V1 per-trigger serialisation invariant); got {max_concurrent}"
+                );
+            }
+            worker.max_concurrent_fires_per_trigger = max_concurrent as usize;
+        }
+
+        if let Some(jitter_secs) = section.startup_jitter_max_secs {
+            settings.startup_jitter_max = Duration::from_secs(jitter_secs);
+        }
+
+        if let Some(jitter_secs) = section.tick_jitter_max_secs {
+            settings.tick_jitter_max = Duration::from_secs(jitter_secs);
+        }
+
+        settings.worker = worker;
+    }
+
+    // Layer 1: environment variable overrides.
+    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_ENABLED") {
+        match raw.to_ascii_lowercase().as_str() {
+            "1" | "true" => settings.enabled = true,
+            "0" | "false" => settings.enabled = false,
+            other => anyhow::bail!(
+                "IRONCLAW_TRIGGER_POLLER_ENABLED must be one of 1, true, 0, false (got {other:?})"
+            ),
+        }
+    }
+
+    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") {
+        let secs: u64 = raw.parse().map_err(|_| {
+            anyhow::anyhow!(
+                "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be a positive integer, got {raw:?}"
+            )
+        })?;
+        if secs == 0 {
+            anyhow::bail!("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be greater than 0");
+        }
+        settings.worker.poll_interval = Duration::from_secs(secs);
+    }
+
+    Ok(settings)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -872,5 +968,102 @@ default_project = "project-alpha"
                 .expect_err("legacy client vars without redirect URI must not be ignored");
 
         assert!(error.to_string().contains("GOOGLE_OAUTH_REDIRECT_URI"));
+    }
+
+    // --- trigger_poller_settings tests ---
+
+    use super::trigger_poller_settings;
+    use ironclaw_reborn_config::TriggerPollerConfigSection;
+    use std::time::Duration;
+
+    fn make_config_with_trigger_poller(
+        section: TriggerPollerConfigSection,
+    ) -> ironclaw_reborn_config::RebornConfigFile {
+        ironclaw_reborn_config::RebornConfigFile {
+            trigger_poller: Some(section),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn trigger_poller_settings_default_is_disabled() {
+        // No config file, no env → disabled with zero jitter.
+        let settings = trigger_poller_settings(None).expect("default trigger poller settings");
+
+        assert!(!settings.enabled, "default must be disabled");
+        assert_eq!(settings.startup_jitter_max, Duration::ZERO);
+        assert_eq!(settings.tick_jitter_max, Duration::ZERO);
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_enabled_maps_worker_fields() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            poll_interval_secs: Some(15),
+            fires_per_tick: Some(50),
+            max_concurrent_fires_per_trigger: Some(1),
+            startup_jitter_max_secs: Some(3),
+            tick_jitter_max_secs: Some(7),
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings =
+            trigger_poller_settings(Some(&config)).expect("trigger poller settings from config");
+
+        assert!(settings.enabled, "config enabled=true must be reflected");
+        assert_eq!(settings.worker.poll_interval, Duration::from_secs(15));
+        assert_eq!(settings.worker.fires_per_tick, 50);
+        assert_eq!(settings.worker.max_concurrent_fires_per_trigger, 1);
+        assert_eq!(settings.startup_jitter_max, Duration::from_secs(3));
+        assert_eq!(settings.tick_jitter_max, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn trigger_poller_settings_max_concurrent_fires_greater_than_1_is_error() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            max_concurrent_fires_per_trigger: Some(2),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("max_concurrent_fires_per_trigger=2 must be rejected");
+
+        assert!(
+            err.to_string().contains("max_concurrent_fires_per_trigger"),
+            "error must mention the field, got: {err}",
+        );
+    }
+
+    // NOTE: tests that mutate real process env vars are inherently racy when
+    // run in parallel with other tests in the same process. We follow the
+    // pattern used elsewhere in this crate: set the variable, run the
+    // assertion, then always restore the original value in a defer-style
+    // guard so a panicking assertion cannot leave the env dirty.
+    #[test]
+    fn trigger_poller_settings_env_enabled_overrides_config_disabled() {
+        // Config says disabled; env says enabled — env must win.
+        let section = TriggerPollerConfigSection {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let key = "IRONCLAW_TRIGGER_POLLER_ENABLED";
+        let prior = std::env::var(key).ok();
+        // Safety: single-threaded test binary segment; restored below.
+        unsafe { std::env::set_var(key, "true") };
+        let result = trigger_poller_settings(Some(&config));
+        match prior {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+
+        let settings = result.expect("env override should succeed");
+        assert!(
+            settings.enabled,
+            "IRONCLAW_TRIGGER_POLLER_ENABLED=true must override config enabled=false"
+        );
     }
 }

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -15,6 +15,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::context::RebornCliContext;
 
+#[cfg(test)]
+mod test_env;
 mod trigger_poller;
 
 use trigger_poller::trigger_poller_settings;
@@ -606,6 +608,7 @@ mod tests {
     use ironclaw_reborn_composition::RebornCompositionProfile;
     use ironclaw_reborn_config::RebornBootConfig;
 
+    use super::test_env::{EnvGuard, lock_trigger_env};
     use super::{
         RuntimeInputCaller, RuntimeInputOptions, block_on_cli, build_runtime_input,
         build_runtime_input_with_options, resolve_google_oauth_config,
@@ -793,32 +796,9 @@ default_project = "project-alpha"
 
     #[test]
     fn build_runtime_input_maps_trigger_poller_enabled_config() {
-        // Inline RAII guards so the test is self-contained and does not
-        // depend on anything inside trigger_poller::tests.
-        struct EnvGuard {
-            key: &'static str,
-            prior: Option<String>,
-        }
-        impl EnvGuard {
-            fn clear(key: &'static str) -> Self {
-                let prior = std::env::var(key).ok();
-                // SAFETY: env mutation is process-global; Drop restores on
-                // unwind. Cleared keys are only read by trigger_poller_settings
-                // in this test's call stack.
-                unsafe { std::env::remove_var(key) };
-                Self { key, prior }
-            }
-        }
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                match self.prior.take() {
-                    Some(v) => unsafe { std::env::set_var(self.key, v) },
-                    None => unsafe { std::env::remove_var(self.key) },
-                }
-            }
-        }
-        let _g1 = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
-        let _g2 = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
 
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -430,7 +430,14 @@ fn resolve_google_oauth_config(
     }))
 }
 
-pub(super) fn optional_nonempty_env(name: &str) -> Option<String> {
+/// Read an env var with lenient presence semantics: unset OR
+/// present-but-blank both collapse to `None`. Used for optional-config
+/// callers (OAuth client overrides, etc.) where a blank slot is benign.
+///
+/// **Not** for operator-control knobs like `IRONCLAW_TRIGGER_POLLER_*` —
+/// those use `runtime::trigger_poller::strict_env_var`, which treats
+/// present-blank as a fatal misconfiguration.
+fn optional_nonempty_env(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
         .map(|value| value.trim().to_string())
@@ -830,6 +837,71 @@ poll_interval_secs = 42
             input.trigger_poller.worker.poll_interval,
             std::time::Duration::from_secs(42),
             "config poll_interval_secs must reach worker.poll_interval"
+        );
+    }
+
+    #[test]
+    fn build_runtime_input_env_enables_trigger_poller_with_no_config_section() {
+        // No [trigger_poller] in config; env var enables → input.trigger_poller.enabled must be true.
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "true");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        // No config.toml written → no [trigger_poller] section at all.
+
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.to_string_lossy().to_string().into()),
+            None,
+            None,
+            None,
+        )
+        .expect("boot config");
+
+        let input = build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+
+        assert!(
+            input.trigger_poller.enabled,
+            "IRONCLAW_TRIGGER_POLLER_ENABLED=true must reach input.trigger_poller.enabled through build_runtime_input"
+        );
+    }
+
+    #[test]
+    fn build_runtime_input_env_interval_overrides_config_interval() {
+        // Config says interval=15s, env says interval=45s → env must win at the caller boundary.
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS", "45");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        std::fs::write(
+            reborn_home.join("config.toml"),
+            r#"
+[trigger_poller]
+enabled = true
+poll_interval_secs = 15
+"#,
+        )
+        .expect("write config");
+
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.to_string_lossy().to_string().into()),
+            None,
+            None,
+            None,
+        )
+        .expect("boot config");
+
+        let input = build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+
+        assert_eq!(
+            input.trigger_poller.worker.poll_interval,
+            std::time::Duration::from_secs(45),
+            "env IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=45 must override config poll_interval_secs=15 through build_runtime_input"
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -7,14 +7,17 @@ use anyhow::Context;
 use ironclaw_reborn_composition::{
     OAuthClientConfig, PollSettings, RebornBuildInput, RebornCompositionProfile,
     RebornLocalRuntimeProfileOptions, RebornRuntimeIdentity, RebornRuntimeInput,
-    TriggerPollerSettings, TurnRunnerSettings, build_reborn_runtime,
-    local_runtime_build_input_with_options,
+    TurnRunnerSettings, build_reborn_runtime, local_runtime_build_input_with_options,
 };
 use ironclaw_reborn_config::{REBORN_PROFILE_ENV, RebornBootConfig, RebornProfile};
 use secrecy::SecretString;
 use tokio_util::sync::CancellationToken;
 
 use crate::context::RebornCliContext;
+
+mod trigger_poller;
+
+use trigger_poller::trigger_poller_settings;
 
 pub(crate) fn init_tracing() {
     use tracing_subscriber::EnvFilter;
@@ -425,7 +428,7 @@ fn resolve_google_oauth_config(
     }))
 }
 
-fn optional_nonempty_env(name: &str) -> Option<String> {
+pub(super) fn optional_nonempty_env(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
         .map(|value| value.trim().to_string())
@@ -593,98 +596,6 @@ fn runner_settings(
             settings.poll_interval = Duration::from_millis(ms);
         }
     }
-    Ok(settings)
-}
-
-/// Build [`TriggerPollerSettings`] by merging three layers of configuration.
-///
-/// Precedence (highest first):
-/// 1. Environment variables:
-///    - `IRONCLAW_TRIGGER_POLLER_ENABLED` — `1`/`true` → enabled, `0`/`false` → disabled
-///      (case-insensitive). Overrides any `enabled` value from the config file.
-///    - `IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS` — parse as `u64`; overrides the
-///      config-file `poll_interval_secs`.  Must be > 0.
-/// 2. Config-file `[trigger_poller]` section — all fields are optional; any field
-///    absent here falls through to the compiled default.
-/// 3. Compiled default — `TriggerPollerSettings::default()` (disabled, all limits
-///    at the `ironclaw_triggers` crate defaults).
-///
-/// V1 invariant: `max_concurrent_fires_per_trigger` must be exactly 1. Passing
-/// any other value (via config or, were an env override ever added, env) returns
-/// an error rather than silently breaking per-trigger serialisation.
-fn trigger_poller_settings(
-    config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
-) -> anyhow::Result<TriggerPollerSettings> {
-    // Layer 3: compiled default (disabled).
-    let mut settings = TriggerPollerSettings::default();
-
-    // Layer 2: config-file [trigger_poller] section.
-    if let Some(section) = config_file.and_then(|file| file.trigger_poller.as_ref()) {
-        if let Some(enabled) = section.enabled {
-            settings.enabled = enabled;
-        }
-
-        // Build a mutable worker config to apply section overrides.
-        let mut worker = settings.worker;
-
-        if let Some(secs) = section.poll_interval_secs {
-            if secs == 0 {
-                anyhow::bail!(
-                    "config file [trigger_poller].poll_interval_secs must be greater than 0"
-                );
-            }
-            worker.poll_interval = Duration::from_secs(secs);
-        }
-
-        if let Some(fires) = section.fires_per_tick {
-            worker.fires_per_tick = fires as usize;
-        }
-
-        if let Some(max_concurrent) = section.max_concurrent_fires_per_trigger {
-            // V1 invariant: per-trigger concurrency is locked at 1.
-            if max_concurrent != 1 {
-                anyhow::bail!(
-                    "config file [trigger_poller].max_concurrent_fires_per_trigger must be 1 \
-                     (V1 per-trigger serialisation invariant); got {max_concurrent}"
-                );
-            }
-            worker.max_concurrent_fires_per_trigger = max_concurrent as usize;
-        }
-
-        if let Some(jitter_secs) = section.startup_jitter_max_secs {
-            settings.startup_jitter_max = Duration::from_secs(jitter_secs);
-        }
-
-        if let Some(jitter_secs) = section.tick_jitter_max_secs {
-            settings.tick_jitter_max = Duration::from_secs(jitter_secs);
-        }
-
-        settings.worker = worker;
-    }
-
-    // Layer 1: environment variable overrides.
-    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_ENABLED") {
-        match raw.to_ascii_lowercase().as_str() {
-            "1" | "true" => settings.enabled = true,
-            "0" | "false" => settings.enabled = false,
-            other => anyhow::bail!(
-                "IRONCLAW_TRIGGER_POLLER_ENABLED must be one of 1, true, 0, false (got {other:?})"
-            ),
-        }
-    }
-
-    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") {
-        let secs: u64 = raw.parse().map_err(|_| {
-            anyhow::anyhow!(
-                "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be a positive integer, got {raw:?}"
-            )
-        })?;
-        if secs == 0 {
-            anyhow::bail!("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be greater than 0");
-        }
-        settings.worker.poll_interval = Duration::from_secs(secs);
-    }
-
     Ok(settings)
 }
 
@@ -968,102 +879,5 @@ default_project = "project-alpha"
                 .expect_err("legacy client vars without redirect URI must not be ignored");
 
         assert!(error.to_string().contains("GOOGLE_OAUTH_REDIRECT_URI"));
-    }
-
-    // --- trigger_poller_settings tests ---
-
-    use super::trigger_poller_settings;
-    use ironclaw_reborn_config::TriggerPollerConfigSection;
-    use std::time::Duration;
-
-    fn make_config_with_trigger_poller(
-        section: TriggerPollerConfigSection,
-    ) -> ironclaw_reborn_config::RebornConfigFile {
-        ironclaw_reborn_config::RebornConfigFile {
-            trigger_poller: Some(section),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn trigger_poller_settings_default_is_disabled() {
-        // No config file, no env → disabled with zero jitter.
-        let settings = trigger_poller_settings(None).expect("default trigger poller settings");
-
-        assert!(!settings.enabled, "default must be disabled");
-        assert_eq!(settings.startup_jitter_max, Duration::ZERO);
-        assert_eq!(settings.tick_jitter_max, Duration::ZERO);
-    }
-
-    #[test]
-    fn trigger_poller_settings_config_enabled_maps_worker_fields() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            poll_interval_secs: Some(15),
-            fires_per_tick: Some(50),
-            max_concurrent_fires_per_trigger: Some(1),
-            startup_jitter_max_secs: Some(3),
-            tick_jitter_max_secs: Some(7),
-        };
-        let config = make_config_with_trigger_poller(section);
-
-        let settings =
-            trigger_poller_settings(Some(&config)).expect("trigger poller settings from config");
-
-        assert!(settings.enabled, "config enabled=true must be reflected");
-        assert_eq!(settings.worker.poll_interval, Duration::from_secs(15));
-        assert_eq!(settings.worker.fires_per_tick, 50);
-        assert_eq!(settings.worker.max_concurrent_fires_per_trigger, 1);
-        assert_eq!(settings.startup_jitter_max, Duration::from_secs(3));
-        assert_eq!(settings.tick_jitter_max, Duration::from_secs(7));
-    }
-
-    #[test]
-    fn trigger_poller_settings_max_concurrent_fires_greater_than_1_is_error() {
-        let section = TriggerPollerConfigSection {
-            enabled: Some(true),
-            max_concurrent_fires_per_trigger: Some(2),
-            ..Default::default()
-        };
-        let config = make_config_with_trigger_poller(section);
-
-        let err = trigger_poller_settings(Some(&config))
-            .expect_err("max_concurrent_fires_per_trigger=2 must be rejected");
-
-        assert!(
-            err.to_string().contains("max_concurrent_fires_per_trigger"),
-            "error must mention the field, got: {err}",
-        );
-    }
-
-    // NOTE: tests that mutate real process env vars are inherently racy when
-    // run in parallel with other tests in the same process. We follow the
-    // pattern used elsewhere in this crate: set the variable, run the
-    // assertion, then always restore the original value in a defer-style
-    // guard so a panicking assertion cannot leave the env dirty.
-    #[test]
-    fn trigger_poller_settings_env_enabled_overrides_config_disabled() {
-        // Config says disabled; env says enabled — env must win.
-        let section = TriggerPollerConfigSection {
-            enabled: Some(false),
-            ..Default::default()
-        };
-        let config = make_config_with_trigger_poller(section);
-
-        let key = "IRONCLAW_TRIGGER_POLLER_ENABLED";
-        let prior = std::env::var(key).ok();
-        // Safety: single-threaded test binary segment; restored below.
-        unsafe { std::env::set_var(key, "true") };
-        let result = trigger_poller_settings(Some(&config));
-        match prior {
-            Some(v) => unsafe { std::env::set_var(key, v) },
-            None => unsafe { std::env::remove_var(key) },
-        }
-
-        let settings = result.expect("env override should succeed");
-        assert!(
-            settings.enabled,
-            "IRONCLAW_TRIGGER_POLLER_ENABLED=true must override config enabled=false"
-        );
     }
 }

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -792,6 +792,68 @@ default_project = "project-alpha"
     }
 
     #[test]
+    fn build_runtime_input_maps_trigger_poller_enabled_config() {
+        // Inline RAII guards so the test is self-contained and does not
+        // depend on anything inside trigger_poller::tests.
+        struct EnvGuard {
+            key: &'static str,
+            prior: Option<String>,
+        }
+        impl EnvGuard {
+            fn clear(key: &'static str) -> Self {
+                let prior = std::env::var(key).ok();
+                // SAFETY: env mutation is process-global; Drop restores on
+                // unwind. Cleared keys are only read by trigger_poller_settings
+                // in this test's call stack.
+                unsafe { std::env::remove_var(key) };
+                Self { key, prior }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match self.prior.take() {
+                    Some(v) => unsafe { std::env::set_var(self.key, v) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
+        let _g1 = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _g2 = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        std::fs::write(
+            reborn_home.join("config.toml"),
+            r#"
+[trigger_poller]
+enabled = true
+poll_interval_secs = 42
+"#,
+        )
+        .expect("write config");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.into_os_string()),
+            None,
+            None,
+            None,
+        )
+        .expect("boot config");
+
+        let input = build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+
+        assert!(
+            input.trigger_poller.enabled,
+            "[trigger_poller] enabled=true in config must reach runtime_input.trigger_poller.enabled"
+        );
+        assert_eq!(
+            input.trigger_poller.worker.poll_interval,
+            std::time::Duration::from_secs(42),
+            "config poll_interval_secs must reach worker.poll_interval"
+        );
+    }
+
+    #[test]
     fn resolve_google_oauth_config_returns_none_when_no_vars_set() {
         let config =
             resolve_google_oauth_config(|_| None).expect("empty env should not fail setup");

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -435,8 +435,8 @@ fn resolve_google_oauth_config(
 /// callers (OAuth client overrides, etc.) where a blank slot is benign.
 ///
 /// **Not** for operator-control knobs like `IRONCLAW_TRIGGER_POLLER_*` —
-/// those use `runtime::trigger_poller::strict_env_var`, which treats
-/// present-blank as a fatal misconfiguration.
+/// those use a strict-presence variant in the `trigger_poller` submodule,
+/// which treats a present-but-blank value as a fatal misconfiguration.
 fn optional_nonempty_env(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
@@ -902,6 +902,39 @@ poll_interval_secs = 15
             input.trigger_poller.worker.poll_interval,
             std::time::Duration::from_secs(45),
             "env IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=45 must override config poll_interval_secs=15 through build_runtime_input"
+        );
+    }
+
+    #[test]
+    fn build_runtime_input_rejects_invalid_trigger_poller_enabled_env() {
+        // Invalid env value (`yes`) must error out through build_runtime_input,
+        // not slip through to the runtime input. Closes the caller-level gap
+        // for the error path; previous tests covered only happy/override paths.
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "yes");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.to_string_lossy().to_string().into()),
+            None,
+            None,
+            None,
+        )
+        .expect("boot config");
+
+        let err = match build_runtime_input(&config, RuntimeInputCaller::Run) {
+            Ok(_) => panic!(
+                "invalid IRONCLAW_TRIGGER_POLLER_ENABLED must propagate as Err through build_runtime_input"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("IRONCLAW_TRIGGER_POLLER_ENABLED"),
+            "caller-level error must surface the env var name, got: {err}",
         );
     }
 

--- a/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
@@ -5,8 +5,6 @@
 //!
 //! Not exposed outside `#[cfg(test)]`.
 
-#![cfg(test)]
-
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
 /// Serializes every test that touches `IRONCLAW_TRIGGER_*` env vars so

--- a/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/test_env.rs
@@ -1,0 +1,60 @@
+//! Shared test-only env-var harness for `runtime::tests` and
+//! `runtime::trigger_poller::tests`. Both modules read or mutate the
+//! `IRONCLAW_TRIGGER_POLLER_*` env vars; without a single lock + single
+//! `EnvGuard` they would race in the same test binary.
+//!
+//! Not exposed outside `#[cfg(test)]`.
+
+#![cfg(test)]
+
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+/// Serializes every test that touches `IRONCLAW_TRIGGER_*` env vars so
+/// they cannot race each other. cargo test runs tests in parallel by
+/// default; without this each env-mutating test would observe sibling
+/// tests' mutations. Held for the whole body of every env-touching test.
+static TRIGGER_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+pub(super) fn lock_trigger_env() -> MutexGuard<'static, ()> {
+    TRIGGER_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// RAII guard that snapshots an env var on construction and restores it
+/// on drop. Restores on panic too (Drop runs during unwind), which the
+/// manual snapshot/restore pattern does not. Tests install this guard so
+/// other tests running in parallel cannot observe their mutations.
+pub(super) struct EnvGuard {
+    key: &'static str,
+    prior: Option<String>,
+}
+
+impl EnvGuard {
+    pub(super) fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        // SAFETY: env mutation is process-global; restore on Drop covers
+        // panic unwind. Callers must hold `lock_trigger_env()` for the
+        // life of this guard to serialise against sibling test threads.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prior }
+    }
+
+    pub(super) fn clear(key: &'static str) -> Self {
+        let prior = std::env::var(key).ok();
+        // SAFETY: see EnvGuard::set.
+        unsafe { std::env::remove_var(key) };
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.prior.take() {
+            // SAFETY: see EnvGuard::set.
+            Some(v) => unsafe { std::env::set_var(self.key, v) },
+            // SAFETY: see EnvGuard::set.
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -1,0 +1,360 @@
+use std::time::Duration;
+
+use ironclaw_reborn_composition::TriggerPollerSettings;
+
+use super::optional_nonempty_env;
+
+/// Build [`TriggerPollerSettings`] by merging three layers of configuration.
+///
+/// Precedence (highest first):
+/// 1. Environment variables:
+///    - `IRONCLAW_TRIGGER_POLLER_ENABLED` — `1`/`true` → enabled, `0`/`false` → disabled
+///      (case-insensitive). Overrides any `enabled` value from the config file.
+///    - `IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS` — parse as `u64`; overrides the
+///      config-file `poll_interval_secs`.  Must be > 0.
+/// 2. Config-file `[trigger_poller]` section — all fields are optional; any field
+///    absent here falls through to the compiled default.
+/// 3. Compiled default — `TriggerPollerSettings::default()` (disabled, all limits
+///    at the `ironclaw_triggers` crate defaults).
+///
+/// V1 invariant: `max_concurrent_fires_per_trigger` must be exactly 1. Passing
+/// any other value (via config or, were an env override ever added, env) returns
+/// an error rather than silently breaking per-trigger serialisation. The same
+/// invariant is also enforced at spawn time by `TriggerPollerWorkerConfig::validate`
+/// (in `ironclaw_triggers`); the CLI layer keeps the guard here so an invalid
+/// config fails at boot-config parse rather than at first poller spawn.
+pub(super) fn trigger_poller_settings(
+    config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
+) -> anyhow::Result<TriggerPollerSettings> {
+    // Layer 3: compiled default (disabled).
+    let mut settings = TriggerPollerSettings::default();
+
+    // Layer 2: config-file [trigger_poller] section.
+    if let Some(section) = config_file.and_then(|file| file.trigger_poller.as_ref()) {
+        if let Some(enabled) = section.enabled {
+            settings.enabled = enabled;
+        }
+
+        // Build a mutable worker config to apply section overrides.
+        let mut worker = settings.worker;
+
+        if let Some(secs) = section.poll_interval_secs {
+            if secs == 0 {
+                anyhow::bail!(
+                    "config file [trigger_poller].poll_interval_secs must be greater than 0"
+                );
+            }
+            worker.poll_interval = Duration::from_secs(secs);
+        }
+
+        if let Some(fires) = section.fires_per_tick {
+            if fires == 0 {
+                anyhow::bail!("config file [trigger_poller].fires_per_tick must be greater than 0");
+            }
+            worker.fires_per_tick = fires as usize;
+        }
+
+        if let Some(max_concurrent) = section.max_concurrent_fires_per_trigger {
+            // V1 invariant: per-trigger concurrency is locked at 1.
+            if max_concurrent != 1 {
+                anyhow::bail!(
+                    "config file [trigger_poller].max_concurrent_fires_per_trigger must be 1 \
+                     (V1 per-trigger serialisation invariant); got {max_concurrent}"
+                );
+            }
+            worker.max_concurrent_fires_per_trigger = max_concurrent as usize;
+        }
+
+        if let Some(jitter_secs) = section.startup_jitter_max_secs {
+            settings.startup_jitter_max = Duration::from_secs(jitter_secs);
+        }
+
+        if let Some(jitter_secs) = section.tick_jitter_max_secs {
+            settings.tick_jitter_max = Duration::from_secs(jitter_secs);
+        }
+
+        settings.worker = worker;
+    }
+
+    // Layer 1: environment variable overrides.
+    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_ENABLED") {
+        match raw.to_ascii_lowercase().as_str() {
+            "1" | "true" => settings.enabled = true,
+            "0" | "false" => settings.enabled = false,
+            other => anyhow::bail!(
+                "IRONCLAW_TRIGGER_POLLER_ENABLED must be one of 1, true, 0, false (got {other:?})"
+            ),
+        }
+    }
+
+    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") {
+        let secs: u64 = raw.parse().map_err(|e| {
+            anyhow::anyhow!(
+                "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be a positive integer, got {raw:?}: {e}"
+            )
+        })?;
+        if secs == 0 {
+            anyhow::bail!("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be greater than 0");
+        }
+        settings.worker.poll_interval = Duration::from_secs(secs);
+    }
+
+    Ok(settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::trigger_poller_settings;
+    use ironclaw_reborn_config::TriggerPollerConfigSection;
+    use std::sync::{LazyLock, Mutex, MutexGuard};
+    use std::time::Duration;
+
+    /// Serializes every test that touches `IRONCLAW_TRIGGER_*` env vars so
+    /// they cannot race each other. cargo test runs tests in parallel by
+    /// default; without this each env-mutating test would observe sibling
+    /// tests' mutations. Held for the whole body of every env-touching test.
+    static TRIGGER_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn lock_trigger_env() -> MutexGuard<'static, ()> {
+        TRIGGER_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn make_config_with_trigger_poller(
+        section: TriggerPollerConfigSection,
+    ) -> ironclaw_reborn_config::RebornConfigFile {
+        ironclaw_reborn_config::RebornConfigFile {
+            trigger_poller: Some(section),
+            ..Default::default()
+        }
+    }
+
+    /// RAII guard that snapshots an env var on construction and restores it on
+    /// drop. Restores on panic too (Drop runs during unwind), which the manual
+    /// snapshot/restore pattern does not. Tests that read `IRONCLAW_TRIGGER_*`
+    /// env vars (including the default-is-disabled case) install this guard so
+    /// other tests running in parallel cannot observe their mutations.
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: env mutation is process-global; restore on Drop covers
+            // panic unwind, but tests that mutate the same key in parallel can
+            // still race. The two `IRONCLAW_TRIGGER_*` keys are used only by
+            // tests in this module and `#[serial(trigger_poller_env)]` would
+            // be needed to make this fully race-free across crates.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prior }
+        }
+
+        fn clear(key: &'static str) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: see above.
+            unsafe { std::env::remove_var(key) };
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                // SAFETY: see EnvGuard::set.
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                // SAFETY: see EnvGuard::set.
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn trigger_poller_settings_default_is_disabled() {
+        // No config file, no env → disabled with zero jitter. Hold the env
+        // lock for the whole test so a sibling test cannot mutate the env
+        // between EnvGuard::clear and the call below.
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let settings = trigger_poller_settings(None).expect("default trigger poller settings");
+
+        assert!(!settings.enabled, "default must be disabled");
+        assert_eq!(settings.startup_jitter_max, Duration::ZERO);
+        assert_eq!(settings.tick_jitter_max, Duration::ZERO);
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_enabled_maps_worker_fields() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            poll_interval_secs: Some(15),
+            fires_per_tick: Some(50),
+            max_concurrent_fires_per_trigger: Some(1),
+            startup_jitter_max_secs: Some(3),
+            tick_jitter_max_secs: Some(7),
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings =
+            trigger_poller_settings(Some(&config)).expect("trigger poller settings from config");
+
+        assert!(settings.enabled, "config enabled=true must be reflected");
+        assert_eq!(settings.worker.poll_interval, Duration::from_secs(15));
+        assert_eq!(settings.worker.fires_per_tick, 50);
+        assert_eq!(settings.worker.max_concurrent_fires_per_trigger, 1);
+        assert_eq!(settings.startup_jitter_max, Duration::from_secs(3));
+        assert_eq!(settings.tick_jitter_max, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn trigger_poller_settings_max_concurrent_fires_greater_than_1_is_error() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            max_concurrent_fires_per_trigger: Some(2),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("max_concurrent_fires_per_trigger=2 must be rejected");
+
+        assert!(
+            err.to_string().contains("max_concurrent_fires_per_trigger"),
+            "error must mention the field, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_poll_interval_zero_is_error() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            poll_interval_secs: Some(0),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("poll_interval_secs=0 must be rejected");
+
+        assert!(
+            err.to_string().contains("poll_interval_secs"),
+            "error must mention the field, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_overrides_config_disabled() {
+        // Config says disabled; env says enabled — env must win.
+        let _lock = lock_trigger_env();
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "true");
+
+        let section = TriggerPollerConfigSection {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings = trigger_poller_settings(Some(&config)).expect("env override should succeed");
+        assert!(
+            settings.enabled,
+            "IRONCLAW_TRIGGER_POLLER_ENABLED=true must override config enabled=false"
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_interval_overrides_config_interval() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS", "45");
+
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            poll_interval_secs: Some(15),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings =
+            trigger_poller_settings(Some(&config)).expect("env interval override should succeed");
+        assert_eq!(
+            settings.worker.poll_interval,
+            Duration::from_secs(45),
+            "env value 45 must override config value 15"
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_interval_zero_is_error() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS", "0");
+
+        let err = trigger_poller_settings(None)
+            .expect_err("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS=0 must be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS"),
+            "error must mention the env var, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_interval_non_numeric_preserves_parse_error() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS", "10s");
+
+        let err =
+            trigger_poller_settings(None).expect_err("non-numeric env interval must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") && msg.contains("10s"),
+            "error must surface env var name and offending value, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_invalid_value_is_error() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "yes");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let err = trigger_poller_settings(None)
+            .expect_err("IRONCLAW_TRIGGER_POLLER_ENABLED=yes must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("IRONCLAW_TRIGGER_POLLER_ENABLED") && msg.contains("yes"),
+            "error must surface env var name and offending value, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_fires_per_tick_zero_is_error() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            fires_per_tick: Some(0),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err =
+            trigger_poller_settings(Some(&config)).expect_err("fires_per_tick=0 must be rejected");
+
+        assert!(
+            err.to_string().contains("fires_per_tick"),
+            "error must mention the field, got: {err}",
+        );
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -129,8 +129,10 @@ pub(super) fn trigger_poller_settings(
         match raw.to_ascii_lowercase().as_str() {
             "1" | "true" => settings.enabled = true,
             "0" | "false" => settings.enabled = false,
-            other => {
-                let display = truncate_env_value_for_display(other);
+            _ => {
+                // Display the operator's original value (case preserved), not the
+                // lowercased match key — they need to find it in their config.
+                let display = truncate_env_value_for_display(&raw);
                 anyhow::bail!(
                     "IRONCLAW_TRIGGER_POLLER_ENABLED must be one of 1, true, 0, false (got {display:?})"
                 )
@@ -158,22 +160,10 @@ pub(super) fn trigger_poller_settings(
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_env::{EnvGuard, lock_trigger_env};
     use super::trigger_poller_settings;
     use ironclaw_reborn_config::TriggerPollerConfigSection;
-    use std::sync::{LazyLock, Mutex, MutexGuard};
     use std::time::Duration;
-
-    /// Serializes every test that touches `IRONCLAW_TRIGGER_*` env vars so
-    /// they cannot race each other. cargo test runs tests in parallel by
-    /// default; without this each env-mutating test would observe sibling
-    /// tests' mutations. Held for the whole body of every env-touching test.
-    static TRIGGER_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-    fn lock_trigger_env() -> MutexGuard<'static, ()> {
-        TRIGGER_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
 
     fn make_config_with_trigger_poller(
         section: TriggerPollerConfigSection,
@@ -181,47 +171,6 @@ mod tests {
         ironclaw_reborn_config::RebornConfigFile {
             trigger_poller: Some(section),
             ..Default::default()
-        }
-    }
-
-    /// RAII guard that snapshots an env var on construction and restores it on
-    /// drop. Restores on panic too (Drop runs during unwind), which the manual
-    /// snapshot/restore pattern does not. Tests that read `IRONCLAW_TRIGGER_*`
-    /// env vars (including the default-is-disabled case) install this guard so
-    /// other tests running in parallel cannot observe their mutations.
-    struct EnvGuard {
-        key: &'static str,
-        prior: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prior = std::env::var(key).ok();
-            // SAFETY: env mutation is process-global; restore on Drop covers
-            // panic unwind, but tests that mutate the same key in parallel can
-            // still race. The two `IRONCLAW_TRIGGER_*` keys are used only by
-            // tests in this module and `#[serial(trigger_poller_env)]` would
-            // be needed to make this fully race-free across crates.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, prior }
-        }
-
-        fn clear(key: &'static str) -> Self {
-            let prior = std::env::var(key).ok();
-            // SAFETY: see above.
-            unsafe { std::env::remove_var(key) };
-            Self { key, prior }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.prior.take() {
-                // SAFETY: see EnvGuard::set.
-                Some(v) => unsafe { std::env::set_var(self.key, v) },
-                // SAFETY: see EnvGuard::set.
-                None => unsafe { std::env::remove_var(self.key) },
-            }
         }
     }
 
@@ -522,6 +471,142 @@ mod tests {
         assert!(
             msg.contains("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") && msg.contains("86400"),
             "error must surface env var name and value, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_invalid_value_preserves_case() {
+        // Operator must see what they actually typed (e.g. "YES"), not the
+        // lowercased match key, so they can find the value in their config.
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "YES");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let err = trigger_poller_settings(None)
+            .expect_err("IRONCLAW_TRIGGER_POLLER_ENABLED=YES must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("YES"),
+            "error must surface the operator's original (un-lowercased) value, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_poll_interval_at_cap_is_accepted() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            poll_interval_secs: Some(3600),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings = trigger_poller_settings(Some(&config))
+            .expect("poll_interval_secs at the cap must be accepted");
+        assert_eq!(settings.worker.poll_interval, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_fires_per_tick_at_cap_is_accepted() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            fires_per_tick: Some(1000),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings = trigger_poller_settings(Some(&config))
+            .expect("fires_per_tick at the cap must be accepted");
+        assert_eq!(settings.worker.fires_per_tick, 1000);
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_jitter_at_cap_is_accepted() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            startup_jitter_max_secs: Some(3600),
+            tick_jitter_max_secs: Some(3600),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings =
+            trigger_poller_settings(Some(&config)).expect("jitter at the cap must be accepted");
+        assert_eq!(settings.startup_jitter_max, Duration::from_secs(3600));
+        assert_eq!(settings.tick_jitter_max, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn trigger_poller_settings_max_concurrent_fires_zero_is_error() {
+        // 0 has distinct semantic meaning in some systems (unlimited
+        // concurrency); confirm the V1 guard rejects it explicitly.
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            max_concurrent_fires_per_trigger: Some(0),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("max_concurrent_fires_per_trigger=0 must be rejected");
+        assert!(
+            err.to_string().contains("max_concurrent_fires_per_trigger"),
+            "error must mention the field, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_numeric_one_enables() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "1");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let settings = trigger_poller_settings(None).expect("ENABLED=1 must succeed");
+        assert!(
+            settings.enabled,
+            "IRONCLAW_TRIGGER_POLLER_ENABLED=1 must enable"
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_numeric_zero_disables() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "0");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings = trigger_poller_settings(Some(&config)).expect("ENABLED=0 must succeed");
+        assert!(
+            !settings.enabled,
+            "IRONCLAW_TRIGGER_POLLER_ENABLED=0 must disable"
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_long_value_is_truncated() {
+        // Operator pastes an 80-char string into the env slot by mistake. The
+        // error message must NOT echo the full value verbatim (it might be a
+        // credential); the truncation ellipsis MUST appear.
+        let _lock = lock_trigger_env();
+        let long_value: String = "x".repeat(80);
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", &long_value);
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let err = trigger_poller_settings(None).expect_err("long ENABLED value must be rejected");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains('…'),
+            "truncation ellipsis must appear in error, got: {msg}",
+        );
+        assert!(
+            !msg.contains(&long_value),
+            "full untruncated value must not appear in error, got: {msg}",
         );
     }
 }

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -527,6 +527,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_poll_interval_at_cap_is_accepted() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
         let section = TriggerPollerConfigSection {
             enabled: Some(true),
             poll_interval_secs: Some(3600),
@@ -541,6 +544,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_fires_per_tick_at_cap_is_accepted() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
         let section = TriggerPollerConfigSection {
             enabled: Some(true),
             fires_per_tick: Some(1000),
@@ -555,6 +561,9 @@ mod tests {
 
     #[test]
     fn trigger_poller_settings_config_jitter_at_cap_is_accepted() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
         let section = TriggerPollerConfigSection {
             enabled: Some(true),
             startup_jitter_max_secs: Some(3600),

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -4,6 +4,23 @@ use ironclaw_reborn_composition::TriggerPollerSettings;
 
 use super::optional_nonempty_env;
 
+/// Upper bound on `poll_interval_secs` (config) and
+/// `IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS` (env). One hour caps the
+/// common typo class of writing a value in milliseconds — `60_000`,
+/// `86_400_000` — which would otherwise suspend the poller for hours
+/// or years before the operator notices nothing is firing.
+const MAX_POLL_INTERVAL_SECS: u64 = 3600;
+
+/// Upper bound on the two jitter knobs. Larger than this, jitter no
+/// longer feels like jitter and a misconfig has effectively replaced
+/// the poll interval with a multi-hour randomised pause.
+const MAX_JITTER_SECS: u64 = 3600;
+
+/// Upper bound on `fires_per_tick`. The compiled default is 32; 1000
+/// leaves plenty of headroom for a future high-throughput deployment
+/// while rejecting accidents like `u32::MAX` (~4B dispatches per tick).
+const MAX_FIRES_PER_TICK: u32 = 1000;
+
 /// Truncate an env-var value to a bounded length before echoing it in an
 /// error message. Prevents the value from blowing up startup logs if the
 /// operator accidentally pastes a long string (e.g. a credential) into the
@@ -54,17 +71,21 @@ pub(super) fn trigger_poller_settings(
         let mut worker = settings.worker;
 
         if let Some(secs) = section.poll_interval_secs {
-            if secs == 0 {
+            if secs == 0 || secs > MAX_POLL_INTERVAL_SECS {
                 anyhow::bail!(
-                    "config file [trigger_poller].poll_interval_secs must be greater than 0"
+                    "config file [trigger_poller].poll_interval_secs must be in 1..={MAX_POLL_INTERVAL_SECS}; \
+                     got {secs}"
                 );
             }
             worker.poll_interval = Duration::from_secs(secs);
         }
 
         if let Some(fires) = section.fires_per_tick {
-            if fires == 0 {
-                anyhow::bail!("config file [trigger_poller].fires_per_tick must be greater than 0");
+            if fires == 0 || fires > MAX_FIRES_PER_TICK {
+                anyhow::bail!(
+                    "config file [trigger_poller].fires_per_tick must be in 1..={MAX_FIRES_PER_TICK}; \
+                     got {fires}"
+                );
             }
             worker.fires_per_tick = fires as usize;
         }
@@ -81,10 +102,22 @@ pub(super) fn trigger_poller_settings(
         }
 
         if let Some(jitter_secs) = section.startup_jitter_max_secs {
+            if jitter_secs > MAX_JITTER_SECS {
+                anyhow::bail!(
+                    "config file [trigger_poller].startup_jitter_max_secs must be <= {MAX_JITTER_SECS}; \
+                     got {jitter_secs}"
+                );
+            }
             settings.startup_jitter_max = Duration::from_secs(jitter_secs);
         }
 
         if let Some(jitter_secs) = section.tick_jitter_max_secs {
+            if jitter_secs > MAX_JITTER_SECS {
+                anyhow::bail!(
+                    "config file [trigger_poller].tick_jitter_max_secs must be <= {MAX_JITTER_SECS}; \
+                     got {jitter_secs}"
+                );
+            }
             settings.tick_jitter_max = Duration::from_secs(jitter_secs);
         }
 
@@ -112,8 +145,10 @@ pub(super) fn trigger_poller_settings(
                 "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be a positive integer, got {display:?}: {e}"
             )
         })?;
-        if secs == 0 {
-            anyhow::bail!("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be greater than 0");
+        if secs == 0 || secs > MAX_POLL_INTERVAL_SECS {
+            anyhow::bail!(
+                "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be in 1..={MAX_POLL_INTERVAL_SECS}; got {secs}"
+            );
         }
         settings.worker.poll_interval = Duration::from_secs(secs);
     }
@@ -395,6 +430,98 @@ mod tests {
         assert!(
             err.to_string().contains("fires_per_tick"),
             "error must mention the field, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_poll_interval_above_cap_is_error() {
+        // 86_400 secs = 1 day = far above the 3600s cap. Models the
+        // common typo class of writing a millisecond value (e.g. 86_400_000).
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            poll_interval_secs: Some(86_400),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("poll_interval_secs above the cap must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("poll_interval_secs") && msg.contains("86400"),
+            "error must mention the field and the offending value, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_fires_per_tick_above_cap_is_error() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            fires_per_tick: Some(10_000),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("fires_per_tick above the cap must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fires_per_tick") && msg.contains("10000"),
+            "error must mention the field and the offending value, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_startup_jitter_above_cap_is_error() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            startup_jitter_max_secs: Some(3601),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("startup_jitter_max_secs above the cap must be rejected");
+
+        assert!(
+            err.to_string().contains("startup_jitter_max_secs"),
+            "error must mention the field, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_config_tick_jitter_above_cap_is_error() {
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            tick_jitter_max_secs: Some(3601),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config))
+            .expect_err("tick_jitter_max_secs above the cap must be rejected");
+
+        assert!(
+            err.to_string().contains("tick_jitter_max_secs"),
+            "error must mention the field, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_interval_above_cap_is_error() {
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS", "86400");
+
+        let err = trigger_poller_settings(None)
+            .expect_err("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS above the cap must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") && msg.contains("86400"),
+            "error must surface env var name and value, got: {msg}",
         );
     }
 }

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -2,7 +2,38 @@ use std::time::Duration;
 
 use ironclaw_reborn_composition::TriggerPollerSettings;
 
-use super::optional_nonempty_env;
+/// Read a trigger-poller env var with **strict** presence semantics.
+///
+/// `IRONCLAW_TRIGGER_POLLER_*` env vars are operator-control knobs: presence
+/// is authoritative, not just non-empty content. Treat the var as
+///
+/// - unset → `Ok(None)` (fall through to the config/default layer)
+/// - set, empty or all-whitespace → fatal (operator must unset or fix)
+/// - set, non-empty → `Ok(Some(value))` (caller validates content)
+///
+/// Distinct from the broader `optional_nonempty_env` used by optional-config
+/// callers (OAuth, etc.), which intentionally collapses present-blank to
+/// absent. Here, a present-but-blank env slot is almost always a bug — a
+/// shell typo, a half-set deployment template, or a credential injector
+/// that failed to populate the slot — and falling through silently would
+/// drop the operator's intended kill-switch or interval override with no
+/// visible signal.
+fn strict_env_var(name: &str) -> anyhow::Result<Option<String>> {
+    match std::env::var(name) {
+        Ok(value) => {
+            if value.trim().is_empty() {
+                anyhow::bail!(
+                    "{name} is set but empty or whitespace-only; either unset it or provide a valid value"
+                );
+            }
+            Ok(Some(value))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => anyhow::bail!(
+            "{name} contains non-UTF-8 bytes; either unset it or provide a valid value"
+        ),
+    }
+}
 
 /// Upper bound on `poll_interval_secs` (config) and
 /// `IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS` (env). One hour caps the
@@ -124,9 +155,11 @@ pub(super) fn trigger_poller_settings(
         settings.worker = worker;
     }
 
-    // Layer 1: environment variable overrides.
-    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_ENABLED") {
-        match raw.to_ascii_lowercase().as_str() {
+    // Layer 1: environment variable overrides. Uses strict presence
+    // semantics — a present-but-blank value is fatal, not a silent
+    // fall-through to config/default.
+    if let Some(raw) = strict_env_var("IRONCLAW_TRIGGER_POLLER_ENABLED")? {
+        match raw.trim().to_ascii_lowercase().as_str() {
             "1" | "true" => settings.enabled = true,
             "0" | "false" => settings.enabled = false,
             _ => {
@@ -140,8 +173,8 @@ pub(super) fn trigger_poller_settings(
         }
     }
 
-    if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") {
-        let secs: u64 = raw.parse().map_err(|e| {
+    if let Some(raw) = strict_env_var("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS")? {
+        let secs: u64 = raw.trim().parse().map_err(|e| {
             let display = truncate_env_value_for_display(&raw);
             anyhow::anyhow!(
                 "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be a positive integer, got {display:?}: {e}"
@@ -607,6 +640,66 @@ mod tests {
         assert!(
             !msg.contains(&long_value),
             "full untruncated value must not appear in error, got: {msg}",
+        );
+    }
+
+    // --- strict env contract: present-blank is fatal, not fall-through ---
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_empty_is_error() {
+        // ENABLED="" must NOT silently fall through to config — operator's
+        // env slot is present but empty, almost always a deployment bug.
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let err = trigger_poller_settings(Some(&config)).expect_err(
+            "empty IRONCLAW_TRIGGER_POLLER_ENABLED must be rejected, not silently dropped",
+        );
+
+        assert!(
+            err.to_string().contains("IRONCLAW_TRIGGER_POLLER_ENABLED"),
+            "error must mention the env var, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_enabled_whitespace_is_error() {
+        // ENABLED="   " (all-whitespace) hits the same fatal path as "".
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "   ");
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+
+        let err = trigger_poller_settings(None)
+            .expect_err("whitespace-only IRONCLAW_TRIGGER_POLLER_ENABLED must be rejected");
+
+        assert!(
+            err.to_string().contains("IRONCLAW_TRIGGER_POLLER_ENABLED"),
+            "error must mention the env var, got: {err}",
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_interval_empty_is_error() {
+        // INTERVAL_SECS="" follows the same strict contract.
+        let _lock = lock_trigger_env();
+        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
+        let _interval = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS", "");
+
+        let err = trigger_poller_settings(None).expect_err(
+            "empty IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be rejected, not silently dropped",
+        );
+
+        assert!(
+            err.to_string()
+                .contains("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS"),
+            "error must mention the env var, got: {err}",
         );
     }
 }

--- a/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/trigger_poller.rs
@@ -4,6 +4,21 @@ use ironclaw_reborn_composition::TriggerPollerSettings;
 
 use super::optional_nonempty_env;
 
+/// Truncate an env-var value to a bounded length before echoing it in an
+/// error message. Prevents the value from blowing up startup logs if the
+/// operator accidentally pastes a long string (e.g. a credential) into the
+/// env slot. Char-aware so we cannot split a multi-byte UTF-8 codepoint.
+fn truncate_env_value_for_display(raw: &str) -> String {
+    const MAX_CHARS: usize = 64;
+    let mut iter = raw.chars();
+    let truncated: String = iter.by_ref().take(MAX_CHARS).collect();
+    if iter.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
 /// Build [`TriggerPollerSettings`] by merging three layers of configuration.
 ///
 /// Precedence (highest first):
@@ -81,16 +96,20 @@ pub(super) fn trigger_poller_settings(
         match raw.to_ascii_lowercase().as_str() {
             "1" | "true" => settings.enabled = true,
             "0" | "false" => settings.enabled = false,
-            other => anyhow::bail!(
-                "IRONCLAW_TRIGGER_POLLER_ENABLED must be one of 1, true, 0, false (got {other:?})"
-            ),
+            other => {
+                let display = truncate_env_value_for_display(other);
+                anyhow::bail!(
+                    "IRONCLAW_TRIGGER_POLLER_ENABLED must be one of 1, true, 0, false (got {display:?})"
+                )
+            }
         }
     }
 
     if let Some(raw) = optional_nonempty_env("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS") {
         let secs: u64 = raw.parse().map_err(|e| {
+            let display = truncate_env_value_for_display(&raw);
             anyhow::anyhow!(
-                "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be a positive integer, got {raw:?}: {e}"
+                "IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS must be a positive integer, got {display:?}: {e}"
             )
         })?;
         if secs == 0 {
@@ -267,6 +286,27 @@ mod tests {
         assert!(
             settings.enabled,
             "IRONCLAW_TRIGGER_POLLER_ENABLED=true must override config enabled=false"
+        );
+    }
+
+    #[test]
+    fn trigger_poller_settings_env_disabled_overrides_config_enabled() {
+        // Operator kill-switch: config has enabled=true but the env var disables.
+        let _lock = lock_trigger_env();
+        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+        let _enabled = EnvGuard::set("IRONCLAW_TRIGGER_POLLER_ENABLED", "false");
+
+        let section = TriggerPollerConfigSection {
+            enabled: Some(true),
+            ..Default::default()
+        };
+        let config = make_config_with_trigger_poller(section);
+
+        let settings =
+            trigger_poller_settings(Some(&config)).expect("env kill-switch should succeed");
+        assert!(
+            !settings.enabled,
+            "IRONCLAW_TRIGGER_POLLER_ENABLED=false must override config enabled=true"
         );
     }
 

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -37,7 +37,7 @@ use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::secrets_guard::{InlineSecretError, reject_inline_secret};
@@ -82,6 +82,9 @@ pub struct RebornConfigFile {
     /// `budget_set` tool or CLI at runtime. Setting any limit to `0` means
     /// "unlimited" for that dimension.
     pub budget: Option<BudgetSection>,
+    /// Trigger poller lifecycle settings. All fields optional; absent section
+    /// leaves all limits at the compiled defaults in the composition root.
+    pub trigger_poller: Option<TriggerPollerConfigSection>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -247,6 +250,38 @@ pub struct BudgetSection {
     /// Default `1.20` (20% safety margin); reconcile releases the
     /// overshoot.
     pub overestimate_factor: Option<f64>,
+}
+
+/// `[trigger_poller]` section. Controls the background trigger-poller worker.
+///
+/// All fields are optional so a sparse or absent section is valid; the
+/// composition root applies its own compiled defaults for any field not set
+/// here. Env vars override this section; CLI flags override env vars.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TriggerPollerConfigSection {
+    /// Enable or disable the trigger poller. Default `false` (off) in
+    /// composition; operators MUST set `enabled = true` to activate it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// How often the poller ticks, in seconds. Default in composition is 60.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub poll_interval_secs: Option<u64>,
+    /// Maximum triggers to fire per tick. Default in composition is 100.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fires_per_tick: Option<u32>,
+    /// Maximum concurrent fires allowed for a single trigger. Default in
+    /// composition is 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_concurrent_fires_per_trigger: Option<u32>,
+    /// Upper bound (seconds) of a random jitter delay before the first tick.
+    /// Spreads startup load across instances. Default in composition is 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_jitter_max_secs: Option<u64>,
+    /// Upper bound (seconds) of a random jitter added to each tick interval.
+    /// Prevents synchronized thundering-herd across instances. Default 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tick_jitter_max_secs: Option<u64>,
 }
 
 /// One `[llm.<slot>]` entry. The slot name (typically `"default"` or
@@ -1248,6 +1283,68 @@ not_a_field = 1.0
 "#;
         let err = RebornConfigFile::parse_text(toml, &attributed())
             .expect_err("deny_unknown_fields must catch typos in [budget]");
+        assert!(matches!(err, RebornConfigFileError::Toml { .. }));
+    }
+
+    #[test]
+    fn trigger_poller_full_section_parses() {
+        let toml = r#"
+[trigger_poller]
+enabled = true
+poll_interval_secs = 30
+fires_per_tick = 50
+max_concurrent_fires_per_trigger = 3
+startup_jitter_max_secs = 10
+tick_jitter_max_secs = 5
+"#;
+        let cfg = RebornConfigFile::parse_text(toml, &attributed())
+            .expect("full trigger_poller section must parse");
+        let tp = cfg
+            .trigger_poller
+            .as_ref()
+            .expect("trigger_poller section present");
+        assert_eq!(tp.enabled, Some(true));
+        assert_eq!(tp.poll_interval_secs, Some(30));
+        assert_eq!(tp.fires_per_tick, Some(50));
+        assert_eq!(tp.max_concurrent_fires_per_trigger, Some(3));
+        assert_eq!(tp.startup_jitter_max_secs, Some(10));
+        assert_eq!(tp.tick_jitter_max_secs, Some(5));
+    }
+
+    #[test]
+    fn trigger_poller_absent_section_yields_none() {
+        let cfg = RebornConfigFile::parse_text("", &attributed()).expect("empty TOML must parse");
+        assert!(cfg.trigger_poller.is_none());
+    }
+
+    #[test]
+    fn trigger_poller_partial_section_other_fields_none() {
+        let toml = r#"
+[trigger_poller]
+enabled = true
+"#;
+        let cfg = RebornConfigFile::parse_text(toml, &attributed())
+            .expect("partial trigger_poller section must parse");
+        let tp = cfg
+            .trigger_poller
+            .as_ref()
+            .expect("trigger_poller section present");
+        assert_eq!(tp.enabled, Some(true));
+        assert_eq!(tp.poll_interval_secs, None);
+        assert_eq!(tp.fires_per_tick, None);
+        assert_eq!(tp.max_concurrent_fires_per_trigger, None);
+        assert_eq!(tp.startup_jitter_max_secs, None);
+        assert_eq!(tp.tick_jitter_max_secs, None);
+    }
+
+    #[test]
+    fn trigger_poller_rejects_unknown_key() {
+        let toml = r#"
+[trigger_poller]
+not_a_field = true
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("deny_unknown_fields must catch typos in [trigger_poller]");
         assert!(matches!(err, RebornConfigFileError::Toml { .. }));
     }
 }

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -37,7 +37,7 @@ use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use thiserror::Error;
 
 use crate::secrets_guard::{InlineSecretError, reject_inline_secret};
@@ -83,7 +83,7 @@ pub struct RebornConfigFile {
     /// "unlimited" for that dimension.
     pub budget: Option<BudgetSection>,
     /// Trigger poller lifecycle settings. All fields optional; absent section
-    /// leaves all limits at the compiled defaults in the composition root.
+    /// leaves the worker at the compiled defaults in the composition root.
     pub trigger_poller: Option<TriggerPollerConfigSection>,
 }
 
@@ -257,30 +257,24 @@ pub struct BudgetSection {
 /// All fields are optional so a sparse or absent section is valid; the
 /// composition root applies its own compiled defaults for any field not set
 /// here. Env vars override this section; CLI flags override env vars.
-#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TriggerPollerConfigSection {
     /// Enable or disable the trigger poller. Default `false` (off) in
     /// composition; operators MUST set `enabled = true` to activate it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    /// How often the poller ticks, in seconds. Default in composition is 60.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// How often the poller ticks, in seconds. Default in composition is 30.
     pub poll_interval_secs: Option<u64>,
-    /// Maximum triggers to fire per tick. Default in composition is 100.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Maximum triggers to fire per tick. Default in composition is 32.
     pub fires_per_tick: Option<u32>,
     /// Maximum concurrent fires allowed for a single trigger. Default in
     /// composition is 1.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_concurrent_fires_per_trigger: Option<u32>,
     /// Upper bound (seconds) of a random jitter delay before the first tick.
     /// Spreads startup load across instances. Default in composition is 0.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub startup_jitter_max_secs: Option<u64>,
     /// Upper bound (seconds) of a random jitter added to each tick interval.
     /// Prevents synchronized thundering-herd across instances. Default 0.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tick_jitter_max_secs: Option<u64>,
 }
 

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -264,23 +264,24 @@ pub struct TriggerPollerConfigSection {
     /// composition; operators MUST set `enabled = true` to activate it.
     pub enabled: Option<bool>,
     /// How often the poller ticks, in seconds. Default in composition is 30.
-    /// Range `1..=3600` is enforced by the CLI settings layer; values outside
-    /// the range are a fatal boot error (`runtime/trigger_poller.rs`).
+    /// Range `1..=3600` is enforced at boot by the CLI settings layer;
+    /// values outside the range are a fatal startup error.
     pub poll_interval_secs: Option<u64>,
     /// Maximum triggers to fire per tick. Default in composition is 32.
-    /// Range `1..=1000` is enforced by the CLI settings layer.
+    /// Range `1..=1000` is enforced at boot by the CLI settings layer;
+    /// values outside the range are a fatal startup error.
     pub fires_per_tick: Option<u32>,
     /// Maximum concurrent fires allowed for a single trigger. Default in
-    /// composition is 1. V1 invariant: must equal 1 (enforced by the CLI
-    /// settings layer); any other value is a fatal boot error.
+    /// composition is 1. V1 invariant: must equal 1, enforced at boot by
+    /// the CLI settings layer; any other value is a fatal startup error.
     pub max_concurrent_fires_per_trigger: Option<u32>,
     /// Upper bound (seconds) of a random jitter delay before the first tick.
     /// Spreads startup load across instances. Default in composition is 0.
-    /// Range `0..=3600` is enforced by the CLI settings layer.
+    /// Range `0..=3600` is enforced at boot by the CLI settings layer.
     pub startup_jitter_max_secs: Option<u64>,
     /// Upper bound (seconds) of a random jitter added to each tick interval.
     /// Prevents synchronized thundering-herd across instances. Default 0.
-    /// Range `0..=3600` is enforced by the CLI settings layer.
+    /// Range `0..=3600` is enforced at boot by the CLI settings layer.
     pub tick_jitter_max_secs: Option<u64>,
 }
 

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -1300,6 +1300,10 @@ tick_jitter_max_secs = 5
         assert_eq!(tp.enabled, Some(true));
         assert_eq!(tp.poll_interval_secs, Some(30));
         assert_eq!(tp.fires_per_tick, Some(50));
+        // max_concurrent_fires_per_trigger is intentionally not 1 here: this test
+        // exercises the parse layer, which deliberately accepts any u32. The CLI
+        // settings layer (trigger_poller_settings) enforces the V1 invariant that
+        // the value must equal 1 — see runtime/trigger_poller.rs.
         assert_eq!(tp.max_concurrent_fires_per_trigger, Some(3));
         assert_eq!(tp.startup_jitter_max_secs, Some(10));
         assert_eq!(tp.tick_jitter_max_secs, Some(5));

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -264,17 +264,23 @@ pub struct TriggerPollerConfigSection {
     /// composition; operators MUST set `enabled = true` to activate it.
     pub enabled: Option<bool>,
     /// How often the poller ticks, in seconds. Default in composition is 30.
+    /// Range `1..=3600` is enforced by the CLI settings layer; values outside
+    /// the range are a fatal boot error (`runtime/trigger_poller.rs`).
     pub poll_interval_secs: Option<u64>,
     /// Maximum triggers to fire per tick. Default in composition is 32.
+    /// Range `1..=1000` is enforced by the CLI settings layer.
     pub fires_per_tick: Option<u32>,
     /// Maximum concurrent fires allowed for a single trigger. Default in
-    /// composition is 1.
+    /// composition is 1. V1 invariant: must equal 1 (enforced by the CLI
+    /// settings layer); any other value is a fatal boot error.
     pub max_concurrent_fires_per_trigger: Option<u32>,
     /// Upper bound (seconds) of a random jitter delay before the first tick.
     /// Spreads startup load across instances. Default in composition is 0.
+    /// Range `0..=3600` is enforced by the CLI settings layer.
     pub startup_jitter_max_secs: Option<u64>,
     /// Upper bound (seconds) of a random jitter added to each tick interval.
     /// Prevents synchronized thundering-herd across instances. Default 0.
+    /// Range `0..=3600` is enforced by the CLI settings layer.
     pub tick_jitter_max_secs: Option<u64>,
 }
 

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -256,7 +256,7 @@ pub struct BudgetSection {
 ///
 /// All fields are optional so a sparse or absent section is valid; the
 /// composition root applies its own compiled defaults for any field not set
-/// here. Env vars override this section; CLI flags override env vars.
+/// here. Env vars (`IRONCLAW_TRIGGER_POLLER_*`) override this section.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TriggerPollerConfigSection {

--- a/crates/ironclaw_reborn_config/src/lib.rs
+++ b/crates/ironclaw_reborn_config/src/lib.rs
@@ -38,8 +38,8 @@ pub use config_file::{
     BootSection, BudgetSection, DefaultLlmSlotUpdate, DefaultLlmSlotUpdateSession, DriversSection,
     HarnessSection, IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection, PolicySection,
     REBORN_CONFIG_API_VERSION, RebornConfigFile, RebornConfigFileError,
-    RebornConfigFileUpdateError, RunnerSection, begin_default_llm_slot_update,
-    update_default_llm_slot,
+    RebornConfigFileUpdateError, RunnerSection, TriggerPollerConfigSection,
+    begin_default_llm_slot_update, update_default_llm_slot,
 };
 pub use doctor::RebornDoctorReport;
 pub use home::{REBORN_HOME_ENV, RebornConfigError, RebornHome, RebornHomeSource};


### PR DESCRIPTION
## Summary

Enable the trigger poller from `[trigger_poller]` in the Reborn config
file plus two env-var overrides. PR 18 wired the lifecycle; PR 18.6
gives operators the surface to turn it on. Default stays **off** in
every shipped profile — no behavior change unless explicitly enabled.

## What changed

- **`ironclaw_reborn_config`**: new `[trigger_poller]` TOML section
  (`TriggerPollerConfigSection`) with optional fields: `enabled`,
  `poll_interval_secs`, `fires_per_tick`,
  `max_concurrent_fires_per_trigger`, `startup_jitter_max_secs`,
  `tick_jitter_max_secs`. `#[serde(deny_unknown_fields)]` matches the
  sibling sections.
- **`ironclaw_reborn_cli` (`runtime/trigger_poller.rs`)**: new
  `trigger_poller_settings()` helper merges three layers — compiled
  default → config-file section → env vars. Precedence is env > config
  > default. Env vars:
    - `IRONCLAW_TRIGGER_POLLER_ENABLED` — `1`/`true` enable,
      `0`/`false` disable (case-insensitive); any other value is a
      fatal startup error.
    - `IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS` — `u64`, must be > 0.
- **V1 invariants enforced at parse time** (fail at boot, not at
  spawn): `poll_interval_secs > 0`, `fires_per_tick > 0`,
  `max_concurrent_fires_per_trigger == 1`. The third also re-checks at
  spawn in `TriggerPollerWorkerConfig::validate`; the CLI guard is
  kept deliberately so misconfig fails during boot-config validation.
- **`.env.example`**: documents the two env vars with their accepted
  values and the fatal-on-bad-value behavior.
- **Module split**: `runtime.rs` → `runtime/mod.rs` + new
  `runtime/trigger_poller.rs` so the poller helper + its tests live
  in their own ~360-line file and `mod.rs` stays below the 1000-line
  soft norm in `.claude/rules/architecture.md`.

## Test coverage

11 new unit tests in `runtime::trigger_poller::tests` and 4 in
`config_file::tests`:

- Defaults: no section, no env → disabled with zero jitter
- Config: full section maps every worker field; partial section leaves
  other fields at defaults
- Config errors: `poll_interval_secs = 0`, `fires_per_tick = 0`,
  `max_concurrent_fires_per_trigger = 2`, unknown TOML key
- Env: `ENABLED=true` overrides config-`false`; `INTERVAL_SECS=45`
  overrides config interval; `INTERVAL_SECS=0` errors;
  `INTERVAL_SECS="10s"` preserves the underlying parse error in the
  message; `ENABLED=yes` errors with the offending value

Env-mutating tests are serialized via a static `LazyLock<Mutex>` and
use a panic-safe RAII `EnvGuard` so a failed assertion cannot leak
mutated env into sibling tests in the same process.

## Out of scope

- Actually enabling the poller in any shipped profile — still
  default-off; operator opt-in only.
- Authentication / authz at fire time — tracked in PR 18.5b.
- Tooling for managing triggers in the web UI — tracked in PR 18.9 /
  18.10 (Automations panel).
- E2E that drives a real cron through the poller — tracked in PR 18.7
  (full-path integration) and PR 18.8 (Python e2e).

## Test plan

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy -p ironclaw_reborn_cli -p ironclaw_reborn_config --all-targets --all-features`
- [ ] `cargo test -p ironclaw_reborn_cli -p ironclaw_reborn_config`
- [ ] Manual smoke: drop `[trigger_poller] enabled = true` into a
      Reborn config, start the binary, confirm the poller spawn log
      appears in stderr.
- [ ] Manual smoke: same with `IRONCLAW_TRIGGER_POLLER_ENABLED=1`
      and no config section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)