### PR TITLE
[codex] Improve bundled skill parse diagnostics

### DIFF
--- a/crates/ironclaw_reborn_composition/build.rs
+++ b/crates/ironclaw_reborn_composition/build.rs
@@ -59,8 +59,12 @@ fn embed_reborn_skills(repo_root: &Path) -> BuildResult<()> {
         }
 
         let skill_md_content = fs::read_to_string(&skill_md)?;
-        let parsed = parse_skill_md(&skill_md_content)
-            .map_err(|error| build_error(format!("parse bundled SKILL.md: {error}")))?;
+        let parsed = parse_skill_md(&skill_md_content).map_err(|error| {
+            build_error(format!(
+                "parse bundled Reborn skill `{dir_name}` at {}: {error}",
+                skill_md.display()
+            ))
+        })?;
         if parsed.manifest.name != dir_name {
             return Err(build_error(format!(
                 "bundled Reborn skill `{}` manifest name `{}` must match directory name",


### PR DESCRIPTION
## Summary
- Include the bundled skill directory name and exact `SKILL.md` path when Reborn bundled-skill parsing fails during the build script.

## Why
A local malformed `skills/daily-digest-email-docs/SKILL.md` produced only `parse bundled SKILL.md`, which made the failure look like the whole build was broken without pointing to the offending local skill file.

## Validation
- `cargo fmt --check`
- `cargo check -p ironclaw_reborn_composition`
- Temporarily created a malformed local bundled skill and confirmed the error names the skill and path, then removed it and reran the clean check.