### PR TITLE
webui v2 thread-state: thermo cleanup (post #4419)

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/lib/thread-meta.js
+++ b/crates/ironclaw_webui_v2_static/static/js/lib/thread-meta.js
@@ -4,9 +4,10 @@
  * Recent group is the only consumer; future surfaces (resume cards, palette,
  * etc.) should reuse it so threads sort consistently everywhere.
  *
- * `formatRelativeTime` is the project-wide thread time-label format.
- * Anything that renders "when did this thread last move" should go through
- * here so the wording stays consistent.
+ * `formatThreadActivityLabel` and `formatThreadActivityTooltip` are the
+ * project-wide thread time-label functions. Anything that renders "when did
+ * this thread last move" should go through here so the wording stays
+ * consistent.
  */
 
 /** ISO timestamp the UI considers most recent for sorting/labelling. */

--- a/crates/ironclaw_webui_v2_static/static/js/lib/thread-state.js
+++ b/crates/ironclaw_webui_v2_static/static/js/lib/thread-state.js
@@ -25,8 +25,9 @@
  *   - Subscribers receive a snapshot Map; the internal map is never
  *     handed out so a misbehaving listener cannot mutate the store.
  *
- * No persistence. Server-truth re-seeds via the writer on reconnect,
- * so reload-loss is acceptable.
+ * Persistence: NEEDS_ATTENTION and FAILED survive page refresh via
+ * localStorage (key: ironclaw:v2-thread-attention). RUNNING is not persisted;
+ * see PERSISTED_STATES below for the full rationale.
  */
 
 import { React } from "./html.js";
@@ -38,20 +39,31 @@ export const THREAD_STATE = Object.freeze({
   FAILED: "failed",
 });
 
-/* Persistence policy: only the "the user has something to do" subset
- * survives reload. RUNNING is the most-likely-stale state across a page
- * lifetime (the run almost certainly completed while the tab was closed),
- * so writing it to localStorage would cause confusing false-positive
- * green dots on first load. NEEDS_ATTENTION is the opposite — a pending
- * gate remains pending until the user acts, so persisting it is exactly
- * what the user expects ("I left an approval hanging; the app remembered").
- * FAILED is not yet populated by any writer but is treated like
+/* Only the "user must act" subset survives page refresh.
+ *
+ * RUNNING is intentionally excluded: across a page lifetime the run almost
+ * certainly completed while the tab was closed, so a persisted RUNNING
+ * would show a false-positive green dot on reload.
+ *
+ * NEEDS_ATTENTION is the opposite — a pending gate remains pending until
+ * the user acts. Persisting it is exactly what the user expects
+ * ("I left an approval hanging; the app remembered").
+ *
+ * FAILED is not yet populated by any writer but is grouped with
  * NEEDS_ATTENTION for symmetry when it lands. */
 const PERSISTED_STATES = new Set([
   THREAD_STATE.NEEDS_ATTENTION,
   THREAD_STATE.FAILED,
 ]);
 const STORAGE_KEY = "ironclaw:v2-thread-attention";
+
+// ── Module state (declared before the functions that mutate it) ────────
+
+const subscribers = new Set();
+/** @type {Map<string, string>} */
+const states = new Map();
+
+// ── Storage helpers ────────────────────────────────────────────────────
 
 function readPersisted() {
   try {
@@ -87,23 +99,19 @@ function writePersisted() {
   }
 }
 
-const subscribers = new Set();
-/** @type {Map<string, string>} */
-const states = new Map();
-
 // Seed from previous session so a pending approval survives page refresh.
 for (const [id, state] of readPersisted()) {
   states.set(id, state);
 }
 
+// ── Internal helpers ───────────────────────────────────────────────────
+
 function snapshot() {
   return new Map(states);
 }
 
+/* Notify subscribers with a fresh snapshot. Pure — no side-effects. */
 function emit() {
-  // Persist before notifying so subscribers reading the store observe a
-  // consistent in-memory + persisted view.
-  writePersisted();
   const snap = snapshot();
   for (const listener of subscribers) {
     try {
@@ -118,15 +126,22 @@ function emit() {
  * Set the state of a thread. Passing `null`/`undefined` clears the
  * entry, returning the thread to the implicit `idle`. No-op when the
  * new state matches the current one (suppresses redundant emits).
+ *
+ * Writes to localStorage only when the persisted subset (NEEDS_ATTENTION,
+ * FAILED) actually changes — RUNNING transitions never touch storage.
  */
 export function setThreadState(threadId, state) {
   if (!threadId) return;
+  const prevState = states.get(threadId);
   if (state == null) {
-    if (states.delete(threadId)) emit();
+    if (!states.delete(threadId)) return;
+    if (PERSISTED_STATES.has(prevState)) writePersisted();
+    emit();
     return;
   }
-  if (states.get(threadId) === state) return;
+  if (prevState === state) return;
   states.set(threadId, state);
+  if (PERSISTED_STATES.has(state) || PERSISTED_STATES.has(prevState)) writePersisted();
   emit();
 }
 


### PR DESCRIPTION
Five findings from a thermo-nuclear code-quality review pass on the two new lib files shipped in #4419. All changes are comment accuracy and structural — no behavior change, no API surface change.

## Findings fixed

### `lib/thread-state.js` — 4 fixes

**1. Stale header comment contradicted the implementation.**
The module-level block comment ended with *"No persistence. Server-truth re-seeds via the writer on reconnect, so reload-loss is acceptable."* — directly contradicting the 50 lines of localStorage persistence code that follow. Updated to a one-line summary pointing to `PERSISTED_STATES` for the full rationale.

**2. Duplicate persistence policy.**
The module header and the `PERSISTED_STATES` block comment both explained the RUNNING exclusion with nearly identical wording (same example, same reasoning). Deduplicated: `PERSISTED_STATES` block is now the detailed single source of truth; the module header just references it.

**3. Declaration order.**
`readPersisted()` and `writePersisted()` referenced `states` (a `const` declared ~30 lines later in the file). JS hoists function declarations so runtime was safe, but reading top-to-bottom `states` appeared to come from nowhere inside these functions. Moved module state (`subscribers`, `states`) before the storage helpers that use them — standard data-before-functions convention.

**4. `emit()` had an unconditional `writePersisted()` call.**
Every `RUNNING` state transition triggered a `localStorage` write even though `RUNNING` is excluded from `PERSISTED_STATES`. The write was a no-op but still looped all states and called `localStorage.setItem/removeItem` unnecessarily. Moved `writePersisted()` into `setThreadState()`, guarded by `PERSISTED_STATES.has(state) || PERSISTED_STATES.has(prevState)`. `RUNNING` transitions now cost 0 storage I/O. Also restores `emit()` to a single responsibility (notify subscribers — pure, no side-effects).

### `lib/thread-meta.js` — 1 fix

**5. File header referenced `formatRelativeTime`** which was renamed to `formatThreadActivityLabel` / `formatThreadActivityTooltip` before #4419 landed. Updated to the actual exported names.

## Validation

- `node --check` clean on both files
- `cargo test -p ironclaw_webui_v2_static` — **24 passed, 0 failed**
- Behavior smoke (in-process): `RUNNING` still costs 0 storage calls; `NEEDS_ATTENTION` still writes on set + removes on clear

## Diff

```
 .../js/lib/thread-meta.js    |  7 +--
 .../js/lib/thread-state.js   | 53 +++++++++++++++-------
```

2 files, +38 / −22.
