### PR TITLE
Fix extension capability counts in WebUI summaries

### DIFF
--- a/crates/ironclaw_product_workflow/src/lifecycle.rs
+++ b/crates/ironclaw_product_workflow/src/lifecycle.rs
@@ -339,6 +339,8 @@ pub struct LifecycleExtensionSummary {
     pub description: String,
     pub source: LifecycleExtensionSource,
     pub runtime_kind: LifecycleExtensionRuntimeKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub visible_capability_ids: Vec<String>,
     pub visible_read_only_capability_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub credential_requirements: Vec<LifecycleExtensionCredentialRequirement>,

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
@@ -391,6 +391,7 @@ mod tests {
                 description: "test extension".to_string(),
                 source: LifecycleExtensionSource::HostBundled,
                 runtime_kind,
+                visible_capability_ids: Vec::new(),
                 visible_read_only_capability_ids: Vec::new(),
                 credential_requirements,
                 onboarding,

--- a/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
@@ -213,7 +213,7 @@ fn extension_info(installed: LifecycleInstalledExtensionSummary) -> RebornExtens
             LifecyclePhase::Active | LifecyclePhase::Activating | LifecyclePhase::Configured
         ),
         active: phase == LifecyclePhase::Active,
-        tools: summary.visible_read_only_capability_ids,
+        tools: summary.visible_capability_ids,
         needs_setup: matches!(
             phase,
             LifecyclePhase::Installed | LifecyclePhase::Configured | LifecyclePhase::Failed
@@ -404,6 +404,7 @@ mod tests {
             description: "test extension".to_string(),
             source: LifecycleExtensionSource::HostBundled,
             runtime_kind: LifecycleExtensionRuntimeKind::WasmTool,
+            visible_capability_ids: Vec::new(),
             visible_read_only_capability_ids: Vec::new(),
             credential_requirements: vec![LifecycleExtensionCredentialRequirement {
                 name: "fixture_token".to_string(),

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -539,6 +539,7 @@ impl RecordingLifecycleFacade {
             description: "test extension".to_string(),
             source: LifecycleExtensionSource::HostBundled,
             runtime_kind: LifecycleExtensionRuntimeKind::FirstParty,
+            visible_capability_ids: Vec::new(),
             visible_read_only_capability_ids: Vec::new(),
             credential_requirements: self.credential_requirements.clone(),
             onboarding: self.onboarding.clone(),
@@ -3472,6 +3473,7 @@ async fn list_extensions_projects_onboarding_payload_through_reborn_services() {
         .expect("extension list response");
     let extension = response.extensions.first().expect("one extension");
 
+    assert_eq!(extension.tools, vec!["github.read", "github.write"]);
     assert_eq!(
         extension.onboarding_state,
         Some(RebornExtensionOnboardingState::SetupRequired)
@@ -3634,6 +3636,7 @@ fn extension_summary(
         description: "test extension".to_string(),
         source: LifecycleExtensionSource::HostBundled,
         runtime_kind: LifecycleExtensionRuntimeKind::FirstParty,
+        visible_capability_ids: vec![format!("{package_id}.read"), format!("{package_id}.write")],
         visible_read_only_capability_ids: Vec::new(),
         credential_requirements,
         onboarding,

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -1,6 +1,6 @@
 use ironclaw_extensions::{
-    CapabilityVisibility, ExtensionAssetPath, ExtensionManifest, ExtensionPackage,
-    ExtensionRuntime, ManifestSource,
+    CapabilityDeclV2, CapabilityVisibility, ExtensionAssetPath, ExtensionManifest,
+    ExtensionPackage, ExtensionRuntime, ManifestSource,
 };
 use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{CapabilityId, ExtensionId, VirtualPath, sha256_digest_token};
@@ -70,7 +70,10 @@ pub(crate) struct AvailableExtensionPackage {
 
 impl AvailableExtensionPackage {
     pub(crate) fn summary(&self) -> LifecycleExtensionSummary {
-        let visible_read_only_capability_ids = visible_capability_ids(self)
+        let visible_capability_ids = visible_capability_ids(self)
+            .map(|id| id.as_str().to_string())
+            .collect::<Vec<_>>();
+        let visible_read_only_capability_ids = visible_read_only_capability_ids(self)
             .map(|id| id.as_str().to_string())
             .collect::<Vec<_>>();
         LifecycleExtensionSummary {
@@ -80,6 +83,7 @@ impl AvailableExtensionPackage {
             description: self.package.manifest.description.clone(),
             source: LifecycleExtensionSource::HostBundled,
             runtime_kind: runtime_kind(&self.package.manifest.runtime),
+            visible_capability_ids,
             visible_read_only_capability_ids,
             credential_requirements: credential_requirements(self),
             onboarding: onboarding(self.package_ref.id.as_str()),
@@ -1392,14 +1396,26 @@ fn map_binding_error(error: impl std::fmt::Display) -> ProductWorkflowError {
 pub(crate) fn visible_capability_ids(
     extension: &AvailableExtensionPackage,
 ) -> impl Iterator<Item = &CapabilityId> {
+    visible_capabilities(extension).map(|capability| &capability.id)
+}
+
+pub(crate) fn visible_read_only_capability_ids(
+    extension: &AvailableExtensionPackage,
+) -> impl Iterator<Item = &CapabilityId> {
+    visible_capabilities(extension)
+        .filter(|capability| !capability.effects.iter().any(|effect| effect.is_write()))
+        .map(|capability| &capability.id)
+}
+
+fn visible_capabilities(
+    extension: &AvailableExtensionPackage,
+) -> impl Iterator<Item = &CapabilityDeclV2> {
     extension
         .package
         .manifest
         .capabilities
         .iter()
         .filter(|capability| capability.visibility == CapabilityVisibility::Model)
-        .filter(|capability| !capability.effects.iter().any(|effect| effect.is_write()))
-        .map(|capability| &capability.id)
 }
 
 #[cfg(test)]
@@ -1425,10 +1441,27 @@ mod tests {
     use crate::nearai_mcp::nearai_mcp_endpoint_from_base;
 
     #[test]
-    fn visible_capability_ids_excludes_write_effects() {
+    fn visible_capability_ids_include_write_effects() {
         let extension = test_extension_package();
 
         let visible = visible_capability_ids(&extension)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            visible,
+            vec![
+                CapabilityId::new("fixture.search").unwrap(),
+                CapabilityId::new("fixture.write").unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn visible_read_only_capability_ids_excludes_write_effects() {
+        let extension = test_extension_package();
+
+        let visible = visible_read_only_capability_ids(&extension)
             .cloned()
             .collect::<Vec<_>>();
 
@@ -1639,6 +1672,11 @@ mod tests {
         assert!(capabilities.contains_key("google-drive.upload_file"));
 
         let summary = package.summary();
+        assert!(
+            summary
+                .visible_capability_ids
+                .contains(&"google-drive.upload_file".to_string())
+        );
         assert!(
             summary
                 .visible_read_only_capability_ids

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle.rs
@@ -2117,6 +2117,20 @@ mod tests {
             .find(|extension| extension.package_ref.id.as_str() == "google-calendar")
             .expect("google-calendar search result");
         assert_eq!(
+            calendar.visible_capability_ids,
+            vec![
+                "google-calendar.list_calendars",
+                "google-calendar.list_events",
+                "google-calendar.get_event",
+                "google-calendar.find_free_slots",
+                "google-calendar.create_event",
+                "google-calendar.update_event",
+                "google-calendar.delete_event",
+                "google-calendar.add_attendees",
+                "google-calendar.set_reminder",
+            ]
+        );
+        assert_eq!(
             calendar.visible_read_only_capability_ids,
             vec![
                 "google-calendar.list_calendars",
@@ -2142,6 +2156,17 @@ mod tests {
         };
         assert_eq!(extensions.len(), 1);
         assert_eq!(extensions[0].package_ref.id.as_str(), "gmail");
+        assert_eq!(
+            extensions[0].visible_capability_ids,
+            vec![
+                "gmail.list_messages",
+                "gmail.get_message",
+                "gmail.send_message",
+                "gmail.create_draft",
+                "gmail.reply_to_message",
+                "gmail.trash_message",
+            ]
+        );
         assert_eq!(
             extensions[0].visible_read_only_capability_ids,
             vec!["gmail.list_messages", "gmail.get_message"]

--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle_command.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle_command.rs
@@ -151,11 +151,7 @@ fn render_search_payload(
                 format_args!("  description: {}", terminal_safe(&extension.description)),
             );
         }
-        render_string_array(
-            output,
-            &extension.visible_read_only_capability_ids,
-            "  capability",
-        );
+        render_string_array(output, &extension.visible_capability_ids, "  capability");
     }
 }
 
@@ -238,6 +234,7 @@ mod tests {
                     source: LifecycleExtensionSource::HostBundled,
                     runtime_kind:
                         ironclaw_product_workflow::LifecycleExtensionRuntimeKind::WasmTool,
+                    visible_capability_ids: Vec::new(),
                     visible_read_only_capability_ids: Vec::new(),
                     credential_requirements: Vec::new(),
                     onboarding: None,


### PR DESCRIPTION
## Summary
- Add an all-model-visible capability list to lifecycle extension summaries while retaining the read-only subset.
- Project WebUI extension `tools` from the full visible capability list so card counts match the real extension capability surface.
- Update lifecycle/CLI rendering and regression tests for GSuite/Gmail counts.

## Tests
- cargo fmt
- cargo test -p ironclaw_product_workflow --test reborn_services_contract
- cargo test -p ironclaw_reborn_composition visible_capability_ids
- cargo test -p ironclaw_reborn_composition visible_read_only_capability_ids_excludes_write_effects
- cargo test -p ironclaw_reborn_composition bundled_gsuite_wasm_capabilities_are_operation_scoped
- cargo test -p ironclaw_reborn_composition extension_lifecycle_installs_activates_and_removes_gsuite