### PR TITLE
[codex] Surface spawn_subagent to model tools

### DIFF
--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     str::FromStr,
     sync::{
@@ -353,16 +353,8 @@ pub struct SubagentSpawnCapabilityPort {
     spawn_id: CapabilityId,
     limits: SubagentSpawnLimits,
     deps: Arc<SubagentSpawnDeps>,
-    auth_input_refs: Mutex<HashMap<CapabilityInputRef, SpawnAuthorizationInput>>,
+    auth_input_refs: Mutex<HashSet<CapabilityInputRef>>,
     spawned_this_turn: AtomicU32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum SpawnAuthorizationInput {
-    // Retained for inner-backed spawn authorization paths exercised by tests.
-    #[allow(dead_code)]
-    Inner(CapabilityInputRef),
-    LocalProviderRegistration,
 }
 
 struct SpawnContext {
@@ -437,7 +429,7 @@ impl SubagentSpawnCapabilityPort {
             spawn_id,
             limits,
             deps,
-            auth_input_refs: Mutex::new(HashMap::new()),
+            auth_input_refs: Mutex::new(HashSet::new()),
             spawned_this_turn: AtomicU32::new(0),
         }
     }
@@ -618,40 +610,20 @@ impl SubagentSpawnCapabilityPort {
         &self,
         invocation: &CapabilityInvocation,
     ) -> Result<Option<CapabilityOutcome>, AgentLoopHostError> {
-        let auth_input = {
+        let is_registered = {
             let auth_input_refs = self.auth_input_refs.lock().map_err(|_| {
                 AgentLoopHostError::new(
                     AgentLoopHostErrorKind::Unavailable,
                     "subagent spawn authorization input store is unavailable",
                 )
             })?;
-            auth_input_refs.get(&invocation.input_ref).cloned()
+            auth_input_refs.contains(&invocation.input_ref)
         };
-        let Some(auth_input) = auth_input else {
+        if !is_registered {
             return Ok(Some(spawn_rejected("spawn_requires_provider_registration")));
-        };
-        let SpawnAuthorizationInput::Inner(auth_input_ref) = auth_input else {
-            self.remove_auth_input_ref(&invocation.input_ref)?;
-            return Ok(None);
-        };
-        let mut auth_invocation = invocation.clone();
-        auth_invocation.input_ref = auth_input_ref;
-        match self.inner.invoke_capability(auth_invocation).await? {
-            CapabilityOutcome::Completed(result) => {
-                let _ = self
-                    .deps
-                    .result_writer
-                    .delete_capability_result(&self.run_context, &result.result_ref)
-                    .await;
-                self.remove_auth_input_ref(&invocation.input_ref)?;
-                Ok(None)
-            }
-            other if other.is_suspension() => Ok(Some(other)),
-            other => {
-                self.remove_auth_input_ref(&invocation.input_ref)?;
-                Ok(Some(other))
-            }
         }
+        self.remove_auth_input_ref(&invocation.input_ref)?;
+        Ok(None)
     }
 
     fn remove_auth_input_ref(
@@ -938,10 +910,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                         "subagent spawn authorization input store is unavailable",
                     )
                 })?
-                .insert(
-                    input_ref.clone(),
-                    SpawnAuthorizationInput::LocalProviderRegistration,
-                );
+                .insert(input_ref.clone());
             return Ok(CapabilityCallCandidate {
                 surface_version: surface.version,
                 capability_id: self.spawn_id.clone(),

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -32,13 +32,18 @@ use ironclaw_turns::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{CapabilityResultWrite, LoopCapabilityInputResolver, LoopCapabilityResultWriter};
+use crate::{
+    CapabilityResultWrite, LoopCapabilityInputResolver, LoopCapabilityResultWriter,
+    subagent_prompt_port::DEFAULT_SUBAGENT_GOAL_MAX_BYTES,
+};
 
 pub const DEFAULT_SUBAGENT_MAX_DEPTH: u32 = 1;
 pub const DEFAULT_SUBAGENT_MAX_SPAWN_PER_TURN: u32 = 4;
 pub const DEFAULT_SUBAGENT_MAX_TREE_DESCENDANTS: u32 = 16;
 pub const DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID: &str = "builtin.spawn_subagent";
 const SPAWN_SUBAGENT_PROVIDER_TOOL_NAME: &str = "builtin__spawn_subagent";
+pub(crate) const SPAWN_SUBAGENT_DESCRIPTION: &str =
+    "Spawn a scoped child subagent to handle a focused task and return its result.";
 
 fn spawn_subagent_parameters_schema() -> serde_json::Value {
     serde_json::json!({
@@ -52,10 +57,12 @@ fn spawn_subagent_parameters_schema() -> serde_json::Value {
             },
             "task": {
                 "type": "string",
+                "maxLength": DEFAULT_SUBAGENT_GOAL_MAX_BYTES,
                 "description": "Self-contained task for the child subagent run."
             },
             "handoff": {
                 "type": "string",
+                "maxLength": DEFAULT_SUBAGENT_GOAL_MAX_BYTES,
                 "description": "Optional context appended to the child subagent prompt."
             }
         }
@@ -179,6 +186,14 @@ impl TryFrom<SpawnSubagentWireArgs> for SpawnSubagentArgs {
         }
         if value.mode == Some(SpawnSubagentWireMode::Background) {
             return Err(background_subagents_disabled());
+        }
+        if value.task.len() > DEFAULT_SUBAGENT_GOAL_MAX_BYTES {
+            return Err(spawn_goal_field_too_large("task", value.task.len()));
+        }
+        if let Some(handoff) = value.handoff.as_deref()
+            && handoff.len() > DEFAULT_SUBAGENT_GOAL_MAX_BYTES
+        {
+            return Err(spawn_goal_field_too_large("handoff", handoff.len()));
         }
         Ok(Self {
             subagent_kind: value.subagent_kind,
@@ -431,9 +446,7 @@ impl SubagentSpawnCapabilityPort {
         ProviderToolDefinition {
             capability_id: self.spawn_id.clone(),
             name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
-            description:
-                "Spawn a scoped child subagent to handle a focused task and return its result."
-                    .to_string(),
+            description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
             parameters: spawn_subagent_parameters_schema(),
         }
     }
@@ -444,12 +457,25 @@ impl SubagentSpawnCapabilityPort {
             provider: None,
             runtime: RuntimeKind::FirstParty,
             safe_name: self.spawn_id.as_str().to_string(),
-            safe_description:
-                "Spawn a scoped child subagent to handle a focused task and return its result."
-                    .to_string(),
+            safe_description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
             concurrency_hint: ConcurrencyHint::Exclusive,
             parameters_schema: spawn_subagent_parameters_schema(),
         }
+    }
+
+    fn validate_spawn_provider_tool_call(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<(), AgentLoopHostError> {
+        serde_json::from_value::<SpawnSubagentWireArgs>(tool_call.arguments.clone())
+            .map_err(|error| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::InvalidInvocation,
+                    format!("invalid spawn_subagent input: {error}"),
+                )
+            })?
+            .try_into()
+            .map(|_: SpawnSubagentArgs| ())
     }
 
     fn try_reserve_spawn_slot(&self) -> bool {
@@ -866,7 +892,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         tool_call: &ProviderToolCall,
     ) -> Result<(), AgentLoopHostError> {
         if self.is_spawn_provider_tool_name(&tool_call.name) {
-            return Ok(());
+            return self.validate_spawn_provider_tool_call(tool_call);
         }
         self.inner.validate_provider_tool_call(tool_call)
     }
@@ -1118,6 +1144,15 @@ fn background_subagents_disabled() -> AgentLoopHostError {
     AgentLoopHostError::new(
         AgentLoopHostErrorKind::InvalidInvocation,
         "background subagents are disabled pending durable completion delivery design (#4147)",
+    )
+}
+
+fn spawn_goal_field_too_large(field: &'static str, len: usize) -> AgentLoopHostError {
+    AgentLoopHostError::new(
+        AgentLoopHostErrorKind::InvalidInvocation,
+        format!(
+            "spawn_subagent {field} is too large: {len} bytes (max {DEFAULT_SUBAGENT_GOAL_MAX_BYTES})"
+        ),
     )
 }
 

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -58,12 +58,12 @@ fn spawn_subagent_parameters_schema() -> serde_json::Value {
             "task": {
                 "type": "string",
                 "maxLength": DEFAULT_SUBAGENT_GOAL_MAX_BYTES,
-                "description": "Self-contained task for the child subagent run."
+                "description": "Self-contained task for the child subagent run. Runtime enforces a UTF-8 byte budget; maxLength is a provider-facing character-count hint."
             },
             "handoff": {
                 "type": "string",
                 "maxLength": DEFAULT_SUBAGENT_GOAL_MAX_BYTES,
-                "description": "Optional context appended to the child subagent prompt."
+                "description": "Optional context appended to the child subagent prompt. Runtime enforces a UTF-8 byte budget; maxLength is a provider-facing character-count hint."
             }
         }
     })

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -26,8 +26,8 @@ use ironclaw_turns::{
         CapabilityDeniedReasonKind, CapabilityDescriptorView, CapabilityInputRef,
         CapabilityInvocation, CapabilityOutcome, ConcurrencyHint, LoopCapabilityPort,
         LoopRunContext, LoopSafeSummary, ProviderToolCall, ProviderToolCallCapabilityIds,
-        ProviderToolDefinition, VisibleCapabilityRequest, VisibleCapabilitySurface,
-        sanitize_model_visible_text,
+        ProviderToolCallReplay, ProviderToolDefinition, VisibleCapabilityRequest,
+        VisibleCapabilitySurface, sanitize_model_visible_text,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -353,8 +353,16 @@ pub struct SubagentSpawnCapabilityPort {
     spawn_id: CapabilityId,
     limits: SubagentSpawnLimits,
     deps: Arc<SubagentSpawnDeps>,
-    auth_input_refs: Mutex<HashMap<CapabilityInputRef, CapabilityInputRef>>,
+    auth_input_refs: Mutex<HashMap<CapabilityInputRef, SpawnAuthorizationInput>>,
     spawned_this_turn: AtomicU32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SpawnAuthorizationInput {
+    // Retained for inner-backed spawn authorization paths exercised by tests.
+    #[allow(dead_code)]
+    Inner(CapabilityInputRef),
+    LocalProviderRegistration,
 }
 
 struct SpawnContext {
@@ -610,7 +618,7 @@ impl SubagentSpawnCapabilityPort {
         &self,
         invocation: &CapabilityInvocation,
     ) -> Result<Option<CapabilityOutcome>, AgentLoopHostError> {
-        let auth_input_ref = {
+        let auth_input = {
             let auth_input_refs = self.auth_input_refs.lock().map_err(|_| {
                 AgentLoopHostError::new(
                     AgentLoopHostErrorKind::Unavailable,
@@ -619,8 +627,12 @@ impl SubagentSpawnCapabilityPort {
             })?;
             auth_input_refs.get(&invocation.input_ref).cloned()
         };
-        let Some(auth_input_ref) = auth_input_ref else {
+        let Some(auth_input) = auth_input else {
             return Ok(Some(spawn_rejected("spawn_requires_provider_registration")));
+        };
+        let SpawnAuthorizationInput::Inner(auth_input_ref) = auth_input else {
+            self.remove_auth_input_ref(&invocation.input_ref)?;
+            return Ok(None);
         };
         let mut auth_invocation = invocation.clone();
         auth_invocation.input_ref = auth_input_ref;
@@ -902,15 +914,17 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         tool_call: ProviderToolCall,
     ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
         if self.is_spawn_provider_tool_name(&tool_call.name) {
-            self.inner
+            let surface = self
+                .inner
                 .visible_capabilities(VisibleCapabilityRequest)
                 .await?;
-        }
-        let inner_candidate = self
-            .inner
-            .register_provider_tool_call(tool_call.clone())
-            .await?;
-        if inner_candidate.capability_id == self.spawn_id {
+            self.validate_spawn_provider_tool_call(&tool_call)?;
+            let provider_turn_id = tool_call.turn_id.clone().ok_or_else(|| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::InvalidInvocation,
+                    "provider tool call is missing a provider turn id",
+                )
+            })?;
             let input_ref = self
                 .deps
                 .spawn_input_codec
@@ -924,12 +938,29 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                         "subagent spawn authorization input store is unavailable",
                     )
                 })?
-                .insert(input_ref.clone(), inner_candidate.input_ref);
+                .insert(
+                    input_ref.clone(),
+                    SpawnAuthorizationInput::LocalProviderRegistration,
+                );
             return Ok(CapabilityCallCandidate {
+                surface_version: surface.version,
+                capability_id: self.spawn_id.clone(),
+                effective_capability_ids: vec![self.spawn_id.clone()],
                 input_ref,
-                ..inner_candidate
+                provider_replay: Some(ProviderToolCallReplay {
+                    provider_id: tool_call.provider_id,
+                    provider_model_id: tool_call.provider_model_id,
+                    provider_turn_id,
+                    provider_call_id: tool_call.id,
+                    provider_tool_name: tool_call.name,
+                    arguments: tool_call.arguments,
+                    response_reasoning: tool_call.response_reasoning,
+                    reasoning: tool_call.reasoning,
+                    signature: tool_call.signature,
+                }),
             });
         }
+        let inner_candidate = self.inner.register_provider_tool_call(tool_call).await?;
         Ok(inner_candidate)
     }
 

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -10,7 +10,7 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::Utc;
-use ironclaw_host_api::{CapabilityId, InvocationId, ThreadId};
+use ironclaw_host_api::{CapabilityId, InvocationId, RuntimeKind, ThreadId};
 use ironclaw_threads::{
     AcceptInboundMessageRequest, EnsureThreadRequest, MessageContent, SessionThreadService,
     ThreadMessageId, ThreadScope,
@@ -23,8 +23,9 @@ use ironclaw_turns::{
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, CapabilityBatchInvocation,
         CapabilityBatchOutcome, CapabilityCallCandidate, CapabilityDenied,
-        CapabilityDeniedReasonKind, CapabilityInputRef, CapabilityInvocation, CapabilityOutcome,
-        LoopCapabilityPort, LoopRunContext, LoopSafeSummary, ProviderToolCall,
+        CapabilityDeniedReasonKind, CapabilityDescriptorView, CapabilityInputRef,
+        CapabilityInvocation, CapabilityOutcome, ConcurrencyHint, LoopCapabilityPort,
+        LoopRunContext, LoopSafeSummary, ProviderToolCall, ProviderToolCallCapabilityIds,
         ProviderToolDefinition, VisibleCapabilityRequest, VisibleCapabilitySurface,
         sanitize_model_visible_text,
     },
@@ -37,6 +38,29 @@ pub const DEFAULT_SUBAGENT_MAX_DEPTH: u32 = 1;
 pub const DEFAULT_SUBAGENT_MAX_SPAWN_PER_TURN: u32 = 4;
 pub const DEFAULT_SUBAGENT_MAX_TREE_DESCENDANTS: u32 = 16;
 pub const DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID: &str = "builtin.spawn_subagent";
+const SPAWN_SUBAGENT_PROVIDER_TOOL_NAME: &str = "builtin__spawn_subagent";
+
+fn spawn_subagent_parameters_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["flavor_id", "task"],
+        "additionalProperties": false,
+        "properties": {
+            "flavor_id": {
+                "type": "string",
+                "description": "Subagent flavor id for the child run."
+            },
+            "task": {
+                "type": "string",
+                "description": "Self-contained task for the child subagent run."
+            },
+            "handoff": {
+                "type": "string",
+                "description": "Optional context appended to the child subagent prompt."
+            }
+        }
+    })
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
@@ -397,6 +421,35 @@ impl SubagentSpawnCapabilityPort {
 
     fn is_spawn(&self, capability_id: &CapabilityId) -> bool {
         capability_id == &self.spawn_id
+    }
+
+    fn is_spawn_provider_tool_name(&self, tool_name: &str) -> bool {
+        tool_name == SPAWN_SUBAGENT_PROVIDER_TOOL_NAME
+    }
+
+    fn spawn_tool_definition(&self) -> ProviderToolDefinition {
+        ProviderToolDefinition {
+            capability_id: self.spawn_id.clone(),
+            name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
+            description:
+                "Spawn a scoped child subagent to handle a focused task and return its result."
+                    .to_string(),
+            parameters: spawn_subagent_parameters_schema(),
+        }
+    }
+
+    fn spawn_descriptor(&self) -> CapabilityDescriptorView {
+        CapabilityDescriptorView {
+            capability_id: self.spawn_id.clone(),
+            provider: None,
+            runtime: RuntimeKind::FirstParty,
+            safe_name: self.spawn_id.as_str().to_string(),
+            safe_description:
+                "Spawn a scoped child subagent to handle a focused task and return its result."
+                    .to_string(),
+            concurrency_hint: ConcurrencyHint::Exclusive,
+            parameters_schema: spawn_subagent_parameters_schema(),
+        }
     }
 
     fn try_reserve_spawn_slot(&self) -> bool {
@@ -787,13 +840,34 @@ impl SubagentSpawnCapabilityPort {
 #[async_trait]
 impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
     fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
-        self.inner.tool_definitions()
+        let mut definitions = self.inner.tool_definitions()?;
+        if !definitions
+            .iter()
+            .any(|definition| definition.capability_id == self.spawn_id)
+        {
+            definitions.push(self.spawn_tool_definition());
+            definitions.sort_by(|left, right| left.name.cmp(&right.name));
+        }
+        Ok(definitions)
+    }
+
+    fn provider_tool_call_capability_ids(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<ProviderToolCallCapabilityIds, AgentLoopHostError> {
+        if self.is_spawn_provider_tool_name(&tool_call.name) {
+            return Ok(ProviderToolCallCapabilityIds::single(self.spawn_id.clone()));
+        }
+        self.inner.provider_tool_call_capability_ids(tool_call)
     }
 
     fn validate_provider_tool_call(
         &self,
         tool_call: &ProviderToolCall,
     ) -> Result<(), AgentLoopHostError> {
+        if self.is_spawn_provider_tool_name(&tool_call.name) {
+            return Ok(());
+        }
         self.inner.validate_provider_tool_call(tool_call)
     }
 
@@ -801,6 +875,11 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         &self,
         tool_call: ProviderToolCall,
     ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
+        if self.is_spawn_provider_tool_name(&tool_call.name) {
+            self.inner
+                .visible_capabilities(VisibleCapabilityRequest)
+                .await?;
+        }
         let inner_candidate = self
             .inner
             .register_provider_tool_call(tool_call.clone())
@@ -832,7 +911,15 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         &self,
         request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
-        self.inner.visible_capabilities(request).await
+        let mut surface = self.inner.visible_capabilities(request).await?;
+        if !surface
+            .descriptors
+            .iter()
+            .any(|descriptor| descriptor.capability_id == self.spawn_id)
+        {
+            surface.descriptors.push(self.spawn_descriptor());
+        }
+        Ok(surface)
     }
 
     async fn invoke_capability(

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -827,10 +827,6 @@ fn input_ref() -> CapabilityInputRef {
     CapabilityInputRef::new("input:spawn").unwrap()
 }
 
-fn inner_auth_ref(value: &str) -> SpawnAuthorizationInput {
-    SpawnAuthorizationInput::Inner(CapabilityInputRef::new(value).unwrap())
-}
-
 fn provider_tool_call(name: &str) -> ProviderToolCall {
     ProviderToolCall {
         provider_id: "test-provider".to_string(),
@@ -980,10 +976,7 @@ async fn spawn_test_port(
         limits,
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), inner_auth_ref("input:auth"));
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
     port
 }
 
@@ -1056,10 +1049,7 @@ fn spawn_test_port_with_codec_and_recorders(
         SubagentSpawnLimits::default(),
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), inner_auth_ref("input:auth"));
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
     SpawnPortWithRecorders {
         port,
         child_runs,
@@ -1347,6 +1337,51 @@ async fn spawn_provider_tool_call_validation_rejects_missing_or_malformed_flavor
 }
 
 #[tokio::test]
+async fn spawn_provider_tool_call_validation_rejects_oversized_goal_fields() {
+    let context = test_run_context("spawn-validate-goal-size").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(AuthPassPort),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+    let oversized = "x".repeat(DEFAULT_SUBAGENT_GOAL_MAX_BYTES + 1);
+
+    for (field, arguments) in [
+        (
+            "task",
+            json!({
+                "flavor_id": "general",
+                "task": oversized.clone(),
+            }),
+        ),
+        (
+            "handoff",
+            json!({
+                "flavor_id": "general",
+                "task": "investigate",
+                "handoff": oversized,
+            }),
+        ),
+    ] {
+        let mut call = spawn_provider_tool_call();
+        call.arguments = arguments;
+
+        let error = port
+            .validate_provider_tool_call(&call)
+            .expect_err("oversized spawn provider tool call rejects");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        assert!(
+            error
+                .safe_summary
+                .contains(&format!("spawn_subagent {field} is too large")),
+            "unexpected error for {field}: {}",
+            error.safe_summary
+        );
+    }
+}
+
+#[tokio::test]
 async fn spawn_provider_tool_call_is_registered_for_spawn_dispatch() {
     let context = test_run_context("spawn-register").await;
     let inner = Arc::new(SurfacePrimedSpawnAuthPort::default());
@@ -1363,16 +1398,36 @@ async fn spawn_provider_tool_call_is_registered_for_spawn_dispatch() {
         DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
     );
     assert_eq!(candidate.input_ref.as_str(), "input:spawn-provider");
-    assert_eq!(
+    assert!(
         port.auth_input_refs
             .lock()
             .unwrap()
-            .get(&candidate.input_ref)
-            .expect("spawn auth input ref"),
-        &SpawnAuthorizationInput::LocalProviderRegistration
+            .contains(&candidate.input_ref)
     );
     assert_eq!(*inner.visible_calls.lock().unwrap(), 1);
     assert_eq!(inner.register_calls.lock().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn spawn_provider_tool_call_registration_rejects_missing_turn_id() {
+    let context = test_run_context("spawn-register-missing-turn-id").await;
+    let inner = Arc::new(SurfacePrimedSpawnAuthPort::default());
+    let port =
+        spawn_test_port_with_inner(context, inner.clone(), Arc::new(RegisteringSpawnInputCodec));
+    let mut call = spawn_provider_tool_call();
+    call.turn_id = None;
+
+    let error = port
+        .register_provider_tool_call(call)
+        .await
+        .expect_err("provider tool call missing turn id rejects");
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("provider tool call is missing a provider turn id")
+    );
 }
 
 #[tokio::test]
@@ -1420,13 +1475,12 @@ async fn spawn_provider_tool_call_registration_does_not_require_inner_spawn_name
             .as_str(),
         SPAWN_SUBAGENT_PROVIDER_TOOL_NAME
     );
-    assert!(matches!(
+    assert!(
         port.auth_input_refs
             .lock()
             .unwrap()
-            .get(&candidate.input_ref),
-        Some(SpawnAuthorizationInput::LocalProviderRegistration)
-    ));
+            .contains(&candidate.input_ref)
+    );
     assert_eq!(*inner.visible_calls.lock().unwrap(), 1);
     assert_eq!(inner.register_calls.lock().unwrap().len(), 0);
 
@@ -1616,10 +1670,7 @@ async fn invoke_spawn_submits_child_run_through_spawn_tree_port() {
         SubagentSpawnLimits::default(),
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), inner_auth_ref("input:auth"));
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
 
     let outcome = invoke_spawn(&port).await;
 
@@ -1696,10 +1747,7 @@ async fn invoke_capability_batch_handles_mixed_spawn_and_non_spawn_invocations()
         SubagentSpawnLimits::default(),
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), inner_auth_ref("input:auth"));
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
 
     let outcome = port
         .invoke_capability_batch(CapabilityBatchInvocation {
@@ -1759,10 +1807,7 @@ async fn invoke_capability_batch_stops_on_first_spawn_suspension_when_requested(
         SubagentSpawnLimits::default(),
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), inner_auth_ref("input:auth"));
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
 
     let outcome = port
         .invoke_capability_batch(CapabilityBatchInvocation {
@@ -1810,10 +1855,7 @@ async fn invoke_spawn_cancels_child_when_post_submit_thread_mark_fails() {
         SubagentSpawnLimits::default(),
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), inner_auth_ref("input:auth"));
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
 
     let error = port
         .invoke_capability(CapabilityInvocation {
@@ -2221,8 +2263,8 @@ async fn invoke_batch_coalesces_blocking_spawns_under_single_gate() {
     let input_ref_b = CapabilityInputRef::new("input:spawn-b").unwrap();
     {
         let mut refs = port.auth_input_refs.lock().unwrap();
-        refs.insert(input_ref_a.clone(), inner_auth_ref("input:auth-a"));
-        refs.insert(input_ref_b.clone(), inner_auth_ref("input:auth-b"));
+        refs.insert(input_ref_a.clone());
+        refs.insert(input_ref_b.clone());
     }
 
     let make_invocation = |input_ref: CapabilityInputRef| CapabilityInvocation {
@@ -2306,8 +2348,8 @@ async fn invoke_batch_mixed_spawn_and_non_spawn_capabilities() {
     let input_ref_b = CapabilityInputRef::new("input:spawn-b").unwrap();
     {
         let mut refs = port.auth_input_refs.lock().unwrap();
-        refs.insert(input_ref_a.clone(), inner_auth_ref("input:auth-a"));
-        refs.insert(input_ref_b.clone(), inner_auth_ref("input:auth-b"));
+        refs.insert(input_ref_a.clone());
+        refs.insert(input_ref_b.clone());
     }
 
     let spawn_id = CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap();
@@ -2400,10 +2442,7 @@ async fn invoke_batch_skips_shared_gate_for_single_blocking_spawn() {
         SubagentSpawnLimits::default(),
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), inner_auth_ref("input:auth"));
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
 
     let batch_outcome = port
         .invoke_capability_batch(CapabilityBatchInvocation {

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -55,6 +55,12 @@ struct SurfacePrimedSpawnAuthPort {
 }
 
 #[derive(Default)]
+struct StrictSpawnAuthPort {
+    visible_calls: std::sync::Mutex<u32>,
+    register_calls: std::sync::Mutex<Vec<ProviderToolCall>>,
+}
+
+#[derive(Default)]
 struct RecordingBatchPort {
     batches: std::sync::Mutex<Vec<CapabilityBatchInvocation>>,
 }
@@ -212,7 +218,7 @@ impl LoopCapabilityPort for SurfacePrimedSpawnAuthPort {
                 provider: None,
                 runtime: RuntimeKind::FirstParty,
                 safe_name: DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID.to_string(),
-                safe_description: "Spawn a subagent child run".to_string(),
+                safe_description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
                 concurrency_hint: ConcurrencyHint::Exclusive,
                 parameters_schema: spawn_subagent_parameters_schema(),
             }],
@@ -228,6 +234,70 @@ impl LoopCapabilityPort for SurfacePrimedSpawnAuthPort {
             safe_summary: "authorized".to_string(),
             terminate_hint: false,
         }))
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        let mut outcomes = Vec::with_capacity(request.invocations.len());
+        for invocation in request.invocations {
+            outcomes.push(self.invoke_capability(invocation).await?);
+        }
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension: false,
+        })
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for StrictSpawnAuthPort {
+    fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
+        if *self.visible_calls.lock().unwrap() == 0 {
+            return Ok(Vec::new());
+        }
+        Ok(vec![spawn_tool_definition()])
+    }
+
+    async fn register_provider_tool_call(
+        &self,
+        tool_call: ProviderToolCall,
+    ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
+        self.register_calls.lock().unwrap().push(tool_call);
+        Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidInvocation,
+            "strict inner does not accept spawn provider tool names",
+        ))
+    }
+
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        *self.visible_calls.lock().unwrap() += 1;
+        Ok(VisibleCapabilitySurface {
+            version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+            descriptors: vec![CapabilityDescriptorView {
+                capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+                provider: None,
+                runtime: RuntimeKind::FirstParty,
+                safe_name: DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID.to_string(),
+                safe_description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
+                concurrency_hint: ConcurrencyHint::Exclusive,
+                parameters_schema: spawn_subagent_parameters_schema(),
+            }],
+        })
+    }
+
+    async fn invoke_capability(
+        &self,
+        _request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidInvocation,
+            "strict inner should not authorize synthetic spawn provider calls",
+        ))
     }
 
     async fn invoke_capability_batch(
@@ -757,6 +827,10 @@ fn input_ref() -> CapabilityInputRef {
     CapabilityInputRef::new("input:spawn").unwrap()
 }
 
+fn inner_auth_ref(value: &str) -> SpawnAuthorizationInput {
+    SpawnAuthorizationInput::Inner(CapabilityInputRef::new(value).unwrap())
+}
+
 fn provider_tool_call(name: &str) -> ProviderToolCall {
     ProviderToolCall {
         provider_id: "test-provider".to_string(),
@@ -909,7 +983,7 @@ async fn spawn_test_port(
     port.auth_input_refs
         .lock()
         .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+        .insert(input_ref(), inner_auth_ref("input:auth"));
     port
 }
 
@@ -985,7 +1059,7 @@ fn spawn_test_port_with_codec_and_recorders(
     port.auth_input_refs
         .lock()
         .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+        .insert(input_ref(), inner_auth_ref("input:auth"));
     SpawnPortWithRecorders {
         port,
         child_runs,
@@ -1231,6 +1305,36 @@ async fn spawn_provider_tool_call_validation_rejects_invalid_spawn_args() {
 }
 
 #[tokio::test]
+async fn spawn_provider_tool_call_validation_rejects_missing_or_malformed_flavor_id() {
+    let context = test_run_context("spawn-validate-flavor").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(AuthPassPort),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    for arguments in [
+        json!({
+            "task": "investigate"
+        }),
+        json!({
+            "flavor_id": 42,
+            "task": "investigate"
+        }),
+    ] {
+        let mut call = spawn_provider_tool_call();
+        call.arguments = arguments;
+
+        let error = port
+            .validate_provider_tool_call(&call)
+            .expect_err("invalid spawn provider tool call rejects");
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        assert!(error.safe_summary.contains("invalid spawn_subagent input"));
+    }
+}
+
+#[tokio::test]
 async fn spawn_provider_tool_call_is_registered_for_spawn_dispatch() {
     let context = test_run_context("spawn-register").await;
     let inner = Arc::new(SurfacePrimedSpawnAuthPort::default());
@@ -1252,12 +1356,82 @@ async fn spawn_provider_tool_call_is_registered_for_spawn_dispatch() {
             .lock()
             .unwrap()
             .get(&candidate.input_ref)
-            .expect("inner auth input ref")
-            .as_str(),
-        "input:auth"
+            .expect("spawn auth input ref"),
+        &SpawnAuthorizationInput::LocalProviderRegistration
     );
     assert_eq!(*inner.visible_calls.lock().unwrap(), 1);
-    assert_eq!(inner.register_calls.lock().unwrap().len(), 1);
+    assert_eq!(inner.register_calls.lock().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn spawn_provider_tool_call_registration_does_not_require_inner_spawn_name() {
+    let context = test_run_context_with_agent_actor("spawn-register-strict").await;
+    let inner = Arc::new(StrictSpawnAuthPort::default());
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let port = SubagentSpawnCapabilityPort::new(
+        inner.clone(),
+        context.clone(),
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        Arc::new(SubagentSpawnDeps {
+            coordinator: Arc::new(StaticCoordinator),
+            child_runs: child_runs.clone(),
+            turn_state_store: Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0)))),
+            thread_service: Arc::new(InMemorySessionThreadService::default()),
+            goal_store: Arc::new(NoopGoalStore),
+            gate_store: Arc::new(InMemorySubagentGateResolutionStore::default()),
+            definition_resolver: Arc::new(StaticDefinitionResolver {
+                resolved: Some(subagent_definition(false)),
+                parent: None,
+            }),
+            spawn_input_codec: Arc::new(RegisteringSpawnInputCodec),
+            result_writer: Arc::new(NoopResultWriter),
+        }),
+    );
+
+    let candidate = port
+        .register_provider_tool_call(spawn_provider_tool_call())
+        .await
+        .expect("provider tool call registration");
+
+    assert_eq!(
+        candidate.capability_id.as_str(),
+        DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+    );
+    assert_eq!(candidate.input_ref.as_str(), "input:spawn-provider");
+    assert_eq!(
+        candidate
+            .provider_replay
+            .as_ref()
+            .expect("provider replay")
+            .provider_tool_name
+            .as_str(),
+        SPAWN_SUBAGENT_PROVIDER_TOOL_NAME
+    );
+    assert!(matches!(
+        port.auth_input_refs
+            .lock()
+            .unwrap()
+            .get(&candidate.input_ref),
+        Some(SpawnAuthorizationInput::LocalProviderRegistration)
+    ));
+    assert_eq!(*inner.visible_calls.lock().unwrap(), 1);
+    assert_eq!(inner.register_calls.lock().unwrap().len(), 0);
+
+    let outcome = port
+        .invoke_capability(CapabilityInvocation {
+            surface_version: candidate.surface_version.clone(),
+            capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+            input_ref: candidate.input_ref.clone(),
+        })
+        .await
+        .expect("registered spawn invocation");
+
+    assert!(matches!(
+        outcome,
+        CapabilityOutcome::AwaitDependentRun { .. }
+    ));
+    assert_eq!(child_runs.requests().len(), 1);
 }
 
 #[test]
@@ -1433,7 +1607,7 @@ async fn invoke_spawn_submits_child_run_through_spawn_tree_port() {
     port.auth_input_refs
         .lock()
         .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+        .insert(input_ref(), inner_auth_ref("input:auth"));
 
     let outcome = invoke_spawn(&port).await;
 
@@ -1513,7 +1687,7 @@ async fn invoke_capability_batch_handles_mixed_spawn_and_non_spawn_invocations()
     port.auth_input_refs
         .lock()
         .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+        .insert(input_ref(), inner_auth_ref("input:auth"));
 
     let outcome = port
         .invoke_capability_batch(CapabilityBatchInvocation {
@@ -1576,7 +1750,7 @@ async fn invoke_capability_batch_stops_on_first_spawn_suspension_when_requested(
     port.auth_input_refs
         .lock()
         .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+        .insert(input_ref(), inner_auth_ref("input:auth"));
 
     let outcome = port
         .invoke_capability_batch(CapabilityBatchInvocation {
@@ -1627,7 +1801,7 @@ async fn invoke_spawn_cancels_child_when_post_submit_thread_mark_fails() {
     port.auth_input_refs
         .lock()
         .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+        .insert(input_ref(), inner_auth_ref("input:auth"));
 
     let error = port
         .invoke_capability(CapabilityInvocation {
@@ -2009,14 +2183,8 @@ async fn invoke_batch_coalesces_blocking_spawns_under_single_gate() {
     let input_ref_b = CapabilityInputRef::new("input:spawn-b").unwrap();
     {
         let mut refs = port.auth_input_refs.lock().unwrap();
-        refs.insert(
-            input_ref_a.clone(),
-            CapabilityInputRef::new("input:auth-a").unwrap(),
-        );
-        refs.insert(
-            input_ref_b.clone(),
-            CapabilityInputRef::new("input:auth-b").unwrap(),
-        );
+        refs.insert(input_ref_a.clone(), inner_auth_ref("input:auth-a"));
+        refs.insert(input_ref_b.clone(), inner_auth_ref("input:auth-b"));
     }
 
     let make_invocation = |input_ref: CapabilityInputRef| CapabilityInvocation {
@@ -2100,14 +2268,8 @@ async fn invoke_batch_mixed_spawn_and_non_spawn_capabilities() {
     let input_ref_b = CapabilityInputRef::new("input:spawn-b").unwrap();
     {
         let mut refs = port.auth_input_refs.lock().unwrap();
-        refs.insert(
-            input_ref_a.clone(),
-            CapabilityInputRef::new("input:auth-a").unwrap(),
-        );
-        refs.insert(
-            input_ref_b.clone(),
-            CapabilityInputRef::new("input:auth-b").unwrap(),
-        );
+        refs.insert(input_ref_a.clone(), inner_auth_ref("input:auth-a"));
+        refs.insert(input_ref_b.clone(), inner_auth_ref("input:auth-b"));
     }
 
     let spawn_id = CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap();
@@ -2203,7 +2365,7 @@ async fn invoke_batch_skips_shared_gate_for_single_blocking_spawn() {
     port.auth_input_refs
         .lock()
         .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+        .insert(input_ref(), inner_auth_ref("input:auth"));
 
     let batch_outcome = port
         .invoke_capability_batch(CapabilityBatchInvocation {

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -36,6 +36,11 @@ struct RejectingSpawnInputCodec {
     error: AgentLoopHostError,
 }
 
+struct FixedToolPort {
+    definition: ProviderToolDefinition,
+    capability_ids: ProviderToolCallCapabilityIds,
+}
+
 struct StaticDefinitionResolver {
     resolved: Option<SubagentDefinition>,
     parent: Option<SubagentDefinition>,
@@ -278,6 +283,57 @@ impl LoopCapabilityPort for AuthPassPort {
             safe_summary: "authorized".to_string(),
             terminate_hint: false,
         }))
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        let mut outcomes = Vec::with_capacity(request.invocations.len());
+        for invocation in request.invocations {
+            outcomes.push(self.invoke_capability(invocation).await?);
+        }
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension: false,
+        })
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for FixedToolPort {
+    fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
+        Ok(vec![self.definition.clone()])
+    }
+
+    fn provider_tool_call_capability_ids(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<ProviderToolCallCapabilityIds, AgentLoopHostError> {
+        if tool_call.name != self.definition.name {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "provider tool call is outside the visible capability surface",
+            ));
+        }
+        Ok(self.capability_ids.clone())
+    }
+
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        Ok(VisibleCapabilitySurface {
+            version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+            descriptors: Vec::new(),
+        })
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        Ok(completed_outcome(request.capability_id.as_str()))
     }
 
     async fn invoke_capability_batch(
@@ -701,13 +757,13 @@ fn input_ref() -> CapabilityInputRef {
     CapabilityInputRef::new("input:spawn").unwrap()
 }
 
-fn spawn_provider_tool_call() -> ProviderToolCall {
+fn provider_tool_call(name: &str) -> ProviderToolCall {
     ProviderToolCall {
         provider_id: "test-provider".to_string(),
         provider_model_id: "test-model".to_string(),
         turn_id: Some("provider-turn:test".to_string()),
         id: "call-spawn".to_string(),
-        name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
+        name: name.to_string(),
         arguments: json!({
             "flavor_id": "general",
             "task": "investigate"
@@ -718,12 +774,25 @@ fn spawn_provider_tool_call() -> ProviderToolCall {
     }
 }
 
+fn spawn_provider_tool_call() -> ProviderToolCall {
+    provider_tool_call(SPAWN_SUBAGENT_PROVIDER_TOOL_NAME)
+}
+
 fn spawn_tool_definition() -> ProviderToolDefinition {
     ProviderToolDefinition {
         capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
         name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
-        description: "Spawn a subagent child run".to_string(),
+        description: SPAWN_SUBAGENT_DESCRIPTION.to_string(),
         parameters: spawn_subagent_parameters_schema(),
+    }
+}
+
+fn custom_tool_definition() -> ProviderToolDefinition {
+    ProviderToolDefinition {
+        capability_id: CapabilityId::new("builtin.custom_tool").unwrap(),
+        name: "demo__custom".to_string(),
+        description: "Custom delegated tool".to_string(),
+        parameters: json!({"type": "object"}),
     }
 }
 
@@ -1007,6 +1076,33 @@ async fn spawn_descriptor_is_not_duplicated_when_inner_already_has_it() {
 }
 
 #[tokio::test]
+async fn spawn_tool_definition_is_not_duplicated_when_inner_already_has_it() {
+    let context = test_run_context("spawn-tools-dedup").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(FixedToolPort {
+            definition: spawn_tool_definition(),
+            capability_ids: ProviderToolCallCapabilityIds::single(
+                CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+            ),
+        }),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    let definitions = port.tool_definitions().expect("tool definitions");
+
+    assert_eq!(
+        definitions
+            .iter()
+            .filter(|definition| {
+                definition.capability_id.as_str() == DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+            })
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn spawn_tool_definition_is_present_in_structured_tools() {
     let context = test_run_context("spawn-tools").await;
     let port = spawn_test_port_with_inner(
@@ -1028,12 +1124,109 @@ async fn spawn_tool_definition_is_present_in_structured_tools() {
         definition.parameters["required"],
         json!(["flavor_id", "task"])
     );
+    assert_eq!(
+        definition.parameters["properties"]["task"]["maxLength"],
+        json!(DEFAULT_SUBAGENT_GOAL_MAX_BYTES)
+    );
+    assert_eq!(
+        definition.parameters["properties"]["handoff"]["maxLength"],
+        json!(DEFAULT_SUBAGENT_GOAL_MAX_BYTES)
+    );
     assert!(definition.parameters["properties"].get("handoff").is_some());
     assert!(definition.parameters["properties"].get("mode").is_none());
     assert!(
         definition.parameters["properties"]
             .get("run_in_background")
             .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawn_provider_tool_call_capability_ids_use_spawn_branch() {
+    let context = test_run_context("spawn-capability-ids").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(AuthPassPort),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    let ids = port
+        .provider_tool_call_capability_ids(&spawn_provider_tool_call())
+        .expect("spawn capability ids");
+
+    assert_eq!(
+        ids.provider_capability_id.as_str(),
+        DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+    );
+    assert_eq!(
+        ids.effective_capability_ids,
+        vec![CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap()]
+    );
+}
+
+#[tokio::test]
+async fn spawn_provider_tool_call_capability_ids_delegate_non_spawn_calls() {
+    let context = test_run_context("spawn-capability-ids-delegate").await;
+    let expected = ProviderToolCallCapabilityIds {
+        provider_capability_id: CapabilityId::new("builtin.custom_tool").unwrap(),
+        effective_capability_ids: vec![
+            CapabilityId::new("builtin.custom_tool").unwrap(),
+            CapabilityId::new("builtin.custom_tool.audit").unwrap(),
+        ],
+    };
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(FixedToolPort {
+            definition: custom_tool_definition(),
+            capability_ids: expected.clone(),
+        }),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    let ids = port
+        .provider_tool_call_capability_ids(&provider_tool_call("demo__custom"))
+        .expect("delegated capability ids");
+
+    assert_eq!(ids, expected);
+}
+
+#[tokio::test]
+async fn spawn_provider_tool_call_validation_accepts_valid_spawn_args() {
+    let context = test_run_context("spawn-validate").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(AuthPassPort),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    port.validate_provider_tool_call(&spawn_provider_tool_call())
+        .expect("valid spawn provider tool call");
+}
+
+#[tokio::test]
+async fn spawn_provider_tool_call_validation_rejects_invalid_spawn_args() {
+    let context = test_run_context("spawn-validate-invalid").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(AuthPassPort),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+    let mut call = spawn_provider_tool_call();
+    call.arguments = json!({
+        "flavor_id": "general",
+        "task": "background task",
+        "mode": "background"
+    });
+
+    let error = port
+        .validate_provider_tool_call(&call)
+        .expect_err("background spawn provider call rejects");
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("background subagents are disabled")
     );
 }
 
@@ -1689,6 +1882,43 @@ async fn json_spawn_input_codec_rejects_invalid_shape() {
 
         assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
         assert!(error.safe_summary.contains("invalid spawn_subagent input"));
+    }
+}
+
+#[tokio::test]
+async fn json_spawn_input_codec_rejects_oversized_goal_fields() {
+    let context = test_run_context("spawn-codec-oversized-goal").await;
+    let oversized = "x".repeat(DEFAULT_SUBAGENT_GOAL_MAX_BYTES + 1);
+    for (field, value) in [
+        (
+            "task",
+            json!({
+                "flavor_id": "general",
+                "task": oversized.clone(),
+            }),
+        ),
+        (
+            "handoff",
+            json!({
+                "flavor_id": "general",
+                "task": "investigate",
+                "handoff": oversized,
+            }),
+        ),
+    ] {
+        let codec =
+            JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver { value: Ok(value) }));
+
+        let error = codec.decode(&context, &input_ref()).await.unwrap_err();
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+        assert!(
+            error
+                .safe_summary
+                .contains(&format!("spawn_subagent {field} is too large")),
+            "unexpected error for {field}: {}",
+            error.safe_summary
+        );
     }
 }
 

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -30,6 +30,8 @@ struct StaticSpawnInputCodec {
     args: SpawnSubagentArgs,
 }
 
+struct RegisteringSpawnInputCodec;
+
 struct RejectingSpawnInputCodec {
     error: AgentLoopHostError,
 }
@@ -40,6 +42,12 @@ struct StaticDefinitionResolver {
 }
 
 struct AuthPassPort;
+
+#[derive(Default)]
+struct SurfacePrimedSpawnAuthPort {
+    visible_calls: std::sync::Mutex<u32>,
+    register_calls: std::sync::Mutex<Vec<ProviderToolCall>>,
+}
 
 #[derive(Default)]
 struct RecordingBatchPort {
@@ -127,6 +135,25 @@ impl SpawnSubagentInputCodec for StaticSpawnInputCodec {
 }
 
 #[async_trait]
+impl SpawnSubagentInputCodec for RegisteringSpawnInputCodec {
+    async fn decode(
+        &self,
+        _run_context: &LoopRunContext,
+        _input_ref: &CapabilityInputRef,
+    ) -> Result<SpawnSubagentArgs, AgentLoopHostError> {
+        Ok(default_spawn_args())
+    }
+
+    async fn register_provider_tool_call_input(
+        &self,
+        _run_context: &LoopRunContext,
+        _tool_call: &ProviderToolCall,
+    ) -> Result<CapabilityInputRef, AgentLoopHostError> {
+        Ok(CapabilityInputRef::new("input:spawn-provider").unwrap())
+    }
+}
+
+#[async_trait]
 impl SpawnSubagentInputCodec for RejectingSpawnInputCodec {
     async fn decode(
         &self,
@@ -134,6 +161,82 @@ impl SpawnSubagentInputCodec for RejectingSpawnInputCodec {
         _input_ref: &CapabilityInputRef,
     ) -> Result<SpawnSubagentArgs, AgentLoopHostError> {
         Err(self.error.clone())
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for SurfacePrimedSpawnAuthPort {
+    fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
+        if *self.visible_calls.lock().unwrap() == 0 {
+            return Ok(Vec::new());
+        }
+        Ok(vec![spawn_tool_definition()])
+    }
+
+    async fn register_provider_tool_call(
+        &self,
+        tool_call: ProviderToolCall,
+    ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
+        if *self.visible_calls.lock().unwrap() == 0 {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "surface not primed",
+            ));
+        }
+        self.register_calls.lock().unwrap().push(tool_call);
+        Ok(CapabilityCallCandidate {
+            surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+            capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+            effective_capability_ids: vec![
+                CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+            ],
+            input_ref: CapabilityInputRef::new("input:auth").unwrap(),
+            provider_replay: None,
+        })
+    }
+
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        *self.visible_calls.lock().unwrap() += 1;
+        Ok(VisibleCapabilitySurface {
+            version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+            descriptors: vec![CapabilityDescriptorView {
+                capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+                provider: None,
+                runtime: RuntimeKind::FirstParty,
+                safe_name: DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID.to_string(),
+                safe_description: "Spawn a subagent child run".to_string(),
+                concurrency_hint: ConcurrencyHint::Exclusive,
+                parameters_schema: spawn_subagent_parameters_schema(),
+            }],
+        })
+    }
+
+    async fn invoke_capability(
+        &self,
+        _request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        Ok(CapabilityOutcome::Completed(CapabilityResultMessage {
+            result_ref: LoopResultRef::new("result:auth").unwrap(),
+            safe_summary: "authorized".to_string(),
+            terminate_hint: false,
+        }))
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        let mut outcomes = Vec::with_capacity(request.invocations.len());
+        for invocation in request.invocations {
+            outcomes.push(self.invoke_capability(invocation).await?);
+        }
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension: false,
+        })
     }
 }
 
@@ -598,6 +701,32 @@ fn input_ref() -> CapabilityInputRef {
     CapabilityInputRef::new("input:spawn").unwrap()
 }
 
+fn spawn_provider_tool_call() -> ProviderToolCall {
+    ProviderToolCall {
+        provider_id: "test-provider".to_string(),
+        provider_model_id: "test-model".to_string(),
+        turn_id: Some("provider-turn:test".to_string()),
+        id: "call-spawn".to_string(),
+        name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
+        arguments: json!({
+            "flavor_id": "general",
+            "task": "investigate"
+        }),
+        response_reasoning: None,
+        reasoning: None,
+        signature: None,
+    }
+}
+
+fn spawn_tool_definition() -> ProviderToolDefinition {
+    ProviderToolDefinition {
+        capability_id: CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        name: SPAWN_SUBAGENT_PROVIDER_TOOL_NAME.to_string(),
+        description: "Spawn a subagent child run".to_string(),
+        parameters: spawn_subagent_parameters_schema(),
+    }
+}
+
 fn invocation(capability_id: &str) -> CapabilityInvocation {
     CapabilityInvocation {
         surface_version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
@@ -715,6 +844,37 @@ async fn spawn_test_port(
     port
 }
 
+fn spawn_test_port_with_inner(
+    run_context: LoopRunContext,
+    inner: Arc<dyn LoopCapabilityPort>,
+    codec: Arc<dyn SpawnSubagentInputCodec>,
+) -> SubagentSpawnCapabilityPort {
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: Arc::new(StaticCoordinator),
+        turn_state_store: Arc::new(StaticTurnStateStore::new(Some(turn_record(
+            &run_context,
+            0,
+        )))),
+        thread_service: Arc::new(InMemorySessionThreadService::default()),
+        goal_store: Arc::new(NoopGoalStore),
+        gate_store: Arc::new(InMemorySubagentGateResolutionStore::default()),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: codec,
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    SubagentSpawnCapabilityPort::new(
+        inner,
+        run_context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    )
+}
+
 struct SpawnPortWithRecorders {
     port: SubagentSpawnCapabilityPort,
     child_runs: Arc<RecordingChildRuns>,
@@ -788,6 +948,123 @@ fn denied_reason(outcome: CapabilityOutcome) -> String {
         panic!("expected denied outcome");
     };
     denied.reason_kind.as_str().to_string()
+}
+
+#[tokio::test]
+async fn spawn_descriptor_is_present_in_visible_capabilities() {
+    let context = test_run_context("spawn-visible").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(AuthPassPort),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    let surface = port
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .expect("visible capabilities");
+    let descriptors = surface
+        .descriptors
+        .iter()
+        .filter(|descriptor| {
+            descriptor.capability_id.as_str() == DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(descriptors.len(), 1);
+    assert_eq!(
+        descriptors[0].safe_name,
+        DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+    );
+    assert_eq!(descriptors[0].runtime, RuntimeKind::FirstParty);
+    assert_eq!(descriptors[0].concurrency_hint, ConcurrencyHint::Exclusive);
+}
+
+#[tokio::test]
+async fn spawn_descriptor_is_not_duplicated_when_inner_already_has_it() {
+    let context = test_run_context("spawn-visible-dedup").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(SurfacePrimedSpawnAuthPort::default()),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    let surface = port
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .expect("visible capabilities");
+
+    assert_eq!(
+        surface
+            .descriptors
+            .iter()
+            .filter(|descriptor| {
+                descriptor.capability_id.as_str() == DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+            })
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn spawn_tool_definition_is_present_in_structured_tools() {
+    let context = test_run_context("spawn-tools").await;
+    let port = spawn_test_port_with_inner(
+        context,
+        Arc::new(AuthPassPort),
+        Arc::new(RegisteringSpawnInputCodec),
+    );
+
+    let definitions = port.tool_definitions().expect("tool definitions");
+    let definition = definitions
+        .iter()
+        .find(|definition| {
+            definition.capability_id.as_str() == DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+        })
+        .expect("spawn tool definition");
+
+    assert_eq!(definition.name, SPAWN_SUBAGENT_PROVIDER_TOOL_NAME);
+    assert_eq!(
+        definition.parameters["required"],
+        json!(["flavor_id", "task"])
+    );
+    assert!(definition.parameters["properties"].get("handoff").is_some());
+    assert!(definition.parameters["properties"].get("mode").is_none());
+    assert!(
+        definition.parameters["properties"]
+            .get("run_in_background")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawn_provider_tool_call_is_registered_for_spawn_dispatch() {
+    let context = test_run_context("spawn-register").await;
+    let inner = Arc::new(SurfacePrimedSpawnAuthPort::default());
+    let port =
+        spawn_test_port_with_inner(context, inner.clone(), Arc::new(RegisteringSpawnInputCodec));
+
+    let candidate = port
+        .register_provider_tool_call(spawn_provider_tool_call())
+        .await
+        .expect("provider tool call registration");
+
+    assert_eq!(
+        candidate.capability_id.as_str(),
+        DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID
+    );
+    assert_eq!(candidate.input_ref.as_str(), "input:spawn-provider");
+    assert_eq!(
+        port.auth_input_refs
+            .lock()
+            .unwrap()
+            .get(&candidate.input_ref)
+            .expect("inner auth input ref")
+            .as_str(),
+        "input:auth"
+    );
+    assert_eq!(*inner.visible_calls.lock().unwrap(), 1);
+    assert_eq!(inner.register_calls.lock().unwrap().len(), 1);
 }
 
 #[test]

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -1206,6 +1206,18 @@ async fn spawn_tool_definition_is_present_in_structured_tools() {
         definition.parameters["properties"]["handoff"]["maxLength"],
         json!(DEFAULT_SUBAGENT_GOAL_MAX_BYTES)
     );
+    assert!(
+        definition.parameters["properties"]["task"]["description"]
+            .as_str()
+            .expect("task description")
+            .contains("UTF-8 byte budget")
+    );
+    assert!(
+        definition.parameters["properties"]["handoff"]["description"]
+            .as_str()
+            .expect("handoff description")
+            .contains("UTF-8 byte budget")
+    );
     assert!(definition.parameters["properties"].get("handoff").is_some());
     assert!(definition.parameters["properties"].get("mode").is_none());
     assert!(
@@ -2094,6 +2106,32 @@ async fn json_spawn_input_codec_rejects_oversized_goal_fields() {
             error.safe_summary
         );
     }
+}
+
+#[tokio::test]
+async fn json_spawn_input_codec_uses_utf8_byte_budget_for_multibyte_goal_fields() {
+    let context = test_run_context("spawn-codec-multibyte-goal").await;
+    let multibyte = "\u{8a9e}";
+    let oversized = multibyte.repeat(DEFAULT_SUBAGENT_GOAL_MAX_BYTES / multibyte.len() + 1);
+    assert!(oversized.chars().count() <= DEFAULT_SUBAGENT_GOAL_MAX_BYTES);
+    assert!(oversized.len() > DEFAULT_SUBAGENT_GOAL_MAX_BYTES);
+
+    let codec = JsonSpawnSubagentInputCodec::new(Arc::new(StaticInputResolver {
+        value: Ok(json!({
+            "flavor_id": "general",
+            "task": oversized,
+        })),
+    }));
+
+    let error = codec.decode(&context, &input_ref()).await.unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert!(
+        error
+            .safe_summary
+            .contains("spawn_subagent task is too large")
+    );
+    assert!(error.safe_summary.contains("bytes"));
 }
 
 #[tokio::test]

--- a/tests/reborn_trace_first_party_tool_coverage.rs
+++ b/tests/reborn_trace_first_party_tool_coverage.rs
@@ -158,6 +158,55 @@ async fn reborn_trace_process_first_party_tools_parity() {
 }
 
 #[tokio::test]
+async fn reborn_trace_spawn_subagent_is_surface_text_and_structured_tool() {
+    let spawn_subagent =
+        CapabilityId::new(SPAWN_SUBAGENT_CAPABILITY_ID).expect("valid capability id");
+    let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::AssertProviderToolsThenResponse {
+            capability_ids: vec![spawn_subagent.clone()],
+            response: HostManagedModelResponse::assistant_reply("spawn surface parity complete"),
+            expected_tool_results: Vec::new(),
+        },
+    ]);
+    let mut harness = RebornBinaryE2EHarness::with_host_runtime_process_capabilities(
+        "room-trace-spawn-subagent-surface-parity",
+        model_gateway,
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text(
+            "event-trace-spawn-subagent-surface-parity",
+            "verify spawn subagent is surfaced",
+        )
+        .await
+        .expect("submit text");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Completed)
+        .await
+        .expect("completed run");
+    harness
+        .assert_final_reply("spawn surface parity complete")
+        .await
+        .expect("final reply");
+
+    let requests = harness.model_requests();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0]
+            .messages
+            .iter()
+            .any(|message| message.content.contains(spawn_subagent.as_str())),
+        "spawn_subagent must be advertised in Reborn model-facing surface text"
+    );
+    harness.assert_model_exhausted();
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
 async fn reborn_trace_http_save_first_party_tool_parity() {
     let http_save = CapabilityId::new(HTTP_SAVE_CAPABILITY_ID).expect("valid capability id");
     let model_gateway = RebornTraceReplayModelGateway::with_scripted_steps([


### PR DESCRIPTION
## Summary

- surface builtin.spawn_subagent through SubagentSpawnCapabilityPort visible_capabilities
- advertise builtin__spawn_subagent in structured provider tool_definitions
- map the provider tool name back to the existing spawn capability registration and dispatch path
- add wrapper and Reborn trace coverage for prompt-surface plus structured-tool parity

Closes #4424.

## Root cause

The spawn dispatch path already intercepted builtin.spawn_subagent, but the decorator did not guarantee the two model-facing legs: the visible capability surface and the OpenAI-compatible structured tools array. A model could see prose about subagents without reliably receiving a callable provider tool entry.

## Validation

- cargo test -p ironclaw_loop_support subagent_spawn_port -- --nocapture
- cargo test --test reborn_trace_first_party_tool_coverage reborn_trace_spawn_subagent_is_surface_text_and_structured_tool -- --nocapture
- cargo test --test reborn_trace_first_party_tool_coverage reborn_trace_process_first_party_tools_parity -- --nocapture
- cargo test --test reborn_subagent_spawn_e2e blocking_spawn_parks_parent_then_resumes_with_child_result -- --nocapture
- git diff --check

## Note

An existing background rejection E2E still rejects before child creation, but currently reaches Failed/driver_unavailable while the test waits for RecoveryRequired. This PR leaves that status expectation untouched because background delivery semantics are out of scope here.