### PR TITLE
[codex] Normalize synthesized skill install names

### DIFF
--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -2208,8 +2208,8 @@ async fn builtin_skill_install_accepts_and_replays_named_plain_markdown_content(
     let (filesystem, mounts) = mounted_skill_filesystem(temp.path());
     let runtime = runtime_with_filesystem(filesystem);
     let input = json!({
-        "name": "qa-smoke-skill",
-        "content": "# QA Smoke\n\nSay \"qa skill loaded\" when asked.\n"
+        "name": "daily digest email docs",
+        "content": "# Daily Digest\n\nSummarize updates for an email.\n"
     });
 
     let installed = invoke_with_context(
@@ -2228,7 +2228,7 @@ async fn builtin_skill_install_accepts_and_replays_named_plain_markdown_content(
     .unwrap();
 
     assert_eq!(installed["installed"], json!(true));
-    assert_eq!(installed["name"], json!("qa-smoke-skill"));
+    assert_eq!(installed["name"], json!("daily-digest-email-docs"));
     assert_eq!(installed["source"], json!("user"));
 
     let replayed = invoke_with_context(
@@ -2245,7 +2245,7 @@ async fn builtin_skill_install_accepts_and_replays_named_plain_markdown_content(
     .unwrap();
 
     assert_eq!(replayed["installed"], json!(true));
-    assert_eq!(replayed["name"], json!("qa-smoke-skill"));
+    assert_eq!(replayed["name"], json!("daily-digest-email-docs"));
 
     let listed = invoke_with_context(
         &runtime,
@@ -2256,7 +2256,10 @@ async fn builtin_skill_install_accepts_and_replays_named_plain_markdown_content(
     .await
     .unwrap();
     assert_eq!(listed["count"], json!(1));
-    assert_eq!(listed["skills"][0]["name"], json!("qa-smoke-skill"));
+    assert_eq!(
+        listed["skills"][0]["name"],
+        json!("daily-digest-email-docs")
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::parser::starts_with_frontmatter_delimiter;
+use crate::validation::normalize_skill_identifier;
 use crate::{
     MAX_PROMPT_FILE_SIZE, ParsedSkill, SkillParseError, normalize_line_endings, parse_skill_md,
     validate_skill_name,
@@ -210,6 +211,7 @@ pub struct SkillInstallResult {
 struct PreparedSkillInstall {
     content: String,
     parsed: ParsedSkill,
+    synthesized_frontmatter: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -321,6 +323,7 @@ pub async fn install_skill(
         ));
     }
     if let Some(requested_name) = request.name
+        && !prepared.synthesized_frontmatter
         && requested_name != prepared.parsed.manifest.name
     {
         tracing::debug!(
@@ -417,6 +420,7 @@ fn prepare_install_content(
         Ok(parsed) => Ok(PreparedSkillInstall {
             content: normalized_content,
             parsed,
+            synthesized_frontmatter: false,
         }),
         Err(SkillParseError::MissingFrontmatter)
             if !starts_with_frontmatter_delimiter(&normalized_content) =>
@@ -426,7 +430,11 @@ fn prepare_install_content(
                 tracing::debug!(%error, "skill install failed to parse synthesized SKILL.md content");
                 skill_parse_error(error)
             })?;
-            Ok(PreparedSkillInstall { content, parsed })
+            Ok(PreparedSkillInstall {
+                content,
+                parsed,
+                synthesized_frontmatter: true,
+            })
         }
         Err(error) => {
             tracing::debug!(%error, "skill install failed to parse SKILL.md content");
@@ -444,7 +452,7 @@ fn synthesize_install_frontmatter(
         tracing::debug!(%error, "skill install failed to parse SKILL.md content");
         return Err(skill_parse_error(error));
     };
-    if !validate_skill_name(requested_name) {
+    let Some(skill_name) = normalize_skill_identifier(requested_name) else {
         tracing::debug!(
             requested_name,
             "skill install rejected invalid requested name"
@@ -452,9 +460,9 @@ fn synthesize_install_frontmatter(
         return Err(SkillManagementError::new(
             SkillManagementErrorKind::InvalidInput,
         ));
-    }
+    };
 
-    let mut rendered = format!("---\nname: {requested_name}\n---\n\n");
+    let mut rendered = format!("---\nname: {skill_name}\n---\n\n");
     rendered.push_str(normalized_content);
     Ok(rendered)
 }

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -18,6 +18,8 @@ use ironclaw_host_api::{HostApiError, MountView, ResourceScope, ScopedPath, Virt
 
 mod install_bundle;
 #[cfg(test)]
+mod install_name_tests;
+#[cfg(test)]
 mod tests;
 
 pub use install_bundle::{
@@ -211,7 +213,6 @@ pub struct SkillInstallResult {
 struct PreparedSkillInstall {
     content: String,
     parsed: ParsedSkill,
-    synthesized_frontmatter: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -322,19 +323,6 @@ pub async fn install_skill(
             SkillManagementErrorKind::Resource,
         ));
     }
-    if let Some(requested_name) = request.name
-        && !prepared.synthesized_frontmatter
-        && requested_name != prepared.parsed.manifest.name
-    {
-        tracing::debug!(
-            requested_name,
-            parsed_name = %prepared.parsed.manifest.name,
-            "skill install rejected name mismatch"
-        );
-        return Err(SkillManagementError::new(
-            SkillManagementErrorKind::InvalidInput,
-        ));
-    }
     validate_install_bundle_files(request.files)?;
 
     let skill_name = prepared.parsed.manifest.name;
@@ -417,11 +405,13 @@ fn prepare_install_content(
 ) -> Result<PreparedSkillInstall, SkillManagementError> {
     let normalized_content = normalize_line_endings(content);
     match parse_skill_md(&normalized_content) {
-        Ok(parsed) => Ok(PreparedSkillInstall {
-            content: normalized_content,
-            parsed,
-            synthesized_frontmatter: false,
-        }),
+        Ok(parsed) => {
+            validate_requested_name_matches_manifest(requested_name, &parsed.manifest.name)?;
+            Ok(PreparedSkillInstall {
+                content: normalized_content,
+                parsed,
+            })
+        }
         Err(SkillParseError::MissingFrontmatter)
             if !starts_with_frontmatter_delimiter(&normalized_content) =>
         {
@@ -430,17 +420,32 @@ fn prepare_install_content(
                 tracing::debug!(%error, "skill install failed to parse synthesized SKILL.md content");
                 skill_parse_error(error)
             })?;
-            Ok(PreparedSkillInstall {
-                content,
-                parsed,
-                synthesized_frontmatter: true,
-            })
+            Ok(PreparedSkillInstall { content, parsed })
         }
         Err(error) => {
             tracing::debug!(%error, "skill install failed to parse SKILL.md content");
             Err(skill_parse_error(error))
         }
     }
+}
+
+fn validate_requested_name_matches_manifest(
+    requested_name: Option<&str>,
+    manifest_name: &str,
+) -> Result<(), SkillManagementError> {
+    if let Some(requested_name) = requested_name
+        && normalize_skill_identifier(requested_name).as_deref() != Some(manifest_name)
+    {
+        tracing::debug!(
+            requested_name,
+            parsed_name = %manifest_name,
+            "skill install rejected name mismatch"
+        );
+        return Err(SkillManagementError::new(
+            SkillManagementErrorKind::InvalidInput,
+        ));
+    }
+    Ok(())
 }
 
 fn synthesize_install_frontmatter(

--- a/crates/ironclaw_skills/src/management.rs
+++ b/crates/ironclaw_skills/src/management.rs
@@ -18,8 +18,6 @@ use ironclaw_host_api::{HostApiError, MountView, ResourceScope, ScopedPath, Virt
 
 mod install_bundle;
 #[cfg(test)]
-mod install_name_tests;
-#[cfg(test)]
 mod tests;
 
 pub use install_bundle::{

--- a/crates/ironclaw_skills/src/management/install_name_tests.rs
+++ b/crates/ironclaw_skills/src/management/install_name_tests.rs
@@ -1,0 +1,104 @@
+use std::sync::Arc;
+
+use ironclaw_filesystem::{InMemoryBackend, RootFilesystem};
+use ironclaw_host_api::{
+    MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, VirtualPath,
+};
+
+use super::*;
+
+#[tokio::test]
+async fn install_normalizes_plain_markdown_requested_display_name() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem.clone(), skill_mounts());
+
+    let installed = install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("Daily Digest Email Docs"),
+            content: "# Daily Digest\n\nSummarize updates for an email.\n",
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(installed.name, "daily-digest-email-docs");
+    let written = read_file(
+        filesystem.as_ref(),
+        "/projects/skills/daily-digest-email-docs/SKILL.md",
+    )
+    .await;
+    assert!(written.starts_with("---\nname: daily-digest-email-docs\n---\n\n"));
+
+    let listed = list_skills(&context).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "daily-digest-email-docs");
+}
+
+#[tokio::test]
+async fn install_accepts_frontmatter_matching_requested_display_name() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem, skill_mounts());
+
+    let installed = install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("Daily Digest Email Docs"),
+            content: &skill_md(
+                "daily-digest-email-docs",
+                "daily digest description",
+                "DAILY_DIGEST_PROMPT",
+            ),
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(installed.name, "daily-digest-email-docs");
+    let listed = list_skills(&context).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "daily-digest-email-docs");
+}
+
+fn skill_mounts() -> MountView {
+    MountView::new(vec![
+        MountGrant::new(
+            MountAlias::new("/skills").unwrap(),
+            VirtualPath::new("/projects/skills").unwrap(),
+            MountPermissions::read_write_list_delete(),
+        ),
+        MountGrant::new(
+            MountAlias::new("/system/skills").unwrap(),
+            VirtualPath::new("/projects/system/skills").unwrap(),
+            MountPermissions::read_only(),
+        ),
+    ])
+    .unwrap()
+}
+
+fn skill_management_context(
+    filesystem: Arc<InMemoryBackend>,
+    mounts: MountView,
+) -> SkillManagementContext {
+    let filesystem: Arc<dyn RootFilesystem> = filesystem;
+    SkillManagementContext::new(filesystem, mounts, ResourceScope::system())
+}
+
+fn skill_md(name: &str, description: &str, prompt: &str) -> String {
+    format!("---\nname: {name}\ndescription: {description}\n---\n{prompt}\n")
+}
+
+async fn read_file(root: &InMemoryBackend, path: &str) -> String {
+    let bytes = root
+        .read_file_bounded(&VirtualPath::new(path).unwrap(), 1024)
+        .await
+        .unwrap()
+        .unwrap_or_else(|| panic!("{path} should exist"));
+    String::from_utf8(bytes).unwrap()
+}

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -128,37 +128,6 @@ async fn install_accepts_named_plain_markdown_content() {
 }
 
 #[tokio::test]
-async fn install_normalizes_plain_markdown_requested_display_name() {
-    let filesystem = Arc::new(InMemoryBackend::default());
-    let context = skill_management_context(filesystem.clone(), skill_mounts());
-
-    let installed = install_skill(
-        &context,
-        SkillInstallRequest {
-            name: Some("Daily Digest Email Docs"),
-            content: "# Daily Digest\n\nSummarize updates for an email.\n",
-            files: &[],
-            source: SkillInstallSource::User,
-            source_url: None,
-        },
-    )
-    .await
-    .unwrap();
-
-    assert_eq!(installed.name, "daily-digest-email-docs");
-    let written = read_file(
-        filesystem.as_ref(),
-        "/projects/skills/daily-digest-email-docs/SKILL.md",
-    )
-    .await;
-    assert!(written.starts_with("---\nname: daily-digest-email-docs\n---\n\n"));
-
-    let listed = list_skills(&context).await.unwrap();
-    assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].name, "daily-digest-email-docs");
-}
-
-#[tokio::test]
 async fn install_matching_existing_skill_is_idempotent() {
     let filesystem = Arc::new(InMemoryBackend::default());
     let context = skill_management_context(filesystem.clone(), skill_mounts());

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -128,6 +128,37 @@ async fn install_accepts_named_plain_markdown_content() {
 }
 
 #[tokio::test]
+async fn install_normalizes_plain_markdown_requested_display_name() {
+    let filesystem = Arc::new(InMemoryBackend::default());
+    let context = skill_management_context(filesystem.clone(), skill_mounts());
+
+    let installed = install_skill(
+        &context,
+        SkillInstallRequest {
+            name: Some("Daily Digest Email Docs"),
+            content: "# Daily Digest\n\nSummarize updates for an email.\n",
+            files: &[],
+            source: SkillInstallSource::User,
+            source_url: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(installed.name, "daily-digest-email-docs");
+    let written = read_file(
+        filesystem.as_ref(),
+        "/projects/skills/daily-digest-email-docs/SKILL.md",
+    )
+    .await;
+    assert!(written.starts_with("---\nname: daily-digest-email-docs\n---\n\n"));
+
+    let listed = list_skills(&context).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "daily-digest-email-docs");
+}
+
+#[tokio::test]
 async fn install_matching_existing_skill_is_idempotent() {
     let filesystem = Arc::new(InMemoryBackend::default());
     let context = skill_management_context(filesystem.clone(), skill_mounts());

--- a/crates/ironclaw_skills/src/management/tests.rs
+++ b/crates/ironclaw_skills/src/management/tests.rs
@@ -12,6 +12,8 @@ use ironclaw_host_api::{
 use super::install_bundle::MAX_INSTALL_BUNDLE_FILE_BYTES;
 use super::*;
 
+mod install_name;
+
 #[tokio::test]
 async fn install_list_and_remove_user_skills_through_scoped_mounts() {
     let filesystem = Arc::new(InMemoryBackend::default());

--- a/crates/ironclaw_skills/src/management/tests/install_name.rs
+++ b/crates/ironclaw_skills/src/management/tests/install_name.rs
@@ -1,10 +1,3 @@
-use std::sync::Arc;
-
-use ironclaw_filesystem::{InMemoryBackend, RootFilesystem};
-use ironclaw_host_api::{
-    MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, VirtualPath,
-};
-
 use super::*;
 
 #[tokio::test]
@@ -64,41 +57,4 @@ async fn install_accepts_frontmatter_matching_requested_display_name() {
     let listed = list_skills(&context).await.unwrap();
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].name, "daily-digest-email-docs");
-}
-
-fn skill_mounts() -> MountView {
-    MountView::new(vec![
-        MountGrant::new(
-            MountAlias::new("/skills").unwrap(),
-            VirtualPath::new("/projects/skills").unwrap(),
-            MountPermissions::read_write_list_delete(),
-        ),
-        MountGrant::new(
-            MountAlias::new("/system/skills").unwrap(),
-            VirtualPath::new("/projects/system/skills").unwrap(),
-            MountPermissions::read_only(),
-        ),
-    ])
-    .unwrap()
-}
-
-fn skill_management_context(
-    filesystem: Arc<InMemoryBackend>,
-    mounts: MountView,
-) -> SkillManagementContext {
-    let filesystem: Arc<dyn RootFilesystem> = filesystem;
-    SkillManagementContext::new(filesystem, mounts, ResourceScope::system())
-}
-
-fn skill_md(name: &str, description: &str, prompt: &str) -> String {
-    format!("---\nname: {name}\ndescription: {description}\n---\n{prompt}\n")
-}
-
-async fn read_file(root: &InMemoryBackend, path: &str) -> String {
-    let bytes = root
-        .read_file_bounded(&VirtualPath::new(path).unwrap(), 1024)
-        .await
-        .unwrap()
-        .unwrap_or_else(|| panic!("{path} should exist"));
-    String::from_utf8(bytes).unwrap()
 }


### PR DESCRIPTION
## Summary
- Normalize natural-language requested names when `skill_install` synthesizes SKILL.md frontmatter for plain markdown content.
- Preserve strict requested-name mismatch checks for content that already has explicit frontmatter.
- Add regression coverage through both `ironclaw_skills` management and the first-party `builtin.skill_install` runtime path.

## Root Cause
Plain markdown installs synthesize frontmatter from the requested `name`, but that path validated the raw model-provided name before normalization. Names like `daily digest email docs` therefore failed with `InvalidInput` before installation could proceed.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_skills install_normalizes_plain_markdown_requested_display_name`
- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_skill_install_accepts_and_replays_named_plain_markdown_content`