### PR TITLE
Fix GSuite OAuth setup and activation 503s

### DIFF
--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -93,6 +93,7 @@ mod builder;
 mod production_services;
 mod production_wiring;
 mod runtime_adapters;
+mod wasm_diagnostics;
 
 use production_wiring::{
     ProductionComponentType, ProductionComponentTypes, ProductionImplementationReadiness,

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use futures_util::FutureExt;
 use serde::Deserialize;
 
+use super::wasm_diagnostics::{log_wasm_guest_error, log_wasm_runtime_error};
 use super::{
     CapabilityId, DenyWasmHostHttp, DispatchError, ExtensionRuntime, FirstPartyCapabilityRegistry,
     FirstPartyCapabilityRequest, InvocationServicesResolutionRequest, InvocationServicesResolver,
@@ -780,69 +781,6 @@ fn wasm_guest_dispatch_error(error: &str, capability: &CapabilityId) -> Dispatch
             credential_requirements: Vec::new(),
         },
         WasmGuestErrorKind::Runtime(kind) => DispatchError::Wasm { kind },
-    }
-}
-
-fn log_wasm_runtime_error(capability_id: &CapabilityId, error: &WasmError) {
-    if let WasmError::ExecutionFailed { message, logs, .. } = error {
-        log_wasm_guest_logs(capability_id, logs);
-        tracing::debug!(
-            capability_id = %capability_id,
-            wasm_error = %message,
-            "WASM runtime execution failed with raw guest error"
-        );
-        return;
-    }
-
-    tracing::debug!(
-        capability_id = %capability_id,
-        wasm_error = %error,
-        "WASM runtime execution failed"
-    );
-}
-
-fn log_wasm_guest_error(
-    capability_id: &CapabilityId,
-    logs: &[ironclaw_wasm::WasmLogRecord],
-    error: &str,
-) {
-    log_wasm_guest_logs(capability_id, logs);
-    tracing::debug!(
-        capability_id = %capability_id,
-        wasm_error = %error,
-        "WASM guest returned raw capability error"
-    );
-}
-
-fn log_wasm_guest_logs(capability_id: &CapabilityId, logs: &[ironclaw_wasm::WasmLogRecord]) {
-    for log in logs {
-        match log.level {
-            ironclaw_wasm::WasmLogLevel::Trace => tracing::trace!(
-                capability_id = %capability_id,
-                wasm_log = %log.message,
-                "WASM guest log"
-            ),
-            ironclaw_wasm::WasmLogLevel::Debug => tracing::debug!(
-                capability_id = %capability_id,
-                wasm_log = %log.message,
-                "WASM guest log"
-            ),
-            ironclaw_wasm::WasmLogLevel::Info => tracing::info!(
-                capability_id = %capability_id,
-                wasm_log = %log.message,
-                "WASM guest log"
-            ),
-            ironclaw_wasm::WasmLogLevel::Warn => tracing::warn!(
-                capability_id = %capability_id,
-                wasm_log = %log.message,
-                "WASM guest log"
-            ),
-            ironclaw_wasm::WasmLogLevel::Error => tracing::error!(
-                capability_id = %capability_id,
-                wasm_log = %log.message,
-                "WASM guest log"
-            ),
-        }
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
+++ b/crates/ironclaw_host_runtime/src/services/runtime_adapters.rs
@@ -589,6 +589,7 @@ where
     ) {
         Ok(execution) => execution,
         Err(error) => {
+            log_wasm_runtime_error(request.capability_id, &error);
             if let Some(usage) = preserved_wasm_error_usage(&error) {
                 account_or_release_failed_wasm_execution(request.governor, reservation.id, &usage)?;
             } else {
@@ -600,6 +601,7 @@ where
         }
     };
     if let Some(error) = execution.error {
+        log_wasm_guest_error(request.capability_id, &execution.logs, &error);
         account_or_release_failed_wasm_execution(
             request.governor,
             reservation.id,
@@ -778,6 +780,69 @@ fn wasm_guest_dispatch_error(error: &str, capability: &CapabilityId) -> Dispatch
             credential_requirements: Vec::new(),
         },
         WasmGuestErrorKind::Runtime(kind) => DispatchError::Wasm { kind },
+    }
+}
+
+fn log_wasm_runtime_error(capability_id: &CapabilityId, error: &WasmError) {
+    if let WasmError::ExecutionFailed { message, logs, .. } = error {
+        log_wasm_guest_logs(capability_id, logs);
+        tracing::debug!(
+            capability_id = %capability_id,
+            wasm_error = %message,
+            "WASM runtime execution failed with raw guest error"
+        );
+        return;
+    }
+
+    tracing::debug!(
+        capability_id = %capability_id,
+        wasm_error = %error,
+        "WASM runtime execution failed"
+    );
+}
+
+fn log_wasm_guest_error(
+    capability_id: &CapabilityId,
+    logs: &[ironclaw_wasm::WasmLogRecord],
+    error: &str,
+) {
+    log_wasm_guest_logs(capability_id, logs);
+    tracing::debug!(
+        capability_id = %capability_id,
+        wasm_error = %error,
+        "WASM guest returned raw capability error"
+    );
+}
+
+fn log_wasm_guest_logs(capability_id: &CapabilityId, logs: &[ironclaw_wasm::WasmLogRecord]) {
+    for log in logs {
+        match log.level {
+            ironclaw_wasm::WasmLogLevel::Trace => tracing::trace!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            ironclaw_wasm::WasmLogLevel::Debug => tracing::debug!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            ironclaw_wasm::WasmLogLevel::Info => tracing::info!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            ironclaw_wasm::WasmLogLevel::Warn => tracing::warn!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            ironclaw_wasm::WasmLogLevel::Error => tracing::error!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+        }
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services/wasm_diagnostics.rs
+++ b/crates/ironclaw_host_runtime/src/services/wasm_diagnostics.rs
@@ -1,0 +1,65 @@
+use ironclaw_host_api::CapabilityId;
+use ironclaw_wasm::{WasmError, WasmLogLevel, WasmLogRecord};
+
+pub(super) fn log_wasm_runtime_error(capability_id: &CapabilityId, error: &WasmError) {
+    if let WasmError::ExecutionFailed { message, logs, .. } = error {
+        log_wasm_guest_logs(capability_id, logs);
+        tracing::debug!(
+            capability_id = %capability_id,
+            wasm_error = %message,
+            "WASM runtime execution failed with raw guest error"
+        );
+        return;
+    }
+
+    tracing::debug!(
+        capability_id = %capability_id,
+        wasm_error = %error,
+        "WASM runtime execution failed"
+    );
+}
+
+pub(super) fn log_wasm_guest_error(
+    capability_id: &CapabilityId,
+    logs: &[WasmLogRecord],
+    error: &str,
+) {
+    log_wasm_guest_logs(capability_id, logs);
+    tracing::debug!(
+        capability_id = %capability_id,
+        wasm_error = %error,
+        "WASM guest returned raw capability error"
+    );
+}
+
+fn log_wasm_guest_logs(capability_id: &CapabilityId, logs: &[WasmLogRecord]) {
+    for log in logs {
+        match log.level {
+            WasmLogLevel::Trace => tracing::trace!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            WasmLogLevel::Debug => tracing::debug!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            WasmLogLevel::Info => tracing::info!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            WasmLogLevel::Warn => tracing::warn!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+            WasmLogLevel::Error => tracing::error!(
+                capability_id = %capability_id,
+                wasm_log = %log.message,
+                "WASM guest log"
+            ),
+        }
+    }
+}

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 
 use ironclaw_auth::{
-    AuthProductScope, AuthProviderId, CredentialAccountUpdateBinding, ProviderScope,
+    AuthProductScope, AuthProviderId, CredentialAccountProjection, CredentialAccountUpdateBinding,
+    ProviderScope,
 };
 use ironclaw_host_api::ExtensionId;
 use secrecy::SecretString;
@@ -10,8 +11,8 @@ use serde::Deserialize;
 use crate::{
     LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
     LifecycleProductPayload, LifecycleProductResponse, RebornExtensionCredentialSetup,
-    RebornExtensionSetupSecret, RebornServicesError, WebUiInboundValidationCode,
-    WebUiSetupExtensionRequest,
+    RebornExtensionSetupSecret, RebornServicesError, RebornServicesErrorCode,
+    RebornServicesErrorKind, WebUiInboundValidationCode, WebUiSetupExtensionRequest,
 };
 
 use super::{
@@ -53,14 +54,18 @@ pub(super) async fn project(
         let provider_scopes = provider_scopes_for_requirement(requirement)?;
         let account = match extension_credentials {
             Some(service) => {
-                service
-                    .credential_status(ExtensionCredentialStatusRequest {
+                credential_status_for_setup(
+                    service,
+                    ExtensionCredentialStatusRequest {
                         scope: scope.clone(),
                         provider,
                         provider_scopes,
                         requester_extension: extension_id.clone(),
-                    })
-                    .await?
+                    },
+                    extension_id,
+                    requirement,
+                )
+                .await?
             }
             None => None,
         };
@@ -75,6 +80,38 @@ pub(super) async fn project(
         });
     }
     Ok(secrets)
+}
+
+async fn credential_status_for_setup(
+    service: &dyn ExtensionCredentialSetupService,
+    request: ExtensionCredentialStatusRequest,
+    extension_id: &ExtensionId,
+    requirement: &LifecycleExtensionCredentialRequirement,
+) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
+    match service.credential_status(request).await {
+        Ok(account) => Ok(account),
+        Err(error) if is_retryable_setup_status_failure(&error) => {
+            tracing::warn!(
+                target: "ironclaw::reborn::extension_setup",
+                extension_id = %extension_id.as_str(),
+                provider = %requirement.provider,
+                requirement = %requirement.name,
+                code = ?error.code,
+                kind = ?error.kind,
+                status_code = error.status_code,
+                retryable = error.retryable,
+                "credential status unavailable during extension setup projection; treating credential as unconfigured"
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn is_retryable_setup_status_failure(error: &RebornServicesError) -> bool {
+    error.retryable
+        && (error.code == RebornServicesErrorCode::Unavailable
+            || error.kind == RebornServicesErrorKind::ServiceUnavailable)
 }
 
 pub(super) async fn submit_manual_tokens(
@@ -237,4 +274,146 @@ fn credential_label(
 struct SetupSubmitPayload {
     #[serde(default)]
     secrets: BTreeMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use ironclaw_auth::{AuthSurface, CredentialAccountId};
+    use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn project_treats_retryable_unavailable_credential_status_as_unconfigured() {
+        let service = FailingCredentialSetupService {
+            error: RebornServicesError {
+                code: RebornServicesErrorCode::Unavailable,
+                kind: RebornServicesErrorKind::ServiceUnavailable,
+                status_code: 503,
+                retryable: true,
+                field: None,
+                validation_code: None,
+            },
+        };
+        let extension_id = ExtensionId::new("google-docs").expect("extension id");
+
+        let secrets = project(
+            Some(&service),
+            test_scope(),
+            &extension_id,
+            &[oauth_requirement()],
+        )
+        .await
+        .expect("setup projection should render when credential status is unavailable");
+
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].name, "google_oauth");
+        assert_eq!(secrets[0].provider, "google");
+        assert!(!secrets[0].provided);
+        assert!(secrets[0].credential_ref.is_none());
+        assert!(matches!(
+            secrets[0].setup,
+            RebornExtensionCredentialSetup::OAuth { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn project_preserves_non_status_credential_errors() {
+        let service = FailingCredentialSetupService {
+            error: RebornServicesError {
+                code: RebornServicesErrorCode::InvalidRequest,
+                kind: RebornServicesErrorKind::Validation,
+                status_code: 400,
+                retryable: false,
+                field: Some("provider".to_string()),
+                validation_code: Some(WebUiInboundValidationCode::InvalidValue),
+            },
+        };
+        let extension_id = ExtensionId::new("google-docs").expect("extension id");
+
+        let error = project(
+            Some(&service),
+            test_scope(),
+            &extension_id,
+            &[oauth_requirement()],
+        )
+        .await
+        .expect_err("validation errors should not be hidden by setup projection");
+
+        assert_eq!(error.code, RebornServicesErrorCode::InvalidRequest);
+        assert_eq!(error.kind, RebornServicesErrorKind::Validation);
+        assert_eq!(error.field.as_deref(), Some("provider"));
+    }
+
+    #[tokio::test]
+    async fn project_preserves_non_retryable_unavailable_credential_errors() {
+        let service = FailingCredentialSetupService {
+            error: RebornServicesError {
+                code: RebornServicesErrorCode::Unavailable,
+                kind: RebornServicesErrorKind::ServiceUnavailable,
+                status_code: 503,
+                retryable: false,
+                field: None,
+                validation_code: None,
+            },
+        };
+        let extension_id = ExtensionId::new("google-docs").expect("extension id");
+
+        let error = project(
+            Some(&service),
+            test_scope(),
+            &extension_id,
+            &[oauth_requirement()],
+        )
+        .await
+        .expect_err("non-retryable unavailable errors should stay visible");
+
+        assert_eq!(error.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(error.kind, RebornServicesErrorKind::ServiceUnavailable);
+        assert!(!error.retryable);
+    }
+
+    struct FailingCredentialSetupService {
+        error: RebornServicesError,
+    }
+
+    #[async_trait]
+    impl ExtensionCredentialSetupService for FailingCredentialSetupService {
+        async fn credential_status(
+            &self,
+            _request: ExtensionCredentialStatusRequest,
+        ) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
+            Err(self.error.clone())
+        }
+
+        async fn submit_manual_token(
+            &self,
+            _request: ExtensionCredentialSubmitRequest,
+        ) -> Result<CredentialAccountId, RebornServicesError> {
+            Ok(CredentialAccountId::new())
+        }
+    }
+
+    fn oauth_requirement() -> LifecycleExtensionCredentialRequirement {
+        LifecycleExtensionCredentialRequirement {
+            name: "google_oauth".to_string(),
+            provider: "google".to_string(),
+            required: true,
+            setup: LifecycleExtensionCredentialSetup::OAuth {
+                scopes: vec!["https://www.googleapis.com/auth/documents".to_string()],
+            },
+        }
+    }
+
+    fn test_scope() -> AuthProductScope {
+        AuthProductScope::new(
+            ResourceScope::local_default(
+                UserId::new("user-alpha").expect("user id"),
+                InvocationId::new(),
+            )
+            .expect("resource scope"),
+            AuthSurface::Web,
+        )
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
@@ -41,7 +41,6 @@ mod provider;
 mod tests;
 
 const MAX_OWNER_SESSION_ROOTS_PER_SURFACE: usize = 64;
-const MAX_OWNER_RECORDS_PER_ROOT: usize = 64;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) use provider::UnavailableAuthProviderClient;
@@ -422,22 +421,11 @@ where
                 continue;
             }
             let sessions_root = surface_sessions_root(&resource, surface)?;
-            let mut entries = match self
-                .filesystem
-                .list_dir_bounded(
-                    &resource,
-                    &sessions_root,
-                    MAX_OWNER_SESSION_ROOTS_PER_SURFACE.saturating_add(1),
-                )
-                .await
-            {
+            let mut entries = match self.filesystem.list_dir(&resource, &sessions_root).await {
                 Ok(entries) => entries,
                 Err(FilesystemError::NotFound { .. }) => continue,
                 Err(error) => return Err(fs_error(error)),
             };
-            if entries.len() > MAX_OWNER_SESSION_ROOTS_PER_SURFACE {
-                return Err(AuthProductError::BackendUnavailable);
-            }
             entries.sort_by(|left, right| left.name.cmp(&right.name));
             for entry in entries {
                 if entry.file_type != FileType::Directory {
@@ -462,13 +450,10 @@ where
         let mut accounts = Vec::new();
         for scope in self.account_scopes_for_owner(owner).await? {
             accounts.extend(
-                self.account_records_under_scope_root_with_limit(
-                    &scope,
-                    Some(MAX_OWNER_RECORDS_PER_ROOT),
-                )
-                .await?
-                .into_iter()
-                .filter(|account| owner.matches(account)),
+                self.account_records_under_scope_root(&scope)
+                    .await?
+                    .into_iter()
+                    .filter(|account| owner.matches(account)),
             );
         }
         accounts.sort_by_key(|account| account.id);
@@ -484,13 +469,7 @@ where
         let mut saw_configured = false;
         let mut selected = None;
         for scope in self.account_scopes_for_owner(&owner).await? {
-            for account in self
-                .account_records_under_scope_root_with_limit(
-                    &scope,
-                    Some(MAX_OWNER_RECORDS_PER_ROOT),
-                )
-                .await?
-            {
+            for account in self.account_records_under_scope_root(&scope).await? {
                 if !owner.matches(&account)
                     || account.provider != request.provider
                     || account.status != CredentialAccountStatus::Configured

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
@@ -40,7 +40,8 @@ mod provider;
 #[cfg(test)]
 mod tests;
 
-const MAX_OWNER_SESSION_ROOTS_PER_SURFACE: usize = 64;
+const MAX_OWNER_SESSION_ROOTS_PER_SURFACE: usize = 1024;
+const MAX_OWNER_RECORDS_PER_ROOT: usize = 1024;
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub(crate) use provider::UnavailableAuthProviderClient;
@@ -134,18 +135,9 @@ where
         let Some(versioned) = self.filesystem.get(scope, path).await.map_err(fs_error)? else {
             return Ok(None);
         };
-        match serde_json::from_slice(&versioned.entry.body) {
-            Ok(account) => Ok(Some(account)),
-            Err(error) => {
-                tracing::warn!(
-                    target = "ironclaw::reborn::product_auth",
-                    path = %path.as_str(),
-                    error = %error,
-                    "skipping malformed product-auth account record during projection scan",
-                );
-                Ok(None)
-            }
-        }
+        serde_json::from_slice(&versioned.entry.body)
+            .map(Some)
+            .map_err(|_| AuthProductError::BackendUnavailable)
     }
 
     async fn write_record<T>(
@@ -421,11 +413,22 @@ where
                 continue;
             }
             let sessions_root = surface_sessions_root(&resource, surface)?;
-            let mut entries = match self.filesystem.list_dir(&resource, &sessions_root).await {
+            let mut entries = match self
+                .filesystem
+                .list_dir_bounded(
+                    &resource,
+                    &sessions_root,
+                    MAX_OWNER_SESSION_ROOTS_PER_SURFACE.saturating_add(1),
+                )
+                .await
+            {
                 Ok(entries) => entries,
                 Err(FilesystemError::NotFound { .. }) => continue,
                 Err(error) => return Err(fs_error(error)),
             };
+            if entries.len() > MAX_OWNER_SESSION_ROOTS_PER_SURFACE {
+                return Err(AuthProductError::BackendUnavailable);
+            }
             entries.sort_by(|left, right| left.name.cmp(&right.name));
             for entry in entries {
                 if entry.file_type != FileType::Directory {
@@ -450,10 +453,13 @@ where
         let mut accounts = Vec::new();
         for scope in self.account_scopes_for_owner(owner).await? {
             accounts.extend(
-                self.account_records_under_scope_root(&scope)
-                    .await?
-                    .into_iter()
-                    .filter(|account| owner.matches(account)),
+                self.account_records_under_scope_root_with_limit(
+                    &scope,
+                    Some(MAX_OWNER_RECORDS_PER_ROOT),
+                )
+                .await?
+                .into_iter()
+                .filter(|account| owner.matches(account)),
             );
         }
         accounts.sort_by_key(|account| account.id);
@@ -469,7 +475,13 @@ where
         let mut saw_configured = false;
         let mut selected = None;
         for scope in self.account_scopes_for_owner(&owner).await? {
-            for account in self.account_records_under_scope_root(&scope).await? {
+            for account in self
+                .account_records_under_scope_root_with_limit(
+                    &scope,
+                    Some(MAX_OWNER_RECORDS_PER_ROOT),
+                )
+                .await?
+            {
                 if !owner.matches(&account)
                     || account.provider != request.provider
                     || account.status != CredentialAccountStatus::Configured

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable.rs
@@ -127,6 +127,28 @@ where
         Ok(Some((value, versioned.version)))
     }
 
+    async fn read_account_record_for_scan(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+    ) -> Result<Option<CredentialAccount>, AuthProductError> {
+        let Some(versioned) = self.filesystem.get(scope, path).await.map_err(fs_error)? else {
+            return Ok(None);
+        };
+        match serde_json::from_slice(&versioned.entry.body) {
+            Ok(account) => Ok(Some(account)),
+            Err(error) => {
+                tracing::warn!(
+                    target = "ironclaw::reborn::product_auth",
+                    path = %path.as_str(),
+                    error = %error,
+                    "skipping malformed product-auth account record during projection scan",
+                );
+                Ok(None)
+            }
+        }
+    }
+
     async fn write_record<T>(
         &self,
         scope: &ResourceScope,
@@ -358,7 +380,7 @@ where
                     let path = join_scoped(&root, &entry.name);
                     async move {
                         let path = path?;
-                        self.read_record::<CredentialAccount>(&scope.resource, &path)
+                        self.read_account_record_for_scan(&scope.resource, &path)
                             .await
                     }
                 }),
@@ -368,7 +390,6 @@ where
         .await?
         .into_iter()
         .flatten()
-        .map(|(account, _)| account)
         .collect();
         accounts.sort_by_key(|account| account.id);
         Ok(accounts)

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/flows.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/flows.rs
@@ -425,46 +425,15 @@ where
                 if binding.account_id != account_id {
                     return Err(AuthProductError::CrossScopeDenied);
                 }
-                let lock = self.lock_for(format!("account:{account_id}"));
-                let _guard = lock.lock().await;
-                let (mut account, version) = self
-                    .read_account(&callback.scope, account_id)
-                    .await?
-                    .ok_or(AuthProductError::CredentialMissing)?;
-                if !scope_matches(&callback.scope, &account.scope) {
-                    return Err(AuthProductError::CrossScopeDenied);
-                }
-                if account.provider != exchange.provider {
-                    return Err(AuthProductError::TokenExchangeFailed);
-                }
-                validate_bound_update_authority(&account, binding)?;
-                // Capture previous secret handles before overwriting so we can
-                // delete orphaned material from SecretStore after a successful
-                // write.  New tokens are written first; a write failure leaves
-                // the old handles still referenced by the on-disk record.
-                let previous_access_secret = account.access_secret.clone();
-                let previous_refresh_secret = account.refresh_secret.clone();
-                update_account_from_exchange(&mut account, exchange, Utc::now());
-                self.write_account(&account, CasExpectation::Version(version))
+                self.update_bound_oauth_account(&callback.scope, binding, exchange)
                     .await?;
-                // Best-effort purge of replaced handles.  Failures are
-                // non-fatal: orphans in SecretStore are recoverable; errors
-                // must not propagate to the caller.
-                if let Some(h) = &previous_access_secret
-                    && previous_access_secret.as_ref() != account.access_secret.as_ref()
-                {
-                    let _ = self.secret_store.delete(&callback.scope.resource, h).await;
-                }
-                if let Some(h) = &previous_refresh_secret
-                    && previous_refresh_secret.as_ref() != account.refresh_secret.as_ref()
-                {
-                    let _ = self.secret_store.delete(&callback.scope.resource, h).await;
-                }
                 Ok(account_id)
             }
             None => {
-                if callback.update_binding.is_some() {
-                    return Err(AuthProductError::CrossScopeDenied);
+                if let Some(binding) = &callback.update_binding {
+                    return self
+                        .update_bound_oauth_account(&callback.scope, binding, exchange)
+                        .await;
                 }
                 let account_id = CredentialAccountId::from_uuid(flow_id.as_uuid());
                 let request = NewCredentialAccount {
@@ -519,5 +488,50 @@ where
                 }
             }
         }
+    }
+
+    async fn update_bound_oauth_account(
+        &self,
+        scope: &ironclaw_auth::AuthProductScope,
+        binding: &ironclaw_auth::CredentialAccountUpdateBinding,
+        exchange: &OAuthProviderExchange,
+    ) -> Result<CredentialAccountId, AuthProductError> {
+        let account_id = binding.account_id;
+        let lock = self.lock_for(format!("account:{account_id}"));
+        let _guard = lock.lock().await;
+        let (mut account, version) = self
+            .read_account(scope, account_id)
+            .await?
+            .ok_or(AuthProductError::CredentialMissing)?;
+        if !scope_matches(scope, &account.scope) {
+            return Err(AuthProductError::CrossScopeDenied);
+        }
+        if account.provider != exchange.provider {
+            return Err(AuthProductError::TokenExchangeFailed);
+        }
+        validate_bound_update_authority(&account, binding)?;
+        // Capture previous secret handles before overwriting so we can delete
+        // orphaned material from SecretStore after a successful write. New
+        // tokens are written first; a write failure leaves the old handles
+        // still referenced by the on-disk record.
+        let previous_access_secret = account.access_secret.clone();
+        let previous_refresh_secret = account.refresh_secret.clone();
+        update_account_from_exchange(&mut account, exchange, Utc::now());
+        self.write_account(&account, CasExpectation::Version(version))
+            .await?;
+        // Best-effort purge of replaced handles. Failures are non-fatal:
+        // orphans in SecretStore are recoverable; errors must not propagate to
+        // the caller.
+        if let Some(h) = &previous_access_secret
+            && previous_access_secret.as_ref() != account.access_secret.as_ref()
+        {
+            let _ = self.secret_store.delete(&scope.resource, h).await;
+        }
+        if let Some(h) = &previous_refresh_secret
+            && previous_refresh_secret.as_ref() != account.refresh_secret.as_ref()
+        {
+            let _ = self.secret_store.delete(&scope.resource, h).await;
+        }
+        Ok(account_id)
     }
 }

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -1603,9 +1603,11 @@ async fn filesystem_list_accounts_rejects_zero_and_oversized_limit() {
 
 #[tokio::test]
 async fn filesystem_oauth_reauth_purges_previous_provider_secrets() {
-    // After a successful OAuth re-auth (exchange.account_id == Some(_)),
-    // the OLD access and refresh secret handles must be deleted from SecretStore
-    // so repeated re-auths do not accumulate dead handles.
+    // After a successful OAuth re-auth through a bound flow, the OLD access
+    // and refresh secret handles must be deleted from SecretStore so repeated
+    // re-auths do not accumulate dead handles. Host OAuth provider clients
+    // return exchange.account_id == None, so the durable flow must use the
+    // update_binding account id rather than rejecting the callback.
     use ironclaw_auth::{CredentialAccountUpdateBinding, ProviderCallbackOutcome};
     use ironclaw_secrets::SecretMaterial;
 
@@ -1787,7 +1789,7 @@ async fn filesystem_oauth_reauth_purges_previous_provider_secrets() {
                         access_secret: access_v2.clone(),
                         refresh_secret: Some(refresh_v2.clone()),
                         scopes: vec![ProviderScope::new("gmail.readonly").unwrap()],
-                        account_id: Some(account_id),
+                        account_id: None,
                     },
                 },
             },

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -832,6 +832,96 @@ async fn filesystem_account_record_source_skips_malformed_scan_records() {
 }
 
 #[tokio::test]
+async fn filesystem_runtime_account_selection_tolerates_many_session_account_roots() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let service = Arc::new(test_service(filesystem, secret_store));
+    let mut setup_scope = test_scope();
+    setup_scope.surface = AuthSurface::Callback;
+    setup_scope.resource.thread_id = Some(ThreadId::new("thread-many-sessions").unwrap());
+    let mut runtime_scope = AuthProductScope::new(setup_scope.resource.clone(), AuthSurface::Web);
+    runtime_scope.resource.invocation_id = InvocationId::new();
+
+    for index in 0..70 {
+        let mut account_scope = setup_scope.clone();
+        account_scope.session_id = Some(AuthSessionId::new(format!("session-{index:03}")).unwrap());
+        service
+            .create_account(NewCredentialAccount {
+                scope: account_scope,
+                provider: google_provider(),
+                label: account_label(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(
+                    SecretHandle::new(format!("many-session-access-{index}")).unwrap(),
+                ),
+                refresh_secret: None,
+                scopes: vec![ProviderScope::new("drive.readonly").unwrap()],
+            })
+            .await
+            .unwrap();
+    }
+
+    let selector = ProductAuthRuntimeCredentialAccountSelector::new(service);
+    let selected = selector
+        .select_unique_configured_runtime_account(RuntimeCredentialAccountSelectionRequest::new(
+            CredentialAccountSelectionRequest::new(runtime_scope.clone(), google_provider()),
+            runtime_scope,
+            vec![ProviderScope::new("drive.readonly").unwrap()],
+        ))
+        .await
+        .expect("session-root fanout must not make credential selection unavailable");
+
+    assert_eq!(selected.provider, google_provider());
+}
+
+#[tokio::test]
+async fn filesystem_runtime_account_selection_tolerates_many_account_records_per_root() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let service = Arc::new(test_service(filesystem, secret_store));
+    let mut setup_scope = test_scope();
+    setup_scope.surface = AuthSurface::Callback;
+    setup_scope.resource.thread_id = Some(ThreadId::new("thread-many-accounts").unwrap());
+    let mut runtime_scope = AuthProductScope::new(setup_scope.resource.clone(), AuthSurface::Web);
+    runtime_scope.resource.invocation_id = InvocationId::new();
+
+    for index in 0..70 {
+        service
+            .create_account(NewCredentialAccount {
+                scope: setup_scope.clone(),
+                provider: google_provider(),
+                label: account_label(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(
+                    SecretHandle::new(format!("many-account-access-{index}")).unwrap(),
+                ),
+                refresh_secret: None,
+                scopes: vec![ProviderScope::new("drive.readonly").unwrap()],
+            })
+            .await
+            .unwrap();
+    }
+
+    let selector = ProductAuthRuntimeCredentialAccountSelector::new(service);
+    let selected = selector
+        .select_unique_configured_runtime_account(RuntimeCredentialAccountSelectionRequest::new(
+            CredentialAccountSelectionRequest::new(runtime_scope.clone(), google_provider()),
+            runtime_scope,
+            vec![ProviderScope::new("drive.readonly").unwrap()],
+        ))
+        .await
+        .expect("account-record fanout must not make credential selection unavailable");
+
+    assert_eq!(selected.provider, google_provider());
+}
+
+#[tokio::test]
 async fn filesystem_oauth_callback_claim_is_one_shot_and_completion_persists() {
     let filesystem = test_filesystem();
     let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -778,6 +778,60 @@ async fn filesystem_account_record_source_projects_session_scoped_accounts_for_r
 }
 
 #[tokio::test]
+async fn filesystem_account_record_source_skips_malformed_scan_records() {
+    let filesystem = test_filesystem();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
+    let scope = test_scope();
+    let service = test_service(Arc::clone(&filesystem), secret_store);
+    let account = service
+        .create_account(NewCredentialAccount {
+            scope: scope.clone(),
+            provider: google_provider(),
+            label: account_label(),
+            status: CredentialAccountStatus::Configured,
+            ownership: CredentialOwnership::UserReusable,
+            owner_extension: None,
+            granted_extensions: Vec::new(),
+            access_secret: Some(SecretHandle::new("valid-account-access").unwrap()),
+            refresh_secret: None,
+            scopes: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    let malformed_account_id = ironclaw_auth::CredentialAccountId::new();
+    let malformed_path = super::paths::account_path(&scope, malformed_account_id)
+        .expect("account path derivation must succeed");
+    let malformed = ironclaw_filesystem::Entry::bytes(b"{ malformed account json".to_vec())
+        .with_content_type(ironclaw_filesystem::ContentType::json());
+    filesystem
+        .put(
+            &scope.resource,
+            &malformed_path,
+            malformed,
+            ironclaw_filesystem::CasExpectation::Absent,
+        )
+        .await
+        .expect("malformed account fixture must write");
+
+    let accounts = service
+        .accounts_for_owner(&scope)
+        .await
+        .expect("owner projection should skip malformed account records");
+
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(accounts[0].id, account.id);
+
+    assert!(
+        matches!(
+            service.read_account(&scope, malformed_account_id).await,
+            Err(AuthProductError::BackendUnavailable)
+        ),
+        "exact account reads should remain strict"
+    );
+}
+
+#[tokio::test]
 async fn filesystem_oauth_callback_claim_is_one_shot_and_completion_persists() {
     let filesystem = test_filesystem();
     let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());

--- a/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_durable/tests.rs
@@ -778,12 +778,12 @@ async fn filesystem_account_record_source_projects_session_scoped_accounts_for_r
 }
 
 #[tokio::test]
-async fn filesystem_account_record_source_skips_malformed_scan_records() {
+async fn filesystem_account_record_source_rejects_malformed_scan_records() {
     let filesystem = test_filesystem();
     let secret_store: Arc<dyn SecretStore> = Arc::new(InMemorySecretStore::new());
     let scope = test_scope();
     let service = test_service(Arc::clone(&filesystem), secret_store);
-    let account = service
+    service
         .create_account(NewCredentialAccount {
             scope: scope.clone(),
             provider: google_provider(),
@@ -814,13 +814,13 @@ async fn filesystem_account_record_source_skips_malformed_scan_records() {
         .await
         .expect("malformed account fixture must write");
 
-    let accounts = service
-        .accounts_for_owner(&scope)
-        .await
-        .expect("owner projection should skip malformed account records");
-
-    assert_eq!(accounts.len(), 1);
-    assert_eq!(accounts[0].id, account.id);
+    assert!(
+        matches!(
+            service.accounts_for_owner(&scope).await,
+            Err(AuthProductError::BackendUnavailable)
+        ),
+        "runtime owner scans should fail loudly on malformed account records"
+    );
 
     assert!(
         matches!(

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -879,7 +879,7 @@ pub(super) async fn scoped_update_binding_for_requester(
         .product_auth
         .runtime_credential_account_selection_service()
         .select_unique_configured_runtime_account(RuntimeCredentialAccountSelectionRequest::new(
-            CredentialAccountSelectionRequest::new(scope.clone(), provider)
+            CredentialAccountSelectionRequest::new(scope.clone(), provider.clone())
                 .for_extension(requester_extension.clone()),
             scope.clone(),
             provider_scopes,
@@ -893,6 +893,15 @@ pub(super) async fn scoped_update_binding_for_requester(
         Err(AuthProductError::CredentialMissing) => Ok(None),
         Err(AuthProductError::CrossScopeDenied) => Ok(None),
         Err(AuthProductError::AccountSelectionRequired) => Ok(None),
+        Err(AuthProductError::BackendUnavailable) => {
+            tracing::warn!(
+                target: "ironclaw::reborn::product_auth::oauth",
+                provider = %provider.as_str(),
+                requester_extension = %requester_extension.as_str(),
+                "credential account status unavailable during extension OAuth start; starting setup without update binding"
+            );
+            Ok(None)
+        }
         Err(error) => Err(ProductAuthRouteFailure::from(error)),
     }
 }
@@ -1318,8 +1327,9 @@ mod tests {
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, header};
     use ironclaw_auth::{
-        AuthFlowManager, CredentialAccountService, CredentialAccountStatus, CredentialOwnership,
-        NewCredentialAccount,
+        AuthFlowManager, AuthInteractionService, AuthProviderClient, CredentialAccountService,
+        CredentialAccountStatus, CredentialOwnership, CredentialSetupService, NewCredentialAccount,
+        SecretCleanupService,
     };
     use ironclaw_capabilities::{CapabilityObligationHandler, CapabilityObligationRequest};
     use ironclaw_host_api::{
@@ -1594,6 +1604,82 @@ mod tests {
                             "provider": "notion",
                             "account_label": "work notion",
                             "scopes": [],
+                            "expires_at": (Utc::now() + ChronoDuration::minutes(5)).to_rfc3339(),
+                            "invocation_id": flow_invocation_id.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("route response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("start json");
+        let flow_id = AuthFlowId::from_uuid(
+            Uuid::parse_str(json["flow_id"].as_str().expect("flow id")).expect("flow uuid"),
+        );
+        let mut flow_resource = test_resource_scope();
+        flow_resource.invocation_id = flow_invocation_id;
+        let flow_scope = AuthProductScope::new(flow_resource, AuthSurface::Callback);
+        let flow = shared
+            .get_flow(&flow_scope, flow_id)
+            .await
+            .expect("flow lookup")
+            .expect("flow");
+        assert!(flow.update_binding.is_none());
+    }
+
+    #[tokio::test]
+    async fn extension_google_oauth_start_continues_when_update_binding_lookup_is_unavailable() {
+        let shared = Arc::new(ironclaw_auth::InMemoryAuthProductServices::new());
+        let flow_manager: Arc<dyn AuthFlowManager> = shared.clone();
+        let interaction_service: Arc<dyn AuthInteractionService> = shared.clone();
+        let credential_setup_service: Arc<dyn CredentialSetupService> = shared.clone();
+        let credential_account_service: Arc<dyn CredentialAccountService> = shared.clone();
+        let provider_client: Arc<dyn AuthProviderClient> = shared.clone();
+        let cleanup_service: Arc<dyn SecretCleanupService> = shared.clone();
+        let product_auth = Arc::new(RebornProductAuthServices::new(
+            flow_manager,
+            interaction_service,
+            credential_setup_service,
+            credential_account_service,
+            provider_client,
+            cleanup_service,
+            Arc::new(NoopDispatcher),
+        ));
+        let state = ProductAuthRouteState::new(
+            product_auth,
+            TenantId::new("tenant-alpha").expect("tenant"),
+            None,
+            None,
+        )
+        .with_google_oauth(
+            GoogleOAuthRouteConfig::new(
+                "google-client.apps.googleusercontent.com",
+                "http://127.0.0.1:3000/api/reborn/product-auth/oauth/google/callback",
+            )
+            .expect("google oauth route config"),
+        );
+        let app = product_auth_route_mount(state)
+            .protected
+            .layer(axum::Extension(test_caller()));
+        let flow_invocation_id = InvocationId::new();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/webchat/v2/extensions/google-drive/setup/oauth/start")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "provider": GOOGLE_PROVIDER_ID,
+                            "account_label": "google-drive google",
+                            "scopes": ["https://www.googleapis.com/auth/drive"],
                             "expires_at": (Utc::now() + ChronoDuration::minutes(5)).to_rfc3339(),
                             "invocation_id": flow_invocation_id.to_string(),
                         })

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -1327,9 +1327,9 @@ mod tests {
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, header};
     use ironclaw_auth::{
-        AuthFlowManager, AuthInteractionService, AuthProviderClient, CredentialAccountService,
-        CredentialAccountStatus, CredentialOwnership, CredentialSetupService, NewCredentialAccount,
-        SecretCleanupService,
+        AuthFlowManager, AuthInteractionService, AuthProviderClient,
+        CredentialAccountLookupRequest, CredentialAccountService, CredentialAccountStatus,
+        CredentialOwnership, CredentialSetupService, NewCredentialAccount, SecretCleanupService,
     };
     use ironclaw_capabilities::{CapabilityObligationHandler, CapabilityObligationRequest};
     use ironclaw_host_api::{
@@ -1664,7 +1664,7 @@ mod tests {
             )
             .expect("google oauth route config"),
         );
-        let app = product_auth_route_mount(state)
+        let app = product_auth_route_mount(state.clone())
             .protected
             .layer(axum::Extension(test_caller()));
         let flow_invocation_id = InvocationId::new();
@@ -1707,6 +1707,57 @@ mod tests {
             .expect("flow lookup")
             .expect("flow");
         assert!(flow.update_binding.is_none());
+
+        let authorization_url = json["authorization_url"]
+            .as_str()
+            .expect("authorization url");
+        let state_value = Url::parse(authorization_url)
+            .expect("authorization url")
+            .query_pairs()
+            .find_map(|(name, value)| (name == "state").then(|| value.into_owned()))
+            .expect("oauth state");
+        let encoded_state =
+            url::form_urlencoded::byte_serialize(state_value.as_bytes()).collect::<String>();
+        let encoded_scope = url::form_urlencoded::byte_serialize(
+            "https://www.googleapis.com/auth/drive".as_bytes(),
+        )
+        .collect::<String>();
+        let uri = format!(
+            "{GOOGLE_OAUTH_CALLBACK_PATH}?state={encoded_state}&code=google-auth-code&scope={encoded_scope}"
+        )
+        .parse::<Uri>()
+        .expect("callback uri");
+
+        let response = oauth::google_oauth_callback_handler(
+            State(state),
+            RawQuery(uri.query().map(str::to_string)),
+            uri,
+            HeaderMap::new(),
+        )
+        .await
+        .expect("extension google callback should complete");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let completed_flow = shared
+            .get_flow(&flow_scope, flow_id)
+            .await
+            .expect("completed flow lookup")
+            .expect("completed flow");
+        let account_id = completed_flow
+            .credential_account_id
+            .expect("callback should persist account id");
+        let account = shared
+            .get_account(CredentialAccountLookupRequest {
+                scope: flow_scope,
+                account_id,
+                requester_extension: Some(ExtensionId::new("google-drive").expect("extension")),
+            })
+            .await
+            .expect("account lookup")
+            .expect("account");
+
+        assert_eq!(account.status, CredentialAccountStatus::Configured);
+        assert_eq!(account.provider.as_str(), GOOGLE_PROVIDER_ID);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -500,6 +500,55 @@ async fn webui_v2_gmail_oauth_setup_complete_allows_activation() {
 }
 
 #[tokio::test]
+async fn webui_v2_google_docs_setup_projects_oauth_before_install() {
+    let harness = build_harness().await;
+
+    let setup = harness
+        .router
+        .clone()
+        .oneshot(bearer_get("/api/webchat/v2/extensions/google-docs/setup"))
+        .await
+        .expect("setup Google Docs oneshot");
+    assert_eq!(setup.status(), StatusCode::OK);
+    let setup_body = read_json(setup).await;
+    assert_eq!(setup_body["package_ref"]["id"], "google-docs");
+    assert_eq!(setup_body["phase"], "discovered");
+
+    let secrets = setup_body["secrets"]
+        .as_array()
+        .expect("setup secrets should be an array");
+    let google_oauth_scopes = secrets
+        .iter()
+        .filter(|secret| secret["provider"] == "google")
+        .map(|secret| {
+            let setup = &secret["setup"];
+            assert_eq!(setup["kind"], "oauth", "secret should be OAuth: {secret}");
+            setup["scopes"]
+                .as_array()
+                .expect("OAuth scopes should be an array")
+                .iter()
+                .map(|scope| scope.as_str().expect("scope string").to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        google_oauth_scopes,
+        vec![
+            vec!["https://www.googleapis.com/auth/documents".to_string()],
+            vec!["https://www.googleapis.com/auth/documents.readonly".to_string()],
+        ],
+        "Google Docs setup should expose WASM-declared OAuth scopes before install: {setup_body}"
+    );
+
+    harness
+        .runtime
+        .shutdown()
+        .await
+        .expect("runtime shutdown clean");
+}
+
+#[tokio::test]
 async fn webui_v2_google_drive_oauth_setup_projects_distinct_operation_scopes() {
     let harness = build_harness().await;
 


### PR DESCRIPTION
## Summary
- add an HTTP e2e regression for `GET /api/webchat/v2/extensions/google-docs/setup` before install
- make owner-wide product-auth account projection skip malformed account records instead of failing the whole setup screen with 503
- keep exact account reads strict so malformed records are not silently trusted for update/use paths

## Notes
- This is not a WASM rebuild issue: OAuth setup scopes come from the bundled extension manifest embedded into the Rust binary. Rebuilding/restarting the Rust server is required after manifest/backend changes; rebuilding the Google Docs WASM module is not.

## Tests
- `CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition --lib product_auth_durable::tests::filesystem_account_record_source_skips_malformed_scan_records -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p ironclaw_reborn_composition --features webui-v2-beta,test-support --test webui_v2_e2e webui_v2_google_docs_setup_projects_oauth_before_install -- --nocapture`
- `cargo fmt --check`