### PR TITLE
chore: v0.29.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.1](https://github.com/nearai/ironclaw/compare/ironclaw-v0.29.0...ironclaw-v0.29.1) - 2026-06-04
+
+### Added
+
+- *(web)* plumb temperature through Responses API ([#3641](https://github.com/nearai/ironclaw/pull/3641))
+
+### Fixed
+
+- *(engine)* scope v1 history for channel conversations ([#4320](https://github.com/nearai/ironclaw/pull/4320))
+
+### CI / Release
+
+- *(release)* add WeCom release artifact ([#4107](https://github.com/nearai/ironclaw/pull/4107))
+- *(ci)* track `nearai/benchmarks` at `main` instead of pinning ([#4217](https://github.com/nearai/ironclaw/pull/4217))
+- *(ci)* grant `id-token: write` to unblock nearai-bench reusable workflow ([#4220](https://github.com/nearai/ironclaw/pull/4220))
+- *(ci)* scope `id-token: write` to the nearai-bench job ([#4221](https://github.com/nearai/ironclaw/pull/4221))
+
 ## [0.29.0](https://github.com/nearai/ironclaw/compare/ironclaw-v0.28.2...ironclaw-v0.29.0) - 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 
 [package]
 name = "ironclaw"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
## New release

* `ironclaw`: 0.29.0 -> 0.29.1

## Changes included

* Add Responses API temperature support ([#3641](https://github.com/nearai/ironclaw/pull/3641))
* Add WeCom release artifact metadata ([#4107](https://github.com/nearai/ironclaw/pull/4107))
* Fix and scope nearai-bench CI permissions ([#4217](https://github.com/nearai/ironclaw/pull/4217), [#4220](https://github.com/nearai/ironclaw/pull/4220), [#4221](https://github.com/nearai/ironclaw/pull/4221))
* Scope v1 history for channel conversations ([#4320](https://github.com/nearai/ironclaw/pull/4320))

## Validation

* `git diff --check origin/main..HEAD`
* `cargo metadata --no-deps --format-version 1`
* `./scripts/check-version-bumps.sh`

This release-prep PR updates the root package version, Cargo.lock, and CHANGELOG. After merge, the release tag should be `ironclaw-v0.29.1`; pushing that tag triggers cargo-dist release artifacts, installers, WASM bundles, Docker images, and the GitHub Release.