### PR TITLE
[codex] Fix WebUI live projection cursor resume

### DIFF
--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -390,6 +390,7 @@ impl WebuiProjectionBatch {
         payloads: Vec<ProductOutboundPayload>,
         total: usize,
         already_delivered: usize,
+        cursor_kind: RuntimePayloadCursorKind,
     ) -> Result<bool, ProductAdapterError> {
         if total == 0 {
             return Ok(true);
@@ -411,16 +412,26 @@ impl WebuiProjectionBatch {
         for (index, payload) in payloads.into_iter().take(remaining_capacity).enumerate() {
             let delivered = already_delivered + index + 1;
             self.runtime_payloads_pushed += 1;
-            if delivered == total {
-                self.cursor.runtime = Some(max_projection_cursor(
-                    final_cursor.clone(),
-                    item_cursor.clone(),
-                ));
-                self.cursor.runtime_item = None;
-                self.cursor.runtime_payloads_delivered = 0;
-            } else {
-                self.cursor.runtime_item = Some(item_cursor.runtime);
-                self.cursor.runtime_payloads_delivered = delivered;
+            match cursor_kind {
+                RuntimePayloadCursorKind::DurableRuntime => {
+                    if delivered == total {
+                        self.cursor.runtime = Some(max_projection_cursor(
+                            final_cursor.clone(),
+                            item_cursor.clone(),
+                        ));
+                        self.cursor.runtime_item = None;
+                        self.cursor.runtime_payloads_delivered = 0;
+                    } else {
+                        self.cursor.runtime_item = Some(item_cursor.runtime);
+                        self.cursor.runtime_payloads_delivered = delivered;
+                    }
+                }
+                RuntimePayloadCursorKind::LiveProgress => {
+                    self.cursor.live = Some(max_projection_cursor(
+                        final_cursor.clone(),
+                        item_cursor.clone(),
+                    ));
+                }
             }
             self.push(payload);
         }
@@ -441,6 +452,7 @@ impl WebuiProjectionBatch {
             scope,
             display_previews,
             self.cursor.runtime_item,
+            self.cursor.live.as_ref().map(|cursor| cursor.runtime),
             already_delivered,
             remaining_capacity,
         )
@@ -452,6 +464,7 @@ impl WebuiProjectionBatch {
                 runtime_item.payloads,
                 runtime_item.total,
                 runtime_item.already_delivered,
+                runtime_item.cursor_kind,
             );
         }
         Ok(true)
@@ -497,6 +510,8 @@ fn runtime_projection_scope(actor: &TurnActor, scope: &TurnScope) -> EventProjec
 struct WebuiProjectionCursor {
     runtime: Option<EventProjectionCursor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    live: Option<EventProjectionCursor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     runtime_item: Option<EventCursor>,
     turn: Option<TurnEventProjectionCursor>,
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -512,6 +527,7 @@ fn parse_webui_projection_cursor(
 ) -> Result<WebuiProjectionCursor, ProductAdapterError> {
     if let Ok(parsed) = serde_json::from_str::<WebuiProjectionCursor>(cursor)
         && (parsed.runtime.is_some()
+            || parsed.live.is_some()
             || parsed.turn.is_some()
             || parsed.runtime_payloads_delivered > 0)
     {
@@ -531,6 +547,7 @@ fn parse_webui_projection_cursor(
     })?;
     Ok(WebuiProjectionCursor {
         runtime: Some(runtime),
+        live: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 0,
@@ -548,6 +565,14 @@ fn validate_webui_projection_cursor_scope(
         return Err(ProductAdapterError::InvalidIdentifier {
             kind: "projection_cursor",
             reason: "runtime cursor scope does not match subscription scope".to_string(),
+        });
+    }
+    if let Some(live) = cursor.live.as_ref()
+        && &live.scope != projection_scope
+    {
+        return Err(ProductAdapterError::InvalidIdentifier {
+            kind: "projection_cursor",
+            reason: "live cursor scope does not match subscription scope".to_string(),
         });
     }
     if let Some(turn) = cursor.turn.as_ref()
@@ -574,6 +599,7 @@ async fn item_to_payloads(
     scope: &TurnScope,
     display_previews: &dyn CapabilityDisplayPreviewSource,
     expected_item: Option<EventCursor>,
+    last_live_cursor: Option<EventCursor>,
     already_delivered: usize,
     capacity: usize,
 ) -> RuntimePayloadItemResult {
@@ -607,7 +633,7 @@ async fn item_to_payloads(
                     .await
                 }
                 ironclaw_event_streams::ProductProjectionEnvelope::ThreadLiveUpdate(update) => {
-                    live_update_payloads(scope, update, cursor, expected_item, already_delivered)
+                    live_update_payloads(scope, update, cursor, last_live_cursor)
                 }
                 _ => Err(internal_projection_error(
                     "unexpected projection update envelope",
@@ -641,16 +667,10 @@ fn live_update_payloads(
     scope: &TurnScope,
     update: &ThreadLiveProjectionUpdate,
     cursor: EventProjectionCursor,
-    expected_item: Option<EventCursor>,
-    already_delivered: usize,
+    last_live_cursor: Option<EventCursor>,
 ) -> RuntimePayloadItemResult {
-    let already_delivered =
-        effective_runtime_payload_offset(already_delivered, expected_item, cursor.runtime);
-    if already_delivered > 0 {
-        return Err(ProductAdapterError::InvalidIdentifier {
-            kind: "projection_cursor",
-            reason: "runtime delivery offset exceeds runtime item payload count".to_string(),
-        });
+    if last_live_cursor.is_some_and(|last| cursor.runtime <= last) {
+        return Ok(None);
     }
     let items = product_items_for_live_update(update);
     if items.is_empty() {
@@ -663,6 +683,7 @@ fn live_update_payloads(
         payloads: vec![ProductOutboundPayload::ProjectionUpdate { state }],
         total: 1,
         already_delivered: 0,
+        cursor_kind: RuntimePayloadCursorKind::LiveProgress,
     }))
 }
 
@@ -707,6 +728,7 @@ async fn snapshot_payloads(
         payloads,
         total,
         already_delivered,
+        cursor_kind: RuntimePayloadCursorKind::DurableRuntime,
     }))
 }
 
@@ -751,6 +773,7 @@ async fn replay_payloads(
         payloads,
         total,
         already_delivered,
+        cursor_kind: RuntimePayloadCursorKind::DurableRuntime,
     }))
 }
 
@@ -761,9 +784,16 @@ struct RuntimePayloadItem {
     payloads: Vec<ProductOutboundPayload>,
     total: usize,
     already_delivered: usize,
+    cursor_kind: RuntimePayloadCursorKind,
 }
 
 type RuntimePayloadItemResult = Result<Option<RuntimePayloadItem>, ProductAdapterError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimePayloadCursorKind {
+    DurableRuntime,
+    LiveProgress,
+}
 
 #[cfg(test)]
 struct RuntimePayloadItemInput {
@@ -830,6 +860,7 @@ async fn runtime_payloads_for_item(
         payloads,
         total,
         already_delivered,
+        cursor_kind: RuntimePayloadCursorKind::DurableRuntime,
     }))
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection.rs
+++ b/crates/ironclaw_reborn_composition/src/projection.rs
@@ -383,14 +383,13 @@ impl WebuiProjectionBatch {
         &self.cursor
     }
 
-    fn push_runtime_payloads(
+    fn push_durable_runtime_payloads(
         &mut self,
         final_cursor: EventProjectionCursor,
         item_cursor: EventProjectionCursor,
         payloads: Vec<ProductOutboundPayload>,
         total: usize,
         already_delivered: usize,
-        cursor_kind: RuntimePayloadCursorKind,
     ) -> Result<bool, ProductAdapterError> {
         if total == 0 {
             return Ok(true);
@@ -412,30 +411,34 @@ impl WebuiProjectionBatch {
         for (index, payload) in payloads.into_iter().take(remaining_capacity).enumerate() {
             let delivered = already_delivered + index + 1;
             self.runtime_payloads_pushed += 1;
-            match cursor_kind {
-                RuntimePayloadCursorKind::DurableRuntime => {
-                    if delivered == total {
-                        self.cursor.runtime = Some(max_projection_cursor(
-                            final_cursor.clone(),
-                            item_cursor.clone(),
-                        ));
-                        self.cursor.runtime_item = None;
-                        self.cursor.runtime_payloads_delivered = 0;
-                    } else {
-                        self.cursor.runtime_item = Some(item_cursor.runtime);
-                        self.cursor.runtime_payloads_delivered = delivered;
-                    }
-                }
-                RuntimePayloadCursorKind::LiveProgress => {
-                    self.cursor.live = Some(max_projection_cursor(
-                        final_cursor.clone(),
-                        item_cursor.clone(),
-                    ));
-                }
+            if delivered == total {
+                self.cursor.runtime = Some(max_projection_cursor(
+                    final_cursor.clone(),
+                    item_cursor.clone(),
+                ));
+                self.cursor.runtime_item = None;
+                self.cursor.runtime_payloads_delivered = 0;
+            } else {
+                self.cursor.runtime_item = Some(item_cursor.runtime);
+                self.cursor.runtime_payloads_delivered = delivered;
             }
             self.push(payload);
         }
         Ok(self.cursor.runtime_payloads_delivered == 0)
+    }
+
+    fn push_live_payload(
+        &mut self,
+        cursor: EventProjectionCursor,
+        payload: ProductOutboundPayload,
+    ) -> bool {
+        if !self.has_runtime_payload_capacity() {
+            return false;
+        }
+        self.runtime_payloads_pushed += 1;
+        self.cursor.live = Some(cursor);
+        self.push(payload);
+        true
     }
 
     async fn push_runtime_item(
@@ -458,14 +461,20 @@ impl WebuiProjectionBatch {
         )
         .await?
         {
-            return self.push_runtime_payloads(
-                runtime_item.final_cursor,
-                runtime_item.item_cursor,
-                runtime_item.payloads,
-                runtime_item.total,
-                runtime_item.already_delivered,
-                runtime_item.cursor_kind,
-            );
+            match runtime_item {
+                RuntimePayloadItem::Durable(durable) => {
+                    return self.push_durable_runtime_payloads(
+                        durable.final_cursor,
+                        durable.item_cursor,
+                        durable.payloads,
+                        durable.total,
+                        durable.already_delivered,
+                    );
+                }
+                RuntimePayloadItem::Live { cursor, payload } => {
+                    return Ok(self.push_live_payload(cursor, payload));
+                }
+            }
         }
         Ok(true)
     }
@@ -677,14 +686,46 @@ fn live_update_payloads(
         return Ok(None);
     }
     let state = ProductProjectionState::new(scope.thread_id.to_string(), items)?;
-    Ok(Some(RuntimePayloadItem {
-        final_cursor: cursor.clone(),
-        item_cursor: cursor,
-        payloads: vec![ProductOutboundPayload::ProjectionUpdate { state }],
-        total: 1,
-        already_delivered: 0,
-        cursor_kind: RuntimePayloadCursorKind::LiveProgress,
+    Ok(Some(RuntimePayloadItem::Live {
+        cursor,
+        payload: ProductOutboundPayload::ProjectionUpdate { state },
     }))
+}
+
+#[derive(Debug)]
+struct DurableRuntimePayloadItem {
+    final_cursor: EventProjectionCursor,
+    item_cursor: EventProjectionCursor,
+    payloads: Vec<ProductOutboundPayload>,
+    total: usize,
+    already_delivered: usize,
+}
+
+#[derive(Debug)]
+enum RuntimePayloadItem {
+    Durable(DurableRuntimePayloadItem),
+    Live {
+        cursor: EventProjectionCursor,
+        payload: ProductOutboundPayload,
+    },
+}
+
+type RuntimePayloadItemResult = Result<Option<RuntimePayloadItem>, ProductAdapterError>;
+
+fn durable_runtime_payload_item(
+    final_cursor: EventProjectionCursor,
+    item_cursor: EventProjectionCursor,
+    payloads: Vec<ProductOutboundPayload>,
+    total: usize,
+    already_delivered: usize,
+) -> RuntimePayloadItem {
+    RuntimePayloadItem::Durable(DurableRuntimePayloadItem {
+        final_cursor,
+        item_cursor,
+        payloads,
+        total,
+        already_delivered,
+    })
 }
 
 async fn snapshot_payloads(
@@ -722,14 +763,13 @@ async fn snapshot_payloads(
         .skip(already_delivered)
         .take(capacity)
         .collect();
-    Ok(Some(RuntimePayloadItem {
-        final_cursor: cursor,
+    Ok(Some(durable_runtime_payload_item(
+        cursor,
         item_cursor,
         payloads,
         total,
         already_delivered,
-        cursor_kind: RuntimePayloadCursorKind::DurableRuntime,
-    }))
+    )))
 }
 
 async fn replay_payloads(
@@ -767,32 +807,13 @@ async fn replay_payloads(
         .skip(already_delivered)
         .take(capacity)
         .collect();
-    Ok(Some(RuntimePayloadItem {
-        final_cursor: cursor,
+    Ok(Some(durable_runtime_payload_item(
+        cursor,
         item_cursor,
         payloads,
         total,
         already_delivered,
-        cursor_kind: RuntimePayloadCursorKind::DurableRuntime,
-    }))
-}
-
-#[derive(Debug)]
-struct RuntimePayloadItem {
-    final_cursor: EventProjectionCursor,
-    item_cursor: EventProjectionCursor,
-    payloads: Vec<ProductOutboundPayload>,
-    total: usize,
-    already_delivered: usize,
-    cursor_kind: RuntimePayloadCursorKind,
-}
-
-type RuntimePayloadItemResult = Result<Option<RuntimePayloadItem>, ProductAdapterError>;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RuntimePayloadCursorKind {
-    DurableRuntime,
-    LiveProgress,
+    )))
 }
 
 #[cfg(test)]
@@ -817,7 +838,7 @@ async fn runtime_payloads_for_item(
     expected_item: Option<EventCursor>,
     already_delivered: usize,
     capacity: usize,
-) -> RuntimePayloadItemResult {
+) -> Result<Option<DurableRuntimePayloadItem>, ProductAdapterError> {
     let RuntimePayloadItemInput {
         runs,
         capability_activities,
@@ -854,13 +875,12 @@ async fn runtime_payloads_for_item(
         .skip(already_delivered)
         .take(capacity)
         .collect();
-    Ok(Some(RuntimePayloadItem {
+    Ok(Some(DurableRuntimePayloadItem {
         final_cursor: cursor,
         item_cursor,
         payloads,
         total,
         already_delivered,
-        cursor_kind: RuntimePayloadCursorKind::DurableRuntime,
     }))
 }
 

--- a/crates/ironclaw_reborn_composition/src/projection/tests/cursor_validation.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/cursor_validation.rs
@@ -53,6 +53,7 @@ async fn webui_event_stream_rejects_runtime_delivery_offset_above_payload_limit(
         runtime: Some(EventProjectionCursor::origin_for_scope(
             runtime_projection_scope(&actor, &scope),
         )),
+        live: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: WEBUI_RUNTIME_ITEM_MAX_PAYLOADS + 2,
@@ -105,6 +106,7 @@ async fn webui_event_stream_rejects_runtime_delivery_offset_above_item_payload_c
         runtime: Some(EventProjectionCursor::origin_for_scope(
             runtime_projection_scope(&actor, &scope),
         )),
+        live: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 3,
@@ -155,6 +157,7 @@ async fn webui_event_stream_rejects_legacy_partial_snapshot_offset_above_item_pa
     let scope = TurnScope::new(tenant_id, Some(agent_id), None, thread_id);
     let cursor = product_cursor_from_webui_cursor(&WebuiProjectionCursor {
         runtime: None,
+        live: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 3,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
@@ -803,6 +803,7 @@ async fn webui_event_stream_live_cursor_does_not_poison_runtime_failure_resume()
 
     sink.publish_loop_milestone(LoopHostMilestone {
         scope: scope.clone(),
+        actor: None,
         turn_id: TurnId::new(),
         run_id: TurnRunId::from_uuid(invocation_id.as_uuid()),
         loop_driver_id: LoopDriverId::new("test_loop").unwrap(),

--- a/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/runtime_stream.rs
@@ -621,6 +621,106 @@ async fn webui_event_stream_drains_work_summary_projection_from_driver_note() {
 }
 
 #[tokio::test]
+async fn webui_event_stream_live_cursor_does_not_poison_runtime_failure_resume() {
+    let tenant_id = TenantId::new("webui-live-failure-tenant").unwrap();
+    let user_id = UserId::new("webui-live-failure-user").unwrap();
+    let agent_id = AgentId::new("webui-live-failure-agent").unwrap();
+    let thread_id = ThreadId::new("webui-live-failure-thread").unwrap();
+    let invocation_id = InvocationId::new();
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    let event_log_for_append = Arc::clone(&event_log);
+    let event_log: Arc<dyn DurableEventLog> = event_log;
+    let services = build_reborn_projection_services(
+        event_log,
+        ReplyTargetBindingRef::new("webui-live-failure-reply").unwrap(),
+    );
+    let sink = services.with_live_progress_milestone_sink_for_publisher(
+        Arc::new(InMemoryLoopHostMilestoneSink::default()),
+        services.live_projection_publisher(user_id.clone()),
+    );
+    let actor = TurnActor::new(user_id.clone());
+    let scope = TurnScope::new(
+        tenant_id.clone(),
+        Some(agent_id.clone()),
+        None,
+        thread_id.clone(),
+    );
+
+    sink.publish_loop_milestone(LoopHostMilestone {
+        scope: scope.clone(),
+        turn_id: TurnId::new(),
+        run_id: TurnRunId::from_uuid(invocation_id.as_uuid()),
+        loop_driver_id: LoopDriverId::new("test_loop").unwrap(),
+        kind: LoopHostMilestoneKind::DriverNote {
+            kind: LoopDriverNoteKind::Planning,
+            safe_summary: LoopSafeSummary::new("checking tools").unwrap(),
+        },
+    })
+    .await
+    .unwrap();
+
+    let live_events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor: actor.clone(),
+            scope: scope.clone(),
+            after_cursor: None,
+        })
+        .await
+        .unwrap();
+    assert!(live_events.iter().any(|event| {
+        matches!(
+            event.payload(),
+            ProductOutboundPayload::ProjectionUpdate { state }
+                if state.items.iter().any(|item| matches!(
+                    item,
+                    ProductProjectionItem::WorkSummary { body, .. } if body == "checking tools"
+                ))
+        )
+    }));
+    let live_cursor =
+        parse_webui_projection_cursor(live_events.last().unwrap().projection_cursor().as_str())
+            .unwrap();
+    assert!(
+        live_cursor.runtime.is_none(),
+        "live progress must not advance the durable runtime cursor"
+    );
+    assert!(live_cursor.live.is_some());
+
+    let runtime_scope = resource_scope(&tenant_id, &user_id, &agent_id, &thread_id, invocation_id);
+    event_log_for_append
+        .append(RuntimeEvent::model_started(
+            runtime_scope.clone(),
+            CapabilityId::new("loop.model").unwrap(),
+        ))
+        .await
+        .unwrap();
+    event_log_for_append
+        .append(RuntimeEvent::loop_failed(
+            runtime_scope,
+            CapabilityId::new("loop.run").unwrap(),
+            "driver_unavailable",
+        ))
+        .await
+        .unwrap();
+
+    let resumed_events = services
+        .webui_event_stream()
+        .drain(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: Some(live_events.last().unwrap().projection_cursor().clone()),
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        contains_run_status(&resumed_events, invocation_id, "failed"),
+        "runtime failure after live progress must still be delivered from the live cursor"
+    );
+}
+
+#[tokio::test]
 async fn webui_event_stream_maps_subscription_terminated_work_summary_to_context() {
     let tenant_id = TenantId::new("webui-terminated-summary-tenant").unwrap();
     let user_id = UserId::new("webui-terminated-summary-user").unwrap();
@@ -832,6 +932,7 @@ async fn webui_event_stream_accepts_legacy_partial_origin_cursor() {
     let scope = TurnScope::new(tenant_id, Some(agent_id), None, thread_id);
     let legacy_cursor = product_cursor_from_webui_cursor(&WebuiProjectionCursor {
         runtime: None,
+        live: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 1,

--- a/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
+++ b/crates/ironclaw_reborn_composition/src/projection/tests/turn_stream.rs
@@ -296,6 +296,7 @@ async fn webui_event_stream_rejects_foreign_composite_turn_cursor() {
     let scope_b = TurnScope::new(tenant_id, Some(agent_id), None, thread_b);
     let cursor = product_cursor_from_webui_cursor(&WebuiProjectionCursor {
         runtime: None,
+        live: None,
         runtime_item: None,
         turn: Some(TurnEventProjectionCursor::for_scope(
             scope_a,
@@ -348,6 +349,7 @@ async fn webui_event_stream_rejects_foreign_composite_runtime_cursor() {
         runtime: Some(EventProjectionCursor::origin_for_scope(
             runtime_projection_scope(&actor, &scope_a),
         )),
+        live: None,
         runtime_item: None,
         turn: None,
         runtime_payloads_delivered: 1,


### PR DESCRIPTION
## Summary
- split WebUI projection cursors so synthetic live-progress updates no longer advance the durable runtime cursor
- keep legacy/composite cursor parsing backward-compatible while validating the new live cursor scope
- add regression coverage for live progress followed by a terminal runtime failure resume

## Root Cause
Live progress uses synthetic high-range cursors, but WebUI was recording those cursors in the same `runtime` field used for durable projection replay. After a live update, the next poll could resume durable replay from a cursor durable events would never reach, so terminal failure updates could be missed and WebUI could remain stuck in a processing state.

## Validation
- `cargo test -p ironclaw_reborn_composition projection::tests::runtime_stream`
- `cargo test -p ironclaw_reborn_composition projection::tests::cursor_validation`
- `cargo test -p ironclaw_reborn_composition webui_event_stream_rejects_foreign_composite_runtime_cursor`
- `cargo test -p ironclaw_reborn_composition webui_event_stream_rejects_foreign_composite_turn_cursor`
- `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings`