### PR TITLE
PR18.7: trigger poller full-path integration test

### DIFF
--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -3,6 +3,7 @@
 - Own only top-level Reborn composition for production/app startup.
 - Expose facade-shaped handles only: `HostRuntime`, `TurnCoordinator`, product-auth `RebornProductAuthServices`, WebUI `RebornServicesApi`, readiness.
 - Keep lower substrate handles private to factories and owning crates.
+- Substrate handles MAY be exposed via `#[cfg(any(test, feature = "test-support"))]` pub accessors on `RebornRuntime` when downstream integration tests need to drive production-shape state the facade doesn't yet surface (e.g. seeding `TriggerRecord` rows, `pair_external_actor` calls). These seams ship zero bytes in production binaries. New test-support accessors must carry a doc-comment naming the production call site they mirror and an explicit note that the handle is for tests only.
 - Do not depend on the root `ironclaw` crate or `src/` modules.
 - Do not add legacy bridge modes here until an accepted migration contract exists.
 - Do not route live v1/product traffic here; callers must opt in through explicit Reborn adapters.

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -210,6 +210,9 @@ pub struct RebornRuntime {
     worker_handle: JoinHandle<()>,
     worker_cancel: CancellationToken,
     trigger_poller_handle: Option<TriggerPollerRuntimeHandle>,
+    #[cfg(any(test, feature = "test-support"))]
+    trigger_conversation_pairing:
+        Option<Arc<dyn ironclaw_conversations::ConversationActorPairingService>>,
     budget_event_projection: Option<crate::budget_events::BudgetEventProjection>,
     poll_settings: PollSettings,
     actor_user_id: UserId,
@@ -233,9 +236,27 @@ pub(crate) type LocalDevSelectableSkillContextSource =
 type LocalDevSkillExecutionAdapter =
     SkillExecutionAdapter<FilesystemSkillBundleSource<LocalDevRootFilesystem>>;
 
+// TODO(trigger-poller-test-handles): when a second test-only handle is
+// needed off the trigger poller seam (e.g. trusted_submitter,
+// materializer, active_run_lookup for cleanup-state tests), consolidate
+// the cfg-gated fields into a dedicated `TriggerPollerTestHandles`
+// struct exposed via a single `RebornRuntime::trigger_poller_test_handles()`
+// accessor. That removes the current `TriggerPollerServices` /
+// `TriggerPollerServicesInner` split (review f-ptr-1/f-ptr-2) without
+// inventing cfg-gated function parameters. Premature today: only one
+// test-only handle exists, so the shape isn't proven yet.
 struct TriggerPollerServices {
     materializer: Arc<dyn ironclaw_triggers::TriggerPromptMaterializer>,
     trusted_submitter: Arc<dyn ironclaw_triggers::TrustedTriggerFireSubmitter>,
+    /// Test-support handle on the SAME conversation services instance the
+    /// poller-side materializer/submitter use, so integration tests can call
+    /// the production `pair_external_actor` API to seed the trigger
+    /// creator's actor pairing before driving the poller. Without this
+    /// pre-seed, real `ConversationContentRefMaterializer` fails closed with
+    /// `BindingRequired` — by design — and the trusted-ingress turn is
+    /// never submitted.
+    #[cfg(any(test, feature = "test-support"))]
+    pairing_service: Arc<dyn ironclaw_conversations::ConversationActorPairingService>,
 }
 
 async fn build_trigger_poller_services(
@@ -257,7 +278,14 @@ async fn build_trigger_poller_services(
         .map_err(|error| RebornRuntimeError::InvalidArgument {
             reason: format!("trigger conversation services unavailable: {error}"),
         })?;
-        Ok(build_trigger_poller_services_from_conversation_services(
+        #[cfg(any(test, feature = "test-support"))]
+        let pairing_service: Arc<
+            dyn ironclaw_conversations::ConversationActorPairingService,
+        > = Arc::new(conversations.clone());
+        let TriggerPollerServicesInner {
+            materializer,
+            trusted_submitter,
+        } = build_trigger_poller_services_from_conversation_services(
             conversations.clone(),
             conversations,
             turn_coordinator,
@@ -265,13 +293,26 @@ async fn build_trigger_poller_services(
             default_agent_id,
             authorizer,
             trusted_ingress,
-        ))
+        );
+        Ok(TriggerPollerServices {
+            materializer,
+            trusted_submitter,
+            #[cfg(any(test, feature = "test-support"))]
+            pairing_service,
+        })
     }
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     {
         let _ = local_runtime;
         let conversations = InMemoryConversationServices::default();
-        Ok(build_trigger_poller_services_from_conversation_services(
+        #[cfg(any(test, feature = "test-support"))]
+        let pairing_service: Arc<
+            dyn ironclaw_conversations::ConversationActorPairingService,
+        > = Arc::new(conversations.clone());
+        let TriggerPollerServicesInner {
+            materializer,
+            trusted_submitter,
+        } = build_trigger_poller_services_from_conversation_services(
             conversations.clone(),
             conversations,
             turn_coordinator,
@@ -279,8 +320,19 @@ async fn build_trigger_poller_services(
             default_agent_id,
             authorizer,
             trusted_ingress,
-        ))
+        );
+        Ok(TriggerPollerServices {
+            materializer,
+            trusted_submitter,
+            #[cfg(any(test, feature = "test-support"))]
+            pairing_service,
+        })
     }
+}
+
+struct TriggerPollerServicesInner {
+    materializer: Arc<dyn ironclaw_triggers::TriggerPromptMaterializer>,
+    trusted_submitter: Arc<dyn ironclaw_triggers::TrustedTriggerFireSubmitter>,
 }
 
 fn build_trigger_poller_services_from_conversation_services<B, S>(
@@ -291,7 +343,7 @@ fn build_trigger_poller_services_from_conversation_services<B, S>(
     default_agent_id: AgentId,
     authorizer: Arc<dyn crate::trigger_poller_trusted_submit::TriggerFireAuthorizer>,
     trusted_ingress: ironclaw_trusted_ingress::HostTrustedTriggerIngress,
-) -> TriggerPollerServices
+) -> TriggerPollerServicesInner
 where
     B: ironclaw_conversations::ConversationBindingService + Clone + 'static,
     S: ironclaw_conversations::SessionThreadService + 'static,
@@ -308,7 +360,7 @@ where
         turn_coordinator,
         trusted_ingress,
     ));
-    TriggerPollerServices {
+    TriggerPollerServicesInner {
         materializer,
         trusted_submitter,
     }
@@ -466,6 +518,38 @@ impl RebornRuntime {
     /// Diagnostic id for the no-profile run profile selected by this runtime.
     pub fn default_run_profile_id(&self) -> &str {
         &self.default_run_profile_id
+    }
+
+    /// Test-only accessor for the composition-owned trigger repository so
+    /// integration tests can seed `TriggerRecord` rows that the spawned
+    /// trigger poller will observe through its production read path. Returns
+    /// `None` when the runtime was built without a local-runtime substrate
+    /// (e.g. production-shape profiles that haven't been wired end-to-end
+    /// yet). Gated behind `test-support` so the substrate handle never leaks
+    /// into production builds.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn trigger_repository(&self) -> Option<Arc<dyn ironclaw_triggers::TriggerRepository>> {
+        self.services
+            .local_runtime
+            .as_ref()
+            .map(|local_runtime| Arc::clone(&local_runtime.trigger_repository))
+    }
+
+    /// Test-only accessor for the SAME `ConversationActorPairingService`
+    /// instance the spawned trigger poller's
+    /// [`ConversationContentRefMaterializer`] consults. Integration tests
+    /// use this to call the production `pair_external_actor` API and seed
+    /// the trigger creator's actor pairing — without it, the materializer
+    /// fails closed with `BindingRequired` (by design: trigger fires never
+    /// auto-pair unknown actors). Returns `None` when the trigger poller
+    /// wasn't built for this runtime (poller disabled). Gated behind
+    /// `test-support` so the conversation handle never leaks into
+    /// production builds.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn trigger_conversation_pairing(
+        &self,
+    ) -> Option<Arc<dyn ironclaw_conversations::ConversationActorPairingService>> {
+        self.trigger_conversation_pairing.as_ref().map(Arc::clone)
     }
 
     pub(crate) fn webui_thread_service(&self) -> Arc<dyn SessionThreadService> {
@@ -1444,7 +1528,18 @@ pub async fn build_reborn_runtime(
     };
     services.turn_coordinator = Some(Arc::clone(&planned_turn_coordinator));
 
-    let trigger_poller_handle = if trigger_poller.enabled {
+    // Both `trigger_poller_handle` and the test-support
+    // `trigger_conversation_pairing_value` are produced atomically inside
+    // a single `if trigger_poller.enabled` expression. Avoid a
+    // `let mut … = None` sentinel pattern flagged by code review
+    // (review f-ptr-3): the `let X;` deferred-init form is single-assign
+    // per branch and Rust's borrow checker prevents reads before init.
+    let trigger_poller_handle: Option<TriggerPollerRuntimeHandle>;
+    #[cfg(any(test, feature = "test-support"))]
+    let trigger_conversation_pairing_value: Option<
+        Arc<dyn ironclaw_conversations::ConversationActorPairingService>,
+    >;
+    if trigger_poller.enabled {
         let trigger_poller_services = build_trigger_poller_services(
             local_runtime,
             Arc::clone(&planned_turn_coordinator),
@@ -1454,7 +1549,12 @@ pub async fn build_reborn_runtime(
         )
         .await?;
         let active_run_lookup = build_trigger_active_run_lookup(Arc::clone(&turn_state_store));
-        spawn_trigger_poller(
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            trigger_conversation_pairing_value =
+                Some(Arc::clone(&trigger_poller_services.pairing_service));
+        }
+        trigger_poller_handle = spawn_trigger_poller(
             trigger_poller,
             TriggerPollerCompositionDeps {
                 repository: Arc::clone(&local_runtime.trigger_repository),
@@ -1465,10 +1565,14 @@ pub async fn build_reborn_runtime(
         )
         .map_err(|error| RebornRuntimeError::InvalidArgument {
             reason: format!("trigger poller could not be started: {error}"),
-        })?
+        })?;
     } else {
-        None
-    };
+        trigger_poller_handle = None;
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            trigger_conversation_pairing_value = None;
+        }
+    }
     let worker_cancel = CancellationToken::new();
     let worker = Arc::clone(&composition.worker);
     let worker_cancel_clone = worker_cancel.clone();
@@ -1506,6 +1610,8 @@ pub async fn build_reborn_runtime(
         worker_handle,
         worker_cancel,
         trigger_poller_handle,
+        #[cfg(any(test, feature = "test-support"))]
+        trigger_conversation_pairing: trigger_conversation_pairing_value,
         budget_event_projection,
         poll_settings: poll,
         actor_user_id,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -236,7 +236,7 @@ pub(crate) type LocalDevSelectableSkillContextSource =
 type LocalDevSkillExecutionAdapter =
     SkillExecutionAdapter<FilesystemSkillBundleSource<LocalDevRootFilesystem>>;
 
-// TODO(trigger-poller-test-handles): when a second test-only handle is
+// TODO(#4416): when a second test-only handle is
 // needed off the trigger poller seam (e.g. trusted_submitter,
 // materializer, active_run_lookup for cleanup-state tests), consolidate
 // the cfg-gated fields into a dedicated `TriggerPollerTestHandles`
@@ -526,7 +526,10 @@ impl RebornRuntime {
     /// `None` when the runtime was built without a local-runtime substrate
     /// (e.g. production-shape profiles that haven't been wired end-to-end
     /// yet). Gated behind `test-support` so the substrate handle never leaks
-    /// into production builds.
+    /// into production builds. Mirrors the production read path exercised by
+    /// the spawned trigger poller worker, which calls
+    /// `TriggerRepository::list_due_triggers` on every tick and the
+    /// per-trigger `claim_due_fire` / `mark_fire_*` mutation methods.
     #[cfg(any(test, feature = "test-support"))]
     pub fn trigger_repository(&self) -> Option<Arc<dyn ironclaw_triggers::TriggerRepository>> {
         self.services

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -27,8 +27,8 @@ use ironclaw_reborn_composition::{
     TriggerPollerSettings, build_reborn_runtime,
 };
 use ironclaw_triggers::{
-    TriggerCompletionPolicy, TriggerId, TriggerPollerWorkerConfig, TriggerRecord, TriggerSchedule,
-    TriggerSourceKind, TriggerState,
+    TriggerCompletionPolicy, TriggerId, TriggerPollerWorkerConfig, TriggerRecord,
+    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use tokio::sync::Mutex as TokioMutex;
 
@@ -77,6 +77,44 @@ impl HostManagedModelGateway for RecordingGateway {
             "trigger e2e ok".to_string(),
         ))
     }
+}
+
+/// Poll `repo` until `predicate` returns `true` or `deadline` elapses.
+///
+/// Returns the last record seen. If the predicate is satisfied before the
+/// deadline, the returned record satisfies the predicate. If the deadline
+/// elapses, the returned record is the last one read (which may not satisfy
+/// the predicate — callers should then let the existing assertions fail with
+/// the diagnostic they already carry).
+///
+/// Used by the happy-path and Recurring tests to wait for the settle writes
+/// (step 3: `mark_fire_accepted` / `mark_fire_replayed`) to become visible
+/// after the first-pass loop breaks on `record_was_mutated && prompt_seen`.
+async fn wait_for_settled<F>(
+    repo: &Arc<dyn TriggerRepository>,
+    tenant_id: &TenantId,
+    trigger_id: TriggerId,
+    deadline: Duration,
+    mut predicate: F,
+) -> TriggerRecord
+where
+    F: FnMut(&TriggerRecord) -> bool,
+{
+    let stop = Instant::now() + deadline;
+    let mut last: Option<TriggerRecord> = None;
+    while Instant::now() < stop {
+        let current = repo
+            .get_trigger(tenant_id.clone(), trigger_id)
+            .await
+            .expect("get_trigger")
+            .expect("record present");
+        if predicate(&current) {
+            return current;
+        }
+        last = Some(current);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    last.expect("at least one read should have succeeded in wait_for_settled")
 }
 
 /// Shared runtime builder. Every test passes the `TriggerPollerSettings` it
@@ -186,7 +224,6 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
     let deadline = Instant::now() + Duration::from_secs(15);
     let mut record_was_mutated = false;
     let mut prompt_seen = false;
-    let mut final_record: Option<TriggerRecord> = None;
 
     while Instant::now() < deadline {
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -215,17 +252,28 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
             }
         }
 
-        final_record = Some(current);
-
         if record_was_mutated && prompt_seen {
             break;
         }
     }
 
-    // Final snapshot for diagnostics, once.
-    let captured_contents = recording_gateway.captured_message_contents().await;
+    // Wait for the settle writes (mark_fire_accepted sets last_fired_slot, last_run_at)
+    // to become visible. The first-pass loop breaks as soon as the claim+prompt are seen;
+    // the settle may still be in flight.
+    let final_record = wait_for_settled(
+        &repo,
+        &tenant_id,
+        record.trigger_id,
+        Duration::from_secs(5),
+        |r| r.last_fired_slot.is_some() && r.last_run_at.is_some(),
+    )
+    .await;
 
     runtime.shutdown().await.expect("runtime shutdown");
+
+    // Final snapshot for diagnostics, once. Taken after shutdown so a request
+    // submitted between snapshot and shutdown completion cannot be invisible.
+    let captured_contents = recording_gateway.captured_message_contents().await;
 
     assert!(
         record_was_mutated,
@@ -235,6 +283,22 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
         prompt_seen,
         "LLM gateway never received a request containing the trigger prompt within 15s \
          — captured_messages: {captured_contents:?}"
+    );
+    // CompleteAfterFirstFire: the settle write (mark_fire_accepted) records last_fired_slot
+    // and last_run_at. State transitions to Completed only when the terminal-failure path is
+    // taken; successful first-fire keeps state=Scheduled until a separate lifecycle step.
+    assert!(
+        final_record.last_fired_slot.is_some(),
+        "CompleteAfterFirstFire policy: last_fired_slot should be set after fire — record: {final_record:?}",
+    );
+    assert!(
+        final_record.last_run_at.is_some(),
+        "CompleteAfterFirstFire policy: last_run_at should be set after fire — record: {final_record:?}",
+    );
+    assert_eq!(
+        final_record.last_status,
+        Some(TriggerRunStatus::Ok),
+        "CompleteAfterFirstFire policy: last_status should be Ok after fire — record: {final_record:?}",
     );
 }
 
@@ -345,9 +409,13 @@ async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
 
     // Clone the repo handle before shutdown (Arc is cheap to clone).
     let repo_after = repo.clone();
-    let captured_contents = recording_gateway.captured_message_contents().await;
 
     runtime.shutdown().await.expect("runtime shutdown");
+
+    // Snapshot captured_contents AFTER shutdown so a request submitted between
+    // snapshot and shutdown completion cannot produce a false-green result.
+    // The recording_gateway Arc is independent of the runtime.
+    let captured_contents = recording_gateway.captured_message_contents().await;
 
     let current = repo_after
         .get_trigger(tenant_id.clone(), record.trigger_id)
@@ -451,9 +519,13 @@ async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
 
     // Clone the repo handle before shutdown (Arc is cheap to clone).
     let repo_after = repo.clone();
-    let captured_contents = recording_gateway.captured_message_contents().await;
 
     runtime.shutdown().await.expect("runtime shutdown");
+
+    // Snapshot captured_contents AFTER shutdown so a request submitted between
+    // snapshot and shutdown completion cannot produce a false-green result.
+    // The recording_gateway Arc is independent of the runtime.
+    let captured_contents = recording_gateway.captured_message_contents().await;
 
     let current = repo_after
         .get_trigger(tenant_id.clone(), record.trigger_id)
@@ -556,7 +628,6 @@ async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
     let deadline = Instant::now() + Duration::from_secs(15);
     let mut record_was_mutated = false;
     let mut prompt_seen = false;
-    let mut final_record: Option<TriggerRecord> = None;
 
     while Instant::now() < deadline {
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -584,21 +655,32 @@ async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
             }
         }
 
-        final_record = Some(current);
-
         if record_was_mutated && prompt_seen {
             break;
         }
     }
 
-    // Final snapshot for diagnostics, once.
-    let captured_contents = recording_gateway.captured_message_contents().await;
+    // Wait for the settle writes (mark_fire_replayed sets last_fired_slot, advances
+    // next_run_at) to become visible. The first-pass loop breaks as soon as the
+    // claim+prompt are seen; the settle may still be in flight.
+    let settled = wait_for_settled(
+        &repo,
+        &tenant_id,
+        record.trigger_id,
+        Duration::from_secs(5),
+        |r| r.last_fired_slot.is_some() && r.next_run_at > original_next_run_at,
+    )
+    .await;
 
     runtime.shutdown().await.expect("runtime shutdown");
 
+    // Final snapshot for diagnostics, once. Taken after shutdown so a request
+    // submitted between snapshot and shutdown completion cannot be invisible.
+    let captured_contents = recording_gateway.captured_message_contents().await;
+
     assert!(
         record_was_mutated,
-        "poller did not mutate recurring trigger record within 15s — record: {final_record:?}"
+        "poller did not mutate recurring trigger record within 15s — record: {settled:?}"
     );
     assert!(
         prompt_seen,
@@ -606,27 +688,25 @@ async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
          — captured_messages: {captured_contents:?}"
     );
 
-    let current = final_record.expect("final_record set when record_was_mutated is true");
-
     // Recurring triggers must remain Scheduled (not Completed) after firing.
     assert_eq!(
-        current.state,
+        settled.state,
         TriggerState::Scheduled,
         "recurring trigger should remain Scheduled after fire — state: {:?}",
-        current.state
+        settled.state
     );
     assert!(
-        current.last_fired_slot.is_some(),
+        settled.last_fired_slot.is_some(),
         "recurring trigger should have last_fired_slot set after fire"
     );
     assert!(
-        current.last_run_at.is_some(),
+        settled.last_run_at.is_some(),
         "recurring trigger should have last_run_at set after fire"
     );
     assert!(
-        current.next_run_at > original_next_run_at,
+        settled.next_run_at > original_next_run_at,
         "recurring trigger next_run_at should have advanced — original: {:?}, current: {:?}",
         original_next_run_at,
-        current.next_run_at
+        settled.next_run_at
     );
 }

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -7,7 +7,7 @@
 
 #![cfg(feature = "test-support")]
 
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -30,6 +30,7 @@ use ironclaw_triggers::{
     TriggerCompletionPolicy, TriggerId, TriggerPollerWorkerConfig, TriggerRecord, TriggerSchedule,
     TriggerSourceKind, TriggerState,
 };
+use tokio::sync::Mutex as TokioMutex;
 
 const TENANT: &str = "trigger-e2e-tenant";
 const USER: &str = "trigger-e2e-owner";
@@ -52,16 +53,12 @@ fn local_dev_runtime_policy() -> EffectiveRuntimePolicy {
 
 #[derive(Debug, Default)]
 struct RecordingGateway {
-    requests: Arc<StdMutex<Vec<HostManagedModelRequest>>>,
+    requests: Arc<TokioMutex<Vec<HostManagedModelRequest>>>,
 }
 
 impl RecordingGateway {
-    fn captured_message_contents(&self) -> Vec<String> {
-        let snapshot = self
-            .requests
-            .lock()
-            .expect("recording gateway lock poisoned")
-            .clone();
+    async fn captured_message_contents(&self) -> Vec<String> {
+        let snapshot = self.requests.lock().await.clone();
         snapshot
             .iter()
             .flat_map(|req| req.messages.iter().map(|m| m.content.clone()))
@@ -75,10 +72,7 @@ impl HostManagedModelGateway for RecordingGateway {
         &self,
         request: HostManagedModelRequest,
     ) -> Result<HostManagedModelResponse, HostManagedModelError> {
-        self.requests
-            .lock()
-            .expect("recording gateway lock poisoned")
-            .push(request);
+        self.requests.lock().await.push(request);
         Ok(HostManagedModelResponse::assistant_reply(
             "trigger e2e ok".to_string(),
         ))
@@ -115,7 +109,7 @@ async fn build_runtime_with(
 async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
     let root = tempfile::tempdir().expect("tempdir");
     let recording_gateway = Arc::new(RecordingGateway {
-        requests: Arc::new(StdMutex::new(Vec::new())),
+        requests: Arc::new(TokioMutex::new(Vec::new())),
     });
 
     let runtime = build_runtime_with(
@@ -193,7 +187,6 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
     let mut record_was_mutated = false;
     let mut prompt_seen = false;
     let mut final_record: Option<TriggerRecord> = None;
-    let mut captured_contents: Vec<String> = Vec::new();
 
     while Instant::now() < deadline {
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -210,25 +203,27 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
             || current.active_fire_slot.is_some()
             || current.state == TriggerState::Completed;
 
-        let contents = recording_gateway.captured_message_contents();
-        let trigger_prompt_seen = contents
-            .iter()
-            .any(|content| content.contains(TRIGGER_PROMPT));
-
-        final_record = Some(current);
-        captured_contents = contents;
-
         if mutated {
             record_was_mutated = true;
+            // Only poll the gateway after the record was touched.
+            let contents = recording_gateway.captured_message_contents().await;
+            if contents
+                .iter()
+                .any(|content| content.contains(TRIGGER_PROMPT))
+            {
+                prompt_seen = true;
+            }
         }
-        if trigger_prompt_seen {
-            prompt_seen = true;
-        }
+
+        final_record = Some(current);
 
         if record_was_mutated && prompt_seen {
             break;
         }
     }
+
+    // Final snapshot for diagnostics, once.
+    let captured_contents = recording_gateway.captured_message_contents().await;
 
     runtime.shutdown().await.expect("runtime shutdown");
 
@@ -247,7 +242,7 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
 async fn trigger_conversation_pairing_returns_none_when_poller_disabled() {
     let root = tempfile::tempdir().expect("tempdir");
     let recording_gateway = Arc::new(RecordingGateway {
-        requests: Arc::new(StdMutex::new(Vec::new())),
+        requests: Arc::new(TokioMutex::new(Vec::new())),
     });
 
     // Use the default settings (enabled: false) — do NOT call
@@ -278,7 +273,7 @@ async fn trigger_conversation_pairing_returns_none_when_poller_disabled() {
 async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
     let root = tempfile::tempdir().expect("tempdir");
     let recording_gateway = Arc::new(RecordingGateway {
-        requests: Arc::new(StdMutex::new(Vec::new())),
+        requests: Arc::new(TokioMutex::new(Vec::new())),
     });
 
     let runtime = build_runtime_with(
@@ -348,13 +343,17 @@ async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
     // Sleep for ~500ms — 25 poll cycles at 20ms. Generous margin.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    let current = repo
+    // Clone the repo handle before shutdown (Arc is cheap to clone).
+    let repo_after = repo.clone();
+    let captured_contents = recording_gateway.captured_message_contents().await;
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    let current = repo_after
         .get_trigger(tenant_id.clone(), record.trigger_id)
         .await
         .expect("get_trigger")
         .expect("record present");
-
-    runtime.shutdown().await.expect("runtime shutdown");
 
     assert!(
         current.last_fired_slot.is_none(),
@@ -383,7 +382,7 @@ async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
         current.state
     );
     assert!(
-        recording_gateway.captured_message_contents().is_empty(),
+        captured_contents.is_empty(),
         "LLM gateway should not have received any requests for a future trigger"
     );
 }
@@ -392,7 +391,7 @@ async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
 async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
     let root = tempfile::tempdir().expect("tempdir");
     let recording_gateway = Arc::new(RecordingGateway {
-        requests: Arc::new(StdMutex::new(Vec::new())),
+        requests: Arc::new(TokioMutex::new(Vec::new())),
     });
 
     let runtime = build_runtime_with(
@@ -450,20 +449,24 @@ async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
     // Sleep for ~1s — 50 poll cycles at 20ms — to give the poller multiple chances.
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    let current = repo
+    // Clone the repo handle before shutdown (Arc is cheap to clone).
+    let repo_after = repo.clone();
+    let captured_contents = recording_gateway.captured_message_contents().await;
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    let current = repo_after
         .get_trigger(tenant_id.clone(), record.trigger_id)
         .await
         .expect("get_trigger")
         .expect("record present");
 
-    runtime.shutdown().await.expect("runtime shutdown");
-
     // Safety guarantee: no turn was ever submitted to the LLM gateway.
     assert!(
-        recording_gateway.captured_message_contents().is_empty(),
+        captured_contents.is_empty(),
         "LLM gateway should not have received any requests for an unpaired actor — \
          captured: {:?}",
-        recording_gateway.captured_message_contents()
+        captured_contents
     );
 
     // The trigger must not be marked Completed (failure-closed behavior).
@@ -473,5 +476,157 @@ async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
         "unpaired trigger must not be marked Completed — state: {:?}, last_status: {:?}",
         current.state,
         current.last_status
+    );
+}
+
+#[tokio::test]
+async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(TokioMutex::new(Vec::new())),
+    });
+
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings {
+            enabled: true,
+            worker: TriggerPollerWorkerConfig {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
+            startup_jitter_max: Duration::ZERO,
+            tick_jitter_max: Duration::ZERO,
+        },
+    )
+    .await;
+
+    let repo = runtime
+        .trigger_repository()
+        .expect("local-dev runtime exposes trigger repository");
+    let pairing = runtime
+        .trigger_conversation_pairing()
+        .expect("trigger poller runtime exposes conversation pairing service");
+
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let agent_id = AgentId::new(AGENT).expect("agent id");
+    let trigger_id = TriggerId::new();
+
+    // Pair the external actor — same as the happy-path test.
+    pairing
+        .pair_external_actor(
+            tenant_id.clone(),
+            AdapterKind::new("trigger").expect("adapter kind"),
+            AdapterInstallationId::new("reborn-trigger-poller").expect("installation id"),
+            ExternalActorRef::new("user", user_id.as_str()).expect("actor ref"),
+            user_id.clone(),
+        )
+        .await
+        .expect("pair external actor for trigger creator");
+
+    let original_next_run_at = Utc::now() - chrono::Duration::seconds(120);
+
+    let record = TriggerRecord {
+        trigger_id,
+        tenant_id: tenant_id.clone(),
+        creator_user_id: user_id,
+        agent_id: Some(agent_id),
+        project_id: None,
+        name: "trigger-e2e-recurring".to_string(),
+        source: TriggerSourceKind::Schedule,
+        // Every minute — already at MIN_FIRE_CADENCE.
+        schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
+        completion_policy: TriggerCompletionPolicy::Recurring,
+        prompt: TRIGGER_PROMPT.to_string(),
+        state: TriggerState::Scheduled,
+        next_run_at: original_next_run_at,
+        last_run_at: None,
+        last_fired_slot: None,
+        last_status: None,
+        active_fire_slot: None,
+        active_run_ref: None,
+        created_at: Utc::now(),
+    };
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("upsert trigger record");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut record_was_mutated = false;
+    let mut prompt_seen = false;
+    let mut final_record: Option<TriggerRecord> = None;
+
+    while Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let current = repo
+            .get_trigger(tenant_id.clone(), record.trigger_id)
+            .await
+            .expect("get_trigger")
+            .expect("record present");
+
+        let mutated = current.last_fired_slot.is_some()
+            || current.last_run_at.is_some()
+            || current.last_status.is_some()
+            || current.active_fire_slot.is_some();
+
+        if mutated {
+            record_was_mutated = true;
+            // Only poll the gateway after the record was touched.
+            let contents = recording_gateway.captured_message_contents().await;
+            if contents
+                .iter()
+                .any(|content| content.contains(TRIGGER_PROMPT))
+            {
+                prompt_seen = true;
+            }
+        }
+
+        final_record = Some(current);
+
+        if record_was_mutated && prompt_seen {
+            break;
+        }
+    }
+
+    // Final snapshot for diagnostics, once.
+    let captured_contents = recording_gateway.captured_message_contents().await;
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    assert!(
+        record_was_mutated,
+        "poller did not mutate recurring trigger record within 15s — record: {final_record:?}"
+    );
+    assert!(
+        prompt_seen,
+        "LLM gateway never received a request for recurring trigger within 15s \
+         — captured_messages: {captured_contents:?}"
+    );
+
+    let current = final_record.expect("final_record set when record_was_mutated is true");
+
+    // Recurring triggers must remain Scheduled (not Completed) after firing.
+    assert_eq!(
+        current.state,
+        TriggerState::Scheduled,
+        "recurring trigger should remain Scheduled after fire — state: {:?}",
+        current.state
+    );
+    assert!(
+        current.last_fired_slot.is_some(),
+        "recurring trigger should have last_fired_slot set after fire"
+    );
+    assert!(
+        current.last_run_at.is_some(),
+        "recurring trigger should have last_run_at set after fire"
+    );
+    assert!(
+        current.next_run_at > original_next_run_at,
+        "recurring trigger next_run_at should have advanced — original: {:?}, current: {:?}",
+        original_next_run_at,
+        current.next_run_at
     );
 }

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -285,8 +285,10 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
          — captured_messages: {captured_contents:?}"
     );
     // CompleteAfterFirstFire: the settle write (mark_fire_accepted) records last_fired_slot
-    // and last_run_at. State transitions to Completed only when the terminal-failure path is
-    // taken; successful first-fire keeps state=Scheduled until a separate lifecycle step.
+    // and last_run_at. `state` transitions to `Completed` only when the terminal-failure
+    // path runs (`mark_fire_terminally_failed`); the policy field is currently stored but
+    // never consulted by `mark_fire_accepted` — see issue #4420 for the production gap.
+    // Once that is fixed, tighten this to `assert_eq!(state, TriggerState::Completed, ...)`.
     assert!(
         final_record.last_fired_slot.is_some(),
         "CompleteAfterFirstFire policy: last_fired_slot should be set after fire — record: {final_record:?}",

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -1,0 +1,477 @@
+//! Full-path integration test for the composition-owned trigger poller.
+//!
+//! Drives a real `RebornRuntime` with the trigger poller enabled, seeds a
+//! due `TriggerRecord` via the in-memory repository, and asserts that the
+//! spawned background task (a) mutates the record and (b) causes the LLM
+//! gateway to receive a request whose content includes the trigger prompt.
+
+#![cfg(feature = "test-support")]
+
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_conversations::{AdapterInstallationId, AdapterKind, ExternalActorRef};
+use ironclaw_host_api::runtime_policy::{
+    ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
+    NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
+};
+use ironclaw_host_api::{AgentId, TenantId, UserId};
+use ironclaw_loop_support::{
+    HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
+    HostManagedModelResponse,
+};
+use ironclaw_reborn_composition::{
+    RebornBuildInput, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
+    TriggerPollerSettings, build_reborn_runtime,
+};
+use ironclaw_triggers::{
+    TriggerCompletionPolicy, TriggerId, TriggerPollerWorkerConfig, TriggerRecord, TriggerSchedule,
+    TriggerSourceKind, TriggerState,
+};
+
+const TENANT: &str = "trigger-e2e-tenant";
+const USER: &str = "trigger-e2e-owner";
+const AGENT: &str = "trigger-e2e-agent";
+const TRIGGER_PROMPT: &str = "trigger-e2e-prompt-marker-do-not-rephrase";
+
+fn local_dev_runtime_policy() -> EffectiveRuntimePolicy {
+    EffectiveRuntimePolicy {
+        deployment: DeploymentMode::LocalSingleUser,
+        requested_profile: RuntimeProfile::LocalDev,
+        resolved_profile: RuntimeProfile::LocalDev,
+        filesystem_backend: FilesystemBackendKind::HostWorkspace,
+        process_backend: ProcessBackendKind::LocalHost,
+        network_mode: NetworkMode::DirectLogged,
+        secret_mode: SecretMode::ScrubbedEnv,
+        approval_policy: ApprovalPolicy::AskDestructive,
+        audit_mode: AuditMode::LocalMinimal,
+    }
+}
+
+#[derive(Debug, Default)]
+struct RecordingGateway {
+    requests: Arc<StdMutex<Vec<HostManagedModelRequest>>>,
+}
+
+impl RecordingGateway {
+    fn captured_message_contents(&self) -> Vec<String> {
+        let snapshot = self
+            .requests
+            .lock()
+            .expect("recording gateway lock poisoned")
+            .clone();
+        snapshot
+            .iter()
+            .flat_map(|req| req.messages.iter().map(|m| m.content.clone()))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl HostManagedModelGateway for RecordingGateway {
+    async fn stream_model(
+        &self,
+        request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        self.requests
+            .lock()
+            .expect("recording gateway lock poisoned")
+            .push(request);
+        Ok(HostManagedModelResponse::assistant_reply(
+            "trigger e2e ok".to_string(),
+        ))
+    }
+}
+
+/// Shared runtime builder. Every test passes the `TriggerPollerSettings` it
+/// wants; identity, runtime policy, and model-gateway override are shared.
+async fn build_runtime_with(
+    root: &tempfile::TempDir,
+    recording_gateway: Arc<RecordingGateway>,
+    trigger_poller: TriggerPollerSettings,
+) -> RebornRuntime {
+    let input =
+        RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev(USER, root.path().join("local-dev"))
+                .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: TENANT.to_string(),
+            agent_id: AGENT.to_string(),
+            source_binding_id: "trigger-e2e-source".to_string(),
+            reply_target_binding_id: "trigger-e2e-reply".to_string(),
+        })
+        .with_trigger_poller_settings(trigger_poller)
+        .with_model_gateway_override(
+            Arc::clone(&recording_gateway) as Arc<dyn HostManagedModelGateway>
+        );
+
+    build_reborn_runtime(input).await.expect("runtime builds")
+}
+
+#[tokio::test]
+async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    });
+
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings {
+            enabled: true,
+            worker: TriggerPollerWorkerConfig {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
+            startup_jitter_max: Duration::ZERO,
+            tick_jitter_max: Duration::ZERO,
+        },
+    )
+    .await;
+
+    let repo = runtime
+        .trigger_repository()
+        .expect("local-dev runtime exposes trigger repository");
+    let pairing = runtime
+        .trigger_conversation_pairing()
+        .expect("trigger poller runtime exposes conversation pairing service");
+
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let agent_id = AgentId::new(AGENT).expect("agent id");
+    let trigger_id = TriggerId::new();
+
+    // Seed the trigger creator's actor pairing through the production
+    // `ConversationActorPairingService` API. The trusted trigger
+    // submission path fails closed for unpaired actors by design; in
+    // production, onboarding establishes this pairing before any trigger
+    // can be created. The adapter kind / installation id / external actor
+    // ref must match the values
+    // `crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs`
+    // hardcodes for trigger fires.
+    pairing
+        .pair_external_actor(
+            tenant_id.clone(),
+            AdapterKind::new("trigger").expect("adapter kind"),
+            AdapterInstallationId::new("reborn-trigger-poller").expect("installation id"),
+            ExternalActorRef::new("user", user_id.as_str()).expect("actor ref"),
+            user_id.clone(),
+        )
+        .await
+        .expect("pair external actor for trigger creator");
+
+    let record = TriggerRecord {
+        trigger_id,
+        tenant_id: tenant_id.clone(),
+        creator_user_id: user_id,
+        agent_id: Some(agent_id),
+        project_id: None,
+        name: "trigger-e2e-test".to_string(),
+        source: TriggerSourceKind::Schedule,
+        schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
+        completion_policy: TriggerCompletionPolicy::CompleteAfterFirstFire,
+        prompt: TRIGGER_PROMPT.to_string(),
+        state: TriggerState::Scheduled,
+        next_run_at: Utc::now() - chrono::Duration::seconds(120),
+        last_run_at: None,
+        last_fired_slot: None,
+        last_status: None,
+        active_fire_slot: None,
+        active_run_ref: None,
+        created_at: Utc::now(),
+    };
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("upsert trigger record");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut record_was_mutated = false;
+    let mut prompt_seen = false;
+    let mut final_record: Option<TriggerRecord> = None;
+    let mut captured_contents: Vec<String> = Vec::new();
+
+    while Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let current = repo
+            .get_trigger(tenant_id.clone(), record.trigger_id)
+            .await
+            .expect("get_trigger")
+            .expect("record present");
+
+        let mutated = current.last_fired_slot.is_some()
+            || current.last_run_at.is_some()
+            || current.last_status.is_some()
+            || current.active_fire_slot.is_some()
+            || current.state == TriggerState::Completed;
+
+        let contents = recording_gateway.captured_message_contents();
+        let trigger_prompt_seen = contents
+            .iter()
+            .any(|content| content.contains(TRIGGER_PROMPT));
+
+        final_record = Some(current);
+        captured_contents = contents;
+
+        if mutated {
+            record_was_mutated = true;
+        }
+        if trigger_prompt_seen {
+            prompt_seen = true;
+        }
+
+        if record_was_mutated && prompt_seen {
+            break;
+        }
+    }
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    assert!(
+        record_was_mutated,
+        "poller did not mutate trigger record within 15s — record: {final_record:?}"
+    );
+    assert!(
+        prompt_seen,
+        "LLM gateway never received a request containing the trigger prompt within 15s \
+         — captured_messages: {captured_contents:?}"
+    );
+}
+
+#[tokio::test]
+async fn trigger_conversation_pairing_returns_none_when_poller_disabled() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    });
+
+    // Use the default settings (enabled: false) — do NOT call
+    // with_trigger_poller_settings with enabled: true.
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings::default(),
+    )
+    .await;
+
+    // The trigger repository is built regardless of poller state.
+    assert!(
+        runtime.trigger_repository().is_some(),
+        "trigger repository should be present even when poller is disabled"
+    );
+
+    // When the poller is disabled, no conversation pairing service is wired.
+    assert!(
+        runtime.trigger_conversation_pairing().is_none(),
+        "trigger_conversation_pairing should be None when poller is disabled"
+    );
+
+    runtime.shutdown().await.expect("runtime shutdown");
+}
+
+#[tokio::test]
+async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    });
+
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings {
+            enabled: true,
+            worker: TriggerPollerWorkerConfig {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
+            startup_jitter_max: Duration::ZERO,
+            tick_jitter_max: Duration::ZERO,
+        },
+    )
+    .await;
+
+    let repo = runtime
+        .trigger_repository()
+        .expect("local-dev runtime exposes trigger repository");
+    let pairing = runtime
+        .trigger_conversation_pairing()
+        .expect("trigger poller runtime exposes conversation pairing service");
+
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let agent_id = AgentId::new(AGENT).expect("agent id");
+    let trigger_id = TriggerId::new();
+
+    pairing
+        .pair_external_actor(
+            tenant_id.clone(),
+            AdapterKind::new("trigger").expect("adapter kind"),
+            AdapterInstallationId::new("reborn-trigger-poller").expect("installation id"),
+            ExternalActorRef::new("user", user_id.as_str()).expect("actor ref"),
+            user_id.clone(),
+        )
+        .await
+        .expect("pair external actor for trigger creator");
+
+    // Seed a trigger that is NOT due — next_run_at is one hour in the future.
+    let record = TriggerRecord {
+        trigger_id,
+        tenant_id: tenant_id.clone(),
+        creator_user_id: user_id,
+        agent_id: Some(agent_id),
+        project_id: None,
+        name: "trigger-e2e-future".to_string(),
+        source: TriggerSourceKind::Schedule,
+        schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
+        completion_policy: TriggerCompletionPolicy::CompleteAfterFirstFire,
+        prompt: TRIGGER_PROMPT.to_string(),
+        state: TriggerState::Scheduled,
+        next_run_at: Utc::now() + chrono::Duration::seconds(3600),
+        last_run_at: None,
+        last_fired_slot: None,
+        last_status: None,
+        active_fire_slot: None,
+        active_run_ref: None,
+        created_at: Utc::now(),
+    };
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("upsert trigger record");
+
+    // Sleep for ~500ms — 25 poll cycles at 20ms. Generous margin.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let current = repo
+        .get_trigger(tenant_id.clone(), record.trigger_id)
+        .await
+        .expect("get_trigger")
+        .expect("record present");
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    assert!(
+        current.last_fired_slot.is_none(),
+        "poller should not have fired a future trigger — last_fired_slot: {:?}",
+        current.last_fired_slot
+    );
+    assert!(
+        current.last_run_at.is_none(),
+        "poller should not have run a future trigger — last_run_at: {:?}",
+        current.last_run_at
+    );
+    assert!(
+        current.last_status.is_none(),
+        "poller should not have set a status on a future trigger — last_status: {:?}",
+        current.last_status
+    );
+    assert!(
+        current.active_fire_slot.is_none(),
+        "poller should not have set active_fire_slot on a future trigger — active_fire_slot: {:?}",
+        current.active_fire_slot
+    );
+    assert_eq!(
+        current.state,
+        TriggerState::Scheduled,
+        "future trigger should remain Scheduled — state: {:?}",
+        current.state
+    );
+    assert!(
+        recording_gateway.captured_message_contents().is_empty(),
+        "LLM gateway should not have received any requests for a future trigger"
+    );
+}
+
+#[tokio::test]
+async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    });
+
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings {
+            enabled: true,
+            worker: TriggerPollerWorkerConfig {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
+            startup_jitter_max: Duration::ZERO,
+            tick_jitter_max: Duration::ZERO,
+        },
+    )
+    .await;
+
+    let repo = runtime
+        .trigger_repository()
+        .expect("local-dev runtime exposes trigger repository");
+
+    // Intentionally do NOT call pair_external_actor — the actor is unpaired.
+
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let agent_id = AgentId::new(AGENT).expect("agent id");
+    let trigger_id = TriggerId::new();
+
+    // Seed a past-due trigger.
+    let record = TriggerRecord {
+        trigger_id,
+        tenant_id: tenant_id.clone(),
+        creator_user_id: user_id,
+        agent_id: Some(agent_id),
+        project_id: None,
+        name: "trigger-e2e-unpaired".to_string(),
+        source: TriggerSourceKind::Schedule,
+        schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
+        completion_policy: TriggerCompletionPolicy::CompleteAfterFirstFire,
+        prompt: TRIGGER_PROMPT.to_string(),
+        state: TriggerState::Scheduled,
+        next_run_at: Utc::now() - chrono::Duration::seconds(120),
+        last_run_at: None,
+        last_fired_slot: None,
+        last_status: None,
+        active_fire_slot: None,
+        active_run_ref: None,
+        created_at: Utc::now(),
+    };
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("upsert trigger record");
+
+    // Sleep for ~1s — 50 poll cycles at 20ms — to give the poller multiple chances.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let current = repo
+        .get_trigger(tenant_id.clone(), record.trigger_id)
+        .await
+        .expect("get_trigger")
+        .expect("record present");
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    // Safety guarantee: no turn was ever submitted to the LLM gateway.
+    assert!(
+        recording_gateway.captured_message_contents().is_empty(),
+        "LLM gateway should not have received any requests for an unpaired actor — \
+         captured: {:?}",
+        recording_gateway.captured_message_contents()
+    );
+
+    // The trigger must not be marked Completed (failure-closed behavior).
+    assert_ne!(
+        current.state,
+        TriggerState::Completed,
+        "unpaired trigger must not be marked Completed — state: {:?}, last_status: {:?}",
+        current.state,
+        current.last_status
+    );
+}


### PR DESCRIPTION
## Summary

- Composition-tier integration test that drives the real background trigger poller spawned by `build_reborn_runtime`, seeds a due `TriggerRecord`, and asserts the poller mutates the record and submits a trusted-ingress turn that reaches the LLM gateway with the trigger prompt.
- Only the LLM gateway is overridden (via existing `with_model_gateway_override` shim). Conversation pairing, materializer, submitter, repository, turn coordinator, trusted ingress, and turn-runner are all production wiring. Actor pairing is seeded through the production `ConversationActorPairingService::pair_external_actor` API.
- Two cfg-gated test-support accessors on `RebornRuntime` (`trigger_repository()`, `trigger_conversation_pairing()`) for tests to drive production-shape state; `crates/ironclaw_reborn_composition/CLAUDE.md` amended with an explicit test-support exception to the "facade-shaped handles only" rule.

## What's new

`crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs` — four tests:
- `trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger` (happy path)
- `trigger_conversation_pairing_returns_none_when_poller_disabled`
- `trigger_poller_does_not_fire_trigger_with_future_next_run_at`
- `trigger_poller_does_not_submit_turn_for_unpaired_actor` — locks in the fail-closed design contract from `trigger_poller_trusted_submit.rs`

`crates/ironclaw_reborn_composition/src/runtime.rs`:
- `pub fn trigger_repository(&self) -> Option<Arc<dyn TriggerRepository>>` (cfg-gated)
- `pub fn trigger_conversation_pairing(&self) -> Option<Arc<dyn ConversationActorPairingService>>` (cfg-gated)
- `TriggerPollerServices.pairing_service` cfg-gated field carrying the same conversation services Arc the poller-side materializer/submitter use
- `if trigger_poller.enabled` block refactored to `let X;` deferred-init (no mut sentinel)
- TODO comment on `TriggerPollerServices` pointing at the `TriggerPollerTestHandles` consolidation when a second test-only handle lands

`crates/ironclaw_reborn_composition/CLAUDE.md`: one-line bullet codifying the cfg-gated test-support seam exception.

## Code review

Ran `/code-review --local` (8 reviewer subagents). 9 findings raw; 7 applied, 2 deferred:

- Applied: rename to `local_dev_runtime_policy` (matches sibling pattern), clone-then-drop on `RecordingGateway` mutex, three new tests (None-branch, future-trigger negative, BindingRequired failure-closed), CLAUDE.md amendment, mut-sentinel rewrite.
- Deferred with inline TODO: `TriggerPollerServicesInner` struct + cfg-arm duplication (review f-ptr-1/f-ptr-2). Test-only code, ships zero bytes in prod. Consolidate into `TriggerPollerTestHandles` when the second test-only handle is needed.

`.review/findings.json` + `.review/findings.md` written locally (gitignored).

## Test plan

- [x] `cargo build -p ironclaw_reborn_composition` (production, no features) — clean
- [x] `cargo build -p ironclaw_reborn_composition --features test-support --tests` — clean
- [x] `cargo test -p ironclaw_reborn_composition --features test-support --test trigger_poller_e2e` — 4/4 green
- [x] `cargo clippy -p ironclaw_reborn_composition --features test-support --tests --all-targets -- -D warnings` — clean
- [x] `cargo test -p ironclaw_architecture` — 23/23 green (boundary tests)
- [x] `cargo fmt --all` — clean

## Plan refs

`docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)