### PR TITLE
[codex] fix subagent spawn compensation

### DIFF
--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -1086,6 +1086,8 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 let suspended = outcome.is_suspension();
                 outcomes.push(outcome);
                 if suspended && request.stop_on_first_suspension && !batch_await_dependent {
+                    // Suspension is a partial-success boundary, not a failed
+                    // batch; prior successful spawns remain committed.
                     return Ok(CapabilityBatchOutcome {
                         outcomes,
                         stopped_on_suspension: true,
@@ -1119,6 +1121,8 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
             let stopped = inner.stopped_on_suspension;
             outcomes.extend(inner.outcomes);
             if stopped && request.stop_on_first_suspension {
+                // Propagate the inner partial-success stop without rolling back
+                // earlier successful spawns from this outer batch.
                 return Ok(CapabilityBatchOutcome {
                     outcomes,
                     stopped_on_suspension: true,

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -371,10 +371,29 @@ struct SpawnCompensationState {
     gate_written: Option<GateRef>,
     result_written: Option<LoopResultRef>,
     submitted_child_tree: Option<(TurnScope, TurnRunId)>,
+    submitted_child_run: Option<(TurnScope, TurnActor, TurnRunId)>,
+    thread_written: Option<(ThreadScope, ThreadId)>,
 }
 
 impl SpawnCompensationState {
     async fn rollback(&mut self, deps: &SubagentSpawnDeps, run_context: &LoopRunContext) {
+        if let Some((scope, actor, run_id)) = self.submitted_child_run.as_ref()
+            && let Ok(idempotency_key) = IdempotencyKey::new(format!(
+                "subagent-rollback-cancel:{}:{}",
+                run_context.run_id, run_id
+            ))
+        {
+            let _ = deps
+                .turn_state_store
+                .request_cancel(CancelRunRequest {
+                    scope: scope.clone(),
+                    actor: actor.clone(),
+                    run_id: *run_id,
+                    reason: SanitizedCancelReason::Superseded,
+                    idempotency_key,
+                })
+                .await;
+        }
         if let Some(gate_ref) = self.gate_written.as_ref() {
             let _ = deps.gate_store.delete_awaited_child(gate_ref).await;
         }
@@ -392,6 +411,9 @@ impl SpawnCompensationState {
                 .turn_state_store
                 .release_tree_descendants(scope, *tree_root, 1)
                 .await;
+        }
+        if let Some((scope, thread_id)) = self.thread_written.as_ref() {
+            let _ = deps.thread_service.delete_thread(scope, thread_id).await;
         }
     }
 }
@@ -518,15 +540,35 @@ impl SubagentSpawnCapabilityPort {
         args: SpawnSubagentArgs,
         gate_override: Option<GateRef>,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        self.handle_spawn_with_gate_recording(invocation, args, gate_override)
+            .await
+            .map(|(outcome, _)| outcome)
+    }
+
+    async fn handle_spawn_with_gate_recording(
+        &self,
+        invocation: &CapabilityInvocation,
+        args: SpawnSubagentArgs,
+        gate_override: Option<GateRef>,
+    ) -> Result<(CapabilityOutcome, SpawnCompensationState), AgentLoopHostError> {
         let Some(spawn_slot) = self.reserve_spawn_slot() else {
-            return Ok(spawn_rejected("fanout_cap_exceeded"));
+            return Ok((
+                spawn_rejected("fanout_cap_exceeded"),
+                SpawnCompensationState::default(),
+            ));
         };
 
         let Some(agent_id) = self.run_context.scope.agent_id.clone() else {
-            return Ok(spawn_rejected("spawn_requires_agent_scope"));
+            return Ok((
+                spawn_rejected("spawn_requires_agent_scope"),
+                SpawnCompensationState::default(),
+            ));
         };
         let Some(actor) = self.run_context.actor.clone() else {
-            return Ok(spawn_rejected("spawn_requires_actor"));
+            return Ok((
+                spawn_rejected("spawn_requires_actor"),
+                SpawnCompensationState::default(),
+            ));
         };
         let owner_user_id = actor.user_id.clone();
         let parent_record = self
@@ -543,7 +585,10 @@ impl SubagentSpawnCapabilityPort {
             })?;
         let child_depth = parent_record.subagent_depth.saturating_add(1);
         if child_depth > self.limits.max_depth {
-            return Ok(spawn_rejected("depth_cap_exceeded"));
+            return Ok((
+                spawn_rejected("depth_cap_exceeded"),
+                SpawnCompensationState::default(),
+            ));
         }
         let parent_definition = self
             .deps
@@ -552,10 +597,16 @@ impl SubagentSpawnCapabilityPort {
             .await?;
         match parent_definition {
             Some(parent_definition) if !parent_definition.allow_nesting => {
-                return Ok(spawn_rejected("nesting_not_permitted"));
+                return Ok((
+                    spawn_rejected("nesting_not_permitted"),
+                    SpawnCompensationState::default(),
+                ));
             }
             None if parent_record.subagent_depth > 0 => {
-                return Ok(spawn_rejected("nesting_not_permitted"));
+                return Ok((
+                    spawn_rejected("nesting_not_permitted"),
+                    SpawnCompensationState::default(),
+                ));
             }
             _ => {}
         }
@@ -566,7 +617,10 @@ impl SubagentSpawnCapabilityPort {
             .resolve_kind(&args.subagent_kind)
             .await?;
         let Some(definition) = resolved else {
-            return Ok(spawn_rejected("unknown_subagent_kind"));
+            return Ok((
+                spawn_rejected("unknown_subagent_kind"),
+                SpawnCompensationState::default(),
+            ));
         };
 
         let child_scope = ThreadScope {
@@ -595,7 +649,7 @@ impl SubagentSpawnCapabilityPort {
         match result {
             Ok(outcome) => {
                 spawn_slot.commit();
-                Ok(outcome)
+                Ok((outcome, compensation))
             }
             Err(error) => {
                 compensation
@@ -712,6 +766,7 @@ impl SubagentSpawnCapabilityPort {
             })
             .await
             .map_err(map_thread_error)?;
+        compensation.thread_written = Some((child_scope.clone(), child_thread.thread_id.clone()));
         let child_turn_scope = TurnScope::new(
             child_scope.tenant_id.clone(),
             Some(child_scope.agent_id.clone()),
@@ -797,6 +852,7 @@ impl SubagentSpawnCapabilityPort {
             .await
             .map_err(map_turn_error)?;
         compensation.submitted_child_tree = Some((self.run_context.scope.clone(), tree_root));
+        compensation.submitted_child_run = Some((child_turn_scope.clone(), actor.clone(), run_id));
         if let Err(error) = self
             .deps
             .thread_service
@@ -809,8 +865,6 @@ impl SubagentSpawnCapabilityPort {
             )
             .await
         {
-            self.cancel_child_after_submission_failure(&child_turn_scope, actor, run_id)
-                .await?;
             return Err(map_thread_error(error));
         }
 
@@ -822,28 +876,12 @@ impl SubagentSpawnCapabilityPort {
         })
     }
 
-    async fn cancel_child_after_submission_failure(
-        &self,
-        child_scope: &TurnScope,
-        actor: TurnActor,
-        child_run_id: TurnRunId,
-    ) -> Result<(), AgentLoopHostError> {
-        self.deps
-            .turn_state_store
-            .request_cancel(CancelRunRequest {
-                scope: child_scope.clone(),
-                actor,
-                run_id: child_run_id,
-                reason: SanitizedCancelReason::Superseded,
-                idempotency_key: IdempotencyKey::new(format!(
-                    "subagent-cancel:{}:{}",
-                    self.run_context.run_id, child_run_id
-                ))
-                .map_err(invalid_static_ref)?,
-            })
-            .await
-            .map(|_| ())
-            .map_err(map_turn_error)
+    async fn rollback_batch_compensation(&self, compensations: &mut Vec<SpawnCompensationState>) {
+        while let Some(mut compensation) = compensations.pop() {
+            compensation
+                .rollback(self.deps.as_ref(), &self.run_context)
+                .await;
+        }
     }
 }
 
@@ -971,6 +1009,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         request: CapabilityBatchInvocation,
     ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
         let mut outcomes = Vec::with_capacity(request.invocations.len());
+        let mut batch_compensations = Vec::new();
         // Pre-decode every spawn invocation before allocating the shared batch
         // gate. Only batches with at least two valid blocking spawns benefit
         // from gate coalescing; otherwise the gate would be created and never
@@ -1001,18 +1040,41 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
         while index < request.invocations.len() {
             let invocation = &request.invocations[index];
             if self.is_spawn(&invocation.capability_id) {
-                let outcome = if let Some(outcome) = self.authorize_spawn(invocation).await? {
-                    outcome
-                } else {
-                    let args = spawn_args.remove(&index).ok_or_else(|| {
-                        AgentLoopHostError::new(
-                            AgentLoopHostErrorKind::Invalid,
-                            "subagent spawn args missing from pre-decode pass",
-                        )
-                    })?;
-                    let gate_override = batch_blocking_gate.clone();
-                    self.handle_spawn_with_gate(invocation, args, gate_override)
-                        .await?
+                let outcome = match self.authorize_spawn(invocation).await {
+                    Ok(Some(outcome)) => outcome,
+                    Ok(None) => {
+                        let args = match spawn_args.remove(&index) {
+                            Some(args) => args,
+                            None => {
+                                let error = AgentLoopHostError::new(
+                                    AgentLoopHostErrorKind::Invalid,
+                                    "subagent spawn args missing from pre-decode pass",
+                                );
+                                self.rollback_batch_compensation(&mut batch_compensations)
+                                    .await;
+                                return Err(error);
+                            }
+                        };
+                        let gate_override = batch_blocking_gate.clone();
+                        let (outcome, compensation) = match self
+                            .handle_spawn_with_gate_recording(invocation, args, gate_override)
+                            .await
+                        {
+                            Ok(result) => result,
+                            Err(error) => {
+                                self.rollback_batch_compensation(&mut batch_compensations)
+                                    .await;
+                                return Err(error);
+                            }
+                        };
+                        batch_compensations.push(compensation);
+                        outcome
+                    }
+                    Err(error) => {
+                        self.rollback_batch_compensation(&mut batch_compensations)
+                            .await;
+                        return Err(error);
+                    }
                 };
                 let batch_await_dependent = matches!(
                     &outcome,
@@ -1045,7 +1107,15 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                     invocations: request.invocations[start..index].to_vec(),
                     stop_on_first_suspension: request.stop_on_first_suspension,
                 })
-                .await?;
+                .await;
+            let inner = match inner {
+                Ok(inner) => inner,
+                Err(error) => {
+                    self.rollback_batch_compensation(&mut batch_compensations)
+                        .await;
+                    return Err(error);
+                }
+            };
             let stopped = inner.stopped_on_suspension;
             outcomes.extend(inner.outcomes);
             if stopped && request.stop_on_first_suspension {

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -373,26 +373,37 @@ struct SpawnCompensationState {
     submitted_child_tree: Option<(TurnScope, TurnRunId)>,
     submitted_child_run: Option<(TurnScope, TurnActor, TurnRunId)>,
     thread_written: Option<(ThreadScope, ThreadId)>,
+    spawn_slot_committed: bool,
 }
 
 impl SpawnCompensationState {
     async fn rollback(&mut self, deps: &SubagentSpawnDeps, run_context: &LoopRunContext) {
-        if let Some((scope, actor, run_id)) = self.submitted_child_run.as_ref()
-            && let Ok(idempotency_key) = IdempotencyKey::new(format!(
+        if let Some((scope, actor, run_id)) = self.submitted_child_run.as_ref() {
+            match IdempotencyKey::new(format!(
                 "subagent-rollback-cancel:{}:{}",
                 run_context.run_id, run_id
-            ))
-        {
-            let _ = deps
-                .turn_state_store
-                .request_cancel(CancelRunRequest {
-                    scope: scope.clone(),
-                    actor: actor.clone(),
-                    run_id: *run_id,
-                    reason: SanitizedCancelReason::Superseded,
-                    idempotency_key,
-                })
-                .await;
+            )) {
+                Ok(idempotency_key) => {
+                    let _ = deps
+                        .turn_state_store
+                        .request_cancel(CancelRunRequest {
+                            scope: scope.clone(),
+                            actor: actor.clone(),
+                            run_id: *run_id,
+                            reason: SanitizedCancelReason::Superseded,
+                            idempotency_key,
+                        })
+                        .await;
+                }
+                Err(reason) => {
+                    tracing::warn!(
+                        run_id = %run_context.run_id,
+                        child_run_id = %run_id,
+                        %reason,
+                        "subagent rollback skipped child-run cancel because idempotency key was invalid"
+                    );
+                }
+            }
         }
         if let Some(gate_ref) = self.gate_written.as_ref() {
             let _ = deps.gate_store.delete_awaited_child(gate_ref).await;
@@ -540,9 +551,9 @@ impl SubagentSpawnCapabilityPort {
         args: SpawnSubagentArgs,
         gate_override: Option<GateRef>,
     ) -> Result<CapabilityOutcome, AgentLoopHostError> {
-        self.handle_spawn_with_gate_recording(invocation, args, gate_override)
+        let mut compensation = SpawnCompensationState::default();
+        self.handle_spawn_with_gate_recording(invocation, args, gate_override, &mut compensation)
             .await
-            .map(|(outcome, _)| outcome)
     }
 
     async fn handle_spawn_with_gate_recording(
@@ -550,25 +561,17 @@ impl SubagentSpawnCapabilityPort {
         invocation: &CapabilityInvocation,
         args: SpawnSubagentArgs,
         gate_override: Option<GateRef>,
-    ) -> Result<(CapabilityOutcome, SpawnCompensationState), AgentLoopHostError> {
+        compensation: &mut SpawnCompensationState,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
         let Some(spawn_slot) = self.reserve_spawn_slot() else {
-            return Ok((
-                spawn_rejected("fanout_cap_exceeded"),
-                SpawnCompensationState::default(),
-            ));
+            return Ok(spawn_rejected("fanout_cap_exceeded"));
         };
 
         let Some(agent_id) = self.run_context.scope.agent_id.clone() else {
-            return Ok((
-                spawn_rejected("spawn_requires_agent_scope"),
-                SpawnCompensationState::default(),
-            ));
+            return Ok(spawn_rejected("spawn_requires_agent_scope"));
         };
         let Some(actor) = self.run_context.actor.clone() else {
-            return Ok((
-                spawn_rejected("spawn_requires_actor"),
-                SpawnCompensationState::default(),
-            ));
+            return Ok(spawn_rejected("spawn_requires_actor"));
         };
         let owner_user_id = actor.user_id.clone();
         let parent_record = self
@@ -585,10 +588,7 @@ impl SubagentSpawnCapabilityPort {
             })?;
         let child_depth = parent_record.subagent_depth.saturating_add(1);
         if child_depth > self.limits.max_depth {
-            return Ok((
-                spawn_rejected("depth_cap_exceeded"),
-                SpawnCompensationState::default(),
-            ));
+            return Ok(spawn_rejected("depth_cap_exceeded"));
         }
         let parent_definition = self
             .deps
@@ -597,16 +597,10 @@ impl SubagentSpawnCapabilityPort {
             .await?;
         match parent_definition {
             Some(parent_definition) if !parent_definition.allow_nesting => {
-                return Ok((
-                    spawn_rejected("nesting_not_permitted"),
-                    SpawnCompensationState::default(),
-                ));
+                return Ok(spawn_rejected("nesting_not_permitted"));
             }
             None if parent_record.subagent_depth > 0 => {
-                return Ok((
-                    spawn_rejected("nesting_not_permitted"),
-                    SpawnCompensationState::default(),
-                ));
+                return Ok(spawn_rejected("nesting_not_permitted"));
             }
             _ => {}
         }
@@ -617,10 +611,7 @@ impl SubagentSpawnCapabilityPort {
             .resolve_kind(&args.subagent_kind)
             .await?;
         let Some(definition) = resolved else {
-            return Ok((
-                spawn_rejected("unknown_subagent_kind"),
-                SpawnCompensationState::default(),
-            ));
+            return Ok(spawn_rejected("unknown_subagent_kind"));
         };
 
         let child_scope = ThreadScope {
@@ -634,7 +625,6 @@ impl SubagentSpawnCapabilityPort {
         let tree_root = parent_record
             .spawn_tree_root_run_id
             .unwrap_or(self.run_context.run_id);
-        let mut compensation = SpawnCompensationState::default();
         let spawn_ctx = SpawnContext {
             definition,
             child_scope,
@@ -644,12 +634,13 @@ impl SubagentSpawnCapabilityPort {
         };
 
         let result = self
-            .finish_spawn(args, spawn_ctx, actor, invocation, &mut compensation)
+            .finish_spawn(args, spawn_ctx, actor, invocation, compensation)
             .await;
         match result {
             Ok(outcome) => {
                 spawn_slot.commit();
-                Ok((outcome, compensation))
+                compensation.spawn_slot_committed = true;
+                Ok(outcome)
             }
             Err(error) => {
                 compensation
@@ -878,9 +869,13 @@ impl SubagentSpawnCapabilityPort {
 
     async fn rollback_batch_compensation(&self, compensations: &mut Vec<SpawnCompensationState>) {
         while let Some(mut compensation) = compensations.pop() {
+            let release_spawn_slot = compensation.spawn_slot_committed;
             compensation
                 .rollback(self.deps.as_ref(), &self.run_context)
                 .await;
+            if release_spawn_slot {
+                self.release_spawn_slot();
+            }
         }
     }
 }
@@ -1056,8 +1051,14 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                             }
                         };
                         let gate_override = batch_blocking_gate.clone();
-                        let (outcome, compensation) = match self
-                            .handle_spawn_with_gate_recording(invocation, args, gate_override)
+                        let mut compensation = SpawnCompensationState::default();
+                        let outcome = match self
+                            .handle_spawn_with_gate_recording(
+                                invocation,
+                                args,
+                                gate_override,
+                                &mut compensation,
+                            )
                             .await
                         {
                             Ok(result) => result,

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port.rs
@@ -868,6 +868,9 @@ impl SubagentSpawnCapabilityPort {
     }
 
     async fn rollback_batch_compensation(&self, compensations: &mut Vec<SpawnCompensationState>) {
+        // Roll back in reverse creation order. Each compensation performs
+        // destructive best-effort cleanup, so keeping this serial preserves a
+        // deterministic unwind order across child runs and their resources.
         while let Some(mut compensation) = compensations.pop() {
             let release_spawn_slot = compensation.spawn_slot_committed;
             compensation
@@ -1089,6 +1092,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
                 if suspended && request.stop_on_first_suspension && !batch_await_dependent {
                     // Suspension is a partial-success boundary, not a failed
                     // batch; prior successful spawns remain committed.
+                    batch_compensations.clear();
                     return Ok(CapabilityBatchOutcome {
                         outcomes,
                         stopped_on_suspension: true,
@@ -1124,6 +1128,7 @@ impl LoopCapabilityPort for SubagentSpawnCapabilityPort {
             if stopped && request.stop_on_first_suspension {
                 // Propagate the inner partial-success stop without rolling back
                 // earlier successful spawns from this outer batch.
+                batch_compensations.clear();
                 return Ok(CapabilityBatchOutcome {
                     outcomes,
                     stopped_on_suspension: true,

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -65,6 +65,8 @@ struct RecordingBatchPort {
     batches: std::sync::Mutex<Vec<CapabilityBatchInvocation>>,
 }
 
+struct FailingBatchPort;
+
 struct NoopResultWriter;
 
 struct NoopGoalStore;
@@ -469,6 +471,36 @@ impl LoopCapabilityResultWriter for NoopResultWriter {
 }
 
 #[async_trait]
+impl LoopCapabilityPort for FailingBatchPort {
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        Ok(VisibleCapabilitySurface {
+            version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+            descriptors: Vec::new(),
+        })
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        Ok(completed_outcome(request.capability_id.as_str()))
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        _request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Unavailable,
+            "forced batch failure",
+        ))
+    }
+}
+
+#[async_trait]
 impl SubagentSpawnGoalStore for NoopGoalStore {
     async fn put_goal(
         &self,
@@ -715,6 +747,14 @@ impl SessionThreadService for FailingMarkThreadService {
         request: ThreadHistoryRequest,
     ) -> Result<SessionThreadRecord, SessionThreadError> {
         self.inner.read_thread(request).await
+    }
+
+    async fn delete_thread(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        self.inner.delete_thread(scope, thread_id).await
     }
 
     async fn create_summary_artifact(
@@ -1783,6 +1823,84 @@ async fn invoke_capability_batch_handles_mixed_spawn_and_non_spawn_invocations()
 }
 
 #[tokio::test]
+async fn invoke_capability_batch_rolls_back_preceding_spawn_on_inner_batch_failure() {
+    let context = test_run_context_with_agent_actor("spawn-batch-rollback").await;
+    let actor = context.actor.clone().unwrap();
+    let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let goal_store = Arc::new(RecordingGoalStore::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: turn_store.clone(),
+        thread_service: thread_service.clone(),
+        goal_store: goal_store.clone(),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: default_spawn_args(),
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        Arc::new(FailingBatchPort),
+        context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+    port.auth_input_refs
+        .lock()
+        .unwrap()
+        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+
+    let error = port
+        .invoke_capability_batch(CapabilityBatchInvocation {
+            invocations: vec![
+                invocation(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID),
+                invocation("regular.fails"),
+            ],
+            stop_on_first_suspension: false,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::Unavailable);
+    let child_requests = child_runs.requests();
+    assert_eq!(child_requests.len(), 1);
+    let child_request = &child_requests[0];
+    let cancels = turn_store.cancels();
+    assert_eq!(cancels.len(), 1);
+    assert_eq!(Some(cancels[0].run_id), child_request.requested_run_id);
+    assert!(gate_store.records().is_empty());
+    assert_eq!(goal_store.deletes().len(), 1);
+    assert_eq!(turn_store.releases.lock().unwrap().len(), 1);
+
+    let child_thread_scope = ThreadScope {
+        tenant_id: child_request.child_scope.tenant_id.clone(),
+        agent_id: child_request.child_scope.agent_id.clone().unwrap(),
+        project_id: child_request.child_scope.project_id.clone(),
+        owner_user_id: Some(actor.user_id),
+        mission_id: None,
+    };
+    let read = thread_service
+        .read_thread(ThreadHistoryRequest {
+            scope: child_thread_scope,
+            thread_id: child_request.child_scope.thread_id.clone(),
+        })
+        .await;
+    assert!(matches!(
+        read,
+        Err(SessionThreadError::UnknownThread { .. })
+    ));
+}
+
+#[tokio::test]
 async fn invoke_capability_batch_stops_on_first_spawn_suspension_when_requested() {
     let context = test_run_context_with_agent_actor("spawn-batch-stop").await;
     let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
@@ -1831,15 +1949,17 @@ async fn invoke_capability_batch_stops_on_first_spawn_suspension_when_requested(
 #[tokio::test]
 async fn invoke_spawn_cancels_child_when_post_submit_thread_mark_fails() {
     let context = test_run_context_with_agent_actor("spawn-mark-fails").await;
+    let actor = context.actor.clone().unwrap();
     let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
     let child_runs = Arc::new(RecordingChildRuns::default());
     let goal_store = Arc::new(RecordingGoalStore::default());
     let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let thread_service = Arc::new(FailingMarkThreadService::default());
     let deps = Arc::new(SubagentSpawnDeps {
         coordinator: Arc::new(StaticCoordinator),
         child_runs: child_runs.clone(),
         turn_state_store: turn_store.clone(),
-        thread_service: Arc::new(FailingMarkThreadService::default()),
+        thread_service: thread_service.clone(),
         goal_store: goal_store.clone(),
         gate_store: gate_store.clone(),
         definition_resolver: Arc::new(StaticDefinitionResolver {
@@ -1880,6 +2000,25 @@ async fn invoke_spawn_cancels_child_when_post_submit_thread_mark_fails() {
     );
     assert!(gate_store.records().is_empty());
     assert_eq!(goal_store.deletes().len(), 1);
+    let child_requests = child_runs.requests();
+    let child_request = &child_requests[0];
+    let child_thread_scope = ThreadScope {
+        tenant_id: child_request.child_scope.tenant_id.clone(),
+        agent_id: child_request.child_scope.agent_id.clone().unwrap(),
+        project_id: child_request.child_scope.project_id.clone(),
+        owner_user_id: Some(actor.user_id),
+        mission_id: None,
+    };
+    let read = thread_service
+        .read_thread(ThreadHistoryRequest {
+            scope: child_thread_scope,
+            thread_id: child_request.child_scope.thread_id.clone(),
+        })
+        .await;
+    assert!(matches!(
+        read,
+        Err(SessionThreadError::UnknownThread { .. })
+    ));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -1851,7 +1851,10 @@ async fn invoke_capability_batch_rolls_back_preceding_spawn_on_inner_batch_failu
         Arc::new(FailingBatchPort),
         context,
         CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
-        SubagentSpawnLimits::default(),
+        SubagentSpawnLimits {
+            max_spawn_per_turn: 1,
+            ..SubagentSpawnLimits::default()
+        },
         deps,
     );
     port.auth_input_refs
@@ -1898,6 +1901,18 @@ async fn invoke_capability_batch_rolls_back_preceding_spawn_on_inner_batch_failu
         read,
         Err(SessionThreadError::UnknownThread { .. })
     ));
+
+    port.auth_input_refs.lock().unwrap().insert(
+        input_ref(),
+        CapabilityInputRef::new("input:auth-retry").unwrap(),
+    );
+    assert!(
+        matches!(
+            invoke_spawn(&port).await,
+            CapabilityOutcome::AwaitDependentRun { .. }
+        ),
+        "rolled-back batch spawns must release their per-turn spawn slot"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
+++ b/crates/ironclaw_loop_support/src/subagent_spawn_port/tests.rs
@@ -67,6 +67,11 @@ struct RecordingBatchPort {
 
 struct FailingBatchPort;
 
+#[derive(Default)]
+struct SuspendedBatchPort {
+    batches: std::sync::Mutex<Vec<CapabilityBatchInvocation>>,
+}
+
 struct NoopResultWriter;
 
 struct NoopGoalStore;
@@ -456,6 +461,43 @@ impl LoopCapabilityPort for RecordingBatchPort {
                 .map(|invocation| completed_outcome(invocation.capability_id.as_str()))
                 .collect(),
             stopped_on_suspension: false,
+        })
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for SuspendedBatchPort {
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        Ok(VisibleCapabilitySurface {
+            version: CapabilitySurfaceVersion::new("surface:test").unwrap(),
+            descriptors: Vec::new(),
+        })
+    }
+
+    async fn invoke_capability(
+        &self,
+        _request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        Ok(CapabilityOutcome::ApprovalRequired {
+            gate_ref: LoopGateRef::new("gate:inner-suspended").unwrap(),
+            safe_summary: "approval required".to_string(),
+        })
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        self.batches.lock().unwrap().push(request);
+        Ok(CapabilityBatchOutcome {
+            outcomes: vec![CapabilityOutcome::ApprovalRequired {
+                gate_ref: LoopGateRef::new("gate:inner-suspended").unwrap(),
+                safe_summary: "approval required".to_string(),
+            }],
+            stopped_on_suspension: true,
         })
     }
 }
@@ -1857,10 +1899,7 @@ async fn invoke_capability_batch_rolls_back_preceding_spawn_on_inner_batch_failu
         },
         deps,
     );
-    port.auth_input_refs
-        .lock()
-        .unwrap()
-        .insert(input_ref(), CapabilityInputRef::new("input:auth").unwrap());
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
 
     let error = port
         .invoke_capability_batch(CapabilityBatchInvocation {
@@ -1902,10 +1941,7 @@ async fn invoke_capability_batch_rolls_back_preceding_spawn_on_inner_batch_failu
         Err(SessionThreadError::UnknownThread { .. })
     ));
 
-    port.auth_input_refs.lock().unwrap().insert(
-        input_ref(),
-        CapabilityInputRef::new("input:auth-retry").unwrap(),
-    );
+    port.auth_input_refs.lock().unwrap().insert(input_ref());
     assert!(
         matches!(
             invoke_spawn(&port).await,
@@ -1918,15 +1954,20 @@ async fn invoke_capability_batch_rolls_back_preceding_spawn_on_inner_batch_failu
 #[tokio::test]
 async fn invoke_capability_batch_stops_on_first_spawn_suspension_when_requested() {
     let context = test_run_context_with_agent_actor("spawn-batch-stop").await;
+    let actor = context.actor.clone().unwrap();
     let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let goal_store = Arc::new(RecordingGoalStore::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
     let inner = Arc::new(RecordingBatchPort::default());
     let deps = Arc::new(SubagentSpawnDeps {
         coordinator: Arc::new(StaticCoordinator),
-        child_runs: Arc::new(RecordingChildRuns::default()),
-        turn_state_store: turn_store,
-        thread_service: Arc::new(InMemorySessionThreadService::default()),
-        goal_store: Arc::new(NoopGoalStore),
-        gate_store: Arc::new(InMemorySubagentGateResolutionStore::default()),
+        child_runs: child_runs.clone(),
+        turn_state_store: turn_store.clone(),
+        thread_service: thread_service.clone(),
+        goal_store: goal_store.clone(),
+        gate_store: gate_store.clone(),
         definition_resolver: Arc::new(StaticDefinitionResolver {
             resolved: Some(subagent_definition(false)),
             parent: None,
@@ -1959,6 +2000,110 @@ async fn invoke_capability_batch_stops_on_first_spawn_suspension_when_requested(
     assert_eq!(outcome.outcomes.len(), 1);
     assert!(outcome.stopped_on_suspension);
     assert!(inner.batches.lock().unwrap().is_empty());
+    let child_requests = child_runs.requests();
+    assert_eq!(child_requests.len(), 1);
+    assert!(turn_store.cancels().is_empty());
+    assert!(turn_store.releases.lock().unwrap().is_empty());
+    assert!(goal_store.deletes().is_empty());
+    assert_eq!(goal_store.puts().len(), 1);
+    assert_eq!(gate_store.records().len(), 1);
+
+    let child_request = &child_requests[0];
+    let child_thread_scope = ThreadScope {
+        tenant_id: child_request.child_scope.tenant_id.clone(),
+        agent_id: child_request.child_scope.agent_id.clone().unwrap(),
+        project_id: child_request.child_scope.project_id.clone(),
+        owner_user_id: Some(actor.user_id),
+        mission_id: None,
+    };
+    let read = thread_service
+        .read_thread(ThreadHistoryRequest {
+            scope: child_thread_scope,
+            thread_id: child_request.child_scope.thread_id.clone(),
+        })
+        .await;
+    assert!(
+        read.is_ok(),
+        "partial-success suspension must keep the child thread committed"
+    );
+}
+
+#[tokio::test]
+async fn invoke_capability_batch_preserves_spawns_on_inner_batch_suspension() {
+    let context = test_run_context_with_agent_actor("spawn-inner-batch-stop").await;
+    let turn_store = Arc::new(StaticTurnStateStore::new(Some(turn_record(&context, 0))));
+    let child_runs = Arc::new(RecordingChildRuns::default());
+    let goal_store = Arc::new(RecordingGoalStore::default());
+    let gate_store = Arc::new(InMemorySubagentGateResolutionStore::default());
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let inner = Arc::new(SuspendedBatchPort::default());
+    let deps = Arc::new(SubagentSpawnDeps {
+        coordinator: Arc::new(StaticCoordinator),
+        child_runs: child_runs.clone(),
+        turn_state_store: turn_store.clone(),
+        thread_service,
+        goal_store: goal_store.clone(),
+        gate_store: gate_store.clone(),
+        definition_resolver: Arc::new(StaticDefinitionResolver {
+            resolved: Some(subagent_definition(false)),
+            parent: None,
+        }),
+        spawn_input_codec: Arc::new(StaticSpawnInputCodec {
+            args: default_spawn_args(),
+        }),
+        result_writer: Arc::new(NoopResultWriter),
+    });
+    let port = SubagentSpawnCapabilityPort::new(
+        inner.clone(),
+        context,
+        CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap(),
+        SubagentSpawnLimits::default(),
+        deps,
+    );
+    let input_ref_a = CapabilityInputRef::new("input:spawn-a").unwrap();
+    let input_ref_b = CapabilityInputRef::new("input:spawn-b").unwrap();
+    {
+        let mut refs = port.auth_input_refs.lock().unwrap();
+        refs.insert(input_ref_a.clone());
+        refs.insert(input_ref_b.clone());
+    }
+
+    let spawn_id = CapabilityId::new(DEFAULT_SPAWN_SUBAGENT_CAPABILITY_ID).unwrap();
+    let inner_id = CapabilityId::new("inner.suspended").unwrap();
+    let surface_version = CapabilitySurfaceVersion::new("surface:test").unwrap();
+    let outcome = port
+        .invoke_capability_batch(CapabilityBatchInvocation {
+            invocations: vec![
+                CapabilityInvocation {
+                    surface_version: surface_version.clone(),
+                    capability_id: spawn_id.clone(),
+                    input_ref: input_ref_a,
+                },
+                CapabilityInvocation {
+                    surface_version: surface_version.clone(),
+                    capability_id: spawn_id,
+                    input_ref: input_ref_b,
+                },
+                CapabilityInvocation {
+                    surface_version,
+                    capability_id: inner_id,
+                    input_ref: CapabilityInputRef::new("input:inner").unwrap(),
+                },
+            ],
+            stop_on_first_suspension: true,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.outcomes.len(), 3);
+    assert!(outcome.stopped_on_suspension);
+    assert_eq!(inner.batches.lock().unwrap().len(), 1);
+    assert_eq!(child_runs.requests().len(), 2);
+    assert!(turn_store.cancels().is_empty());
+    assert!(turn_store.releases.lock().unwrap().is_empty());
+    assert!(goal_store.deletes().is_empty());
+    assert_eq!(goal_store.puts().len(), 2);
+    assert_eq!(gate_store.records().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/src/subagent/completion_observer.rs
+++ b/crates/ironclaw_reborn/src/subagent/completion_observer.rs
@@ -798,7 +798,9 @@ mod tests {
         TurnStateStore, events::TurnLifecycleEvent,
     };
 
-    use crate::subagent::goal_store::InMemoryBoundedSubagentGoalStore;
+    use crate::subagent::goal_store::{
+        InMemoryBoundedSubagentGoalStore, SubagentGoal, SubagentGoalStoreError,
+    };
 
     use super::*;
 
@@ -1290,6 +1292,16 @@ mod tests {
 
         let gate_store = Arc::new(BoundedSubagentGateResolutionStore::new());
         let goal_store = Arc::new(InMemoryBoundedSubagentGoalStore::new());
+        goal_store
+            .put(
+                &child_scope,
+                child_run_id,
+                SubagentGoal {
+                    task: "child task".to_string(),
+                    handoff: None,
+                },
+            )
+            .unwrap();
         let mut parent_run_context =
             ironclaw_agent_loop::test_support::test_run_context("completion-observer");
         parent_run_context.scope = parent_scope.clone();
@@ -1318,7 +1330,7 @@ mod tests {
         let result_writer = Arc::new(RecordingResultWriter::new(result_ref));
         let observer = SubagentCompletionObserver::new(
             Arc::clone(&gate_store),
-            goal_store,
+            goal_store.clone(),
             turn_state_store.clone(),
             result_writer.clone(),
             Arc::new(RecordingCoordinator::default()),
@@ -1329,7 +1341,7 @@ mod tests {
         observer
             .handle_terminal(&TurnLifecycleEvent {
                 cursor: EventCursor(7),
-                scope: child_scope,
+                scope: child_scope.clone(),
                 occurred_at: None,
                 owner_user_id: Some(owner),
                 run_id: child_run_id,
@@ -1345,6 +1357,10 @@ mod tests {
             turn_state_store.releases(),
             vec![(parent_scope.clone(), tree_root_run_id, 1)]
         );
+        assert!(matches!(
+            goal_store.get(&child_scope, child_run_id),
+            Err(SubagentGoalStoreError::NotFound { .. })
+        ));
         let writes = result_writer.writes();
         assert_eq!(writes.len(), 1);
         assert_eq!(writes[0]["status"], "completed");

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -20,7 +20,7 @@
 //! property that satisfies the "narrow Reborn public surface" requirement
 //! pinned by `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -84,7 +84,7 @@ use ironclaw_turns::{
     ReplyTargetBindingRef, RunProfileResolutionRequest, SanitizedCancelReason, SourceBindingRef,
     SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError,
     TurnEventProjectionSource, TurnId, TurnPersistenceSnapshot, TurnRunId, TurnRunRecord,
-    TurnScope, TurnStatus,
+    TurnScope, TurnSpawnTreeStateStore, TurnStatus,
     run_profile::{LoopHostMilestoneSink, LoopRunContext},
 };
 
@@ -206,6 +206,7 @@ impl From<DefaultPlannedRuntimeBuildError> for RebornRuntimeError {
 pub struct RebornRuntime {
     services: RebornServices,
     turn_coordinator: Arc<dyn TurnCoordinator>,
+    turn_tree_store: Arc<dyn TurnSpawnTreeStateStore>,
     thread_service: Arc<dyn SessionThreadService>,
     thread_scope: ThreadScope,
     worker_handle: JoinHandle<()>,
@@ -540,7 +541,10 @@ impl RebornRuntime {
         )))
     }
 
+    /// Test-only override for the runtime HTTP egress handle that mirrors the
+    /// local runtime service slot populated by build_reborn_runtime.
     #[cfg(all(test, feature = "slack-v2-host-beta"))]
+    #[allow(dead_code)]
     pub(crate) fn set_local_runtime_http_egress_for_test(
         &mut self,
         runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,
@@ -1095,14 +1099,87 @@ impl RebornRuntime {
                 .map_err(|reason| RebornRuntimeError::InvalidArgument { reason })?,
             })
             .await?;
-        if matches!(
+        let cancellation_accepted = matches!(
             response.status,
             TurnStatus::CancelRequested | TurnStatus::Cancelled
-        ) {
+        );
+        if cancellation_accepted {
             self.append_webui_loop_cancelled(scope, run_id).await?;
         }
         self.wake_sender.wake();
+        if cancellation_accepted {
+            self.cancel_descendant_runs(scope, run_id, reason, idempotency_suffix)
+                .await?;
+        }
         Ok(response)
+    }
+
+    async fn cancel_descendant_runs(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        reason: SanitizedCancelReason,
+        idempotency_suffix: &str,
+    ) -> Result<(), RebornRuntimeError> {
+        let mut stack = self.turn_tree_store.children_of(scope, run_id).await?;
+        while let Some(child) = stack.pop() {
+            let grandchildren = self
+                .turn_tree_store
+                .children_of(&child.scope, child.run_id)
+                .await?;
+            stack.extend(grandchildren);
+            if child.status.is_terminal() {
+                continue;
+            }
+            let idempotency_key = IdempotencyKey::new(format!(
+                "{}-{}-descendant-{}",
+                self.source_binding_ref.as_str(),
+                idempotency_suffix,
+                child.run_id
+            ))
+            .map_err(|reason| RebornRuntimeError::InvalidArgument { reason })?;
+            let child_scope = child.scope.clone();
+            let child_run_id = child.run_id;
+            let response = self
+                .turn_coordinator
+                .cancel_run(CancelRunRequest {
+                    scope: child_scope.clone(),
+                    actor: TurnActor::new(self.actor_user_id.clone()),
+                    run_id: child_run_id,
+                    reason,
+                    idempotency_key,
+                })
+                .await;
+            let response = match response {
+                Ok(response) => response,
+                Err(error) => {
+                    let state = self
+                        .turn_coordinator
+                        .get_run_state(GetRunStateRequest {
+                            scope: child_scope,
+                            run_id: child_run_id,
+                        })
+                        .await?;
+                    if matches!(
+                        state.status,
+                        TurnStatus::CancelRequested | TurnStatus::Cancelled
+                    ) {
+                        self.wake_sender.wake();
+                        continue;
+                    }
+                    return Err(error.into());
+                }
+            };
+            if matches!(
+                response.status,
+                TurnStatus::CancelRequested | TurnStatus::Cancelled
+            ) {
+                self.append_webui_loop_cancelled(&child.scope, child_run_id)
+                    .await?;
+            }
+            self.wake_sender.wake();
+        }
+        Ok(())
     }
 
     async fn append_webui_loop_cancelled(
@@ -1651,6 +1728,7 @@ pub async fn build_reborn_runtime(
     Ok(RebornRuntime {
         services,
         turn_coordinator,
+        turn_tree_store: turn_state_store,
         thread_service,
         thread_scope,
         worker_handle,
@@ -1999,6 +2077,7 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use chrono::Utc;
     use ironclaw_auth::{GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_CALENDAR_READONLY_SCOPE};
 
     /// Wiring guard: the `regex_skill_activation_enabled` flag from
@@ -2044,7 +2123,7 @@ mod tests {
     use ironclaw_host_api::{
         Action, AgentId, ApprovalRequest, ApprovalRequestId, AuditStage, CapabilityId,
         CorrelationId, EffectKind, InvocationFingerprint, InvocationId, Principal,
-        ResourceEstimate, ResourceScope, TenantId, UserId,
+        ResourceEstimate, ResourceScope, TenantId, ThreadId, UserId,
         runtime_policy::{
             ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy,
             FilesystemBackendKind, NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
@@ -2054,6 +2133,7 @@ mod tests {
         HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
         HostManagedModelMessageRole, HostManagedModelRequest, HostManagedModelResponse,
         HostSkillContextBuildError, HostSkillContextCandidate, HostSkillContextSource, ModelCost,
+        SpawnSubagentMode, SubagentKindId, SubagentThreadKind, SubagentThreadMetadata,
     };
     use ironclaw_product_adapters::{ProductOutboundPayload, ProductProjectionItem};
     use ironclaw_product_workflow::{
@@ -2066,11 +2146,15 @@ mod tests {
     };
     use ironclaw_run_state::ApprovalRequestStore;
     use ironclaw_skills::SkillTrust;
-    use ironclaw_threads::{LoadContextMessagesRequest, MessageKind, ThreadHistoryRequest};
+    use ironclaw_threads::{
+        AppendToolResultReferenceRequest, EnsureThreadRequest, LoadContextMessagesRequest,
+        MessageKind, ThreadHistoryRequest, ThreadScope, ToolResultSafeSummary,
+    };
     use ironclaw_turns::{
-        AcceptedMessageRef, BlockedReason, IdempotencyKey, ReplyTargetBindingRef, SourceBindingRef,
-        SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCheckpointId, TurnId, TurnLeaseToken,
-        TurnRunId, TurnRunnerId, TurnStatus,
+        AcceptedMessageRef, AllowAllTurnAdmissionPolicy, BlockedReason, GetRunStateRequest,
+        IdempotencyKey, LoopResultRef, ReplyTargetBindingRef, SanitizedCancelReason,
+        SourceBindingRef, SubmitChildRunRequest, SubmitTurnRequest, SubmitTurnResponse, TurnActor,
+        TurnCheckpointId, TurnId, TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope, TurnStatus,
         run_profile::{
             InMemoryRunProfileResolver, LoopCapabilityPort, LoopCheckpointStateRef, LoopRunContext,
             ModelProfileId, ProviderToolCall, RunProfileResolutionRequest, RunProfileResolver,
@@ -2883,6 +2967,156 @@ mod tests {
         assert_eq!(reply.status, TurnStatus::Completed);
         assert_eq!(reply.text.as_deref(), Some("recorded runtime reply"));
         assert_eq!(recorded_request_count(&requests), 1);
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn cancel_run_propagates_to_subagent_children() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let gateway = Arc::new(RecordingGateway {
+            reply: "unused".to_string(),
+            requests: Arc::new(StdMutex::new(Vec::new())),
+        });
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev(
+                "runtime-cancel-child-owner",
+                root.path().join("local-dev"),
+            )
+            .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-cancel-child-tenant".to_string(),
+            agent_id: "runtime-cancel-child-agent".to_string(),
+            source_binding_id: "runtime-cancel-child-source".to_string(),
+            reply_target_binding_id: "runtime-cancel-child-reply".to_string(),
+        })
+        .with_model_gateway_override(gateway);
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let conversation = runtime.new_conversation().await.expect("conversation");
+        let parent_scope = runtime.turn_scope_for(&conversation.0);
+        let actor = TurnActor::new(runtime.actor_user_id.clone());
+        let parent = runtime
+            .turn_coordinator
+            .submit_turn(SubmitTurnRequest {
+                scope: parent_scope.clone(),
+                actor: actor.clone(),
+                accepted_message_ref: AcceptedMessageRef::new("msg:cancel-parent").unwrap(),
+                source_binding_ref: SourceBindingRef::new("source:cancel-parent").unwrap(),
+                reply_target_binding_ref: ReplyTargetBindingRef::new("reply:cancel-parent")
+                    .unwrap(),
+                requested_run_profile: None,
+                idempotency_key: IdempotencyKey::new("cancel-parent").unwrap(),
+                received_at: Utc::now(),
+                requested_run_id: None,
+                parent_run_id: None,
+                subagent_depth: 0,
+                spawn_tree_root_run_id: None,
+            })
+            .await
+            .expect("parent submitted");
+        let SubmitTurnResponse::Accepted {
+            run_id: parent_run_id,
+            ..
+        } = parent;
+        let child_scope = TurnScope::new(
+            parent_scope.tenant_id.clone(),
+            parent_scope.agent_id.clone(),
+            parent_scope.project_id.clone(),
+            ThreadId::new("runtime-cancel-child-thread").unwrap(),
+        );
+        let child = runtime
+            .turn_tree_store
+            .submit_child_turn(
+                SubmitChildRunRequest {
+                    parent_scope: parent_scope.clone(),
+                    parent_run_id,
+                    child_scope: child_scope.clone(),
+                    actor,
+                    accepted_message_ref: AcceptedMessageRef::new("msg:cancel-child").unwrap(),
+                    source_binding_ref: SourceBindingRef::new("source:cancel-child").unwrap(),
+                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply:cancel-child")
+                        .unwrap(),
+                    requested_run_profile: None,
+                    idempotency_key: IdempotencyKey::new("cancel-child").unwrap(),
+                    received_at: Utc::now(),
+                    requested_run_id: None,
+                    spawn_tree_descendant_cap: 4,
+                },
+                &AllowAllTurnAdmissionPolicy,
+                &InMemoryRunProfileResolver::default(),
+            )
+            .await
+            .expect("child submitted");
+        let SubmitTurnResponse::Accepted {
+            run_id: child_run_id,
+            ..
+        } = child;
+        let result_ref = LoopResultRef::new("result:runtime-cancel-child").unwrap();
+        runtime
+            .thread_service
+            .append_tool_result_reference(AppendToolResultReferenceRequest {
+                scope: runtime.thread_scope.clone(),
+                thread_id: parent_scope.thread_id.clone(),
+                turn_run_id: parent_run_id.to_string(),
+                result_ref: result_ref.as_str().to_string(),
+                safe_summary: ToolResultSafeSummary::new("subagent spawned").unwrap(),
+                provider_call: None,
+            })
+            .await
+            .expect("parent result reference seeded");
+        let child_thread_scope = ThreadScope {
+            tenant_id: child_scope.tenant_id.clone(),
+            agent_id: child_scope.agent_id.clone().unwrap(),
+            project_id: child_scope.project_id.clone(),
+            owner_user_id: Some(runtime.actor_user_id.clone()),
+            mission_id: None,
+        };
+        runtime
+            .thread_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: child_thread_scope,
+                thread_id: Some(child_scope.thread_id.clone()),
+                created_by_actor_id: "test".to_string(),
+                title: Some("Subagent".to_string()),
+                metadata_json: Some(
+                    serde_json::to_string(&SubagentThreadMetadata {
+                        kind: SubagentThreadKind::Subagent,
+                        parent_run_id,
+                        parent_thread_id: parent_scope.thread_id.clone(),
+                        tree_root_run_id: parent_run_id,
+                        child_run_id,
+                        subagent_kind: SubagentKindId::new("general").unwrap(),
+                        mode: SpawnSubagentMode::Blocking,
+                        result_ref,
+                        handoff: None,
+                    })
+                    .unwrap(),
+                ),
+            })
+            .await
+            .expect("child thread metadata seeded");
+
+        runtime
+            .cancel_run(
+                &parent_scope,
+                parent_run_id,
+                SanitizedCancelReason::UserRequested,
+                "test-parent-cancel",
+            )
+            .await
+            .expect("parent cancellation succeeds");
+
+        let child_state = runtime
+            .turn_coordinator
+            .get_run_state(GetRunStateRequest {
+                scope: child_scope,
+                run_id: child_run_id,
+            })
+            .await
+            .expect("child state");
+        assert_eq!(child_state.status, TurnStatus::Cancelled);
 
         runtime.shutdown().await.expect("runtime shutdown");
     }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1142,14 +1142,14 @@ impl RebornRuntime {
                 );
                 break;
             }
+            if child.status.is_terminal() {
+                continue;
+            }
             let grandchildren = self
                 .turn_tree_store
                 .children_of(&child.scope, child.run_id)
                 .await?;
             stack.extend(grandchildren);
-            if child.status.is_terminal() {
-                continue;
-            }
             let idempotency_key = IdempotencyKey::new(format!(
                 "{}-{}-descendant-{}",
                 self.source_binding_ref.as_str(),

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -31,6 +31,8 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+const MAX_DESCENDANT_CANCEL_NODES: usize = 1_000;
+
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 use ironclaw_conversations::InMemoryConversationServices;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -545,6 +547,8 @@ impl RebornRuntime {
     /// local runtime service slot populated by build_reborn_runtime.
     #[cfg(all(test, feature = "slack-v2-host-beta"))]
     #[allow(dead_code)]
+    /// Test-only mutator for the local runtime HTTP egress binding used by
+    /// production capability policy wiring during runtime construction.
     pub(crate) fn set_local_runtime_http_egress_for_test(
         &mut self,
         runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,
@@ -1122,7 +1126,22 @@ impl RebornRuntime {
         idempotency_suffix: &str,
     ) -> Result<(), RebornRuntimeError> {
         let mut stack = self.turn_tree_store.children_of(scope, run_id).await?;
+        let mut visited = HashSet::new();
+        let mut visited_count = 0_usize;
         while let Some(child) = stack.pop() {
+            if !visited.insert(child.run_id) {
+                continue;
+            }
+            visited_count += 1;
+            if visited_count > MAX_DESCENDANT_CANCEL_NODES {
+                tracing::warn!(
+                    scope = ?scope,
+                    run_id = %run_id,
+                    max_nodes = MAX_DESCENDANT_CANCEL_NODES,
+                    "stopped descendant cancellation traversal after node budget was reached"
+                );
+                break;
+            }
             let grandchildren = self
                 .turn_tree_store
                 .children_of(&child.scope, child.run_id)

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -1309,17 +1309,13 @@ where
         scope: &ThreadScope,
         thread_id: &ThreadId,
     ) -> Result<(), SessionThreadError> {
-        let record = self
-            .read_thread(ThreadHistoryRequest {
-                scope: scope.clone(),
-                thread_id: thread_id.clone(),
-            })
-            .await?;
-        if record.scope != *scope {
-            return Err(SessionThreadError::UnknownThread {
-                thread_id: thread_id.clone(),
-            });
-        }
+        // read_thread/read_thread_versioned enforce exact-scope ownership and
+        // preserve the same UnknownThread shape for absent or cross-scope rows.
+        self.read_thread(ThreadHistoryRequest {
+            scope: scope.clone(),
+            thread_id: thread_id.clone(),
+        })
+        .await?;
         match self
             .filesystem
             .delete(&scope.to_resource_scope(), &thread_root(scope, thread_id)?)

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -1304,6 +1304,24 @@ where
         Ok(thread.record)
     }
 
+    async fn delete_thread(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        match self
+            .filesystem
+            .delete(&scope.to_resource_scope(), &thread_root(scope, thread_id)?)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(error) if is_not_found(&error) => Err(SessionThreadError::UnknownThread {
+                thread_id: thread_id.clone(),
+            }),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     async fn create_summary_artifact(
         &self,
         request: CreateSummaryArtifactRequest,
@@ -1599,6 +1617,13 @@ fn thread_record_path(
         "{}/thread.json",
         thread_root_string(scope, thread_id)
     ))
+}
+
+fn thread_root(
+    scope: &ThreadScope,
+    thread_id: &ThreadId,
+) -> Result<ScopedPath, SessionThreadError> {
+    scoped_path(&thread_root_string(scope, thread_id))
 }
 
 fn messages_root(

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -1309,6 +1309,17 @@ where
         scope: &ThreadScope,
         thread_id: &ThreadId,
     ) -> Result<(), SessionThreadError> {
+        let record = self
+            .read_thread(ThreadHistoryRequest {
+                scope: scope.clone(),
+                thread_id: thread_id.clone(),
+            })
+            .await?;
+        if record.scope != *scope {
+            return Err(SessionThreadError::UnknownThread {
+                thread_id: thread_id.clone(),
+            });
+        }
         match self
             .filesystem
             .delete(&scope.to_resource_scope(), &thread_root(scope, thread_id)?)

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -572,6 +572,31 @@ impl SessionThreadService for InMemorySessionThreadService {
         Ok(thread.record.clone())
     }
 
+    async fn delete_thread(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        let mut state = self.state.lock().await;
+        let existing =
+            state
+                .threads
+                .get(thread_id)
+                .ok_or_else(|| SessionThreadError::UnknownThread {
+                    thread_id: thread_id.clone(),
+                })?;
+        if &existing.record.scope != scope {
+            return Err(SessionThreadError::UnknownThread {
+                thread_id: thread_id.clone(),
+            });
+        }
+        state.threads.remove(thread_id);
+        state
+            .inbound_idempotency
+            .retain(|_, record| &record.thread_id != thread_id);
+        Ok(())
+    }
+
     async fn create_summary_artifact(
         &self,
         request: CreateSummaryArtifactRequest,

--- a/crates/ironclaw_threads/src/service.rs
+++ b/crates/ironclaw_threads/src/service.rs
@@ -188,6 +188,19 @@ pub trait SessionThreadService: Send + Sync {
             .map(|history| history.thread)
     }
 
+    /// Delete a thread and its transcript only when it belongs to the supplied
+    /// exact scope. Implementations must return the same non-enumerating
+    /// missing shape for absent and cross-scope threads.
+    async fn delete_thread(
+        &self,
+        _scope: &ThreadScope,
+        _thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        Err(SessionThreadError::Backend(
+            "delete_thread is not implemented by this SessionThreadService backend".to_string(),
+        ))
+    }
+
     async fn create_summary_artifact(
         &self,
         request: CreateSummaryArtifactRequest,
@@ -406,6 +419,14 @@ where
         request: ThreadHistoryRequest,
     ) -> Result<SessionThreadRecord, SessionThreadError> {
         self.as_ref().read_thread(request).await
+    }
+
+    async fn delete_thread(
+        &self,
+        scope: &ThreadScope,
+        thread_id: &ThreadId,
+    ) -> Result<(), SessionThreadError> {
+        self.as_ref().delete_thread(scope, thread_id).await
     }
 
     async fn create_summary_artifact(

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -26,6 +26,66 @@ use ironclaw_threads::{
 };
 
 #[tokio::test]
+async fn filesystem_delete_thread_removes_owned_thread_and_hides_missing_or_wrong_scope() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-delete", "alice");
+    let service = FilesystemSessionThreadService::new(scoped);
+    let owned_scope = scope("delete-owned");
+    let wrong_scope = scope("delete-wrong");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: owned_scope.clone(),
+            thread_id: Some(ThreadId::new("thread-delete-owned").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let wrong_scope_error = service
+        .delete_thread(&wrong_scope, &thread.thread_id)
+        .await
+        .expect_err("wrong-scope delete should hide thread existence");
+    assert_unknown_thread(wrong_scope_error, &thread.thread_id);
+
+    service
+        .read_thread(ThreadHistoryRequest {
+            scope: owned_scope.clone(),
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .expect("wrong-scope delete must not remove owned thread");
+
+    service
+        .delete_thread(&owned_scope, &thread.thread_id)
+        .await
+        .expect("owned delete succeeds");
+
+    let deleted_error = service
+        .read_thread(ThreadHistoryRequest {
+            scope: owned_scope.clone(),
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .expect_err("deleted thread should no longer be readable");
+    assert_unknown_thread(deleted_error, &thread.thread_id);
+
+    let repeat_error = service
+        .delete_thread(&owned_scope, &thread.thread_id)
+        .await
+        .expect_err("repeat delete should be non-enumerating missing shape");
+    assert_unknown_thread(repeat_error, &thread.thread_id);
+
+    let missing = ThreadId::new("thread-delete-missing").unwrap();
+    let missing_error = service
+        .delete_thread(&owned_scope, &missing)
+        .await
+        .expect_err("missing delete should be non-enumerating");
+    assert_unknown_thread(missing_error, &missing);
+}
+
+#[tokio::test]
 async fn durable_history_round_trips_through_filesystem_store() {
     let backend = Arc::new(InMemoryBackend::new());
     let scoped = scoped_threads_fs_at(Arc::clone(&backend), "tenant-a", "alice");
@@ -963,6 +1023,13 @@ fn scope(label: &str) -> ThreadScope {
         project_id: Some(ProjectId::new(format!("project-{label}")).unwrap()),
         owner_user_id: Some(UserId::new(format!("user-{label}")).unwrap()),
         mission_id: None,
+    }
+}
+
+fn assert_unknown_thread(error: SessionThreadError, thread_id: &ThreadId) {
+    match error {
+        SessionThreadError::UnknownThread { thread_id: actual } => assert_eq!(actual, *thread_id),
+        other => panic!("expected UnknownThread for {thread_id}, got {other:?}"),
     }
 }
 

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -74,6 +74,71 @@ fn same_tenant_scope(agent_label: &str) -> ThreadScope {
     }
 }
 
+fn assert_unknown_thread(error: SessionThreadError, thread_id: &ThreadId) {
+    match error {
+        SessionThreadError::UnknownThread { thread_id: actual } => assert_eq!(actual, *thread_id),
+        other => panic!("expected UnknownThread for {thread_id}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn delete_thread_removes_owned_thread_and_hides_missing_or_wrong_scope() {
+    let service = InMemorySessionThreadService::default();
+    let owned_scope = scope("delete-owned");
+    let wrong_scope = scope("delete-wrong");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: owned_scope.clone(),
+            thread_id: Some(ThreadId::new("thread-delete-owned").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let wrong_scope_error = service
+        .delete_thread(&wrong_scope, &thread.thread_id)
+        .await
+        .expect_err("wrong-scope delete should hide thread existence");
+    assert_unknown_thread(wrong_scope_error, &thread.thread_id);
+
+    service
+        .read_thread(ThreadHistoryRequest {
+            scope: owned_scope.clone(),
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .expect("wrong-scope delete must not remove owned thread");
+
+    service
+        .delete_thread(&owned_scope, &thread.thread_id)
+        .await
+        .expect("owned delete succeeds");
+
+    let deleted_error = service
+        .read_thread(ThreadHistoryRequest {
+            scope: owned_scope.clone(),
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .expect_err("deleted thread should no longer be readable");
+    assert_unknown_thread(deleted_error, &thread.thread_id);
+
+    let repeat_error = service
+        .delete_thread(&owned_scope, &thread.thread_id)
+        .await
+        .expect_err("repeat delete should be non-enumerating missing shape");
+    assert_unknown_thread(repeat_error, &thread.thread_id);
+
+    let missing = ThreadId::new("thread-delete-missing").unwrap();
+    let missing_error = service
+        .delete_thread(&owned_scope, &missing)
+        .await
+        .expect_err("missing delete should be non-enumerating");
+    assert_unknown_thread(missing_error, &missing);
+}
+
 #[tokio::test]
 async fn append_tool_result_reference_is_finalized_and_idempotent_per_run_result_ref() {
     let service = InMemorySessionThreadService::default();


### PR DESCRIPTION
## Summary
- add scoped thread deletion so subagent spawn rollback can remove child threads
- make spawn rollback cancel submitted child runs and clean gate/goal/result/reservation/thread side effects
- roll back prior successful spawns when a later mixed batch invocation fails
- propagate runtime parent cancellation to nonterminal subagent descendants

Fixes #4350.

## Details
Issue #4350 had one stale claim: terminal completion already deleted subagent goals. This PR keeps that behavior and adds a regression assertion for it.

The main fix stays within existing Reborn ownership:
- loop support owns spawn compensation and batch rollback
- thread service owns scoped transcript deletion
- runtime composition owns parent-cancel fanout over the existing spawn tree store

## Tests
- `cargo test -p ironclaw_loop_support subagent_spawn_port`
- `cargo test -p ironclaw_reborn subagent::completion_observer`
- `cargo test -p ironclaw_reborn_composition runtime::tests`
- `cargo test -p ironclaw_threads`
- `cargo test -p ironclaw_reborn_composition runtime::tests::cancel_run_propagates_to_subagent_children`
- `cargo clippy -p ironclaw_threads -p ironclaw_loop_support -p ironclaw_reborn -p ironclaw_reborn_composition --tests -- -D warnings`
- `git diff --check`
