### PR TITLE
Classify MCP upstream auth failures as auth-required

### DIFF
--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -172,8 +172,18 @@ where
                 },
             )
             .await
-            .map_err(|error| DispatchError::Mcp {
-                kind: mcp_error_kind(&error),
+            .map_err(|error| match error {
+                McpError::AuthRequired {
+                    required_secrets,
+                    credential_requirements,
+                } => DispatchError::AuthRequired {
+                    capability: request.capability_id.clone(),
+                    required_secrets,
+                    credential_requirements,
+                },
+                error => DispatchError::Mcp {
+                    kind: mcp_error_kind(&error),
+                },
             })?;
 
         Ok(RuntimeAdapterResult {
@@ -904,6 +914,7 @@ fn mcp_error_kind(error: &McpError) -> RuntimeDispatchErrorKind {
     match error {
         McpError::Resource(_) => RuntimeDispatchErrorKind::Resource,
         McpError::Client { .. } => RuntimeDispatchErrorKind::Client,
+        McpError::AuthRequired { .. } => RuntimeDispatchErrorKind::Client,
         McpError::UnsupportedTransport { .. } => RuntimeDispatchErrorKind::UnsupportedRunner,
         McpError::HostHttpEgressRequired { .. } => RuntimeDispatchErrorKind::NetworkDenied,
         McpError::ExternalStdioTransportUnsupported => RuntimeDispatchErrorKind::UnsupportedRunner,

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -29,15 +29,17 @@ use serde_json::{Value, json};
 use super::{
     CapabilitySurfaceVersion, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
     FirstPartyCapabilityRegistry, FirstPartyRuntimeAdapter, HostRuntimeServices,
-    LocalHostProcessPort, LocalInvocationServicesResolver, NetworkMode, ProcessBackendKind,
-    ProcessResultStore, ProcessStore, ProductionWiringComponent, ProductionWiringConfig,
-    ProductionWiringIssueKind, RootFilesystem, RuntimeAdapter, RuntimeAdapterRequest,
-    RuntimeAdapterResult, RuntimeProfile, SecretMode, ServiceResolvedRuntimeAdapter,
+    LocalHostProcessPort, LocalInvocationServicesResolver, McpRuntimeAdapter, NetworkMode,
+    ProcessBackendKind, ProcessResultStore, ProcessStore, ProductionWiringComponent,
+    ProductionWiringConfig, ProductionWiringIssueKind, RootFilesystem, RuntimeAdapter,
+    RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeProfile, SecretMode,
+    ServiceResolvedRuntimeAdapter,
 };
 use crate::CommandExecutionRequest;
 use crate::obligations::{NetworkObligationPolicyStore, RuntimeSecretInjectionStore};
 
 mod first_party_runtime_adapter;
+mod mcp_runtime_adapter;
 
 #[tokio::test]
 async fn shared_extension_registry_returns_same_instance() {

--- a/crates/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests/mcp_runtime_adapter.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    DispatchError, ExtensionId, ResourceEstimate, RuntimeCredentialAccountProviderId,
+    RuntimeCredentialAuthRequirement, RuntimeKind,
+};
+use ironclaw_mcp::{McpError, McpExecutionRequest, McpExecutionResult, McpExecutor};
+use serde_json::json;
+
+use super::*;
+
+#[tokio::test]
+async fn mcp_adapter_maps_executor_auth_required_to_dispatch_auth_required() {
+    let requirement = RuntimeCredentialAuthRequirement {
+        provider: RuntimeCredentialAccountProviderId::new("github").unwrap(),
+        requester_extension: ExtensionId::new("mcp").unwrap(),
+        provider_scopes: vec!["repo".to_string()],
+    };
+    let adapter = McpRuntimeAdapter::from_executor(Arc::new(AuthRequiredMcpExecutor {
+        requirement: requirement.clone(),
+    }));
+    let descriptor = test_descriptor(RuntimeKind::Mcp, Vec::new());
+    let filesystem = LocalFilesystem::new();
+    let governor = InMemoryResourceGovernor::new();
+    let package = test_package(MCP_MANIFEST, "test");
+    let policy = policy_with(
+        FilesystemBackendKind::HostWorkspace,
+        ProcessBackendKind::LocalHost,
+        NetworkMode::DirectLogged,
+        SecretMode::ScrubbedEnv,
+    );
+
+    let result = adapter
+        .dispatch_json(RuntimeAdapterRequest {
+            package: &package,
+            descriptor: &descriptor,
+            filesystem: &filesystem,
+            governor: &governor,
+            runtime_policy: &policy,
+            capability_id: &descriptor.id,
+            scope: sample_scope(),
+            estimate: ResourceEstimate::default(),
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"query": "auth through adapter"}),
+        })
+        .await;
+
+    match result {
+        Err(DispatchError::AuthRequired {
+            capability,
+            required_secrets,
+            credential_requirements,
+        }) => {
+            assert_eq!(capability, descriptor.id);
+            assert!(required_secrets.is_empty());
+            assert_eq!(credential_requirements, vec![requirement]);
+        }
+        other => panic!("expected AuthRequired, got {other:?}"),
+    }
+}
+
+const MCP_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
+id = "test"
+name = "Test MCP"
+version = "0.1.0"
+description = "MCP adapter test extension"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "https://mcp.example.test/rpc"
+
+[[capabilities]]
+id = "test.capability"
+description = "Search through MCP"
+effects = ["network"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/test-mcp/search.input.v1.json"
+output_schema_ref = "schemas/test-mcp/search.output.v1.json"
+"#;
+
+struct AuthRequiredMcpExecutor {
+    requirement: RuntimeCredentialAuthRequirement,
+}
+
+#[async_trait]
+impl McpExecutor for AuthRequiredMcpExecutor {
+    async fn execute_extension_json(
+        &self,
+        _governor: &dyn ResourceGovernor,
+        _request: McpExecutionRequest<'_>,
+    ) -> Result<McpExecutionResult, McpError> {
+        Err(McpError::AuthRequired {
+            required_secrets: Vec::new(),
+            credential_requirements: vec![self.requirement.clone()],
+        })
+    }
+}

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -3662,6 +3662,7 @@ async fn host_runtime_services_maps_mcp_client_failure_through_private_adapter()
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
+    .with_runtime_http_egress(Arc::new(RecordingRuntimeHttpEgress::new()))
     .with_mcp_runtime(Arc::new(ClientErrorMcpExecutor));
 
     let outcome = services

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -2390,7 +2390,7 @@ async fn mcp_http_client_cannot_use_direct_secret_store_lease_with_production_eg
         .await
         .expect_err("production MCP egress must require staged credentials");
 
-    assert_eq!(error, "request_denied");
+    assert_eq!(error.stable_reason(), "request_denied");
     let requests = network_recorder.lock().unwrap();
     assert_eq!(
         requests.len(),

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -19,9 +19,10 @@ use futures_util::FutureExt as _;
 use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, ResourceEstimate, ResourceReservation,
-    ResourceReservationId, ResourceScope, ResourceUsage, RuntimeCredentialInjection,
+    ResourceReservationId, ResourceScope, ResourceUsage, RuntimeCredentialAuthRequirement,
+    RuntimeCredentialInjection, RuntimeCredentialRequirement, RuntimeCredentialRequirementSource,
     RuntimeCredentialSource, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
-    RuntimeHttpEgressResponse, RuntimeKind,
+    RuntimeHttpEgressResponse, RuntimeKind, SecretHandle,
 };
 use ironclaw_resources::{ResourceError, ResourceGovernor, ResourceReceipt};
 use serde_json::Value;
@@ -83,6 +84,18 @@ pub struct McpClientRequest {
     pub max_output_bytes: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct McpAuthContext {
+    required_secrets: Vec<SecretHandle>,
+    credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+}
+
+#[derive(Debug)]
+struct PreparedMcpClientRequest {
+    request: McpClientRequest,
+    auth_context: McpAuthContext,
+}
+
 /// Raw MCP adapter output before resource reconciliation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct McpClientOutput {
@@ -140,14 +153,43 @@ pub trait McpClient: Send + Sync {
         false
     }
 
-    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String>;
+    async fn call_tool(&self, request: McpClientRequest)
+    -> Result<McpClientOutput, McpClientError>;
 
     async fn discover_tools(
         &self,
         request: McpClientRequest,
-    ) -> Result<McpToolDiscoveryOutput, String> {
+    ) -> Result<McpToolDiscoveryOutput, McpClientError> {
         let _ = request;
-        Err(request_denied())
+        Err(McpClientError::client(request_denied()))
+    }
+}
+
+/// Stable, sanitized MCP client-side failure categories.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpClientError {
+    Client { reason: String },
+    AuthRequired,
+}
+
+impl McpClientError {
+    pub fn client(reason: impl Into<String>) -> Self {
+        Self::Client {
+            reason: reason.into(),
+        }
+    }
+
+    pub fn stable_reason(&self) -> &str {
+        match self {
+            Self::Client { reason } => reason,
+            Self::AuthRequired => "auth_required",
+        }
+    }
+}
+
+impl From<String> for McpClientError {
+    fn from(reason: String) -> Self {
+        Self::client(reason)
     }
 }
 
@@ -439,7 +481,7 @@ where
         id: Option<u64>,
         method: McpJsonRpcMethod,
         params: Option<Value>,
-    ) -> Result<McpJsonRpcExchange, String> {
+    ) -> Result<McpJsonRpcExchange, McpClientError> {
         let planned = self.plan_json_rpc(request, id, method, params)?;
         self.send_planned_json_rpc(request, session_key, planned)
             .await
@@ -451,9 +493,13 @@ where
         id: Option<u64>,
         method: McpJsonRpcMethod,
         params: Option<Value>,
-    ) -> Result<PlannedMcpJsonRpc, String> {
-        let url = request.url.as_deref().ok_or_else(request_denied)?;
-        let body = encode_json_rpc_request(id, method.as_str(), params)?;
+    ) -> Result<PlannedMcpJsonRpc, McpClientError> {
+        let url = request
+            .url
+            .as_deref()
+            .ok_or_else(|| McpClientError::client(request_denied()))?;
+        let body =
+            encode_json_rpc_request(id, method.as_str(), params).map_err(McpClientError::client)?;
         let policy_headers = vec![
             ("Content-Type".to_string(), "application/json".to_string()),
             (
@@ -487,7 +533,7 @@ where
         request: &McpClientRequest,
         session_key: &McpHostHttpSessionKey,
         planned: PlannedMcpJsonRpc,
-    ) -> Result<McpJsonRpcExchange, String> {
+    ) -> Result<McpJsonRpcExchange, McpClientError> {
         let mut headers = planned.policy_headers;
         if let Some(session) = self.current_session(session_key)? {
             headers.push((
@@ -529,9 +575,12 @@ where
         };
 
         if !(200..300).contains(&response.status) {
-            return Err(response_error());
+            if is_mcp_auth_response_status(response.status) {
+                return Err(McpClientError::AuthRequired);
+            }
+            return Err(McpClientError::client(response_error()));
         }
-        let session_id = mcp_session_id_from_response(&response)?;
+        let session_id = mcp_session_id_from_response(&response).map_err(McpClientError::client)?;
 
         if response.status == 202 && planned.id.is_none() {
             return Ok(McpJsonRpcExchange {
@@ -545,7 +594,7 @@ where
         }
 
         Ok(McpJsonRpcExchange {
-            response: parse_mcp_response(&response, planned.id)?,
+            response: parse_mcp_response(&response, planned.id).map_err(McpClientError::client)?,
             session_id,
             usage,
         })
@@ -554,20 +603,24 @@ where
     fn current_session(
         &self,
         session_key: &McpHostHttpSessionKey,
-    ) -> Result<Option<McpHostHttpSession>, String> {
+    ) -> Result<Option<McpHostHttpSession>, McpClientError> {
         self.state
             .sessions
             .lock()
             .map(|guard| guard.get(session_key).cloned())
-            .map_err(|_| request_denied())
+            .map_err(|_| McpClientError::client(request_denied()))
     }
 
     fn store_session(
         &self,
         session_key: &McpHostHttpSessionKey,
         session: McpHostHttpSession,
-    ) -> Result<(), String> {
-        let mut guard = self.state.sessions.lock().map_err(|_| request_denied())?;
+    ) -> Result<(), McpClientError> {
+        let mut guard = self
+            .state
+            .sessions
+            .lock()
+            .map_err(|_| McpClientError::client(request_denied()))?;
         guard.insert(session_key.clone(), session);
         Ok(())
     }
@@ -576,11 +629,15 @@ where
         &self,
         session_key: &McpHostHttpSessionKey,
         session_id: Option<String>,
-    ) -> Result<(), String> {
+    ) -> Result<(), McpClientError> {
         let Some(session_id) = session_id else {
             return Ok(());
         };
-        let mut guard = self.state.sessions.lock().map_err(|_| request_denied())?;
+        let mut guard = self
+            .state
+            .sessions
+            .lock()
+            .map_err(|_| McpClientError::client(request_denied()))?;
         if let Some(session) = guard.get_mut(session_key) {
             session.session_id = Some(session_id);
         }
@@ -591,7 +648,7 @@ where
         &self,
         request: &McpClientRequest,
         session_key: &McpHostHttpSessionKey,
-    ) -> Result<ResourceUsage, String> {
+    ) -> Result<ResourceUsage, McpClientError> {
         let mut usage = ResourceUsage::default();
         let initialize_id = self.next_request_id();
         let initialize = self
@@ -605,13 +662,14 @@ where
             .await?;
         accumulate_usage(&mut usage, initialize.usage);
         if initialize.response.error {
-            return Err(response_error());
+            return Err(McpClientError::client(response_error()));
         }
         self.store_session(
             session_key,
             McpHostHttpSession {
                 session_id: initialize.session_id,
-                protocol_version: protocol_version_from_initialize_response(&initialize.response)?,
+                protocol_version: protocol_version_from_initialize_response(&initialize.response)
+                    .map_err(McpClientError::client)?,
             },
         )?;
 
@@ -627,7 +685,7 @@ where
         accumulate_usage(&mut usage, initialized.usage);
         self.update_session_id(session_key, initialized.session_id.clone())?;
         if initialized.response.error {
-            return Err(response_error());
+            return Err(McpClientError::client(response_error()));
         }
         Ok(usage)
     }
@@ -643,12 +701,18 @@ where
         true
     }
 
-    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String> {
+    async fn call_tool(
+        &self,
+        request: McpClientRequest,
+    ) -> Result<McpClientOutput, McpClientError> {
         if !requires_host_http_egress(&request.transport) {
-            return Err(request_denied());
+            return Err(McpClientError::client(request_denied()));
         }
 
-        let url = request.url.as_deref().ok_or_else(request_denied)?;
+        let url = request
+            .url
+            .as_deref()
+            .ok_or_else(|| McpClientError::client(request_denied()))?;
         let session_key = McpHostHttpSessionKey::new(&request.scope, &request.provider, url);
         let _session_cleanup =
             McpHostHttpSessionCleanup::new(Arc::clone(&self.state), session_key.clone());
@@ -665,7 +729,8 @@ where
             McpJsonRpcMethod::ToolsCall,
             Some(tool_call_params),
         )?;
-        validate_tools_call_credential_injections(&tool_call_plan.plan.credential_injections)?;
+        validate_tools_call_credential_injections(&tool_call_plan.plan.credential_injections)
+            .map_err(McpClientError::client)?;
 
         let mut usage = self.initialize_session(&request, &session_key).await?;
 
@@ -675,12 +740,15 @@ where
         accumulate_usage(&mut usage, call.usage);
         self.update_session_id(&session_key, call.session_id.clone())?;
         if call.response.error {
-            return Err(response_error());
+            return Err(McpClientError::client(response_error()));
         }
-        let output = call.response.result.ok_or_else(response_error)?;
+        let output = call
+            .response
+            .result
+            .ok_or_else(|| McpClientError::client(response_error()))?;
         let output_bytes = serde_json::to_vec(&output)
             .map(|bytes| bytes.len() as u64)
-            .map_err(|_| response_error())?;
+            .map_err(|_| McpClientError::client(response_error()))?;
         usage.output_bytes = usage.output_bytes.max(output_bytes);
 
         Ok(McpClientOutput {
@@ -693,12 +761,15 @@ where
     async fn discover_tools(
         &self,
         request: McpClientRequest,
-    ) -> Result<McpToolDiscoveryOutput, String> {
+    ) -> Result<McpToolDiscoveryOutput, McpClientError> {
         if !requires_host_http_egress(&request.transport) {
-            return Err(request_denied());
+            return Err(McpClientError::client(request_denied()));
         }
 
-        let url = request.url.as_deref().ok_or_else(request_denied)?;
+        let url = request
+            .url
+            .as_deref()
+            .ok_or_else(|| McpClientError::client(request_denied()))?;
         let session_key = McpHostHttpSessionKey::new(&request.scope, &request.provider, url);
         let _session_cleanup =
             McpHostHttpSessionCleanup::new(Arc::clone(&self.state), session_key.clone());
@@ -710,7 +781,8 @@ where
             McpJsonRpcMethod::ToolsList,
             None,
         )?;
-        validate_staged_credential_injections(&tools_list_plan.plan.credential_injections)?;
+        validate_staged_credential_injections(&tools_list_plan.plan.credential_injections)
+            .map_err(McpClientError::client)?;
 
         let mut usage = self.initialize_session(&request, &session_key).await?;
         let tools = self
@@ -719,11 +791,14 @@ where
         accumulate_usage(&mut usage, tools.usage);
         self.update_session_id(&session_key, tools.session_id.clone())?;
         if tools.response.error {
-            return Err(response_error());
+            return Err(McpClientError::client(response_error()));
         }
-        let result = tools.response.result.ok_or_else(response_error)?;
+        let result = tools
+            .response
+            .result
+            .ok_or_else(|| McpClientError::client(response_error()))?;
         Ok(McpToolDiscoveryOutput {
-            tools: parse_tools_list_result(&result)?,
+            tools: parse_tools_list_result(&result).map_err(McpClientError::client)?,
             usage,
         })
     }
@@ -804,10 +879,14 @@ fn validate_staged_credential_injections(
     Ok(())
 }
 
-fn mcp_client_http_error(error: McpHostHttpError) -> String {
+fn mcp_client_http_error(error: McpHostHttpError) -> McpClientError {
     match error {
-        McpHostHttpError::Egress { reason } => reason,
+        McpHostHttpError::Egress { reason } => McpClientError::client(reason),
     }
+}
+
+fn is_mcp_auth_response_status(status: u16) -> bool {
+    matches!(status, 401 | 403)
 }
 
 fn effective_mcp_response_body_limit(host_limit: Option<u64>, client_limit: u64) -> Option<u64> {
@@ -1161,6 +1240,11 @@ pub enum McpError {
     Resource(Box<ResourceError>),
     #[error("MCP client error: {reason}")]
     Client { reason: String },
+    #[error("MCP capability requires authentication")]
+    AuthRequired {
+        required_secrets: Vec<SecretHandle>,
+        credential_requirements: Vec<RuntimeCredentialAuthRequirement>,
+    },
     #[error("unsupported MCP transport {transport}")]
     UnsupportedTransport { transport: String },
     #[error("MCP transport {transport} requires host-mediated HTTP egress")]
@@ -1216,6 +1300,8 @@ where
         G: ResourceGovernor + ?Sized,
     {
         let client_request = self.prepare_client_request(&request)?;
+        let auth_context = client_request.auth_context;
+        let client_request = client_request.request;
         let transport = client_request.transport.clone();
         if requires_host_http_egress(&transport) && !self.client.uses_host_mediated_http_egress() {
             return Err(McpError::HostHttpEgressRequired { transport });
@@ -1229,11 +1315,11 @@ where
 
         let output = match self.client.call_tool(client_request).await {
             Ok(output) => output,
-            Err(reason) => {
+            Err(error) => {
                 return Err(release_after_failure(
                     governor,
                     reservation.id,
-                    McpError::Client { reason },
+                    mcp_error_from_client_error(error, auth_context),
                 ));
             }
         };
@@ -1284,7 +1370,7 @@ where
     fn prepare_client_request(
         &self,
         request: &McpExecutionRequest<'_>,
-    ) -> Result<McpClientRequest, McpError> {
+    ) -> Result<PreparedMcpClientRequest, McpError> {
         let descriptor = request
             .package
             .capabilities
@@ -1339,17 +1425,58 @@ where
             });
         }
 
-        Ok(McpClientRequest {
-            provider: request.package.id.clone(),
-            capability_id: request.capability_id.clone(),
-            scope: request.scope.clone(),
-            transport: transport.clone(),
-            command: command.clone(),
-            args: args.clone(),
-            url: url.clone(),
-            input: request.invocation.input.clone(),
-            max_output_bytes: self.config.max_output_bytes,
+        let auth_context = mcp_auth_context(&descriptor.provider, &descriptor.runtime_credentials);
+
+        Ok(PreparedMcpClientRequest {
+            request: McpClientRequest {
+                provider: request.package.id.clone(),
+                capability_id: request.capability_id.clone(),
+                scope: request.scope.clone(),
+                transport: transport.clone(),
+                command: command.clone(),
+                args: args.clone(),
+                url: url.clone(),
+                input: request.invocation.input.clone(),
+                max_output_bytes: self.config.max_output_bytes,
+            },
+            auth_context,
         })
+    }
+}
+
+fn mcp_error_from_client_error(error: McpClientError, auth_context: McpAuthContext) -> McpError {
+    match error {
+        McpClientError::Client { reason } => McpError::Client { reason },
+        McpClientError::AuthRequired => McpError::AuthRequired {
+            required_secrets: auth_context.required_secrets,
+            credential_requirements: auth_context.credential_requirements,
+        },
+    }
+}
+
+fn mcp_auth_context(
+    requester_extension: &ExtensionId,
+    credentials: &[RuntimeCredentialRequirement],
+) -> McpAuthContext {
+    let mut required_secrets = Vec::new();
+    let mut credential_requirements = Vec::new();
+    for credential in credentials.iter().filter(|credential| credential.required) {
+        match &credential.source {
+            RuntimeCredentialRequirementSource::SecretHandle => {
+                required_secrets.push(credential.handle.clone());
+            }
+            RuntimeCredentialRequirementSource::ProductAuthAccount { provider, .. } => {
+                credential_requirements.push(RuntimeCredentialAuthRequirement {
+                    provider: provider.clone(),
+                    requester_extension: requester_extension.clone(),
+                    provider_scopes: credential.provider_scopes.clone(),
+                });
+            }
+        }
+    }
+    McpAuthContext {
+        required_secrets,
+        credential_requirements,
     }
 }
 

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -288,6 +288,35 @@ async fn concrete_mcp_http_client_routes_json_rpc_through_shared_egress() {
 }
 
 #[tokio::test]
+async fn concrete_mcp_http_client_maps_upstream_auth_status_to_auth_required() {
+    let egress = RecordingRuntimeEgress::auth_required();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let error = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("upstream MCP auth failures must become auth-required errors");
+
+    assert!(matches!(error, McpClientError::AuthRequired));
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(json_rpc_method(&requests[0].body), "initialize");
+}
+
+#[tokio::test]
 async fn concrete_mcp_http_client_uses_negotiated_protocol_version_header() {
     let egress = RecordingRuntimeEgress::json_rpc_with_protocol_version("2025-03-26");
     let client = McpHostHttpClient::new(
@@ -386,7 +415,7 @@ async fn concrete_mcp_http_client_rejects_missing_or_unsafe_initialize_protocol_
             .await
             .expect_err("unsafe initialize protocol versions must fail the call");
 
-        assert_eq!(error, "response_error");
+        assert_eq!(error.stable_reason(), "response_error");
     }
 }
 
@@ -426,7 +455,7 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
         .await
         .expect_err("direct secret-store leases must fail before MCP transport");
 
-    assert_eq!(error, "request_denied");
+    assert_eq!(error.stable_reason(), "request_denied");
     assert!(
         egress.requests().is_empty(),
         "direct leases must be rejected before initialize or tools/call transport"
@@ -577,7 +606,7 @@ async fn concrete_mcp_http_client_does_not_reuse_session_from_failed_initialize(
         })
         .await
         .expect_err("failed initialize responses must fail the call");
-    assert_eq!(error, "response_error");
+    assert_eq!(error.stable_reason(), "response_error");
 
     client
         .call_tool(McpClientRequest {
@@ -629,7 +658,7 @@ async fn concrete_mcp_http_client_rejects_json_rpc_response_without_matching_id(
         .await
         .expect_err("ID-bearing JSON-RPC requests must reject missing response ids");
 
-    assert_eq!(error, "response_error");
+    assert_eq!(error.stable_reason(), "response_error");
 }
 
 #[tokio::test]
@@ -775,6 +804,31 @@ async fn concrete_mcp_http_client_discovers_tool_schemas_through_shared_egress()
 }
 
 #[tokio::test]
+async fn concrete_mcp_http_client_maps_discovery_auth_status_to_auth_required() {
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(RecordingRuntimeEgress::auth_required())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let error = client
+        .discover_tools(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("upstream MCP discovery auth failures must stay typed");
+
+    assert!(matches!(error, McpClientError::AuthRequired));
+}
+
+#[tokio::test]
 async fn concrete_mcp_http_client_caps_missing_plan_limit_to_client_output_limit() {
     let mut plan = host_http_plan();
     plan.response_body_limit = None;
@@ -829,7 +883,7 @@ async fn concrete_mcp_http_client_rejects_invalid_session_id_before_reuse() {
         .await
         .expect_err("invalid upstream session ids must not be reused as request headers");
 
-    assert_eq!(error, "response_error");
+    assert_eq!(error.stable_reason(), "response_error");
 }
 
 #[tokio::test]
@@ -854,9 +908,9 @@ async fn concrete_mcp_http_client_sanitizes_shared_egress_failures() {
         .await
         .expect_err("raw shared-egress errors must not leak through the MCP client");
 
-    assert_eq!(error, "network_error");
-    assert!(!error.contains("sk-test-secret"));
-    assert!(!error.contains("10.0.0.7"));
+    assert_eq!(error.stable_reason(), "network_error");
+    assert!(!format!("{error:?}").contains("sk-test-secret"));
+    assert!(!format!("{error:?}").contains("10.0.0.7"));
 }
 
 #[tokio::test]
@@ -929,7 +983,7 @@ async fn mcp_runtime_denies_budget_before_adapter_call() {
 #[tokio::test]
 async fn mcp_runtime_releases_reservation_when_adapter_fails() {
     let package = package_from_manifest(MCP_MANIFEST);
-    let client = RecordingMcpClient::new(Err("server disconnected".to_string()));
+    let client = RecordingMcpClient::new(Err(McpClientError::client("server disconnected")));
     let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client.clone());
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
@@ -962,7 +1016,7 @@ async fn mcp_runtime_releases_reservation_when_adapter_fails() {
 #[tokio::test]
 async fn mcp_runtime_preserves_adapter_error_when_release_cleanup_fails() {
     let package = package_from_manifest(MCP_MANIFEST);
-    let client = RecordingMcpClient::new(Err("server disconnected".to_string()));
+    let client = RecordingMcpClient::new(Err(McpClientError::client("server disconnected")));
     let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client);
     let governor = ReleaseFailingGovernor::new();
 
@@ -1185,13 +1239,13 @@ async fn mcp_runtime_rejects_output_when_adapter_under_reports_size() {
 
 #[derive(Clone)]
 struct RecordingMcpClient {
-    output: Result<McpClientOutput, String>,
+    output: Result<McpClientOutput, McpClientError>,
     requests: Arc<Mutex<Vec<McpClientRequest>>>,
     host_mediated_http: bool,
 }
 
 impl RecordingMcpClient {
-    fn new(output: Result<McpClientOutput, String>) -> Self {
+    fn new(output: Result<McpClientOutput, McpClientError>) -> Self {
         Self {
             output,
             requests: Arc::new(Mutex::new(Vec::new())),
@@ -1199,7 +1253,7 @@ impl RecordingMcpClient {
         }
     }
 
-    fn direct_network(output: Result<McpClientOutput, String>) -> Self {
+    fn direct_network(output: Result<McpClientOutput, McpClientError>) -> Self {
         Self {
             output,
             requests: Arc::new(Mutex::new(Vec::new())),
@@ -1214,7 +1268,10 @@ impl McpClient for RecordingMcpClient {
         self.host_mediated_http
     }
 
-    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String> {
+    async fn call_tool(
+        &self,
+        request: McpClientRequest,
+    ) -> Result<McpClientOutput, McpClientError> {
         self.requests.lock().unwrap().push(request);
         self.output.clone()
     }
@@ -1223,6 +1280,7 @@ impl McpClient for RecordingMcpClient {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RecordedResponseMode {
     Json,
+    AuthRequired,
     JsonMissingProtocolVersion,
     Sse,
 }
@@ -1243,6 +1301,14 @@ impl RecordingRuntimeEgress {
         Self {
             mode: RecordedResponseMode::Json,
             protocol_version,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn auth_required() -> Self {
+        Self {
+            mode: RecordedResponseMode::AuthRequired,
+            protocol_version: "2025-06-18",
             requests: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -1276,6 +1342,17 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         let method = json_rpc_method(&request.body);
         self.requests.lock().unwrap().push(request.clone());
+        if self.mode == RecordedResponseMode::AuthRequired {
+            return Ok(RuntimeHttpEgressResponse {
+                status: 401,
+                headers: vec![],
+                body: br#"{"error":"unauthorized"}"#.to_vec(),
+                saved_body: None,
+                request_bytes: request.body.len() as u64,
+                response_bytes: 24,
+                redaction_applied: false,
+            });
+        }
         match method.as_str() {
             "initialize" => {
                 let mut result = json!({
@@ -1319,6 +1396,9 @@ impl RuntimeHttpEgress for RecordingRuntimeEgress {
                         id,
                         json!({"content":[{"type":"text","text":"ok from sse"}],"isError":false}),
                     )),
+                    RecordedResponseMode::AuthRequired => {
+                        unreachable!("auth-required mode returns before JSON-RPC method dispatch")
+                    }
                 }
             }
             "tools/list" => Ok(runtime_json_response(

--- a/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -49,7 +49,9 @@ async fn mcp_lane_executes_manifest_transport_and_reconciles_resources() {
 
 #[tokio::test]
 async fn mcp_lane_client_failure_releases_reservation() {
-    let client = RecordingMcpClient::new(Err("server disconnected with raw stderr".to_string()));
+    let client = RecordingMcpClient::new(Err(McpClientError::client(
+        "server disconnected with raw stderr",
+    )));
     let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client);
     let (governor, account) = mcp_governor();
 
@@ -59,6 +61,46 @@ async fn mcp_lane_client_failure_releases_reservation() {
         .unwrap_err();
 
     assert!(matches!(err, McpError::Client { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn mcp_lane_auth_failure_returns_manifest_credential_context_and_releases_reservation() {
+    let client = RecordingMcpClient::new(Err(McpClientError::AuthRequired));
+    let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client);
+    let (governor, account) = mcp_governor();
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            mcp_request_from_manifest(MCP_PRODUCT_AUTH_MANIFEST, json!({"query":"auth"})),
+        )
+        .await
+        .unwrap_err();
+
+    match err {
+        McpError::AuthRequired {
+            required_secrets,
+            credential_requirements,
+        } => {
+            assert!(required_secrets.is_empty());
+            assert_eq!(credential_requirements.len(), 1);
+            assert_eq!(
+                credential_requirements[0].provider,
+                RuntimeCredentialAccountProviderId::new("github").unwrap()
+            );
+            assert_eq!(
+                credential_requirements[0].requester_extension,
+                ExtensionId::new("github-mcp").unwrap()
+            );
+            assert_eq!(
+                credential_requirements[0].provider_scopes,
+                vec!["repo".to_string()]
+            );
+        }
+        other => panic!("expected auth-required MCP error, got {other:?}"),
+    }
     assert_eq!(governor.reserved_for(&account), ResourceTally::default());
     assert_eq!(governor.usage_for(&account), ResourceTally::default());
 }
@@ -90,12 +132,12 @@ async fn mcp_lane_output_limit_releases_reservation() {
 
 #[derive(Clone)]
 struct RecordingMcpClient {
-    output: Result<McpClientOutput, String>,
+    output: Result<McpClientOutput, McpClientError>,
     requests: Arc<Mutex<Vec<McpClientRequest>>>,
 }
 
 impl RecordingMcpClient {
-    fn new(output: Result<McpClientOutput, String>) -> Self {
+    fn new(output: Result<McpClientOutput, McpClientError>) -> Self {
         Self {
             output,
             requests: Arc::new(Mutex::new(Vec::new())),
@@ -113,7 +155,10 @@ impl McpClient for RecordingMcpClient {
         true
     }
 
-    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String> {
+    async fn call_tool(
+        &self,
+        request: McpClientRequest,
+    ) -> Result<McpClientOutput, McpClientError> {
         self.requests.lock().unwrap().push(request);
         self.output.clone()
     }
@@ -162,7 +207,14 @@ fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGove
 }
 
 fn mcp_request(input: serde_json::Value) -> McpExecutionRequest<'static> {
-    let package = Box::leak(Box::new(package_from_manifest(MCP_MANIFEST)));
+    mcp_request_from_manifest(MCP_MANIFEST, input)
+}
+
+fn mcp_request_from_manifest(
+    manifest: &'static str,
+    input: serde_json::Value,
+) -> McpExecutionRequest<'static> {
+    let package = Box::leak(Box::new(package_from_manifest(manifest)));
     let capability_id = Box::leak(Box::new(CapabilityId::new("github-mcp.search").unwrap()));
     McpExecutionRequest {
         package,
@@ -217,6 +269,37 @@ section = "capability_provider.tools"
 id = "github-mcp.search"
 description = "Search GitHub"
 effects = ["network", "dispatch_capability"]
+default_permission = "ask"
+visibility = "api"
+input_schema_ref = "schemas/github-mcp/search.input.v1.json"
+output_schema_ref = "schemas/github-mcp/search.output.v1.json"
+"#;
+
+const MCP_PRODUCT_AUTH_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
+id = "github-mcp"
+name = "GitHub MCP"
+version = "0.1.0"
+description = "GitHub MCP adapter"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "http"
+url = "https://mcp.example.test/rpc"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "github-mcp.search"
+description = "Search GitHub"
+effects = ["network", "dispatch_capability", "use_secret"]
+runtime_credentials = [
+  { handle = "github_runtime_token", source = { type = "product_auth_account", provider = "github" }, provider_scopes = ["repo"], audience = { scheme = "https", host_pattern = "api.github.com" }, target = { type = "header", name = "authorization", prefix = "Bearer " } },
+]
 default_permission = "ask"
 visibility = "api"
 input_schema_ref = "schemas/github-mcp/search.input.v1.json"

--- a/crates/ironclaw_reborn_composition/src/mcp_discovery.rs
+++ b/crates/ironclaw_reborn_composition/src/mcp_discovery.rs
@@ -76,7 +76,7 @@ pub(crate) async fn discover_hosted_mcp_package(
             max_output_bytes: MCP_RESPONSE_BODY_LIMIT,
         })
         .await
-        .map_err(HostedMcpDiscoveryError::Transient)?;
+        .map_err(|error| HostedMcpDiscoveryError::Transient(error.stable_reason().to_string()))?;
     if output.tools.is_empty() {
         return Err(HostedMcpDiscoveryError::Transient(format!(
             "hosted MCP provider {} returned no discoverable tools",


### PR DESCRIPTION
## Summary
- classify hosted MCP upstream 401/403 responses as typed MCP auth-required failures instead of opaque client/backend errors
- project manifest runtime credential requirements into the auth-required context so product auth recovery can prompt for the right provider/scopes
- map MCP auth-required errors through host-runtime dispatch as `AuthRequired` outcomes

## Root Cause
The Notion MCP call reached the MCP HTTP client, but the upstream auth failure was collapsed into a generic MCP client/backend dispatch failure. That bypassed the existing auth gate path, so the user saw an opaque backend/client error instead of being prompted to reconnect Notion.

## Verification
- `cargo test -p ironclaw_mcp`
- `cargo test -p ironclaw_host_runtime host_runtime_services_maps_mcp_ --test host_runtime_services_contract`
- `cargo test -p ironclaw_host_runtime --no-run`
- `cargo fmt --check`
- `git diff --check`