### PR TITLE
Fix WebUI turn activity ownership

### DIFF
--- a/crates/ironclaw_event_streams/src/types.rs
+++ b/crates/ironclaw_event_streams/src/types.rs
@@ -170,9 +170,11 @@ pub struct ThreadLiveProjectionUpdate {
 pub enum ThreadLiveProjectionItem {
     Thinking {
         id: String,
+        run_id: TurnRunId,
         body: String,
     },
     CapabilityActivity {
+        run_id: TurnRunId,
         invocation_id: InvocationId,
         capability_id: CapabilityId,
     },

--- a/crates/ironclaw_product_adapters/src/outbound.rs
+++ b/crates/ironclaw_product_adapters/src/outbound.rs
@@ -216,6 +216,7 @@ pub enum ProductWorkSummaryPhase {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CapabilityActivityView {
     pub invocation_id: InvocationId,
+    pub turn_run_id: Option<TurnRunId>,
     pub thread_id: Option<ThreadId>,
     pub capability_id: CapabilityId,
     pub status: CapabilityActivityStatusView,
@@ -237,6 +238,8 @@ impl Serialize for CapabilityActivityView {
         #[derive(Serialize)]
         struct Wire<'a> {
             invocation_id: &'a InvocationId,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            turn_run_id: &'a Option<TurnRunId>,
             thread_id: &'a Option<ThreadId>,
             capability_id: &'a CapabilityId,
             status: CapabilityActivityStatusView,
@@ -250,6 +253,7 @@ impl Serialize for CapabilityActivityView {
 
         Wire {
             invocation_id: &self.invocation_id,
+            turn_run_id: &self.turn_run_id,
             thread_id: &self.thread_id,
             capability_id: &self.capability_id,
             status: self.status,
@@ -268,6 +272,7 @@ impl CapabilityActivityView {
     pub fn new(input: CapabilityActivityViewInput) -> Result<Self, ProductAdapterError> {
         let value = Self {
             invocation_id: input.invocation_id,
+            turn_run_id: input.turn_run_id,
             thread_id: input.thread_id,
             capability_id: input.capability_id,
             status: input.status,
@@ -293,6 +298,7 @@ impl CapabilityActivityView {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CapabilityActivityViewInput {
     pub invocation_id: InvocationId,
+    pub turn_run_id: Option<TurnRunId>,
     pub thread_id: Option<ThreadId>,
     pub capability_id: CapabilityId,
     pub status: CapabilityActivityStatusView,
@@ -312,6 +318,8 @@ impl<'de> Deserialize<'de> for CapabilityActivityView {
         #[derive(Deserialize)]
         struct Wire {
             invocation_id: InvocationId,
+            #[serde(default)]
+            turn_run_id: Option<TurnRunId>,
             thread_id: Option<ThreadId>,
             capability_id: CapabilityId,
             status: CapabilityActivityStatusView,
@@ -325,6 +333,7 @@ impl<'de> Deserialize<'de> for CapabilityActivityView {
         let wire = Wire::deserialize(deserializer)?;
         Self::new(CapabilityActivityViewInput {
             invocation_id: wire.invocation_id,
+            turn_run_id: wire.turn_run_id,
             thread_id: wire.thread_id,
             capability_id: wire.capability_id,
             status: wire.status,
@@ -353,6 +362,7 @@ pub enum CapabilityActivityStatusView {
 pub struct CapabilityDisplayPreviewView {
     pub timeline_message_id: Option<String>,
     pub invocation_id: InvocationId,
+    pub turn_run_id: Option<TurnRunId>,
     pub thread_id: Option<ThreadId>,
     pub capability_id: CapabilityId,
     pub status: CapabilityActivityStatusView,
@@ -373,6 +383,7 @@ impl CapabilityDisplayPreviewView {
         let value = Self {
             timeline_message_id: input.timeline_message_id,
             invocation_id: input.invocation_id,
+            turn_run_id: input.turn_run_id,
             thread_id: input.thread_id,
             capability_id: input.capability_id,
             status: input.status,
@@ -439,6 +450,8 @@ impl Serialize for CapabilityDisplayPreviewView {
         struct Wire<'a> {
             timeline_message_id: &'a Option<String>,
             invocation_id: &'a InvocationId,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            turn_run_id: &'a Option<TurnRunId>,
             thread_id: &'a Option<ThreadId>,
             capability_id: &'a CapabilityId,
             status: CapabilityActivityStatusView,
@@ -457,6 +470,7 @@ impl Serialize for CapabilityDisplayPreviewView {
         Wire {
             timeline_message_id: &self.timeline_message_id,
             invocation_id: &self.invocation_id,
+            turn_run_id: &self.turn_run_id,
             thread_id: &self.thread_id,
             capability_id: &self.capability_id,
             status: self.status,
@@ -479,6 +493,7 @@ impl Serialize for CapabilityDisplayPreviewView {
 pub struct CapabilityDisplayPreviewViewInput {
     pub timeline_message_id: Option<String>,
     pub invocation_id: InvocationId,
+    pub turn_run_id: Option<TurnRunId>,
     pub thread_id: Option<ThreadId>,
     pub capability_id: CapabilityId,
     pub status: CapabilityActivityStatusView,
@@ -504,6 +519,8 @@ impl<'de> Deserialize<'de> for CapabilityDisplayPreviewView {
             #[serde(default)]
             timeline_message_id: Option<String>,
             invocation_id: InvocationId,
+            #[serde(default)]
+            turn_run_id: Option<TurnRunId>,
             thread_id: Option<ThreadId>,
             capability_id: CapabilityId,
             status: CapabilityActivityStatusView,
@@ -522,6 +539,7 @@ impl<'de> Deserialize<'de> for CapabilityDisplayPreviewView {
         Self::new(CapabilityDisplayPreviewViewInput {
             timeline_message_id: wire.timeline_message_id,
             invocation_id: wire.invocation_id,
+            turn_run_id: wire.turn_run_id,
             thread_id: wire.thread_id,
             capability_id: wire.capability_id,
             status: wire.status,
@@ -606,6 +624,8 @@ pub enum ProductProjectionItem {
     },
     Thinking {
         id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        run_id: Option<TurnRunId>,
         body: String,
     },
     CapabilityActivity(CapabilityActivityView),
@@ -645,7 +665,7 @@ pub enum ProductProjectionItem {
 impl ProductProjectionItem {
     fn validate(&self) -> Result<(), ProductAdapterError> {
         match self {
-            Self::Text { id, body } | Self::Thinking { id, body } => {
+            Self::Text { id, body } | Self::Thinking { id, body, .. } => {
                 validate_bounded_text("projection_item_id", id, PROJECTION_ITEM_ID_MAX_BYTES)?;
                 validate_bounded_text("projection_text", body, PROJECTION_TEXT_MAX_BYTES)
             }
@@ -743,6 +763,8 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
             },
             Thinking {
                 id: String,
+                #[serde(default)]
+                run_id: Option<TurnRunId>,
                 body: String,
             },
             CapabilityActivity(CapabilityActivityView),
@@ -773,7 +795,9 @@ impl<'de> Deserialize<'de> for ProductProjectionItem {
         }
         let value = match Wire::deserialize(deserializer)? {
             Wire::Text { id, body } => ProductProjectionItem::Text { id, body },
-            Wire::Thinking { id, body } => ProductProjectionItem::Thinking { id, body },
+            Wire::Thinking { id, run_id, body } => {
+                ProductProjectionItem::Thinking { id, run_id, body }
+            }
             Wire::CapabilityActivity(activity) => {
                 ProductProjectionItem::CapabilityActivity(activity)
             }
@@ -987,15 +1011,18 @@ mod tests {
 
     #[test]
     fn projection_state_round_trips_thinking_item() {
+        let run_id = TurnRunId::new();
         let state = ProductProjectionState::new(
             "thread-1",
             vec![ProductProjectionItem::Thinking {
                 id: "thinking:run:1".to_string(),
+                run_id: Some(run_id),
                 body: "checking context".to_string(),
             }],
         )
         .expect("valid thinking projection");
         let value = serde_json::to_value(&state).expect("serialize");
+        assert_eq!(value["items"][0]["thinking"]["run_id"], run_id.to_string());
         assert_eq!(value["items"][0]["thinking"]["body"], "checking context");
         let decoded: ProductProjectionState =
             serde_json::from_value(value).expect("deserialize thinking projection");
@@ -1010,6 +1037,7 @@ mod tests {
             vec![ProductProjectionItem::CapabilityActivity(
                 CapabilityActivityView::new(CapabilityActivityViewInput {
                     invocation_id,
+                    turn_run_id: None,
                     thread_id: Some(ThreadId::new("thread-1").unwrap()),
                     capability_id: CapabilityId::new("builtin.http").unwrap(),
                     status: CapabilityActivityStatusView::Started,
@@ -1199,8 +1227,10 @@ mod tests {
 
     #[test]
     fn capability_activity_view_is_metadata_only() {
+        let run_id = TurnRunId::new();
         let view = CapabilityActivityView::new(CapabilityActivityViewInput {
             invocation_id: InvocationId::new(),
+            turn_run_id: Some(run_id),
             thread_id: Some(ThreadId::new("thread-tool-activity").expect("thread id")),
             capability_id: CapabilityId::new("script.echo").expect("capability id"),
             status: CapabilityActivityStatusView::Completed,
@@ -1216,6 +1246,7 @@ mod tests {
         let rendered = serde_json::to_string(&json).expect("render");
 
         assert_eq!(json["status"], "completed");
+        assert_eq!(json["turn_run_id"], run_id.to_string());
         assert_eq!(json["output_bytes"], 12);
         for forbidden in [
             "arguments",
@@ -1234,9 +1265,11 @@ mod tests {
 
     #[test]
     fn capability_display_preview_view_allows_bounded_display_material() {
+        let run_id = TurnRunId::new();
         let view = CapabilityDisplayPreviewView::new(CapabilityDisplayPreviewViewInput {
             timeline_message_id: Some("timeline-message-1".to_string()),
             invocation_id: InvocationId::new(),
+            turn_run_id: Some(run_id),
             thread_id: Some(ThreadId::new("thread-tool-preview").expect("thread id")),
             capability_id: CapabilityId::new("builtin.read_file").expect("capability id"),
             status: CapabilityActivityStatusView::Completed,
@@ -1255,6 +1288,7 @@ mod tests {
 
         let json = serde_json::to_value(&view).expect("serialize");
         assert_eq!(json["title"], "read_file");
+        assert_eq!(json["turn_run_id"], run_id.to_string());
         assert_eq!(json["subtitle"], "src/main.rs");
         assert_eq!(json["output_kind"], "text");
     }
@@ -1424,6 +1458,7 @@ mod tests {
     fn capability_activity_view_rejects_unsafe_error_kind_on_serialize() {
         let view = CapabilityActivityView {
             invocation_id: InvocationId::new(),
+            turn_run_id: Some(TurnRunId::new()),
             thread_id: Some(ThreadId::new("thread-tool-activity").expect("thread id")),
             capability_id: CapabilityId::new("script.echo").expect("capability id"),
             status: CapabilityActivityStatusView::Failed,

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -870,6 +870,9 @@ async fn runtime_payload_from_candidate(
         RuntimePayloadCandidate::CapabilityActivity(activity) => {
             CapabilityActivityView::new(CapabilityActivityViewInput {
                 invocation_id: activity.invocation_id,
+                turn_run_id: activity
+                    .run_id
+                    .map(|run_id| TurnRunId::from_uuid(run_id.as_uuid())),
                 thread_id: activity.thread_id,
                 capability_id: activity.capability_id,
                 status: capability_activity_status_wire(activity.status),

--- a/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/display_preview.rs
@@ -11,7 +11,7 @@ use ironclaw_product_adapters::{
     CapabilityDisplayPreviewView, CapabilityDisplayPreviewViewInput, ProductAdapterError,
 };
 use ironclaw_threads::ThreadMessageId;
-use ironclaw_turns::run_profile::CapabilityInputRef;
+use ironclaw_turns::{TurnRunId, run_profile::CapabilityInputRef};
 
 use super::capability_activity_status_wire;
 
@@ -236,6 +236,7 @@ fn capability_display_preview_from_store(
             .timeline_message_id
             .map(|message_id| message_id.to_string()),
         invocation_id: activity.invocation_id,
+        turn_run_id: turn_run_id_for_activity(activity),
         thread_id: activity.thread_id.clone(),
         capability_id: activity.capability_id.clone(),
         status: capability_activity_status_wire(activity.status),
@@ -270,6 +271,7 @@ fn failed_capability_display_preview(
     CapabilityDisplayPreviewView::new(CapabilityDisplayPreviewViewInput {
         timeline_message_id: None,
         invocation_id: activity.invocation_id,
+        turn_run_id: turn_run_id_for_activity(activity),
         thread_id: activity.thread_id.clone(),
         capability_id: activity.capability_id.clone(),
         status: capability_activity_status_wire(activity.status),
@@ -289,6 +291,12 @@ fn failed_capability_display_preview(
         updated_at: activity.updated_at,
     })
     .map(Some)
+}
+
+fn turn_run_id_for_activity(activity: &CapabilityActivityProjection) -> Option<TurnRunId> {
+    activity
+        .run_id
+        .map(|run_id| TurnRunId::from_uuid(run_id.as_uuid()))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/live_progress.rs
@@ -136,17 +136,20 @@ pub(super) fn product_items_for_live_update(
         .items
         .iter()
         .filter_map(|item| match item {
-            ThreadLiveProjectionItem::Thinking { id, body } => {
+            ThreadLiveProjectionItem::Thinking { id, run_id, body } => {
                 Some(ProductProjectionItem::Thinking {
                     id: id.clone(),
+                    run_id: Some(*run_id),
                     body: body.clone(),
                 })
             }
             ThreadLiveProjectionItem::CapabilityActivity {
+                run_id,
                 invocation_id,
                 capability_id,
             } => match CapabilityActivityView::new(CapabilityActivityViewInput {
                 invocation_id: *invocation_id,
+                turn_run_id: Some(*run_id),
                 thread_id: Some(update.thread_id.clone()),
                 capability_id: capability_id.clone(),
                 status: CapabilityActivityStatusView::Started,
@@ -220,6 +223,7 @@ impl LiveProgressMilestoneSink {
             sequence,
             ThreadLiveProjectionItem::Thinking {
                 id: thinking_id(milestone.run_id, sequence),
+                run_id: milestone.run_id,
                 body: safe_delta,
             },
         );
@@ -236,6 +240,7 @@ impl LiveProgressMilestoneSink {
             &milestone.scope,
             sequence,
             ThreadLiveProjectionItem::CapabilityActivity {
+                run_id: milestone.run_id,
                 invocation_id,
                 capability_id: capability_id.clone(),
             },

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -1344,6 +1344,7 @@ fn make_capability_activity_envelope(cursor: &str) -> ProductOutboundEnvelope {
         cursor,
         ProductOutboundPayload::CapabilityActivity(CapabilityActivityView {
             invocation_id: InvocationId::new(),
+            turn_run_id: Some(TurnRunId::new()),
             thread_id: Some(ThreadId::new("thread-x").expect("thread id")),
             capability_id: CapabilityId::new("script.echo").expect("capability id"),
             status: CapabilityActivityStatusView::Running,

--- a/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_schema_contract.rs
@@ -33,6 +33,7 @@ fn progress(kind: ProgressKind) -> ProgressUpdateView {
 fn capability_activity() -> CapabilityActivityView {
     CapabilityActivityView {
         invocation_id: InvocationId::new(),
+        turn_run_id: Some(run_id()),
         thread_id: Some(ThreadId::new("thread-alpha").expect("thread")),
         capability_id: CapabilityId::new("script.echo").expect("capability"),
         status: CapabilityActivityStatusView::Running,
@@ -49,6 +50,7 @@ fn capability_display_preview() -> CapabilityDisplayPreviewView {
     CapabilityDisplayPreviewView {
         timeline_message_id: Some("timeline-message-1".to_string()),
         invocation_id: InvocationId::new(),
+        turn_run_id: Some(run_id()),
         thread_id: Some(ThreadId::new("thread-alpha").expect("thread")),
         capability_id: CapabilityId::new("builtin.read_file").expect("capability"),
         status: CapabilityActivityStatusView::Completed,

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.js
@@ -1,8 +1,7 @@
 // Map v2 `ThreadMessageRecord[]` from RebornTimelineResponse into
 // the message shape the UI components render. Kept narrow: the v2
-// timeline contract has no attachments, no generated images, no
-// turn-grouping metadata — those v1 affordances are out of scope
-// for issue #3886.
+// timeline contract has no attachments or generated images; turn grouping
+// consumes the normalized `turnRunId` carried by records and previews.
 
 export function messagesFromTimeline(records, pendingMessages = []) {
   const seen = new Set();
@@ -143,6 +142,7 @@ export function toolCardFromPreview(preview) {
     truncated: Boolean(preview.truncated),
     outputBytes: preview.output_bytes ?? null,
     outputKind: preview.output_kind || null,
+    turnRunId: preview.turn_run_id || null,
   };
 }
 
@@ -166,6 +166,7 @@ export function toolCardFromActivity(activity) {
     truncated: false,
     outputBytes: activity.output_bytes ?? null,
     outputKind: null,
+    turnRunId: activity.turn_run_id || null,
   };
 }
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
@@ -116,7 +116,7 @@ function isActivity(msg) {
 }
 
 function hasToolCalls(msg) {
-  return msg.toolCalls && msg.toolCalls.length > 0;
+  return msg?.toolCalls && msg.toolCalls.length > 0;
 }
 
 function turnRunIdForMessage(msg) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.js
@@ -3,14 +3,15 @@
    activity before the answer so the answer still closes its turn, including
    when a later user follow-up has already been appended. */
 export function groupMessages(messages) {
+  const orderedMessages = moveDelayedActivityBeforeFinalReply(messages);
   const items = [];
 
-  for (let index = 0; index < messages.length; index += 1) {
-    const msg = messages[index];
+  for (let index = 0; index < orderedMessages.length; index += 1) {
+    const msg = orderedMessages[index];
 
     if (isFinalAssistantReply(msg)) {
-      const activity = followingActivity(messages, index + 1);
-      const boundary = messages[index + 1 + activity.length];
+      const activity = followingActivity(orderedMessages, index + 1);
+      const boundary = orderedMessages[index + 1 + activity.length];
       if (activity.length > 0 && (!boundary || boundary.role === "user")) {
         appendActivityRun(items, activity);
         appendMessage(items, msg);
@@ -20,7 +21,7 @@ export function groupMessages(messages) {
     }
 
     if (isActivity(msg)) {
-      const activity = followingActivity(messages, index);
+      const activity = followingActivity(orderedMessages, index);
       appendActivityRun(items, activity);
       index += activity.length - 1;
       continue;
@@ -32,12 +33,59 @@ export function groupMessages(messages) {
   return items;
 }
 
+function moveDelayedActivityBeforeFinalReply(messages) {
+  const finalReplyByRun = new Map();
+  for (let index = 0; index < messages.length; index += 1) {
+    const msg = messages[index];
+    const runId = turnRunIdForMessage(msg);
+    if (runId && isFinalAssistantReply(msg)) {
+      finalReplyByRun.set(runId, index);
+    }
+  }
+  if (finalReplyByRun.size === 0) return messages;
+
+  const delayedByFinalIndex = new Map();
+  const delayedIndexes = new Set();
+  for (let index = 0; index < messages.length; index += 1) {
+    const msg = messages[index];
+    if (!isActivity(msg)) continue;
+    const runId = turnRunIdForMessage(msg);
+    const finalIndex = runId ? finalReplyByRun.get(runId) : undefined;
+    if (finalIndex === undefined || finalIndex >= index) continue;
+
+    const delayed = delayedByFinalIndex.get(finalIndex) || [];
+    delayed.push(msg);
+    delayedByFinalIndex.set(finalIndex, delayed);
+    delayedIndexes.add(index);
+  }
+  if (delayedIndexes.size === 0) return messages;
+
+  const ordered = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    if (delayedIndexes.has(index)) continue;
+    const delayed = delayedByFinalIndex.get(index);
+    if (delayed) ordered.push(...delayed);
+    ordered.push(messages[index]);
+  }
+  return ordered;
+}
+
 function followingActivity(messages, start) {
   let end = start;
-  while (end < messages.length && isActivity(messages[end])) {
+  const runId = turnRunIdForMessage(messages[start]);
+  while (
+    end < messages.length &&
+    isActivity(messages[end]) &&
+    sameActivityRun(runId, messages[end])
+  ) {
     end += 1;
   }
   return messages.slice(start, end);
+}
+
+function sameActivityRun(referenceRunId, msg) {
+  const runId = turnRunIdForMessage(msg);
+  return !referenceRunId || !runId || runId === referenceRunId;
 }
 
 function appendActivityRun(items, activity) {
@@ -69,4 +117,8 @@ function isActivity(msg) {
 
 function hasToolCalls(msg) {
   return msg.toolCalls && msg.toolCalls.length > 0;
+}
+
+function turnRunIdForMessage(msg) {
+  return msg?.turnRunId || null;
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs
@@ -123,6 +123,69 @@ test("groupMessages: follow-up user does not break prior final reply ordering", 
   assert.equal(grouped[2].message.id, "u");
 });
 
+test("groupMessages: delayed same-run activity moves before its final reply", () => {
+  const grouped = groupMessages([
+    { id: "u1", role: "user", content: "check email", turnRunId: "run-1" },
+    {
+      id: "m1",
+      role: "assistant",
+      content: "Here are the top emails.",
+      isFinalReply: true,
+      turnRunId: "run-1",
+    },
+    { id: "u2", role: "user", content: "now check calendar", turnRunId: "run-2" },
+    {
+      id: "thinking-thinking:run-1:3",
+      role: "thinking",
+      content: "rank emails",
+      turnRunId: "run-1",
+    },
+    {
+      id: "tool-gmail",
+      role: "tool_activity",
+      toolName: "gmail",
+      turnRunId: "run-1",
+    },
+  ]);
+
+  assert.equal(grouped.length, 4);
+  assert.deepEqual(
+    grouped.map((item) => item.type === "activity-run" ? item.id : item.message.id),
+    ["u1", "activity-run-thinking-thinking:run-1:3", "m1", "u2"],
+  );
+  assert.deepEqual(
+    grouped[1].activity.map((item) => item.id),
+    ["thinking-thinking:run-1:3", "tool-gmail"],
+  );
+});
+
+test("groupMessages: delayed different-run activity stays with the later turn", () => {
+  const grouped = groupMessages([
+    {
+      id: "m1",
+      role: "assistant",
+      content: "Done.",
+      isFinalReply: true,
+      turnRunId: "run-1",
+    },
+    { id: "u2", role: "user", content: "next", turnRunId: "run-2" },
+    {
+      id: "tool-calendar",
+      role: "tool_activity",
+      toolName: "calendar",
+      turnRunId: "run-2",
+    },
+  ]);
+
+  assert.equal(grouped.length, 3);
+  assert.equal(grouped[0].type, "message");
+  assert.equal(grouped[0].message.id, "m1");
+  assert.equal(grouped[1].type, "message");
+  assert.equal(grouped[1].message.id, "u2");
+  assert.equal(grouped[2].type, "activity-run");
+  assert.deepEqual(grouped[2].activity.map((item) => item.id), ["tool-calendar"]);
+});
+
 test("groupMessages: system note after activity keeps original order", () => {
   const grouped = groupMessages([
     { id: "m", role: "assistant", content: "answer", isFinalReply: true },

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.js
@@ -351,6 +351,7 @@ function applyProjectionItems({
           role: "thinking",
           content: item.thinking.body || "",
           timestamp: new Date().toISOString(),
+          turnRunId: item.thinking.run_id || null,
         };
         if (existing >= 0) {
           const copy = [...prev];
@@ -454,6 +455,7 @@ function upsertToolFromActivity(setMessages, invocationId, card) {
         toolStatus: nextStatus,
         toolError: card.toolError || current.toolError,
         updatedAt: card.updatedAt || current.updatedAt,
+        turnRunId: card.turnRunId || current.turnRunId || null,
       };
       return copy;
     }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs
@@ -68,10 +68,12 @@ test("useChatEvents: projection activity preserves reasoning/tool chronology", (
     frame: {
       state: {
         items: [
-          { thinking: { id: "run-1:1", body: "before tool" } },
+          { run_status: { run_id: "run-1", status: "running" } },
+          { thinking: { id: "run-1:1", run_id: "run-1", body: "before tool" } },
           {
             capability_activity: {
               invocation_id: "invocation-1",
+              turn_run_id: "run-1",
               thread_id: threadId,
               capability_id: "builtin.http",
               status: "started",
@@ -83,7 +85,7 @@ test("useChatEvents: projection activity preserves reasoning/tool chronology", (
               updated_at: "2026-06-03T11:44:43Z",
             },
           },
-          { thinking: { id: "run-1:2", body: "after tool" } },
+          { thinking: { id: "run-1:2", run_id: "run-1", body: "after tool" } },
         ],
       },
     },
@@ -99,4 +101,8 @@ test("useChatEvents: projection activity preserves reasoning/tool chronology", (
   );
   assert.equal(messages[1].toolName, "builtin.http");
   assert.equal(messages[1].toolStatus, "running");
+  assert.deepEqual(
+    Array.from(messages, (message) => message.turnRunId),
+    ["run-1", "run-1", "run-1"],
+  );
 });


### PR DESCRIPTION
## Summary
- Carry explicit turn run IDs through live projection thinking/tool activity payloads and product adapter DTOs.
- Preserve `turnRunId` in WebUI SSE/history mappers so reasoning and tool cards are owned by the correct run.
- Reorder delayed same-run activity before its finalized assistant reply, while leaving different-run activity with the later turn.

## Root cause
Live projection activity did not consistently expose the owning turn run to the WebUI. The UI then grouped late-arriving reasoning/tool activity by array position or inferred IDs, so failed calls and reasoning from a previous run could render under the next user turn.

## Thermo loop
- Loops run: 2/5
- Fixed: 2 maintainability findings in iteration 1 (stale mapper comment, duplicated display-preview run-id conversion)
- Stop condition: no actionable thermo-level issues found in iteration 2

## Validation
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/message-groups.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/useChatEvents.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/chat/lib/history-messages.test.mjs`
- `cargo test -p ironclaw_product_adapters outbound --lib`
- `cargo test -p ironclaw_reborn_composition projection::tests::live_progress_stream --lib`
- `cargo test -p ironclaw_reborn_composition projection::tests::runtime_stream --lib`
- `cargo test -p ironclaw_reborn_composition projection::tests::display_preview --lib`
- `cargo fmt`
- `git diff --check`
