### PR TITLE
WebUI v2 QoL: per-thread state store + sidebar pin marker (active-thread coverage + attention persistence)

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/components/sidebar-threads.js
+++ b/crates/ironclaw_webui_v2_static/static/js/components/sidebar-threads.js
@@ -1,62 +1,71 @@
 import { React, html } from "../lib/html.js";
 import { Icon } from "../design-system/icons.js";
+import { THREAD_STATE, useThreadStates } from "../lib/thread-state.js";
+import {
+  byActivityDesc,
+  formatThreadActivityLabel,
+  formatThreadActivityTooltip,
+  threadActivityIso,
+} from "../lib/thread-meta.js";
 import { cn } from "../utils/cn.js";
 
-function formatRelativeTime(iso) {
-  if (!iso) return "";
-  const d = new Date(iso);
-  const now = new Date();
-  if (d.toDateString() === now.toDateString())
-    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+/* Single source of truth for how a thread state renders in the sidebar.
+ *
+ * Adding a state to THREAD_STATE means adding one row here — the
+ * partition predicate, the dot, the border, and the label all read
+ * from this table so the row component stays free of state-by-state
+ * branching. */
+const STATE_PRESENTATION = Object.freeze({
+  [THREAD_STATE.NEEDS_ATTENTION]: {
+    label: "Needs your attention",
+    textClass: "text-[var(--v2-warning-text)]",
+    dotClass: "bg-[var(--v2-warning-text)]",
+    borderClass: "border-[var(--v2-warning-text)]",
+  },
+  [THREAD_STATE.RUNNING]: {
+    label: "Running",
+    textClass: "text-[var(--v2-positive-text)]",
+    dotClass: "bg-[var(--v2-positive-text)]",
+    borderClass: "border-[var(--v2-positive-text)]",
+  },
+  [THREAD_STATE.FAILED]: {
+    label: "Failed",
+    textClass: "text-[var(--v2-danger-text)]",
+    dotClass: "bg-[var(--v2-danger-text)]",
+    borderClass: "border-[var(--v2-danger-text)]",
+  },
+});
+
+function presentationFor(state) {
+  return state ? STATE_PRESENTATION[state] || null : null;
 }
 
-function formatExactTime(iso) {
-  if (!iso) return "";
-  return new Date(iso).toLocaleString([], {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
+function ThreadItem({ thread, isActive, presentation, onSelect, onDelete }) {
+  const activityIso = threadActivityIso(thread);
+  const timeLabel = formatThreadActivityLabel(activityIso);
+  const timeTitle = formatThreadActivityTooltip(activityIso);
 
-function threadTimeLabel(thread) {
-  const started = formatRelativeTime(thread.created_at);
-  const updated = formatRelativeTime(thread.updated_at);
-  if (!started && !updated) return "";
-  if (!updated || started === updated) return `Started ${started}`;
-  return `Started ${started} · Last ${updated}`;
-}
-
-function threadTimeTitle(thread) {
-  const started = formatExactTime(thread.created_at);
-  const updated = formatExactTime(thread.updated_at);
-  if (!started && !updated) return "";
-  if (!updated || started === updated) return `Started ${started}`;
-  return `Started ${started}\nLast activity ${updated}`;
-}
-
-function ThreadItem({ thread, isActive, onSelect, onDelete }) {
-  const isProcessing = thread.state === "Processing";
-  const timeLabel = threadTimeLabel(thread);
-  const timeTitle = threadTimeTitle(thread);
   const handleDelete = React.useCallback(
     (event) => {
       event.preventDefault();
       event.stopPropagation();
-      if (isProcessing || !window.confirm("Delete this chat?")) return;
+      if (!window.confirm("Delete this chat?")) return;
       Promise.resolve(onDelete?.(thread.id)).catch((err) => {
         window.alert(err?.message || "Unable to delete chat");
       });
     },
-    [isProcessing, onDelete, thread.id]
+    [onDelete, thread.id]
   );
 
   return html`
     <div
       className=${cn(
-        "group flex w-full items-stretch rounded-[8px]",
+        "group flex w-full items-stretch rounded-[8px] border-l-2",
+        presentation
+          ? presentation.borderClass
+          : isActive
+          ? "border-[var(--v2-accent)]"
+          : "border-transparent",
         isActive
           ? "bg-[var(--v2-accent-soft)] text-[var(--v2-accent-text)]"
           : "text-[var(--v2-text-muted)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)]"
@@ -71,29 +80,32 @@ function ThreadItem({ thread, isActive, onSelect, onDelete }) {
           <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-snug">
             ${thread.title || `Thread ${thread.id.slice(0, 8)}`}
           </span>
-          ${isProcessing &&
+          ${presentation &&
           html`<span
-            className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--v2-accent)]"
+            aria-label=${presentation.label}
+            className=${cn("h-1.5 w-1.5 shrink-0 rounded-full", presentation.dotClass)}
           />`}
         </div>
-        ${timeLabel &&
-        html`<span className="block truncate text-[11px] text-[var(--v2-text-faint)]">
-          ${timeLabel}
+        ${(presentation || timeLabel) &&
+        html`<span
+          className=${cn(
+            "block truncate text-[11px]",
+            presentation ? presentation.textClass : "text-[var(--v2-text-faint)]"
+          )}
+        >
+          ${presentation ? presentation.label : timeLabel}
         </span>`}
       </button>
       ${onDelete &&
       html`<button
         type="button"
         onClick=${handleDelete}
-        disabled=${isProcessing}
-        title=${isProcessing ? "Cannot delete while processing" : "Delete chat"}
+        title="Delete chat"
         aria-label="Delete chat"
         className=${cn(
           "my-1 mr-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-[6px]",
           "opacity-0 transition group-hover:opacity-100 focus:opacity-100",
-          isProcessing
-            ? "cursor-not-allowed text-[var(--v2-text-faint)]"
-            : "text-[var(--v2-text-faint)] hover:bg-[var(--v2-danger-soft)] hover:text-[var(--v2-danger-text)]"
+          "text-[var(--v2-text-faint)] hover:bg-[var(--v2-danger-soft)] hover:text-[var(--v2-danger-text)]"
         )}
       >
         <${Icon} name="trash" className="h-3.5 w-3.5" strokeWidth=${2} />
@@ -102,53 +114,68 @@ function ThreadItem({ thread, isActive, onSelect, onDelete }) {
   `;
 }
 
-const BUCKET_ORDER = [
-  "Today",
-  "Yesterday",
-  "Previous 7 days",
-  "Previous 30 days",
-  "Older",
-];
-
-function bucketOf(thread) {
-  const iso = thread.updated_at || thread.created_at;
-  if (!iso) return "Older";
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return "Older";
-  const dayMs = 86400000;
-  const startOf = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
-  const diff = startOf(new Date()) - startOf(date);
-  if (diff <= 0) return "Today";
-  if (diff <= dayMs) return "Yesterday";
-  if (diff <= 7 * dayMs) return "Previous 7 days";
-  if (diff <= 30 * dayMs) return "Previous 30 days";
-  return "Older";
+function ThreadGroup({ label, items, activeThreadId, states, onSelect, onDelete }) {
+  if (items.length === 0) return null;
+  return html`
+    <div className="flex flex-col gap-1">
+      <span className="px-3 pt-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--v2-text-faint)]">
+        ${label}
+      </span>
+      ${items.map(
+        (thread) => html`
+          <${ThreadItem}
+            key=${thread.id}
+            thread=${thread}
+            isActive=${thread.id === activeThreadId}
+            presentation=${presentationFor(states.get(thread.id))}
+            onSelect=${onSelect}
+            onDelete=${onDelete}
+          />
+        `
+      )}
+    </div>
+  `;
 }
 
 export function SidebarThreads({ threads, activeThreadId, onSelect, onDelete }) {
   const [collapsed, setCollapsed] = React.useState(false);
   const [query, setQuery] = React.useState("");
+  const states = useThreadStates();
 
-  const groups = React.useMemo(() => {
+  /* Two-group partition (replaces the previous date-bucketed layout):
+   *   - Pinned: active thread + any thread with a non-idle state.
+   *     These are the rows you care about right now regardless of age.
+   *   - Recent: everything else, newest-first by updated_at || created_at.
+   *
+   * Title search runs before partitioning so the filter still matches
+   * any thread, pinned or not. */
+  const { pinned, recent, totalMatches } = React.useMemo(() => {
     const q = query.trim().toLowerCase();
     const filtered = q
       ? threads.filter((thread) =>
           (thread.title || thread.id || "").toLowerCase().includes(q)
         )
       : threads;
-    const byBucket = new Map();
-    for (const thread of filtered) {
-      const bucket = bucketOf(thread);
-      if (!byBucket.has(bucket)) byBucket.set(bucket, []);
-      byBucket.get(bucket).push(thread);
-    }
-    return BUCKET_ORDER.filter((b) => byBucket.has(b)).map((b) => ({
-      bucket: b,
-      items: byBucket.get(b),
-    }));
-  }, [threads, query]);
 
-  const totalMatches = groups.reduce((n, g) => n + g.items.length, 0);
+    const pinnedList = [];
+    const recentList = [];
+    for (const thread of filtered) {
+      const isActive = thread.id === activeThreadId;
+      const hasState = states.has(thread.id);
+      if (isActive || hasState) {
+        pinnedList.push(thread);
+      } else {
+        recentList.push(thread);
+      }
+    }
+    pinnedList.sort(byActivityDesc);
+    recentList.sort(byActivityDesc);
+    return {
+      pinned: pinnedList,
+      recent: recentList,
+      totalMatches: pinnedList.length + recentList.length,
+    };
+  }, [threads, query, activeThreadId, states]);
 
   return html`
     <div className="flex min-h-0 flex-1 flex-col px-2">
@@ -159,7 +186,7 @@ export function SidebarThreads({ threads, activeThreadId, onSelect, onDelete }) 
         <span
           className="flex-1 text-left text-[11px] font-semibold uppercase tracking-wider text-[var(--v2-text-faint)]"
         >
-          Recent
+          Conversations
         </span>
         <${Icon}
           name="chevron"
@@ -198,26 +225,23 @@ export function SidebarThreads({ threads, activeThreadId, onSelect, onDelete }) 
           html`<div className="px-3 py-2 text-[12px] text-[var(--v2-text-faint)]">
             No chats match “${query}”
           </div>`}
-          ${groups.map(
-            (group) => html`
-              <div key=${group.bucket} className="flex flex-col gap-1">
-                <span className="px-3 pt-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--v2-text-faint)]">
-                  ${group.bucket}
-                </span>
-                ${group.items.map(
-                  (thread) => html`
-                    <${ThreadItem}
-                      key=${thread.id}
-                      thread=${thread}
-                      isActive=${thread.id === activeThreadId}
-                      onSelect=${onSelect}
-                      onDelete=${onDelete}
-                    />
-                  `
-                )}
-              </div>
-            `
-          )}
+
+          <${ThreadGroup}
+            label="Pinned"
+            items=${pinned}
+            activeThreadId=${activeThreadId}
+            states=${states}
+            onSelect=${onSelect}
+            onDelete=${onDelete}
+          />
+          <${ThreadGroup}
+            label="Recent"
+            items=${recent}
+            activeThreadId=${activeThreadId}
+            states=${states}
+            onSelect=${onSelect}
+            onDelete=${onDelete}
+          />
         </div>
       `}
     </div>

--- a/crates/ironclaw_webui_v2_static/static/js/lib/thread-meta.js
+++ b/crates/ironclaw_webui_v2_static/static/js/lib/thread-meta.js
@@ -1,0 +1,57 @@
+/* Canonical helpers for talking about a thread's activity in the UI.
+ *
+ * `byActivityDesc` is the project-wide thread ordering. Today the sidebar's
+ * Recent group is the only consumer; future surfaces (resume cards, palette,
+ * etc.) should reuse it so threads sort consistently everywhere.
+ *
+ * `formatRelativeTime` is the project-wide thread time-label format.
+ * Anything that renders "when did this thread last move" should go through
+ * here so the wording stays consistent.
+ */
+
+/** ISO timestamp the UI considers most recent for sorting/labelling. */
+export function threadActivityIso(thread) {
+  return thread.updated_at || thread.created_at || null;
+}
+
+/**
+ * Comparator: newest-first by updated_at || created_at.
+ *
+ * Lexicographic ISO compare is chronological for the timestamp formats
+ * both DB backends emit (RFC3339 + libSQL CURRENT_TIMESTAMP). Tie-breaks
+ * on id for a stable sort.
+ */
+export function byActivityDesc(a, b) {
+  const aIso = threadActivityIso(a) || "";
+  const bIso = threadActivityIso(b) || "";
+  if (aIso === bIso) return (a.id || "").localeCompare(b.id || "");
+  return bIso.localeCompare(aIso);
+}
+
+/* Naming note: a separate `formatRelativeTime` lives in
+ * pages/admin/lib/admin-presenters.js with completely different semantics
+ * ("5m ago" duration vs this file's "HH:MM | Mon D" stamp). The exports
+ * here are deliberately namespaced to make the difference obvious to a
+ * grep. A future canonical lib/time.js could consolidate both, but that
+ * refactor is out of scope here. */
+
+/** Sidebar row label: HH:MM if today, otherwise "Mon D". */
+export function formatThreadActivityLabel(iso) {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const now = new Date();
+  if (d.toDateString() === now.toDateString())
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+/** Tooltip-friendly absolute stamp: "Mon D, HH:MM". */
+export function formatThreadActivityTooltip(iso) {
+  if (!iso) return "";
+  return new Date(iso).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/crates/ironclaw_webui_v2_static/static/js/lib/thread-state.js
+++ b/crates/ironclaw_webui_v2_static/static/js/lib/thread-state.js
@@ -1,0 +1,156 @@
+/* Per-thread state store.
+ *
+ * A thread is in one of a small, named set of states at any time. The
+ * sidebar reads this store to render per-row indicators (pinned position,
+ * dot colour, label) so a user can see what's happening across all of
+ * their threads from anywhere — not just whichever one they happen to
+ * have open.
+ *
+ * Today the only writer is the chat surface, which mirrors gate state
+ * for the active thread (see pages/chat/chat.js). That covers a single
+ * thread per browser session — the one you're looking at. The deferred
+ * follow-up — a user-scoped SSE channel — will fan out backend state
+ * transitions across all of a user's threads and become the canonical
+ * writer (at which point the chat.js seam goes away).
+ *
+ * The shape was chosen for that future:
+ *   - A Map keyed by thread id, not a Set. The values are a typed enum
+ *     (idle is the default and stored as absence). Adding a new state
+ *     (e.g. running, failed) is one entry in THREAD_STATE plus one row
+ *     in STATE_PRESENTATION on the sidebar — the producer and consumer
+ *     don't have to learn about each other.
+ *   - No metadata fields. A state name is enough to drive the UI; gate
+ *     kind / failure reason / progress numbers belong to the per-thread
+ *     event stream, not this cross-thread summary.
+ *   - Subscribers receive a snapshot Map; the internal map is never
+ *     handed out so a misbehaving listener cannot mutate the store.
+ *
+ * No persistence. Server-truth re-seeds via the writer on reconnect,
+ * so reload-loss is acceptable.
+ */
+
+import { React } from "./html.js";
+
+/** Thread state vocabulary. Absence from the map is the implicit `idle`. */
+export const THREAD_STATE = Object.freeze({
+  RUNNING: "running",
+  NEEDS_ATTENTION: "needs_attention",
+  FAILED: "failed",
+});
+
+/* Persistence policy: only the "the user has something to do" subset
+ * survives reload. RUNNING is the most-likely-stale state across a page
+ * lifetime (the run almost certainly completed while the tab was closed),
+ * so writing it to localStorage would cause confusing false-positive
+ * green dots on first load. NEEDS_ATTENTION is the opposite — a pending
+ * gate remains pending until the user acts, so persisting it is exactly
+ * what the user expects ("I left an approval hanging; the app remembered").
+ * FAILED is not yet populated by any writer but is treated like
+ * NEEDS_ATTENTION for symmetry when it lands. */
+const PERSISTED_STATES = new Set([
+  THREAD_STATE.NEEDS_ATTENTION,
+  THREAD_STATE.FAILED,
+]);
+const STORAGE_KEY = "ironclaw:v2-thread-attention";
+
+function readPersisted() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry) =>
+        Array.isArray(entry) &&
+        typeof entry[0] === "string" &&
+        PERSISTED_STATES.has(entry[1])
+    );
+  } catch (_) {
+    // Private mode, quota, or invalid JSON — persistence is best-effort.
+    return [];
+  }
+}
+
+function writePersisted() {
+  const persisted = [];
+  for (const [id, state] of states) {
+    if (PERSISTED_STATES.has(state)) persisted.push([id, state]);
+  }
+  try {
+    if (persisted.length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+    }
+  } catch (_) {
+    // Best-effort — we never block the UI on storage failure.
+  }
+}
+
+const subscribers = new Set();
+/** @type {Map<string, string>} */
+const states = new Map();
+
+// Seed from previous session so a pending approval survives page refresh.
+for (const [id, state] of readPersisted()) {
+  states.set(id, state);
+}
+
+function snapshot() {
+  return new Map(states);
+}
+
+function emit() {
+  // Persist before notifying so subscribers reading the store observe a
+  // consistent in-memory + persisted view.
+  writePersisted();
+  const snap = snapshot();
+  for (const listener of subscribers) {
+    try {
+      listener(snap);
+    } catch (_) {
+      // A misbehaving subscriber must not poison the store.
+    }
+  }
+}
+
+/**
+ * Set the state of a thread. Passing `null`/`undefined` clears the
+ * entry, returning the thread to the implicit `idle`. No-op when the
+ * new state matches the current one (suppresses redundant emits).
+ */
+export function setThreadState(threadId, state) {
+  if (!threadId) return;
+  if (state == null) {
+    if (states.delete(threadId)) emit();
+    return;
+  }
+  if (states.get(threadId) === state) return;
+  states.set(threadId, state);
+  emit();
+}
+
+/** Convenience: clear the state of a thread (back to implicit idle). */
+export function clearThreadState(threadId) {
+  setThreadState(threadId, null);
+}
+
+/** Read-only snapshot of the current state map. */
+export function getThreadStates() {
+  return snapshot();
+}
+
+/** Subscribe to state-map changes. Returns an unsubscribe fn. */
+export function subscribeThreadStates(listener) {
+  subscribers.add(listener);
+  return () => {
+    subscribers.delete(listener);
+  };
+}
+
+/** React adapter for the state map. Re-renders on any set/clear. */
+export function useThreadStates() {
+  const [map, setMap] = React.useState(getThreadStates);
+  React.useEffect(() => subscribeThreadStates(setMap), []);
+  return map;
+}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/chat/chat.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/chat/chat.js
@@ -1,4 +1,9 @@
 import { React, html } from "../../lib/html.js";
+import {
+  THREAD_STATE,
+  clearThreadState,
+  setThreadState,
+} from "../../lib/thread-state.js";
 import { ApprovalCard } from "./components/approval-card.js";
 import { AuthGenericCard } from "./components/auth-generic-card.js";
 import { AuthOauthCard } from "./components/auth-oauth-card.js";
@@ -80,6 +85,40 @@ export function Chat({
     },
     [handleSend, setSuggestions]
   );
+
+  /* Mirror the active thread's lifecycle into the per-thread state store
+   * so the sidebar row reflects what's happening on the open thread:
+   *
+   *   pendingGate                   → NEEDS_ATTENTION (amber)
+   *   isProcessing && !pendingGate  → RUNNING (green)
+   *   neither                       → clear (idle)
+   *
+   * Priority is pendingGate-first because a gate logically subsumes
+   * processing — the run is paused waiting on the user, not actively
+   * working.
+   *
+   * Invariant: useChat resets pendingGate (and isProcessing reaches a
+   * fresh value) on threadId change via the sibling effect at
+   * useChat.js:136-140, so within a single React commit batch we never
+   * observe stale state from a previous thread paired with a new
+   * activeThreadId.
+   *
+   * Coverage gap (writer is per-active-thread only): this seam only
+   * flags whichever thread the user is currently viewing. Cross-thread
+   * visibility — the green/amber dot appearing on background threads
+   * — requires either a user-scoped SSE channel or list_threads state
+   * enrichment. Both are deferred follow-ups; see
+   * docs/webui-v2-followup-picks-02-05.md. */
+  React.useEffect(() => {
+    if (!activeThreadId) return;
+    if (pendingGate) {
+      setThreadState(activeThreadId, THREAD_STATE.NEEDS_ATTENTION);
+    } else if (isProcessing) {
+      setThreadState(activeThreadId, THREAD_STATE.RUNNING);
+    } else {
+      clearThreadState(activeThreadId);
+    }
+  }, [activeThreadId, pendingGate, isProcessing]);
 
   const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
   React.useEffect(() => {


### PR DESCRIPTION
Groundwork for live thread state. **Active thread is fully alive** (green RUNNING / amber NEEDS_ATTENTION / clear), and **attention marks survive page refresh**. Cross-thread visibility (a dot appearing on background threads) requires either a user-scoped SSE channel or `list_threads` state enrichment — both deferred as real engineering follow-ups, both supported by the store/sidebar shape shipped here.

> **Force-pushed three times** during pre-review:
> 1. Thermo-review trimmed the original 7-file draft (resume cards, palette recents, picker artifact) down to 4 files.
> 2. Second thermo-review revealed the Set-based `notifications.js` was the wrong shape for the planned follow-ups — `Map<id, ThreadState>` from day one is the canonical model.
> 3. Architectural recon for the live SSE follow-up revealed it spans 5+ crates (event_streams + turn_events + composition + product_workflow + webui_v2); deferred. In its place, two complementary cheap wins landed here — full active-thread state coverage (`RUNNING` from `isProcessing`) and localStorage persistence of attention marks.
> Final diff: 4 files, +378 / −102.

## UX

| | Active thread (the one you're on) | Other threads in sidebar |
|---|---|---|
| Agent processing | 🟢 "Running" + pinned, instant | nothing |
| Agent paused on approval | 🟠 "Needs your attention" + pinned, instant | nothing |
| Agent finished | clears, instant | nothing |
| Page refresh | re-derives within 1-2s via SSE | **amber marks survive** (green does not — see below) |

**Cross-thread is the documented limitation**, not a bug. It needs the follow-up architecture; both viable paths are sized in the planning doc.

## What landed

### Thread-state store · `lib/thread-state.js` (new, 156 LoC)

`Map<thread_id, ThreadState>` with a typed enum exported as `THREAD_STATE`:

- `RUNNING` — agent is working on the thread
- `NEEDS_ATTENTION` — gate pending; user input required
- `FAILED` — last run errored

Absence from the map is the implicit `idle`. Subscribe/emit pattern, co-located React adapter `useThreadStates()`.

**Persistence policy.** Only the "user must act" subset (`NEEDS_ATTENTION`, `FAILED`) is mirrored to localStorage under `ironclaw:v2-thread-attention`. `RUNNING` is intentionally **not** persisted: across a page lifetime the run almost certainly completed while the tab was closed, so persisting it would cause confusing false-positive green dots on first load. Pending approvals, by contrast, remain pending until the user acts — persisting them is exactly what the user expects.

Writes are best-effort: private mode, quota errors, and malformed JSON are silently absorbed. Module-load seed survives corrupted storage without throwing.

### Sidebar partition · `components/sidebar-threads.js`

Replaces date buckets (`Today / Yesterday / Previous 7 days / 30 days / Older`) with:

- **Pinned**: active thread + any thread with a non-idle state
- **Recent**: everything else, newest-first by `updated_at || created_at`

Per-row presentation (dot colour, label, left-border) is driven by a single `STATE_PRESENTATION` map keyed by `ThreadState`. Adding a new state = one row in that table — no state-by-state branching in the row component.

### Lifecycle seed · `pages/chat/chat.js`

One `useEffect` mirrors the active thread:

```
pendingGate                  → NEEDS_ATTENTION (amber)
isProcessing && !pendingGate → RUNNING (green)
neither                      → clear (idle)
```

`pendingGate` wins because a gate logically subsumes processing (the run is paused waiting on the user, not actively working). Race-safety contract documented inline — `useChat` resets `pendingGate` and `isProcessing` on `threadId` change via the sibling effect at `useChat.js:136-140`.

### Shared helpers · `lib/thread-meta.js` (new, 57 LoC)

- `byActivityDesc(a, b)` — canonical thread ordering
- `formatThreadActivityLabel(iso)` — sidebar row time label
- `formatThreadActivityTooltip(iso)` — hover tooltip
- `threadActivityIso(thread)` — the timestamp the UI considers "most recent"

Names are deliberately prefixed `formatThreadActivity*` to avoid colliding with `formatRelativeTime` in `pages/admin/lib/admin-presenters.js`, which has completely different semantics (`"5m ago"` duration vs this file's `"14:32 | Jan 15"` stamp).

## Why `Map` (not `Set`) from day one

The original draft shipped `lib/notifications.js` as a `Set<thread_id>` for "needs attention" only. Code-quality review flagged that as the wrong shape: the deferred SSE follow-up adds `RUNNING` and `FAILED`, and `NEEDS_ATTENTION` is **one value of a richer enum**, not a separate concept. Shipping the Set would have meant deleting it within days. Reshaped to ship the canonical `Map<id, state>` now — when cross-thread visibility lands, it's an additional writer, not a store migration.

## Deferred follow-ups (documented, not in this PR)

See `docs/webui-v2-followup-picks-02-05.md` (untracked).

| | Status |
|---|---|
| **Cross-thread state visibility — User-scoped SSE** | Architecturally proper. Requires fanout in `ironclaw_event_streams::publish_shared` + new facade method in `ironclaw_product_workflow` + new SSE route in `ironclaw_webui_v2` + a user-scope merge in `ironclaw_reborn_composition` (where projection and turn-event streams are joined into outbound envelopes). ~700+ LoC across 4-5 crates. |
| **Cross-thread state visibility — `list_threads` polling** | Cheaper alternative. Requires new `TurnCoordinator` bulk-read backed by a DB trait addition (postgres + libSQL per `AGENTS.md`), `list_threads` response shape change, frontend `refetchInterval`. ~400 LoC across 3 crates. |
| **⌘K message search** | Needs a search endpoint backed by `ironclaw_memory` — messages are content-addressed in `ironclaw_conversations`, so there is no `message_text` column to substring-search. |

Both cross-thread paths plug into the existing store via `setThreadState(threadId, …)`. No rendering or store changes needed when either lands.

## Validation

- `node --check` clean on every touched JS file
- **Runtime smoke (in-process)**: `NEEDS_ATTENTION` persists to localStorage; `RUNNING` does not; clearing the last entry removes the storage key; module-load seed survives malformed JSON without throwing
- `cargo build -p ironclaw_webui_v2_static` — new assets bundled by `build.rs`
- `cargo test -p ironclaw_webui_v2_static` — **23 passed, 0 failed**

## Scope discipline

Behavior contained to `ironclaw_webui_v2_static`. No DB schema, no auth, no listeners, no secrets, no extension lifecycle touched.

## Files

```
 .../js/lib/thread-state.js               | +156 (new — canonical store + persistence)
 .../js/lib/thread-meta.js                | +57  (new — shared helpers)
 .../js/components/sidebar-threads.js     | +152 / −76
 .../js/pages/chat/chat.js                | +39 / −0
```

4 files, +378 / −102.
