### PR TITLE
[codex] Wire runtime profiles into approval gates

### DIFF
--- a/crates/ironclaw_host_api/src/runtime_policy.rs
+++ b/crates/ironclaw_host_api/src/runtime_policy.rs
@@ -282,6 +282,28 @@ impl RuntimeProfile {
             | Self::Experiment => false,
         }
     }
+
+    /// `true` for profiles whose resolved runtime boundary allows
+    /// `ApprovalPolicy::Minimal` to bypass approval gates.
+    ///
+    /// Exhaustive `match` for the same reason as [`Self::is_local`]: a new
+    /// profile variant must be classified at compile time before it can affect
+    /// Minimal approval bypass.
+    pub const fn allows_minimal_approval_bypass(&self) -> bool {
+        match self {
+            Self::LocalYolo | Self::HostedYoloTenantScoped => true,
+            Self::SecureDefault
+            | Self::LocalSafe
+            | Self::LocalDev
+            | Self::HostedSafe
+            | Self::HostedDev
+            | Self::EnterpriseSafe
+            | Self::EnterpriseDev
+            | Self::EnterpriseYoloDedicated
+            | Self::Sandboxed
+            | Self::Experiment => false,
+        }
+    }
 }
 
 impl std::fmt::Display for RuntimeProfile {
@@ -742,6 +764,38 @@ mod tests {
         }
         for profile in non_yolo {
             assert!(!profile.is_yolo(), "{profile:?} must not be yolo");
+        }
+    }
+
+    #[test]
+    fn minimal_approval_bypass_is_limited_to_local_and_hosted_yolo() {
+        let bypass = [
+            RuntimeProfile::LocalYolo,
+            RuntimeProfile::HostedYoloTenantScoped,
+        ];
+        let gated = [
+            RuntimeProfile::SecureDefault,
+            RuntimeProfile::LocalSafe,
+            RuntimeProfile::LocalDev,
+            RuntimeProfile::HostedSafe,
+            RuntimeProfile::HostedDev,
+            RuntimeProfile::EnterpriseSafe,
+            RuntimeProfile::EnterpriseDev,
+            RuntimeProfile::EnterpriseYoloDedicated,
+            RuntimeProfile::Sandboxed,
+            RuntimeProfile::Experiment,
+        ];
+        for profile in bypass {
+            assert!(
+                profile.allows_minimal_approval_bypass(),
+                "{profile:?} must allow Minimal approval bypass"
+            );
+        }
+        for profile in gated {
+            assert!(
+                !profile.allows_minimal_approval_bypass(),
+                "{profile:?} must keep approval gates under Minimal"
+            );
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -361,6 +361,15 @@ fn local_dev_minimal_policy() -> ironclaw_host_api::runtime_policy::EffectiveRun
     policy
 }
 
+fn local_dev_minimal_enterprise_policy() -> ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy
+{
+    let mut policy = local_dev_policy();
+    policy.resolved_profile =
+        ironclaw_host_api::runtime_policy::RuntimeProfile::EnterpriseYoloDedicated;
+    policy.approval_policy = ironclaw_host_api::runtime_policy::ApprovalPolicy::Minimal;
+    policy
+}
+
 /// Minimal approval policy must complete effectful capabilities without any approval gate.
 /// Verifies the runtime-profile policy allows Minimal bypass only for a yolo
 /// profile.
@@ -393,6 +402,49 @@ async fn local_dev_minimal_policy_shell_invocation_completes_without_approval_ga
 
     // Minimal policy must not create an approval gate.
     assert!(matches!(outcome, RuntimeCapabilityOutcome::Completed(_))); // safety: test-only assertion in #[cfg(test)] module.
+}
+
+#[tokio::test]
+async fn local_dev_minimal_with_enterprise_profile_still_gates_shell() {
+    let dir = tempfile::tempdir().expect("tempdir"); // safety: test-only helper in #[cfg(test)] module.
+    let services = build_reborn_services(
+        RebornBuildInput::local_dev("ent-minimal-owner", dir.path().join("local-dev"))
+            .with_runtime_policy(local_dev_minimal_enterprise_policy()),
+    )
+    .await
+    .expect("local-dev minimal enterprise services build"); // safety: test-only helper in #[cfg(test)] module.
+    let local_runtime = services
+        .local_runtime
+        .as_ref()
+        .expect("local-dev runtime substrate"); // safety: test-only helper in #[cfg(test)] module.
+    let host_runtime = services
+        .host_runtime
+        .as_ref()
+        .expect("local-dev host runtime"); // safety: test-only helper in #[cfg(test)] module.
+    let capability_id = CapabilityId::new(SHELL_CAPABILITY_ID).expect("shell capability"); // safety: test-only helper in #[cfg(test)] module.
+    let context = shell_execution_context("ent-minimal-owner", "thread-ent-minimal");
+
+    let outcome = host_runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context.clone(),
+            capability_id,
+            ResourceEstimate::default(),
+            serde_json::json!({"command": "echo ent"}),
+            trust_decision(shell_allowed_effects()),
+        ))
+        .await
+        .expect("enterprise minimal shell invocation resolves"); // safety: test-only helper in #[cfg(test)] module.
+
+    let RuntimeCapabilityOutcome::ApprovalRequired(gate) = outcome else {
+        panic!("enterprise profile must keep gating even under Minimal, got {outcome:?}");
+    };
+    let approval = local_runtime
+        .approval_requests
+        .get(&context.resource_scope, gate.approval_request_id)
+        .await
+        .expect("approval store read") // safety: test-only helper in #[cfg(test)] module.
+        .expect("approval request persisted"); // safety: test-only helper in #[cfg(test)] module.
+    assert_eq!(approval.status, ApprovalStatus::Pending); // safety: test-only assertion in #[cfg(test)] module.
 }
 
 /// `authorize_spawn_with_trust` RequireApproval-then-resume end-to-end.

--- a/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/local_dev_host_tests/approval_gates.rs
@@ -353,14 +353,17 @@ fn tenant_sandbox_process_policy() -> ironclaw_host_api::runtime_policy::Effecti
 
 fn local_dev_minimal_policy() -> ironclaw_host_api::runtime_policy::EffectiveRuntimePolicy {
     let mut policy = local_dev_policy();
-    // Override approval policy to Minimal (yolo-equivalent via ApprovalPolicy enum).
+    // Minimal is a profile-scoped bypass, so model the resolver's local-yolo
+    // output instead of only overriding the approval enum.
+    policy.requested_profile = ironclaw_host_api::runtime_policy::RuntimeProfile::LocalYolo;
+    policy.resolved_profile = ironclaw_host_api::runtime_policy::RuntimeProfile::LocalYolo;
     policy.approval_policy = ironclaw_host_api::runtime_policy::ApprovalPolicy::Minimal;
     policy
 }
 
 /// Minimal approval policy must complete effectful capabilities without any approval gate.
-/// Verifies `ApprovalPolicy::Minimal => GrantAuthorizer` path in the profile
-/// approval authorizer.
+/// Verifies the runtime-profile policy allows Minimal bypass only for a yolo
+/// profile.
 #[tokio::test]
 async fn local_dev_minimal_policy_shell_invocation_completes_without_approval_gate() {
     let dir = tempfile::tempdir().expect("tempdir"); // safety: test-only helper in #[cfg(test)] module.

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -57,6 +57,7 @@ mod provider_admin_product_command;
 mod readiness;
 mod runtime;
 mod runtime_input;
+mod runtime_profile_approval_policy;
 mod skill_listing;
 mod webui;
 #[cfg(feature = "webui-v2-beta")]

--- a/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_authorization.rs
@@ -1,27 +1,13 @@
 use std::sync::Arc;
 
 use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
-use ironclaw_host_api::{
-    EffectKind,
-    runtime_policy::{ApprovalPolicy, EffectiveRuntimePolicy},
-};
+use ironclaw_host_api::runtime_policy::{ApprovalPolicy, EffectiveRuntimePolicy, RuntimeProfile};
 
 use crate::{
     local_dev_capability_policy::LocalDevCapabilityPolicy,
-    profile_approval_authorization::{
-        ProfileApprovalAuthorizerConfig, ProfileApprovalGatePolicy, profile_approval_authorizer,
-    },
+    profile_approval_authorization::{ProfileApprovalGatePolicy, profile_approval_authorizer},
+    runtime_profile_approval_policy::RuntimeProfileApprovalGatePolicy,
 };
-
-impl ProfileApprovalGatePolicy for LocalDevCapabilityPolicy {
-    fn effects_require_approval(
-        &self,
-        approval_policy: ApprovalPolicy,
-        effects: &[EffectKind],
-    ) -> bool {
-        LocalDevCapabilityPolicy::effects_require_approval(self, approval_policy, effects)
-    }
-}
 
 pub(crate) fn local_dev_authorizer(
     runtime_policy: Option<&EffectiveRuntimePolicy>,
@@ -30,9 +16,12 @@ pub(crate) fn local_dev_authorizer(
     let approval_policy = runtime_policy
         .map(|policy| policy.approval_policy)
         .unwrap_or(ApprovalPolicy::AskDestructive);
-    profile_approval_authorizer(ProfileApprovalAuthorizerConfig {
-        profile_label: "local-dev",
-        approval_policy,
-        gate_policy: capability_policy,
-    })
+    let resolved_profile = runtime_policy
+        .map(|policy| policy.resolved_profile)
+        .unwrap_or(RuntimeProfile::LocalDev);
+    let gate_effects = capability_policy.approval_gate_effects();
+    let gate_policy: Arc<dyn ProfileApprovalGatePolicy> = Arc::new(
+        RuntimeProfileApprovalGatePolicy::new(resolved_profile, gate_effects),
+    );
+    profile_approval_authorizer(approval_policy, gate_policy)
 }

--- a/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/local_dev_capability_policy.rs
@@ -7,10 +7,12 @@ use ironclaw_approvals::LeaseApproval;
 use ironclaw_host_api::{
     Action, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
     ExtensionId, GrantConstraints, MountView, NetworkPolicy, NetworkTargetPattern, PackageId,
-    Principal, runtime_policy::ApprovalPolicy,
+    Principal,
 };
 use serde::Deserialize;
 use thiserror::Error;
+
+use crate::runtime_profile_approval_policy::RuntimeProfileApprovalGateEffectSets;
 
 const LOCAL_DEV_CAPABILITY_POLICY_TOML: &str = include_str!("local_dev_capability_policy.toml");
 
@@ -160,27 +162,11 @@ impl LocalDevCapabilityPolicy {
         })
     }
 
-    pub(crate) fn effects_require_approval(
-        &self,
-        approval_policy: ApprovalPolicy,
-        effects: &[EffectKind],
-    ) -> bool {
-        match approval_policy {
-            ApprovalPolicy::Minimal => false,
-            ApprovalPolicy::AskAlways => !effects.is_empty(),
-            ApprovalPolicy::AskWrites => effects
-                .iter()
-                .any(|effect| self.approval_gates.ask_writes.contains(effect)),
-            ApprovalPolicy::AskDestructive => effects
-                .iter()
-                .any(|effect| self.approval_gates.ask_destructive.contains(effect)),
-            // OrgPolicy is resolved server-side; if it reaches local composition
-            // unresolved, fail toward prompting (require approval).
-            ApprovalPolicy::OrgPolicy => !effects.is_empty(),
-            // Any future ApprovalPolicy variants default to fail-safe: require
-            // approval for non-empty effects rather than silently disabling gates.
-            _ => !effects.is_empty(),
-        }
+    pub(crate) fn approval_gate_effects(&self) -> RuntimeProfileApprovalGateEffectSets {
+        RuntimeProfileApprovalGateEffectSets::new(
+            self.approval_gates.ask_writes.clone(),
+            self.approval_gates.ask_destructive.clone(),
+        )
     }
 }
 
@@ -441,14 +427,12 @@ mod tests {
                 EffectKind::Network,
             ]
         );
+        let gate_effects = policy.approval_gate_effects();
+        assert!(gate_effects.ask_writes.contains(&EffectKind::SpawnProcess));
         assert!(
-            policy.effects_require_approval(
-                ApprovalPolicy::AskDestructive,
-                &[EffectKind::SpawnProcess]
-            )
-        );
-        assert!(
-            !policy.effects_require_approval(ApprovalPolicy::Minimal, &[EffectKind::SpawnProcess])
+            gate_effects
+                .ask_destructive
+                .contains(&EffectKind::SpawnProcess)
         );
         assert!(
             policy

--- a/crates/ironclaw_reborn_composition/src/profile_approval_authorization.rs
+++ b/crates/ironclaw_reborn_composition/src/profile_approval_authorization.rs
@@ -15,39 +15,14 @@ pub(crate) trait ProfileApprovalGatePolicy: Send + Sync {
     ) -> bool;
 }
 
-pub(crate) struct ProfileApprovalAuthorizerConfig {
-    pub(crate) profile_label: &'static str,
-    pub(crate) approval_policy: ApprovalPolicy,
-    pub(crate) gate_policy: Arc<dyn ProfileApprovalGatePolicy>,
-}
-
 pub(crate) fn profile_approval_authorizer(
-    config: ProfileApprovalAuthorizerConfig,
+    approval_policy: ApprovalPolicy,
+    gate_policy: Arc<dyn ProfileApprovalGatePolicy>,
 ) -> Arc<dyn TrustAwareCapabilityDispatchAuthorizer> {
-    match config.approval_policy {
-        // Minimal ~ yolo: skip approval gates entirely and delegate to
-        // the grant authorizer only. Warn so misconfiguration is visible.
-        ApprovalPolicy::Minimal => {
-            tracing::warn!(
-                profile = config.profile_label,
-                "runtime profile is using ApprovalPolicy::Minimal; all capability gates are disabled"
-            );
-            Arc::new(GrantAuthorizer::new())
-        }
-        ApprovalPolicy::AskAlways
-        | ApprovalPolicy::AskWrites
-        | ApprovalPolicy::AskDestructive
-        | ApprovalPolicy::OrgPolicy => Arc::new(ProfileApprovalPolicyAuthorizer::new(
-            config.approval_policy,
-            config.gate_policy,
-        )),
-        // Any future ApprovalPolicy variants default to the gating authorizer
-        // (fail toward requiring approval rather than disabling gates).
-        _ => Arc::new(ProfileApprovalPolicyAuthorizer::new(
-            config.approval_policy,
-            config.gate_policy,
-        )),
-    }
+    Arc::new(ProfileApprovalPolicyAuthorizer::new(
+        approval_policy,
+        gate_policy,
+    ))
 }
 
 struct ProfileApprovalPolicyAuthorizer {
@@ -314,11 +289,7 @@ mod tests {
     fn test_authorizer(
         approval_policy: ApprovalPolicy,
     ) -> Arc<dyn TrustAwareCapabilityDispatchAuthorizer> {
-        profile_approval_authorizer(ProfileApprovalAuthorizerConfig {
-            profile_label: "test-profile",
-            approval_policy,
-            gate_policy: Arc::new(TestGatePolicy),
-        })
+        profile_approval_authorizer(approval_policy, Arc::new(TestGatePolicy))
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
@@ -38,20 +38,7 @@ impl RuntimeProfileApprovalGatePolicy {
     }
 
     fn profile_allows_minimal_bypass(&self) -> bool {
-        match self.resolved_profile {
-            RuntimeProfile::LocalYolo | RuntimeProfile::HostedYoloTenantScoped => true,
-            RuntimeProfile::SecureDefault
-            | RuntimeProfile::LocalSafe
-            | RuntimeProfile::LocalDev
-            | RuntimeProfile::HostedSafe
-            | RuntimeProfile::HostedDev
-            | RuntimeProfile::EnterpriseSafe
-            | RuntimeProfile::EnterpriseDev
-            | RuntimeProfile::EnterpriseYoloDedicated
-            | RuntimeProfile::Sandboxed
-            | RuntimeProfile::Experiment => false,
-            _ => false,
-        }
+        self.resolved_profile.allows_minimal_approval_bypass()
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_profile_approval_policy.rs
@@ -1,0 +1,186 @@
+use ironclaw_host_api::{
+    EffectKind,
+    runtime_policy::{ApprovalPolicy, RuntimeProfile},
+};
+
+use crate::profile_approval_authorization::ProfileApprovalGatePolicy;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeProfileApprovalGateEffectSets {
+    pub(crate) ask_writes: Vec<EffectKind>,
+    pub(crate) ask_destructive: Vec<EffectKind>,
+}
+
+impl RuntimeProfileApprovalGateEffectSets {
+    pub(crate) fn new(ask_writes: Vec<EffectKind>, ask_destructive: Vec<EffectKind>) -> Self {
+        Self {
+            ask_writes,
+            ask_destructive,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeProfileApprovalGatePolicy {
+    resolved_profile: RuntimeProfile,
+    effects: RuntimeProfileApprovalGateEffectSets,
+}
+
+impl RuntimeProfileApprovalGatePolicy {
+    pub(crate) fn new(
+        resolved_profile: RuntimeProfile,
+        effects: RuntimeProfileApprovalGateEffectSets,
+    ) -> Self {
+        Self {
+            resolved_profile,
+            effects,
+        }
+    }
+
+    fn profile_allows_minimal_bypass(&self) -> bool {
+        match self.resolved_profile {
+            RuntimeProfile::LocalYolo | RuntimeProfile::HostedYoloTenantScoped => true,
+            RuntimeProfile::SecureDefault
+            | RuntimeProfile::LocalSafe
+            | RuntimeProfile::LocalDev
+            | RuntimeProfile::HostedSafe
+            | RuntimeProfile::HostedDev
+            | RuntimeProfile::EnterpriseSafe
+            | RuntimeProfile::EnterpriseDev
+            | RuntimeProfile::EnterpriseYoloDedicated
+            | RuntimeProfile::Sandboxed
+            | RuntimeProfile::Experiment => false,
+            _ => false,
+        }
+    }
+}
+
+impl ProfileApprovalGatePolicy for RuntimeProfileApprovalGatePolicy {
+    fn effects_require_approval(
+        &self,
+        approval_policy: ApprovalPolicy,
+        effects: &[EffectKind],
+    ) -> bool {
+        match approval_policy {
+            ApprovalPolicy::Minimal => !self.profile_allows_minimal_bypass() && !effects.is_empty(),
+            ApprovalPolicy::AskAlways => !effects.is_empty(),
+            ApprovalPolicy::AskWrites => effects
+                .iter()
+                .any(|effect| self.effects.ask_writes.contains(effect)),
+            ApprovalPolicy::AskDestructive => effects
+                .iter()
+                .any(|effect| self.effects.ask_destructive.contains(effect)),
+            ApprovalPolicy::OrgPolicy => !effects.is_empty(),
+            // Any future ApprovalPolicy variants default to fail-safe: require
+            // approval for non-empty effects rather than silently disabling gates.
+            _ => !effects.is_empty(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{
+        EffectKind,
+        runtime_policy::{ApprovalPolicy, RuntimeProfile},
+    };
+
+    use super::*;
+
+    fn policy(profile: RuntimeProfile) -> RuntimeProfileApprovalGatePolicy {
+        RuntimeProfileApprovalGatePolicy::new(
+            profile,
+            RuntimeProfileApprovalGateEffectSets::new(
+                vec![EffectKind::WriteFilesystem, EffectKind::SpawnProcess],
+                vec![EffectKind::SpawnProcess],
+            ),
+        )
+    }
+
+    #[test]
+    fn minimal_only_disables_gates_for_local_and_hosted_yolo_profiles() {
+        for profile in [
+            RuntimeProfile::LocalYolo,
+            RuntimeProfile::HostedYoloTenantScoped,
+        ] {
+            assert!(
+                !policy(profile)
+                    .effects_require_approval(ApprovalPolicy::Minimal, &[EffectKind::SpawnProcess]),
+                "{profile:?} should allow Minimal to bypass approval gates"
+            );
+        }
+
+        for profile in [
+            RuntimeProfile::SecureDefault,
+            RuntimeProfile::LocalSafe,
+            RuntimeProfile::LocalDev,
+            RuntimeProfile::HostedSafe,
+            RuntimeProfile::HostedDev,
+            RuntimeProfile::EnterpriseSafe,
+            RuntimeProfile::EnterpriseDev,
+            RuntimeProfile::EnterpriseYoloDedicated,
+            RuntimeProfile::Sandboxed,
+            RuntimeProfile::Experiment,
+        ] {
+            assert!(
+                policy(profile).effects_require_approval(
+                    ApprovalPolicy::Minimal,
+                    &[EffectKind::DispatchCapability]
+                ),
+                "{profile:?} should fail closed if Minimal reaches a non-minimal profile"
+            );
+        }
+    }
+
+    #[test]
+    fn hosted_dev_ask_destructive_gates_process_but_not_read_only_effects() {
+        let policy = policy(RuntimeProfile::HostedDev);
+
+        assert!(
+            policy.effects_require_approval(
+                ApprovalPolicy::AskDestructive,
+                &[EffectKind::SpawnProcess]
+            )
+        );
+        assert!(!policy.effects_require_approval(
+            ApprovalPolicy::AskDestructive,
+            &[EffectKind::ReadFilesystem]
+        ));
+    }
+
+    #[test]
+    fn hosted_safe_ask_writes_gates_writes_but_not_read_only_effects() {
+        let policy = policy(RuntimeProfile::HostedSafe);
+
+        assert!(
+            policy.effects_require_approval(
+                ApprovalPolicy::AskWrites,
+                &[EffectKind::WriteFilesystem]
+            )
+        );
+        assert!(
+            !policy
+                .effects_require_approval(ApprovalPolicy::AskWrites, &[EffectKind::ReadFilesystem])
+        );
+    }
+
+    #[test]
+    fn secure_default_ask_always_gates_read_only_effects() {
+        let policy = policy(RuntimeProfile::SecureDefault);
+
+        assert!(
+            policy
+                .effects_require_approval(ApprovalPolicy::AskAlways, &[EffectKind::ReadFilesystem])
+        );
+    }
+
+    #[test]
+    fn enterprise_yolo_dedicated_org_policy_still_gates_effectful_actions() {
+        let policy = policy(RuntimeProfile::EnterpriseYoloDedicated);
+
+        assert!(policy.effects_require_approval(
+            ApprovalPolicy::OrgPolicy,
+            &[EffectKind::DispatchCapability]
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- add a runtime-profile approval gate policy that interprets approval modes through the resolved runtime profile
- route local-dev authorizer construction through that runtime-profile policy using the existing local-dev effect gate sets
- move the Minimal bypass decision behind the profile policy so only local yolo and hosted tenant-scoped yolo disable gates; enterprise yolo remains gated through OrgPolicy and invalid Minimal combinations fail closed

## Why stacked
This stacks on #4386 (`codex/profile-approval-authorizer`). That PR extracts the shared authorizer boundary; this PR makes the boundary runtime-profile-aware and wires the existing local-dev composition through it.

## Notes
This does not introduce a hosted/enterprise runtime graph in reborn composition. It prepares that wiring by making the selected profile behavior explicit and tested at the approval policy boundary.

## Validation
- `cargo fmt --all`
- `git diff --check`
- `git diff --cached --check`
- `cargo test -p ironclaw_reborn_composition runtime_profile_approval_policy --lib`
- `cargo test -p ironclaw_reborn_composition local_dev_capability_policy --lib`
- `cargo test -p ironclaw_reborn_composition profile_approval --lib`
- `cargo test -p ironclaw_reborn_composition local_dev_ --lib`
- `cargo test -p ironclaw_reborn_composition`