### PR TITLE
[codex] fix reborn skill install replay

### DIFF
--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -2203,18 +2203,19 @@ async fn builtin_skill_install_accepts_content_without_url_fetch() {
 }
 
 #[tokio::test]
-async fn builtin_skill_install_accepts_named_plain_markdown_content() {
+async fn builtin_skill_install_accepts_and_replays_named_plain_markdown_content() {
     let temp = tempfile::tempdir().unwrap();
     let (filesystem, mounts) = mounted_skill_filesystem(temp.path());
     let runtime = runtime_with_filesystem(filesystem);
+    let input = json!({
+        "name": "qa-smoke-skill",
+        "content": "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n"
+    });
 
     let installed = invoke_with_context(
         &runtime,
         SKILL_INSTALL_CAPABILITY_ID,
-        json!({
-            "name": "qa-smoke-skill",
-            "content": "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n"
-        }),
+        input.clone(),
         // skill_install currently declares Network for URL installs too, so the
         // first-party harness needs a non-empty policy even for content input.
         execution_context_with_mounts_and_network(
@@ -2229,6 +2230,22 @@ async fn builtin_skill_install_accepts_named_plain_markdown_content() {
     assert_eq!(installed["installed"], json!(true));
     assert_eq!(installed["name"], json!("qa-smoke-skill"));
     assert_eq!(installed["source"], json!("user"));
+
+    let replayed = invoke_with_context(
+        &runtime,
+        SKILL_INSTALL_CAPABILITY_ID,
+        input,
+        execution_context_with_mounts_and_network(
+            [SKILL_INSTALL_CAPABILITY_ID],
+            mounts.clone(),
+            http_test_policy(),
+        ),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(replayed["installed"], json!(true));
+    assert_eq!(replayed["name"], json!("qa-smoke-skill"));
 
     let listed = invoke_with_context(
         &runtime,

--- a/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
@@ -1042,6 +1042,28 @@ impl DcrOAuthCallbackState {
         }
     }
 
+    pub(crate) fn encode(&self) -> Result<OAuthState, AuthProductError> {
+        let wire = DcrOAuthCallbackStateWire {
+            flow_id: self.flow_id,
+            resource: self.scope.resource.clone(),
+            session_id: self.scope.session_id.clone(),
+            provider: self.provider.clone(),
+            account_label: self.account_label.clone(),
+            requested_scopes: self.requested_scopes.clone(),
+            nonce: self.nonce.clone(),
+        };
+        let payload =
+            serde_json::to_vec(&wire).map_err(|_| AuthProductError::BackendUnavailable)?;
+        OAuthState::new(format!(
+            "{}{}",
+            Self::PREFIX,
+            URL_SAFE_NO_PAD.encode(payload)
+        ))
+    }
+}
+
+#[cfg(any(test, feature = "webui-v2-beta"))]
+impl DcrOAuthCallbackState {
     pub(crate) fn has_prefix(raw: &str) -> bool {
         raw.starts_with(Self::PREFIX)
     }
@@ -1064,25 +1086,6 @@ impl DcrOAuthCallbackState {
 
     pub(crate) fn requested_scopes(&self) -> &[ProviderScope] {
         &self.requested_scopes
-    }
-
-    pub(crate) fn encode(&self) -> Result<OAuthState, AuthProductError> {
-        let wire = DcrOAuthCallbackStateWire {
-            flow_id: self.flow_id,
-            resource: self.scope.resource.clone(),
-            session_id: self.scope.session_id.clone(),
-            provider: self.provider.clone(),
-            account_label: self.account_label.clone(),
-            requested_scopes: self.requested_scopes.clone(),
-            nonce: self.nonce.clone(),
-        };
-        let payload =
-            serde_json::to_vec(&wire).map_err(|_| AuthProductError::BackendUnavailable)?;
-        OAuthState::new(format!(
-            "{}{}",
-            Self::PREFIX,
-            URL_SAFE_NO_PAD.encode(payload)
-        ))
     }
 
     pub(crate) fn decode(raw: &str) -> Result<Self, AuthProductError> {

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -25,8 +25,8 @@ pub use install_bundle::{
 };
 
 use install_bundle::{
-    install_metadata_source, installed_skill_source, publish_skill_install,
-    read_install_metadata_bytes, validate_install_bundle_files,
+    existing_skill_install_matches, install_metadata_source, installed_skill_source,
+    publish_skill_install, read_install_metadata_bytes, validate_install_bundle_files,
 };
 
 pub(super) const USER_SKILLS_ROOT: &str = "/skills";
@@ -342,6 +342,27 @@ pub async fn install_skill(
 
     log_skill_filesystem_phase("stat_existing_dir", &skill_name, &skill_dir);
     if stat_optional(context, &skill_dir).await?.is_some() {
+        if existing_skill_install_matches(
+            context,
+            &skill_name,
+            &prepared.content,
+            request.files,
+            request.source,
+            request.source_url,
+        )
+        .await?
+        {
+            tracing::debug!(
+                skill_name = %skill_name,
+                scoped_path = %skill_dir,
+                "skill install matched existing skill directory"
+            );
+            return Ok(SkillInstallResult {
+                name: skill_name.clone(),
+                scoped_path: format!("{USER_SKILLS_ROOT}/{skill_name}/{SKILL_FILE_NAME}"),
+                source: installed_skill_source(request.source),
+            });
+        }
         tracing::debug!(
             skill_name = %skill_name,
             scoped_path = %skill_dir,

--- a/crates/ironclaw_skills/src/management/install_bundle.rs
+++ b/crates/ironclaw_skills/src/management/install_bundle.rs
@@ -1,4 +1,9 @@
-use ironclaw_filesystem::{FilesystemError, FilesystemOperation};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+};
+
+use ironclaw_filesystem::{FileType, FilesystemError, FilesystemOperation};
 use ironclaw_host_api::ScopedPath;
 
 use crate::{
@@ -87,6 +92,115 @@ pub(super) async fn publish_skill_install(
         return Err(error);
     }
     Ok(())
+}
+
+pub(super) async fn existing_skill_install_matches(
+    context: &SkillManagementContext,
+    skill_name: &str,
+    normalized_content: &str,
+    files: &[SkillInstallFile<'_>],
+    source: SkillInstallSource,
+    source_url: Option<&str>,
+) -> Result<bool, SkillManagementError> {
+    let skill_dir = skill_root_scoped_path(USER_SKILLS_ROOT, skill_name)?;
+    let expected_files = expected_install_files(normalized_content, files, source, source_url)?;
+    existing_files_match_expected(context, &skill_dir, expected_files).await
+}
+
+fn expected_install_files<'a>(
+    normalized_content: &'a str,
+    files: &'a [SkillInstallFile<'a>],
+    source: SkillInstallSource,
+    source_url: Option<&str>,
+) -> Result<BTreeMap<String, Cow<'a, [u8]>>, SkillManagementError> {
+    let mut expected = BTreeMap::from([(
+        SKILL_FILE_NAME.to_string(),
+        Cow::Borrowed(normalized_content.as_bytes()),
+    )]);
+    if source == SkillInstallSource::InstalledUrl {
+        expected.insert(
+            INSTALL_METADATA_FILE_NAME.to_string(),
+            Cow::Owned(install_metadata_bytes(source_url)?),
+        );
+    }
+    for file in files {
+        let relative_path = normalize_install_relative_path(file.relative_path)?;
+        expected.insert(relative_path, Cow::Borrowed(file.contents));
+    }
+    Ok(expected)
+}
+
+async fn existing_files_match_expected(
+    context: &SkillManagementContext,
+    skill_dir: &ScopedPath,
+    mut expected_files: BTreeMap<String, Cow<'_, [u8]>>,
+) -> Result<bool, SkillManagementError> {
+    let expected_dirs = expected_directory_prefixes(expected_files.keys());
+    let expected_entry_count = expected_files.len().saturating_add(expected_dirs.len());
+    let mut stack = vec![(skill_dir.clone(), String::new())];
+    while let Some((dir_path, relative_prefix)) = stack.pop() {
+        let entries = context
+            .filesystem
+            .list_dir_bounded(
+                &context.scope,
+                &dir_path,
+                expected_entry_count.saturating_add(1),
+            )
+            .await
+            .map_err(filesystem_error)?;
+        if entries.len() > expected_entry_count {
+            return Ok(false);
+        }
+        for entry in entries {
+            let relative_path = if relative_prefix.is_empty() {
+                entry.name.clone()
+            } else {
+                format!("{relative_prefix}{}", entry.name)
+            };
+            match entry.file_type {
+                FileType::File => {
+                    let Some(expected_contents) = expected_files.remove(&relative_path) else {
+                        return Ok(false);
+                    };
+                    let file_path = scoped_child(&dir_path, &entry.name)?;
+                    let Some(existing_contents) =
+                        read_existing_file_bytes(context, &file_path, expected_contents.len())
+                            .await?
+                    else {
+                        return Ok(false);
+                    };
+                    if existing_contents != expected_contents.as_ref() {
+                        return Ok(false);
+                    }
+                }
+                FileType::Directory => {
+                    if !expected_dirs.contains(&relative_path) {
+                        return Ok(false);
+                    }
+                    stack.push((
+                        scoped_child(&dir_path, &entry.name)?,
+                        format!("{relative_path}/"),
+                    ));
+                }
+                FileType::Symlink | FileType::Other => return Ok(false),
+            }
+        }
+    }
+    Ok(expected_files.is_empty())
+}
+
+fn expected_directory_prefixes<'a>(
+    paths: impl IntoIterator<Item = &'a String>,
+) -> BTreeSet<String> {
+    let mut dirs = BTreeSet::new();
+    for path in paths {
+        let mut current = path.as_str();
+        while let Some((parent, _)) = current.rsplit_once('/') {
+            dirs.insert(parent.to_string());
+            current = parent;
+        }
+    }
+    dirs
 }
 
 pub(super) fn validate_install_bundle_files(
@@ -225,6 +339,16 @@ fn scoped_parent(path: &ScopedPath) -> Result<Option<ScopedPath>, SkillManagemen
         .map_err(|_| SkillManagementError::new(SkillManagementErrorKind::InvalidInput))
 }
 
+fn scoped_child(parent: &ScopedPath, name: &str) -> Result<ScopedPath, SkillManagementError> {
+    if name.contains('/') || name.contains('\\') || name.chars().any(char::is_control) {
+        return Err(SkillManagementError::new(
+            SkillManagementErrorKind::InvalidInput,
+        ));
+    }
+    ScopedPath::new(format!("{}/{name}", parent.as_str().trim_end_matches('/')))
+        .map_err(|_| SkillManagementError::new(SkillManagementErrorKind::InvalidInput))
+}
+
 async fn create_dir_all(
     context: &SkillManagementContext,
     skill_name: &str,
@@ -268,6 +392,22 @@ async fn cleanup_partial_install(
         return Err(filesystem_error(error));
     }
     Ok(())
+}
+
+async fn read_existing_file_bytes(
+    context: &SkillManagementContext,
+    path: &ScopedPath,
+    expected_len: usize,
+) -> Result<Option<Vec<u8>>, SkillManagementError> {
+    match context
+        .filesystem
+        .read_bytes_bounded(&context.scope, path, expected_len.saturating_add(1))
+        .await
+    {
+        Ok(Some(bytes)) if bytes.len() == expected_len => Ok(Some(bytes)),
+        Ok(Some(_)) | Ok(None) | Err(FilesystemError::NotFound { .. }) => Ok(None),
+        Err(error) => Err(filesystem_error(error)),
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -128,6 +128,92 @@ async fn install_accepts_named_plain_markdown_content() {
 }
 
 #[tokio::test]
+async fn install_matching_existing_skill_is_idempotent() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem.clone(), skill_mounts());
+    let content = "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n";
+    let request = SkillInstallRequest {
+        name: Some("qa-smoke-skill"),
+        content,
+        files: &[],
+        source: SkillInstallSource::User,
+        source_url: None,
+    };
+
+    let first = install_skill(&context, request).await.unwrap();
+    let second = install_skill(&context, request).await.unwrap();
+
+    assert_eq!(first.name, "qa-smoke-skill");
+    assert_eq!(second.name, "qa-smoke-skill");
+    let listed = list_skills(&context).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "qa-smoke-skill");
+}
+
+#[tokio::test]
+async fn install_rejects_existing_skill_with_different_content() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem, skill_mounts());
+
+    install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("qa-smoke-skill"),
+            content: "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n",
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap();
+    let error = install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("qa-smoke-skill"),
+            content: "# QA Smoke\n\nDifferent instructions.\n",
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error.kind(), SkillManagementErrorKind::Conflict);
+}
+
+#[tokio::test]
+async fn install_rejects_existing_skill_with_extra_files() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem.clone(), skill_mounts());
+    let request = SkillInstallRequest {
+        name: Some("qa-smoke-skill"),
+        content: "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n",
+        files: &[],
+        source: SkillInstallSource::User,
+        source_url: None,
+    };
+
+    install_skill(&context, request).await.unwrap();
+    write_file(
+        filesystem.as_ref(),
+        "/projects/skills/qa-smoke-skill/references/guide.md",
+        "# Keep\n".to_string(),
+    )
+    .await;
+    let error = install_skill(&context, request).await.unwrap_err();
+
+    assert_eq!(error.kind(), SkillManagementErrorKind::Conflict);
+    assert_file_contents(
+        filesystem.as_ref(),
+        "/projects/skills/qa-smoke-skill/references/guide.md",
+        b"# Keep\n",
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn install_rejects_malformed_frontmatter_even_with_requested_name() {
     let filesystem = Arc::new(InMemoryBackend::default());
     let context = skill_management_context(filesystem, skill_mounts());
@@ -417,18 +503,7 @@ async fn install_serializes_concurrent_same_name_requests() {
     let (first, second) = tokio::join!(first, second);
 
     let results = [first, second];
-    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
-    assert_eq!(
-        results
-            .iter()
-            .filter(|result| {
-                result
-                    .as_ref()
-                    .is_err_and(|error| error.kind() == SkillManagementErrorKind::Conflict)
-            })
-            .count(),
-        1
-    );
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 2);
     assert_file_contents(
         &filesystem,
         "/projects/skills/shared-helper/SKILL.md",

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -47,12 +47,12 @@ use ironclaw_host_runtime::{
     GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HTTP_SAVE_CAPABILITY_ID,
     HostRuntime, HostRuntimeServices, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID,
     MEMORY_READ_CAPABILITY_ID, MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID,
-    MEMORY_WRITE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, RuntimeCredentialAccountRequest,
-    RuntimeCredentialAccountResolver, SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID,
-    SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID,
-    SurfaceKind, TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID,
-    TRIGGER_REMOVE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
-    builtin_first_party_package,
+    MEMORY_WRITE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, RuntimeCredentialAccessSecret,
+    RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver, SHELL_CAPABILITY_ID,
+    SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID,
+    SPAWN_SUBAGENT_CAPABILITY_ID, SurfaceKind, TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID,
+    TRIGGER_LIST_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
+    builtin_first_party_handlers, builtin_first_party_package,
 };
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilityResultWrite,
@@ -2213,10 +2213,15 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
     async fn resolve_access_secret(
         &self,
         request: RuntimeCredentialAccountRequest<'_>,
-    ) -> Result<SecretHandle, CredentialStageError> {
+    ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
         assert_eq!(request.provider.as_str(), "github");
         assert_eq!(request.requester_extension.as_str(), "github");
-        self.result.clone()
+        self.result
+            .clone()
+            .map(|handle| RuntimeCredentialAccessSecret {
+                scope: request.scope.clone(),
+                handle,
+            })
     }
 }
 


### PR DESCRIPTION
## Summary
- make Reborn skill installs idempotent when the existing user skill exactly matches the requested install
- preserve conflicts for mismatched content, partial directories, extra files, or non-matching bundle/metadata files
- add shared management and first-party Reborn regression coverage for the qa-smoke-skill replay case
- rebase onto current reborn-integration and fix two current-base CI compatibility issues

## Root Cause
Reborn `builtin.skill_install` dispatches through first-party skill management. A repeated install with the same idempotency key can reach the handler again, and the shared install path rejected any pre-existing `/skills/<name>` directory before checking whether it was the same requested install. That made repeat QA flows fail on the second install attempt.

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test -p ironclaw_skills install_rejects_existing_skill_with_extra_files`
- `cargo test -p ironclaw_skills install_matching_existing_skill_is_idempotent`
- `cargo test -p ironclaw_skills install_rejects_existing_skill_with_different_content`
- `cargo test -p ironclaw_skills install_serializes_concurrent_same_name_requests`
- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_skill_install_accepts_and_replays_named_plain_markdown_content`
- `CARGO_INCREMENTAL=0 cargo clippy --test reborn_minimal_dispatch_parity --all-features -- -D warnings`

## Notes
- Local full `cargo clippy --all --tests --examples --all-features -- -D warnings` was attempted, but this workspace exhausted disk while compiling broad unrelated root test targets. The narrower clippy target covers the CI failures observed on this PR; GitHub Actions remains the source of truth for the full matrix.
