### PR TITLE
Enable OAuth setup for GSuite WASM tools

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -336,7 +336,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 | Tool-level streaming | ✅ | ❌ | |
 | Z.AI tool_stream | ✅ | ❌ | Real-time tool call streaming |
 | Plugin tools | ✅ | ✅ | WASM tools |
-| GSuite WASM tools | ✅ | 🚧 | Reborn bundles operation-level Google Drive/Docs/Sheets/Slides WASM packages with host-mediated HTTP egress and product-auth scoped bearer injection; live OAuth/setup UX and full live-recorded parity remain follow-up |
+| GSuite WASM tools | ✅ | 🚧 | Reborn bundles operation-level Google Drive/Docs/Sheets/Slides WASM packages with host-mediated HTTP egress, product-auth scoped bearer injection, and manifest-declared Google OAuth setup metadata; full live-recorded parity remains follow-up |
 | Hosted MCP extensions | ✅ | 🚧 | Reborn composes host-mediated MCP runtime, bundles the current Notion MCP supported tool set, wires Notion ProductAuth OAuth exchange/refresh, can use Reborn ProductAuth DCR OAuth setup through the host callback origin, and can activate hosted MCP packages with live `tools/list` schema discovery through host-staged product-auth credentials |
 | NEAR AI MCP extension | ✅ | 🚧 | Host-bundled Reborn MCP extension exposes `nearai.search` via host-mediated HTTP and `llm_nearai_api_key`; manifest-declared product-auth credentials can now be staged through the hosted MCP runtime/discovery bridge, while NEAR remains a static supported-tool adapter |
 | Tool policies (allow/deny) | ✅ | ✅ | |

--- a/crates/ironclaw_first_party_extensions/assets/google-docs/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-docs/manifest.toml
@@ -14,7 +14,7 @@ id = "google-docs.create_document"
 description = "Create a new Google Docs document."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -28,7 +28,7 @@ id = "google-docs.get_document"
 description = "Get document metadata and structure."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents.readonly"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents.readonly"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -42,7 +42,7 @@ id = "google-docs.read_content"
 description = "Read the document body as plain text."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents.readonly"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents.readonly"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -56,7 +56,7 @@ id = "google-docs.insert_text"
 description = "Insert text at a document position."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -70,7 +70,7 @@ id = "google-docs.delete_content"
 description = "Delete document content in a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -84,7 +84,7 @@ id = "google-docs.replace_text"
 description = "Find and replace text."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -98,7 +98,7 @@ id = "google-docs.format_text"
 description = "Format text in a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -112,7 +112,7 @@ id = "google-docs.format_paragraph"
 description = "Set paragraph style."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -126,7 +126,7 @@ id = "google-docs.insert_table"
 description = "Insert a table."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -140,7 +140,7 @@ id = "google-docs.create_list"
 description = "Create a bulleted or numbered list."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -154,7 +154,7 @@ id = "google-docs.batch_update"
 description = "Execute raw Docs API batchUpdate requests."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/documents"] } }, provider_scopes = ["https://www.googleapis.com/auth/documents"], audience = { scheme = "https", host_pattern = "docs.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"

--- a/crates/ironclaw_first_party_extensions/assets/google-drive/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-drive/manifest.toml
@@ -14,7 +14,7 @@ id = "google-drive.list_files"
 description = "Search or list files and folders."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -28,7 +28,7 @@ id = "google-drive.get_file"
 description = "Get file metadata."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -42,7 +42,7 @@ id = "google-drive.download_file"
 description = "Download file content as text or export a Google Workspace file."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -56,7 +56,7 @@ id = "google-drive.upload_file"
 description = "Upload a new text file."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -70,7 +70,7 @@ id = "google-drive.update_file"
 description = "Update file metadata or move/star a file."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -84,7 +84,7 @@ id = "google-drive.create_folder"
 description = "Create a folder."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -98,7 +98,7 @@ id = "google-drive.delete_file"
 description = "Permanently delete a file or folder."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -112,7 +112,7 @@ id = "google-drive.trash_file"
 description = "Move a file or folder to trash."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -126,7 +126,7 @@ id = "google-drive.share_file"
 description = "Share a file or folder with someone."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -140,7 +140,7 @@ id = "google-drive.list_permissions"
 description = "List file permissions."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -154,7 +154,7 @@ id = "google-drive.remove_permission"
 description = "Revoke a file permission."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -168,7 +168,7 @@ id = "google-drive.list_shared_drives"
 description = "List shared drives."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/drive.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/drive.readonly"], audience = { scheme = "https", host_pattern = "www.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"

--- a/crates/ironclaw_first_party_extensions/assets/google-sheets/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-sheets/manifest.toml
@@ -14,7 +14,7 @@ id = "google-sheets.create_spreadsheet"
 description = "Create a new spreadsheet."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -28,7 +28,7 @@ id = "google-sheets.get_spreadsheet"
 description = "Get spreadsheet metadata."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -42,7 +42,7 @@ id = "google-sheets.read_values"
 description = "Read cell values from a range."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -56,7 +56,7 @@ id = "google-sheets.batch_read_values"
 description = "Read values from multiple ranges."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -70,7 +70,7 @@ id = "google-sheets.write_values"
 description = "Write values to a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -84,7 +84,7 @@ id = "google-sheets.append_values"
 description = "Append rows after existing data."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -98,7 +98,7 @@ id = "google-sheets.clear_values"
 description = "Clear values from a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -112,7 +112,7 @@ id = "google-sheets.add_sheet"
 description = "Add a sheet tab."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -126,7 +126,7 @@ id = "google-sheets.delete_sheet"
 description = "Delete a sheet tab."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -140,7 +140,7 @@ id = "google-sheets.rename_sheet"
 description = "Rename a sheet tab."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -154,7 +154,7 @@ id = "google-sheets.format_cells"
 description = "Format cells in a range."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/spreadsheets"] } }, provider_scopes = ["https://www.googleapis.com/auth/spreadsheets"], audience = { scheme = "https", host_pattern = "sheets.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"

--- a/crates/ironclaw_first_party_extensions/assets/google-slides/manifest.toml
+++ b/crates/ironclaw_first_party_extensions/assets/google-slides/manifest.toml
@@ -14,7 +14,7 @@ id = "google-slides.create_presentation"
 description = "Create a new presentation."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -28,7 +28,7 @@ id = "google-slides.get_presentation"
 description = "Get presentation metadata."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations.readonly"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations.readonly"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -42,7 +42,7 @@ id = "google-slides.get_thumbnail"
 description = "Get a slide thumbnail URL."
 effects = ["dispatch_capability", "network", "use_secret"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations.readonly"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations.readonly"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations.readonly"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -56,7 +56,7 @@ id = "google-slides.create_slide"
 description = "Create a new slide."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -70,7 +70,7 @@ id = "google-slides.delete_object"
 description = "Delete a slide or page element."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -84,7 +84,7 @@ id = "google-slides.insert_text"
 description = "Insert text into a shape."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -98,7 +98,7 @@ id = "google-slides.delete_text"
 description = "Delete text from a shape."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -112,7 +112,7 @@ id = "google-slides.replace_all_text"
 description = "Find and replace text."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -126,7 +126,7 @@ id = "google-slides.create_shape"
 description = "Create a shape or text box."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -140,7 +140,7 @@ id = "google-slides.insert_image"
 description = "Insert an image on a slide."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -154,7 +154,7 @@ id = "google-slides.format_text"
 description = "Format text in a shape."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -168,7 +168,7 @@ id = "google-slides.format_paragraph"
 description = "Set paragraph alignment."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -182,7 +182,7 @@ id = "google-slides.replace_shapes_with_image"
 description = "Replace matching shapes with an image."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"
@@ -196,7 +196,7 @@ id = "google-slides.batch_update"
 description = "Execute raw Slides API batchUpdate requests."
 effects = ["dispatch_capability", "network", "use_secret", "external_write"]
 runtime_credentials = [
-  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google" }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+  { handle = "google_runtime_token", source = { type = "product_auth_account", provider = "google", setup = { kind = "oauth", scopes = ["https://www.googleapis.com/auth/presentations"] } }, provider_scopes = ["https://www.googleapis.com/auth/presentations"], audience = { scheme = "https", host_pattern = "slides.googleapis.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
 ]
 default_permission = "ask"
 visibility = "model"

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
@@ -225,7 +225,12 @@ fn credential_label(
     extension_id: &ExtensionId,
     requirement: &LifecycleExtensionCredentialRequirement,
 ) -> String {
-    format!("{} {}", extension_id.as_str(), requirement.provider)
+    let base = format!("{} {}", extension_id.as_str(), requirement.provider);
+    if requirement.name.contains("__") {
+        format!("{base} {}", requirement.name)
+    } else {
+        base
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -158,7 +158,7 @@ fn runtime_kind(runtime: &ExtensionRuntime) -> LifecycleExtensionRuntimeKind {
 fn credential_requirements(
     package: &AvailableExtensionPackage,
 ) -> Vec<LifecycleExtensionCredentialRequirement> {
-    let mut requirements = Vec::new();
+    let mut requirements: Vec<LifecycleExtensionCredentialRequirement> = Vec::new();
     for capability in &package.package.manifest.capabilities {
         for requirement in &capability.runtime_credentials {
             let ironclaw_host_api::RuntimeCredentialRequirementSource::ProductAuthAccount {
@@ -169,10 +169,9 @@ fn credential_requirements(
                 continue;
             };
             let name = requirement.handle.as_str().to_string();
-            if requirements
-                .iter()
-                .any(|seen: &LifecycleExtensionCredentialRequirement| seen.name == name)
-            {
+            if let Some(seen) = requirements.iter_mut().find(|seen| seen.name == name) {
+                seen.required |= requirement.required;
+                merge_credential_setup(&mut seen.setup, setup);
                 continue;
             }
             requirements.push(LifecycleExtensionCredentialRequirement {
@@ -184,6 +183,26 @@ fn credential_requirements(
         }
     }
     requirements
+}
+
+fn merge_credential_setup(
+    existing: &mut LifecycleExtensionCredentialSetup,
+    setup: &ironclaw_host_api::RuntimeCredentialAccountSetup,
+) {
+    let (
+        LifecycleExtensionCredentialSetup::OAuth { scopes },
+        ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth {
+            scopes: additional_scopes,
+        },
+    ) = (existing, setup)
+    else {
+        return;
+    };
+    for scope in additional_scopes {
+        if !scopes.iter().any(|seen| seen == scope) {
+            scopes.push(scope.clone());
+        }
+    }
 }
 
 fn credential_setup(
@@ -1377,7 +1396,10 @@ mod tests {
         BackendCapabilities, DirEntry, FileStat, FilesystemError, FilesystemOperation,
         InMemoryBackend,
     };
-    use ironclaw_host_api::{EffectKind, HostPortCatalog};
+    use ironclaw_host_api::{
+        EffectKind, HostPortCatalog, RuntimeCredentialAccountSetup,
+        RuntimeCredentialRequirementSource,
+    };
 
     use super::*;
     use crate::nearai_mcp::nearai_mcp_endpoint_from_base;
@@ -1494,6 +1516,82 @@ mod tests {
             &requirement.setup,
             LifecycleExtensionCredentialSetup::OAuth { scopes } if scopes.is_empty()
         ));
+    }
+
+    #[test]
+    fn bundled_gsuite_wasm_credentials_declare_oauth_setup() {
+        let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
+
+        for extension_id in [
+            "google-docs",
+            "google-drive",
+            "google-sheets",
+            "google-slides",
+        ] {
+            let package_ref =
+                LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id).unwrap();
+            let package = catalog.resolve(&package_ref).unwrap();
+            let summary = package.summary();
+            let google_requirement = summary
+                .credential_requirements
+                .iter()
+                .find(|requirement| requirement.provider == "google")
+                .unwrap_or_else(|| panic!("{extension_id} should expose Google OAuth setup"));
+            let LifecycleExtensionCredentialSetup::OAuth {
+                scopes: summary_scopes,
+            } = &google_requirement.setup
+            else {
+                panic!("{extension_id} should expose Google OAuth setup");
+            };
+
+            assert!(
+                !summary_scopes.is_empty(),
+                "{extension_id} should expose Google OAuth setup in its lifecycle summary"
+            );
+
+            let mut credential_count = 0;
+            let mut capability_scopes = Vec::new();
+            for capability in &package.package.manifest.capabilities {
+                for credential in &capability.runtime_credentials {
+                    let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } =
+                        &credential.source
+                    else {
+                        panic!(
+                            "{extension_id} capability {} should use a Google product auth account",
+                            capability.id
+                        );
+                    };
+                    assert_eq!(provider.as_str(), "google");
+
+                    let RuntimeCredentialAccountSetup::OAuth { scopes } = setup else {
+                        panic!(
+                            "{extension_id} capability {} should declare OAuth setup",
+                            capability.id
+                        );
+                    };
+                    assert_eq!(
+                        scopes, &credential.provider_scopes,
+                        "{extension_id} capability {} OAuth setup scopes should match requested provider scopes",
+                        capability.id
+                    );
+                    for scope in scopes {
+                        if !capability_scopes.iter().any(|seen| seen == scope) {
+                            capability_scopes.push(scope.clone());
+                        }
+                    }
+                    credential_count += 1;
+                }
+            }
+
+            assert_eq!(
+                summary_scopes, &capability_scopes,
+                "{extension_id} lifecycle setup should request the package's unique OAuth scopes"
+            );
+            assert!(
+                credential_count > 0,
+                "{extension_id} should declare runtime credentials"
+            );
+        }
     }
 
     #[test]

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -158,7 +158,7 @@ fn runtime_kind(runtime: &ExtensionRuntime) -> LifecycleExtensionRuntimeKind {
 fn credential_requirements(
     package: &AvailableExtensionPackage,
 ) -> Vec<LifecycleExtensionCredentialRequirement> {
-    let mut requirements: Vec<LifecycleExtensionCredentialRequirement> = Vec::new();
+    let mut groups: Vec<CredentialRequirementGroup> = Vec::new();
     for capability in &package.package.manifest.capabilities {
         for requirement in &capability.runtime_credentials {
             let ironclaw_host_api::RuntimeCredentialRequirementSource::ProductAuthAccount {
@@ -168,41 +168,61 @@ fn credential_requirements(
             else {
                 continue;
             };
-            let name = requirement.handle.as_str().to_string();
-            if let Some(seen) = requirements.iter_mut().find(|seen| seen.name == name) {
+            let handle = requirement.handle.as_str().to_string();
+            let provider = provider.as_str().to_string();
+            let setup = credential_setup(setup);
+            if let Some(seen) = groups.iter_mut().find(|seen| {
+                seen.handle == handle && seen.provider == provider && seen.setup == setup
+            }) {
                 seen.required |= requirement.required;
-                merge_credential_setup(&mut seen.setup, setup);
                 continue;
             }
-            requirements.push(LifecycleExtensionCredentialRequirement {
-                name,
-                provider: provider.as_str().to_string(),
+            groups.push(CredentialRequirementGroup {
+                handle,
+                provider,
                 required: requirement.required,
-                setup: credential_setup(setup),
+                setup,
             });
         }
     }
-    requirements
+    groups
+        .iter()
+        .enumerate()
+        .map(|(index, group)| {
+            let has_distinct_source = groups.iter().any(|other| {
+                other.handle == group.handle
+                    && (other.provider != group.provider || other.setup != group.setup)
+            });
+            LifecycleExtensionCredentialRequirement {
+                name: if has_distinct_source {
+                    credential_requirement_name(&groups[..=index], group)
+                } else {
+                    group.handle.clone()
+                },
+                provider: group.provider.clone(),
+                required: group.required,
+                setup: group.setup.clone(),
+            }
+        })
+        .collect()
 }
 
-fn merge_credential_setup(
-    existing: &mut LifecycleExtensionCredentialSetup,
-    setup: &ironclaw_host_api::RuntimeCredentialAccountSetup,
-) {
-    let (
-        LifecycleExtensionCredentialSetup::OAuth { scopes },
-        ironclaw_host_api::RuntimeCredentialAccountSetup::OAuth {
-            scopes: additional_scopes,
-        },
-    ) = (existing, setup)
-    else {
-        return;
-    };
-    for scope in additional_scopes {
-        if !scopes.iter().any(|seen| seen == scope) {
-            scopes.push(scope.clone());
-        }
-    }
+struct CredentialRequirementGroup {
+    handle: String,
+    provider: String,
+    required: bool,
+    setup: LifecycleExtensionCredentialSetup,
+}
+
+fn credential_requirement_name(
+    seen_groups: &[CredentialRequirementGroup],
+    group: &CredentialRequirementGroup,
+) -> String {
+    let ordinal = seen_groups
+        .iter()
+        .filter(|seen| seen.handle == group.handle)
+        .count();
+    format!("{}__{}", group.handle, ordinal)
 }
 
 fn credential_setup(
@@ -1532,25 +1552,14 @@ mod tests {
                 LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id).unwrap();
             let package = catalog.resolve(&package_ref).unwrap();
             let summary = package.summary();
-            let google_requirement = summary
+            let google_requirements = summary
                 .credential_requirements
                 .iter()
-                .find(|requirement| requirement.provider == "google")
-                .unwrap_or_else(|| panic!("{extension_id} should expose Google OAuth setup"));
-            let LifecycleExtensionCredentialSetup::OAuth {
-                scopes: summary_scopes,
-            } = &google_requirement.setup
-            else {
-                panic!("{extension_id} should expose Google OAuth setup");
-            };
-
-            assert!(
-                !summary_scopes.is_empty(),
-                "{extension_id} should expose Google OAuth setup in its lifecycle summary"
-            );
+                .filter(|requirement| requirement.provider == "google")
+                .collect::<Vec<_>>();
 
             let mut credential_count = 0;
-            let mut capability_scopes = Vec::new();
+            let mut capability_scope_sets: Vec<Vec<String>> = Vec::new();
             for capability in &package.package.manifest.capabilities {
                 for credential in &capability.runtime_credentials {
                     let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } =
@@ -1574,19 +1583,36 @@ mod tests {
                         "{extension_id} capability {} OAuth setup scopes should match requested provider scopes",
                         capability.id
                     );
-                    for scope in scopes {
-                        if !capability_scopes.iter().any(|seen| seen == scope) {
-                            capability_scopes.push(scope.clone());
-                        }
+                    if !capability_scope_sets.iter().any(|seen| seen == scopes) {
+                        capability_scope_sets.push(scopes.clone());
                     }
                     credential_count += 1;
                 }
             }
 
             assert_eq!(
-                summary_scopes, &capability_scopes,
-                "{extension_id} lifecycle setup should request the package's unique OAuth scopes"
+                google_requirements.len(),
+                capability_scope_sets.len(),
+                "{extension_id} lifecycle setup should keep distinct OAuth scope sets separate"
             );
+            assert_eq!(
+                google_requirements
+                    .iter()
+                    .map(|requirement| requirement.name.as_str())
+                    .collect::<HashSet<_>>()
+                    .len(),
+                google_requirements.len(),
+                "{extension_id} lifecycle setup should give split OAuth requirements unique names"
+            );
+            for requirement in google_requirements {
+                let LifecycleExtensionCredentialSetup::OAuth { scopes } = &requirement.setup else {
+                    panic!("{extension_id} should expose Google OAuth setup");
+                };
+                assert!(
+                    capability_scope_sets.iter().any(|seen| seen == scopes),
+                    "{extension_id} lifecycle setup should request only operation-level OAuth scopes; got {scopes:?}",
+                );
+            }
             assert!(
                 credential_count > 0,
                 "{extension_id} should declare runtime credentials"

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1813,7 +1813,7 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
-    use ironclaw_auth::GOOGLE_CALENDAR_READONLY_SCOPE;
+    use ironclaw_auth::{GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_CALENDAR_READONLY_SCOPE};
 
     /// Wiring guard: the `regex_skill_activation_enabled` flag from
     /// [`RebornRuntimeInput`] must reach
@@ -3766,16 +3766,36 @@ mod tests {
             )
             .await
             .expect("google setup extension lifecycle projection");
-        assert_eq!(google_setup.secrets.len(), 1);
-        assert_eq!(google_setup.secrets[0].provider, "google");
-        assert!(!google_setup.secrets[0].provided);
-        assert!(matches!(
-            &google_setup.secrets[0].setup,
-            RebornExtensionCredentialSetup::OAuth {
-                scopes,
-                ..
-            } if scopes == &vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()]
-        ));
+        assert_eq!(google_setup.secrets.len(), 2);
+        let google_oauth_setups = google_setup
+            .secrets
+            .iter()
+            .map(|secret| {
+                assert_eq!(secret.provider, "google");
+                assert!(!secret.provided);
+                match &secret.setup {
+                    RebornExtensionCredentialSetup::OAuth {
+                        account_label,
+                        scopes,
+                        ..
+                    } => (account_label.clone(), scopes.clone()),
+                    RebornExtensionCredentialSetup::ManualToken => {
+                        panic!("Google setup secret should use OAuth")
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            google_oauth_setups
+                .iter()
+                .map(|(_, scopes)| scopes.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()],
+                vec![GOOGLE_CALENDAR_EVENTS_SCOPE.to_string()],
+            ]
+        );
+        assert_ne!(google_oauth_setups[0].0, google_oauth_setups[1].0);
         let google_setup_json =
             serde_json::to_value(&google_setup.secrets[0]).expect("serialize setup secret");
         assert_eq!(google_setup_json["setup"]["kind"], "oauth");

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -499,6 +499,77 @@ async fn webui_v2_gmail_oauth_setup_complete_allows_activation() {
     assert_eq!(activate_body["activated"], true);
 }
 
+#[tokio::test]
+async fn webui_v2_google_drive_oauth_setup_projects_distinct_operation_scopes() {
+    let harness = build_harness().await;
+
+    let package_ref = json!({"kind": "extension", "id": "google-drive"});
+    let install = harness
+        .router
+        .clone()
+        .oneshot(bearer_post(
+            "/api/webchat/v2/extensions/install",
+            json!({"package_ref": package_ref}),
+        ))
+        .await
+        .expect("install Google Drive oneshot");
+    assert_eq!(install.status(), StatusCode::OK);
+
+    let setup = harness
+        .router
+        .clone()
+        .oneshot(bearer_get("/api/webchat/v2/extensions/google-drive/setup"))
+        .await
+        .expect("setup Google Drive oneshot");
+    assert_eq!(setup.status(), StatusCode::OK);
+    let setup_body = read_json(setup).await;
+    let secrets = setup_body["secrets"]
+        .as_array()
+        .expect("setup secrets should be an array");
+    let google_oauth_setups = secrets
+        .iter()
+        .filter(|secret| secret["provider"] == "google")
+        .map(|secret| {
+            let setup = &secret["setup"];
+            assert_eq!(setup["kind"], "oauth", "secret should be OAuth: {secret}");
+            (
+                setup["account_label"]
+                    .as_str()
+                    .expect("OAuth account label")
+                    .to_string(),
+                setup["scopes"]
+                    .as_array()
+                    .expect("OAuth scopes should be an array")
+                    .iter()
+                    .map(|scope| scope.as_str().expect("scope string").to_string())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        google_oauth_setups
+            .iter()
+            .map(|(_, scopes)| scopes.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            vec!["https://www.googleapis.com/auth/drive.readonly".to_string()],
+            vec!["https://www.googleapis.com/auth/drive".to_string()],
+        ],
+        "Google Drive setup should keep read-only and write OAuth scopes separate: {setup_body}"
+    );
+    assert_ne!(
+        google_oauth_setups[0].0, google_oauth_setups[1].0,
+        "split Google Drive setup credentials should have distinct account labels"
+    );
+
+    harness
+        .runtime
+        .shutdown()
+        .await
+        .expect("runtime shutdown clean");
+}
+
 /// Walks a `ThreadMessageRecord` JSON object and returns the rendered
 /// text if it is an assistant reply with content. Done as a free
 /// function so the polling loop above can stay readable.

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -47,12 +47,12 @@ use ironclaw_host_runtime::{
     GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HTTP_SAVE_CAPABILITY_ID,
     HostRuntime, HostRuntimeServices, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID,
     MEMORY_READ_CAPABILITY_ID, MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID,
-    MEMORY_WRITE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, RuntimeCredentialAccountRequest,
-    RuntimeCredentialAccountResolver, SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID,
-    SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID,
-    SurfaceKind, TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID,
-    TRIGGER_REMOVE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
-    builtin_first_party_package,
+    MEMORY_WRITE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, RuntimeCredentialAccessSecret,
+    RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver, SHELL_CAPABILITY_ID,
+    SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID,
+    SPAWN_SUBAGENT_CAPABILITY_ID, SurfaceKind, TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID,
+    TRIGGER_LIST_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
+    builtin_first_party_handlers, builtin_first_party_package,
 };
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilityResultWrite,
@@ -2213,10 +2213,15 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
     async fn resolve_access_secret(
         &self,
         request: RuntimeCredentialAccountRequest<'_>,
-    ) -> Result<SecretHandle, CredentialStageError> {
+    ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
         assert_eq!(request.provider.as_str(), "github");
         assert_eq!(request.requester_extension.as_str(), "github");
-        self.result.clone()
+        self.result
+            .clone()
+            .map(|handle| RuntimeCredentialAccessSecret {
+                scope: request.scope.clone(),
+                handle,
+            })
     }
 }
 


### PR DESCRIPTION
## Summary
- add Google OAuth setup metadata to bundled Drive, Docs, Sheets, and Slides WASM runtime credentials
- expose operation-scoped GSuite OAuth setup requirements through lifecycle/WebUI by splitting duplicate credential handles by exact provider/scope set
- keep split OAuth setup account labels distinct so read-only and write-scoped credentials do not collapse during setup
- update GSuite feature parity notes and add bundled catalog plus WebUI setup-route regression coverage

## Tests
- cargo fmt
- git diff --check
- cargo test -p ironclaw_reborn_composition bundled_gsuite_wasm
- CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition --features webui-v2-beta,test-support --test webui_v2_e2e webui_v2_google_drive_oauth_setup_projects_distinct_operation_scopes
- CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition --lib local_dev_webui_bundle_uses_local_lifecycle_facade_for_setup_extension

Stacked on #4354, now merged into reborn-integration.