### PR TITLE
[codex] fix Reborn context overflow compaction

### DIFF
--- a/crates/ironclaw_agent_loop/src/executor/canonical.rs
+++ b/crates/ironclaw_agent_loop/src/executor/canonical.rs
@@ -131,6 +131,10 @@ impl DefaultExecutorPipeline {
                     state = *next;
                     response
                 }
+                ModelStep::RetryIteration(next) => {
+                    state = *next;
+                    continue;
+                }
                 ModelStep::Exit(exit) => return Ok(exit),
             };
 

--- a/crates/ironclaw_agent_loop/src/executor/model.rs
+++ b/crates/ironclaw_agent_loop/src/executor/model.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 
 use crate::{
     state::{CheckpointKind, LoopExecutionState},
-    strategies::{ModelErrorSummary, RecoveryOutcome},
+    strategies::{ModelErrorSummary, RecoveryOutcome, RetryAlteration, RetryScope},
 };
 
 use super::prompt::build_prompt_bundle_for_surface;
@@ -35,7 +35,14 @@ pub(super) enum ModelStep {
         Box<LoopExecutionState>,
         ironclaw_turns::run_profile::LoopModelResponse,
     ),
+    RetryIteration(Box<LoopExecutionState>),
     Exit(LoopExit),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModelRetryAction {
+    RetryCall,
+    RetryIteration,
 }
 
 #[async_trait]
@@ -135,14 +142,18 @@ impl ExecutorStage<ModelInput> for ModelStage {
                         .await
                     {
                         RecoveryOutcome::Retry {
-                            recovery, alter, ..
+                            recovery,
+                            scope,
+                            alter,
                         } => {
                             state.recovery_state = recovery;
                             match CheckpointStage.cancel_if_requested(ctx, state).await? {
                                 CancelCheck::Continue(next) => state = *next,
                                 CancelCheck::Exit(exit) => return Ok(ModelStep::Exit(exit)),
                             }
-                            honor_retry_alteration(alter.as_ref())?;
+                            let retry_action =
+                                apply_model_retry_alteration(&mut state, scope, alter.as_ref())
+                                    .await?;
                             CheckpointStage
                                 .emit_progress(
                                     ctx,
@@ -157,6 +168,9 @@ impl ExecutorStage<ModelInput> for ModelStage {
                                     })?,
                                 )
                                 .await;
+                            if retry_action == ModelRetryAction::RetryIteration {
+                                return Ok(ModelStep::RetryIteration(Box::new(state)));
+                            }
                             let bundle = build_prompt_bundle_for_surface(
                                 ctx,
                                 &state,
@@ -209,4 +223,32 @@ impl ExecutorStage<ModelInput> for ModelStage {
             Some(checked.checkpoint_id),
         )?))
     }
+}
+
+async fn apply_model_retry_alteration(
+    state: &mut LoopExecutionState,
+    scope: RetryScope,
+    alteration: Option<&RetryAlteration>,
+) -> Result<ModelRetryAction, AgentLoopExecutorError> {
+    honor_retry_alteration(alteration)?;
+    match alteration {
+        Some(RetryAlteration::Backoff { delay_ms }) => {
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms.as_u64())).await;
+        }
+        Some(RetryAlteration::ShrinkContext) => {
+            if scope != RetryScope::Iteration {
+                return Err(AgentLoopExecutorError::PlannerContract {
+                    detail: "context shrink retry requires iteration scope",
+                });
+            }
+            state.compaction_state.force_compact_on_next_iteration = true;
+            return Ok(ModelRetryAction::RetryIteration);
+        }
+        Some(RetryAlteration::AdvanceFallback) | None => {}
+    }
+
+    Ok(match scope {
+        RetryScope::Call => ModelRetryAction::RetryCall,
+        RetryScope::Iteration => ModelRetryAction::RetryIteration,
+    })
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -712,6 +712,33 @@ async fn model_context_overflow_retries_through_canonical_compaction_stage() {
 }
 
 #[tokio::test]
+async fn model_shrink_context_call_scope_returns_planner_contract() {
+    let host =
+        MockHost::new(vec![reply_response()]).with_model_errors(vec![AgentLoopHostError::new(
+            AgentLoopHostErrorKind::BudgetExceeded,
+            "model request exceeded its context budget",
+        )]);
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let err = executor
+        .execute_family(
+            &family_with_shrink_context_call_scope_recovery(),
+            &host,
+            state,
+        )
+        .await
+        .expect_err("call-scoped ShrinkContext must violate the planner contract");
+
+    assert!(matches!(
+        err,
+        AgentLoopExecutorError::PlannerContract {
+            detail: "context shrink retry requires iteration scope"
+        }
+    ));
+}
+
+#[tokio::test]
 async fn input_stage_steering_drain_carries_pending_ack() {
     let host = MockHost::new(Vec::new());
     let run_context = host.run_context().clone();

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -670,6 +670,48 @@ async fn prompt_stage_cancellation_after_compaction_success_skips_final_bundle_r
 }
 
 #[tokio::test]
+async fn model_context_overflow_retries_through_canonical_compaction_stage() {
+    let host = MockHost::new(vec![reply_response()])
+        .with_model_errors(vec![AgentLoopHostError::new(
+            AgentLoopHostErrorKind::BudgetExceeded,
+            "model request exceeded its context budget",
+        )])
+        .with_prompt_compaction_indexes(vec![
+            vec![compaction_metadata(1, LoopContextCompactionKind::User, 10)],
+            vec![compaction_metadata(1, LoopContextCompactionKind::User, 10)],
+            Vec::new(),
+        ])
+        .with_compaction_result(Ok(LoopCompactionResponse {
+            summary_artifact_id: LoopSummaryArtifactId::new("summary:overflow-retry")
+                .expect("valid summary id"),
+            compression_ratio_ppm: 100_000,
+        }));
+    let executor = CanonicalAgentLoopExecutor;
+    let state = LoopExecutionState::initial_for_run(host.run_context());
+
+    let exit = executor
+        .execute_family(&crate::families::default(), &host, state)
+        .await
+        .expect("execute");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
+    assert_eq!(host.model_requests().len(), 2);
+    assert_eq!(
+        host.prompt_requests().len(),
+        3,
+        "retry must return to PromptStage so compaction can run before the next model call"
+    );
+    assert!(host.progress_event_names().contains(&"compaction_started"));
+
+    let final_state = final_staged_state(&host);
+    assert_eq!(
+        final_state.compaction_state.last_compacted_through_seq,
+        Some(1)
+    );
+    assert!(!final_state.compaction_state.force_compact_on_next_iteration);
+}
+
+#[tokio::test]
 async fn input_stage_steering_drain_carries_pending_ack() {
     let host = MockHost::new(Vec::new());
     let run_context = host.run_context().clone();

--- a/crates/ironclaw_agent_loop/src/executor/tests/support.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests/support.rs
@@ -33,8 +33,8 @@ use crate::{
         CapabilityErrorClass, CapabilityErrorSummary, CapabilityFilter, CapabilityStrategy,
         ContextStrategy, DefaultCompactionStrategy, GateHandlingStrategy, GateOutcome, GateSummary,
         InputDrainStrategy, ModelErrorSummary, RecoveryOutcome, RecoveryStrategy,
-        ReplyAdmissionOutcome, ReplyAdmissionStrategy, RetryScope, StopConditionStrategy, StopKind,
-        StopOutcome, TurnSummary,
+        ReplyAdmissionOutcome, ReplyAdmissionStrategy, RetryAlteration, RetryScope,
+        StopConditionStrategy, StopKind, StopOutcome, TurnSummary,
     },
 };
 
@@ -413,6 +413,34 @@ impl RecoveryStrategy for RetryPolicyDeniedRecoveryStrategy {
         RecoveryOutcome::Abort {
             recovery: state.recovery_state.clone(),
             failure_kind: LoopFailureKind::DriverBug,
+        }
+    }
+}
+
+pub(super) struct ShrinkContextCallScopeRecoveryStrategy;
+
+#[async_trait]
+impl RecoveryStrategy for ShrinkContextCallScopeRecoveryStrategy {
+    async fn on_capability_error(
+        &self,
+        state: &LoopExecutionState,
+        _err: &CapabilityErrorSummary,
+    ) -> RecoveryOutcome {
+        RecoveryOutcome::Abort {
+            recovery: state.recovery_state.clone(),
+            failure_kind: LoopFailureKind::CapabilityProtocolError,
+        }
+    }
+
+    async fn on_model_error(
+        &self,
+        state: &LoopExecutionState,
+        _err: &ModelErrorSummary,
+    ) -> RecoveryOutcome {
+        RecoveryOutcome::Retry {
+            recovery: state.recovery_state.clone(),
+            scope: RetryScope::Call,
+            alter: Some(RetryAlteration::ShrinkContext),
         }
     }
 }
@@ -998,6 +1026,18 @@ pub(super) fn family_with_retry_policy_denied_recovery() -> LoopFamily {
     let version = ComponentIdentity::from_static(
         "executor-retry-policy-denied-test",
         ComponentDigest([3; 32]),
+    );
+    LoopFamily::new(id, version, Arc::new(planner))
+}
+
+pub(super) fn family_with_shrink_context_call_scope_recovery() -> LoopFamily {
+    let planner = DefaultPlanner::compose_default()
+        .with_recovery(Arc::new(ShrinkContextCallScopeRecoveryStrategy));
+    let id =
+        LoopFamilyId::new("executor-shrink-context-call-scope-test").expect("valid test family id");
+    let version = ComponentIdentity::from_static(
+        "executor-shrink-context-call-scope-test",
+        ComponentDigest([9; 32]),
     );
     LoopFamily::new(id, version, Arc::new(planner))
 }

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -86,7 +86,7 @@ mod tests {
                 2,
             ),
             scope: RetryScope::Call,
-            alter: Some(RetryAlteration::ShrinkContext { drop_messages: 1 }),
+            alter: Some(RetryAlteration::ShrinkContext),
         };
         let stop_outcome = StopOutcome::Stop {
             kind: StopKind::NoProgressDetected,

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -274,7 +274,7 @@ impl RecoveryStrategy for DefaultRecoveryStrategy {
                     self.max_attempts_per_class,
                     kind,
                     RetryScope::Iteration,
-                    |_| Some(RetryAlteration::ShrinkContext { drop_messages: 4 }),
+                    |_| Some(RetryAlteration::ShrinkContext),
                 )
             }
             ModelErrorClass::Transient
@@ -426,7 +426,7 @@ fn backoff_for(attempt: u32) -> BackoffDelayMs {
 #[serde(rename_all = "snake_case", tag = "alteration")]
 pub(crate) enum RetryAlteration {
     /// Shrink context for the next attempt (e.g. on context-overflow).
-    ShrinkContext { drop_messages: u32 },
+    ShrinkContext,
     /// Backoff before retry (executor honors as a sleep).
     Backoff { delay_ms: BackoffDelayMs },
     /// Reserved for future `ModelRouteChain` landing. Skeleton executor MUST
@@ -624,16 +624,10 @@ mod tests {
 
     #[test]
     fn retry_alteration_shrink_context_round_trips() {
-        let alteration = RetryAlteration::ShrinkContext { drop_messages: 4 };
+        let alteration = RetryAlteration::ShrinkContext;
         let value = serde_json::to_value(&alteration).expect("serialize");
         let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, alteration);
-        match restored {
-            RetryAlteration::ShrinkContext { drop_messages } => {
-                assert_eq!(drop_messages, 4)
-            }
-            other => panic!("unexpected variant: {other:?}"),
-        }
     }
 
     #[test]
@@ -666,7 +660,7 @@ mod tests {
         let outcome = RecoveryOutcome::Retry {
             recovery: sample_recovery(),
             scope: RetryScope::Call,
-            alter: Some(RetryAlteration::ShrinkContext { drop_messages: 2 }),
+            alter: Some(RetryAlteration::ShrinkContext),
         };
         let value = serde_json::to_value(&outcome).expect("serialize");
         let restored: RecoveryOutcome = serde_json::from_value(value).expect("deserialize");
@@ -679,10 +673,7 @@ mod tests {
             } => {
                 assert_eq!(recovery, sample_recovery());
                 assert_eq!(scope, RetryScope::Call);
-                assert_eq!(
-                    alter,
-                    Some(RetryAlteration::ShrinkContext { drop_messages: 2 })
-                );
+                assert_eq!(alter, Some(RetryAlteration::ShrinkContext));
             }
             other => panic!("unexpected variant: {other:?}"),
         }
@@ -1007,10 +998,7 @@ mod tests {
                         1
                     );
                     assert_eq!(scope, RetryScope::Iteration);
-                    assert_eq!(
-                        alter,
-                        Some(RetryAlteration::ShrinkContext { drop_messages: 4 })
-                    );
+                    assert_eq!(alter, Some(RetryAlteration::ShrinkContext));
                 }
                 other => panic!("expected context overflow retry, got {other:?}"),
             }

--- a/crates/ironclaw_llm/src/error.rs
+++ b/crates/ironclaw_llm/src/error.rs
@@ -77,6 +77,83 @@ pub enum LlmError {
     Io(#[from] std::io::Error),
 }
 
+pub(crate) fn context_length_error(status_code: u16, response_text: &str) -> Option<LlmError> {
+    if status_code != 413 && status_code != 400 {
+        return None;
+    }
+
+    let lower = response_text.to_ascii_lowercase();
+    let is_context_overflow = status_code == 413 || is_context_length_error_message(&lower);
+    if !is_context_overflow {
+        return None;
+    }
+
+    let (used, limit) = parse_context_token_counts(&lower);
+    Some(LlmError::ContextLengthExceeded { used, limit })
+}
+
+pub(crate) fn is_context_length_error_message(lower: &str) -> bool {
+    const CONTEXT_PATTERNS: &[&str] = &[
+        "context_length_exceeded",
+        "maximum context length",
+        "too many tokens",
+        "payload too large",
+        "longer than the model's context length",
+    ];
+
+    CONTEXT_PATTERNS
+        .iter()
+        .any(|pattern| lower.contains(pattern))
+}
+
+/// Try to extract token counts from a context-length error message.
+///
+/// Handles patterns like:
+/// - "maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens."
+/// - "The input (150000 tokens) is longer than the model's context length (128000 tokens)."
+///
+/// Returns `(0, 0)` if parsing fails.
+pub(crate) fn parse_context_token_counts(lower: &str) -> (usize, usize) {
+    let numbers = token_count_numbers(lower);
+    if numbers.len() < 2 {
+        return (0, 0);
+    }
+
+    // OpenAI pattern: "maximum context length is {limit} tokens. ... resulted in {used} tokens".
+    if lower.contains("maximum context length") {
+        return (numbers[1], numbers[0]);
+    }
+
+    // NEAR/OpenAI-compatible proxy pattern:
+    // "The input ({used} tokens) is longer than the model's context length ({limit} tokens)."
+    if lower.contains("longer than the model's context length") {
+        return (numbers[0], numbers[1]);
+    }
+
+    (0, 0)
+}
+
+fn token_count_numbers(lower: &str) -> Vec<usize> {
+    lower
+        .split("tokens")
+        .filter_map(number_immediately_before)
+        .filter(|&n| n > 0)
+        .collect()
+}
+
+fn number_immediately_before(segment: &str) -> Option<usize> {
+    let digits = segment
+        .chars()
+        .rev()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+    digits.parse().ok().filter(|&n| n > 0)
+}
+
 /// Return actionable setup guidance for a provider's authentication failure.
 ///
 /// This helps users who see an `AuthFailed` error know exactly what to do

--- a/crates/ironclaw_llm/src/error.rs
+++ b/crates/ironclaw_llm/src/error.rs
@@ -142,15 +142,24 @@ fn token_count_numbers(lower: &str) -> Vec<usize> {
 }
 
 fn number_immediately_before(segment: &str) -> Option<usize> {
+    let mut skipped_alphabetic = false;
     let digits = segment
         .chars()
         .rev()
-        .skip_while(|ch| !ch.is_ascii_digit())
+        .skip_while(|ch| {
+            if ch.is_alphabetic() {
+                skipped_alphabetic = true;
+            }
+            !ch.is_ascii_digit()
+        })
         .take_while(|ch| ch.is_ascii_digit())
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect::<String>();
+        .collect::<Vec<_>>();
+
+    if skipped_alphabetic || digits.is_empty() {
+        return None;
+    }
+
+    let digits = digits.into_iter().rev().collect::<String>();
     digits.parse().ok().filter(|&n| n > 0)
 }
 
@@ -260,6 +269,14 @@ mod tests {
         assert!(auth_guidance("groq").contains("GROQ_API_KEY"));
         assert!(auth_guidance("ollama").contains("Ollama is running"));
         assert!(auth_guidance("bedrock").contains("AWS"));
+    }
+
+    #[test]
+    fn parse_context_token_counts_ignores_non_adjacent_digits_before_tokens() {
+        let msg = "provider model 3 has some tokens available. this model's maximum context length is 128000 tokens. however, your messages resulted in 150000 tokens.";
+        let (used, limit) = parse_context_token_counts(msg);
+        assert_eq!(used, 150000);
+        assert_eq!(limit, 128000);
     }
 
     // ------------------------------------------------------------------

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -315,7 +315,7 @@ impl NearAiChatProvider {
                 });
             }
 
-            if let Some(error) = context_length_error(status_code, &response_text) {
+            if let Some(error) = crate::error::context_length_error(status_code, &response_text) {
                 return Err(error);
             }
 
@@ -954,21 +954,6 @@ async fn fetch_pricing(
     Ok(map)
 }
 
-fn context_length_error(status_code: u16, response_text: &str) -> Option<LlmError> {
-    // Payload-size and context-window failures are deterministic caller-side
-    // overflows, not transient service failures. Use the shared
-    // OpenAI-compatible matcher so provider adapters do not drift on upstream
-    // wording variants.
-    let lower = response_text.to_ascii_lowercase();
-    let is_context_overflow = status_code == 413
-        || (status_code == 400 && crate::rig_adapter::is_context_length_error_message(&lower));
-    if !is_context_overflow {
-        return None;
-    }
-    let (used, limit) = crate::rig_adapter::parse_token_counts(&lower);
-    Some(LlmError::ContextLengthExceeded { used, limit })
-}
-
 impl From<ChatMessage> for ChatCompletionMessage {
     fn from(msg: ChatMessage) -> Self {
         let role = match msg.role {
@@ -1221,7 +1206,7 @@ mod tests {
     #[test]
     fn context_length_error_detects_provider_longer_than_context_wording() {
         let body = r#"{"error":{"message":"Provider failed for model 'Qwen/Qwen3.6-35B-A3B-FP8': The input (314325 tokens) is longer than the model's context length (262144 tokens).","type":"invalid_request_error"}}"#;
-        match context_length_error(400, body) {
+        match crate::error::context_length_error(400, body) {
             Some(LlmError::ContextLengthExceeded { used, limit }) => {
                 assert_eq!(used, 314325);
                 assert_eq!(limit, 262144);
@@ -1233,7 +1218,64 @@ mod tests {
     #[test]
     fn context_length_error_does_not_treat_all_bad_requests_as_overflow() {
         let body = r#"{"error":{"message":"invalid tool schema"}}"#;
-        assert!(context_length_error(400, body).is_none());
+        assert!(crate::error::context_length_error(400, body).is_none());
+    }
+
+    #[tokio::test]
+    async fn complete_maps_context_overflow_http_400_to_context_length_exceeded() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut request = vec![0_u8; 4096];
+                let Ok(n) = socket.read(&mut request).await else {
+                    continue;
+                };
+                let request = String::from_utf8_lossy(&request[..n]);
+                let (status, body) = if request.starts_with("POST /v1/chat/completions ") {
+                    (
+                        "400 Bad Request",
+                        serde_json::json!({
+                            "error": {
+                                "message": "Provider failed: The input (314325 tokens) is longer than the model's context length (262144 tokens)."
+                            }
+                        })
+                        .to_string(),
+                    )
+                } else {
+                    ("200 OK", serde_json::json!({ "models": [] }).to_string())
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let provider = NearAiChatProvider::new(test_nearai_config(&base_url), test_session())
+            .expect("provider");
+        let err = provider
+            .complete(CompletionRequest::new(vec![ChatMessage::user(
+                "read my email",
+            )]))
+            .await
+            .expect_err("context overflow should fail the completion");
+
+        match err {
+            LlmError::ContextLengthExceeded { used, limit } => {
+                assert_eq!(used, 314325);
+                assert_eq!(limit, 262144);
+            }
+            other => panic!("expected context-length error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -315,29 +315,8 @@ impl NearAiChatProvider {
                 });
             }
 
-            // Payload too large — the accumulated context exceeds the provider's
-            // request size limit. Map to ContextLengthExceeded so the dispatcher
-            // can trigger automatic compaction instead of crashing.
-            if status_code == 413 {
-                let lower = response_text.to_ascii_lowercase();
-                let (used, limit) = crate::rig_adapter::parse_token_counts(&lower);
-                return Err(LlmError::ContextLengthExceeded { used, limit });
-            }
-
-            // Some providers return 400 with "context_length_exceeded" in the body
-            // (e.g., OpenAI-compatible endpoints behind NEAR AI).
-            if status_code == 400 {
-                let lower = response_text.to_ascii_lowercase();
-                const CONTEXT_PATTERNS: &[&str] = &[
-                    "context_length_exceeded",
-                    "maximum context length",
-                    "too many tokens",
-                    "payload too large",
-                ];
-                if CONTEXT_PATTERNS.iter().any(|p| lower.contains(p)) {
-                    let (used, limit) = crate::rig_adapter::parse_token_counts(&lower);
-                    return Err(LlmError::ContextLengthExceeded { used, limit });
-                }
+            if let Some(error) = context_length_error(status_code, &response_text) {
+                return Err(error);
             }
 
             // Any HTTP 5xx from the upstream LLM gateway — map to BadGateway
@@ -975,6 +954,21 @@ async fn fetch_pricing(
     Ok(map)
 }
 
+fn context_length_error(status_code: u16, response_text: &str) -> Option<LlmError> {
+    // Payload-size and context-window failures are deterministic caller-side
+    // overflows, not transient service failures. Use the shared
+    // OpenAI-compatible matcher so provider adapters do not drift on upstream
+    // wording variants.
+    let lower = response_text.to_ascii_lowercase();
+    let is_context_overflow = status_code == 413
+        || (status_code == 400 && crate::rig_adapter::is_context_length_error_message(&lower));
+    if !is_context_overflow {
+        return None;
+    }
+    let (used, limit) = crate::rig_adapter::parse_token_counts(&lower);
+    Some(LlmError::ContextLengthExceeded { used, limit })
+}
+
 impl From<ChatMessage> for ChatCompletionMessage {
     fn from(msg: ChatMessage) -> Self {
         let role = match msg.role {
@@ -1222,6 +1216,24 @@ mod tests {
             provider.api_url("/chat/completions"),
             "http://127.0.0.1:8318/v1/chat/completions"
         );
+    }
+
+    #[test]
+    fn context_length_error_detects_provider_longer_than_context_wording() {
+        let body = r#"{"error":{"message":"Provider failed for model 'Qwen/Qwen3.6-35B-A3B-FP8': The input (314325 tokens) is longer than the model's context length (262144 tokens).","type":"invalid_request_error"}}"#;
+        match context_length_error(400, body) {
+            Some(LlmError::ContextLengthExceeded { used, limit }) => {
+                assert_eq!(used, 314325);
+                assert_eq!(limit, 262144);
+            }
+            other => panic!("expected context-length error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn context_length_error_does_not_treat_all_bad_requests_as_overflow() {
+        let body = r#"{"error":{"message":"invalid tool schema"}}"#;
+        assert!(context_length_error(400, body).is_none());
     }
 
     #[test]

--- a/crates/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/ironclaw_llm/src/rig_adapter.rs
@@ -799,76 +799,14 @@ fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
     let msg = e.to_string();
     let lower = msg.to_ascii_lowercase();
 
-    if is_context_length_error_message(&lower) {
-        let (used, limit) = parse_token_counts(&lower);
+    if crate::error::is_context_length_error_message(&lower) {
+        let (used, limit) = crate::error::parse_context_token_counts(&lower);
         return LlmError::ContextLengthExceeded { used, limit };
     }
     LlmError::RequestFailed {
         provider: model_name.to_string(),
         reason: msg,
     }
-}
-
-pub(crate) fn is_context_length_error_message(lower: &str) -> bool {
-    const CONTEXT_PATTERNS: &[&str] = &[
-        "context_length_exceeded",
-        "maximum context length",
-        "too many tokens",
-        "payload too large",
-        "longer than the model's context length",
-    ];
-
-    CONTEXT_PATTERNS
-        .iter()
-        .any(|pattern| lower.contains(pattern))
-}
-
-/// Try to extract token counts from a context-length error message.
-///
-/// Handles patterns like:
-/// - "maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens."
-/// - "context_length_exceeded ... 150000 tokens ... limit 128000"
-///
-/// Returns `(0, 0)` if parsing fails.
-pub(crate) fn parse_token_counts(lower: &str) -> (usize, usize) {
-    let numbers = token_count_numbers(lower);
-    if numbers.len() < 2 {
-        return (0, 0);
-    }
-
-    // OpenAI pattern: "maximum context length is {limit} tokens. ... resulted in {used} tokens".
-    if lower.contains("maximum context length") {
-        return (numbers[1], numbers[0]);
-    }
-
-    // NEAR/OpenAI-compatible proxy pattern:
-    // "The input ({used} tokens) is longer than the model's context length ({limit} tokens)."
-    if lower.contains("longer than the model's context length") {
-        return (numbers[0], numbers[1]);
-    }
-
-    (0, 0)
-}
-
-fn token_count_numbers(lower: &str) -> Vec<usize> {
-    lower
-        .split("tokens")
-        .filter_map(number_immediately_before)
-        .filter(|&n| n > 0)
-        .collect()
-}
-
-fn number_immediately_before(segment: &str) -> Option<usize> {
-    let digits = segment
-        .chars()
-        .rev()
-        .skip_while(|ch| !ch.is_ascii_digit())
-        .take_while(|ch| ch.is_ascii_digit())
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect::<String>();
-    digits.parse().ok().filter(|&n| n > 0)
 }
 
 /// Normalize a tool call name returned by an OpenAI-compatible provider.
@@ -893,6 +831,39 @@ fn normalize_tool_name(name: &str, known_tools: &HashSet<String>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rig::completion::CompletionError;
+    use rig::streaming::StreamingCompletionResponse;
+
+    #[derive(Clone)]
+    struct FailingCompletionModel;
+
+    impl CompletionModel for FailingCompletionModel {
+        type Response = serde_json::Value;
+        type StreamingResponse = ();
+        type Client = ();
+
+        fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+            Self
+        }
+
+        async fn completion(
+            &self,
+            _request: RigRequest,
+        ) -> Result<rig::completion::CompletionResponse<Self::Response>, CompletionError> {
+            Err(CompletionError::ProviderError(
+                "HTTP 400 Bad Request: The input (314325 tokens) is longer than the model's context length (262144 tokens).".to_string(),
+            ))
+        }
+
+        async fn stream(
+            &self,
+            _request: RigRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            Err(CompletionError::ProviderError(
+                "stream unsupported".to_string(),
+            ))
+        }
+    }
 
     #[test]
     fn test_round_f32_to_f64_no_precision_artifacts() {
@@ -2557,6 +2528,25 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn complete_maps_longer_than_context_error_to_context_length_exceeded() {
+        let adapter = RigAdapter::new(FailingCompletionModel, "nearai");
+        let err = adapter
+            .complete(CompletionRequest::new(vec![ChatMessage::user(
+                "read my email",
+            )]))
+            .await
+            .expect_err("context overflow should fail the completion");
+
+        match err {
+            LlmError::ContextLengthExceeded { used, limit } => {
+                assert_eq!(used, 314325);
+                assert_eq!(limit, 262144);
+            }
+            other => panic!("expected context-length error, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_map_rig_error_bare_413_no_false_positive() {
         // Bare "413" should NOT trigger ContextLengthExceeded — avoids false
@@ -2587,7 +2577,7 @@ mod tests {
     #[test]
     fn test_parse_token_counts_openai_format() {
         let msg = "this model's maximum context length is 128000 tokens. however, your messages resulted in 150000 tokens.";
-        let (used, limit) = parse_token_counts(msg);
+        let (used, limit) = crate::error::parse_context_token_counts(msg);
         assert_eq!(limit, 128000);
         assert_eq!(used, 150000);
     }
@@ -2595,7 +2585,7 @@ mod tests {
     #[test]
     fn test_parse_token_counts_unparseable_returns_zero() {
         let msg = "context_length_exceeded";
-        let (used, limit) = parse_token_counts(msg);
+        let (used, limit) = crate::error::parse_context_token_counts(msg);
         assert_eq!(used, 0);
         assert_eq!(limit, 0);
     }

--- a/crates/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/ironclaw_llm/src/rig_adapter.rs
@@ -799,14 +799,7 @@ fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
     let msg = e.to_string();
     let lower = msg.to_ascii_lowercase();
 
-    const CONTEXT_PATTERNS: &[&str] = &[
-        "context_length_exceeded",
-        "maximum context length",
-        "too many tokens",
-        "payload too large",
-    ];
-
-    if CONTEXT_PATTERNS.iter().any(|p| lower.contains(p)) {
+    if is_context_length_error_message(&lower) {
         let (used, limit) = parse_token_counts(&lower);
         return LlmError::ContextLengthExceeded { used, limit };
     }
@@ -814,6 +807,20 @@ fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
         provider: model_name.to_string(),
         reason: msg,
     }
+}
+
+pub(crate) fn is_context_length_error_message(lower: &str) -> bool {
+    const CONTEXT_PATTERNS: &[&str] = &[
+        "context_length_exceeded",
+        "maximum context length",
+        "too many tokens",
+        "payload too large",
+        "longer than the model's context length",
+    ];
+
+    CONTEXT_PATTERNS
+        .iter()
+        .any(|pattern| lower.contains(pattern))
 }
 
 /// Try to extract token counts from a context-length error message.
@@ -824,20 +831,44 @@ fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
 ///
 /// Returns `(0, 0)` if parsing fails.
 pub(crate) fn parse_token_counts(lower: &str) -> (usize, usize) {
-    // OpenAI pattern: "maximum context length is {limit} tokens. ... resulted in {used} tokens"
-    if lower.contains("maximum context length") {
-        let numbers: Vec<usize> = lower
-            .split(|c: char| !c.is_ascii_digit())
-            .filter(|s| !s.is_empty())
-            .filter_map(|s| s.parse().ok())
-            .filter(|&n| n > 0)
-            .collect();
-        if numbers.len() >= 2 {
-            // First large number is typically the limit, second is the used count
-            return (numbers[1], numbers[0]);
-        }
+    let numbers = token_count_numbers(lower);
+    if numbers.len() < 2 {
+        return (0, 0);
     }
+
+    // OpenAI pattern: "maximum context length is {limit} tokens. ... resulted in {used} tokens".
+    if lower.contains("maximum context length") {
+        return (numbers[1], numbers[0]);
+    }
+
+    // NEAR/OpenAI-compatible proxy pattern:
+    // "The input ({used} tokens) is longer than the model's context length ({limit} tokens)."
+    if lower.contains("longer than the model's context length") {
+        return (numbers[0], numbers[1]);
+    }
+
     (0, 0)
+}
+
+fn token_count_numbers(lower: &str) -> Vec<usize> {
+    lower
+        .split("tokens")
+        .filter_map(number_immediately_before)
+        .filter(|&n| n > 0)
+        .collect()
+}
+
+fn number_immediately_before(segment: &str) -> Option<usize> {
+    let digits = segment
+        .chars()
+        .rev()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+    digits.parse().ok().filter(|&n| n > 0)
 }
 
 /// Normalize a tool call name returned by an OpenAI-compatible provider.
@@ -2509,6 +2540,21 @@ mod tests {
             matches!(err, LlmError::ContextLengthExceeded { .. }),
             "Should detect payload too large: {err:?}"
         );
+    }
+
+    #[test]
+    fn test_map_rig_error_detects_longer_than_model_context_length() {
+        let err = map_rig_error(
+            "nearai",
+            "HTTP 400 Bad Request: The input (314325 tokens) is longer than the model's context length (262144 tokens).",
+        );
+        match err {
+            LlmError::ContextLengthExceeded { used, limit } => {
+                assert_eq!(used, 314325);
+                assert_eq!(limit, 262144);
+            }
+            other => panic!("Expected ContextLengthExceeded, got: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Classify NEAR/OpenAI-compatible context overflow wording like `input (...) is longer than the model's context length (...)` as `ContextLengthExceeded` instead of a transient request failure.
- Route Reborn model context-overflow recovery back through the canonical prompt/compaction stage instead of rebuilding the same prompt inside `ModelStage`.
- Move shared context-overflow error parsing to `error.rs` so direct NEAR and Rig adapters share a neutral parser.
- Remove the unused `drop_messages` payload from `RetryAlteration::ShrinkContext` so the strategy contract matches the executor behavior.

## Review Follow-up

- Added caller-level tests for NEAR HTTP 400 overflow mapping and RigAdapter overflow mapping.
- Added an executor contract test for invalid call-scoped `ShrinkContext` recovery.
- Hardened token-count parsing so incidental digits before non-count `tokens` text are ignored.

## Root Cause

NEAR returned HTTP 400 with wording that did not match the existing context-overflow patterns, so the provider surfaced it as a generic retryable request failure. Even when context overflow was classified correctly, Reborn produced a shrink-context retry alteration that the model stage did not actually apply through the compaction stage.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_llm` (802 tests)
- `cargo test -p ironclaw_agent_loop`
- `cargo clippy -p ironclaw_llm -p ironclaw_agent_loop --all-targets -- -D warnings`
