### PR TITLE
Wire Slack host-beta route into Reborn serve

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -823,7 +823,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 
 ### P1 - High Priority
 
-- ❌ Slack channel (real implementation)
+- 🚧 Slack channel (real implementation): Reborn host-beta route can be explicitly mounted by `ironclaw-reborn serve` with Slack Events API signing, DM/app-mention routing through Product Workflow/Reborn, and final-reply delivery; production durability/setup remains follow-up.
 - ✅ Telegram channel (WASM, polling-first setup, DM pairing, caption, /start)
 - ❌ WhatsApp channel
 - ✅ Multi-provider failover (`FailoverProvider` with retryable error classification)

--- a/crates/ironclaw_agent_loop/src/executor/assistant_reply.rs
+++ b/crates/ironclaw_agent_loop/src/executor/assistant_reply.rs
@@ -27,6 +27,10 @@ impl ExecutorStage<AssistantReplyInput> for AssistantReplyStage {
         input: AssistantReplyInput,
     ) -> Result<TurnCompletedStep, AgentLoopExecutorError> {
         let mut state = input.state;
+        let output_tokens = input
+            .usage
+            .map(|usage| usage.output_tokens)
+            .unwrap_or_else(|| estimate_output_tokens(&input.reply));
         let reply_ref = ctx
             .host
             .finalize_assistant_message(FinalizeAssistantMessage { reply: input.reply })
@@ -35,9 +39,7 @@ impl ExecutorStage<AssistantReplyInput> for AssistantReplyStage {
                 stage: HostStage::Transcript,
             })?;
         state.assistant_refs.push(reply_ref.clone());
-        if let Some(usage) = input.usage {
-            state.recent_output_token_counts.push(usage.output_tokens);
-        }
+        state.recent_output_token_counts.push(output_tokens);
         state = match CheckpointStage.cancel_if_requested(ctx, state).await? {
             CancelCheck::Continue(state) => *state,
             CancelCheck::Exit(exit) => return Ok(TurnCompletedStep::Exit(exit)),
@@ -48,4 +50,12 @@ impl ExecutorStage<AssistantReplyInput> for AssistantReplyStage {
             summary: TurnSummary::reply_only(reply_ref),
         })
     }
+}
+
+fn estimate_output_tokens(reply: &AssistantReply) -> u32 {
+    if reply.content.is_empty() {
+        return 0;
+    }
+    let estimated = reply.content.len().div_ceil(4).max(1);
+    estimated.min(u32::MAX as usize) as u32
 }

--- a/crates/ironclaw_agent_loop/src/executor/tests.rs
+++ b/crates/ironclaw_agent_loop/src/executor/tests.rs
@@ -914,6 +914,15 @@ async fn assistant_reply_stage_returns_reply_summary() {
         TurnCompletedStep::Continue { state, summary } => {
             assert_eq!(state.assistant_refs, vec![message_ref("msg:assistant")]);
             assert_eq!(
+                state
+                    .recent_output_token_counts
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>(),
+                vec![2],
+                "missing provider usage should still feed no-progress detection"
+            );
+            assert_eq!(
                 summary,
                 TurnSummary::reply_only(message_ref("msg:assistant"))
             );

--- a/crates/ironclaw_product_workflow/src/in_memory_ledger.rs
+++ b/crates/ironclaw_product_workflow/src/in_memory_ledger.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::HashMap,
+    num::NonZeroUsize,
     sync::{Arc, Mutex},
 };
 
@@ -24,6 +25,7 @@ const DEFAULT_IN_FLIGHT_LEASE: Duration = Duration::seconds(60);
 pub struct InMemoryIdempotencyLedger {
     state: Arc<Mutex<InMemoryIdempotencyState>>,
     in_flight_lease: Duration,
+    max_settled_entries: Option<NonZeroUsize>,
 }
 
 #[derive(Default)]
@@ -41,6 +43,15 @@ impl InMemoryIdempotencyLedger {
         Self {
             state: Arc::new(Mutex::new(InMemoryIdempotencyState::default())),
             in_flight_lease,
+            max_settled_entries: None,
+        }
+    }
+
+    pub fn with_settled_entry_limit(max_settled_entries: NonZeroUsize) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(InMemoryIdempotencyState::default())),
+            in_flight_lease: DEFAULT_IN_FLIGHT_LEASE,
+            max_settled_entries: Some(max_settled_entries),
         }
     }
 
@@ -124,6 +135,7 @@ impl IdempotencyLedger for InMemoryIdempotencyLedger {
         }
         state.in_flight.remove(&action.fingerprint);
         state.settled.insert(action.fingerprint.clone(), action);
+        trim_settled_entries(&mut state, self.max_settled_entries);
         Ok(())
     }
 
@@ -136,5 +148,25 @@ impl IdempotencyLedger for InMemoryIdempotencyLedger {
             state.in_flight.remove(&action.fingerprint);
         }
         Ok(())
+    }
+}
+
+fn trim_settled_entries(
+    state: &mut InMemoryIdempotencyState,
+    max_settled_entries: Option<NonZeroUsize>,
+) {
+    let Some(max_settled_entries) = max_settled_entries else {
+        return;
+    };
+    while state.settled.len() > max_settled_entries.get() {
+        let Some(oldest) = state
+            .settled
+            .iter()
+            .min_by_key(|(_, action)| action.settled_at.unwrap_or(action.received_at))
+            .map(|(fingerprint, _)| fingerprint.clone())
+        else {
+            return;
+        };
+        state.settled.remove(&oldest);
     }
 }

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -35,6 +35,13 @@ webui-v2-beta = [
     "ironclaw_reborn_composition/webui-v2-beta",
     "dep:ironclaw_reborn_webui_ingress",
 ]
+# Compile in the Slack Events API host-beta mount for `ironclaw-reborn serve`.
+# Still requires `[slack].enabled = true` at runtime before the route is
+# mounted; ambient Slack env vars alone do not enable it.
+slack-v2-host-beta = [
+    "webui-v2-beta",
+    "ironclaw_reborn_composition/slack-v2-host-beta",
+]
 
 [dependencies]
 anyhow = "1"

--- a/crates/ironclaw_reborn_cli/src/commands/config/init.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/init.rs
@@ -199,6 +199,19 @@ api_key_env = "OPENAI_API_KEY"
 # provider_id = "anthropic"
 # model       = "claude-3-5-sonnet-latest"
 # api_key_env = "ANTHROPIC_API_KEY"
+
+# [slack]
+# # Host-beta Slack Events API route for `ironclaw-reborn serve`.
+# # Requires a binary built with `--features slack-v2-host-beta`.
+# enabled = false
+# installation_id = "install-alpha"
+# team_id = "T123"
+# api_app_id = "A123"
+# slack_user_id = "U123"
+# # Defaults to the WebUI authenticated user when omitted.
+# # user_id = "reborn-cli"
+# signing_secret_env = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET"
+# bot_token_env = "IRONCLAW_REBORN_SLACK_BOT_TOKEN"
 "#,
         api_version = REBORN_CONFIG_API_VERSION,
     )

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -13,6 +13,8 @@ pub(crate) mod repl;
 pub(crate) mod run;
 #[cfg(feature = "webui-v2-beta")]
 pub(crate) mod serve;
+#[cfg(feature = "webui-v2-beta")]
+pub(crate) mod serve_slack;
 pub(crate) mod skills;
 pub(crate) mod traces;
 

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
 use clap::Args;
+#[cfg(feature = "slack-v2-host-beta")]
+use ironclaw_reborn_composition::build_slack_events_route_mount;
 use ironclaw_reborn_composition::{
     GoogleOAuthRouteConfig, RebornBuildInput, RebornReadiness, RebornRuntimeIdentity,
     RebornRuntimeInput, RebornWebuiBundle, WebuiServeConfig, build_reborn_runtime,
@@ -113,7 +115,7 @@ impl ServeCommand {
 
         let authenticator = Arc::new(EnvBearerAuthenticator::new(
             SecretString::from(token_value),
-            user_id,
+            user_id.clone(),
         )?);
 
         // Resolve trusted host-installation default agent/project from
@@ -142,6 +144,19 @@ impl ServeCommand {
             .map(ironclaw_reborn_composition::host_api::ProjectId::new)
             .transpose()
             .map_err(|err| anyhow!("[identity].default_project is invalid: {err}"))?;
+        #[cfg(feature = "slack-v2-host-beta")]
+        let slack_host_beta_config = crate::commands::serve_slack::resolve_slack_host_beta_config(
+            config_file.as_ref().and_then(|file| file.slack.as_ref()),
+            &tenant_id,
+            &default_agent_id,
+            default_project_id.as_ref(),
+            &user_id,
+            &boot_config.home().config_file_path(),
+        )?;
+        #[cfg(not(feature = "slack-v2-host-beta"))]
+        crate::commands::serve_slack::reject_enabled_slack_without_feature(
+            config_file.as_ref().and_then(|file| file.slack.as_ref()),
+        )?;
 
         // Resolve listen address with explicit precedence:
         //   CLI flag (Some(...)) > config file > compile-time default.
@@ -318,6 +333,12 @@ impl ServeCommand {
             }
             if let Some(host) = canonical_host {
                 serve_config = serve_config.with_canonical_host(host);
+            }
+            #[cfg(feature = "slack-v2-host-beta")]
+            if let Some(slack_config) = slack_host_beta_config {
+                let slack_mount = build_slack_events_route_mount(&runtime, slack_config)
+                    .context("failed to compose Slack Events API host-beta route")?;
+                serve_config = serve_config.with_public_route_mount(slack_mount);
             }
             let webui_app = webui_v2_app_with_lifecycle(bundle, serve_config)
                 .context("failed to compose v2 Router")?;

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -1,0 +1,430 @@
+#[cfg(feature = "slack-v2-host-beta")]
+use anyhow::anyhow;
+
+#[cfg(feature = "slack-v2-host-beta")]
+use std::env;
+#[cfg(feature = "slack-v2-host-beta")]
+use std::path::Path;
+
+#[cfg(feature = "slack-v2-host-beta")]
+use ironclaw_reborn_composition::SlackHostBetaConfig;
+#[cfg(feature = "slack-v2-host-beta")]
+use secrecy::SecretString;
+
+#[cfg(feature = "slack-v2-host-beta")]
+const DEFAULT_SLACK_SIGNING_SECRET_ENV_VAR: &str = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET";
+#[cfg(feature = "slack-v2-host-beta")]
+const DEFAULT_SLACK_BOT_TOKEN_ENV_VAR: &str = "IRONCLAW_REBORN_SLACK_BOT_TOKEN";
+
+#[cfg(feature = "slack-v2-host-beta")]
+pub(crate) fn resolve_slack_host_beta_config(
+    section: Option<&ironclaw_reborn_config::SlackSection>,
+    tenant_id: &ironclaw_reborn_composition::host_api::TenantId,
+    default_agent_id: &ironclaw_reborn_composition::host_api::AgentId,
+    default_project_id: Option<&ironclaw_reborn_composition::host_api::ProjectId>,
+    default_user_id: &ironclaw_reborn_composition::host_api::UserId,
+    config_path: &Path,
+) -> anyhow::Result<Option<SlackHostBetaConfig>> {
+    let Some(section) = section else {
+        return Ok(None);
+    };
+    if section.enabled != Some(true) {
+        return Ok(None);
+    }
+
+    let installation_id =
+        required_slack_config_value("installation_id", &section.installation_id, config_path)?;
+    let team_id = required_slack_config_value("team_id", &section.team_id, config_path)?;
+    let api_app_id = optional_slack_config_value("api_app_id", &section.api_app_id)?;
+    let slack_user_id =
+        required_slack_config_value("slack_user_id", &section.slack_user_id, config_path)?;
+    let mapped_user_id = match section.user_id.as_deref() {
+        Some(raw) => ironclaw_reborn_composition::host_api::UserId::new(raw)
+            .map_err(|err| anyhow!("[slack].user_id `{raw}` is invalid: {err}"))?,
+        None => default_user_id.clone(),
+    };
+
+    let signing_secret_env =
+        optional_slack_config_value("signing_secret_env", &section.signing_secret_env)?
+            .unwrap_or_else(|| DEFAULT_SLACK_SIGNING_SECRET_ENV_VAR.to_string());
+    let bot_token_env = optional_slack_config_value("bot_token_env", &section.bot_token_env)?
+        .unwrap_or_else(|| DEFAULT_SLACK_BOT_TOKEN_ENV_VAR.to_string());
+    let signing_secret = required_env_secret(
+        "signing secret",
+        "signing_secret_env",
+        &signing_secret_env,
+        config_path,
+    )?;
+    let bot_token = required_env_secret("bot token", "bot_token_env", &bot_token_env, config_path)?;
+
+    Ok(Some(SlackHostBetaConfig::new(
+        tenant_id.clone(),
+        default_agent_id.clone(),
+        default_project_id.cloned(),
+        installation_id,
+        team_id,
+        api_app_id,
+        slack_user_id,
+        mapped_user_id,
+        SecretString::from(signing_secret),
+        SecretString::from(bot_token),
+    )?))
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+fn required_slack_config_value(
+    field: &'static str,
+    value: &Option<String>,
+    config_path: &Path,
+) -> anyhow::Result<String> {
+    optional_slack_config_value(field, value)?.ok_or_else(|| {
+        anyhow!(
+            "[slack].{field} must be set when [slack].enabled = true in {}",
+            config_path.display()
+        )
+    })
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+fn optional_slack_config_value(
+    field: &'static str,
+    value: &Option<String>,
+) -> anyhow::Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.trim().is_empty() {
+        anyhow::bail!("[slack].{field} must not be empty when set");
+    }
+    if value.trim() != value {
+        anyhow::bail!("[slack].{field} must not contain leading or trailing whitespace when set");
+    }
+    Ok(Some(value.clone()))
+}
+
+#[cfg(feature = "slack-v2-host-beta")]
+fn required_env_secret(
+    label: &'static str,
+    field: &'static str,
+    env_var: &str,
+    config_path: &Path,
+) -> anyhow::Result<String> {
+    let value = env::var(env_var).map_err(|_| {
+        anyhow!(
+            "{env_var} must be set to the Slack {label} when [slack].enabled = true. \
+             Override the variable name via [slack].{field} in {}.",
+            config_path.display()
+        )
+    })?;
+    if value.is_empty() {
+        anyhow::bail!("{env_var} must not be empty when [slack].enabled = true");
+    }
+    Ok(value)
+}
+
+#[cfg(not(feature = "slack-v2-host-beta"))]
+pub(crate) fn reject_enabled_slack_without_feature(
+    section: Option<&ironclaw_reborn_config::SlackSection>,
+) -> anyhow::Result<()> {
+    if section.and_then(|section| section.enabled).unwrap_or(false) {
+        anyhow::bail!(
+            "[slack].enabled = true requires an ironclaw-reborn binary built with \
+             the `slack-v2-host-beta` Cargo feature"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    use secrecy::ExposeSecret;
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_is_disabled_unless_explicitly_enabled() {
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: None,
+            ..Default::default()
+        };
+
+        let resolved = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("disabled Slack should not require fields or env vars");
+
+        assert!(resolved.is_none());
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_requires_identifiers_when_enabled() {
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            ..Default::default()
+        };
+
+        let error = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("enabled Slack must require host-selected identifiers");
+
+        assert!(
+            error.to_string().contains("[slack].installation_id"),
+            "message: {error}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_rejects_empty_required_identifier() {
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some(" ".to_string()),
+            ..Default::default()
+        };
+
+        let error = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("empty Slack identifiers must fail at config resolution");
+
+        assert!(
+            error
+                .to_string()
+                .contains("[slack].installation_id must not be empty"),
+            "message: {error}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_rejects_padded_identifier() {
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            team_id: Some(" T123".to_string()),
+            ..Default::default()
+        };
+
+        let error = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("padded Slack identifiers must fail at config resolution");
+
+        assert!(
+            error
+                .to_string()
+                .contains("[slack].team_id must not contain leading or trailing whitespace"),
+            "message: {error}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_reads_env_secrets_and_defaults_user() {
+        let _lock = env_lock();
+        let _signing = EnvGuard::set(
+            "IRONCLAW_TEST_SLACK_SIGNING_SECRET_DEFAULT_USER",
+            "signing-secret",
+        );
+        let _bot = EnvGuard::set("IRONCLAW_TEST_SLACK_BOT_TOKEN_DEFAULT_USER", "xoxb-token");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
+            slack_user_id: Some("U123".to_string()),
+            signing_secret_env: Some("IRONCLAW_TEST_SLACK_SIGNING_SECRET_DEFAULT_USER".to_string()),
+            bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_DEFAULT_USER".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            Some(&project_id("project")),
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("Slack config should resolve")
+        .expect("Slack should be enabled");
+
+        assert_eq!(resolved.installation_id.as_str(), "install-alpha");
+        assert!(format!("{:?}", resolved.installation_selector).contains("AppTeam"));
+        assert_eq!(resolved.slack_actor.id(), "U123");
+        assert_eq!(resolved.user_id, user_id("web-user"));
+        assert_eq!(resolved.signing_secret.expose_secret(), "signing-secret");
+        assert_eq!(resolved.bot_token.expose_secret(), "xoxb-token");
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_rejects_empty_env_secret_value() {
+        let _lock = env_lock();
+        let _signing = EnvGuard::set("IRONCLAW_TEST_SLACK_EMPTY_SIGNING_SECRET", "");
+        let _bot = EnvGuard::set("IRONCLAW_TEST_SLACK_EMPTY_BOT_TOKEN", "xoxb-token");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            team_id: Some("T123".to_string()),
+            slack_user_id: Some("U123".to_string()),
+            signing_secret_env: Some("IRONCLAW_TEST_SLACK_EMPTY_SIGNING_SECRET".to_string()),
+            bot_token_env: Some("IRONCLAW_TEST_SLACK_EMPTY_BOT_TOKEN".to_string()),
+            ..Default::default()
+        };
+
+        let error = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("empty secret env values must fail at config resolution");
+
+        assert!(
+            error
+                .to_string()
+                .contains("IRONCLAW_TEST_SLACK_EMPTY_SIGNING_SECRET must not be empty"),
+            "message: {error}"
+        );
+        drop(_signing);
+        drop(_bot);
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_accepts_explicit_user_mapping() {
+        let _lock = env_lock();
+        let _signing = EnvGuard::set(
+            "IRONCLAW_TEST_SLACK_SIGNING_SECRET_MAPPED_USER",
+            "signing-secret",
+        );
+        let _bot = EnvGuard::set("IRONCLAW_TEST_SLACK_BOT_TOKEN_MAPPED_USER", "xoxb-token");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            team_id: Some("T123".to_string()),
+            slack_user_id: Some("U123".to_string()),
+            user_id: Some("slack-mapped-user".to_string()),
+            signing_secret_env: Some("IRONCLAW_TEST_SLACK_SIGNING_SECRET_MAPPED_USER".to_string()),
+            bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_MAPPED_USER".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("Slack config should resolve")
+        .expect("Slack should be enabled");
+
+        assert_eq!(resolved.user_id, user_id("slack-mapped-user"));
+    }
+
+    #[cfg(not(feature = "slack-v2-host-beta"))]
+    #[test]
+    fn slack_host_beta_config_fails_loud_without_feature() {
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            ..Default::default()
+        };
+
+        let error = reject_enabled_slack_without_feature(Some(&section))
+            .expect_err("enabled Slack must require the host-beta feature");
+
+        assert!(
+            error.to_string().contains("slack-v2-host-beta"),
+            "message: {error}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    fn tenant_id(raw: &str) -> ironclaw_reborn_composition::host_api::TenantId {
+        ironclaw_reborn_composition::host_api::TenantId::new(raw).expect("valid tenant id")
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    fn agent_id(raw: &str) -> ironclaw_reborn_composition::host_api::AgentId {
+        ironclaw_reborn_composition::host_api::AgentId::new(raw).expect("valid agent id")
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    fn project_id(raw: &str) -> ironclaw_reborn_composition::host_api::ProjectId {
+        ironclaw_reborn_composition::host_api::ProjectId::new(raw).expect("valid project id")
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    fn user_id(raw: &str) -> ironclaw_reborn_composition::host_api::UserId {
+        ironclaw_reborn_composition::host_api::UserId::new(raw).expect("valid user id")
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prior = env::var(key).ok();
+            // SAFETY: env mutation in these tests is serialized through `env_lock()`.
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key, prior }
+        }
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: env mutation in these tests is serialized through `env_lock()`.
+            unsafe {
+                match &self.prior {
+                    Some(value) => env::set_var(self.key, value),
+                    None => env::remove_var(self.key),
+                }
+            }
+        }
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::path::Path;
 
 #[cfg(feature = "slack-v2-host-beta")]
-use ironclaw_reborn_composition::SlackHostBetaConfig;
+use ironclaw_reborn_composition::{SlackHostBetaConfig, SlackHostBetaConfigInput};
 #[cfg(feature = "slack-v2-host-beta")]
 use secrecy::SecretString;
 
@@ -67,18 +67,18 @@ pub(crate) fn resolve_slack_host_beta_config(
     )?;
     let bot_token = required_env_secret("bot token", "bot_token_env", &bot_token_env, config_path)?;
 
-    Ok(Some(SlackHostBetaConfig::new(
-        tenant_id.clone(),
-        default_agent_id.clone(),
-        default_project_id.cloned(),
+    Ok(Some(SlackHostBetaConfig::new(SlackHostBetaConfigInput {
+        tenant_id: tenant_id.clone(),
+        agent_id: default_agent_id.clone(),
+        project_id: default_project_id.cloned(),
         installation_id,
         team_id,
         api_app_id,
         slack_user_id,
-        mapped_user_id,
-        SecretString::from(signing_secret),
-        SecretString::from(bot_token),
-    )?))
+        user_id: mapped_user_id,
+        signing_secret: SecretString::from(signing_secret),
+        bot_token: SecretString::from(bot_token),
+    })?))
 }
 
 #[cfg(feature = "slack-v2-host-beta")]

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -178,7 +178,8 @@ pub use slack_egress::{
 };
 #[cfg(feature = "slack-v2-host-beta")]
 pub use slack_host_beta::{
-    SlackHostBetaBuildError, SlackHostBetaConfig, build_slack_events_route_mount,
+    SlackHostBetaBuildError, SlackHostBetaConfig, SlackHostBetaConfigInput,
+    build_slack_events_route_mount,
 };
 #[cfg(feature = "slack-v2-host-beta")]
 pub use slack_serve::{

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -76,6 +76,8 @@ mod slack_delivery;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_egress;
 #[cfg(feature = "slack-v2-host-beta")]
+mod slack_host_beta;
+#[cfg(feature = "slack-v2-host-beta")]
 pub mod slack_serve;
 #[cfg(feature = "test-support")]
 pub mod test_support;
@@ -175,9 +177,13 @@ pub use slack_egress::{
     SlackProtocolHttpEgress, StaticSlackEgressCredentialProvider,
 };
 #[cfg(feature = "slack-v2-host-beta")]
+pub use slack_host_beta::{
+    SlackHostBetaBuildError, SlackHostBetaConfig, build_slack_events_route_mount,
+};
+#[cfg(feature = "slack-v2-host-beta")]
 pub use slack_serve::{
     SLACK_EVENTS_PATH, SlackEventsRouteState, SlackEventsWebhookDispatcher,
-    slack_events_route_descriptors, slack_events_route_mount,
+    SlackInstallationSelector, slack_events_route_descriptors, slack_events_route_mount,
 };
 pub use webui::{RebornWebuiBundle, build_webui_services};
 #[cfg(feature = "webui-v2-beta")]

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/mod.rs
@@ -895,7 +895,7 @@ pub(super) async fn scoped_update_binding_for_requester(
         Err(AuthProductError::AccountSelectionRequired) => Ok(None),
         Err(AuthProductError::BackendUnavailable) => {
             tracing::warn!(
-                target: "ironclaw::reborn::product_auth::oauth",
+                target: "ironclaw_reborn_composition::product_auth::oauth",
                 provider = %provider.as_str(),
                 requester_extension = %requester_extension.as_str(),
                 "credential account status unavailable during extension OAuth start; starting setup without update binding"

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -40,6 +40,8 @@ use ironclaw_first_party_extension_ports::{
     FirstPartySkillsExtension, FirstPartySkillsExtensionHandles, SelectableSkillContextSource,
     SkillActivationSelectorConfig, SkillExecutionAdapter,
 };
+#[cfg(test)]
+use ironclaw_host_api::RuntimeHttpEgress;
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AgentId, AuditEnvelope, AuditEventId, AuditStage,
     CapabilityId, CorrelationId, DecisionSummary, EffectKind, InvocationId, ResourceScope,
@@ -513,6 +515,21 @@ impl RebornRuntime {
     /// Exposed for diagnostics / readiness reporting; **not** for traffic.
     pub fn services(&self) -> &RebornServices {
         &self.services
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_local_runtime_http_egress_for_test(
+        &mut self,
+        runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,
+    ) {
+        let local_runtime = self
+            .services
+            .local_runtime
+            .as_mut()
+            .expect("test runtime must include local runtime services");
+        Arc::get_mut(local_runtime)
+            .expect("test must mutate local runtime services before cloning the service Arc")
+            .runtime_http_egress = runtime_http_egress;
     }
 
     /// Diagnostic id for the no-profile run profile selected by this runtime.

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -5,6 +5,8 @@
 //! the submitted run to finish, reads the finalized assistant reply, and sends it
 //! through the host-mediated product outbound delivery seam.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -38,6 +40,7 @@ use ironclaw_wasm_product_adapters::ImmediateAckWorkflowObserver;
 use tokio::sync::Semaphore;
 
 const MAX_SLACK_RUN_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const SLACK_RUN_POLL_JITTER_BUCKETS: u32 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlackFinalReplyDeliverySettings {
@@ -255,7 +258,7 @@ impl SlackFinalReplyDeliveryObserver {
             if start.elapsed() >= self.settings.max_wait {
                 return Err(SlackFinalReplyDeliveryError::RunWaitTimedOut { run_id });
             }
-            tokio::time::sleep(poll_interval).await;
+            tokio::time::sleep(jittered_poll_interval(poll_interval, &run_id)).await;
             poll_interval = poll_interval
                 .saturating_mul(2)
                 .min(MAX_SLACK_RUN_POLL_INTERVAL);
@@ -279,6 +282,16 @@ impl SlackFinalReplyDeliveryObserver {
             .await?
             .and_then(|message| message.content))
     }
+}
+
+fn jittered_poll_interval(base: Duration, run_id: &TurnRunId) -> Duration {
+    if base.is_zero() {
+        return base;
+    }
+    let mut hasher = DefaultHasher::new();
+    run_id.to_string().hash(&mut hasher);
+    let bucket = hasher.finish() as u32 % SLACK_RUN_POLL_JITTER_BUCKETS;
+    (base + base / SLACK_RUN_POLL_JITTER_BUCKETS * bucket).min(MAX_SLACK_RUN_POLL_INTERVAL)
 }
 
 #[async_trait]

--- a/crates/ironclaw_reborn_composition/src/slack_egress.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_egress.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern, ResourceScope,
+    CapabilityId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern, ResourceScope,
+    RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeKind,
 };
-use ironclaw_network::{NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest};
 use ironclaw_product_adapters::{
     EgressCredentialHandle, EgressRequest, EgressResponse, ProtocolHttpEgress,
     ProtocolHttpEgressError, RedactedString,
@@ -23,6 +23,7 @@ use thiserror::Error;
 
 const SLACK_EGRESS_TIMEOUT_MS: u32 = 10_000;
 const SLACK_EGRESS_RESPONSE_BODY_LIMIT_BYTES: u64 = 64 * 1024;
+const SLACK_EGRESS_CAPABILITY_ID: &str = "slack.egress";
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum SlackEgressCredentialError {
@@ -91,7 +92,7 @@ impl SlackEgressCredentialProvider for StaticSlackEgressCredentialProvider {
 }
 
 pub struct SlackProtocolHttpEgress {
-    network: Arc<dyn NetworkHttpEgress>,
+    runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
     credentials: Arc<dyn SlackEgressCredentialProvider>,
     policy: EgressPolicy,
     scope: ResourceScope,
@@ -99,13 +100,13 @@ pub struct SlackProtocolHttpEgress {
 
 impl SlackProtocolHttpEgress {
     pub fn new(
-        network: Arc<dyn NetworkHttpEgress>,
+        runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
         credentials: Arc<dyn SlackEgressCredentialProvider>,
         policy: EgressPolicy,
         scope: ResourceScope,
     ) -> Self {
         Self {
-            network,
+            runtime_http_egress,
             credentials,
             policy,
             scope,
@@ -142,10 +143,17 @@ impl ProtocolHttpEgress for SlackProtocolHttpEgress {
             headers.push(("authorization".to_string(), authorization));
         }
 
+        let capability_id = CapabilityId::new(SLACK_EGRESS_CAPABILITY_ID).map_err(|error| {
+            ProtocolHttpEgressError::PolicyDenied {
+                reason: RedactedString::new(format!("invalid Slack egress capability id: {error}")),
+            }
+        })?;
         let response = self
-            .network
-            .execute(NetworkHttpRequest {
+            .runtime_http_egress
+            .execute(RuntimeHttpEgressRequest {
+                runtime: RuntimeKind::FirstParty,
                 scope: self.scope.clone(),
+                capability_id,
                 method: network_method(request.method().as_str())?,
                 url: format!(
                     "https://{}{}",
@@ -154,12 +162,14 @@ impl ProtocolHttpEgress for SlackProtocolHttpEgress {
                 ),
                 headers,
                 body: request.body().to_vec(),
-                policy: slack_network_policy(request.host().as_str()),
+                network_policy: slack_network_policy(request.host().as_str()),
+                credential_injections: Vec::new(),
                 response_body_limit: Some(SLACK_EGRESS_RESPONSE_BODY_LIMIT_BYTES),
+                save_body_to: None,
                 timeout_ms: Some(SLACK_EGRESS_TIMEOUT_MS),
             })
             .await
-            .map_err(map_network_error)?;
+            .map_err(map_runtime_http_error)?;
 
         Ok(EgressResponse::new(response.status, response.body))
     }
@@ -235,17 +245,21 @@ fn map_credential_error(error: SlackEgressCredentialError) -> ProtocolHttpEgress
     }
 }
 
-fn map_network_error(error: NetworkHttpError) -> ProtocolHttpEgressError {
-    match error {
-        NetworkHttpError::PolicyDenied { reason, .. } => ProtocolHttpEgressError::PolicyDenied {
-            reason: RedactedString::new(reason),
-        },
-        NetworkHttpError::InvalidUrl { reason, .. } => ProtocolHttpEgressError::PolicyDenied {
-            reason: RedactedString::new(reason),
-        },
-        NetworkHttpError::ResponseBodyLimit { .. } => ProtocolHttpEgressError::LeakDetected,
-        NetworkHttpError::Dns { reason, .. } | NetworkHttpError::Transport { reason, .. } => {
-            ProtocolHttpEgressError::Network(RedactedString::new(reason))
+fn map_runtime_http_error(error: RuntimeHttpEgressError) -> ProtocolHttpEgressError {
+    match error.reason_code() {
+        ironclaw_host_api::RuntimeHttpEgressReasonCode::PolicyDenied
+        | ironclaw_host_api::RuntimeHttpEgressReasonCode::RequestDenied => {
+            ProtocolHttpEgressError::PolicyDenied {
+                reason: RedactedString::new(error.stable_runtime_reason()),
+            }
+        }
+        ironclaw_host_api::RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
+            ProtocolHttpEgressError::LeakDetected
+        }
+        ironclaw_host_api::RuntimeHttpEgressReasonCode::CredentialUnavailable
+        | ironclaw_host_api::RuntimeHttpEgressReasonCode::NetworkError
+        | ironclaw_host_api::RuntimeHttpEgressReasonCode::ResponseError => {
+            ProtocolHttpEgressError::Network(RedactedString::new(error.stable_runtime_reason()))
         }
     }
 }
@@ -255,7 +269,10 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
-    use ironclaw_network::{NetworkHttpRequest, NetworkHttpResponse, NetworkUsage};
+    use ironclaw_host_api::{
+        RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED, RuntimeHttpEgressResponse,
+        RuntimeHttpSavedBody,
+    };
     use ironclaw_product_adapters::{
         DeclaredEgressHost, DeclaredEgressTarget, EgressCredentialHandle, EgressMethod, EgressPath,
     };
@@ -263,32 +280,52 @@ mod tests {
     use super::*;
 
     #[derive(Default)]
-    struct RecordingNetwork {
-        requests: Mutex<Vec<NetworkHttpRequest>>,
+    struct RecordingRuntimeHttpEgress {
+        requests: Mutex<Vec<RuntimeHttpEgressRequest>>,
     }
 
-    impl RecordingNetwork {
-        fn requests(&self) -> Vec<NetworkHttpRequest> {
-            self.requests.lock().expect("network requests lock").clone()
+    impl RecordingRuntimeHttpEgress {
+        fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
+            self.requests
+                .lock()
+                .expect("runtime HTTP requests lock")
+                .clone()
         }
     }
 
     #[async_trait]
-    impl NetworkHttpEgress for RecordingNetwork {
+    impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
         async fn execute(
             &self,
-            request: NetworkHttpRequest,
-        ) -> Result<NetworkHttpResponse, NetworkHttpError> {
+            request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
             self.requests
                 .lock()
-                .expect("network requests lock")
+                .expect("runtime HTTP requests lock")
                 .push(request);
-            Ok(NetworkHttpResponse {
+            Ok(RuntimeHttpEgressResponse {
                 status: 200,
                 headers: Vec::new(),
                 body: br#"{\"ok\":true}"#.to_vec(),
-                usage: NetworkUsage::default(),
+                saved_body: None::<RuntimeHttpSavedBody>,
+                request_bytes: 0,
+                response_bytes: 0,
+                redaction_applied: false,
             })
+        }
+    }
+
+    struct FailingRuntimeHttpEgress {
+        error: RuntimeHttpEgressError,
+    }
+
+    #[async_trait]
+    impl RuntimeHttpEgress for FailingRuntimeHttpEgress {
+        async fn execute(
+            &self,
+            _request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+            Err(self.error.clone())
         }
     }
 
@@ -310,10 +347,25 @@ mod tests {
         .with_credential_handle(Some(handle))
     }
 
-    fn slack_egress(network: Arc<RecordingNetwork>) -> SlackProtocolHttpEgress {
+    fn slack_egress(runtime_http: Arc<RecordingRuntimeHttpEgress>) -> SlackProtocolHttpEgress {
         let handle = slack_handle();
         SlackProtocolHttpEgress::new(
-            network,
+            runtime_http,
+            Arc::new(StaticSlackEgressCredentialProvider::new(
+                handle.clone(),
+                "xoxb-secret",
+            )),
+            EgressPolicy::new([DeclaredEgressTarget::new(slack_host(), Some(handle))]),
+            ResourceScope::system(),
+        )
+    }
+
+    fn slack_egress_with_runtime(
+        runtime_http: Arc<dyn RuntimeHttpEgress>,
+    ) -> SlackProtocolHttpEgress {
+        let handle = slack_handle();
+        SlackProtocolHttpEgress::new(
+            runtime_http,
             Arc::new(StaticSlackEgressCredentialProvider::new(
                 handle.clone(),
                 "xoxb-secret",
@@ -325,8 +377,8 @@ mod tests {
 
     #[tokio::test]
     async fn slack_protocol_http_egress_validates_policy_and_injects_bearer() {
-        let network = Arc::new(RecordingNetwork::default());
-        let egress = slack_egress(Arc::clone(&network));
+        let runtime_http = Arc::new(RecordingRuntimeHttpEgress::default());
+        let egress = slack_egress(Arc::clone(&runtime_http));
 
         let response = egress
             .send(slack_request(slack_handle()))
@@ -334,7 +386,7 @@ mod tests {
             .expect("slack egress should succeed");
 
         assert_eq!(response.status(), 200);
-        let requests = network.requests();
+        let requests = runtime_http.requests();
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].url, "https://slack.com/api/chat.postMessage");
         assert_eq!(requests[0].method, NetworkMethod::Post);
@@ -350,10 +402,10 @@ mod tests {
 
     #[tokio::test]
     async fn slack_protocol_http_egress_rejects_control_chars_in_bearer_before_network() {
-        let network = Arc::new(RecordingNetwork::default());
+        let runtime_http = Arc::new(RecordingRuntimeHttpEgress::default());
         let handle = slack_handle();
         let egress = SlackProtocolHttpEgress::new(
-            network.clone(),
+            runtime_http.clone(),
             Arc::new(StaticSlackEgressCredentialProvider::new(
                 handle.clone(),
                 "xoxb-secret\r\nX-Injected: true",
@@ -374,15 +426,15 @@ mod tests {
             error,
             ProtocolHttpEgressError::PolicyDenied { .. }
         ));
-        assert!(network.requests().is_empty());
+        assert!(runtime_http.requests().is_empty());
     }
 
     #[tokio::test]
     async fn slack_protocol_http_egress_rejects_unknown_handle_before_network() {
-        let network = Arc::new(RecordingNetwork::default());
+        let runtime_http = Arc::new(RecordingRuntimeHttpEgress::default());
         let unknown = EgressCredentialHandle::new("other_token").expect("other handle");
         let egress = SlackProtocolHttpEgress::new(
-            network.clone(),
+            runtime_http.clone(),
             Arc::new(StaticSlackEgressCredentialProvider::new(
                 slack_handle(),
                 "xoxb-secret",
@@ -403,6 +455,87 @@ mod tests {
             error,
             ProtocolHttpEgressError::UnknownCredentialHandle { .. }
         ));
-        assert!(network.requests().is_empty());
+        assert!(runtime_http.requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn slack_protocol_http_egress_maps_runtime_http_failures() {
+        let cases = [
+            (
+                RuntimeHttpEgressError::Request {
+                    reason: "invalid_url".to_string(),
+                    request_bytes: 12,
+                    response_bytes: 0,
+                },
+                "request-denied",
+                RuntimeErrorExpectation::PolicyDenied,
+            ),
+            (
+                RuntimeHttpEgressError::Network {
+                    reason: "policy_denied".to_string(),
+                    request_bytes: 12,
+                    response_bytes: 0,
+                },
+                "policy-denied",
+                RuntimeErrorExpectation::PolicyDenied,
+            ),
+            (
+                RuntimeHttpEgressError::Response {
+                    reason: RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED.to_string(),
+                    request_bytes: 12,
+                    response_bytes: 65_536,
+                },
+                "body-limit",
+                RuntimeErrorExpectation::LeakDetected,
+            ),
+            (
+                RuntimeHttpEgressError::Network {
+                    reason: "dns_failure".to_string(),
+                    request_bytes: 12,
+                    response_bytes: 0,
+                },
+                "network",
+                RuntimeErrorExpectation::Network,
+            ),
+        ];
+
+        for (runtime_error, label, expectation) in cases {
+            let runtime_http = Arc::new(FailingRuntimeHttpEgress {
+                error: runtime_error,
+            });
+            let egress = slack_egress_with_runtime(runtime_http);
+            let error = match egress.send(slack_request(slack_handle())).await {
+                Ok(response) => panic!("{label} case should fail, got {response:?}"),
+                Err(error) => error,
+            };
+
+            expectation.assert_matches(error, label);
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum RuntimeErrorExpectation {
+        PolicyDenied,
+        LeakDetected,
+        Network,
+    }
+
+    impl RuntimeErrorExpectation {
+        fn assert_matches(self, error: ProtocolHttpEgressError, label: &str) {
+            match self {
+                Self::PolicyDenied => assert!(
+                    matches!(error, ProtocolHttpEgressError::PolicyDenied { .. }),
+                    "{label}: expected policy denied, got {error:?}"
+                ),
+                Self::LeakDetected => assert!(
+                    matches!(error, ProtocolHttpEgressError::LeakDetected),
+                    "{label}: expected leak detected, got {error:?}"
+                ),
+                Self::Network => assert!(
+                    matches!(error, ProtocolHttpEgressError::Network(_)),
+                    "{label}: expected network error, got {error:?}"
+                ),
+            }
+        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -70,40 +70,40 @@ pub struct SlackHostBetaConfig {
     pub bot_token: SecretString,
 }
 
+pub struct SlackHostBetaConfigInput {
+    pub tenant_id: TenantId,
+    pub agent_id: AgentId,
+    pub project_id: Option<ProjectId>,
+    pub installation_id: String,
+    pub team_id: String,
+    pub api_app_id: Option<String>,
+    pub slack_user_id: String,
+    pub user_id: UserId,
+    pub signing_secret: SecretString,
+    pub bot_token: SecretString,
+}
+
 impl SlackHostBetaConfig {
-    // arch-exempt: too_many_args, needs SlackHostBetaBootstrap aggregation, plan #4418
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        tenant_id: TenantId,
-        agent_id: AgentId,
-        project_id: Option<ProjectId>,
-        installation_id: String,
-        team_id: String,
-        api_app_id: Option<String>,
-        slack_user_id: String,
-        user_id: UserId,
-        signing_secret: SecretString,
-        bot_token: SecretString,
-    ) -> Result<Self, SlackHostBetaBuildError> {
-        let installation_id = AdapterInstallationId::new(installation_id)
+    pub fn new(input: SlackHostBetaConfigInput) -> Result<Self, SlackHostBetaBuildError> {
+        let installation_id = AdapterInstallationId::new(input.installation_id)
             .map_err(|reason| invalid_config("installation_id", reason.to_string()))?;
-        let installation_selector = match api_app_id {
-            Some(api_app_id) => SlackInstallationSelector::app_team(api_app_id, team_id),
-            None => SlackInstallationSelector::team(team_id),
+        let installation_selector = match input.api_app_id {
+            Some(api_app_id) => SlackInstallationSelector::app_team(api_app_id, input.team_id),
+            None => SlackInstallationSelector::team(input.team_id),
         };
         let slack_actor =
-            ExternalActorRef::new(SLACK_USER_ACTOR_KIND, slack_user_id, None::<String>)
+            ExternalActorRef::new(SLACK_USER_ACTOR_KIND, input.slack_user_id, None::<String>)
                 .map_err(|reason| invalid_config("slack_user_id", reason.to_string()))?;
         Ok(Self {
-            tenant_id,
-            agent_id,
-            project_id,
+            tenant_id: input.tenant_id,
+            agent_id: input.agent_id,
+            project_id: input.project_id,
             installation_id,
             installation_selector,
             slack_actor,
-            user_id,
-            signing_secret,
-            bot_token,
+            user_id: input.user_id,
+            signing_secret: input.signing_secret,
+            bot_token: input.bot_token,
         })
     }
 }
@@ -358,18 +358,18 @@ mod tests {
     }
 
     fn config() -> SlackHostBetaConfig {
-        SlackHostBetaConfig::new(
-            TenantId::new(TENANT).expect("tenant"),
-            AgentId::new(AGENT).expect("agent"),
-            Some(ProjectId::new(PROJECT).expect("project")),
-            INSTALLATION.to_string(),
-            TEAM.to_string(),
-            Some(API_APP.to_string()),
-            SLACK_USER.to_string(),
-            UserId::new(USER).expect("user"),
-            SecretString::from(SECRET),
-            SecretString::from("xoxb-host-token"),
-        )
+        SlackHostBetaConfig::new(SlackHostBetaConfigInput {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            agent_id: AgentId::new(AGENT).expect("agent"),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            installation_id: INSTALLATION.to_string(),
+            team_id: TEAM.to_string(),
+            api_app_id: Some(API_APP.to_string()),
+            slack_user_id: SLACK_USER.to_string(),
+            user_id: UserId::new(USER).expect("user"),
+            signing_secret: SecretString::from(SECRET),
+            bot_token: SecretString::from("xoxb-host-token"),
+        })
         .expect("valid config")
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -1,0 +1,406 @@
+//! Host-beta Slack Events API composition.
+//!
+//! This module is the single composition point for the native Slack route:
+//! the CLI supplies explicit host config, and this module reuses the already
+//! assembled Reborn runtime services instead of creating a second agent loop.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ironclaw_conversations::InMemoryConversationServices;
+use ironclaw_host_api::{AgentId, ProjectId, ResourceScope, TenantId, UserId};
+use ironclaw_outbound::{InMemoryOutboundStateStore, OutboundStateStore};
+use ironclaw_product_adapters::{
+    AdapterInstallationId, DeliveryStatus, EgressCredentialHandle, ExternalActorRef,
+    OutboundDeliverySink, ProductAdapter, ProductAdapterId,
+};
+use ironclaw_product_workflow::{
+    DefaultInboundTurnService, DefaultProductWorkflow, InMemoryIdempotencyLedger,
+    ProductConversationBindingService, ProductInstallationKey, ProductInstallationScope,
+    StaticProductInstallationResolver,
+};
+use ironclaw_slack_v2_adapter::{
+    SLACK_USER_ACTOR_KIND, SlackV2Adapter, SlackV2AdapterConfig,
+    slack_request_signature_auth_requirement,
+};
+use ironclaw_wasm_product_adapters::{
+    EgressPolicy, HmacWebhookAuth, NativeProductAdapterRunner, NativeProductAdapterRunnerConfig,
+    WebhookAuth,
+};
+use secrecy::{ExposeSecret, SecretString};
+use thiserror::Error;
+
+use crate::RebornRuntime;
+use crate::slack_delivery::{
+    SlackFinalReplyDeliveryObserver, SlackFinalReplyDeliveryServices,
+    SlackFinalReplyDeliverySettings,
+};
+use crate::slack_egress::{SlackProtocolHttpEgress, StaticSlackEgressCredentialProvider};
+use crate::slack_serve::{
+    SlackEventsRouteState, SlackInstallationRecord, SlackInstallationSelector,
+    StaticSlackInstallationResolver, slack_events_route_mount,
+};
+use crate::webui_serve::PublicRouteMount;
+
+const SLACK_ADAPTER_ID: &str = "slack_v2";
+const SLACK_BOT_TOKEN_HANDLE: &str = "slack_bot_token";
+const SLACK_SIGNATURE_HEADER: &str = "X-Slack-Signature";
+const SLACK_TIMESTAMP_HEADER: &str = "X-Slack-Request-Timestamp";
+const SLACK_WEBHOOK_WORKFLOW_TIMEOUT: Duration = Duration::from_secs(2);
+const SLACK_MAX_IN_FLIGHT_WEBHOOKS: usize = 64;
+
+struct NoopSlackDeliverySink;
+
+#[async_trait::async_trait]
+impl OutboundDeliverySink for NoopSlackDeliverySink {
+    async fn record(&self, _status: DeliveryStatus) {}
+}
+
+#[derive(Clone)]
+pub struct SlackHostBetaConfig {
+    pub tenant_id: TenantId,
+    pub agent_id: AgentId,
+    pub project_id: Option<ProjectId>,
+    pub installation_id: AdapterInstallationId,
+    pub installation_selector: SlackInstallationSelector,
+    pub slack_actor: ExternalActorRef,
+    pub user_id: UserId,
+    pub signing_secret: SecretString,
+    pub bot_token: SecretString,
+}
+
+impl SlackHostBetaConfig {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tenant_id: TenantId,
+        agent_id: AgentId,
+        project_id: Option<ProjectId>,
+        installation_id: String,
+        team_id: String,
+        api_app_id: Option<String>,
+        slack_user_id: String,
+        user_id: UserId,
+        signing_secret: SecretString,
+        bot_token: SecretString,
+    ) -> Result<Self, SlackHostBetaBuildError> {
+        let installation_id = AdapterInstallationId::new(installation_id)
+            .map_err(|reason| invalid_config("installation_id", reason.to_string()))?;
+        let installation_selector = match api_app_id {
+            Some(api_app_id) => SlackInstallationSelector::app_team(api_app_id, team_id),
+            None => SlackInstallationSelector::team(team_id),
+        };
+        let slack_actor =
+            ExternalActorRef::new(SLACK_USER_ACTOR_KIND, slack_user_id, None::<String>)
+                .map_err(|reason| invalid_config("slack_user_id", reason.to_string()))?;
+        Ok(Self {
+            tenant_id,
+            agent_id,
+            project_id,
+            installation_id,
+            installation_selector,
+            slack_actor,
+            user_id,
+            signing_secret,
+            bot_token,
+        })
+    }
+}
+
+impl std::fmt::Debug for SlackHostBetaConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SlackHostBetaConfig")
+            .field("tenant_id", &self.tenant_id)
+            .field("agent_id", &self.agent_id)
+            .field("project_id", &self.project_id)
+            .field("installation_id", &self.installation_id)
+            .field("installation_selector", &self.installation_selector)
+            .field("slack_actor", &self.slack_actor)
+            .field("user_id", &self.user_id)
+            .field("signing_secret", &"[REDACTED]")
+            .field("bot_token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SlackHostBetaBuildError {
+    #[error("Slack host-beta requires local runtime HTTP egress")]
+    RuntimeHttpEgressUnavailable,
+    #[error("invalid Slack host-beta config field {field}: {reason}")]
+    InvalidConfig { field: &'static str, reason: String },
+}
+
+pub fn build_slack_events_route_mount(
+    runtime: &RebornRuntime,
+    config: SlackHostBetaConfig,
+) -> Result<PublicRouteMount, SlackHostBetaBuildError> {
+    let adapter_id = ProductAdapterId::new(SLACK_ADAPTER_ID)
+        .map_err(|reason| invalid_config("adapter_id", reason.to_string()))?;
+    let token_handle = EgressCredentialHandle::new(SLACK_BOT_TOKEN_HANDLE)
+        .map_err(|reason| invalid_config("bot_token_handle", reason.to_string()))?;
+    let adapter: Arc<dyn ProductAdapter> = Arc::new(SlackV2Adapter::new(SlackV2AdapterConfig {
+        adapter_id: adapter_id.clone(),
+        installation_id: config.installation_id.clone(),
+        egress_credential_handle: token_handle.clone(),
+        auth_requirement: slack_request_signature_auth_requirement(),
+    }));
+
+    let conversations = Arc::new(InMemoryConversationServices::default());
+    let conversation_port: Arc<dyn ironclaw_conversations::ConversationBindingService> =
+        conversations.clone();
+    let actor_pairings: Arc<dyn ironclaw_conversations::ConversationActorPairingService> =
+        conversations;
+    let scope = ProductInstallationScope::with_default_scope(
+        config.tenant_id.clone(),
+        config.agent_id.clone(),
+        config.project_id.clone(),
+    )
+    .with_preconfigured_actor_binding(config.slack_actor.clone(), config.user_id.clone());
+    let installation_resolver = StaticProductInstallationResolver::new([(
+        ProductInstallationKey::new(adapter_id, config.installation_id.clone()),
+        scope,
+    )]);
+    let binding = ProductConversationBindingService::new(conversation_port, installation_resolver)
+        .with_actor_pairings(actor_pairings);
+
+    let inbound = Arc::new(DefaultInboundTurnService::new(
+        binding.clone(),
+        runtime.webui_thread_service(),
+        runtime.webui_turn_coordinator(),
+    ));
+    let workflow = Arc::new(
+        DefaultProductWorkflow::new(
+            inbound,
+            Arc::new(InMemoryIdempotencyLedger::new()),
+            Arc::new(binding.clone()),
+        )
+        .with_approval_interaction_service(runtime.webui_approval_interaction_service())
+        .with_auth_interaction_service(runtime.webui_auth_interaction_service()),
+    );
+
+    let runner = Arc::new(NativeProductAdapterRunner::with_config(
+        adapter.clone(),
+        workflow,
+        WebhookAuth::Hmac(HmacWebhookAuth::new(
+            SLACK_SIGNATURE_HEADER,
+            SLACK_TIMESTAMP_HEADER,
+            config.signing_secret.expose_secret().as_bytes().to_vec(),
+            config.installation_id.as_str(),
+        )),
+        NativeProductAdapterRunnerConfig::new(
+            SLACK_WEBHOOK_WORKFLOW_TIMEOUT,
+            NonZeroUsize::new(SLACK_MAX_IN_FLIGHT_WEBHOOKS)
+                .ok_or_else(|| invalid_config("max_in_flight", "must be non-zero".to_string()))?,
+        ),
+    ));
+
+    let local_runtime = runtime
+        .services()
+        .local_runtime
+        .as_ref()
+        .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
+    let runtime_http_egress = local_runtime
+        .runtime_http_egress
+        .clone()
+        .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
+    let egress = Arc::new(SlackProtocolHttpEgress::new(
+        runtime_http_egress,
+        Arc::new(StaticSlackEgressCredentialProvider::new(
+            token_handle,
+            config.bot_token.expose_secret().to_string(),
+        )),
+        EgressPolicy::new(adapter.declared_egress().to_vec()),
+        ResourceScope::local_default(
+            config.user_id.clone(),
+            ironclaw_host_api::InvocationId::new(),
+        )
+        .map_err(|reason| invalid_config("resource_scope", reason.to_string()))?,
+    ));
+    let outbound = Arc::new(InMemoryOutboundStateStore::default());
+    let outbound_store: Arc<dyn OutboundStateStore> = outbound.clone();
+    let preferences: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> = outbound;
+    let delivery_sink: Arc<dyn OutboundDeliverySink> = Arc::new(NoopSlackDeliverySink);
+    let observer = Arc::new(SlackFinalReplyDeliveryObserver::with_settings(
+        SlackFinalReplyDeliveryServices {
+            binding_service: Arc::new(binding),
+            thread_service: runtime.webui_thread_service(),
+            turn_coordinator: runtime.webui_turn_coordinator(),
+            outbound_store,
+            communication_preferences: preferences,
+            adapter,
+            egress,
+            delivery_sink,
+        },
+        SlackFinalReplyDeliverySettings::default(),
+    ));
+
+    let slack_resolver = StaticSlackInstallationResolver::new([SlackInstallationRecord::new(
+        config.tenant_id,
+        config.installation_id,
+        config.installation_selector,
+        runner,
+    )
+    .with_workflow_observer(observer)]);
+
+    Ok(slack_events_route_mount(
+        SlackEventsRouteState::from_resolver(Arc::new(slack_resolver)),
+    ))
+}
+
+fn invalid_config(field: &'static str, reason: String) -> SlackHostBetaBuildError {
+    SlackHostBetaBuildError::InvalidConfig { field, reason }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use hmac::{Hmac, Mac};
+    use http_body_util::BodyExt;
+    use ironclaw_loop_support::{
+        HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
+        HostManagedModelResponse,
+    };
+    use ironclaw_turns::run_profile::LoopCapabilityPort;
+    use secrecy::ExposeSecret;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::{
+        RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput, SLACK_EVENTS_PATH,
+        build_reborn_runtime, local_dev_runtime_policy,
+    };
+
+    const TENANT: &str = "tenant:slack-host";
+    const AGENT: &str = "agent:slack-host";
+    const PROJECT: &str = "project:slack-host";
+    const USER: &str = "user:slack-host";
+    const INSTALLATION: &str = "install_host_beta";
+    const TEAM: &str = "T-HOST";
+    const API_APP: &str = "A-HOST";
+    const SLACK_USER: &str = "U-HOST";
+    const SECRET: &str = "host-signing-secret";
+
+    type HmacSha256 = Hmac<sha2::Sha256>;
+
+    #[tokio::test]
+    async fn build_slack_events_route_mount_builds_signed_route_from_reborn_runtime() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let runtime = build_reborn_runtime(
+            RebornRuntimeInput::from_services(
+                RebornBuildInput::local_dev("slack-host-beta-owner", root.path().join("local-dev"))
+                    .with_runtime_policy(local_dev_runtime_policy().expect("local policy")),
+            )
+            .with_identity(RebornRuntimeIdentity {
+                tenant_id: TENANT.to_string(),
+                agent_id: AGENT.to_string(),
+                source_binding_id: "slack-host-source".to_string(),
+                reply_target_binding_id: "slack-host-reply".to_string(),
+            })
+            .with_model_gateway_override(Arc::new(StaticGateway)),
+        )
+        .await
+        .expect("runtime builds");
+
+        let mount = build_slack_events_route_mount(&runtime, config()).expect("route builds");
+        assert_eq!(mount.descriptors.len(), 1);
+        assert!(mount.drain.is_some());
+
+        let body = r#"{"type":"url_verification","challenge":"reborn-slack-ok"}"#;
+        let timestamp = current_unix_timestamp();
+        let response = mount
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SLACK_EVENTS_PATH)
+                    .header(SLACK_TIMESTAMP_HEADER, timestamp.to_string())
+                    .header(SLACK_SIGNATURE_HEADER, slack_signature(timestamp, body))
+                    .body(Body::from(body))
+                    .expect("request builds"),
+            )
+            .await
+            .expect("router responds");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body collects")
+            .to_bytes();
+        assert!(String::from_utf8_lossy(&bytes).contains("reborn-slack-ok"));
+
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[test]
+    fn slack_host_beta_config_binds_slack_actor_to_reborn_user() {
+        let config = config();
+
+        assert_eq!(config.installation_id.as_str(), INSTALLATION);
+        assert_eq!(config.slack_actor.kind(), SLACK_USER_ACTOR_KIND);
+        assert_eq!(config.slack_actor.id(), SLACK_USER);
+        assert_eq!(config.user_id, UserId::new(USER).expect("user id"));
+        assert_eq!(config.signing_secret.expose_secret(), SECRET);
+        assert_eq!(config.bot_token.expose_secret(), "xoxb-host-token");
+    }
+
+    fn config() -> SlackHostBetaConfig {
+        SlackHostBetaConfig::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AgentId::new(AGENT).expect("agent"),
+            Some(ProjectId::new(PROJECT).expect("project")),
+            INSTALLATION.to_string(),
+            TEAM.to_string(),
+            Some(API_APP.to_string()),
+            SLACK_USER.to_string(),
+            UserId::new(USER).expect("user"),
+            SecretString::from(SECRET),
+            SecretString::from("xoxb-host-token"),
+        )
+        .expect("valid config")
+    }
+
+    fn current_unix_timestamp() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after Unix epoch")
+            .as_secs()
+    }
+
+    fn slack_signature(timestamp: u64, body: &str) -> String {
+        let mut mac =
+            HmacSha256::new_from_slice(SECRET.as_bytes()).expect("HMAC accepts any key size");
+        mac.update(format!("v0:{timestamp}:").as_bytes());
+        mac.update(body.as_bytes());
+        format!("v0={:x}", mac.finalize().into_bytes())
+    }
+
+    #[derive(Debug)]
+    struct StaticGateway;
+
+    #[async_trait::async_trait]
+    impl HostManagedModelGateway for StaticGateway {
+        async fn stream_model(
+            &self,
+            _request: HostManagedModelRequest,
+        ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+            Ok(HostManagedModelResponse::assistant_reply("ok"))
+        }
+
+        async fn stream_model_with_capabilities(
+            &self,
+            request: HostManagedModelRequest,
+            _capabilities: Arc<dyn LoopCapabilityPort>,
+        ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+            self.stream_model(request).await
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -49,6 +49,7 @@ const SLACK_SIGNATURE_HEADER: &str = "X-Slack-Signature";
 const SLACK_TIMESTAMP_HEADER: &str = "X-Slack-Request-Timestamp";
 const SLACK_WEBHOOK_WORKFLOW_TIMEOUT: Duration = Duration::from_secs(2);
 const SLACK_MAX_IN_FLIGHT_WEBHOOKS: usize = 64;
+const SLACK_IDEMPOTENCY_LEDGER_SETTLED_LIMIT: usize = 10_000;
 
 struct NoopSlackDeliverySink;
 
@@ -178,7 +179,11 @@ pub fn build_slack_events_route_mount(
     let workflow = Arc::new(
         DefaultProductWorkflow::new(
             inbound,
-            Arc::new(InMemoryIdempotencyLedger::new()),
+            Arc::new(InMemoryIdempotencyLedger::with_settled_entry_limit(
+                NonZeroUsize::new(SLACK_IDEMPOTENCY_LEDGER_SETTLED_LIMIT).ok_or_else(|| {
+                    invalid_config("idempotency_ledger_limit", "must be non-zero".to_string())
+                })?,
+            )),
             Arc::new(binding.clone()),
         )
         .with_approval_interaction_service(runtime.webui_approval_interaction_service())
@@ -263,14 +268,19 @@ mod tests {
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use hmac::{Hmac, Mac};
     use http_body_util::BodyExt;
+    use ironclaw_host_api::{
+        RuntimeHttpEgress, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    };
     use ironclaw_loop_support::{
         HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
         HostManagedModelResponse,
     };
+    use ironclaw_threads::{ListThreadsForScopeRequest, ThreadHistoryRequest, ThreadScope};
     use ironclaw_turns::run_profile::LoopCapabilityPort;
     use secrecy::ExposeSecret;
     use tower::ServiceExt;
@@ -295,22 +305,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_slack_events_route_mount_builds_signed_route_from_reborn_runtime() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let runtime = build_reborn_runtime(
-            RebornRuntimeInput::from_services(
-                RebornBuildInput::local_dev("slack-host-beta-owner", root.path().join("local-dev"))
-                    .with_runtime_policy(local_dev_runtime_policy().expect("local policy")),
-            )
-            .with_identity(RebornRuntimeIdentity {
-                tenant_id: TENANT.to_string(),
-                agent_id: AGENT.to_string(),
-                source_binding_id: "slack-host-source".to_string(),
-                reply_target_binding_id: "slack-host-reply".to_string(),
-            })
-            .with_model_gateway_override(Arc::new(StaticGateway)),
-        )
-        .await
-        .expect("runtime builds");
+        let (runtime, _root) = runtime().await;
 
         let mount = build_slack_events_route_mount(&runtime, config()).expect("route builds");
         assert_eq!(mount.descriptors.len(), 1);
@@ -345,6 +340,70 @@ mod tests {
         runtime.shutdown().await.expect("runtime shuts down");
     }
 
+    #[tokio::test]
+    async fn build_slack_events_route_mount_fails_when_runtime_http_egress_unavailable() {
+        let (mut runtime, _root) = runtime().await;
+        runtime.set_local_runtime_http_egress_for_test(None);
+
+        let error = match build_slack_events_route_mount(&runtime, config()) {
+            Ok(_) => panic!("Slack route requires runtime HTTP egress"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            SlackHostBetaBuildError::RuntimeHttpEgressUnavailable
+        ));
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn build_slack_events_route_mount_dispatches_signed_event_callback() {
+        let (mut runtime, _root) = runtime().await;
+        let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+        runtime.set_local_runtime_http_egress_for_test(Some(egress.clone()));
+        let mount = build_slack_events_route_mount(&runtime, config()).expect("route builds");
+        let body = r#"{
+            "type":"event_callback",
+            "team_id":"T-HOST",
+            "api_app_id":"A-HOST",
+            "event_id":"Ev-host-beta-dispatch",
+            "event":{"type":"message","channel_type":"im","user":"U-HOST","channel":"D-HOST","text":"hello","ts":"1710000000.000010"}
+        }"#;
+        let timestamp = current_unix_timestamp();
+
+        let response = mount
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SLACK_EVENTS_PATH)
+                    .header(SLACK_TIMESTAMP_HEADER, timestamp.to_string())
+                    .header(SLACK_SIGNATURE_HEADER, slack_signature(timestamp, body))
+                    .body(Body::from(body))
+                    .expect("request builds"),
+            )
+            .await
+            .expect("router responds");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        if let Some(drain) = mount.drain.as_ref() {
+            drain.drain().await;
+        }
+        let history = wait_for_slack_thread_history(&runtime).await;
+        assert_eq!(history.messages.len(), 1);
+        assert_eq!(history.messages[0].content.as_deref(), Some("hello"));
+        assert_eq!(
+            history.messages[0].source_binding_id.as_deref(),
+            Some(
+                "adapter:8:slack_v2;installation:17:install_host_beta;agent:16:agent:slack-host;project:18:project:slack-host;space:6:T-HOST;conversation:6:D-HOST;topic:0:;"
+            )
+        );
+
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
     #[test]
     fn slack_host_beta_config_binds_slack_actor_to_reborn_user() {
         let config = config();
@@ -371,6 +430,63 @@ mod tests {
             bot_token: SecretString::from("xoxb-host-token"),
         })
         .expect("valid config")
+    }
+
+    async fn runtime() -> (RebornRuntime, tempfile::TempDir) {
+        let root = tempfile::tempdir().expect("tempdir");
+        let runtime = build_reborn_runtime(
+            RebornRuntimeInput::from_services(
+                RebornBuildInput::local_dev(USER, root.path().join("local-dev"))
+                    .with_runtime_policy(local_dev_runtime_policy().expect("local policy")),
+            )
+            .with_identity(RebornRuntimeIdentity {
+                tenant_id: TENANT.to_string(),
+                agent_id: AGENT.to_string(),
+                source_binding_id: "slack-host-source".to_string(),
+                reply_target_binding_id: "slack-host-reply".to_string(),
+            })
+            .with_model_gateway_override(Arc::new(StaticGateway)),
+        )
+        .await
+        .expect("runtime builds");
+        (runtime, root)
+    }
+
+    async fn wait_for_slack_thread_history(
+        runtime: &RebornRuntime,
+    ) -> ironclaw_threads::ThreadHistory {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let thread_service = runtime.webui_thread_service();
+        let scope = ThreadScope {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            agent_id: AgentId::new(AGENT).expect("agent"),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            owner_user_id: Some(UserId::new(USER).expect("user")),
+            mission_id: None,
+        };
+        loop {
+            let threads = thread_service
+                .list_threads_for_scope(ListThreadsForScopeRequest {
+                    scope: scope.clone(),
+                    limit: Some(1),
+                    cursor: None,
+                })
+                .await
+                .expect("list Slack-created threads");
+            if let Some(thread) = threads.threads.first() {
+                return thread_service
+                    .list_thread_history(ThreadHistoryRequest {
+                        scope,
+                        thread_id: thread.thread_id.clone(),
+                    })
+                    .await
+                    .expect("read Slack-created thread history");
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("signed Slack event did not create a thread");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     fn current_unix_timestamp() -> u64 {
@@ -406,6 +522,33 @@ mod tests {
             _capabilities: Arc<dyn LoopCapabilityPort>,
         ) -> Result<HostManagedModelResponse, HostManagedModelError> {
             self.stream_model(request).await
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingRuntimeHttpEgress {
+        requests: std::sync::Mutex<Vec<RuntimeHttpEgressRequest>>,
+    }
+
+    #[async_trait]
+    impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
+        async fn execute(
+            &self,
+            request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, ironclaw_host_api::RuntimeHttpEgressError> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(request);
+            Ok(RuntimeHttpEgressResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: br#"{"ok":true}"#.to_vec(),
+                saved_body: None,
+                request_bytes: 0,
+                response_bytes: 0,
+                redaction_applied: false,
+            })
         }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -65,7 +65,7 @@ const ADAPTER: &str = "slack_v2";
 const INSTALLATION: &str = "install_alpha";
 const TEAM: &str = "T-A";
 const SLACK_USER: &str = "U123";
-const CHANNEL: &str = "D-A";
+const CHANNEL: &str = "D123";
 const SLACK_SIGNATURE_HEADER: &str = "X-Slack-Signature";
 const SLACK_TIMESTAMP_HEADER: &str = "X-Slack-Request-Timestamp";
 const SECRET: &str = "topsecret";
@@ -703,6 +703,7 @@ fn dm_message(event_id: &'static str, text: &'static str) -> &'static str {
         ("Ev-approval", "needs approval") => DM_APPROVAL,
         ("Ev-block", "needs approval") => DM_BLOCK,
         ("Ev-approve", "approve") => DM_APPROVE,
+        ("Ev-forged", "hello") => DM_FORGED,
         _ => panic!("unknown fixture"),
     }
 }
@@ -722,29 +723,37 @@ const DM_FINAL: &str = r#"{
   "team_id":"T-A",
   "api_app_id":"A-slack",
   "event_id":"Ev-final",
-  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D-A","text":"hello","ts":"1710000000.000001"}
-}"#;
+	  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"hello","ts":"1710000000.000001"}
+	}"#;
 
 const DM_APPROVAL: &str = r#"{
   "type":"event_callback",
   "team_id":"T-A",
   "api_app_id":"A-slack",
   "event_id":"Ev-approval",
-  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D-A","text":"needs approval","ts":"1710000000.000002"}
-}"#;
+	  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"needs approval","ts":"1710000000.000002"}
+	}"#;
 
 const DM_BLOCK: &str = r#"{
   "type":"event_callback",
   "team_id":"T-A",
   "api_app_id":"A-slack",
   "event_id":"Ev-block",
-  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D-A","text":"needs approval","ts":"1710000000.000003"}
-}"#;
+	  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"needs approval","ts":"1710000000.000003"}
+	}"#;
 
 const DM_APPROVE: &str = r#"{
   "type":"event_callback",
   "team_id":"T-A",
   "api_app_id":"A-slack",
   "event_id":"Ev-approve",
-  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D-A","text":"approve","ts":"1710000000.000004"}
-}"#;
+	  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"approve","ts":"1710000000.000004"}
+	}"#;
+
+const DM_FORGED: &str = r#"{
+	  "type":"event_callback",
+	  "team_id":"T-A",
+	  "api_app_id":"A-slack",
+	  "event_id":"Ev-forged",
+	  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"hello","ts":"1710000000.000005"}
+	}"#;

--- a/crates/ironclaw_reborn_composition/src/slack_serve/handler_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/handler_tests.rs
@@ -206,7 +206,7 @@ async fn slack_events_handler_rate_limit_refills_after_window() {
     )]);
     let rate_limit = SlackInstallationRateLimitConfig::new(
         NonZeroU32::new(1).expect("nonzero"),
-        Duration::from_millis(1),
+        Duration::from_millis(50),
     );
     let mount = slack_events_route_mount(SlackEventsRouteState::new(
         SlackIngressService::with_rate_limit_config(Arc::new(resolver), rate_limit),
@@ -214,7 +214,7 @@ async fn slack_events_handler_rate_limit_refills_after_window() {
 
     let first = post_to_mount(&mount, TEAM_A_BODY, "secret-a").await;
     let second = post_to_mount(&mount, TEAM_A_BODY, "secret-a").await;
-    tokio::time::sleep(Duration::from_millis(2)).await;
+    tokio::time::sleep(Duration::from_millis(60)).await;
     let third = post_to_mount(&mount, TEAM_A_BODY, "secret-a").await;
 
     assert_eq!(first.status(), StatusCode::OK);

--- a/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/installation.rs
@@ -613,8 +613,10 @@ impl StaticSlackInstallationResolver {
         body: &[u8],
         error: SlackPayloadParseError,
     ) -> Result<ResolvedSlackIngress, SlackIngressError> {
-        self.ensure_candidate_budget(self.installations.len())?;
-        self.verify_candidates(self.installations.iter(), headers, body)?;
+        let Some(installation) = self.installations.first() else {
+            return Err(SlackIngressError::InstallationNotFound);
+        };
+        self.verify_candidates(std::iter::once(installation), headers, body)?;
         Err(error.into())
     }
 
@@ -820,6 +822,7 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use axum::http::HeaderMap;
     use ironclaw_product_adapters::auth::mark_request_signature_verified;
@@ -831,12 +834,48 @@ mod tests {
         subject: &'static str,
     }
 
+    struct CountingVerifiedDispatcher {
+        subject: &'static str,
+        calls: Arc<AtomicUsize>,
+    }
+
     impl SlackEventsWebhookDispatcher for AlwaysVerifiedDispatcher {
         fn verify_webhook_auth(
             &self,
             _headers: &HeaderMap,
             _body: &[u8],
         ) -> Result<ProtocolAuthEvidence, RunnerError> {
+            Ok(mark_request_signature_verified(
+                "X-Slack-Signature",
+                Some("X-Slack-Request-Timestamp".to_string()),
+                self.subject,
+            ))
+        }
+
+        fn process_verified_webhook_immediate_ack<'a>(
+            &'a self,
+            _body: &'a [u8],
+            _evidence: &'a ProtocolAuthEvidence,
+            _observer: Option<Arc<dyn ImmediateAckWorkflowObserver>>,
+        ) -> Pin<Box<dyn Future<Output = Result<WebhookProcessOutcome, RunnerError>> + Send + 'a>>
+        {
+            Box::pin(async { Ok(WebhookProcessOutcome::AcceptedForAsyncDispatch) })
+        }
+
+        fn drain_immediate_ack_tasks<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async {})
+        }
+    }
+
+    impl SlackEventsWebhookDispatcher for CountingVerifiedDispatcher {
+        fn verify_webhook_auth(
+            &self,
+            _headers: &HeaderMap,
+            _body: &[u8],
+        ) -> Result<ProtocolAuthEvidence, RunnerError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(mark_request_signature_verified(
                 "X-Slack-Signature",
                 Some("X-Slack-Request-Timestamp".to_string()),
@@ -871,6 +910,13 @@ mod tests {
 
     fn dispatcher(subject: &'static str) -> Arc<dyn SlackEventsWebhookDispatcher> {
         Arc::new(AlwaysVerifiedDispatcher { subject })
+    }
+
+    fn counting_dispatcher(
+        subject: &'static str,
+        calls: Arc<AtomicUsize>,
+    ) -> Arc<dyn SlackEventsWebhookDispatcher> {
+        Arc::new(CountingVerifiedDispatcher { subject, calls })
     }
 
     #[test]
@@ -997,5 +1043,39 @@ mod tests {
         assert_eq!(installation.adapter_installation_id().as_str(), "install-b");
         assert_eq!(metadata.install_user_id.as_deref(), Some("U-install-b"));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn static_resolver_verifies_one_candidate_for_unparseable_payload() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let resolver = StaticSlackInstallationResolver::new(vec![
+            SlackInstallationRecord::new(
+                tenant_id("tenant-a"),
+                installation_id("install-a"),
+                SlackInstallationSelector::team("T-A"),
+                counting_dispatcher("install-a", calls.clone()),
+            ),
+            SlackInstallationRecord::new(
+                tenant_id("tenant-b"),
+                installation_id("install-b"),
+                SlackInstallationSelector::team("T-B"),
+                counting_dispatcher("install-b", calls.clone()),
+            ),
+        ]);
+
+        let error = resolver
+            .resolve_ingress(&HeaderMap::new(), br#"{"type":"event_callback""#)
+            .await
+            .expect_err("malformed JSON should stay a parse error after auth");
+
+        assert!(
+            matches!(error, SlackIngressError::Envelope(_)),
+            "error: {error}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "malformed payloads should not HMAC every configured installation"
+        );
     }
 }

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -77,6 +77,11 @@ pub struct RebornConfigFile {
     /// `serve` subcommand is invoked. Optional — sparse configs
     /// fall back to compiled defaults documented on each field.
     pub webui: Option<WebuiSection>,
+    /// Slack Events API host-beta route settings. Consumed by
+    /// `ironclaw-reborn serve` only when the binary is built with the
+    /// Slack host-beta feature. Secrets are env-only; this section stores
+    /// IDs and environment variable names.
+    pub slack: Option<SlackSection>,
     /// Cost-based budgets. Composition seeds defaults on first reservation
     /// for each user/project; per-account overrides happen through the
     /// `budget_set` tool or CLI at runtime. Setting any limit to `0` means
@@ -212,6 +217,36 @@ pub struct WebuiSection {
     /// `host:port`; composition does not parse further. Default
     /// `None` (fall back to Host-header compare + allowlist).
     pub canonical_host: Option<String>,
+}
+
+/// Slack Events API host-beta configuration.
+///
+/// `enabled = true` is required before the standalone Reborn listener mounts
+/// `/webhooks/slack/events`; the route is never enabled by ambient Slack
+/// environment variables alone. Signing secret and bot token values stay
+/// env-only: `signing_secret_env` and `bot_token_env` are variable names.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SlackSection {
+    /// Explicit host-beta enablement gate. Omitted/false means the Slack route
+    /// is not mounted by `ironclaw-reborn serve`.
+    pub enabled: Option<bool>,
+    /// Adapter installation id for this Slack workspace/app installation.
+    pub installation_id: Option<String>,
+    /// Slack team id used to select this installation from signed envelopes.
+    pub team_id: Option<String>,
+    /// Optional Slack app id. When set, installation matching requires both
+    /// `api_app_id` and `team_id`.
+    pub api_app_id: Option<String>,
+    /// Slack user id allowed to route through this beta installation.
+    pub slack_user_id: Option<String>,
+    /// Reborn user id the configured Slack user maps to. Defaults in the CLI
+    /// to the same user as the WebUI env-bearer authenticator.
+    pub user_id: Option<String>,
+    /// Environment variable name containing the Slack signing secret.
+    pub signing_secret_env: Option<String>,
+    /// Environment variable name containing the Slack bot token.
+    pub bot_token_env: Option<String>,
 }
 
 /// `[budget]` section. All limits in USD. **0 = unlimited.**
@@ -551,6 +586,32 @@ impl RebornConfigFile {
                 check(Cow::Borrowed("webui.canonical_host"), host)?;
             }
         }
+        if let Some(slack) = &self.slack {
+            if let Some(installation_id) = &slack.installation_id {
+                check(Cow::Borrowed("slack.installation_id"), installation_id)?;
+            }
+            if let Some(team_id) = &slack.team_id {
+                check(Cow::Borrowed("slack.team_id"), team_id)?;
+            }
+            if let Some(api_app_id) = &slack.api_app_id {
+                check(Cow::Borrowed("slack.api_app_id"), api_app_id)?;
+            }
+            if let Some(slack_user_id) = &slack.slack_user_id {
+                check(Cow::Borrowed("slack.slack_user_id"), slack_user_id)?;
+            }
+            if let Some(user_id) = &slack.user_id {
+                check(Cow::Borrowed("slack.user_id"), user_id)?;
+            }
+            if let Some(signing_secret_env) = &slack.signing_secret_env {
+                check(
+                    Cow::Borrowed("slack.signing_secret_env"),
+                    signing_secret_env,
+                )?;
+            }
+            if let Some(bot_token_env) = &slack.bot_token_env {
+                check(Cow::Borrowed("slack.bot_token_env"), bot_token_env)?;
+            }
+        }
         if let Some(budget) = &self.budget {
             if let Some(tz) = &budget.default_tz {
                 check(Cow::Borrowed("budget.default_tz"), tz)?;
@@ -846,6 +907,7 @@ mod tests {
         assert!(cfg.runner.is_none());
         assert!(cfg.skills.is_none());
         assert!(cfg.llm.is_none());
+        assert!(cfg.slack.is_none());
     }
 
     #[test]
@@ -889,6 +951,16 @@ api_key_env = "OPENAI_API_KEY"
 provider_id = "anthropic"
 model = "claude-3-5-sonnet-latest"
 api_key_env = "ANTHROPIC_API_KEY"
+
+[slack]
+enabled = true
+installation_id = "install-alpha"
+team_id = "T123"
+api_app_id = "A123"
+slack_user_id = "U123"
+user_id = "operator"
+signing_secret_env = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET"
+bot_token_env = "IRONCLAW_REBORN_SLACK_BOT_TOKEN"
 "#;
         let cfg = RebornConfigFile::parse_text(toml, &attributed()).expect("must parse");
         assert_eq!(cfg.api_version.as_deref(), Some("ironclaw.runtime/v1"));
@@ -914,6 +986,13 @@ api_key_env = "ANTHROPIC_API_KEY"
         assert_eq!(default_slot.api_key_env.as_deref(), Some("OPENAI_API_KEY"));
         let llm = cfg.llm.as_ref().unwrap();
         assert!(llm.contains_key("mission"));
+        let slack = cfg.slack.as_ref().expect("slack section present");
+        assert_eq!(slack.enabled, Some(true));
+        assert_eq!(slack.team_id.as_deref(), Some("T123"));
+        assert_eq!(
+            slack.signing_secret_env.as_deref(),
+            Some("IRONCLAW_REBORN_SLACK_SIGNING_SECRET")
+        );
     }
 
     #[test]
@@ -1050,6 +1129,22 @@ api_key_env = "sk-proj-1234567890abcdef1234567890"
         assert!(
             rendered.contains("llm.default.api_key_env"),
             "slot-specific label should guide operator to the bad field: {rendered}"
+        );
+    }
+
+    #[test]
+    fn rejects_inline_secret_in_slack_secret_env_name() {
+        let toml = r#"
+[slack]
+enabled = true
+signing_secret_env = "sk-proj-1234567890abcdef1234567890"
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("inline Slack secret must be rejected");
+        assert!(matches!(err, RebornConfigFileError::InlineSecret { .. }));
+        assert!(
+            err.to_string().contains("slack.signing_secret_env"),
+            "error should identify Slack field: {err}"
         );
     }
 

--- a/crates/ironclaw_reborn_config/src/lib.rs
+++ b/crates/ironclaw_reborn_config/src/lib.rs
@@ -38,7 +38,7 @@ pub use config_file::{
     BootSection, BudgetSection, DefaultLlmSlotUpdate, DefaultLlmSlotUpdateSession, DriversSection,
     HarnessSection, IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection, PolicySection,
     REBORN_CONFIG_API_VERSION, RebornConfigFile, RebornConfigFileError,
-    RebornConfigFileUpdateError, RunnerSection, begin_default_llm_slot_update,
+    RebornConfigFileUpdateError, RunnerSection, SlackSection, begin_default_llm_slot_update,
     update_default_llm_slot,
 };
 pub use doctor::RebornDoctorReport;

--- a/crates/ironclaw_threads/src/service.rs
+++ b/crates/ironclaw_threads/src/service.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use ironclaw_host_api::ThreadId;
 
@@ -246,5 +248,199 @@ pub trait SessionThreadService: Send + Sync {
              override this method before exposing the v2 list-threads route"
                 .to_string(),
         ))
+    }
+}
+
+#[async_trait]
+impl<S> SessionThreadService for Arc<S>
+where
+    S: SessionThreadService + ?Sized,
+{
+    async fn ensure_thread(
+        &self,
+        request: EnsureThreadRequest,
+    ) -> Result<SessionThreadRecord, SessionThreadError> {
+        self.as_ref().ensure_thread(request).await
+    }
+
+    async fn accept_inbound_message(
+        &self,
+        request: AcceptInboundMessageRequest,
+    ) -> Result<AcceptedInboundMessage, SessionThreadError> {
+        self.as_ref().accept_inbound_message(request).await
+    }
+
+    async fn replay_accepted_inbound_message(
+        &self,
+        request: ReplayAcceptedInboundMessageRequest,
+    ) -> Result<Option<AcceptedInboundMessageReplay>, SessionThreadError> {
+        self.as_ref().replay_accepted_inbound_message(request).await
+    }
+
+    async fn mark_message_submitted(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        message_id: ThreadMessageId,
+        turn_id: String,
+        turn_run_id: String,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref()
+            .mark_message_submitted(scope, thread_id, message_id, turn_id, turn_run_id)
+            .await
+    }
+
+    async fn mark_message_deferred_busy(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        message_id: ThreadMessageId,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref()
+            .mark_message_deferred_busy(scope, thread_id, message_id)
+            .await
+    }
+
+    async fn append_assistant_draft(
+        &self,
+        request: AppendAssistantDraftRequest,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref().append_assistant_draft(request).await
+    }
+
+    async fn append_tool_result_reference(
+        &self,
+        request: AppendToolResultReferenceRequest,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref().append_tool_result_reference(request).await
+    }
+
+    async fn append_capability_display_preview(
+        &self,
+        request: AppendCapabilityDisplayPreviewRequest,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref()
+            .append_capability_display_preview(request)
+            .await
+    }
+
+    async fn update_tool_result_reference(
+        &self,
+        request: UpdateToolResultReferenceRequest,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref().update_tool_result_reference(request).await
+    }
+
+    async fn update_assistant_draft(
+        &self,
+        request: UpdateAssistantDraftRequest,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref().update_assistant_draft(request).await
+    }
+
+    async fn finalize_assistant_message(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+        message_id: ThreadMessageId,
+        content: MessageContent,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref()
+            .finalize_assistant_message(scope, thread_id, message_id, content)
+            .await
+    }
+
+    async fn redact_message(
+        &self,
+        request: RedactMessageRequest,
+    ) -> Result<ThreadMessageRecord, SessionThreadError> {
+        self.as_ref().redact_message(request).await
+    }
+
+    async fn load_context_window(
+        &self,
+        request: LoadContextWindowRequest,
+    ) -> Result<ContextWindow, SessionThreadError> {
+        self.as_ref().load_context_window(request).await
+    }
+
+    async fn load_context_messages(
+        &self,
+        request: LoadContextMessagesRequest,
+    ) -> Result<ContextMessages, SessionThreadError> {
+        self.as_ref().load_context_messages(request).await
+    }
+
+    async fn list_thread_history(
+        &self,
+        request: ThreadHistoryRequest,
+    ) -> Result<ThreadHistory, SessionThreadError> {
+        self.as_ref().list_thread_history(request).await
+    }
+
+    async fn list_thread_messages_range(
+        &self,
+        request: ThreadMessageRangeRequest,
+    ) -> Result<ThreadMessageRange, SessionThreadError> {
+        self.as_ref().list_thread_messages_range(request).await
+    }
+
+    async fn latest_thread_message(
+        &self,
+        request: LatestThreadMessageRequest,
+    ) -> Result<Option<ThreadMessageRecord>, SessionThreadError> {
+        self.as_ref().latest_thread_message(request).await
+    }
+
+    async fn finalized_assistant_message_by_run(
+        &self,
+        request: FinalizedAssistantMessageByRunRequest,
+    ) -> Result<Option<ThreadMessageRecord>, SessionThreadError> {
+        self.as_ref()
+            .finalized_assistant_message_by_run(request)
+            .await
+    }
+
+    async fn read_thread(
+        &self,
+        request: ThreadHistoryRequest,
+    ) -> Result<SessionThreadRecord, SessionThreadError> {
+        self.as_ref().read_thread(request).await
+    }
+
+    async fn create_summary_artifact(
+        &self,
+        request: CreateSummaryArtifactRequest,
+    ) -> Result<SummaryArtifact, SessionThreadError> {
+        self.as_ref().create_summary_artifact(request).await
+    }
+
+    fn supports_resolve_scope(&self) -> bool {
+        self.as_ref().supports_resolve_scope()
+    }
+
+    async fn resolve_scope(&self, thread_id: ThreadId) -> Result<ThreadScope, SessionThreadError> {
+        self.as_ref().resolve_scope(thread_id).await
+    }
+
+    async fn update_thread_goal(
+        &self,
+        request: UpdateThreadGoalRequest,
+    ) -> Result<ThreadGoal, SessionThreadError> {
+        self.as_ref().update_thread_goal(request).await
+    }
+
+    async fn read_thread_by_id(
+        &self,
+        thread_id: ThreadId,
+    ) -> Result<SessionThreadRecord, SessionThreadError> {
+        self.as_ref().read_thread_by_id(thread_id).await
+    }
+
+    async fn list_threads_for_scope(
+        &self,
+        request: ListThreadsForScopeRequest,
+    ) -> Result<ListThreadsForScopeResponse, SessionThreadError> {
+        self.as_ref().list_threads_for_scope(request).await
     }
 }


### PR DESCRIPTION
## Summary
- add explicit [slack] config parsing and feature-gated Slack host-beta serve wiring
- compose Slack Events API through the Reborn runtime, ProductWorkflow, host-mediated HTTP egress, and final-reply delivery
- harden review findings with typed Slack host config boundaries plus direct route-builder and runtime egress failure-mapping tests

## User binding note
The standalone Reborn CLI remains DB-free in this slice, so it does not write the app-layer channel_identities table. Slack user binding is explicit in host config: the configured Slack ExternalActorRef is pre-bound to the configured Reborn UserId inside ProductWorkflow. A future DB-backed Reborn serve mode should seed/resolve channel_identities directly.

## Verification
- cargo test -p ironclaw_reborn_cli --features slack-v2-host-beta slack_host_beta_config
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_protocol_http_egress_maps_runtime_http_failures
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta build_slack_events_route_mount_builds_signed_route_from_reborn_runtime
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_host_beta_config_binds_slack_actor_to_reborn_user
- cargo clippy -p ironclaw_reborn_composition --features slack-v2-host-beta --all-targets -- -D warnings
- cargo clippy -p ironclaw_reborn_cli --features slack-v2-host-beta --all-targets -- -D warnings