### PR TITLE
[codex] Add trigger fire auth request seam

### DIFF
--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -621,6 +621,13 @@ mod tests {
         build_runtime_input_with_options, resolve_google_oauth_config,
     };
 
+    fn clear_trigger_poller_env() -> (EnvGuard, EnvGuard) {
+        (
+            EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED"),
+            EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS"),
+        )
+    }
+
     #[tokio::test]
     async fn block_on_cli_can_run_inside_existing_tokio_runtime() {
         let value = block_on_cli(async { Ok::<_, anyhow::Error>(42) }).expect("block future");
@@ -630,6 +637,9 @@ mod tests {
 
     #[test]
     fn build_runtime_input_maps_configured_cli_identity() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         std::fs::create_dir_all(&reborn_home).expect("mkdir");
@@ -662,6 +672,9 @@ default_owner = "custom-owner"
 
     #[test]
     fn build_runtime_input_maps_regex_skill_activation_config() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         std::fs::create_dir_all(&reborn_home).expect("mkdir");
@@ -689,6 +702,9 @@ regex_activation_enabled = false
 
     #[test]
     fn build_runtime_input_rejects_local_dev_yolo_without_host_access_confirmation() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         std::fs::create_dir_all(&reborn_home).expect("mkdir");
@@ -710,6 +726,9 @@ regex_activation_enabled = false
 
     #[test]
     fn build_runtime_input_accepts_confirmed_local_dev_yolo_profile() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         std::fs::create_dir_all(&reborn_home).expect("mkdir");
@@ -748,6 +767,9 @@ regex_activation_enabled = false
     // ensures both branches do the right thing.
     #[test]
     fn build_runtime_input_for_run_rejects_default_project() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         std::fs::create_dir_all(&reborn_home).expect("mkdir");
@@ -778,6 +800,9 @@ default_project = "project-alpha"
 
     #[test]
     fn build_runtime_input_for_serve_accepts_default_project() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
         std::fs::create_dir_all(&reborn_home).expect("mkdir");
@@ -804,8 +829,7 @@ default_project = "project-alpha"
     #[test]
     fn build_runtime_input_maps_trigger_poller_enabled_config() {
         let _lock = lock_trigger_env();
-        let _enabled = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_ENABLED");
-        let _interval = EnvGuard::clear("IRONCLAW_TRIGGER_POLLER_INTERVAL_SECS");
+        let (_enabled, _interval) = clear_trigger_poller_env();
 
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -95,8 +95,9 @@ use crate::projection::{RebornProjectionServices, build_reborn_projection_servic
 use crate::runtime_input::{PollSettings, RebornRuntimeIdentity, RebornRuntimeInput};
 use crate::trigger_poller::{
     ConversationContentRefMaterializer, LocalTriggerTurnSnapshotSource, SnapshotActiveRunLookup,
-    TRIGGER_POLLER_SHUTDOWN_TIMEOUT, TriggerPollerCompositionDeps, TriggerPollerRuntimeHandle,
-    TriggerTurnSnapshotSource, TrustedTenantTriggerFireAuthorizer, spawn_trigger_poller,
+    TRIGGER_POLLER_SHUTDOWN_TIMEOUT, TenantScopedTrustedTriggerFireAuthorizer,
+    TriggerPollerCompositionDeps, TriggerPollerRuntimeHandle, TriggerTurnSnapshotSource,
+    spawn_trigger_poller,
 };
 use crate::{
     RebornBuildError, RebornCompositionProfile, RebornProductAuthServices, RebornServices,
@@ -267,7 +268,7 @@ async fn build_trigger_poller_services(
     tenant_id: TenantId,
     default_agent_id: AgentId,
 ) -> Result<TriggerPollerServices, RebornRuntimeError> {
-    let authorizer = Arc::new(TrustedTenantTriggerFireAuthorizer::new(tenant_id));
+    let authorizer = Arc::new(TenantScopedTrustedTriggerFireAuthorizer::new(tenant_id));
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     {
         let conversations = RebornFilesystemConversationServices::new(Arc::clone(

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -330,12 +330,13 @@ async fn build_trigger_poller_services(
     }
 }
 
+/// Validate the temporary trigger-poller authorizer shape after the caller has
+/// already decided to enable the poller.
 fn validate_trigger_poller_authorization(
     trigger_poller: &TriggerPollerSettings,
 ) -> Result<(), RebornRuntimeError> {
-    if trigger_poller.enabled
-        && !trigger_poller.allow_tenant_scoped_authorizer_without_creator_membership
-    {
+    debug_assert!(trigger_poller.enabled);
+    if !trigger_poller.allow_tenant_scoped_authorizer_without_creator_membership {
         return Err(RebornRuntimeError::InvalidArgument {
             reason: "trigger poller cannot be enabled until fire-time creator authorization is backed by the real agent/project membership source of truth".to_string(),
         });

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -93,7 +93,8 @@ use crate::factory::{LocalDevRootFilesystem, LocalDevTurnStateStore};
 use crate::local_dev_capability_policy::local_dev_capability_policy;
 use crate::projection::{RebornProjectionServices, build_reborn_projection_services};
 use crate::runtime_input::{
-    PollSettings, RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerSettings,
+    PollSettings, RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerAuthorizerConfig,
+    TriggerPollerSettings,
 };
 use crate::trigger_poller::{
     ConversationContentRefMaterializer, LocalTriggerTurnSnapshotSource, SnapshotActiveRunLookup,
@@ -336,12 +337,16 @@ fn validate_trigger_poller_authorization(
     trigger_poller: &TriggerPollerSettings,
 ) -> Result<(), RebornRuntimeError> {
     debug_assert!(trigger_poller.enabled);
-    if !trigger_poller.allow_tenant_scoped_authorizer_without_creator_membership {
-        return Err(RebornRuntimeError::InvalidArgument {
-            reason: "trigger poller cannot be enabled until fire-time creator authorization is backed by the real agent/project membership source of truth".to_string(),
-        });
+    match trigger_poller.authorizer {
+        #[cfg(any(test, feature = "test-support"))]
+        TriggerPollerAuthorizerConfig::TenantScopedPlaceholderForTest => Ok(()),
+        TriggerPollerAuthorizerConfig::CreatorMembershipRequired => {
+            let reason = "trigger poller cannot be enabled until fire-time creator authorization is backed by the real agent/project membership source of truth";
+            Err(RebornRuntimeError::InvalidArgument {
+                reason: reason.to_string(),
+            })
+        }
     }
-    Ok(())
 }
 
 struct TriggerPollerServicesInner {

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -96,11 +96,12 @@ use crate::runtime_input::{
     PollSettings, RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerAuthorizerConfig,
     TriggerPollerSettings,
 };
+#[cfg(any(test, feature = "test-support"))]
+use crate::trigger_poller::TenantScopedTrustedTriggerFireAuthorizer;
 use crate::trigger_poller::{
     ConversationContentRefMaterializer, LocalTriggerTurnSnapshotSource, SnapshotActiveRunLookup,
-    TRIGGER_POLLER_SHUTDOWN_TIMEOUT, TenantScopedTrustedTriggerFireAuthorizer,
-    TriggerPollerCompositionDeps, TriggerPollerRuntimeHandle, TriggerTurnSnapshotSource,
-    spawn_trigger_poller,
+    TRIGGER_POLLER_SHUTDOWN_TIMEOUT, TriggerPollerCompositionDeps, TriggerPollerRuntimeHandle,
+    TriggerTurnSnapshotSource, spawn_trigger_poller,
 };
 use crate::{
     RebornBuildError, RebornCompositionProfile, RebornProductAuthServices, RebornServices,
@@ -268,10 +269,11 @@ async fn build_trigger_poller_services(
     local_runtime: &crate::factory::RebornLocalRuntimeServices,
     turn_coordinator: Arc<dyn TurnCoordinator>,
     thread_service: Arc<dyn SessionThreadService>,
+    authorizer_config: TriggerPollerAuthorizerConfig,
     tenant_id: TenantId,
     default_agent_id: AgentId,
 ) -> Result<TriggerPollerServices, RebornRuntimeError> {
-    let authorizer = Arc::new(TenantScopedTrustedTriggerFireAuthorizer::new(tenant_id));
+    let authorizer = build_trigger_fire_authorizer(authorizer_config, tenant_id)?;
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     {
         let conversations = RebornFilesystemConversationServices::new(Arc::clone(
@@ -331,6 +333,12 @@ async fn build_trigger_poller_services(
     }
 }
 
+fn trigger_poller_authorization_required_error() -> RebornRuntimeError {
+    RebornRuntimeError::InvalidArgument {
+        reason: "trigger poller cannot be enabled until fire-time creator authorization is backed by the real agent/project membership source of truth".to_string(),
+    }
+}
+
 /// Validate the temporary trigger-poller authorizer shape after the caller has
 /// already decided to enable the poller.
 fn validate_trigger_poller_authorization(
@@ -341,10 +349,25 @@ fn validate_trigger_poller_authorization(
         #[cfg(any(test, feature = "test-support"))]
         TriggerPollerAuthorizerConfig::TenantScopedPlaceholderForTest => Ok(()),
         TriggerPollerAuthorizerConfig::CreatorMembershipRequired => {
-            let reason = "trigger poller cannot be enabled until fire-time creator authorization is backed by the real agent/project membership source of truth";
-            Err(RebornRuntimeError::InvalidArgument {
-                reason: reason.to_string(),
-            })
+            Err(trigger_poller_authorization_required_error())
+        }
+    }
+}
+
+fn build_trigger_fire_authorizer(
+    authorizer_config: TriggerPollerAuthorizerConfig,
+    tenant_id: TenantId,
+) -> Result<Arc<dyn crate::trigger_poller_trusted_submit::TriggerFireAuthorizer>, RebornRuntimeError>
+{
+    #[cfg(not(any(test, feature = "test-support")))]
+    let _ = tenant_id;
+    match authorizer_config {
+        #[cfg(any(test, feature = "test-support"))]
+        TriggerPollerAuthorizerConfig::TenantScopedPlaceholderForTest => Ok(Arc::new(
+            TenantScopedTrustedTriggerFireAuthorizer::new(tenant_id),
+        )),
+        TriggerPollerAuthorizerConfig::CreatorMembershipRequired => {
+            Err(trigger_poller_authorization_required_error())
         }
     }
 }
@@ -1580,6 +1603,7 @@ pub async fn build_reborn_runtime(
             local_runtime,
             Arc::clone(&planned_turn_coordinator),
             Arc::clone(&thread_service),
+            trigger_poller.authorizer,
             thread_scope.tenant_id.clone(),
             validated_identity.agent_id.clone(),
         )
@@ -2638,7 +2662,9 @@ mod tests {
                     .shutdown()
                     .await
                     .expect("unexpected runtime shutdown");
-                panic!("tenant-scoped placeholder must not enable trigger poller");
+                panic!(
+                    "creator-membership-required setting must not enable trigger poller without real membership backend"
+                );
             }
             Err(err) => err,
         };

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -92,7 +92,9 @@ use crate::default_system_prompt::DefaultSystemPromptIdentitySource;
 use crate::factory::{LocalDevRootFilesystem, LocalDevTurnStateStore};
 use crate::local_dev_capability_policy::local_dev_capability_policy;
 use crate::projection::{RebornProjectionServices, build_reborn_projection_services};
-use crate::runtime_input::{PollSettings, RebornRuntimeIdentity, RebornRuntimeInput};
+use crate::runtime_input::{
+    PollSettings, RebornRuntimeIdentity, RebornRuntimeInput, TriggerPollerSettings,
+};
 use crate::trigger_poller::{
     ConversationContentRefMaterializer, LocalTriggerTurnSnapshotSource, SnapshotActiveRunLookup,
     TRIGGER_POLLER_SHUTDOWN_TIMEOUT, TenantScopedTrustedTriggerFireAuthorizer,
@@ -326,6 +328,19 @@ async fn build_trigger_poller_services(
             pairing_service,
         })
     }
+}
+
+fn validate_trigger_poller_authorization(
+    trigger_poller: &TriggerPollerSettings,
+) -> Result<(), RebornRuntimeError> {
+    if trigger_poller.enabled
+        && !trigger_poller.allow_tenant_scoped_authorizer_without_creator_membership
+    {
+        return Err(RebornRuntimeError::InvalidArgument {
+            reason: "trigger poller cannot be enabled until fire-time creator authorization is backed by the real agent/project membership source of truth".to_string(),
+        });
+    }
+    Ok(())
 }
 
 struct TriggerPollerServicesInner {
@@ -1554,6 +1569,7 @@ pub async fn build_reborn_runtime(
         Arc<dyn ironclaw_conversations::ConversationActorPairingService>,
     >;
     if trigger_poller.enabled {
+        validate_trigger_poller_authorization(&trigger_poller)?;
         let trigger_poller_services = build_trigger_poller_services(
             local_runtime,
             Arc::clone(&planned_turn_coordinator),
@@ -2573,7 +2589,9 @@ mod tests {
             source_binding_id: "runtime-trigger-readiness-source".to_string(),
             reply_target_binding_id: "runtime-trigger-readiness-reply".to_string(),
         })
-        .with_trigger_poller_settings(TriggerPollerSettings::enabled())
+        .with_trigger_poller_settings(
+            TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test(),
+        )
         .with_model_gateway_override(gateway);
 
         let runtime = build_reborn_runtime(input).await.expect("runtime builds");
@@ -2582,6 +2600,46 @@ mod tests {
         assert!(runtime.services().readiness.workers.trigger_poller);
 
         runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn local_dev_runtime_rejects_trigger_poller_without_creator_authorization() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let gateway = Arc::new(RecordingGateway {
+            reply: "trigger auth required".to_string(),
+            requests: Arc::new(StdMutex::new(Vec::new())),
+        });
+
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev(
+                "runtime-trigger-auth-required-owner",
+                root.path().join("local-dev"),
+            )
+            .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-trigger-auth-required-tenant".to_string(),
+            agent_id: "runtime-trigger-auth-required-agent".to_string(),
+            source_binding_id: "runtime-trigger-auth-required-source".to_string(),
+            reply_target_binding_id: "runtime-trigger-auth-required-reply".to_string(),
+        })
+        .with_trigger_poller_settings(TriggerPollerSettings::enabled())
+        .with_model_gateway_override(gateway);
+
+        let err = match build_reborn_runtime(input).await {
+            Ok(runtime) => {
+                runtime
+                    .shutdown()
+                    .await
+                    .expect("unexpected runtime shutdown");
+                panic!("tenant-scoped placeholder must not enable trigger poller");
+            }
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, super::RebornRuntimeError::InvalidArgument { reason } if reason.contains("fire-time creator authorization"))
+        );
     }
 
     #[tokio::test]
@@ -2629,7 +2687,8 @@ mod tests {
                 ..Default::default()
             },
             ..Default::default()
-        };
+        }
+        .with_tenant_scoped_authorizer_for_test();
 
         let input = RebornRuntimeInput::from_services(
             RebornBuildInput::local_dev(
@@ -2684,7 +2743,9 @@ mod tests {
             source_binding_id: "runtime-trigger-shutdown-source".to_string(),
             reply_target_binding_id: "runtime-trigger-shutdown-reply".to_string(),
         })
-        .with_trigger_poller_settings(TriggerPollerSettings::enabled())
+        .with_trigger_poller_settings(
+            TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test(),
+        )
         .with_model_gateway_override(gateway);
 
         let runtime = build_reborn_runtime(input).await.expect("runtime builds");

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -135,7 +135,14 @@ pub struct TriggerPollerSettings {
     pub worker: TriggerPollerWorkerConfig,
     pub startup_jitter_max: Duration,
     pub tick_jitter_max: Duration,
-    pub(crate) allow_tenant_scoped_authorizer_without_creator_membership: bool,
+    pub(crate) authorizer: TriggerPollerAuthorizerConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TriggerPollerAuthorizerConfig {
+    CreatorMembershipRequired,
+    #[cfg(any(test, feature = "test-support"))]
+    TenantScopedPlaceholderForTest,
 }
 
 impl Default for TriggerPollerSettings {
@@ -145,7 +152,7 @@ impl Default for TriggerPollerSettings {
             worker: TriggerPollerWorkerConfig::default(),
             startup_jitter_max: Duration::ZERO,
             tick_jitter_max: Duration::ZERO,
-            allow_tenant_scoped_authorizer_without_creator_membership: false,
+            authorizer: TriggerPollerAuthorizerConfig::CreatorMembershipRequired,
         }
     }
 }
@@ -170,7 +177,7 @@ impl TriggerPollerSettings {
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn with_tenant_scoped_authorizer_for_test(mut self) -> Self {
-        self.allow_tenant_scoped_authorizer_without_creator_membership = true;
+        self.authorizer = TriggerPollerAuthorizerConfig::TenantScopedPlaceholderForTest;
         self
     }
 }

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -135,6 +135,7 @@ pub struct TriggerPollerSettings {
     pub worker: TriggerPollerWorkerConfig,
     pub startup_jitter_max: Duration,
     pub tick_jitter_max: Duration,
+    pub(crate) allow_tenant_scoped_authorizer_without_creator_membership: bool,
 }
 
 impl Default for TriggerPollerSettings {
@@ -144,6 +145,7 @@ impl Default for TriggerPollerSettings {
             worker: TriggerPollerWorkerConfig::default(),
             startup_jitter_max: Duration::ZERO,
             tick_jitter_max: Duration::ZERO,
+            allow_tenant_scoped_authorizer_without_creator_membership: false,
         }
     }
 }
@@ -154,6 +156,22 @@ impl TriggerPollerSettings {
             enabled: true,
             ..Self::default()
         }
+    }
+
+    pub fn with_worker_config(mut self, worker: TriggerPollerWorkerConfig) -> Self {
+        self.worker = worker;
+        self
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn enabled_with_tenant_scoped_authorizer_for_test() -> Self {
+        Self::enabled().with_tenant_scoped_authorizer_for_test()
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn with_tenant_scoped_authorizer_for_test(mut self) -> Self {
+        self.allow_tenant_scoped_authorizer_without_creator_membership = true;
+        self
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -15,9 +15,9 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::runtime_input::TriggerPollerSettings;
-pub(crate) use crate::trigger_poller_trusted_submit::{
-    ConversationContentRefMaterializer, TenantScopedTrustedTriggerFireAuthorizer,
-};
+pub(crate) use crate::trigger_poller_trusted_submit::ConversationContentRefMaterializer;
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) use crate::trigger_poller_trusted_submit::TenantScopedTrustedTriggerFireAuthorizer;
 
 pub(crate) const TRIGGER_POLLER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/crates/ironclaw_reborn_composition/src/trigger_poller.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::runtime_input::TriggerPollerSettings;
 pub(crate) use crate::trigger_poller_trusted_submit::{
-    ConversationContentRefMaterializer, TrustedTenantTriggerFireAuthorizer,
+    ConversationContentRefMaterializer, TenantScopedTrustedTriggerFireAuthorizer,
 };
 
 pub(crate) const TRIGGER_POLLER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -31,7 +31,7 @@ pub(crate) struct TriggerFireAuthRequest {
 }
 
 impl TriggerFireAuthRequest {
-    fn from_fire(fire: &TriggerFire) -> Self {
+    fn for_fire(fire: &TriggerFire) -> Self {
         Self {
             tenant_id: fire.identity.tenant_id().clone(),
             creator_user_id: fire.creator_user_id.clone(),
@@ -45,7 +45,9 @@ impl TriggerFireAuthRequest {
 
 /// Fire-time host policy hook. The current production implementation is only a
 /// tenant-scope guard; real creator membership authorization remains a separate
-/// source-of-truth integration before external trigger delivery can launch.
+/// source-of-truth integration before external trigger delivery can launch
+/// (tracked by docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md,
+/// PR 18.5b).
 #[async_trait]
 pub(crate) trait TriggerFireAuthorizer: Send + Sync {
     async fn authorize_trigger_fire(
@@ -62,6 +64,7 @@ pub(crate) enum TriggerFireAuthError {
     // Part of the fire-time authorization contract now so backend
     // unavailability has stable retry semantics before the real membership
     // authorizer is wired. The tenant-scope placeholder does not construct it.
+    // arch-exempt: dead_code, Retryable is reserved for real fire-time auth backend failures, plan #4436
     #[allow(dead_code)]
     Retryable {
         reason: String,
@@ -130,7 +133,7 @@ where
         &self,
         fire: TriggerFire,
     ) -> Result<TriggerMaterializedPrompt, TriggerError> {
-        let auth_request = TriggerFireAuthRequest::from_fire(&fire);
+        let auth_request = TriggerFireAuthRequest::for_fire(&fire);
         self.authorizer
             .authorize_trigger_fire(&auth_request)
             .await
@@ -284,9 +287,12 @@ async fn record_trigger_prompt(
 
 fn trigger_authorization_error(error: TriggerFireAuthError) -> TriggerError {
     match error {
-        TriggerFireAuthError::Denied { reason } => TriggerError::InvalidMaterialization {
-            reason: format!("trusted trigger fire authorization denied: {reason}"),
-        },
+        TriggerFireAuthError::Denied { reason } => {
+            tracing::debug!(%reason, "trusted trigger fire authorization denied");
+            TriggerError::InvalidMaterialization {
+                reason: "trusted trigger fire authorization denied".to_string(),
+            }
+        }
         TriggerFireAuthError::Retryable { reason } => TriggerError::Backend {
             reason: format!("trusted trigger fire authorization retryable failure: {reason}"),
         },
@@ -440,6 +446,70 @@ mod tests {
         }
     }
 
+    struct AuthFailureMaterializerFixture {
+        materializer: ConversationContentRefMaterializer<PanicBindingService>,
+        thread_service: Arc<InMemorySessionThreadService>,
+        thread_scope: ThreadScope,
+        authorizer: Arc<StaticTriggerFireAuthorizer>,
+        fire: TriggerFire,
+        auth_request: TriggerFireAuthRequest,
+    }
+
+    fn auth_failure_materializer(error: TriggerFireAuthError) -> AuthFailureMaterializerFixture {
+        let tenant_id = TenantId::new("trigger-auth-failure-tenant").expect("tenant id");
+        let creator_user_id = UserId::new("trigger-auth-failure-user").expect("user id");
+        let agent_id = AgentId::new("trigger-auth-failure-agent").expect("agent id");
+        let project_id = ProjectId::new("trigger-auth-failure-project").expect("project id");
+        let trigger_id = TriggerId::new();
+        let fire_slot = Utc::now();
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let authorizer = Arc::new(StaticTriggerFireAuthorizer::new(Err(error)));
+        let fire = TriggerFire {
+            identity: TriggerFireIdentity::new(tenant_id.clone(), trigger_id, fire_slot),
+            creator_user_id: creator_user_id.clone(),
+            agent_id: Some(agent_id.clone()),
+            project_id: Some(project_id.clone()),
+            prompt: "summarize unread mail".to_string(),
+        };
+        let auth_request = TriggerFireAuthRequest::for_fire(&fire);
+        let thread_scope = ThreadScope {
+            tenant_id,
+            agent_id: agent_id.clone(),
+            project_id: Some(project_id),
+            owner_user_id: Some(creator_user_id),
+            mission_id: None,
+        };
+        let materializer = ConversationContentRefMaterializer::new(
+            PanicBindingService,
+            thread_service.clone(),
+            agent_id,
+            authorizer.clone(),
+        );
+        AuthFailureMaterializerFixture {
+            materializer,
+            thread_service,
+            thread_scope,
+            authorizer,
+            fire,
+            auth_request,
+        }
+    }
+
+    async fn assert_no_prompt_threads(
+        thread_service: &InMemorySessionThreadService,
+        scope: ThreadScope,
+    ) {
+        let threads = thread_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope,
+                limit: Some(10),
+                cursor: None,
+            })
+            .await
+            .expect("threads load");
+        assert!(threads.threads.is_empty());
+    }
+
     struct MissingActiveRunLookup;
 
     #[async_trait]
@@ -558,7 +628,7 @@ mod tests {
             prompt: "summarize unread mail".to_string(),
         };
 
-        let request = TriggerFireAuthRequest::from_fire(&fire);
+        let request = TriggerFireAuthRequest::for_fire(&fire);
 
         assert_eq!(request.tenant_id, tenant_id);
         assert_eq!(request.creator_user_id, creator_user_id);
@@ -566,6 +636,26 @@ mod tests {
         assert_eq!(request.project_id, Some(project_id));
         assert_eq!(request.trigger_id, trigger_id);
         assert_eq!(request.fire_slot, fire_slot);
+    }
+
+    #[tokio::test]
+    async fn trigger_fire_auth_request_preserves_missing_optional_scope() {
+        let tenant_id = TenantId::new("trigger-authorized-tenant").expect("tenant id");
+        let creator_user_id = UserId::new("trigger-authorized-user").expect("user id");
+        let trigger_id = TriggerId::new();
+        let fire_slot = Utc::now();
+        let fire = TriggerFire {
+            identity: TriggerFireIdentity::new(tenant_id, trigger_id, fire_slot),
+            creator_user_id,
+            agent_id: None,
+            project_id: None,
+            prompt: "summarize unread mail".to_string(),
+        };
+
+        let request = TriggerFireAuthRequest::for_fire(&fire);
+
+        assert_eq!(request.agent_id, None);
+        assert_eq!(request.project_id, None);
     }
 
     #[tokio::test]
@@ -581,7 +671,7 @@ mod tests {
             project_id: Some(project_id),
             prompt: "summarize unread mail".to_string(),
         };
-        let request = TriggerFireAuthRequest::from_fire(&fire);
+        let request = TriggerFireAuthRequest::for_fire(&fire);
 
         TenantScopedTrustedTriggerFireAuthorizer::new(tenant_id)
             .authorize_trigger_fire(&request)
@@ -601,7 +691,7 @@ mod tests {
             project_id: None,
             prompt: "summarize unread mail".to_string(),
         };
-        let request = TriggerFireAuthRequest::from_fire(&fire);
+        let request = TriggerFireAuthRequest::for_fire(&fire);
 
         let error = TenantScopedTrustedTriggerFireAuthorizer::new(poller_tenant)
             .authorize_trigger_fire(&request)
@@ -1432,96 +1522,32 @@ mod tests {
 
     #[tokio::test]
     async fn materializer_rejects_authorizer_denial_before_binding_or_prompt_write() {
-        let tenant_id = TenantId::new("trigger-auth-denied-tenant").expect("tenant id");
-        let creator_user_id = UserId::new("trigger-auth-denied-user").expect("user id");
-        let agent_id = AgentId::new("trigger-auth-denied-agent").expect("agent id");
-        let project_id = ProjectId::new("trigger-auth-denied-project").expect("project id");
-        let trigger_id = TriggerId::new();
-        let fire_slot = Utc::now();
-        let thread_service = Arc::new(InMemorySessionThreadService::default());
-        let authorizer = Arc::new(StaticTriggerFireAuthorizer::new(Err(
-            TriggerFireAuthError::Denied {
-                reason: "creator no longer authorized for project".to_string(),
-            },
-        )));
-        let materializer = ConversationContentRefMaterializer::new(
-            PanicBindingService,
-            thread_service.clone(),
-            agent_id.clone(),
-            authorizer.clone(),
-        );
+        let fixture = auth_failure_materializer(TriggerFireAuthError::Denied {
+            reason: "creator no longer authorized for project".to_string(),
+        });
 
-        let error = materializer
-            .materialize_prompt(TriggerFire {
-                identity: TriggerFireIdentity::new(tenant_id.clone(), trigger_id, fire_slot),
-                creator_user_id: creator_user_id.clone(),
-                agent_id: Some(agent_id.clone()),
-                project_id: Some(project_id.clone()),
-                prompt: "summarize unread mail".to_string(),
-            })
+        let error = fixture
+            .materializer
+            .materialize_prompt(fixture.fire)
             .await
             .expect_err("authorization denial rejects before materialization side effects");
 
         assert!(
-            matches!(error, TriggerError::InvalidMaterialization { reason } if reason.contains("creator no longer authorized for project"))
+            matches!(error, TriggerError::InvalidMaterialization { reason } if reason == "trusted trigger fire authorization denied")
         );
-        assert_eq!(
-            authorizer.requests(),
-            vec![TriggerFireAuthRequest {
-                tenant_id: tenant_id.clone(),
-                creator_user_id: creator_user_id.clone(),
-                agent_id: Some(agent_id.clone()),
-                project_id: Some(project_id.clone()),
-                trigger_id,
-                fire_slot,
-            }]
-        );
-        let threads = thread_service
-            .list_threads_for_scope(ListThreadsForScopeRequest {
-                scope: ThreadScope {
-                    tenant_id,
-                    agent_id,
-                    project_id: Some(project_id),
-                    owner_user_id: Some(creator_user_id),
-                    mission_id: None,
-                },
-                limit: Some(10),
-                cursor: None,
-            })
-            .await
-            .expect("threads load");
-        assert!(threads.threads.is_empty());
+        assert_eq!(fixture.authorizer.requests(), vec![fixture.auth_request]);
+        assert_no_prompt_threads(&fixture.thread_service, fixture.thread_scope).await;
     }
 
     #[tokio::test]
     async fn materializer_returns_retryable_error_when_authorizer_backend_fails() {
-        let tenant_id = TenantId::new("trigger-auth-retryable-tenant").expect("tenant id");
-        let creator_user_id = UserId::new("trigger-auth-retryable-user").expect("user id");
-        let agent_id = AgentId::new("trigger-auth-retryable-agent").expect("agent id");
-        let project_id = ProjectId::new("trigger-auth-retryable-project").expect("project id");
-        let trigger_id = TriggerId::new();
-        let fire_slot = Utc::now();
-        let thread_service = Arc::new(InMemorySessionThreadService::default());
-        let authorizer = Arc::new(StaticTriggerFireAuthorizer::new(Err(
-            TriggerFireAuthError::Retryable {
-                reason: "creator authorization backend unavailable".to_string(),
-            },
-        )));
-        let materializer = ConversationContentRefMaterializer::new(
-            PanicBindingService,
-            thread_service.clone(),
-            agent_id.clone(),
-            authorizer.clone(),
-        );
+        let fixture = auth_failure_materializer(TriggerFireAuthError::Retryable {
+            reason: "creator authorization backend unavailable".to_string(),
+        });
 
-        let error = materializer
-            .materialize_prompt(TriggerFire {
-                identity: TriggerFireIdentity::new(tenant_id.clone(), trigger_id, fire_slot),
-                creator_user_id: creator_user_id.clone(),
-                agent_id: Some(agent_id.clone()),
-                project_id: Some(project_id.clone()),
-                prompt: "summarize unread mail".to_string(),
-            })
+        let error = fixture
+            .materializer
+            .materialize_prompt(fixture.fire)
             .await
             .expect_err(
                 "retryable authorization failure rejects before materialization side effects",
@@ -1530,32 +1556,8 @@ mod tests {
         assert!(
             matches!(error, TriggerError::Backend { reason } if reason.contains("creator authorization backend unavailable"))
         );
-        assert_eq!(
-            authorizer.requests(),
-            vec![TriggerFireAuthRequest {
-                tenant_id: tenant_id.clone(),
-                creator_user_id: creator_user_id.clone(),
-                agent_id: Some(agent_id.clone()),
-                project_id: Some(project_id.clone()),
-                trigger_id,
-                fire_slot,
-            }]
-        );
-        let threads = thread_service
-            .list_threads_for_scope(ListThreadsForScopeRequest {
-                scope: ThreadScope {
-                    tenant_id,
-                    agent_id,
-                    project_id: Some(project_id),
-                    owner_user_id: Some(creator_user_id),
-                    mission_id: None,
-                },
-                limit: Some(10),
-                cursor: None,
-            })
-            .await
-            .expect("threads load");
-        assert!(threads.threads.is_empty());
+        assert_eq!(fixture.authorizer.requests(), vec![fixture.auth_request]);
+        assert_no_prompt_threads(&fixture.thread_service, fixture.thread_scope).await;
     }
 
     #[tokio::test]
@@ -1584,7 +1586,7 @@ mod tests {
             .expect_err("foreign tenant fire is rejected before materialization side effects");
 
         assert!(
-            matches!(error, TriggerError::InvalidMaterialization { reason } if reason.contains("outside this trusted poller scope"))
+            matches!(error, TriggerError::InvalidMaterialization { reason } if reason == "trusted trigger fire authorization denied")
         );
         let threads = thread_service
             .list_threads_for_scope(ListThreadsForScopeRequest {

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -293,9 +293,12 @@ fn trigger_authorization_error(error: TriggerFireAuthError) -> TriggerError {
                 reason: "trusted trigger fire authorization denied".to_string(),
             }
         }
-        TriggerFireAuthError::Retryable { reason } => TriggerError::Backend {
-            reason: format!("trusted trigger fire authorization retryable failure: {reason}"),
-        },
+        TriggerFireAuthError::Retryable { reason } => {
+            tracing::debug!(%reason, "trusted trigger fire authorization retryable failure");
+            TriggerError::Backend {
+                reason: "trusted trigger fire authorization retryable failure".to_string(),
+            }
+        }
     }
 }
 
@@ -1554,7 +1557,7 @@ mod tests {
             );
 
         assert!(
-            matches!(error, TriggerError::Backend { reason } if reason.contains("creator authorization backend unavailable"))
+            matches!(error, TriggerError::Backend { reason } if reason == "trusted trigger fire authorization retryable failure")
         );
         assert_eq!(fixture.authorizer.requests(), vec![fixture.auth_request]);
         assert_no_prompt_threads(&fixture.thread_service, fixture.thread_scope).await;

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -58,29 +58,30 @@ pub(crate) trait TriggerFireAuthorizer: Send + Sync {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TriggerFireAuthError {
-    Denied {
-        reason: String,
-    },
+    // arch-exempt: dead_code, Denied is reserved for real fire-time auth backend denials, plan #4436
+    #[allow(dead_code)]
+    Denied { reason: String },
     // Part of the fire-time authorization contract now so backend
     // unavailability has stable retry semantics before the real membership
     // authorizer is wired. The tenant-scope placeholder does not construct it.
     // arch-exempt: dead_code, Retryable is reserved for real fire-time auth backend failures, plan #4436
     #[allow(dead_code)]
-    Retryable {
-        reason: String,
-    },
+    Retryable { reason: String },
 }
 
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) struct TenantScopedTrustedTriggerFireAuthorizer {
     tenant_id: TenantId,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl TenantScopedTrustedTriggerFireAuthorizer {
     pub(crate) fn new(tenant_id: TenantId) -> Self {
         Self { tenant_id }
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 #[async_trait]
 impl TriggerFireAuthorizer for TenantScopedTrustedTriggerFireAuthorizer {
     async fn authorize_trigger_fire(

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -6,7 +6,7 @@ use ironclaw_conversations::{
     ConversationBindingService, ConversationRouteKind, ExternalActorRef, ExternalConversationRef,
     ExternalEventId, InboundTurnError, ResolveConversationRequest,
 };
-use ironclaw_host_api::{AgentId, TenantId};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_safety::{
     InjectionScanner, PromptSafetyRejection, Sanitizer, validate_trusted_trigger_prompt,
 };
@@ -15,35 +15,76 @@ use ironclaw_threads::{
     MessageContent, SessionThreadService as CanonicalSessionThreadService, ThreadScope,
 };
 use ironclaw_triggers::{
-    TriggerError, TriggerFire, TriggerMaterializedPrompt, TriggerPromptMaterializer,
+    TriggerError, TriggerFire, TriggerId, TriggerMaterializedPrompt, TriggerPromptMaterializer,
     TriggerTrustedInboundBinding,
 };
 use ironclaw_turns::{AdmissionRejectionReason, TurnError};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TriggerFireAuthRequest {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) creator_user_id: UserId,
+    pub(crate) agent_id: Option<AgentId>,
+    pub(crate) project_id: Option<ProjectId>,
+    pub(crate) trigger_id: TriggerId,
+    pub(crate) fire_slot: Timestamp,
+}
+
+impl TriggerFireAuthRequest {
+    fn from_fire(fire: &TriggerFire) -> Self {
+        Self {
+            tenant_id: fire.identity.tenant_id().clone(),
+            creator_user_id: fire.creator_user_id.clone(),
+            agent_id: fire.agent_id.clone(),
+            project_id: fire.project_id.clone(),
+            trigger_id: fire.identity.trigger_id(),
+            fire_slot: fire.identity.fire_slot(),
+        }
+    }
+}
+
+/// Fire-time host policy hook. The current production implementation is only a
+/// tenant-scope guard; real creator membership authorization remains a separate
+/// source-of-truth integration before external trigger delivery can launch.
 #[async_trait]
 pub(crate) trait TriggerFireAuthorizer: Send + Sync {
-    async fn authorize_trigger_fire(&self, fire: &TriggerFire) -> Result<(), TriggerFireAuthError>;
+    async fn authorize_trigger_fire(
+        &self,
+        request: &TriggerFireAuthRequest,
+    ) -> Result<(), TriggerFireAuthError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TriggerFireAuthError {
-    Denied { reason: String },
+    Denied {
+        reason: String,
+    },
+    // Part of the fire-time authorization contract now so backend
+    // unavailability has stable retry semantics before the real membership
+    // authorizer is wired. The tenant-scope placeholder does not construct it.
+    #[allow(dead_code)]
+    Retryable {
+        reason: String,
+    },
 }
 
-pub(crate) struct TrustedTenantTriggerFireAuthorizer {
+pub(crate) struct TenantScopedTrustedTriggerFireAuthorizer {
     tenant_id: TenantId,
 }
 
-impl TrustedTenantTriggerFireAuthorizer {
+impl TenantScopedTrustedTriggerFireAuthorizer {
     pub(crate) fn new(tenant_id: TenantId) -> Self {
         Self { tenant_id }
     }
 }
 
 #[async_trait]
-impl TriggerFireAuthorizer for TrustedTenantTriggerFireAuthorizer {
-    async fn authorize_trigger_fire(&self, fire: &TriggerFire) -> Result<(), TriggerFireAuthError> {
-        if fire.identity.tenant_id() != &self.tenant_id {
+impl TriggerFireAuthorizer for TenantScopedTrustedTriggerFireAuthorizer {
+    async fn authorize_trigger_fire(
+        &self,
+        request: &TriggerFireAuthRequest,
+    ) -> Result<(), TriggerFireAuthError> {
+        if request.tenant_id != self.tenant_id {
             return Err(TriggerFireAuthError::Denied {
                 reason: "trigger tenant is outside this trusted poller scope".to_string(),
             });
@@ -89,8 +130,9 @@ where
         &self,
         fire: TriggerFire,
     ) -> Result<TriggerMaterializedPrompt, TriggerError> {
+        let auth_request = TriggerFireAuthRequest::from_fire(&fire);
         self.authorizer
-            .authorize_trigger_fire(&fire)
+            .authorize_trigger_fire(&auth_request)
             .await
             .map_err(trigger_authorization_error)?;
         validate_trusted_trigger_prompt(&*self.prompt_safety, &fire.prompt)
@@ -245,6 +287,9 @@ fn trigger_authorization_error(error: TriggerFireAuthError) -> TriggerError {
         TriggerFireAuthError::Denied { reason } => TriggerError::InvalidMaterialization {
             reason: format!("trusted trigger fire authorization denied: {reason}"),
         },
+        TriggerFireAuthError::Retryable { reason } => TriggerError::Backend {
+            reason: format!("trusted trigger fire authorization retryable failure: {reason}"),
+        },
     }
 }
 
@@ -354,10 +399,45 @@ mod tests {
         SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnId,
         TurnRunId, TurnRunState, TurnScope, TurnStatus,
     };
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn tenant_authorizer(tenant_id: &TenantId) -> Arc<dyn TriggerFireAuthorizer> {
-        Arc::new(TrustedTenantTriggerFireAuthorizer::new(tenant_id.clone()))
+        Arc::new(TenantScopedTrustedTriggerFireAuthorizer::new(
+            tenant_id.clone(),
+        ))
+    }
+
+    struct StaticTriggerFireAuthorizer {
+        result: Result<(), TriggerFireAuthError>,
+        requests: Mutex<Vec<TriggerFireAuthRequest>>,
+    }
+
+    impl StaticTriggerFireAuthorizer {
+        fn new(result: Result<(), TriggerFireAuthError>) -> Self {
+            Self {
+                result,
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn requests(&self) -> Vec<TriggerFireAuthRequest> {
+            self.requests.lock().expect("requests lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl TriggerFireAuthorizer for StaticTriggerFireAuthorizer {
+        async fn authorize_trigger_fire(
+            &self,
+            request: &TriggerFireAuthRequest,
+        ) -> Result<(), TriggerFireAuthError> {
+            self.requests
+                .lock()
+                .expect("requests lock")
+                .push(request.clone());
+            self.result.clone()
+        }
     }
 
     struct MissingActiveRunLookup;
@@ -463,7 +543,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tenant_authorizer_allows_persisted_trigger_scope_inside_tenant() {
+    async fn trigger_fire_auth_request_captures_fire_scope() {
+        let tenant_id = TenantId::new("trigger-authorized-tenant").expect("tenant id");
+        let creator_user_id = UserId::new("trigger-authorized-user").expect("user id");
+        let agent_id = AgentId::new("trigger-authorized-agent").expect("agent id");
+        let project_id = ProjectId::new("trigger-authorized-project").expect("project id");
+        let trigger_id = TriggerId::new();
+        let fire_slot = Utc::now();
+        let fire = TriggerFire {
+            identity: TriggerFireIdentity::new(tenant_id.clone(), trigger_id, fire_slot),
+            creator_user_id: creator_user_id.clone(),
+            agent_id: Some(agent_id.clone()),
+            project_id: Some(project_id.clone()),
+            prompt: "summarize unread mail".to_string(),
+        };
+
+        let request = TriggerFireAuthRequest::from_fire(&fire);
+
+        assert_eq!(request.tenant_id, tenant_id);
+        assert_eq!(request.creator_user_id, creator_user_id);
+        assert_eq!(request.agent_id, Some(agent_id));
+        assert_eq!(request.project_id, Some(project_id));
+        assert_eq!(request.trigger_id, trigger_id);
+        assert_eq!(request.fire_slot, fire_slot);
+    }
+
+    #[tokio::test]
+    async fn tenant_scope_authorizer_allows_persisted_trigger_scope_inside_tenant() {
         let tenant_id = TenantId::new("trigger-authorized-tenant").expect("tenant id");
         let creator_user_id = UserId::new("trigger-authorized-different-user").expect("user id");
         let agent_id = AgentId::new("trigger-authorized-agent").expect("agent id");
@@ -475,15 +581,16 @@ mod tests {
             project_id: Some(project_id),
             prompt: "summarize unread mail".to_string(),
         };
+        let request = TriggerFireAuthRequest::from_fire(&fire);
 
-        TrustedTenantTriggerFireAuthorizer::new(tenant_id)
-            .authorize_trigger_fire(&fire)
+        TenantScopedTrustedTriggerFireAuthorizer::new(tenant_id)
+            .authorize_trigger_fire(&request)
             .await
             .expect("same-tenant persisted trigger scope is trusted");
     }
 
     #[tokio::test]
-    async fn tenant_authorizer_rejects_foreign_tenant_fire() {
+    async fn tenant_scope_authorizer_rejects_foreign_tenant_fire() {
         let poller_tenant = TenantId::new("trigger-poller-tenant").expect("tenant id");
         let foreign_tenant = TenantId::new("trigger-foreign-tenant").expect("tenant id");
         let creator_user_id = UserId::new("trigger-foreign-user").expect("user id");
@@ -494,9 +601,10 @@ mod tests {
             project_id: None,
             prompt: "summarize unread mail".to_string(),
         };
+        let request = TriggerFireAuthRequest::from_fire(&fire);
 
-        let error = TrustedTenantTriggerFireAuthorizer::new(poller_tenant)
-            .authorize_trigger_fire(&fire)
+        let error = TenantScopedTrustedTriggerFireAuthorizer::new(poller_tenant)
+            .authorize_trigger_fire(&request)
             .await
             .expect_err("foreign tenant fire is rejected");
 
@@ -1320,6 +1428,134 @@ mod tests {
         assert!(
             matches!(error, TriggerError::Backend { reason } if reason == "trusted trigger submit retryable failure")
         );
+    }
+
+    #[tokio::test]
+    async fn materializer_rejects_authorizer_denial_before_binding_or_prompt_write() {
+        let tenant_id = TenantId::new("trigger-auth-denied-tenant").expect("tenant id");
+        let creator_user_id = UserId::new("trigger-auth-denied-user").expect("user id");
+        let agent_id = AgentId::new("trigger-auth-denied-agent").expect("agent id");
+        let project_id = ProjectId::new("trigger-auth-denied-project").expect("project id");
+        let trigger_id = TriggerId::new();
+        let fire_slot = Utc::now();
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let authorizer = Arc::new(StaticTriggerFireAuthorizer::new(Err(
+            TriggerFireAuthError::Denied {
+                reason: "creator no longer authorized for project".to_string(),
+            },
+        )));
+        let materializer = ConversationContentRefMaterializer::new(
+            PanicBindingService,
+            thread_service.clone(),
+            agent_id.clone(),
+            authorizer.clone(),
+        );
+
+        let error = materializer
+            .materialize_prompt(TriggerFire {
+                identity: TriggerFireIdentity::new(tenant_id.clone(), trigger_id, fire_slot),
+                creator_user_id: creator_user_id.clone(),
+                agent_id: Some(agent_id.clone()),
+                project_id: Some(project_id.clone()),
+                prompt: "summarize unread mail".to_string(),
+            })
+            .await
+            .expect_err("authorization denial rejects before materialization side effects");
+
+        assert!(
+            matches!(error, TriggerError::InvalidMaterialization { reason } if reason.contains("creator no longer authorized for project"))
+        );
+        assert_eq!(
+            authorizer.requests(),
+            vec![TriggerFireAuthRequest {
+                tenant_id: tenant_id.clone(),
+                creator_user_id: creator_user_id.clone(),
+                agent_id: Some(agent_id.clone()),
+                project_id: Some(project_id.clone()),
+                trigger_id,
+                fire_slot,
+            }]
+        );
+        let threads = thread_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: ThreadScope {
+                    tenant_id,
+                    agent_id,
+                    project_id: Some(project_id),
+                    owner_user_id: Some(creator_user_id),
+                    mission_id: None,
+                },
+                limit: Some(10),
+                cursor: None,
+            })
+            .await
+            .expect("threads load");
+        assert!(threads.threads.is_empty());
+    }
+
+    #[tokio::test]
+    async fn materializer_returns_retryable_error_when_authorizer_backend_fails() {
+        let tenant_id = TenantId::new("trigger-auth-retryable-tenant").expect("tenant id");
+        let creator_user_id = UserId::new("trigger-auth-retryable-user").expect("user id");
+        let agent_id = AgentId::new("trigger-auth-retryable-agent").expect("agent id");
+        let project_id = ProjectId::new("trigger-auth-retryable-project").expect("project id");
+        let trigger_id = TriggerId::new();
+        let fire_slot = Utc::now();
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let authorizer = Arc::new(StaticTriggerFireAuthorizer::new(Err(
+            TriggerFireAuthError::Retryable {
+                reason: "creator authorization backend unavailable".to_string(),
+            },
+        )));
+        let materializer = ConversationContentRefMaterializer::new(
+            PanicBindingService,
+            thread_service.clone(),
+            agent_id.clone(),
+            authorizer.clone(),
+        );
+
+        let error = materializer
+            .materialize_prompt(TriggerFire {
+                identity: TriggerFireIdentity::new(tenant_id.clone(), trigger_id, fire_slot),
+                creator_user_id: creator_user_id.clone(),
+                agent_id: Some(agent_id.clone()),
+                project_id: Some(project_id.clone()),
+                prompt: "summarize unread mail".to_string(),
+            })
+            .await
+            .expect_err(
+                "retryable authorization failure rejects before materialization side effects",
+            );
+
+        assert!(
+            matches!(error, TriggerError::Backend { reason } if reason.contains("creator authorization backend unavailable"))
+        );
+        assert_eq!(
+            authorizer.requests(),
+            vec![TriggerFireAuthRequest {
+                tenant_id: tenant_id.clone(),
+                creator_user_id: creator_user_id.clone(),
+                agent_id: Some(agent_id.clone()),
+                project_id: Some(project_id.clone()),
+                trigger_id,
+                fire_slot,
+            }]
+        );
+        let threads = thread_service
+            .list_threads_for_scope(ListThreadsForScopeRequest {
+                scope: ThreadScope {
+                    tenant_id,
+                    agent_id,
+                    project_id: Some(project_id),
+                    owner_user_id: Some(creator_user_id),
+                    mission_id: None,
+                },
+                limit: Some(10),
+                cursor: None,
+            })
+            .await
+            .expect("threads load");
+        assert!(threads.threads.is_empty());
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -153,15 +153,12 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
     let runtime = build_runtime_with(
         &root,
         Arc::clone(&recording_gateway),
-        TriggerPollerSettings {
-            enabled: true,
-            worker: TriggerPollerWorkerConfig {
+        TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
+            TriggerPollerWorkerConfig {
                 poll_interval: Duration::from_millis(20),
                 ..Default::default()
             },
-            startup_jitter_max: Duration::ZERO,
-            tick_jitter_max: Duration::ZERO,
-        },
+        ),
     )
     .await;
 
@@ -345,15 +342,12 @@ async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
     let runtime = build_runtime_with(
         &root,
         Arc::clone(&recording_gateway),
-        TriggerPollerSettings {
-            enabled: true,
-            worker: TriggerPollerWorkerConfig {
+        TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
+            TriggerPollerWorkerConfig {
                 poll_interval: Duration::from_millis(20),
                 ..Default::default()
             },
-            startup_jitter_max: Duration::ZERO,
-            tick_jitter_max: Duration::ZERO,
-        },
+        ),
     )
     .await;
 
@@ -467,15 +461,12 @@ async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
     let runtime = build_runtime_with(
         &root,
         Arc::clone(&recording_gateway),
-        TriggerPollerSettings {
-            enabled: true,
-            worker: TriggerPollerWorkerConfig {
+        TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
+            TriggerPollerWorkerConfig {
                 poll_interval: Duration::from_millis(20),
                 ..Default::default()
             },
-            startup_jitter_max: Duration::ZERO,
-            tick_jitter_max: Duration::ZERO,
-        },
+        ),
     )
     .await;
 
@@ -563,15 +554,12 @@ async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
     let runtime = build_runtime_with(
         &root,
         Arc::clone(&recording_gateway),
-        TriggerPollerSettings {
-            enabled: true,
-            worker: TriggerPollerWorkerConfig {
+        TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
+            TriggerPollerWorkerConfig {
                 poll_interval: Duration::from_millis(20),
                 ..Default::default()
             },
-            startup_jitter_max: Duration::ZERO,
-            tick_jitter_max: Duration::ZERO,
-        },
+        ),
     )
     .await;
 

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -837,7 +837,7 @@ Two gaps block shipping user-creatable cron jobs:
    `ironclaw_conversations`; product/adapter crates cannot mint host-trusted
    inbound turns directly. Fire-time creator authorization is still a
    tenant-ID-equality placeholder
-   (`TrustedTenantTriggerFireAuthorizer`), not wired to a real agent/project
+   (`TenantScopedTrustedTriggerFireAuthorizer`), not wired to a real agent/project
    access source. Both are plan-mandated before any user-visible trigger launch
    path or external delivery ships (see PR 18 follow-up status and PR 19).
 
@@ -927,7 +927,7 @@ Three independent tracks branch from the PR 18 baseline.
   `creator_user_id`, `agent_id`, `project_id`, `trigger_id`, and `fire_slot`
   (today the trait takes the whole `TriggerFire`).
 - Implement the port against the real agent/project access-control source of
-  truth (today `TrustedTenantTriggerFireAuthorizer` checks tenant-ID equality
+  truth (today `TenantScopedTrustedTriggerFireAuthorizer` checks tenant-ID equality
   only). If no real source exists, keep external delivery disabled.
 - Add a `TriggerFireAuthError::Retryable` variant for backend unavailability;
   `Denied`/revoked stays permanent (clear claim, advance slot); retryable does

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -825,13 +825,13 @@ wiring. A Reborn ownership audit found no boundary breaches.
 
 Two gaps block shipping user-creatable cron jobs:
 
-1. **Poller is never enabled in any shipped binary.** `TriggerPollerSettings`
-   defaults `enabled: false` (`runtime_input.rs`), and the CLI runtime builder
-   (`ironclaw_reborn_cli/src/runtime.rs::build_runtime_input_with_options`)
-   never calls `.with_trigger_poller_settings(...)`. There is no config-file
-   section, no env var, and no `.env.example` entry. Cron triggers can only
-   fire from Rust test code today. This is the hard blocker between "backend
-   exists" and "cron actually fires."
+1. **Poller is not enabled in a shipped runtime without real fire-time creator
+   authorization.** `TriggerPollerSettings` defaults `enabled: false`
+   (`runtime_input.rs`). Even if config/env enables the poller, composition now
+   rejects runtime build unless the placeholder tenant-scope authorizer is
+   explicitly allowed by test-support code. Cron triggers can only fire from Rust
+   test code today. This is the hard blocker between "backend exists" and "cron
+   actually fires."
 2. **Some security hardening is deferred.** Trusted trigger submission is now
    type-sealed through `TrustedTriggerSubmitRequest` and converted inside
    `ironclaw_conversations`; product/adapter crates cannot mint host-trusted
@@ -928,7 +928,9 @@ Three independent tracks branch from the PR 18 baseline.
   (today the trait takes the whole `TriggerFire`).
 - Implement the port against the real agent/project access-control source of
   truth (today `TenantScopedTrustedTriggerFireAuthorizer` checks tenant-ID equality
-  only). If no real source exists, keep external delivery disabled.
+  only). If no real source exists, keep external delivery disabled; composition
+  must fail closed when a normal runtime tries to enable the poller with the
+  tenant-only placeholder.
 - Add a `TriggerFireAuthError::Retryable` variant for backend unavailability;
   `Denied`/revoked stays permanent (clear claim, advance slot); retryable does
   not mark the fire active and keeps `next_run_at` retryable.

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -214,7 +214,10 @@ A trigger fire is synthetic inbound, not a parallel agent loop.
   Backend unavailability while checking that policy must be retryable. The
   fire-time authorization request is a host-owned shape over
   `tenant_id`/`creator_user_id`/`agent_id`/`project_id`/`trigger_id`/`fire_slot`;
-  trigger-domain crates must not own the membership policy.
+  trigger-domain crates must not own the membership policy. Until that request
+  is backed by the real agent/project membership source of truth, a normal
+  runtime must fail closed instead of enabling the trigger poller with the
+  tenant-scope placeholder.
 - The trusted inbound request is a host-owned synthetic inbound shape around the ordinary inbound fields. It carries only ingress identity and turn scope data needed to create the canonical turn, and it has no adapter-supplied requested-scope hints before binding resolution.
 - It must not encode delivery targets, notification targets, or any other outbound routing policy.
 

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -211,6 +211,10 @@ A trigger fire is synthetic inbound, not a parallel agent loop.
   time that `creator_user_id` is still authorized for the target
   `tenant_id`/`agent_id`/`project_id`; revoked or unauthorized creators must
   produce a permanent authorization failure instead of submitting a turn.
+  Backend unavailability while checking that policy must be retryable. The
+  fire-time authorization request is a host-owned shape over
+  `tenant_id`/`creator_user_id`/`agent_id`/`project_id`/`trigger_id`/`fire_slot`;
+  trigger-domain crates must not own the membership policy.
 - The trusted inbound request is a host-owned synthetic inbound shape around the ordinary inbound fields. It carries only ingress identity and turn scope data needed to create the canonical turn, and it has no adapter-supplied requested-scope hints before binding resolution.
 - It must not encode delivery targets, notification targets, or any other outbound routing policy.
 


### PR DESCRIPTION
## Summary

Adds the PR 18.5b fire-time authorization seam for trusted trigger fires:

- introduces a composition-owned `TriggerFireAuthRequest` carrying tenant, creator, agent, project, trigger, and fire-slot scope
- changes the trigger-fire authorizer to consume the typed request instead of the whole `TriggerFire`
- separates denied authorization from retryable authorization backend failures
- renames the current tenant-only placeholder to `TenantScopedTrustedTriggerFireAuthorizer` so it is not mistaken for real creator/project membership authorization
- updates Reborn trigger contract and implementation plan docs

## Notes

This does not invent a real creator-to-agent/project membership backend. The current production authorizer remains tenant-scope only and is documented as non-authoritative for creator membership. External trigger delivery still needs the real access-control source of truth before launch.

## Validation

- `cargo test -p ironclaw_reborn_composition trigger_poller_trusted_submit --lib`
- `cargo clippy -p ironclaw_reborn_composition --lib -- -D warnings`
- `cargo test -p ironclaw_triggers failure --lib`
- `$code-review` with 5.4-mini reviewers; chose Option A for the two design discussion items
