### PR TITLE
[codex] enrich coding tool failure summaries

### DIFF
--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -97,7 +97,10 @@ pub enum CapabilityInvocationError {
     /// of the public contract for routing, metrics, and audit grouping, but
     /// callers that stay in-process can keep typed failure identity.
     #[error("dispatch failed: {kind}")]
-    Dispatch { kind: DispatchFailureKind },
+    Dispatch {
+        kind: DispatchFailureKind,
+        safe_summary: Option<String>,
+    },
 }
 
 impl From<RunStateError> for CapabilityInvocationError {
@@ -134,6 +137,7 @@ impl From<DispatchError> for CapabilityInvocationError {
             | DispatchError::Wasm { .. }
             | DispatchError::FirstParty { .. }) => Self::Dispatch {
                 kind: dispatch_error_kind(&other),
+                safe_summary: dispatch_error_safe_summary(&other),
             },
         }
     }
@@ -141,6 +145,13 @@ impl From<DispatchError> for CapabilityInvocationError {
 
 fn dispatch_error_kind(error: &DispatchError) -> DispatchFailureKind {
     error.failure_kind()
+}
+
+fn dispatch_error_safe_summary(error: &DispatchError) -> Option<String> {
+    match error {
+        DispatchError::FirstParty { safe_summary, .. } => safe_summary.clone(),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -229,6 +240,7 @@ mod tests {
     fn dispatch_error_kind_forwards_first_party_runtime_kind_as_str() {
         let kind = dispatch_error_kind(&DispatchError::FirstParty {
             kind: RuntimeDispatchErrorKind::UndeclaredCapability,
+            safe_summary: None,
         });
         assert_eq!(kind.as_str(), "UndeclaredCapability");
     }
@@ -238,7 +250,7 @@ mod tests {
         let err =
             CapabilityInvocationError::from(DispatchError::UnknownCapability { capability: cap() });
         match err {
-            CapabilityInvocationError::Dispatch { kind } => {
+            CapabilityInvocationError::Dispatch { kind, .. } => {
                 assert_eq!(kind, DispatchFailureKind::UnknownCapability)
             }
             other => panic!("expected Dispatch variant, got {other:?}"),
@@ -251,7 +263,7 @@ mod tests {
             kind: RuntimeDispatchErrorKind::Guest,
         });
         match err {
-            CapabilityInvocationError::Dispatch { kind } => {
+            CapabilityInvocationError::Dispatch { kind, .. } => {
                 assert_eq!(
                     kind,
                     DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)

--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -326,6 +326,7 @@ mod tests {
     fn dispatch_input_encode_returns_no_run_state_transition() {
         let error = CapabilityInvocationError::Dispatch {
             kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InputEncode),
+            safe_summary: None,
         };
         assert!(error.run_state_transition().is_none());
     }
@@ -334,6 +335,7 @@ mod tests {
     fn dispatch_backend_returns_no_run_state_transition() {
         let error = CapabilityInvocationError::Dispatch {
             kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend),
+            safe_summary: None,
         };
         assert!(error.run_state_transition().is_none());
     }
@@ -342,6 +344,7 @@ mod tests {
     fn dispatch_unknown_capability_returns_no_run_state_transition() {
         let error = CapabilityInvocationError::Dispatch {
             kind: DispatchFailureKind::UnknownCapability,
+            safe_summary: None,
         };
         assert!(error.run_state_transition().is_none());
     }

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -857,7 +857,8 @@ async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume(
     assert!(matches!(
         err,
         CapabilityInvocationError::Dispatch {
-            kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend)
+            kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend),
+            safe_summary: None,
         }
     ));
     // Per PR #4236 disposition policy, the capability host no longer

--- a/crates/ironclaw_first_party_extensions/src/coding/file.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/file.rs
@@ -17,7 +17,7 @@ use super::{
     diff_preview::{file_diff_preview, will_use_large_diff_path},
     input_error,
     inputs::{optional_usize, required_str},
-    operation_error,
+    operation_error_with_summary,
     paths::{
         create_parent_dir_unless_sensitive, deny_sensitive_existing_path, filesystem_error,
         is_excluded_name, is_sensitive_scoped_path, is_workspace_path, operation_allowed,
@@ -40,15 +40,21 @@ pub(super) async fn read_file(
         .filesystem
         .stat(&resolved.virtual_path)
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            filesystem_error_with_summary("read_file", resolved.scoped_path.as_str(), error)
+        })?;
     if stat.sensitive {
         return Err(CodingCapabilityError::new(
             RuntimeDispatchErrorKind::FilesystemDenied,
         ));
     }
     if stat.file_type != FileType::File || stat.len > MAX_READ_SIZE {
-        return Err(CodingCapabilityError::new(
+        return Err(CodingCapabilityError::with_safe_summary(
             RuntimeDispatchErrorKind::Resource,
+            format!(
+                "read_file failed for {}: target is not a readable file or exceeds the size limit",
+                safe_summary_path(resolved.scoped_path.as_str())
+            ),
         ));
     }
 
@@ -56,7 +62,9 @@ pub(super) async fn read_file(
         .filesystem
         .read_file(&resolved.virtual_path)
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            filesystem_error_with_summary("read_file", resolved.scoped_path.as_str(), error)
+        })?;
     reject_binary_probe(&bytes)?;
     let (content, _encoding, _line_ending) = decode_text(&bytes)?;
     let lines: Vec<&str> = content.lines().collect();
@@ -282,30 +290,44 @@ pub(super) async fn apply_patch(
         .filesystem
         .stat(&resolved.virtual_path)
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            filesystem_error_with_summary("apply_patch", resolved.scoped_path.as_str(), error)
+        })?;
     if stat.sensitive {
         return Err(CodingCapabilityError::new(
             RuntimeDispatchErrorKind::FilesystemDenied,
         ));
     }
     if stat.file_type != FileType::File || stat.len > MAX_PATCH_SIZE {
-        return Err(CodingCapabilityError::new(
+        return Err(CodingCapabilityError::with_safe_summary(
             RuntimeDispatchErrorKind::Resource,
+            format!(
+                "apply_patch failed for {}: target is not a file or exceeds the patch size limit",
+                safe_summary_path(resolved.scoped_path.as_str())
+            ),
         ));
     }
     let bytes = request
         .filesystem
         .read_file(&resolved.virtual_path)
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            filesystem_error_with_summary("apply_patch", resolved.scoped_path.as_str(), error)
+        })?;
     reject_binary_probe(&bytes)?;
     let (content, encoding, line_ending) = decode_text(&bytes)?;
     let (match_count, match_method) = count_matches(&content, old_string);
     if match_count == 0 {
-        return Err(operation_error());
+        return Err(operation_error_with_summary(format!(
+            "apply_patch failed for {}: old_string matched 0 times",
+            safe_summary_path(resolved.scoped_path.as_str())
+        )));
     }
     if !replace_all && match_count > 1 {
-        return Err(operation_error());
+        return Err(operation_error_with_summary(format!(
+            "apply_patch failed for {}: old_string matched {match_count} times; set replace_all=true or provide a unique old_string",
+            safe_summary_path(resolved.scoped_path.as_str())
+        )));
     }
 
     let (new_content, replacements) =
@@ -315,7 +337,9 @@ pub(super) async fn apply_patch(
         .filesystem
         .write_file(&resolved.virtual_path, &output)
         .await
-        .map_err(filesystem_error)?;
+        .map_err(|error| {
+            filesystem_error_with_summary("apply_patch", resolved.scoped_path.as_str(), error)
+        })?;
     let mut result = json!({
         "path": resolved.scoped_path.as_str(),
         "replacements": replacements,
@@ -329,6 +353,46 @@ pub(super) async fn apply_patch(
         result,
         Some(display_preview),
     ))
+}
+
+fn filesystem_error_with_summary(
+    operation: &str,
+    scoped_path: &str,
+    error: ironclaw_filesystem::FilesystemError,
+) -> CodingCapabilityError {
+    let scoped_path = safe_summary_path(scoped_path);
+    let summary = match &error {
+        ironclaw_filesystem::FilesystemError::NotFound { .. } => {
+            format!("{operation} failed for {scoped_path}: file not found")
+        }
+        ironclaw_filesystem::FilesystemError::PermissionDenied { .. }
+        | ironclaw_filesystem::FilesystemError::MountNotFound { .. }
+        | ironclaw_filesystem::FilesystemError::PathOutsideMount { .. }
+        | ironclaw_filesystem::FilesystemError::SymlinkEscape { .. }
+        | ironclaw_filesystem::FilesystemError::MountConflict { .. }
+        | ironclaw_filesystem::FilesystemError::VersionMismatch { .. }
+        | ironclaw_filesystem::FilesystemError::Unsupported { .. }
+        | ironclaw_filesystem::FilesystemError::IndexConflict { .. } => {
+            format!("{operation} failed for {scoped_path}: permission denied or unsupported path")
+        }
+        ironclaw_filesystem::FilesystemError::Backend { .. }
+        | ironclaw_filesystem::FilesystemError::BackendInfrastructure { .. } => {
+            format!("{operation} failed for {scoped_path}: filesystem backend error")
+        }
+        ironclaw_filesystem::FilesystemError::Contract(_) => {
+            format!("{operation} failed for {scoped_path}: invalid path")
+        }
+        _ => format!("{operation} failed for {scoped_path}: filesystem error"),
+    };
+    let kind = filesystem_error(error).kind();
+    CodingCapabilityError::with_safe_summary(kind, summary)
+}
+
+fn safe_summary_path(scoped_path: &str) -> String {
+    let path_hint = scoped_path
+        .trim_start_matches('/')
+        .replace(['/', '\\'], " ");
+    format!("path {path_hint}")
 }
 
 async fn existing_text_for_preview(

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -91,15 +91,33 @@ impl<'a> CodingCapabilityRequest<'a> {
 #[error("coding capability dispatch failed: {kind}")]
 pub struct CodingCapabilityError {
     kind: RuntimeDispatchErrorKind,
+    safe_summary: Option<String>,
 }
 
 impl CodingCapabilityError {
     pub fn new(kind: RuntimeDispatchErrorKind) -> Self {
-        Self { kind }
+        Self {
+            kind,
+            safe_summary: None,
+        }
+    }
+
+    pub fn with_safe_summary(
+        kind: RuntimeDispatchErrorKind,
+        safe_summary: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            safe_summary: Some(bound_safe_summary(safe_summary.into())),
+        }
     }
 
     pub fn kind(&self) -> RuntimeDispatchErrorKind {
         self.kind
+    }
+
+    pub fn safe_summary(&self) -> Option<&str> {
+        self.safe_summary.as_deref()
     }
 }
 
@@ -145,6 +163,22 @@ fn input_error() -> CodingCapabilityError {
 
 fn operation_error() -> CodingCapabilityError {
     CodingCapabilityError::new(RuntimeDispatchErrorKind::OperationFailed)
+}
+
+fn operation_error_with_summary(summary: impl Into<String>) -> CodingCapabilityError {
+    CodingCapabilityError::with_safe_summary(RuntimeDispatchErrorKind::OperationFailed, summary)
+}
+
+fn bound_safe_summary(summary: String) -> String {
+    const MAX_CHARS: usize = 512;
+    let summary = summary.trim();
+    let mut chars = summary.chars();
+    let bounded: String = chars.by_ref().take(MAX_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{bounded}...")
+    } else {
+        bounded
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_first_party_extensions/src/coding/mod.rs
+++ b/crates/ironclaw_first_party_extensions/src/coding/mod.rs
@@ -171,11 +171,14 @@ fn operation_error_with_summary(summary: impl Into<String>) -> CodingCapabilityE
 
 fn bound_safe_summary(summary: String) -> String {
     const MAX_CHARS: usize = 512;
+    const ELLIPSIS: &str = "...";
     let summary = summary.trim();
     let mut chars = summary.chars();
     let bounded: String = chars.by_ref().take(MAX_CHARS).collect();
     if chars.next().is_some() {
-        format!("{bounded}...")
+        let truncated_limit = MAX_CHARS - ELLIPSIS.chars().count();
+        let bounded: String = bounded.chars().take(truncated_limit).collect();
+        format!("{bounded}{ELLIPSIS}")
     } else {
         bounded
     }
@@ -195,5 +198,20 @@ mod tests {
             assert!(!source.contains("ProcessBackendKind"));
             assert!(!source.contains("FilesystemBackendKind"));
         }
+    }
+
+    #[test]
+    fn safe_summary_bound_includes_ellipsis_in_limit() {
+        let summary = super::bound_safe_summary("x".repeat(600));
+
+        assert_eq!(summary.chars().count(), 512);
+        assert!(summary.ends_with("..."));
+    }
+
+    #[test]
+    fn safe_summary_bound_leaves_exact_limit_unchanged() {
+        let input = "x".repeat(512);
+
+        assert_eq!(super::bound_safe_summary(input.clone()), input);
     }
 }

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -246,7 +246,10 @@ pub enum DispatchError {
     #[error("WASM dispatch failed: {kind}")]
     Wasm { kind: RuntimeDispatchErrorKind },
     #[error("first-party dispatch failed: {kind}")]
-    FirstParty { kind: RuntimeDispatchErrorKind },
+    FirstParty {
+        kind: RuntimeDispatchErrorKind,
+        safe_summary: Option<String>,
+    },
 }
 
 impl fmt::Debug for DispatchError {
@@ -310,7 +313,9 @@ impl fmt::Debug for DispatchError {
             Self::Mcp { kind } => f.debug_struct("Mcp").field("kind", kind).finish(),
             Self::Script { kind } => f.debug_struct("Script").field("kind", kind).finish(),
             Self::Wasm { kind } => f.debug_struct("Wasm").field("kind", kind).finish(),
-            Self::FirstParty { kind } => f.debug_struct("FirstParty").field("kind", kind).finish(),
+            Self::FirstParty { kind, .. } => {
+                f.debug_struct("FirstParty").field("kind", kind).finish()
+            }
         }
     }
 }
@@ -340,7 +345,7 @@ impl DispatchError {
             Self::Mcp { kind }
             | Self::Script { kind }
             | Self::Wasm { kind }
-            | Self::FirstParty { kind } => DispatchFailureKind::Runtime(*kind),
+            | Self::FirstParty { kind, .. } => DispatchFailureKind::Runtime(*kind),
         }
     }
 
@@ -359,7 +364,7 @@ impl DispatchError {
             Self::Mcp { kind }
             | Self::Script { kind }
             | Self::Wasm { kind }
-            | Self::FirstParty { kind } => kind.event_kind(),
+            | Self::FirstParty { kind, .. } => kind.event_kind(),
         }
     }
 }

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -122,6 +122,7 @@ pub enum FirstPartyCapabilityError {
     #[error("first-party capability dispatch failed: {kind}")]
     Dispatch {
         kind: RuntimeDispatchErrorKind,
+        safe_summary: Option<String>,
         usage: Option<ResourceUsage>,
     },
     /// Dispatch was blocked because a staged credential is missing or expired.
@@ -139,7 +140,22 @@ pub enum FirstPartyCapabilityError {
 impl FirstPartyCapabilityError {
     /// Construct a dispatch failure with no auth context.
     pub fn new(kind: RuntimeDispatchErrorKind) -> Self {
-        Self::Dispatch { kind, usage: None }
+        Self::Dispatch {
+            kind,
+            safe_summary: None,
+            usage: None,
+        }
+    }
+
+    pub fn with_safe_summary(
+        kind: RuntimeDispatchErrorKind,
+        safe_summary: impl Into<String>,
+    ) -> Self {
+        Self::Dispatch {
+            kind,
+            safe_summary: Some(safe_summary.into()),
+            usage: None,
+        }
     }
 
     /// Construct an auth-required failure with no specific secret handles.
@@ -178,8 +194,11 @@ impl FirstPartyCapabilityError {
     /// Attach resource usage. Builder-style for use in handler return expressions.
     pub fn with_usage(self, usage: ResourceUsage) -> Self {
         match self {
-            Self::Dispatch { kind, .. } => Self::Dispatch {
+            Self::Dispatch {
+                kind, safe_summary, ..
+            } => Self::Dispatch {
                 kind,
+                safe_summary,
                 usage: Some(usage),
             },
             Self::AuthRequired {
@@ -205,6 +224,13 @@ impl FirstPartyCapabilityError {
     pub fn usage(&self) -> Option<&ResourceUsage> {
         match self {
             Self::Dispatch { usage, .. } | Self::AuthRequired { usage, .. } => usage.as_ref(),
+        }
+    }
+
+    pub fn safe_summary(&self) -> Option<&str> {
+        match self {
+            Self::Dispatch { safe_summary, .. } => safe_summary.as_deref(),
+            Self::AuthRequired { .. } => None,
         }
     }
 

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -521,7 +521,10 @@ fn operation_error() -> FirstPartyCapabilityError {
 }
 
 fn coding_error(error: CodingCapabilityError) -> FirstPartyCapabilityError {
-    FirstPartyCapabilityError::new(error.kind())
+    match error.safe_summary() {
+        Some(summary) => FirstPartyCapabilityError::with_safe_summary(error.kind(), summary),
+        None => FirstPartyCapabilityError::new(error.kind()),
+    }
 }
 
 fn coding_capability_metadata(capability_id: &str) -> Option<CodingCapabilityMetadata> {

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -719,13 +719,16 @@ impl RuntimeCapabilityFailure {
 }
 
 fn bounded_runtime_failure_summary(summary: &str) -> String {
+    const ELLIPSIS: &str = "...";
     let mut chars = summary.chars();
     let bounded: String = chars
         .by_ref()
         .take(MAX_RUNTIME_FAILURE_SUMMARY_CHARS)
         .collect();
     if chars.next().is_some() {
-        format!("{bounded}...")
+        let truncated_limit = MAX_RUNTIME_FAILURE_SUMMARY_CHARS - ELLIPSIS.chars().count();
+        let bounded: String = bounded.chars().take(truncated_limit).collect();
+        format!("{bounded}{ELLIPSIS}")
     } else {
         bounded
     }

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -1413,8 +1413,8 @@ fn sanitized_failure_message(error: &CapabilityInvocationError) -> Option<String
         | ResumeStoreMissing { .. }
         | ProcessManagerMissing { .. }
         | ResumeNotBlocked { .. }
-        | ResumeContextMismatch { .. }
-        | Dispatch { .. } => Some(error.to_string()),
+        | ResumeContextMismatch { .. } => Some(error.to_string()),
+        Dispatch { safe_summary, .. } => safe_summary.clone().or_else(|| Some(error.to_string())),
         InvocationFingerprint { .. } => Some("invocation fingerprint failed".to_string()),
         Lease(_) => Some("capability lease store unavailable".to_string()),
         RunState(_) => Some("run-state store unavailable".to_string()),
@@ -1466,7 +1466,7 @@ pub(crate) fn failure_kind_from(error: &CapabilityInvocationError) -> RuntimeFai
         CapabilityInvocationError::Lease(_)
         | CapabilityInvocationError::RunState(_)
         | CapabilityInvocationError::Process(_) => RuntimeFailureKind::Backend,
-        CapabilityInvocationError::Dispatch { kind } => RuntimeFailureKind::from(*kind),
+        CapabilityInvocationError::Dispatch { kind, .. } => RuntimeFailureKind::from(*kind),
     }
 }
 
@@ -1555,7 +1555,10 @@ mod tests {
     }
 
     fn dispatch(kind: DispatchFailureKind) -> CapabilityInvocationError {
-        CapabilityInvocationError::Dispatch { kind }
+        CapabilityInvocationError::Dispatch {
+            kind,
+            safe_summary: None,
+        }
     }
 
     fn auth_requirement(scopes: &[&str]) -> RuntimeCredentialAuthRequirement {
@@ -1831,6 +1834,22 @@ output_schema_ref = "schemas/test.output.json"
         assert!(
             message.contains("NetworkDenied"),
             "sanitized dispatch message should expose the redacted kind, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn sanitized_failure_message_uses_dispatch_safe_summary() {
+        let error = CapabilityInvocationError::Dispatch {
+            kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OperationFailed),
+            safe_summary: Some(
+                "apply_patch failed for path workspace main.rs: old_string matched 0 times"
+                    .to_string(),
+            ),
+        };
+
+        assert_eq!(
+            sanitized_failure_message(&error).as_deref(),
+            Some("apply_patch failed for path workspace main.rs: old_string matched 0 times")
         );
     }
 

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -40,6 +40,7 @@ use ironclaw_run_state::{
     ApprovalRequestStore, RunStateApprovalStore, RunStateError, RunStateStore, RunStatus,
 };
 use ironclaw_trust::{HostTrustPolicy, TrustDecision, TrustError, TrustPolicy, TrustProvenance};
+use ironclaw_turns::run_profile::LoopSafeSummary;
 
 use crate::{
     BuiltinObligationHandler, BuiltinObligationServices, CancelRuntimeWorkOutcome,
@@ -1414,12 +1415,24 @@ fn sanitized_failure_message(error: &CapabilityInvocationError) -> Option<String
         | ProcessManagerMissing { .. }
         | ResumeNotBlocked { .. }
         | ResumeContextMismatch { .. } => Some(error.to_string()),
-        Dispatch { safe_summary, .. } => safe_summary.clone().or_else(|| Some(error.to_string())),
+        Dispatch { safe_summary, .. } => {
+            Some(dispatch_failure_message(safe_summary.as_deref(), error))
+        }
         InvocationFingerprint { .. } => Some("invocation fingerprint failed".to_string()),
         Lease(_) => Some("capability lease store unavailable".to_string()),
         RunState(_) => Some("run-state store unavailable".to_string()),
         Process(_) => Some("process manager unavailable".to_string()),
     }
+}
+
+fn dispatch_failure_message(
+    safe_summary: Option<&str>,
+    error: &CapabilityInvocationError,
+) -> String {
+    safe_summary
+        .and_then(|summary| LoopSafeSummary::new(summary).ok())
+        .map(|summary| summary.to_string())
+        .unwrap_or_else(|| error.to_string())
 }
 
 pub(crate) fn failure_kind_from(error: &CapabilityInvocationError) -> RuntimeFailureKind {
@@ -1854,6 +1867,18 @@ output_schema_ref = "schemas/test.output.json"
     }
 
     #[test]
+    fn sanitized_failure_message_rejects_unsafe_dispatch_safe_summary() {
+        let error = CapabilityInvocationError::Dispatch {
+            kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OperationFailed),
+            safe_summary: Some("read_file failed for path workspace api_key.txt".to_string()),
+        };
+
+        let message = sanitized_failure_message(&error).expect("dispatch produces a message");
+        assert_eq!(message, "dispatch failed: OperationFailed");
+        assert!(!message.contains("api_key"));
+    }
+
+    #[test]
     fn runtime_failure_kind_as_str_is_stable_snake_case() {
         // Pin the public metric/tracing tokens; renaming any of these is a
         // breaking observability contract change.
@@ -1955,7 +1980,7 @@ output_schema_ref = "schemas/test.output.json"
             Some("x".repeat(3000)),
         );
         let summary = long.safe_summary().expect("long message is still safe");
-        assert_eq!(summary.chars().count(), 515);
+        assert_eq!(summary.chars().count(), 512);
         assert!(summary.ends_with("..."));
 
         let multibyte = RuntimeCapabilityFailure::new(
@@ -1966,8 +1991,15 @@ output_schema_ref = "schemas/test.output.json"
         let summary = multibyte
             .safe_summary()
             .expect("long multibyte message is still safe");
-        assert_eq!(summary.chars().count(), 515);
+        assert_eq!(summary.chars().count(), 512);
         assert!(summary.ends_with("..."));
+
+        let exact = RuntimeCapabilityFailure::new(
+            cap(),
+            RuntimeFailureKind::InvalidInput,
+            Some("x".repeat(512)),
+        );
+        assert_eq!(exact.safe_summary(), Some("x".repeat(512)));
     }
 
     #[test]

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -236,6 +236,7 @@ where
             tracing::debug!("first-party runtime adapter missing handler");
             return Err(DispatchError::FirstParty {
                 kind: RuntimeDispatchErrorKind::UndeclaredCapability,
+                safe_summary: None,
             });
         };
 
@@ -250,6 +251,7 @@ where
                 }
                 DispatchError::FirstParty {
                     kind: planner_error_kind(&error),
+                    safe_summary: None,
                 }
             })?;
         tracing::debug!(
@@ -274,7 +276,10 @@ where
                 if let Some(reservation) = &request.resource_reservation {
                     release_first_party_reservation(request.governor, reservation.id);
                 }
-                DispatchError::FirstParty { kind: error.kind() }
+                DispatchError::FirstParty {
+                    kind: error.kind(),
+                    safe_summary: None,
+                }
             })?;
         tracing::debug!("first-party runtime adapter services resolved");
 
@@ -288,6 +293,7 @@ where
                     tracing::debug!("first-party runtime adapter resource reservation failed");
                     DispatchError::FirstParty {
                         kind: RuntimeDispatchErrorKind::Resource,
+                        safe_summary: None,
                     }
                 })?,
         };
@@ -341,9 +347,9 @@ where
                         required_secrets,
                         credential_requirements,
                     }),
-                    FirstPartyCapabilityError::Dispatch { kind, .. } => {
-                        Err(DispatchError::FirstParty { kind })
-                    }
+                    FirstPartyCapabilityError::Dispatch {
+                        kind, safe_summary, ..
+                    } => Err(DispatchError::FirstParty { kind, safe_summary }),
                 };
             }
             Err(_) => {
@@ -354,6 +360,7 @@ where
                 release_first_party_reservation(request.governor, reservation.id);
                 return Err(DispatchError::FirstParty {
                     kind: RuntimeDispatchErrorKind::Backend,
+                    safe_summary: None,
                 });
             }
         };
@@ -368,6 +375,7 @@ where
                 release_first_party_reservation(request.governor, reservation.id);
                 DispatchError::FirstParty {
                     kind: RuntimeDispatchErrorKind::OutputDecode,
+                    safe_summary: None,
                 }
             })?;
         let mut usage = result.usage;
@@ -388,6 +396,7 @@ where
                 }
                 return Err(DispatchError::FirstParty {
                     kind: RuntimeDispatchErrorKind::Resource,
+                    safe_summary: None,
                 });
             }
         };
@@ -679,6 +688,7 @@ where
         release_first_party_reservation(governor, reservation_id);
         return Err(DispatchError::FirstParty {
             kind: RuntimeDispatchErrorKind::Resource,
+            safe_summary: None,
         });
     }
 
@@ -766,7 +776,10 @@ fn dispatch_error_for_runtime(
         RuntimeKind::Mcp => DispatchError::Mcp { kind },
         RuntimeKind::Script => DispatchError::Script { kind },
         RuntimeKind::Wasm => DispatchError::Wasm { kind },
-        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::FirstParty { kind },
+        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::FirstParty {
+            kind,
+            safe_summary: None,
+        },
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -689,7 +689,8 @@ async fn first_party_adapter_releases_reservation_when_invocation_service_resolu
     assert!(matches!(
         result,
         Err(DispatchError::FirstParty {
-            kind: RuntimeDispatchErrorKind::NetworkDenied
+            kind: RuntimeDispatchErrorKind::NetworkDenied,
+            ..
         })
     ));
     assert_eq!(
@@ -756,7 +757,8 @@ async fn first_party_adapter_releases_reservation_when_planner_denies() {
     assert!(matches!(
         result,
         Err(DispatchError::FirstParty {
-            kind: RuntimeDispatchErrorKind::NetworkDenied
+            kind: RuntimeDispatchErrorKind::NetworkDenied,
+            ..
         })
     ));
     assert_eq!(

--- a/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/first_party_runtime_adapter.rs
@@ -287,7 +287,8 @@ async fn first_party_adapter_maps_panicking_handler_to_backend() {
         matches!(
             result,
             Err(DispatchError::FirstParty {
-                kind: RuntimeDispatchErrorKind::Backend
+                kind: RuntimeDispatchErrorKind::Backend,
+                ..
             })
         ),
         "panicking handler must be contained as Backend, got {result:?}"
@@ -471,7 +472,8 @@ async fn first_party_adapter_releases_reservation_when_reconcile_fails_after_suc
         matches!(
             result,
             Err(DispatchError::FirstParty {
-                kind: RuntimeDispatchErrorKind::Resource
+                kind: RuntimeDispatchErrorKind::Resource,
+                ..
             })
         ),
         "reconcile failure must produce FirstParty{{Resource}}, got {result:?}"

--- a/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_coding_tools.rs
@@ -411,6 +411,65 @@ async fn builtin_apply_patch_returns_unified_diff_display_preview() {
 }
 
 #[tokio::test]
+async fn builtin_apply_patch_failure_reports_path_and_match_count() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("main.rs"), "fn main() {\n    old();\n}\n").unwrap();
+
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_write());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    invoke_with_context(
+        &runtime,
+        READ_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/main.rs"}),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    let failure = invoke_failure_with_context(
+        &runtime,
+        APPLY_PATCH_CAPABILITY_ID,
+        json!({
+            "path": "/workspace/main.rs",
+            "old_string": "missing();",
+            "new_string": "new();"
+        }),
+        context,
+    )
+    .await;
+
+    assert_eq!(failure.kind, RuntimeFailureKind::OperationFailed);
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("apply_patch failed for path workspace main.rs: old_string matched 0 times")
+    );
+}
+
+#[tokio::test]
+async fn builtin_read_file_failure_reports_missing_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let (filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
+    let runtime = runtime_with_filesystem(filesystem);
+    let context = execution_context_with_mounts(coding_capability_ids(), mounts);
+
+    let failure = invoke_failure_with_context(
+        &runtime,
+        READ_FILE_CAPABILITY_ID,
+        json!({"path": "/workspace/missing.py"}),
+        context,
+    )
+    .await;
+
+    assert_eq!(failure.kind, RuntimeFailureKind::OperationFailed);
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("read_file failed for path workspace missing.py: file not found")
+    );
+}
+
+#[tokio::test]
 async fn builtin_coding_glob_reports_visited_entry_budget_as_truncated_result() {
     let temp = tempfile::tempdir().unwrap();
     let (_filesystem, mounts) = mounted_filesystem(temp.path(), MountPermissions::read_only());
@@ -485,6 +544,28 @@ async fn invoke_completed_with_context<R: HostRuntime + ?Sized>(
         .unwrap();
     match outcome {
         RuntimeCapabilityOutcome::Completed(completed) => *completed,
+        other => panic!("unexpected capability outcome: {other:?}"),
+    }
+}
+
+async fn invoke_failure_with_context<R: HostRuntime + ?Sized>(
+    runtime: &R,
+    capability: &str,
+    input: Value,
+    context: ExecutionContext,
+) -> ironclaw_host_runtime::RuntimeCapabilityFailure {
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            CapabilityId::new(capability).unwrap(),
+            ResourceEstimate::default(),
+            input,
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => failure,
         other => panic!("unexpected capability outcome: {other:?}"),
     }
 }

--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -2179,6 +2179,22 @@ mod tests {
                     && denied.safe_summary == "policy denied request"
         ));
 
+        let operation_failed = runtime_failure_to_loop(RuntimeCapabilityFailure::new(
+            capability_id.clone(),
+            RuntimeFailureKind::OperationFailed,
+            Some(
+                "apply_patch failed for path workspace main.rs: old_string matched 0 times"
+                    .to_string(),
+            ),
+        ))
+        .expect("convert operation failure");
+        assert!(matches!(
+            operation_failed,
+            CapabilityOutcome::Failed(failure)
+                if failure.error_kind == CapabilityFailureKind::OperationFailed
+                    && failure.safe_summary == "apply_patch failed for path workspace main.rs: old_string matched 0 times"
+        ));
+
         let missing_runtime = runtime_failure_to_loop(RuntimeCapabilityFailure::new(
             capability_id,
             RuntimeFailureKind::MissingRuntime,


### PR DESCRIPTION
## Summary
- carry optional first-party dispatch summaries through host API, capability invocation errors, production runtime failures, and loop conversion
- enrich Reborn first-party read_file and apply_patch failures with model-visible operation and path hints plus match-count detail
- preserve the loop safe-summary contract by using delimiter-free path hints, for example path workspace main.rs
- harden summary bounds so ellipses fit inside the 512-character limit, and validate proposed dispatch summaries with LoopSafeSummary before production surfaces them

## Root Cause
The coding tools collapsed recoverable filesystem and patch-match failures into typed RuntimeDispatchErrorKind values only. By the time the failure reached the loop and model surface, OperationFailed rendered as a generic dispatch or tool failure, so the model could not tell which path failed or whether apply_patch missed the old string.

PR #4392 covers the no-progress and no-final-reply behavior separately. This PR addresses the operation_failed diagnostic side so the agent has enough safe detail to retry, skip, or summarize partial progress.

## Thermo Loop
Ran thermo-loop max 5. Fixed summary-bound and boundary-validation issues found during review; final pass found no actionable thermo-level maintainability blockers.

## Tests
- cargo fmt --check
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_first_party_extensions safe_summary_bound --lib
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_host_runtime sanitized_failure_message --lib
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_host_runtime runtime_failure_summary_is_bounded_and_blank_messages_are_not_safe --lib
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_host_runtime --test first_party_coding_tools failure_reports
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_loop_support runtime_failure_to_loop_honors_model_visible_disposition --lib
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_capabilities dispatch --lib
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_host_api dispatch --lib
- CARGO_BUILD_JOBS=1 cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold