### PR TITLE
[codex] Bind local dev runtime scope to run actor

### DIFF
--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -69,7 +69,7 @@ pub(super) fn capability_wiring(
     services: &RebornServices,
     thread_service: Arc<dyn SessionThreadService>,
     thread_scope: ThreadScope,
-    user_id: UserId,
+    fallback_user_id: UserId,
     policy: Arc<LocalDevCapabilityPolicy>,
     model_gateway: Arc<dyn HostManagedModelGateway>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
@@ -93,7 +93,7 @@ pub(super) fn capability_wiring(
     let capability_factory: Arc<dyn LoopCapabilityPortFactory> =
         Arc::new(LocalDevLoopCapabilityPortFactory {
             runtime,
-            user_id,
+            fallback_user_id,
             policy,
             workspace_mounts,
             skill_mounts,
@@ -120,7 +120,7 @@ pub(super) fn capability_wiring(
 #[derive(Clone)]
 struct LocalDevLoopCapabilityPortFactory {
     runtime: Arc<dyn HostRuntime>,
-    user_id: UserId,
+    fallback_user_id: UserId,
     policy: Arc<LocalDevCapabilityPolicy>,
     workspace_mounts: MountView,
     skill_mounts: MountView,
@@ -148,7 +148,7 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             .map_err(host_api_agent_loop_error)?;
         let visible_request = local_dev_visible_capability_request(
             run_context,
-            self.user_id.clone(),
+            &self.fallback_user_id,
             workspace_mounts.clone(),
             skill_mounts.clone(),
             memory_mounts.clone(),
@@ -721,7 +721,7 @@ fn model_capability_io_error(error: AgentLoopHostError) -> HostManagedModelError
 
 fn local_dev_visible_capability_request(
     run_context: &LoopRunContext,
-    user_id: UserId,
+    fallback_user_id: &UserId,
     workspace_mounts: MountView,
     skill_mounts: MountView,
     memory_mounts: MountView,
@@ -738,6 +738,10 @@ fn local_dev_visible_capability_request(
     grants
         .grants
         .extend(extension_surface.grants(&extension_id));
+    let user_id = run_context
+        .actor()
+        .map(|actor| actor.user_id.clone())
+        .unwrap_or_else(|| fallback_user_id.clone());
     let mut context = ExecutionContext::local_default(
         user_id,
         extension_id,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/shell_tests.rs
@@ -100,7 +100,7 @@ async fn local_dev_yolo_shell_translates_workspace_workdir_without_scoped_mounts
     let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
     let factory = LocalDevLoopCapabilityPortFactory {
         runtime,
-        user_id: UserId::new("local-dev-shell-user").expect("user id"),
+        fallback_user_id: UserId::new("local-dev-shell-user").expect("user id"),
         policy,
         workspace_mounts,
         skill_mounts,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -59,6 +59,52 @@ mod tests {
         )
     }
 
+    #[tokio::test]
+    async fn local_dev_visible_capability_request_uses_run_actor_for_runtime_scope() {
+        let run_context = run_context("actor-runtime-scope")
+            .await
+            .with_actor(TurnActor::new(
+                UserId::new("sso-user").expect("actor user id"),
+            ));
+        let fallback_user_id = UserId::new("env-operator").expect("fallback user id");
+        let request = visible_request_for_runtime_scope(&run_context, &fallback_user_id);
+
+        assert_eq!(request.context.user_id.as_str(), "sso-user");
+        assert_eq!(request.context.resource_scope.user_id.as_str(), "sso-user");
+    }
+
+    #[tokio::test]
+    async fn local_dev_visible_capability_request_keeps_fallback_user_without_actor() {
+        let run_context = run_context("fallback-runtime-scope").await;
+        let fallback_user_id = UserId::new("env-operator").expect("fallback user id");
+        let request = visible_request_for_runtime_scope(&run_context, &fallback_user_id);
+
+        assert_eq!(request.context.user_id.as_str(), "env-operator");
+        assert_eq!(
+            request.context.resource_scope.user_id.as_str(),
+            "env-operator"
+        );
+    }
+
+    fn visible_request_for_runtime_scope(
+        run_context: &LoopRunContext,
+        fallback_user_id: &UserId,
+    ) -> HostVisibleCapabilityRequest {
+        let policy = crate::local_dev_capability_policy::local_dev_capability_policy()
+            .expect("policy parses");
+
+        local_dev_visible_capability_request(
+            run_context,
+            fallback_user_id,
+            MountView::default(),
+            MountView::default(),
+            MountView::default(),
+            &policy,
+            &LocalDevExtensionSurface::default(),
+        )
+        .expect("visible request")
+    }
+
     fn provider_tool_call_with_name(
         name: impl Into<String>,
         arguments: serde_json::Value,
@@ -809,7 +855,7 @@ mod tests {
         let skill_mounts = local_runtime.skill_mounts.clone();
         let factory = LocalDevLoopCapabilityPortFactory {
             runtime,
-            user_id: UserId::new("skill-activate-user").expect("user id"),
+            fallback_user_id: UserId::new("skill-activate-user").expect("user id"),
             policy,
             workspace_mounts: local_runtime.workspace_mounts.clone(),
             skill_mounts,
@@ -1003,7 +1049,7 @@ mod tests {
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = LocalDevLoopCapabilityPortFactory {
             runtime,
-            user_id: UserId::new("local-yolo-host-user").expect("user id"), // safety: literal test id is valid.
+            fallback_user_id: UserId::new("local-yolo-host-user").expect("user id"), // safety: literal test id is valid.
             policy,
             workspace_mounts,
             skill_mounts,
@@ -1219,7 +1265,7 @@ mod tests {
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = LocalDevLoopCapabilityPortFactory {
             runtime,
-            user_id: UserId::new("local-dev-skill-port-user").expect("user id"), // safety: literal test id is valid.
+            fallback_user_id: UserId::new("local-dev-skill-port-user").expect("user id"), // safety: literal test id is valid.
             policy,
             workspace_mounts,
             skill_mounts,
@@ -1305,7 +1351,7 @@ mod tests {
         let result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
         let factory = LocalDevLoopCapabilityPortFactory {
             runtime,
-            user_id: UserId::new("local-dev-no-host-user").expect("user id"), // safety: literal test id is valid.
+            fallback_user_id: UserId::new("local-dev-no-host-user").expect("user id"), // safety: literal test id is valid.
             policy,
             workspace_mounts,
             skill_mounts,


### PR DESCRIPTION
## Summary

- bind local-dev capability runtime identity to the run actor when present
- keep the configured env user as a fallback for legacy/no-actor runs
- add regression tests for actor-scoped and fallback-scoped capability requests

## Root Cause

SSO requests populate the turn actor, but local-dev capability execution still built its ExecutionContext from the fixed env bearer user. Product-auth runtime credential lookup uses that ExecutionContext resource scope, so SSO users could resolve credentials as the env/admin fallback identity instead of their own user id.

## Validation

- cargo fmt --all -- --check
- cargo test -p ironclaw_reborn_composition local_dev_visible_capability_request_ -- --nocapture
