### PR TITLE
[codex] fix agent loop no-progress fallback reply

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/loop_exit.rs
+++ b/crates/ironclaw_agent_loop/src/executor/loop_exit.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use ironclaw_turns::{LoopExit, LoopFailureKind};
+use ironclaw_turns::{
+    LoopExit, LoopMessageRef,
+    run_profile::{AssistantReply, FinalizeAssistantMessage},
+};
 
 use crate::{
     state::{CheckpointKind, LoopExecutionState},
@@ -10,6 +13,12 @@ use super::{
     AgentLoopExecutorError, CheckpointStage, ExecutorStage, StageContext, completed_exit,
     failed_exit,
 };
+
+const NO_PROGRESS_FALLBACK_REPLY: &str = concat!(
+    "I stopped because I was repeating the same step without making progress. ",
+    "The recent tool activity shows the repeated calls, results, and any failure summaries. ",
+    "Try again with a narrower request, or fix the failed tool/resource and rerun it."
+);
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct ExitStage;
@@ -47,15 +56,13 @@ impl ExitStage {
                 completed_exit(ctx.host, checked.state, Some(checked.checkpoint_id))
             }
             StopKind::NoProgressDetected => {
+                let mut state = state;
+                let reply_ref = finalize_no_progress_fallback(ctx).await?;
+                state.assistant_refs.push(reply_ref);
                 let checked = CheckpointStage
                     .write(ctx, state, CheckpointKind::Final)
                     .await?;
-                failed_exit(
-                    ctx.host,
-                    checked.state,
-                    LoopFailureKind::NoProgressDetected,
-                    Some(checked.checkpoint_id),
-                )
+                completed_exit(ctx.host, checked.state, Some(checked.checkpoint_id))
             }
             StopKind::Aborted(failure_kind) => {
                 let checked = CheckpointStage
@@ -70,4 +77,21 @@ impl ExitStage {
             }
         }
     }
+}
+
+async fn finalize_no_progress_fallback(
+    ctx: StageContext<'_>,
+) -> Result<LoopMessageRef, AgentLoopExecutorError> {
+    let reply_ref = ctx
+        .host
+        .finalize_assistant_message(FinalizeAssistantMessage {
+            reply: AssistantReply {
+                content: NO_PROGRESS_FALLBACK_REPLY.to_string(),
+            },
+        })
+        .await
+        .map_err(|_| AgentLoopExecutorError::HostUnavailable {
+            stage: super::HostStage::Transcript,
+        })?;
+    Ok(reply_ref)
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -1176,7 +1176,7 @@ fn sanitize_result_ref_suffix_handles_empty_special_chars_and_truncation() {
 }
 
 #[tokio::test]
-async fn exit_stage_no_progress_detected_exits_with_failed_loop_exit() {
+async fn exit_stage_no_progress_detected_finalizes_fallback_reply() {
     let host = MockHost::new(Vec::new());
     let family = crate::families::default();
     let ctx = StageContext {
@@ -1197,11 +1197,11 @@ async fn exit_stage_no_progress_detected_exits_with_failed_loop_exit() {
         .expect("exit stage");
 
     match exit {
-        LoopExit::Failed(failed) => {
-            assert_eq!(failed.reason_kind, LoopFailureKind::NoProgressDetected);
-            assert!(failed.checkpoint_id.is_some());
+        LoopExit::Completed(completed) => {
+            assert_eq!(completed.reply_message_refs.len(), 1);
+            assert!(completed.final_checkpoint_id.is_some());
         }
-        other => panic!("expected failed exit, got {other:?}"),
+        other => panic!("expected completed exit with fallback reply, got {other:?}"),
     }
 }
 

--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -59,6 +59,7 @@ pub struct MockAgentLoopDriverHost {
     compaction_result: Mutex<Result<LoopCompactionResponse, LoopCompactionError>>,
     progress_events: Mutex<Vec<LoopProgressEvent>>,
     acked_tokens: Mutex<Vec<LoopInputAckToken>>,
+    finalized_assistant_messages: Mutex<Vec<String>>,
     cancellation: Mutex<Option<LoopCancellationSignal>>,
     cancellation_notify: tokio::sync::Notify,
 }
@@ -90,6 +91,11 @@ impl MockAgentLoopDriverHost {
     /// Returns loop progress events emitted through the host progress port.
     pub fn progress_events(&self) -> Vec<LoopProgressEvent> {
         clone_mutex_vec(&self.progress_events)
+    }
+
+    /// Returns finalized assistant message contents in call order.
+    pub fn finalized_assistant_messages(&self) -> Vec<String> {
+        clone_mutex_vec(&self.finalized_assistant_messages)
     }
 
     /// Sets the exact cancellation signal and wakes async waiters.
@@ -210,6 +216,7 @@ impl MockAgentLoopDriverHostBuilder {
                 compaction_result: Mutex::new(self.compaction_result),
                 progress_events: Mutex::new(Vec::new()),
                 acked_tokens: Mutex::new(Vec::new()),
+                finalized_assistant_messages: Mutex::new(Vec::new()),
                 cancellation: Mutex::new(self.cancellation),
                 cancellation_notify: tokio::sync::Notify::new(),
             },
@@ -754,8 +761,9 @@ impl ironclaw_turns::run_profile::LoopCapabilityPort for MockAgentLoopDriverHost
 impl ironclaw_turns::run_profile::LoopTranscriptPort for MockAgentLoopDriverHost {
     async fn finalize_assistant_message(
         &self,
-        _request: FinalizeAssistantMessage,
+        request: FinalizeAssistantMessage,
     ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        lock_or_panic(&self.finalized_assistant_messages).push(request.reply.content);
         self.record_call(MockHostCall::FinalizeAssistantMessage);
         Ok(loop_message_ref("msg:assistant"))
     }

--- a/crates/ironclaw_agent_loop/tests/safety_nets.rs
+++ b/crates/ironclaw_agent_loop/tests/safety_nets.rs
@@ -21,12 +21,13 @@ async fn repetition_escape_after_three_iterations() {
         .expect("loop execution should succeed");
 
     match exit {
-        LoopExit::Failed(failed) => {
-            assert_eq!(failed.reason_kind, LoopFailureKind::NoProgressDetected);
-            assert!(failed.checkpoint_id.is_some());
+        LoopExit::Completed(completed) => {
+            assert_eq!(completed.reply_message_refs.len(), 1);
+            assert!(completed.final_checkpoint_id.is_some());
         }
-        other => panic!("expected no-progress failure, got {other:?}"),
+        other => panic!("expected no-progress fallback completion, got {other:?}"),
     }
+    assert_no_progress_fallback(&host);
     assert_eq!(host.model_call_count(), 3);
     assert_eq!(
         checkpoints.kinds(),
@@ -59,11 +60,13 @@ async fn failure_run_length_escape() {
         .expect("loop execution should succeed");
 
     match exit {
-        LoopExit::Failed(failed) => {
-            assert_eq!(failed.reason_kind, LoopFailureKind::NoProgressDetected);
+        LoopExit::Completed(completed) => {
+            assert_eq!(completed.reply_message_refs.len(), 1);
+            assert!(completed.final_checkpoint_id.is_some());
         }
-        other => panic!("expected no-progress failure, got {other:?}"),
+        other => panic!("expected no-progress fallback completion, got {other:?}"),
     }
+    assert_no_progress_fallback(&host);
 }
 
 #[tokio::test]
@@ -136,4 +139,11 @@ async fn recovery_budget_exhaustion_uses_single_call_retry() {
             .count(),
         2
     );
+}
+
+fn assert_no_progress_fallback(host: &MockAgentLoopDriverHost) {
+    let messages = host.finalized_assistant_messages();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].contains("repeating the same step without making progress"));
+    assert!(messages[0].contains("repeated calls, results, and any failure summaries"));
 }

--- a/crates/ironclaw_agent_loop/tests/strategy_interactions.rs
+++ b/crates/ironclaw_agent_loop/tests/strategy_interactions.rs
@@ -9,7 +9,7 @@ use ironclaw_agent_loop::{
         ScriptedCapabilityOutcome, ScriptedModelResponse,
     },
 };
-use ironclaw_turns::{LoopExit, LoopFailureKind, run_profile::LoopRunInfoPort};
+use ironclaw_turns::{LoopExit, run_profile::LoopRunInfoPort};
 
 #[tokio::test]
 async fn gate_blocks_before_recovery_budget_exhausts() {
@@ -59,7 +59,7 @@ async fn terminate_hint_after_batch_stops_without_extra_model_call() {
 }
 
 #[tokio::test]
-async fn denied_call_skips_and_repetition_net_catches_stuck_denials() {
+async fn denied_call_skips_and_repetition_net_finalizes_fallback_reply() {
     let (host, _) = MockAgentLoopDriverHost::builder()
         .script(ScenarioScript::same_failure_repeated(
             "demo.echo",
@@ -75,11 +75,15 @@ async fn denied_call_skips_and_repetition_net_catches_stuck_denials() {
         .expect("loop execution should succeed");
 
     match exit {
-        LoopExit::Failed(failed) => {
-            assert_eq!(failed.reason_kind, LoopFailureKind::NoProgressDetected);
+        LoopExit::Completed(completed) => {
+            assert_eq!(completed.reply_message_refs.len(), 1);
+            assert!(completed.final_checkpoint_id.is_some());
         }
-        other => panic!("expected no-progress failure, got {other:?}"),
+        other => panic!("expected no-progress fallback completion, got {other:?}"),
     }
+    let messages = host.finalized_assistant_messages();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].contains("repeating the same step without making progress"));
     assert_eq!(host.model_call_count(), 3);
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/failure_explanation.rs
@@ -2,10 +2,33 @@ use super::*;
 
 #[tokio::test]
 async fn webui_event_stream_projects_failed_run_failure_summary() {
+    assert_failed_run_status_summary(
+        "webui-events-failed-thread",
+        "lease_expired",
+        "The run failed because its runner lease expired.",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn webui_event_stream_projects_no_progress_failure_summary() {
+    assert_failed_run_status_summary(
+        "webui-events-no-progress-thread",
+        "no_progress_detected",
+        "The run stopped because it repeated the same step without making progress.",
+    )
+    .await;
+}
+
+async fn assert_failed_run_status_summary(
+    thread_id: &str,
+    failure_category: &str,
+    expected_summary: &str,
+) {
     let tenant_id = TenantId::new("webui-events-tenant").unwrap();
     let user_id = UserId::new("webui-events-user").unwrap();
     let agent_id = AgentId::new("webui-events-agent").unwrap();
-    let thread_id = ThreadId::new("webui-events-failed-thread").unwrap();
+    let thread_id = ThreadId::new(thread_id).unwrap();
     let turn_run = TurnRunId::new();
     let scope = TurnScope::new(
         tenant_id.clone(),
@@ -30,7 +53,7 @@ async fn webui_event_stream_projects_failed_run_failure_summary() {
                 status: TurnStatus::Failed,
                 kind: TurnEventKind::Failed,
                 blocked_gate: None,
-                sanitized_reason: Some("lease_expired".to_string()),
+                sanitized_reason: Some(failure_category.to_string()),
             }],
         }),
         Arc::new(FakeTurnCoordinator {
@@ -59,8 +82,8 @@ async fn webui_event_stream_projects_failed_run_failure_summary() {
                     failure_summary: Some(summary),
                 } if *run_id == turn_run
                     && status == "failed"
-                    && category.category() == "lease_expired"
-                    && summary == "The run failed because its runner lease expired."
+                    && category.category() == failure_category
+                    && summary == expected_summary
             )
         }),
         _ => false,

--- a/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/turn_events.rs
@@ -581,6 +581,9 @@ fn failure_summary_for_category(category: &str) -> &'static str {
         "exit_application_failed" => "The run failed while recording its final result.",
         "lease_expired" => "The run failed because its runner lease expired.",
         "interrupted_unexpectedly" => "The run stopped before it could complete cleanly.",
+        "no_progress_detected" => {
+            "The run stopped because it repeated the same step without making progress."
+        }
         "unknown_failure" => "The run failed for an unknown reason.",
         _ => "The run failed before producing a reply.",
     }


### PR DESCRIPTION
## Summary

Fix the no-progress loop exit path so repeated tool failures, such as repeated `read_file` operation failures during the Telegram connect flow, still produce a durable user-facing assistant reply instead of collapsing the turn with no response.

## Root Cause

`StopKind::NoProgressDetected` previously mapped directly to `LoopExit::Failed` without assistant message refs. The web projection then had no reply to render and fell back to the generic "run failed before producing a reply" state.

## Changes

- Finalize a deterministic fallback assistant message when the agent loop detects no progress.
- Preserve the final checkpoint and return a completed exit with the fallback reply ref.
- Add a specific projection summary for legacy `no_progress_detected` failed events.
- Strengthen regression tests for repeated calls, repeated failures, denied-call repetition, finalized fallback content, and projection summaries.

## Validation

- `cargo fmt`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo test -p ironclaw_agent_loop exit_stage_no_progress_detected_finalizes_fallback_reply --tests`
- `CARGO_BUILD_JOBS=1 cargo test -p ironclaw_agent_loop --test safety_nets`
- `CARGO_BUILD_JOBS=1 cargo test -p ironclaw_agent_loop --test strategy_interactions`
- `CARGO_BUILD_JOBS=1 cargo test -p ironclaw_reborn_composition webui_event_stream_projects_no_progress_failure_summary --lib`

Note: the composition test emitted a pre-existing dead-code warning in `oauth_dcr.rs`; it is unrelated to this change.
