### PR TITLE
[codex] fix(webuiv2): collapse turn activity chronology

### DIFF
--- a/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
+++ b/crates/ironclaw_reborn_composition/src/oauth_dcr.rs
@@ -1022,6 +1022,7 @@ struct DcrOAuthCallbackStateWire {
     nonce: String,
 }
 
+#[allow(dead_code)] // Used by the optional product-auth route surface; all-features test targets can compile this module without that route.
 impl DcrOAuthCallbackState {
     const PREFIX: &'static str = "icd1.";
 

--- a/crates/ironclaw_webui_v2_static/src/assets.rs
+++ b/crates/ironclaw_webui_v2_static/src/assets.rs
@@ -134,7 +134,7 @@ mod tests {
             .next()
             .expect("thinking branch follows text branch");
         assert!(
-            text_branch.contains("terminal run_status is the only"),
+            text_branch.contains("run_status remains the source of"),
             "text branch should document that run_status owns gate clearing"
         );
         assert!(
@@ -149,8 +149,9 @@ mod tests {
         assert!(groups.contains("function isFinalAssistantReply"));
         assert!(groups.contains("msg.isFinalReply === true"));
         assert!(groups.contains("msg.status === \"finalized\""));
-        assert!(groups.contains("appendGroupedMessages(items, reordered.before);"));
-        assert!(groups.contains("appendGroupedMessages(items, reordered.activity);"));
+        assert!(groups.contains("function followingActivity"));
+        assert!(groups.contains("type: \"activity-run\""));
+        assert!(groups.contains("appendActivityRun(items, activity);"));
         assert!(!groups.contains("lastAssistantReplyIndex"));
 
         let history = asset_text("js/pages/chat/lib/history-messages.js");
@@ -200,7 +201,9 @@ mod tests {
             "OAuth setup should watch in-flight authorization, not only popup close"
         );
         assert!(
-            use_extensions.contains("refreshSetupState();\n        if ((popup && popup.closed)"),
+            use_extensions.contains(
+                "refreshSetupState();\n        if (\n          setupIsConfigured() ||\n          (popup && popup.closed)"
+            ),
             "OAuth setup must refresh setup state before waiting for popup close"
         );
     }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/activity-run.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/activity-run.js
@@ -1,0 +1,80 @@
+import { Icon } from "../../../design-system/icons.js";
+import { React, html } from "../../../lib/html.js";
+import { summarizeActivity } from "../lib/activity-summary.js";
+import { MarkdownRenderer } from "./markdown-renderer.js";
+import { ToolActivity } from "./tool-activity.js";
+
+export function ActivityRun({ activity }) {
+  const summary = summarizeActivity(activity);
+  const [expanded, setExpanded] = React.useState(false);
+
+  return html`
+    <div className="mr-auto flex w-full max-w-[85%] flex-col">
+      <button
+        type="button"
+        onClick=${() => setExpanded((value) => !value)}
+        aria-expanded=${expanded ? "true" : "false"}
+        className=${[
+          "v2-button flex w-full items-center gap-2 border-0 bg-transparent px-1 py-1.5 text-left text-sm",
+          summary.hasError
+            ? "text-[var(--v2-danger-text)]"
+            : "text-iron-400 hover:text-iron-200",
+        ].join(" ")}
+      >
+        <${Icon} name="layers" className="h-4 w-4 shrink-0" />
+        <span className="truncate">${summary.label}</span>
+        <${Icon}
+          name="chevron"
+          className=${["ml-auto h-3.5 w-3.5 shrink-0", expanded ? "rotate-180" : ""].join(" ")}
+        />
+      </button>
+
+      ${expanded &&
+      html`
+        <div className="mt-2 flex flex-col gap-3">
+          ${activity.map((item, index) => html`
+            <${ActivityItem}
+              key=${item.id || `${item.role || "activity"}-${index}`}
+              item=${item}
+            />
+          `)}
+        </div>
+      `}
+    </div>
+  `;
+}
+
+function ActivityItem({ item }) {
+  if (item.role === "thinking") {
+    return html`<${ReasoningItem} content=${item.content} />`;
+  }
+
+  if (item.role === "tool_activity" || hasToolCalls(item)) {
+    const activity = hasToolCalls(item)
+      ? { id: item.id, toolCalls: item.toolCalls }
+      : item;
+    return html`<${ToolActivity} activity=${activity} />`;
+  }
+
+  return null;
+}
+
+function ReasoningItem({ content }) {
+  if (!content) return null;
+  return html`
+    <div className="flex gap-3">
+      <div
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/10 bg-iron-800 text-iron-100"
+      >
+        <${Icon} name="spark" className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 max-w-[85%] flex-1 border-l-2 border-white/10 pl-3 text-iron-300">
+        <${MarkdownRenderer} content=${content} className="text-[13px]" />
+      </div>
+    </div>
+  `;
+}
+
+function hasToolCalls(item) {
+  return item.toolCalls && item.toolCalls.length > 0;
+}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-list.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/components/message-list.js
@@ -1,7 +1,7 @@
 import { React, html } from "../../../lib/html.js";
 import { useT } from "../../../lib/i18n.js";
+import { ActivityRun } from "./activity-run.js";
 import { MessageBubble } from "./message-bubble.js";
-import { ToolRun } from "./tool-activity.js";
 import { Icon } from "../../../design-system/icons.js";
 import { groupMessages } from "../lib/message-groups.js";
 
@@ -70,8 +70,8 @@ export function MessageList({
           </div>
         `}
         ${grouped.map((item) =>
-          item.type === "tool-run"
-            ? html`<${ToolRun} key=${item.id} tools=${item.tools} />`
+          item.type === "activity-run"
+            ? html`<${ActivityRun} key=${item.id} activity=${item.activity} />`
             : html`<${MessageBubble}
                 key=${item.id}
                 message=${item.message}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/activity-summary.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/activity-summary.js
@@ -1,0 +1,49 @@
+export function summarizeActivity(activity) {
+  let reasoning = 0;
+  let tools = 0;
+  let failed = 0;
+  let running = 0;
+
+  for (const item of activity) {
+    if (item.role === "thinking") reasoning += 1;
+    if (item.role === "tool_activity") {
+      const summary = summarizeToolItems([item]);
+      tools += summary.tools;
+      failed += summary.failed;
+      running += summary.running;
+    }
+    if (hasToolCalls(item)) {
+      const summary = summarizeToolItems(item.toolCalls);
+      tools += summary.tools;
+      failed += summary.failed;
+      running += summary.running;
+    }
+  }
+
+  const parts = [];
+  if (reasoning) parts.push(`${reasoning} reasoning`);
+  if (tools) parts.push(`${tools} ${tools === 1 ? "tool" : "tools"}`);
+  if (failed) parts.push(`${failed} failed`);
+  if (!failed && running) parts.push("running");
+
+  return {
+    hasError: failed > 0,
+    label: `Activity${parts.length ? ` - ${parts.join(", ")}` : ""}`,
+  };
+}
+
+function summarizeToolItems(items) {
+  let failed = 0;
+  let running = 0;
+
+  for (const item of items) {
+    if (item.toolStatus === "error") failed += 1;
+    if (item.toolStatus === "running") running += 1;
+  }
+
+  return { tools: items.length, failed, running };
+}
+
+function hasToolCalls(item) {
+  return item.toolCalls && item.toolCalls.length > 0;
+}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/activity-summary.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/activity-summary.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { summarizeActivity } from "./activity-summary.js";
+
+test("summarizeActivity: nested toolCalls surface failed and running status", () => {
+  const summary = summarizeActivity([
+    { id: "r", role: "thinking", content: "checking" },
+    {
+      id: "g",
+      role: "assistant",
+      toolCalls: [
+        { id: "a", toolStatus: "error" },
+        { id: "b", toolStatus: "running" },
+      ],
+    },
+  ]);
+
+  assert.equal(summary.hasError, true);
+  assert.equal(summary.label, "Activity - 1 reasoning, 2 tools, 1 failed");
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
@@ -1,76 +1,70 @@
-/* Collapse consecutive single tool_activity messages into runs for rendering.
-   If the persisted timeline puts trailing reasoning/tool activity after the
-   final assistant reply, render that activity before the reply so the answer
-   stays last. Earlier assistant messages keep their original position because
-   they are middle-of-turn narration. */
+/* Collapse ordered reasoning/tool events into one activity run. If delayed
+   activity arrives immediately after a finalized assistant answer, render that
+   activity before the answer so the answer still closes its turn, including
+   when a later user follow-up has already been appended. */
 export function groupMessages(messages) {
   const items = [];
-  const reordered = trailingActivityBeforeFinalReply(messages);
-  if (reordered) {
-    appendGroupedMessages(items, reordered.before);
-    appendGroupedMessages(items, reordered.activity);
-    appendGroupedMessages(items, [reordered.reply]);
-    return items;
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const msg = messages[index];
+
+    if (isFinalAssistantReply(msg)) {
+      const activity = followingActivity(messages, index + 1);
+      const boundary = messages[index + 1 + activity.length];
+      if (activity.length > 0 && (!boundary || boundary.role === "user")) {
+        appendActivityRun(items, activity);
+        appendMessage(items, msg);
+        index += activity.length;
+        continue;
+      }
+    }
+
+    if (isActivity(msg)) {
+      const activity = followingActivity(messages, index);
+      appendActivityRun(items, activity);
+      index += activity.length - 1;
+      continue;
+    }
+
+    appendMessage(items, msg);
   }
 
-  appendGroupedMessages(items, messages);
   return items;
 }
 
-function appendGroupedMessages(items, messages) {
-  let run = null;
-  for (const msg of messages) {
-    const isToolActivity = isCollapsibleToolActivity(msg);
-    if (isToolActivity) {
-      if (!run) {
-        run = { type: "tool-run", id: `tool-run-${msg.id}`, tools: [] };
-        items.push(run);
-      }
-      run.tools.push(msg);
-    } else {
-      run = null;
-      items.push({ type: "message", id: msg.id, message: msg });
-    }
+function followingActivity(messages, start) {
+  let end = start;
+  while (end < messages.length && isActivity(messages[end])) {
+    end += 1;
   }
+  return messages.slice(start, end);
 }
 
-function trailingActivityBeforeFinalReply(messages) {
-  const lastAssistant = lastFinalAssistantReplyIndex(messages);
-  if (lastAssistant < 0 || lastAssistant === messages.length - 1) return null;
-
-  const trailing = messages.slice(lastAssistant + 1);
-  if (!trailing.every(isAuxiliaryActivity)) return null;
-
-  return {
-    before: messages.slice(0, lastAssistant),
-    activity: trailing,
-    reply: messages[lastAssistant],
-  };
+function appendActivityRun(items, activity) {
+  if (activity.length === 0) return;
+  items.push({
+    type: "activity-run",
+    id: `activity-run-${activity[0].id}`,
+    activity,
+  });
 }
 
-function lastFinalAssistantReplyIndex(messages) {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (isFinalAssistantReply(messages[i])) return i;
-  }
-  return -1;
+function appendMessage(items, message) {
+  items.push({ type: "message", id: message.id, message });
 }
 
 function isFinalAssistantReply(msg) {
   return (
     msg.role === "assistant" &&
-    !(msg.toolCalls && msg.toolCalls.length > 0) &&
+    !hasToolCalls(msg) &&
     (msg.isFinalReply === true ||
       ((msg.kind === "assistant" || msg.kind === "assistant_message") &&
         msg.status === "finalized"))
   );
 }
 
-function isAuxiliaryActivity(msg) {
+function isActivity(msg) {
   return msg.role === "thinking" || msg.role === "tool_activity" || hasToolCalls(msg);
-}
-
-function isCollapsibleToolActivity(msg) {
-  return msg.role === "tool_activity" && !hasToolCalls(msg);
 }
 
 function hasToolCalls(msg) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
@@ -10,8 +10,8 @@ test("groupMessages: consecutive tool_activity messages collapse into one run", 
   ]);
 
   assert.equal(grouped.length, 1);
-  assert.equal(grouped[0].type, "tool-run");
-  assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a", "b"]);
+  assert.equal(grouped[0].type, "activity-run");
+  assert.deepEqual(grouped[0].activity.map((item) => item.id), ["a", "b"]);
 });
 
 test("groupMessages: non-auxiliary messages break tool runs", () => {
@@ -22,22 +22,21 @@ test("groupMessages: non-auxiliary messages break tool runs", () => {
   ]);
 
   assert.equal(grouped.length, 3);
-  assert.equal(grouped[0].type, "tool-run");
+  assert.equal(grouped[0].type, "activity-run");
   assert.equal(grouped[1].type, "message");
-  assert.equal(grouped[2].type, "tool-run");
+  assert.equal(grouped[2].type, "activity-run");
 });
 
-test("groupMessages: toolCalls-bearing messages are not grouped and break runs", () => {
+test("groupMessages: toolCalls-bearing messages stay inside activity runs", () => {
   const grouped = groupMessages([
     { id: "a", role: "tool_activity" },
     { id: "g", role: "assistant", toolCalls: [{ toolName: "read" }] },
     { id: "b", role: "tool_activity" },
   ]);
 
-  assert.equal(grouped.length, 3);
-  assert.equal(grouped[0].type, "tool-run");
-  assert.equal(grouped[1].type, "message");
-  assert.equal(grouped[2].type, "tool-run");
+  assert.equal(grouped.length, 1);
+  assert.equal(grouped[0].type, "activity-run");
+  assert.deepEqual(grouped[0].activity.map((item) => item.id), ["a", "g", "b"]);
 });
 
 test("groupMessages: final assistant renders after trailing activity", () => {
@@ -53,15 +52,13 @@ test("groupMessages: final assistant renders after trailing activity", () => {
     { id: "r", role: "thinking", content: "Need to check the integration." },
   ]);
 
-  assert.equal(grouped.length, 4);
+  assert.equal(grouped.length, 3);
   assert.equal(grouped[0].type, "message");
   assert.equal(grouped[0].message.id, "u");
-  assert.equal(grouped[1].type, "tool-run");
-  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["a"]);
+  assert.equal(grouped[1].type, "activity-run");
+  assert.deepEqual(grouped[1].activity.map((item) => item.id), ["a", "r"]);
   assert.equal(grouped[2].type, "message");
-  assert.equal(grouped[2].message.id, "r");
-  assert.equal(grouped[3].type, "message");
-  assert.equal(grouped[3].message.id, "m");
+  assert.equal(grouped[2].message.id, "m");
 });
 
 test("groupMessages: trailing activity stays separate from earlier tool runs", () => {
@@ -72,10 +69,10 @@ test("groupMessages: trailing activity stays separate from earlier tool runs", (
   ]);
 
   assert.equal(grouped.length, 3);
-  assert.equal(grouped[0].type, "tool-run");
-  assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a"]);
-  assert.equal(grouped[1].type, "tool-run");
-  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["b"]);
+  assert.equal(grouped[0].type, "activity-run");
+  assert.deepEqual(grouped[0].activity.map((item) => item.id), ["a"]);
+  assert.equal(grouped[1].type, "activity-run");
+  assert.deepEqual(grouped[1].activity.map((item) => item.id), ["b"]);
   assert.equal(grouped[2].type, "message");
   assert.equal(grouped[2].message.id, "m");
 });
@@ -90,7 +87,7 @@ test("groupMessages: middle assistant stays before its following activity", () =
   assert.equal(grouped.length, 3);
   assert.equal(grouped[0].type, "message");
   assert.equal(grouped[0].message.id, "m1");
-  assert.equal(grouped[1].type, "tool-run");
+  assert.equal(grouped[1].type, "activity-run");
   assert.equal(grouped[2].type, "message");
   assert.equal(grouped[2].message.id, "m2");
 });
@@ -105,11 +102,28 @@ test("groupMessages: middle assistant is not hoisted before final reply arrives"
   assert.equal(grouped.length, 2);
   assert.equal(grouped[0].type, "message");
   assert.equal(grouped[0].message.id, "m");
-  assert.equal(grouped[1].type, "tool-run");
-  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["a", "b"]);
+  assert.equal(grouped[1].type, "activity-run");
+  assert.deepEqual(grouped[1].activity.map((item) => item.id), ["a", "b"]);
 });
 
-test("groupMessages: assistant is not hoisted when non-auxiliary message trails", () => {
+test("groupMessages: follow-up user does not break prior final reply ordering", () => {
+  const grouped = groupMessages([
+    { id: "m", role: "assistant", content: "answer", isFinalReply: true },
+    { id: "a", role: "tool_activity", toolName: "read" },
+    { id: "r", role: "thinking", content: "checking" },
+    { id: "u", role: "user", content: "did you finish?" },
+  ]);
+
+  assert.equal(grouped.length, 3);
+  assert.equal(grouped[0].type, "activity-run");
+  assert.deepEqual(grouped[0].activity.map((item) => item.id), ["a", "r"]);
+  assert.equal(grouped[1].type, "message");
+  assert.equal(grouped[1].message.id, "m");
+  assert.equal(grouped[2].type, "message");
+  assert.equal(grouped[2].message.id, "u");
+});
+
+test("groupMessages: system note after activity keeps original order", () => {
   const grouped = groupMessages([
     { id: "m", role: "assistant", content: "answer", isFinalReply: true },
     { id: "a", role: "tool_activity", toolName: "read" },
@@ -119,25 +133,23 @@ test("groupMessages: assistant is not hoisted when non-auxiliary message trails"
   assert.equal(grouped.length, 3);
   assert.equal(grouped[0].type, "message");
   assert.equal(grouped[0].message.id, "m");
-  assert.equal(grouped[1].type, "tool-run");
+  assert.equal(grouped[1].type, "activity-run");
   assert.equal(grouped[2].type, "message");
   assert.equal(grouped[2].message.id, "s");
 });
 
-test("groupMessages: toolCalls assistant is not the hoist target", () => {
+test("groupMessages: toolCalls assistant is hoisted as activity, not final reply", () => {
   const grouped = groupMessages([
     { id: "m", role: "assistant", content: "answer", isFinalReply: true },
     { id: "a", role: "tool_activity", toolName: "read" },
     { id: "g", role: "assistant", toolCalls: [{ toolName: "read" }] },
   ]);
 
-  assert.equal(grouped.length, 3);
-  assert.equal(grouped[0].type, "tool-run");
-  assert.deepEqual(grouped[0].tools.map((t) => t.id), ["a"]);
+  assert.equal(grouped.length, 2);
+  assert.equal(grouped[0].type, "activity-run");
+  assert.deepEqual(grouped[0].activity.map((item) => item.id), ["a", "g"]);
   assert.equal(grouped[1].type, "message");
-  assert.equal(grouped[1].message.id, "g");
-  assert.equal(grouped[2].type, "message");
-  assert.equal(grouped[2].message.id, "m");
+  assert.equal(grouped[1].message.id, "m");
 });
 
 test("groupMessages: no reordering when timeline has no assistant reply", () => {
@@ -150,6 +162,6 @@ test("groupMessages: no reordering when timeline has no assistant reply", () => 
   assert.equal(grouped.length, 2);
   assert.equal(grouped[0].type, "message");
   assert.equal(grouped[0].message.id, "u");
-  assert.equal(grouped[1].type, "tool-run");
-  assert.deepEqual(grouped[1].tools.map((t) => t.id), ["a", "b"]);
+  assert.equal(grouped[1].type, "activity-run");
+  assert.deepEqual(grouped[1].activity.map((item) => item.id), ["a", "b"]);
 });

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -47,12 +47,12 @@ use ironclaw_host_runtime::{
     GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HTTP_SAVE_CAPABILITY_ID,
     HostRuntime, HostRuntimeServices, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID,
     MEMORY_READ_CAPABILITY_ID, MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID,
-    MEMORY_WRITE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, RuntimeCredentialAccountRequest,
-    RuntimeCredentialAccountResolver, SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID,
-    SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID,
-    SurfaceKind, TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID,
-    TRIGGER_REMOVE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
-    builtin_first_party_package,
+    MEMORY_WRITE_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, RuntimeCredentialAccessSecret,
+    RuntimeCredentialAccountRequest, RuntimeCredentialAccountResolver, SHELL_CAPABILITY_ID,
+    SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID,
+    SPAWN_SUBAGENT_CAPABILITY_ID, SurfaceKind, TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID,
+    TRIGGER_LIST_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
+    builtin_first_party_handlers, builtin_first_party_package,
 };
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilityResultWrite,
@@ -2213,10 +2213,15 @@ impl RuntimeCredentialAccountResolver for FixedRuntimeCredentialAccountResolver 
     async fn resolve_access_secret(
         &self,
         request: RuntimeCredentialAccountRequest<'_>,
-    ) -> Result<SecretHandle, CredentialStageError> {
+    ) -> Result<RuntimeCredentialAccessSecret, CredentialStageError> {
         assert_eq!(request.provider.as_str(), "github");
         assert_eq!(request.requester_extension.as_str(), "github");
-        self.result.clone()
+        self.result
+            .clone()
+            .map(|handle| RuntimeCredentialAccessSecret {
+                scope: request.scope.clone(),
+                handle,
+            })
     }
 }
 


### PR DESCRIPTION
## Summary
- collapse reasoning and tool activity into one ordered `Activity` disclosure per contiguous activity run
- render delayed activity before a finalized assistant reply when that reply should close the turn, including after a follow-up user message arrives
- keep tool-call-bearing assistant records inside the activity run instead of rendering them as standalone message bubbles
- split deterministic activity-summary presentation into a tested helper so nested tool-call failures/running states appear in the collapsed label
- repair all-features CI blockers in Reborn test support after the runtime credential resolver return type changed

## Root Cause
The previous UI still rendered reasoning and tool records as separate visual units after grouping. When persisted activity arrived around a finalized assistant answer, especially once a follow-up user message had been appended, independent reasoning/tool rows could still look chronologically detached from the assistant answer they belonged to.

The root-cause fix is to stop trying to visually interleave each auxiliary record as its own chat item. `groupMessages` now projects contiguous reasoning/tool records into a single ordered activity-run item, and only moves that whole activity run ahead of a finalized assistant reply when the next boundary is the end of the timeline or a new user turn. The final assistant answer remains the last visible item for its turn, while the activity details remain available in chronological order inside one collapsed disclosure.

## Thermo Loop
- Iteration 1 fixed nested `toolCalls` summary handling so failed/running nested calls are reflected in the collapsed activity label.
- Iteration 2 found no remaining actionable thermo-level issues.

## Tests
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/activity-summary.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs`
- `cargo test -p ironclaw_webui_v2_static`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --test reborn_adapter_installation_scope_isolation_parity --all-features -- -D warnings`
- `cargo clippy --test reborn_subagent_spawn_e2e --all-features -- -D warnings`
- `cargo clippy --all --tests --examples --all-features -- -D warnings`

Note: I could not run an in-app browser smoke test from this tool context because the browser tool was not exposed in that turn.
