### PR TITLE
feat(reborn): wire Slack personal binding host state

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -823,7 +823,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 
 ### P1 - High Priority
 
-- 🚧 Slack channel (real implementation): Reborn host-beta route can be explicitly mounted by `ironclaw-reborn serve` with Slack Events API signing, DM/app-mention routing through Product Workflow/Reborn, and final-reply delivery; production durability/setup remains follow-up.
+- 🚧 Slack channel (real implementation): Reborn host-beta route can be explicitly mounted by `ironclaw-reborn serve` with Slack Events API signing, DM/app-mention routing through Product Workflow/Reborn, final-reply delivery, and host-state-backed personal binding pairing; production install/setup hardening and fuller E2E coverage remain follow-up.
 - ✅ Telegram channel (WASM, polling-first setup, DM pairing, caption, /start)
 - ❌ WhatsApp channel
 - ✅ Multi-provider failover (`FailoverProvider` with retryable error classification)

--- a/crates/ironclaw_reborn_cli/src/commands/config/init.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/init.rs
@@ -206,7 +206,9 @@ api_key_env = "OPENAI_API_KEY"
 # enabled = false
 # installation_id = "install-alpha"
 # team_id = "T123"
+# # Required for tenant app-scoped personal-binding pairing.
 # api_app_id = "A123"
+# # Optional legacy static mapping. Omit for the pairing-code flow.
 # slack_user_id = "U123"
 # # Defaults to the WebUI authenticated user when omitted.
 # # user_id = "reborn-cli"

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use clap::Args;
 #[cfg(feature = "slack-v2-host-beta")]
-use ironclaw_reborn_composition::build_slack_events_route_mount;
+use ironclaw_reborn_composition::build_slack_host_beta_mounts;
 use ironclaw_reborn_composition::{
     GoogleOAuthRouteConfig, RebornBuildInput, RebornReadiness, RebornRuntimeIdentity,
     RebornRuntimeInput, RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig,
@@ -388,9 +388,11 @@ impl ServeCommand {
             }
             #[cfg(feature = "slack-v2-host-beta")]
             if let Some(slack_config) = slack_host_beta_config {
-                let slack_mount = build_slack_events_route_mount(&runtime, slack_config)
-                    .context("failed to compose Slack Events API host-beta route")?;
-                serve_config = serve_config.with_public_route_mount(slack_mount);
+                let slack_mounts = build_slack_host_beta_mounts(&runtime, slack_config)
+                    .context("failed to compose Slack host-beta routes")?;
+                serve_config = serve_config
+                    .with_public_route_mount(slack_mounts.events)
+                    .with_slack_personal_binding_pairing(slack_mounts.personal_binding_pairing);
             }
             if let Some(mount) = public_mount {
                 serve_config = serve_config.with_public_route_mount(mount);

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -67,7 +67,7 @@ pub(crate) fn resolve_slack_host_beta_config(
     let installation_id =
         required_slack_config_value("installation_id", &section.installation_id, config_path)?;
     let team_id = required_slack_config_value("team_id", &section.team_id, config_path)?;
-    let api_app_id = optional_slack_config_value("api_app_id", &section.api_app_id)?;
+    let api_app_id = required_slack_config_value("api_app_id", &section.api_app_id, config_path)?;
     let slack_user_id = optional_slack_config_value("slack_user_id", &section.slack_user_id)?;
     let mapped_user_id = match optional_slack_config_value("user_id", &section.user_id)? {
         Some(raw) => {
@@ -104,7 +104,7 @@ pub(crate) fn resolve_slack_host_beta_config(
         project_id: default_project_id.cloned(),
         installation_id,
         team_id,
-        api_app_id,
+        api_app_id: Some(api_app_id),
         slack_user_id,
         user_id: mapped_user_id,
         signing_secret: SecretString::from(signing_secret),
@@ -363,6 +363,32 @@ mod tests {
 
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
+    fn slack_host_beta_config_requires_api_app_id_for_pairing() {
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            team_id: Some("T123".to_string()),
+            ..Default::default()
+        };
+
+        let error = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect_err("enabled Slack pairing must require api_app_id");
+
+        assert!(
+            error.to_string().contains("[slack].api_app_id"),
+            "message: {error}"
+        );
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
     fn slack_host_beta_config_rejects_empty_env_secret_value() {
         let _lock = env_lock();
         let _signing = EnvGuard::set("IRONCLAW_TEST_SLACK_EMPTY_SIGNING_SECRET", "");
@@ -371,6 +397,7 @@ mod tests {
             enabled: Some(true),
             installation_id: Some("install-alpha".to_string()),
             team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
             slack_user_id: Some("U123".to_string()),
             signing_secret_env: Some("IRONCLAW_TEST_SLACK_EMPTY_SIGNING_SECRET".to_string()),
             bot_token_env: Some("IRONCLAW_TEST_SLACK_EMPTY_BOT_TOKEN".to_string()),
@@ -410,11 +437,11 @@ mod tests {
             enabled: Some(true),
             installation_id: Some("install-alpha".to_string()),
             team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
             slack_user_id: Some("U123".to_string()),
             user_id: Some("web-user".to_string()),
             signing_secret_env: Some("IRONCLAW_TEST_SLACK_SIGNING_SECRET_MAPPED_USER".to_string()),
             bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_MAPPED_USER".to_string()),
-            ..Default::default()
         };
 
         let resolved = resolve_slack_host_beta_config(
@@ -444,13 +471,13 @@ mod tests {
             enabled: Some(true),
             installation_id: Some("install-alpha".to_string()),
             team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
             slack_user_id: Some("U123".to_string()),
             user_id: Some("slack-mapped-user".to_string()),
             signing_secret_env: Some(
                 "IRONCLAW_TEST_SLACK_SIGNING_SECRET_DIVERGENT_USER".to_string(),
             ),
             bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_DIVERGENT_USER".to_string()),
-            ..Default::default()
         };
 
         let error = resolve_slack_host_beta_config(
@@ -478,6 +505,7 @@ mod tests {
             enabled: Some(true),
             installation_id: Some("install-alpha".to_string()),
             team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
             slack_user_id: Some("U123".to_string()),
             user_id: Some(" web-user".to_string()),
             ..Default::default()
@@ -508,6 +536,7 @@ mod tests {
             enabled: Some(true),
             installation_id: Some("install-alpha".to_string()),
             team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
             slack_user_id: Some("U123".to_string()),
             user_id: Some("invalid user".to_string()),
             ..Default::default()
@@ -539,6 +568,7 @@ mod tests {
             enabled: Some(true),
             installation_id: Some("install-alpha".to_string()),
             team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
             slack_user_id: Some("U123".to_string()),
             signing_secret_env: Some("IRONCLAW_TEST_SLACK_UNSET_SIGNING_SECRET".to_string()),
             bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_UNSET_SIGNING".to_string()),

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -68,8 +68,7 @@ pub(crate) fn resolve_slack_host_beta_config(
         required_slack_config_value("installation_id", &section.installation_id, config_path)?;
     let team_id = required_slack_config_value("team_id", &section.team_id, config_path)?;
     let api_app_id = optional_slack_config_value("api_app_id", &section.api_app_id)?;
-    let slack_user_id =
-        required_slack_config_value("slack_user_id", &section.slack_user_id, config_path)?;
+    let slack_user_id = optional_slack_config_value("slack_user_id", &section.slack_user_id)?;
     let mapped_user_id = match optional_slack_config_value("user_id", &section.user_id)? {
         Some(raw) => {
             let user_id = ironclaw_reborn_composition::host_api::UserId::new(&raw)
@@ -317,10 +316,49 @@ mod tests {
 
         assert_eq!(resolved.installation_id.as_str(), "install-alpha");
         assert!(format!("{:?}", resolved.installation_selector).contains("AppTeam"));
-        assert_eq!(resolved.slack_actor.id(), "U123");
+        assert_eq!(
+            resolved.slack_actor.as_ref().expect("legacy actor").id(),
+            "U123"
+        );
         assert_eq!(resolved.user_id, user_id("web-user"));
         assert_eq!(resolved.signing_secret.expose_secret(), "signing-secret");
         assert_eq!(resolved.bot_token.expose_secret(), "xoxb-token");
+    }
+
+    #[cfg(feature = "slack-v2-host-beta")]
+    #[test]
+    fn slack_host_beta_config_does_not_require_static_slack_user() {
+        let _lock = env_lock();
+        let _signing = EnvGuard::set(
+            "IRONCLAW_TEST_SLACK_SIGNING_SECRET_NO_STATIC_USER",
+            "signing-secret",
+        );
+        let _bot = EnvGuard::set("IRONCLAW_TEST_SLACK_BOT_TOKEN_NO_STATIC_USER", "xoxb-token");
+        let section = ironclaw_reborn_config::SlackSection {
+            enabled: Some(true),
+            installation_id: Some("install-alpha".to_string()),
+            team_id: Some("T123".to_string()),
+            api_app_id: Some("A123".to_string()),
+            signing_secret_env: Some(
+                "IRONCLAW_TEST_SLACK_SIGNING_SECRET_NO_STATIC_USER".to_string(),
+            ),
+            bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_NO_STATIC_USER".to_string()),
+            ..Default::default()
+        };
+
+        let resolved = resolve_slack_host_beta_config(
+            Some(&section),
+            &tenant_id("tenant"),
+            &agent_id("agent"),
+            None,
+            &user_id("web-user"),
+            Path::new("/tmp/reborn-config.toml"),
+        )
+        .expect("Slack config should resolve")
+        .expect("Slack should be enabled");
+
+        assert!(resolved.slack_actor.is_none());
+        assert_eq!(resolved.user_id, user_id("web-user"));
     }
 
     #[cfg(feature = "slack-v2-host-beta")]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -353,6 +353,8 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) skill_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
     pub(crate) workspace_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
     #[cfg(any(feature = "libsql", feature = "postgres"))]
+    pub(crate) host_state_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
     pub(crate) subagent_goal_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
     pub(crate) workspace_mounts: MountView,
     pub(crate) local_dev_storage_root: PathBuf,
@@ -835,6 +837,7 @@ fn build_local_dev_store_graph(
         memory_mounts,
         skill_filesystem,
         workspace_filesystem,
+        host_state_filesystem: Arc::clone(&scoped_filesystem),
         subagent_goal_filesystem: Arc::clone(&scoped_filesystem),
         workspace_mounts,
         local_dev_storage_root,
@@ -921,6 +924,8 @@ fn build_local_dev_store_graph(
         memory_mounts,
         skill_filesystem,
         workspace_filesystem,
+        #[cfg(feature = "postgres")]
+        host_state_filesystem: Arc::clone(&subagent_goal_filesystem),
         #[cfg(feature = "postgres")]
         subagent_goal_filesystem,
         workspace_mounts,

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -81,6 +81,8 @@ mod slack_egress;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_host_beta;
 #[cfg(feature = "slack-v2-host-beta")]
+mod slack_host_state;
+#[cfg(feature = "slack-v2-host-beta")]
 mod slack_personal_binding;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_personal_binding_pairing;
@@ -195,8 +197,9 @@ pub use slack_egress::{
 };
 #[cfg(feature = "slack-v2-host-beta")]
 pub use slack_host_beta::{
-    SlackHostBetaBuildError, SlackHostBetaConfig, SlackHostBetaConfigInput,
+    SlackHostBetaBuildError, SlackHostBetaConfig, SlackHostBetaConfigInput, SlackHostBetaMounts,
     build_slack_events_route_mount, build_slack_events_route_mount_with_actor_user_resolver,
+    build_slack_host_beta_mounts,
 };
 #[cfg(feature = "slack-v2-host-beta")]
 pub use slack_personal_binding::{

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -83,6 +83,8 @@ mod slack_host_beta;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_host_state;
 #[cfg(feature = "slack-v2-host-beta")]
+mod slack_pairing_notifier;
+#[cfg(feature = "slack-v2-host-beta")]
 mod slack_personal_binding;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_personal_binding_pairing;

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -12,17 +12,18 @@ use ironclaw_conversations::InMemoryConversationServices;
 use ironclaw_host_api::{AgentId, ProjectId, ResourceScope, TenantId, UserId};
 use ironclaw_outbound::{InMemoryOutboundStateStore, OutboundStateStore};
 use ironclaw_product_adapters::{
-    AdapterInstallationId, DeliveryStatus, EgressCredentialHandle, ExternalActorRef,
-    OutboundDeliverySink, ProductAdapter, ProductAdapterId,
+    AdapterInstallationId, DeclaredEgressHost, DeclaredEgressTarget, DeliveryStatus,
+    EgressCredentialHandle, ExternalActorRef, OutboundDeliverySink, ProductAdapter,
+    ProductAdapterId, ProtocolHttpEgress,
 };
 use ironclaw_product_workflow::{
     DefaultInboundTurnService, DefaultProductWorkflow, InMemoryIdempotencyLedger,
     ProductActorUserResolver, ProductConversationBindingService, ProductInstallationKey,
-    ProductInstallationScope, StaticProductActorUserResolver, StaticProductInstallationResolver,
+    ProductInstallationScope, StaticProductInstallationResolver,
 };
 use ironclaw_slack_v2_adapter::{
-    SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID, SlackV2Adapter, SlackV2AdapterConfig,
-    slack_request_signature_auth_requirement,
+    SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID, SlackV2Adapter,
+    SlackV2AdapterConfig, slack_request_signature_auth_requirement,
 };
 use ironclaw_wasm_product_adapters::{
     EgressPolicy, HmacWebhookAuth, NativeProductAdapterRunner, NativeProductAdapterRunnerConfig,
@@ -37,6 +38,16 @@ use crate::slack_delivery::{
     SlackFinalReplyDeliverySettings,
 };
 use crate::slack_egress::{SlackProtocolHttpEgress, StaticSlackEgressCredentialProvider};
+use crate::slack_host_state::{FilesystemSlackHostState, SlackPairingChallengeHttpNotifier};
+use crate::slack_personal_binding::{
+    RebornUserIdentityBindingStore, SlackPersonalBindingInstallation,
+    SlackPersonalUserBindingService,
+};
+use crate::slack_personal_binding_pairing::{
+    SlackPairingActorResolver, SlackPersonalBindingPairingChallengeStore,
+    SlackPersonalBindingPairingNotifier, SlackPersonalBindingPairingService,
+};
+use crate::slack_personal_binding_pairing_serve::SlackPersonalBindingPairingRouteConfig;
 use crate::slack_serve::{
     SlackEventsRouteState, SlackInstallationRecord, SlackInstallationSelector,
     StaticSlackInstallationResolver, slack_events_route_mount,
@@ -64,10 +75,11 @@ pub struct SlackHostBetaConfig {
     pub project_id: Option<ProjectId>,
     pub installation_id: AdapterInstallationId,
     pub installation_selector: SlackInstallationSelector,
-    /// Slack actor used by the legacy static personal-binding builder.
-    pub slack_actor: ExternalActorRef,
-    /// Host user used by the legacy static personal-binding builder and as the
-    /// resource owner for Slack bot-token egress.
+    /// Optional Slack actor retained only for legacy static personal-binding
+    /// tests/config. Tenant app host-beta resolution uses durable personal
+    /// bindings and does not require a preselected Slack user.
+    pub slack_actor: Option<ExternalActorRef>,
+    /// Host user used as the resource owner for Slack bot-token egress.
     pub user_id: UserId,
     pub signing_secret: SecretString,
     pub bot_token: SecretString,
@@ -80,7 +92,7 @@ pub struct SlackHostBetaConfigInput {
     pub installation_id: String,
     pub team_id: String,
     pub api_app_id: Option<String>,
-    pub slack_user_id: String,
+    pub slack_user_id: Option<String>,
     pub user_id: UserId,
     pub signing_secret: SecretString,
     pub bot_token: SecretString,
@@ -94,9 +106,13 @@ impl SlackHostBetaConfig {
             Some(api_app_id) => SlackInstallationSelector::app_team(api_app_id, input.team_id),
             None => SlackInstallationSelector::team(input.team_id),
         };
-        let slack_actor =
-            ExternalActorRef::new(SLACK_USER_ACTOR_KIND, input.slack_user_id, None::<String>)
-                .map_err(|reason| invalid_config("slack_user_id", reason.to_string()))?;
+        let slack_actor = input
+            .slack_user_id
+            .map(|slack_user_id| {
+                ExternalActorRef::new(SLACK_USER_ACTOR_KIND, slack_user_id, None::<String>)
+                    .map_err(|reason| invalid_config("slack_user_id", reason.to_string()))
+            })
+            .transpose()?;
         Ok(Self {
             tenant_id: input.tenant_id,
             agent_id: input.agent_id,
@@ -132,19 +148,69 @@ impl std::fmt::Debug for SlackHostBetaConfig {
 pub enum SlackHostBetaBuildError {
     #[error("Slack host-beta requires local runtime HTTP egress")]
     RuntimeHttpEgressUnavailable,
+    #[error("Slack host-beta requires durable host state")]
+    DurableHostStateUnavailable,
     #[error("invalid Slack host-beta config field {field}: {reason}")]
     InvalidConfig { field: &'static str, reason: String },
+}
+
+pub struct SlackHostBetaMounts {
+    pub events: PublicRouteMount,
+    pub personal_binding_pairing: SlackPersonalBindingPairingRouteConfig,
 }
 
 pub fn build_slack_events_route_mount(
     runtime: &RebornRuntime,
     config: SlackHostBetaConfig,
 ) -> Result<PublicRouteMount, SlackHostBetaBuildError> {
-    let actor_user_resolver = Arc::new(StaticProductActorUserResolver::new([(
-        config.slack_actor.clone(),
+    build_slack_host_beta_mounts(runtime, config).map(|mounts| mounts.events)
+}
+
+pub fn build_slack_host_beta_mounts(
+    runtime: &RebornRuntime,
+    config: SlackHostBetaConfig,
+) -> Result<SlackHostBetaMounts, SlackHostBetaBuildError> {
+    let local_runtime = runtime
+        .services()
+        .local_runtime
+        .as_ref()
+        .ok_or(SlackHostBetaBuildError::DurableHostStateUnavailable)?;
+    let state = Arc::new(FilesystemSlackHostState::new(
+        Arc::clone(&local_runtime.host_state_filesystem),
+        config.tenant_id.clone(),
         config.user_id.clone(),
-    )]));
-    build_slack_events_route_mount_with_actor_user_resolver(runtime, config, actor_user_resolver)
+        config.agent_id.clone(),
+        config.project_id.clone(),
+    ));
+    let binding_store: Arc<dyn RebornUserIdentityBindingStore> = state.clone();
+    let binding_service = SlackPersonalUserBindingService::new(
+        [SlackPersonalBindingInstallation {
+            tenant_id: config.tenant_id.clone(),
+            installation_id: config.installation_id.clone(),
+            selector: config.installation_selector.clone(),
+        }],
+        binding_store,
+    );
+    let token_handle = slack_bot_token_handle()?;
+    let notifier: Arc<dyn SlackPersonalBindingPairingNotifier> =
+        Arc::new(SlackPairingChallengeHttpNotifier::new(
+            slack_protocol_egress(runtime, &config, token_handle.clone())?,
+            token_handle,
+        ));
+    let challenge_store: Arc<dyn SlackPersonalBindingPairingChallengeStore> = state.clone();
+    let pairing =
+        SlackPersonalBindingPairingService::new(binding_service, challenge_store, notifier);
+    let actor_user_resolver = Arc::new(SlackPairingActorResolver::new(state, pairing.clone()));
+    let events = build_slack_events_route_mount_with_actor_user_resolver(
+        runtime,
+        config,
+        actor_user_resolver,
+    )?;
+
+    Ok(SlackHostBetaMounts {
+        events,
+        personal_binding_pairing: SlackPersonalBindingPairingRouteConfig::new(pairing),
+    })
 }
 
 pub fn build_slack_events_route_mount_with_actor_user_resolver(
@@ -159,8 +225,7 @@ pub fn build_slack_events_route_mount_with_actor_user_resolver(
     );
     let adapter_id = ProductAdapterId::new(SLACK_V2_ADAPTER_ID)
         .map_err(|reason| invalid_config("adapter_id", reason.to_string()))?;
-    let token_handle = EgressCredentialHandle::new(SLACK_BOT_TOKEN_HANDLE)
-        .map_err(|reason| invalid_config("bot_token_handle", reason.to_string()))?;
+    let token_handle = slack_bot_token_handle()?;
     let adapter: Arc<dyn ProductAdapter> = Arc::new(SlackV2Adapter::new(SlackV2AdapterConfig {
         adapter_id: adapter_id.clone(),
         installation_id: config.installation_id.clone(),
@@ -220,28 +285,7 @@ pub fn build_slack_events_route_mount_with_actor_user_resolver(
         ),
     ));
 
-    let local_runtime = runtime
-        .services()
-        .local_runtime
-        .as_ref()
-        .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
-    let runtime_http_egress = local_runtime
-        .runtime_http_egress
-        .clone()
-        .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
-    let egress = Arc::new(SlackProtocolHttpEgress::new(
-        runtime_http_egress,
-        Arc::new(StaticSlackEgressCredentialProvider::new(
-            token_handle,
-            config.bot_token.expose_secret().to_string(),
-        )),
-        EgressPolicy::new(adapter.declared_egress().to_vec()),
-        ResourceScope::local_default(
-            config.user_id.clone(),
-            ironclaw_host_api::InvocationId::new(),
-        )
-        .map_err(|reason| invalid_config("resource_scope", reason.to_string()))?,
-    ));
+    let egress = slack_protocol_egress(runtime, &config, token_handle)?;
     let outbound = Arc::new(InMemoryOutboundStateStore::default());
     let outbound_store: Arc<dyn OutboundStateStore> = outbound.clone();
     let preferences: Arc<dyn ironclaw_outbound::CommunicationPreferenceRepository> = outbound;
@@ -271,6 +315,57 @@ pub fn build_slack_events_route_mount_with_actor_user_resolver(
     Ok(slack_events_route_mount(
         SlackEventsRouteState::from_resolver(Arc::new(slack_resolver)),
     ))
+}
+
+fn slack_bot_token_handle() -> Result<EgressCredentialHandle, SlackHostBetaBuildError> {
+    EgressCredentialHandle::new(SLACK_BOT_TOKEN_HANDLE)
+        .map_err(|reason| invalid_config("bot_token_handle", reason.to_string()))
+}
+
+fn slack_protocol_egress(
+    runtime: &RebornRuntime,
+    config: &SlackHostBetaConfig,
+    token_handle: EgressCredentialHandle,
+) -> Result<Arc<dyn ProtocolHttpEgress>, SlackHostBetaBuildError> {
+    let local_runtime = runtime
+        .services()
+        .local_runtime
+        .as_ref()
+        .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
+    let runtime_http_egress = local_runtime
+        .runtime_http_egress
+        .clone()
+        .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
+    Ok(Arc::new(SlackProtocolHttpEgress::new(
+        runtime_http_egress,
+        Arc::new(StaticSlackEgressCredentialProvider::new(
+            token_handle.clone(),
+            config.bot_token.expose_secret().to_string(),
+        )),
+        EgressPolicy::new(slack_declared_egress_targets(token_handle)),
+        slack_egress_scope(config),
+    )))
+}
+
+fn slack_egress_scope(config: &SlackHostBetaConfig) -> ResourceScope {
+    ResourceScope {
+        tenant_id: config.tenant_id.clone(),
+        user_id: config.user_id.clone(),
+        agent_id: Some(config.agent_id.clone()),
+        project_id: config.project_id.clone(),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: ironclaw_host_api::InvocationId::new(),
+    }
+}
+
+fn slack_declared_egress_targets(
+    token_handle: EgressCredentialHandle,
+) -> Vec<DeclaredEgressTarget> {
+    vec![DeclaredEgressTarget::new(
+        DeclaredEgressHost::new(SLACK_API_HOST).expect("static Slack host valid"),
+        Some(token_handle),
+    )]
 }
 
 fn invalid_config(field: &'static str, reason: String) -> SlackHostBetaBuildError {
@@ -461,15 +556,31 @@ mod tests {
     }
 
     #[test]
-    fn slack_host_beta_config_binds_slack_actor_to_reborn_user() {
+    fn slack_host_beta_config_keeps_optional_legacy_slack_actor() {
         let config = config();
 
         assert_eq!(config.installation_id.as_str(), INSTALLATION);
-        assert_eq!(config.slack_actor.kind(), SLACK_USER_ACTOR_KIND);
-        assert_eq!(config.slack_actor.id(), SLACK_USER);
+        let slack_actor = config.slack_actor.as_ref().expect("legacy actor");
+        assert_eq!(slack_actor.kind(), SLACK_USER_ACTOR_KIND);
+        assert_eq!(slack_actor.id(), SLACK_USER);
         assert_eq!(config.user_id, UserId::new(USER).expect("user id"));
         assert_eq!(config.signing_secret.expose_secret(), SECRET);
         assert_eq!(config.bot_token.expose_secret(), "xoxb-host-token");
+    }
+
+    #[test]
+    fn slack_egress_scope_uses_configured_tenant_agent_and_project() {
+        let config = config();
+
+        let scope = slack_egress_scope(&config);
+
+        assert_eq!(scope.tenant_id, TenantId::new(TENANT).expect("tenant"));
+        assert_eq!(scope.user_id, UserId::new(USER).expect("user"));
+        assert_eq!(scope.agent_id, Some(AgentId::new(AGENT).expect("agent")));
+        assert_eq!(
+            scope.project_id,
+            Some(ProjectId::new(PROJECT).expect("project"))
+        );
     }
 
     fn config() -> SlackHostBetaConfig {
@@ -480,7 +591,7 @@ mod tests {
             installation_id: INSTALLATION.to_string(),
             team_id: TEAM.to_string(),
             api_app_id: Some(API_APP.to_string()),
-            slack_user_id: SLACK_USER.to_string(),
+            slack_user_id: Some(SLACK_USER.to_string()),
             user_id: UserId::new(USER).expect("user"),
             signing_secret: SecretString::from(SECRET),
             bot_token: SecretString::from("xoxb-host-token"),

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -361,7 +361,7 @@ fn slack_protocol_egress(
             token_handle.clone(),
             config.bot_token.expose_secret().to_string(),
         )),
-        EgressPolicy::new(slack_declared_egress_targets(token_handle)),
+        EgressPolicy::new(slack_declared_egress_targets(token_handle)?),
         slack_egress_scope(config),
     )))
 }
@@ -380,11 +380,10 @@ fn slack_egress_scope(config: &SlackHostBetaConfig) -> ResourceScope {
 
 fn slack_declared_egress_targets(
     token_handle: EgressCredentialHandle,
-) -> Vec<DeclaredEgressTarget> {
-    vec![DeclaredEgressTarget::new(
-        DeclaredEgressHost::new(SLACK_API_HOST).expect("static Slack host valid"),
-        Some(token_handle),
-    )]
+) -> Result<Vec<DeclaredEgressTarget>, SlackHostBetaBuildError> {
+    let host = DeclaredEgressHost::new(SLACK_API_HOST)
+        .map_err(|reason| invalid_config("slack_api_host", reason.to_string()))?;
+    Ok(vec![DeclaredEgressTarget::new(host, Some(token_handle))])
 }
 
 #[derive(Clone)]
@@ -475,7 +474,9 @@ mod tests {
         HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
         HostManagedModelResponse,
     };
-    use ironclaw_product_workflow::{ProductActorUserResolutionRequest, ProductWorkflowError};
+    use ironclaw_product_workflow::{
+        ProductActorUserResolutionRequest, ProductWorkflowError, WebUiAuthenticatedCaller,
+    };
     use ironclaw_threads::{ListThreadsForScopeRequest, ThreadHistoryRequest, ThreadScope};
     use ironclaw_turns::run_profile::LoopCapabilityPort;
     use secrecy::ExposeSecret;
@@ -680,6 +681,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn build_slack_host_beta_mounts_pairs_unknown_slack_actor_then_routes_bound_event() {
+        let (mut runtime, _root) = runtime().await;
+        let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+        runtime.set_local_runtime_http_egress_for_test(Some(egress.clone()));
+        let mounts =
+            build_slack_host_beta_mounts(&runtime, config_without_legacy_actor()).expect("mounts");
+
+        let first_body =
+            dm_event_body_with("Ev-host-beta-pairing-first", "pair me", "1710000000.000020");
+        post_signed_slack_event(&mounts.events, &first_body).await;
+        if let Some(drain) = mounts.events.drain.as_ref() {
+            drain.drain().await;
+        }
+        let pairing_code = wait_for_pairing_code(&egress).await;
+
+        let pairing_mount =
+            slack_personal_binding_pairing_route_mount(mounts.personal_binding_pairing);
+        let redeem_body = format!(r#"{{"code":"{pairing_code}"}}"#);
+        let redeem_response = pairing_mount
+            .protected
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SLACK_PERSONAL_BINDING_PAIRING_REDEEM_PATH)
+                    .header("content-type", "application/json")
+                    .extension(WebUiAuthenticatedCaller {
+                        tenant_id: TenantId::new(TENANT).expect("tenant"),
+                        user_id: UserId::new(USER).expect("user"),
+                        agent_id: Some(AgentId::new(AGENT).expect("agent")),
+                        project_id: Some(ProjectId::new(PROJECT).expect("project")),
+                    })
+                    .body(Body::from(redeem_body))
+                    .expect("redeem request builds"),
+            )
+            .await
+            .expect("redeem route responds");
+
+        assert_eq!(redeem_response.status(), StatusCode::OK);
+
+        let second_body = dm_event_body_with(
+            "Ev-host-beta-pairing-second",
+            "after pairing",
+            "1710000000.000030",
+        );
+        post_signed_slack_event(&mounts.events, &second_body).await;
+        if let Some(drain) = mounts.events.drain.as_ref() {
+            drain.drain().await;
+        }
+
+        let history = wait_for_slack_thread_history(&runtime).await;
+        assert_eq!(history.messages.len(), 1);
+        assert_eq!(
+            history.messages[0].content.as_deref(),
+            Some("after pairing")
+        );
+
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
     async fn build_slack_host_beta_mounts_rejects_team_only_selector_for_pairing() {
         let root = tempfile::tempdir().expect("tempdir");
         let runtime = build_reborn_runtime(
@@ -794,6 +855,42 @@ mod tests {
         .expect("valid config")
     }
 
+    fn config_without_legacy_actor() -> SlackHostBetaConfig {
+        SlackHostBetaConfig::new(SlackHostBetaConfigInput {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            agent_id: AgentId::new(AGENT).expect("agent"),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            installation_id: INSTALLATION.to_string(),
+            team_id: TEAM.to_string(),
+            api_app_id: Some(API_APP.to_string()),
+            slack_user_id: None,
+            user_id: UserId::new(USER).expect("user"),
+            signing_secret: SecretString::from(SECRET),
+            bot_token: SecretString::from("xoxb-host-token"),
+        })
+        .expect("valid config")
+    }
+
+    async fn post_signed_slack_event(mount: &PublicRouteMount, body: &str) {
+        let timestamp = current_unix_timestamp();
+        let response = mount
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SLACK_EVENTS_PATH)
+                    .header(SLACK_TIMESTAMP_HEADER, timestamp.to_string())
+                    .header(SLACK_SIGNATURE_HEADER, slack_signature(timestamp, body))
+                    .body(Body::from(body.to_string()))
+                    .expect("request builds"),
+            )
+            .await
+            .expect("router responds");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
     async fn runtime() -> (RebornRuntime, tempfile::TempDir) {
         let root = tempfile::tempdir().expect("tempdir");
         let runtime = build_reborn_runtime(
@@ -883,6 +980,24 @@ mod tests {
         }"#
     }
 
+    fn dm_event_body_with(event_id: &str, text: &str, ts: &str) -> String {
+        serde_json::json!({
+            "type": "event_callback",
+            "team_id": TEAM,
+            "api_app_id": API_APP,
+            "event_id": event_id,
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "user": SLACK_USER,
+                "channel": "D-HOST",
+                "text": text,
+                "ts": ts
+            }
+        })
+        .to_string()
+    }
+
     async fn wait_for_resolver_calls(
         resolver: &RecordingProductActorUserResolver,
         expected_len: usize,
@@ -895,6 +1010,16 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
         resolver.calls()
+    }
+
+    async fn wait_for_pairing_code(egress: &RecordingRuntimeHttpEgress) -> String {
+        for _ in 0..40 {
+            if let Some(code) = egress.pairing_code() {
+                return code;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("Slack pairing notifier did not post a pairing code");
     }
 
     #[derive(Debug)]
@@ -980,6 +1105,11 @@ mod tests {
             &self,
             request: RuntimeHttpEgressRequest,
         ) -> Result<RuntimeHttpEgressResponse, ironclaw_host_api::RuntimeHttpEgressError> {
+            let response = if request.url.contains("/api/conversations.open") {
+                br#"{"ok":true,"channel":{"id":"D-HOST"}}"#.to_vec()
+            } else {
+                br#"{"ok":true}"#.to_vec()
+            };
             self.requests
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -987,12 +1117,32 @@ mod tests {
             Ok(RuntimeHttpEgressResponse {
                 status: 200,
                 headers: Vec::new(),
-                body: br#"{"ok":true}"#.to_vec(),
+                body: response,
                 saved_body: None,
                 request_bytes: 0,
                 response_bytes: 0,
                 redaction_applied: false,
             })
+        }
+    }
+
+    impl RecordingRuntimeHttpEgress {
+        fn pairing_code(&self) -> Option<String> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .filter(|request| request.url.contains("/api/chat.postMessage"))
+                .filter_map(|request| {
+                    serde_json::from_slice::<serde_json::Value>(&request.body).ok()
+                })
+                .filter_map(|body| body["text"].as_str().map(str::to_string))
+                .find_map(|text| {
+                    text.split(" code ")
+                        .nth(1)
+                        .and_then(|suffix| suffix.split(" in WebChat").next())
+                        .map(str::to_string)
+                })
         }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -18,8 +18,9 @@ use ironclaw_product_adapters::{
 };
 use ironclaw_product_workflow::{
     DefaultInboundTurnService, DefaultProductWorkflow, InMemoryIdempotencyLedger,
-    ProductActorUserResolver, ProductConversationBindingService, ProductInstallationKey,
-    ProductInstallationScope, StaticProductInstallationResolver,
+    ProductActorUserResolutionRequest, ProductActorUserResolver, ProductConversationBindingService,
+    ProductInstallationKey, ProductInstallationScope, ProductWorkflowError,
+    StaticProductInstallationResolver,
 };
 use ironclaw_slack_v2_adapter::{
     SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID, SlackV2Adapter,
@@ -33,12 +34,14 @@ use secrecy::{ExposeSecret, SecretString};
 use thiserror::Error;
 
 use crate::RebornRuntime;
+use crate::slack_actor_identity::SlackUserIdentityActorResolver;
 use crate::slack_delivery::{
     SlackFinalReplyDeliveryObserver, SlackFinalReplyDeliveryServices,
     SlackFinalReplyDeliverySettings,
 };
 use crate::slack_egress::{SlackProtocolHttpEgress, StaticSlackEgressCredentialProvider};
-use crate::slack_host_state::{FilesystemSlackHostState, SlackPairingChallengeHttpNotifier};
+use crate::slack_host_state::FilesystemSlackHostState;
+use crate::slack_pairing_notifier::SlackPairingChallengeHttpNotifier;
 use crate::slack_personal_binding::{
     RebornUserIdentityBindingStore, SlackPersonalBindingInstallation,
     SlackPersonalUserBindingService,
@@ -150,6 +153,10 @@ pub enum SlackHostBetaBuildError {
     RuntimeHttpEgressUnavailable,
     #[error("Slack host-beta requires durable host state")]
     DurableHostStateUnavailable,
+    #[error(
+        "Slack host-beta personal binding requires [slack].api_app_id for tenant app-scoped pairing"
+    )]
+    TenantAppSelectorRequired,
     #[error("invalid Slack host-beta config field {field}: {reason}")]
     InvalidConfig { field: &'static str, reason: String },
 }
@@ -170,6 +177,12 @@ pub fn build_slack_host_beta_mounts(
     runtime: &RebornRuntime,
     config: SlackHostBetaConfig,
 ) -> Result<SlackHostBetaMounts, SlackHostBetaBuildError> {
+    if !matches!(
+        config.installation_selector,
+        SlackInstallationSelector::AppTeam { .. }
+    ) {
+        return Err(SlackHostBetaBuildError::TenantAppSelectorRequired);
+    }
     let local_runtime = runtime
         .services()
         .local_runtime
@@ -200,7 +213,13 @@ pub fn build_slack_host_beta_mounts(
     let challenge_store: Arc<dyn SlackPersonalBindingPairingChallengeStore> = state.clone();
     let pairing =
         SlackPersonalBindingPairingService::new(binding_service, challenge_store, notifier);
-    let actor_user_resolver = Arc::new(SlackPairingActorResolver::new(state, pairing.clone()));
+    let actor_user_resolver = Arc::new(SlackHostBetaActorUserResolver::new(
+        config.installation_id.clone(),
+        config.slack_actor.clone(),
+        config.user_id.clone(),
+        Arc::new(SlackUserIdentityActorResolver::new(state.clone())),
+        Arc::new(SlackPairingActorResolver::new(state, pairing.clone())),
+    ));
     let events = build_slack_events_route_mount_with_actor_user_resolver(
         runtime,
         config,
@@ -368,6 +387,73 @@ fn slack_declared_egress_targets(
     )]
 }
 
+#[derive(Clone)]
+struct SlackHostBetaActorUserResolver {
+    installation_id: AdapterInstallationId,
+    legacy_slack_actor: Option<ExternalActorRef>,
+    legacy_user_id: UserId,
+    cached_identity: Arc<dyn ProductActorUserResolver>,
+    pairing: Arc<dyn ProductActorUserResolver>,
+}
+
+impl SlackHostBetaActorUserResolver {
+    fn new(
+        installation_id: AdapterInstallationId,
+        legacy_slack_actor: Option<ExternalActorRef>,
+        legacy_user_id: UserId,
+        cached_identity: Arc<dyn ProductActorUserResolver>,
+        pairing: Arc<dyn ProductActorUserResolver>,
+    ) -> Self {
+        Self {
+            installation_id,
+            legacy_slack_actor,
+            legacy_user_id,
+            cached_identity,
+            pairing,
+        }
+    }
+
+    fn resolve_legacy_static_actor(
+        &self,
+        request: &ProductActorUserResolutionRequest,
+    ) -> Option<UserId> {
+        let legacy_actor = self.legacy_slack_actor.as_ref()?;
+        if request.adapter_id.as_str() == SLACK_V2_ADAPTER_ID
+            && request.installation_id == self.installation_id
+            && request.external_actor_ref == *legacy_actor
+        {
+            return Some(self.legacy_user_id.clone());
+        }
+        None
+    }
+}
+
+impl std::fmt::Debug for SlackHostBetaActorUserResolver {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("SlackHostBetaActorUserResolver(..)")
+    }
+}
+
+#[async_trait::async_trait]
+impl ProductActorUserResolver for SlackHostBetaActorUserResolver {
+    async fn resolve_product_actor_user(
+        &self,
+        request: ProductActorUserResolutionRequest,
+    ) -> Result<Option<UserId>, ProductWorkflowError> {
+        if let Some(user_id) = self.resolve_legacy_static_actor(&request) {
+            return Ok(Some(user_id));
+        }
+        if let Some(user_id) = self
+            .cached_identity
+            .resolve_product_actor_user(request.clone())
+            .await?
+        {
+            return Ok(Some(user_id));
+        }
+        self.pairing.resolve_product_actor_user(request).await
+    }
+}
+
 fn invalid_config(field: &'static str, reason: String) -> SlackHostBetaBuildError {
     SlackHostBetaBuildError::InvalidConfig { field, reason }
 }
@@ -396,6 +482,9 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+    use crate::slack_personal_binding_pairing_serve::{
+        SLACK_PERSONAL_BINDING_PAIRING_REDEEM_PATH, slack_personal_binding_pairing_route_mount,
+    };
     use crate::{
         RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput, SLACK_EVENTS_PATH,
         build_reborn_runtime, local_dev_runtime_policy,
@@ -555,6 +644,85 @@ mod tests {
         runtime.shutdown().await.expect("runtime shuts down");
     }
 
+    #[tokio::test]
+    async fn build_slack_host_beta_mounts_exposes_events_and_pairing_redeem_route() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let runtime = build_reborn_runtime(
+            RebornRuntimeInput::from_services(
+                RebornBuildInput::local_dev("slack-host-beta-owner", root.path().join("local-dev"))
+                    .with_runtime_policy(local_dev_runtime_policy().expect("local policy")),
+            )
+            .with_identity(RebornRuntimeIdentity {
+                tenant_id: TENANT.to_string(),
+                agent_id: AGENT.to_string(),
+                source_binding_id: "slack-host-source".to_string(),
+                reply_target_binding_id: "slack-host-reply".to_string(),
+            })
+            .with_model_gateway_override(Arc::new(StaticGateway)),
+        )
+        .await
+        .expect("runtime builds");
+
+        let mounts = build_slack_host_beta_mounts(&runtime, config()).expect("mounts build");
+        let pairing_mount =
+            slack_personal_binding_pairing_route_mount(mounts.personal_binding_pairing);
+
+        assert_eq!(mounts.events.descriptors.len(), 1);
+        assert!(
+            pairing_mount
+                .descriptors
+                .iter()
+                .any(|descriptor| descriptor.route_pattern().as_str()
+                    == SLACK_PERSONAL_BINDING_PAIRING_REDEEM_PATH)
+        );
+
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn build_slack_host_beta_mounts_rejects_team_only_selector_for_pairing() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let runtime = build_reborn_runtime(
+            RebornRuntimeInput::from_services(
+                RebornBuildInput::local_dev("slack-host-beta-owner", root.path().join("local-dev"))
+                    .with_runtime_policy(local_dev_runtime_policy().expect("local policy")),
+            )
+            .with_identity(RebornRuntimeIdentity {
+                tenant_id: TENANT.to_string(),
+                agent_id: AGENT.to_string(),
+                source_binding_id: "slack-host-source".to_string(),
+                reply_target_binding_id: "slack-host-reply".to_string(),
+            })
+            .with_model_gateway_override(Arc::new(StaticGateway)),
+        )
+        .await
+        .expect("runtime builds");
+        let team_only_config = SlackHostBetaConfig::new(SlackHostBetaConfigInput {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            agent_id: AgentId::new(AGENT).expect("agent"),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            installation_id: INSTALLATION.to_string(),
+            team_id: TEAM.to_string(),
+            api_app_id: None,
+            slack_user_id: Some(SLACK_USER.to_string()),
+            user_id: UserId::new(USER).expect("user"),
+            signing_secret: SecretString::from(SECRET),
+            bot_token: SecretString::from("xoxb-host-token"),
+        })
+        .expect("team-only config still parses");
+
+        let error = match build_slack_host_beta_mounts(&runtime, team_only_config) {
+            Ok(_) => panic!("pairing requires tenant app selector"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            SlackHostBetaBuildError::TenantAppSelectorRequired
+        ));
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
     #[test]
     fn slack_host_beta_config_keeps_optional_legacy_slack_actor() {
         let config = config();
@@ -581,6 +749,33 @@ mod tests {
             scope.project_id,
             Some(ProjectId::new(PROJECT).expect("project"))
         );
+    }
+
+    #[tokio::test]
+    async fn layered_resolver_preserves_configured_legacy_slack_actor_mapping() {
+        let resolver = SlackHostBetaActorUserResolver::new(
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            Some(
+                ExternalActorRef::new(SLACK_USER_ACTOR_KIND, SLACK_USER, None::<String>)
+                    .expect("actor"),
+            ),
+            UserId::new(USER).expect("user"),
+            Arc::new(FailingProductActorUserResolver),
+            Arc::new(FailingProductActorUserResolver),
+        );
+        let request = ProductActorUserResolutionRequest::new(
+            ProductAdapterId::new(SLACK_V2_ADAPTER_ID).expect("adapter"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            ExternalActorRef::new(SLACK_USER_ACTOR_KIND, SLACK_USER, None::<String>)
+                .expect("actor"),
+        );
+
+        let resolved = resolver
+            .resolve_product_actor_user(request)
+            .await
+            .expect("resolver succeeds");
+
+        assert_eq!(resolved, Some(UserId::new(USER).expect("user")));
     }
 
     fn config() -> SlackHostBetaConfig {
@@ -735,6 +930,21 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(request);
             Ok(Some(self.user_id.clone()))
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingProductActorUserResolver;
+
+    #[async_trait::async_trait]
+    impl ProductActorUserResolver for FailingProductActorUserResolver {
+        async fn resolve_product_actor_user(
+            &self,
+            _request: ProductActorUserResolutionRequest,
+        ) -> Result<Option<UserId>, ProductWorkflowError> {
+            Err(ProductWorkflowError::BindingResolutionFailed {
+                reason: "fallback should not be called".into(),
+            })
         }
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -486,8 +486,8 @@ where
     }
 
     async fn cleanup_pairing_code_record(&self, path: &ScopedPath) {
-        if let Err(error) = self.delete_record(path).await {
-            tracing::warn!("failed to delete Slack pairing code record: {error}");
+        if self.delete_record(path).await.is_err() {
+            tracing::warn!("failed to delete Slack pairing code record");
         }
     }
 
@@ -509,19 +509,30 @@ where
         actor_path: &ScopedPath,
         code: &SlackPersonalBindingPairingCode,
     ) {
-        let should_delete = match self
+        let Some((mut record, version)) = (match self
             .read_record::<StoredSlackPairingActorChallenge>(actor_path)
             .await
         {
-            Ok(Some((record, _))) => record.code == code.as_str(),
-            Ok(None) => false,
-            Err(error) => {
-                tracing::warn!("failed to read Slack pairing actor record for cleanup: {error}");
-                false
+            Ok(Some((record, version))) if record.code == code.as_str() => Some((record, version)),
+            Ok(Some(_)) | Ok(None) => None,
+            Err(_) => {
+                tracing::warn!("failed to read Slack pairing actor record for cleanup");
+                None
             }
+        }) else {
+            return;
         };
-        if should_delete && let Err(error) = self.delete_record(actor_path).await {
-            tracing::warn!("failed to delete Slack pairing actor record: {error}");
+        let now = Utc::now();
+        record.expires_at = now;
+        record.updated_at = now;
+        match self
+            .write_record(actor_path, &record, CasExpectation::Version(version))
+            .await
+        {
+            Ok(_) | Err(FilesystemError::VersionMismatch { .. }) => {}
+            Err(_) => {
+                tracing::warn!("failed to expire Slack pairing actor record for cleanup");
+            }
         }
     }
 }
@@ -816,6 +827,38 @@ mod tests {
 
         assert_eq!(successes, 1);
         assert_eq!(not_found, 1);
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_reissues_after_consumed_actor_challenge() {
+        let state = state();
+        let consumed = state
+            .issue_challenge(challenge())
+            .await
+            .expect("issue succeeds");
+
+        state
+            .consume_challenge(&consumed.code)
+            .await
+            .expect("consume succeeds");
+        let reissued = state
+            .issue_challenge(challenge())
+            .await
+            .expect("reissue succeeds");
+
+        assert_ne!(reissued.code, consumed.code);
+        assert_eq!(reissued.challenge, challenge());
+        assert!(matches!(
+            state.get_challenge(&consumed.code).await,
+            Err(SlackPersonalBindingPairingError::ChallengeNotFound)
+        ));
+        assert_eq!(
+            state
+                .get_challenge(&reissued.code)
+                .await
+                .expect("reissued code remains active"),
+            challenge()
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -20,11 +20,7 @@ use ironclaw_filesystem::{
 use ironclaw_host_api::{
     AgentId, InvocationId, ProjectId, ResourceScope, ScopedPath, TenantId, UserId,
 };
-use ironclaw_product_adapters::{
-    AdapterInstallationId, DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod,
-    EgressPath, EgressRequest, ProtocolHttpEgress,
-};
-use ironclaw_slack_v2_adapter::SLACK_API_HOST;
+use ironclaw_product_adapters::AdapterInstallationId;
 use rand::{RngCore, rngs::OsRng};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
@@ -35,21 +31,17 @@ use crate::slack_personal_binding::{
 use crate::slack_personal_binding_pairing::{
     IssuedSlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingChallenge,
     SlackPersonalBindingPairingChallengeStore, SlackPersonalBindingPairingCode,
-    SlackPersonalBindingPairingError, SlackPersonalBindingPairingNotification,
-    SlackPersonalBindingPairingNotifier,
+    SlackPersonalBindingPairingError,
 };
 use crate::slack_serve::SlackUserId;
 
 const SLACK_HOST_STATE_ROOT: &str = "/tenant-shared/slack-personal-binding";
 const IDENTITY_ROOT: &str = "/tenant-shared/slack-personal-binding/identities";
 const PAIRING_CODE_ROOT: &str = "/tenant-shared/slack-personal-binding/pairing/codes";
+const PAIRING_ACTOR_ROOT: &str = "/tenant-shared/slack-personal-binding/pairing/actors";
 const PAIRING_CODE_LEN: usize = 8;
 const PAIRING_CODE_RETRIES: usize = 16;
 const DEFAULT_PAIRING_TTL: Duration = Duration::from_secs(10 * 60);
-const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
-const SLACK_POST_MESSAGE_PATH: &str = "/api/chat.postMessage";
-const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
-
 #[derive(Clone)]
 pub(crate) struct FilesystemSlackHostState<F>
 where
@@ -151,6 +143,10 @@ where
             .await
     }
 
+    async fn delete_record(&self, path: &ScopedPath) -> Result<(), FilesystemError> {
+        self.filesystem.delete(&self.scope, path).await
+    }
+
     fn identity_path(
         provider: &str,
         provider_user_id: &str,
@@ -167,6 +163,24 @@ where
         code: &SlackPersonalBindingPairingCode,
     ) -> Result<ScopedPath, FilesystemError> {
         scoped_path(&format!("{}/{}.json", PAIRING_CODE_ROOT, code.as_str()))
+    }
+
+    fn pairing_actor_path(
+        challenge: &SlackPersonalBindingPairingChallenge,
+    ) -> Result<ScopedPath, FilesystemError> {
+        Self::pairing_actor_path_for(&challenge.installation_id, challenge.slack_user_id.as_str())
+    }
+
+    fn pairing_actor_path_for(
+        installation_id: &AdapterInstallationId,
+        slack_user_id: &str,
+    ) -> Result<ScopedPath, FilesystemError> {
+        scoped_path(&format!(
+            "{}/{}/{}.json",
+            PAIRING_ACTOR_ROOT,
+            path_segment(installation_id.as_str()),
+            path_segment(slack_user_id)
+        ))
     }
 }
 
@@ -289,6 +303,30 @@ where
         &self,
         challenge: SlackPersonalBindingPairingChallenge,
     ) -> Result<IssuedSlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingError> {
+        let actor_path = Self::pairing_actor_path(&challenge).map_err(map_pairing_fs_error)?;
+        let actor_lock = self.lock_for(format!(
+            "pairing-actor:{}:{}",
+            challenge.installation_id.as_str(),
+            challenge.slack_user_id.as_str()
+        ));
+        let _actor_guard = actor_lock.lock().await;
+        let existing_actor = self
+            .read_record::<StoredSlackPairingActorChallenge>(&actor_path)
+            .await
+            .map_err(map_pairing_fs_error)?;
+        if let Some((actor_record, _)) = existing_actor.as_ref()
+            && let Some(issued) = self
+                .active_actor_pairing_challenge(actor_record, &challenge)
+                .await?
+        {
+            return Ok(issued);
+        }
+        if let Some((actor_record, _)) = existing_actor.as_ref()
+            && actor_record.expires_at <= Utc::now()
+        {
+            self.cleanup_actor_pairing_code_record(actor_record).await;
+        }
+
         let expires_at = Utc::now()
             + chrono::Duration::from_std(self.pairing_ttl).map_err(|_| {
                 SlackPersonalBindingPairingError::Backend(
@@ -304,6 +342,39 @@ where
                 .await
             {
                 Ok(_) => {
+                    let actor_record =
+                        StoredSlackPairingActorChallenge::pending(&code, &challenge, expires_at);
+                    let actor_cas = existing_actor
+                        .as_ref()
+                        .map(|(_, version)| CasExpectation::Version(*version))
+                        .unwrap_or(CasExpectation::Absent);
+                    match self
+                        .write_record(&actor_path, &actor_record, actor_cas)
+                        .await
+                    {
+                        Ok(_) => {}
+                        Err(FilesystemError::VersionMismatch { .. }) => {
+                            self.cleanup_pairing_code_record(&path).await;
+                            let Some((winner, _)) = self
+                                .read_record::<StoredSlackPairingActorChallenge>(&actor_path)
+                                .await
+                                .map_err(map_pairing_fs_error)?
+                            else {
+                                continue;
+                            };
+                            if let Some(issued) = self
+                                .active_actor_pairing_challenge(&winner, &challenge)
+                                .await?
+                            {
+                                return Ok(issued);
+                            }
+                            continue;
+                        }
+                        Err(error) => {
+                            self.cleanup_pairing_code_record(&path).await;
+                            return Err(map_pairing_fs_error(error));
+                        }
+                    }
                     return Ok(IssuedSlackPersonalBindingPairingChallenge { code, challenge });
                 }
                 Err(FilesystemError::VersionMismatch { .. }) => continue,
@@ -346,6 +417,17 @@ where
             return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
         };
         let challenge = active_pairing_challenge(&record)?;
+        let actor_path = Self::pairing_actor_path_for(
+            &challenge.installation_id,
+            challenge.slack_user_id.as_str(),
+        )
+        .map_err(map_pairing_fs_error)?;
+        let actor_lock = self.lock_for(format!(
+            "pairing-actor:{}:{}",
+            challenge.installation_id.as_str(),
+            challenge.slack_user_id.as_str()
+        ));
+        let _actor_guard = actor_lock.lock().await;
         record.status = StoredSlackPairingStatus::Consumed;
         record.consumed_at = Some(Utc::now());
         match self
@@ -358,105 +440,89 @@ where
             }
             Err(error) => return Err(map_pairing_fs_error(error)),
         }
+        self.cleanup_pairing_code_record(&path).await;
+        self.cleanup_pairing_actor_record(&actor_path, code).await;
         Ok(challenge)
     }
 }
 
-pub(crate) struct SlackPairingChallengeHttpNotifier {
-    egress: Arc<dyn ProtocolHttpEgress>,
-    credential_handle: EgressCredentialHandle,
-}
-
-impl SlackPairingChallengeHttpNotifier {
-    pub(crate) fn new(
-        egress: Arc<dyn ProtocolHttpEgress>,
-        credential_handle: EgressCredentialHandle,
-    ) -> Self {
-        Self {
-            egress,
-            credential_handle,
+impl<F> FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn active_actor_pairing_challenge(
+        &self,
+        actor_record: &StoredSlackPairingActorChallenge,
+        requested: &SlackPersonalBindingPairingChallenge,
+    ) -> Result<Option<IssuedSlackPersonalBindingPairingChallenge>, SlackPersonalBindingPairingError>
+    {
+        if actor_record.installation_id != requested.installation_id.as_str()
+            || actor_record.slack_user_id != requested.slack_user_id.as_str()
+            || actor_record.expires_at <= Utc::now()
+        {
+            return Ok(None);
         }
-    }
-}
-
-#[async_trait::async_trait]
-impl SlackPersonalBindingPairingNotifier for SlackPairingChallengeHttpNotifier {
-    async fn send_pairing_challenge(
-        &self,
-        notification: SlackPersonalBindingPairingNotification,
-    ) -> Result<(), SlackPersonalBindingPairingError> {
-        let channel = self
-            .open_dm_channel(notification.slack_user_id.as_str())
-            .await?;
-        let body = serde_json::to_vec(&SlackPairingPostMessage {
-            channel,
-            text: format!(
-                "Connect this Slack account to Ironclaw by entering code {} in WebChat.",
-                notification.code.as_str()
-            ),
-            mrkdwn: false,
-        })
-        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
-        let response = self
-            .send_slack_request(SLACK_POST_MESSAGE_PATH, body)
-            .await?;
-        slack_ok_response("Slack pairing DM", response.body())?;
-        Ok(())
-    }
-}
-
-impl SlackPairingChallengeHttpNotifier {
-    async fn open_dm_channel(
-        &self,
-        slack_user_id: &str,
-    ) -> Result<String, SlackPersonalBindingPairingError> {
-        let body = serde_json::to_vec(&SlackConversationsOpenRequest {
-            users: slack_user_id.to_string(),
-        })
-        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
-        let response = self
-            .send_slack_request(SLACK_CONVERSATIONS_OPEN_PATH, body)
-            .await?;
-        let opened: SlackConversationsOpenResponse =
-            slack_json_response("Slack conversations.open", response.body())?;
-        if !opened.ok {
-            return Err(SlackPersonalBindingPairingError::Backend(format!(
-                "Slack rejected conversations.open ({})",
-                opened.error.unwrap_or_else(|| "unknown_error".into())
-            )));
-        }
-        opened
-            .channel
-            .map(|channel| channel.id)
-            .filter(|id| !id.is_empty())
-            .ok_or_else(|| {
-                SlackPersonalBindingPairingError::Backend(
-                    "Slack conversations.open response did not include a channel id".into(),
-                )
-            })
-    }
-
-    async fn send_slack_request(
-        &self,
-        path: &'static str,
-        body: Vec<u8>,
-    ) -> Result<ironclaw_product_adapters::EgressResponse, SlackPersonalBindingPairingError> {
-        let response = self
-            .egress
-            .send(slack_api_request(
-                path,
-                body,
-                self.credential_handle.clone(),
-            ))
+        let code = SlackPersonalBindingPairingCode::new(actor_record.code.clone())?;
+        let path = Self::pairing_code_path(&code).map_err(map_pairing_fs_error)?;
+        let Some((code_record, _)) = self
+            .read_record::<StoredSlackPairingChallenge>(&path)
             .await
-            .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
-        if !(200..300).contains(&response.status()) {
-            return Err(SlackPersonalBindingPairingError::Backend(format!(
-                "Slack API request {path} failed with HTTP {}",
-                response.status()
-            )));
+            .map_err(map_pairing_fs_error)?
+        else {
+            return Ok(None);
+        };
+        let challenge = match active_pairing_challenge(&code_record) {
+            Ok(challenge) => challenge,
+            Err(SlackPersonalBindingPairingError::ChallengeNotFound) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        if challenge == *requested {
+            return Ok(Some(IssuedSlackPersonalBindingPairingChallenge {
+                code,
+                challenge,
+            }));
         }
-        Ok(response)
+        Ok(None)
+    }
+
+    async fn cleanup_pairing_code_record(&self, path: &ScopedPath) {
+        if let Err(error) = self.delete_record(path).await {
+            tracing::warn!("failed to delete Slack pairing code record: {error}");
+        }
+    }
+
+    async fn cleanup_actor_pairing_code_record(
+        &self,
+        actor_record: &StoredSlackPairingActorChallenge,
+    ) {
+        let Ok(code) = SlackPersonalBindingPairingCode::new(actor_record.code.clone()) else {
+            return;
+        };
+        let Ok(path) = Self::pairing_code_path(&code) else {
+            return;
+        };
+        self.cleanup_pairing_code_record(&path).await;
+    }
+
+    async fn cleanup_pairing_actor_record(
+        &self,
+        actor_path: &ScopedPath,
+        code: &SlackPersonalBindingPairingCode,
+    ) {
+        let should_delete = match self
+            .read_record::<StoredSlackPairingActorChallenge>(actor_path)
+            .await
+        {
+            Ok(Some((record, _))) => record.code == code.as_str(),
+            Ok(None) => false,
+            Err(error) => {
+                tracing::warn!("failed to read Slack pairing actor record for cleanup: {error}");
+                false
+            }
+        };
+        if should_delete && let Err(error) = self.delete_record(actor_path).await {
+            tracing::warn!("failed to delete Slack pairing actor record: {error}");
+        }
     }
 }
 
@@ -532,83 +598,28 @@ impl StoredSlackPairingChallenge {
     }
 }
 
-#[derive(Debug, Serialize)]
-struct SlackConversationsOpenRequest {
-    users: String,
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredSlackPairingActorChallenge {
+    installation_id: String,
+    slack_user_id: String,
+    code: String,
+    expires_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Deserialize)]
-struct SlackConversationsOpenResponse {
-    ok: bool,
-    error: Option<String>,
-    channel: Option<SlackConversationsOpenChannel>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SlackConversationsOpenChannel {
-    id: String,
-}
-
-#[derive(Debug, Serialize)]
-struct SlackPairingPostMessage {
-    channel: String,
-    text: String,
-    mrkdwn: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct SlackApiResponse {
-    ok: bool,
-    error: Option<String>,
-}
-
-fn slack_api_request(
-    path: &'static str,
-    body: Vec<u8>,
-    credential_handle: EgressCredentialHandle,
-) -> EgressRequest {
-    let host = DeclaredEgressHost::new(SLACK_API_HOST).expect("static Slack host valid");
-    let method = EgressMethod::post();
-    let path = EgressPath::new(path).expect("static Slack API path valid");
-    let content_type = EgressHeader::new("content-type", "application/json")
-        .expect("static content-type header valid");
-    EgressRequest::new(host, method, path)
-        .with_header(content_type)
-        .with_body(body)
-        .with_credential_handle(Some(credential_handle))
-}
-
-fn slack_json_response<T>(
-    label: &'static str,
-    body: &[u8],
-) -> Result<T, SlackPersonalBindingPairingError>
-where
-    T: DeserializeOwned,
-{
-    if body.len() > SLACK_API_RESPONSE_LIMIT {
-        return Err(SlackPersonalBindingPairingError::Backend(format!(
-            "{label} response exceeded body limit"
-        )));
-    }
-    serde_json::from_slice(body).map_err(|error| {
-        SlackPersonalBindingPairingError::Backend(format!(
-            "{label} response was invalid JSON: {error}"
-        ))
-    })
-}
-
-fn slack_ok_response(
-    label: &'static str,
-    body: &[u8],
-) -> Result<(), SlackPersonalBindingPairingError> {
-    let response: SlackApiResponse = slack_json_response(label, body)?;
-    if response.ok {
-        Ok(())
-    } else {
-        Err(SlackPersonalBindingPairingError::Backend(format!(
-            "Slack rejected {label} ({})",
-            response.error.unwrap_or_else(|| "unknown_error".into())
-        )))
+impl StoredSlackPairingActorChallenge {
+    fn pending(
+        code: &SlackPersonalBindingPairingCode,
+        challenge: &SlackPersonalBindingPairingChallenge,
+        expires_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            installation_id: challenge.installation_id.as_str().to_string(),
+            slack_user_id: challenge.slack_user_id.as_str().to_string(),
+            code: code.as_str().to_string(),
+            expires_at,
+            updated_at: Utc::now(),
+        }
     }
 }
 
@@ -757,6 +768,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filesystem_slack_host_state_reuses_active_pairing_code_for_actor() {
+        let state = state();
+
+        let first = state
+            .issue_challenge(challenge())
+            .await
+            .expect("first issue succeeds");
+        let second = state
+            .issue_challenge(challenge())
+            .await
+            .expect("second issue succeeds");
+
+        assert_eq!(second.code, first.code);
+        assert_eq!(second.challenge, challenge());
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_concurrent_consume_allows_exactly_one_success() {
+        let state = Arc::new(state());
+        let issued = state
+            .issue_challenge(challenge())
+            .await
+            .expect("issue succeeds");
+        let first_state = Arc::clone(&state);
+        let second_state = Arc::clone(&state);
+        let first_code = issued.code.clone();
+        let second_code = issued.code.clone();
+
+        let (first, second) = tokio::join!(
+            first_state.consume_challenge(&first_code),
+            second_state.consume_challenge(&second_code)
+        );
+        let successes = [&first, &second]
+            .into_iter()
+            .filter(|result| result.is_ok())
+            .count();
+        let not_found = [&first, &second]
+            .into_iter()
+            .filter(|result| {
+                matches!(
+                    result,
+                    Err(SlackPersonalBindingPairingError::ChallengeNotFound)
+                )
+            })
+            .count();
+
+        assert_eq!(successes, 1);
+        assert_eq!(not_found, 1);
+    }
+
+    #[tokio::test]
     async fn filesystem_slack_host_state_rejects_expired_pairing_code() {
         let state = state().with_pairing_ttl(Duration::from_millis(1));
         let issued = state
@@ -769,34 +831,6 @@ mod tests {
             state.consume_challenge(&issued.code).await,
             Err(SlackPersonalBindingPairingError::ChallengeNotFound)
         ));
-    }
-
-    #[tokio::test]
-    async fn slack_pairing_notifier_posts_code_to_slack_user() {
-        let egress = Arc::new(RecordingEgress::default());
-        let notifier = SlackPairingChallengeHttpNotifier::new(
-            egress.clone(),
-            EgressCredentialHandle::new("slack_bot_token").unwrap(),
-        );
-
-        notifier
-            .send_pairing_challenge(SlackPersonalBindingPairingNotification {
-                installation_id: installation(),
-                slack_user_id: SlackUserId::new("U123"),
-                code: SlackPersonalBindingPairingCode::new("ABCD1234").unwrap(),
-            })
-            .await
-            .expect("notification succeeds");
-
-        let calls = egress.calls();
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].path().as_str(), SLACK_CONVERSATIONS_OPEN_PATH);
-        let open_body: serde_json::Value = serde_json::from_slice(calls[0].body()).unwrap();
-        assert_eq!(open_body["users"], "U123");
-        assert_eq!(calls[1].path().as_str(), SLACK_POST_MESSAGE_PATH);
-        let post_body: serde_json::Value = serde_json::from_slice(calls[1].body()).unwrap();
-        assert_eq!(post_body["channel"], "D123");
-        assert!(post_body["text"].as_str().unwrap().contains("ABCD1234"));
     }
 
     fn state() -> FilesystemSlackHostState<InMemoryBackend> {
@@ -856,44 +890,5 @@ mod tests {
 
     fn user(value: &str) -> UserId {
         UserId::new(value).unwrap()
-    }
-
-    #[derive(Default)]
-    struct RecordingEgress {
-        calls: Mutex<Vec<EgressRequest>>,
-    }
-
-    impl RecordingEgress {
-        fn calls(&self) -> Vec<EgressRequest> {
-            self.calls
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .clone()
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl ProtocolHttpEgress for RecordingEgress {
-        async fn send(
-            &self,
-            request: EgressRequest,
-        ) -> Result<
-            ironclaw_product_adapters::EgressResponse,
-            ironclaw_product_adapters::ProtocolHttpEgressError,
-        > {
-            self.calls
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .push(request);
-            let response = match self.calls().last().map(|request| request.path().as_str()) {
-                Some(SLACK_CONVERSATIONS_OPEN_PATH) => {
-                    br#"{"ok":true,"channel":{"id":"D123"}}"#.to_vec()
-                }
-                _ => br#"{"ok":true}"#.to_vec(),
-            };
-            Ok(ironclaw_product_adapters::EgressResponse::new(
-                200, response,
-            ))
-        }
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -1,0 +1,899 @@
+//! Durable host state for Slack host-beta personal binding.
+//!
+//! The Slack ingress path starts before a Slack actor is bound to a Reborn
+//! user, so this state is tenant-scoped and lives under `/tenant-shared`.
+//! The underlying `ScopedFilesystem` still routes through host APIs and is
+//! backed by the selected durable root filesystem in libSQL/Postgres builds.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, Weak},
+    time::Duration,
+};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
+use ironclaw_filesystem::{
+    CasExpectation, ContentType, Entry, FilesystemError, FilesystemOperation, RecordVersion,
+    RootFilesystem, ScopedFilesystem,
+};
+use ironclaw_host_api::{
+    AgentId, InvocationId, ProjectId, ResourceScope, ScopedPath, TenantId, UserId,
+};
+use ironclaw_product_adapters::{
+    AdapterInstallationId, DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod,
+    EgressPath, EgressRequest, ProtocolHttpEgress,
+};
+use ironclaw_slack_v2_adapter::SLACK_API_HOST;
+use rand::{RngCore, rngs::OsRng};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use crate::slack_actor_identity::{RebornUserIdentityLookup, RebornUserIdentityLookupError};
+use crate::slack_personal_binding::{
+    RebornUserIdentityBinding, RebornUserIdentityBindingError, RebornUserIdentityBindingStore,
+};
+use crate::slack_personal_binding_pairing::{
+    IssuedSlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingChallenge,
+    SlackPersonalBindingPairingChallengeStore, SlackPersonalBindingPairingCode,
+    SlackPersonalBindingPairingError, SlackPersonalBindingPairingNotification,
+    SlackPersonalBindingPairingNotifier,
+};
+use crate::slack_serve::SlackUserId;
+
+const SLACK_HOST_STATE_ROOT: &str = "/tenant-shared/slack-personal-binding";
+const IDENTITY_ROOT: &str = "/tenant-shared/slack-personal-binding/identities";
+const PAIRING_CODE_ROOT: &str = "/tenant-shared/slack-personal-binding/pairing/codes";
+const PAIRING_CODE_LEN: usize = 8;
+const PAIRING_CODE_RETRIES: usize = 16;
+const DEFAULT_PAIRING_TTL: Duration = Duration::from_secs(10 * 60);
+const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
+const SLACK_POST_MESSAGE_PATH: &str = "/api/chat.postMessage";
+const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
+
+#[derive(Clone)]
+pub(crate) struct FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    filesystem: Arc<ScopedFilesystem<F>>,
+    scope: ResourceScope,
+    pairing_ttl: Duration,
+    locks: Arc<Mutex<HashMap<String, Weak<tokio::sync::Mutex<()>>>>>,
+}
+
+impl<F> FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    pub(crate) fn new(
+        filesystem: Arc<ScopedFilesystem<F>>,
+        tenant_id: TenantId,
+        user_id: UserId,
+        agent_id: AgentId,
+        project_id: Option<ProjectId>,
+    ) -> Self {
+        Self {
+            filesystem,
+            scope: ResourceScope {
+                tenant_id,
+                user_id,
+                agent_id: Some(agent_id),
+                project_id,
+                mission_id: None,
+                thread_id: None,
+                invocation_id: InvocationId::new(),
+            },
+            pairing_ttl: DEFAULT_PAIRING_TTL,
+            locks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_pairing_ttl(mut self, pairing_ttl: Duration) -> Self {
+        self.pairing_ttl = pairing_ttl;
+        self
+    }
+
+    fn lock_for(&self, key: String) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self
+            .locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(key, Arc::downgrade(&lock));
+        lock
+    }
+
+    async fn read_record<T>(
+        &self,
+        path: &ScopedPath,
+    ) -> Result<Option<(T, RecordVersion)>, FilesystemError>
+    where
+        T: DeserializeOwned,
+    {
+        let Some(versioned) = self.filesystem.get(&self.scope, path).await? else {
+            return Ok(None);
+        };
+        let value = serde_json::from_slice(&versioned.entry.body).map_err(|_| {
+            FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::ReadFile,
+                reason: "Slack host-state record is invalid JSON".into(),
+            }
+        })?;
+        Ok(Some((value, versioned.version)))
+    }
+
+    async fn write_record<T>(
+        &self,
+        path: &ScopedPath,
+        value: &T,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError>
+    where
+        T: Serialize,
+    {
+        let body =
+            serde_json::to_vec(value).map_err(|_| FilesystemError::BackendInfrastructure {
+                operation: FilesystemOperation::WriteFile,
+                reason: "Slack host-state record could not be serialized".into(),
+            })?;
+        self.filesystem
+            .put(
+                &self.scope,
+                path,
+                Entry::bytes(body).with_content_type(ContentType::json()),
+                cas,
+            )
+            .await
+    }
+
+    fn identity_path(
+        provider: &str,
+        provider_user_id: &str,
+    ) -> Result<ScopedPath, FilesystemError> {
+        scoped_path(&format!(
+            "{}/{}/{}.json",
+            IDENTITY_ROOT,
+            path_segment(provider),
+            path_segment(provider_user_id)
+        ))
+    }
+
+    fn pairing_code_path(
+        code: &SlackPersonalBindingPairingCode,
+    ) -> Result<ScopedPath, FilesystemError> {
+        scoped_path(&format!("{}/{}.json", PAIRING_CODE_ROOT, code.as_str()))
+    }
+}
+
+#[async_trait::async_trait]
+impl<F> RebornUserIdentityLookup for FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn resolve_user_identity(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+    ) -> Result<Option<UserId>, RebornUserIdentityLookupError> {
+        let path = Self::identity_path(provider, provider_user_id).map_err(map_lookup_fs_error)?;
+        let Some((record, _)) = self
+            .read_record::<StoredSlackUserIdentity>(&path)
+            .await
+            .map_err(map_lookup_fs_error)?
+        else {
+            return Ok(None);
+        };
+        let user_id = UserId::new(record.user_id)
+            .map_err(|error| RebornUserIdentityLookupError::InvalidUserId(error.to_string()))?;
+        Ok(Some(user_id))
+    }
+}
+
+#[async_trait::async_trait]
+impl<F> RebornUserIdentityBindingStore for FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn bind_user_identity(
+        &self,
+        binding: RebornUserIdentityBinding,
+    ) -> Result<(), RebornUserIdentityBindingError> {
+        let path =
+            Self::identity_path(binding.provider.as_str(), binding.provider_user_id.as_str())
+                .map_err(map_binding_fs_error)?;
+        let lock = self.lock_for(format!(
+            "identity:{}:{}",
+            binding.provider.as_str(),
+            binding.provider_user_id.as_str()
+        ));
+        let _guard = lock.lock().await;
+        if let Some((existing, version)) = self
+            .read_record::<StoredSlackUserIdentity>(&path)
+            .await
+            .map_err(map_binding_fs_error)?
+        {
+            if existing.user_id != binding.user_id.as_str() {
+                return Err(RebornUserIdentityBindingError::Backend(
+                    "Slack actor is already bound to a different user".into(),
+                ));
+            }
+            let updated = StoredSlackUserIdentity::from_binding(&binding, existing.created_at);
+            match self
+                .write_record(&path, &updated, CasExpectation::Version(version))
+                .await
+            {
+                Ok(_) => {}
+                Err(FilesystemError::VersionMismatch { .. }) => {
+                    self.reconcile_identity_version_mismatch(&path, &binding)
+                        .await?;
+                }
+                Err(error) => return Err(map_binding_fs_error(error)),
+            }
+            return Ok(());
+        }
+
+        let record = StoredSlackUserIdentity::from_binding(&binding, Utc::now());
+        match self
+            .write_record(&path, &record, CasExpectation::Absent)
+            .await
+        {
+            Ok(_) => {}
+            Err(FilesystemError::VersionMismatch { .. }) => {
+                self.reconcile_identity_version_mismatch(&path, &binding)
+                    .await?;
+            }
+            Err(error) => return Err(map_binding_fs_error(error)),
+        }
+        Ok(())
+    }
+}
+
+impl<F> FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn reconcile_identity_version_mismatch(
+        &self,
+        path: &ScopedPath,
+        binding: &RebornUserIdentityBinding,
+    ) -> Result<(), RebornUserIdentityBindingError> {
+        let Some((existing, _)) = self
+            .read_record::<StoredSlackUserIdentity>(path)
+            .await
+            .map_err(map_binding_fs_error)?
+        else {
+            return Err(RebornUserIdentityBindingError::Backend(
+                "Slack actor binding changed concurrently".into(),
+            ));
+        };
+        if existing.user_id == binding.user_id.as_str() {
+            return Ok(());
+        }
+        Err(RebornUserIdentityBindingError::Backend(
+            "Slack actor is already bound to a different user".into(),
+        ))
+    }
+}
+
+#[async_trait::async_trait]
+impl<F> SlackPersonalBindingPairingChallengeStore for FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn issue_challenge(
+        &self,
+        challenge: SlackPersonalBindingPairingChallenge,
+    ) -> Result<IssuedSlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingError> {
+        let expires_at = Utc::now()
+            + chrono::Duration::from_std(self.pairing_ttl).map_err(|_| {
+                SlackPersonalBindingPairingError::Backend(
+                    "Slack pairing TTL could not be represented".into(),
+                )
+            })?;
+        for _ in 0..PAIRING_CODE_RETRIES {
+            let code = SlackPersonalBindingPairingCode::new(random_pairing_code())?;
+            let path = Self::pairing_code_path(&code).map_err(map_pairing_fs_error)?;
+            let record = StoredSlackPairingChallenge::pending(&code, &challenge, expires_at);
+            match self
+                .write_record(&path, &record, CasExpectation::Absent)
+                .await
+            {
+                Ok(_) => {
+                    return Ok(IssuedSlackPersonalBindingPairingChallenge { code, challenge });
+                }
+                Err(FilesystemError::VersionMismatch { .. }) => continue,
+                Err(error) => return Err(map_pairing_fs_error(error)),
+            }
+        }
+        Err(SlackPersonalBindingPairingError::Backend(
+            "could not allocate a unique Slack pairing code".into(),
+        ))
+    }
+
+    async fn get_challenge(
+        &self,
+        code: &SlackPersonalBindingPairingCode,
+    ) -> Result<SlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingError> {
+        let path = Self::pairing_code_path(code).map_err(map_pairing_fs_error)?;
+        let Some((record, _)) = self
+            .read_record::<StoredSlackPairingChallenge>(&path)
+            .await
+            .map_err(map_pairing_fs_error)?
+        else {
+            return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
+        };
+
+        active_pairing_challenge(&record)
+    }
+
+    async fn consume_challenge(
+        &self,
+        code: &SlackPersonalBindingPairingCode,
+    ) -> Result<SlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingError> {
+        let path = Self::pairing_code_path(code).map_err(map_pairing_fs_error)?;
+        let lock = self.lock_for(format!("pairing:{}", code.as_str()));
+        let _guard = lock.lock().await;
+        let Some((mut record, version)) = self
+            .read_record::<StoredSlackPairingChallenge>(&path)
+            .await
+            .map_err(map_pairing_fs_error)?
+        else {
+            return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
+        };
+        let challenge = active_pairing_challenge(&record)?;
+        record.status = StoredSlackPairingStatus::Consumed;
+        record.consumed_at = Some(Utc::now());
+        match self
+            .write_record(&path, &record, CasExpectation::Version(version))
+            .await
+        {
+            Ok(_) => {}
+            Err(FilesystemError::VersionMismatch { .. }) => {
+                return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
+            }
+            Err(error) => return Err(map_pairing_fs_error(error)),
+        }
+        Ok(challenge)
+    }
+}
+
+pub(crate) struct SlackPairingChallengeHttpNotifier {
+    egress: Arc<dyn ProtocolHttpEgress>,
+    credential_handle: EgressCredentialHandle,
+}
+
+impl SlackPairingChallengeHttpNotifier {
+    pub(crate) fn new(
+        egress: Arc<dyn ProtocolHttpEgress>,
+        credential_handle: EgressCredentialHandle,
+    ) -> Self {
+        Self {
+            egress,
+            credential_handle,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SlackPersonalBindingPairingNotifier for SlackPairingChallengeHttpNotifier {
+    async fn send_pairing_challenge(
+        &self,
+        notification: SlackPersonalBindingPairingNotification,
+    ) -> Result<(), SlackPersonalBindingPairingError> {
+        let channel = self
+            .open_dm_channel(notification.slack_user_id.as_str())
+            .await?;
+        let body = serde_json::to_vec(&SlackPairingPostMessage {
+            channel,
+            text: format!(
+                "Connect this Slack account to Ironclaw by entering code {} in WebChat.",
+                notification.code.as_str()
+            ),
+            mrkdwn: false,
+        })
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        let response = self
+            .send_slack_request(SLACK_POST_MESSAGE_PATH, body)
+            .await?;
+        slack_ok_response("Slack pairing DM", response.body())?;
+        Ok(())
+    }
+}
+
+impl SlackPairingChallengeHttpNotifier {
+    async fn open_dm_channel(
+        &self,
+        slack_user_id: &str,
+    ) -> Result<String, SlackPersonalBindingPairingError> {
+        let body = serde_json::to_vec(&SlackConversationsOpenRequest {
+            users: slack_user_id.to_string(),
+        })
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        let response = self
+            .send_slack_request(SLACK_CONVERSATIONS_OPEN_PATH, body)
+            .await?;
+        let opened: SlackConversationsOpenResponse =
+            slack_json_response("Slack conversations.open", response.body())?;
+        if !opened.ok {
+            return Err(SlackPersonalBindingPairingError::Backend(format!(
+                "Slack rejected conversations.open ({})",
+                opened.error.unwrap_or_else(|| "unknown_error".into())
+            )));
+        }
+        opened
+            .channel
+            .map(|channel| channel.id)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| {
+                SlackPersonalBindingPairingError::Backend(
+                    "Slack conversations.open response did not include a channel id".into(),
+                )
+            })
+    }
+
+    async fn send_slack_request(
+        &self,
+        path: &'static str,
+        body: Vec<u8>,
+    ) -> Result<ironclaw_product_adapters::EgressResponse, SlackPersonalBindingPairingError> {
+        let response = self
+            .egress
+            .send(slack_api_request(
+                path,
+                body,
+                self.credential_handle.clone(),
+            ))
+            .await
+            .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        if !(200..300).contains(&response.status()) {
+            return Err(SlackPersonalBindingPairingError::Backend(format!(
+                "Slack API request {path} failed with HTTP {}",
+                response.status()
+            )));
+        }
+        Ok(response)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredSlackUserIdentity {
+    provider: String,
+    provider_user_id: String,
+    user_id: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl StoredSlackUserIdentity {
+    fn from_binding(binding: &RebornUserIdentityBinding, created_at: DateTime<Utc>) -> Self {
+        Self {
+            provider: binding.provider.as_str().to_string(),
+            provider_user_id: binding.provider_user_id.as_str().to_string(),
+            user_id: binding.user_id.as_str().to_string(),
+            created_at,
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[cfg(test)]
+    fn binding(&self) -> RebornUserIdentityBinding {
+        RebornUserIdentityBinding {
+            provider: crate::slack_personal_binding::RebornIdentityProviderId::new(
+                self.provider.clone(),
+            )
+            .expect("valid provider"),
+            provider_user_id: crate::slack_personal_binding::RebornIdentityProviderUserId::new(
+                self.provider_user_id.clone(),
+            )
+            .expect("valid provider user id"),
+            user_id: UserId::new(self.user_id.clone()).expect("valid user id"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StoredSlackPairingStatus {
+    Pending,
+    Consumed,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredSlackPairingChallenge {
+    code: String,
+    installation_id: String,
+    slack_user_id: String,
+    status: StoredSlackPairingStatus,
+    created_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    consumed_at: Option<DateTime<Utc>>,
+}
+
+impl StoredSlackPairingChallenge {
+    fn pending(
+        code: &SlackPersonalBindingPairingCode,
+        challenge: &SlackPersonalBindingPairingChallenge,
+        expires_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            code: code.as_str().to_string(),
+            installation_id: challenge.installation_id.as_str().to_string(),
+            slack_user_id: challenge.slack_user_id.as_str().to_string(),
+            status: StoredSlackPairingStatus::Pending,
+            created_at: Utc::now(),
+            expires_at,
+            consumed_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SlackConversationsOpenRequest {
+    users: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenResponse {
+    ok: bool,
+    error: Option<String>,
+    channel: Option<SlackConversationsOpenChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenChannel {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackPairingPostMessage {
+    channel: String,
+    text: String,
+    mrkdwn: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackApiResponse {
+    ok: bool,
+    error: Option<String>,
+}
+
+fn slack_api_request(
+    path: &'static str,
+    body: Vec<u8>,
+    credential_handle: EgressCredentialHandle,
+) -> EgressRequest {
+    let host = DeclaredEgressHost::new(SLACK_API_HOST).expect("static Slack host valid");
+    let method = EgressMethod::post();
+    let path = EgressPath::new(path).expect("static Slack API path valid");
+    let content_type = EgressHeader::new("content-type", "application/json")
+        .expect("static content-type header valid");
+    EgressRequest::new(host, method, path)
+        .with_header(content_type)
+        .with_body(body)
+        .with_credential_handle(Some(credential_handle))
+}
+
+fn slack_json_response<T>(
+    label: &'static str,
+    body: &[u8],
+) -> Result<T, SlackPersonalBindingPairingError>
+where
+    T: DeserializeOwned,
+{
+    if body.len() > SLACK_API_RESPONSE_LIMIT {
+        return Err(SlackPersonalBindingPairingError::Backend(format!(
+            "{label} response exceeded body limit"
+        )));
+    }
+    serde_json::from_slice(body).map_err(|error| {
+        SlackPersonalBindingPairingError::Backend(format!(
+            "{label} response was invalid JSON: {error}"
+        ))
+    })
+}
+
+fn slack_ok_response(
+    label: &'static str,
+    body: &[u8],
+) -> Result<(), SlackPersonalBindingPairingError> {
+    let response: SlackApiResponse = slack_json_response(label, body)?;
+    if response.ok {
+        Ok(())
+    } else {
+        Err(SlackPersonalBindingPairingError::Backend(format!(
+            "Slack rejected {label} ({})",
+            response.error.unwrap_or_else(|| "unknown_error".into())
+        )))
+    }
+}
+
+fn active_pairing_challenge(
+    record: &StoredSlackPairingChallenge,
+) -> Result<SlackPersonalBindingPairingChallenge, SlackPersonalBindingPairingError> {
+    if record.status != StoredSlackPairingStatus::Pending || record.expires_at <= Utc::now() {
+        return Err(SlackPersonalBindingPairingError::ChallengeNotFound);
+    }
+    Ok(SlackPersonalBindingPairingChallenge {
+        installation_id: AdapterInstallationId::new(record.installation_id.clone())
+            .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?,
+        slack_user_id: SlackUserId::new(record.slack_user_id.clone()),
+    })
+}
+
+fn random_pairing_code() -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    let mut bytes = [0_u8; PAIRING_CODE_LEN];
+    OsRng.fill_bytes(&mut bytes);
+    bytes
+        .iter()
+        .map(|byte| ALPHABET[usize::from(*byte) % ALPHABET.len()] as char)
+        .collect()
+}
+
+fn path_segment(value: &str) -> String {
+    URL_SAFE_NO_PAD.encode(value.as_bytes())
+}
+
+fn scoped_path(raw: &str) -> Result<ScopedPath, FilesystemError> {
+    ScopedPath::new(raw).map_err(|error| FilesystemError::BackendInfrastructure {
+        operation: FilesystemOperation::WriteFile,
+        reason: format!("invalid Slack host-state path under {SLACK_HOST_STATE_ROOT}: {error}"),
+    })
+}
+
+fn map_lookup_fs_error(error: FilesystemError) -> RebornUserIdentityLookupError {
+    RebornUserIdentityLookupError::Backend(error.to_string())
+}
+
+fn map_binding_fs_error(error: FilesystemError) -> RebornUserIdentityBindingError {
+    RebornUserIdentityBindingError::Backend(error.to_string())
+}
+
+fn map_pairing_fs_error(error: FilesystemError) -> SlackPersonalBindingPairingError {
+    SlackPersonalBindingPairingError::Backend(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_filesystem::InMemoryBackend;
+    use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+
+    use crate::slack_personal_binding::{RebornIdentityProviderId, RebornIdentityProviderUserId};
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_binds_and_resolves_identity() {
+        let state = state();
+        let binding = RebornUserIdentityBinding {
+            provider: RebornIdentityProviderId::new("slack").unwrap(),
+            provider_user_id: RebornIdentityProviderUserId::new("install-alpha:U123").unwrap(),
+            user_id: user("user:alice"),
+        };
+
+        state
+            .bind_user_identity(binding.clone())
+            .await
+            .expect("bind succeeds");
+        let resolved = state
+            .resolve_user_identity("slack", "install-alpha:U123")
+            .await
+            .expect("resolve succeeds");
+
+        assert_eq!(resolved, Some(user("user:alice")));
+        let stored = read_identity(&state, "slack", "install-alpha:U123").await;
+        assert_eq!(stored.binding(), binding);
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_rejects_rebinding_actor_to_different_user() {
+        let state = state();
+        state
+            .bind_user_identity(binding("user:alice"))
+            .await
+            .expect("first bind succeeds");
+        let error = state
+            .bind_user_identity(binding("user:bob"))
+            .await
+            .expect_err("rebind should fail");
+
+        assert!(matches!(error, RebornUserIdentityBindingError::Backend(_)));
+        assert_eq!(
+            state
+                .resolve_user_identity("slack", "install-alpha:U123")
+                .await
+                .expect("resolve succeeds"),
+            Some(user("user:alice"))
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_consumes_pairing_code_once() {
+        let state = state();
+        let issued = state
+            .issue_challenge(challenge())
+            .await
+            .expect("issue succeeds");
+
+        let consumed = state
+            .consume_challenge(&issued.code)
+            .await
+            .expect("consume succeeds");
+
+        assert_eq!(consumed, challenge());
+        assert!(matches!(
+            state.consume_challenge(&issued.code).await,
+            Err(SlackPersonalBindingPairingError::ChallengeNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_previews_pairing_code_without_consuming_it() {
+        let state = state();
+        let issued = state
+            .issue_challenge(challenge())
+            .await
+            .expect("issue succeeds");
+
+        let preview = state
+            .get_challenge(&issued.code)
+            .await
+            .expect("preview succeeds");
+        let consumed = state
+            .consume_challenge(&issued.code)
+            .await
+            .expect("consume succeeds");
+
+        assert_eq!(preview, challenge());
+        assert_eq!(consumed, challenge());
+        assert!(matches!(
+            state.get_challenge(&issued.code).await,
+            Err(SlackPersonalBindingPairingError::ChallengeNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_rejects_expired_pairing_code() {
+        let state = state().with_pairing_ttl(Duration::from_millis(1));
+        let issued = state
+            .issue_challenge(challenge())
+            .await
+            .expect("issue succeeds");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        assert!(matches!(
+            state.consume_challenge(&issued.code).await,
+            Err(SlackPersonalBindingPairingError::ChallengeNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn slack_pairing_notifier_posts_code_to_slack_user() {
+        let egress = Arc::new(RecordingEgress::default());
+        let notifier = SlackPairingChallengeHttpNotifier::new(
+            egress.clone(),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+
+        notifier
+            .send_pairing_challenge(SlackPersonalBindingPairingNotification {
+                installation_id: installation(),
+                slack_user_id: SlackUserId::new("U123"),
+                code: SlackPersonalBindingPairingCode::new("ABCD1234").unwrap(),
+            })
+            .await
+            .expect("notification succeeds");
+
+        let calls = egress.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].path().as_str(), SLACK_CONVERSATIONS_OPEN_PATH);
+        let open_body: serde_json::Value = serde_json::from_slice(calls[0].body()).unwrap();
+        assert_eq!(open_body["users"], "U123");
+        assert_eq!(calls[1].path().as_str(), SLACK_POST_MESSAGE_PATH);
+        let post_body: serde_json::Value = serde_json::from_slice(calls[1].body()).unwrap();
+        assert_eq!(post_body["channel"], "D123");
+        assert!(post_body["text"].as_str().unwrap().contains("ABCD1234"));
+    }
+
+    fn state() -> FilesystemSlackHostState<InMemoryBackend> {
+        let root = Arc::new(InMemoryBackend::default());
+        let scoped = Arc::new(ScopedFilesystem::with_fixed_view(
+            root,
+            MountView::new(vec![MountGrant::new(
+                MountAlias::new("/tenant-shared").unwrap(),
+                VirtualPath::new("/tenants/tenant-alpha/shared").unwrap(),
+                MountPermissions::read_write_list_delete(),
+            )])
+            .unwrap(),
+        ));
+        FilesystemSlackHostState::new(
+            scoped,
+            TenantId::new("tenant-alpha").unwrap(),
+            user("user:host"),
+            AgentId::new("agent:host").unwrap(),
+            Some(ProjectId::new("project:host").unwrap()),
+        )
+    }
+
+    fn binding(user_id: &str) -> RebornUserIdentityBinding {
+        RebornUserIdentityBinding {
+            provider: RebornIdentityProviderId::new("slack").unwrap(),
+            provider_user_id: RebornIdentityProviderUserId::new("install-alpha:U123").unwrap(),
+            user_id: user(user_id),
+        }
+    }
+
+    async fn read_identity(
+        state: &FilesystemSlackHostState<InMemoryBackend>,
+        provider: &str,
+        provider_user_id: &str,
+    ) -> StoredSlackUserIdentity {
+        let path =
+            FilesystemSlackHostState::<InMemoryBackend>::identity_path(provider, provider_user_id)
+                .unwrap();
+        state
+            .read_record(&path)
+            .await
+            .unwrap()
+            .expect("identity exists")
+            .0
+    }
+
+    fn challenge() -> SlackPersonalBindingPairingChallenge {
+        SlackPersonalBindingPairingChallenge {
+            installation_id: installation(),
+            slack_user_id: SlackUserId::new("U123"),
+        }
+    }
+
+    fn installation() -> AdapterInstallationId {
+        AdapterInstallationId::new("install-alpha").unwrap()
+    }
+
+    fn user(value: &str) -> UserId {
+        UserId::new(value).unwrap()
+    }
+
+    #[derive(Default)]
+    struct RecordingEgress {
+        calls: Mutex<Vec<EgressRequest>>,
+    }
+
+    impl RecordingEgress {
+        fn calls(&self) -> Vec<EgressRequest> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ProtocolHttpEgress for RecordingEgress {
+        async fn send(
+            &self,
+            request: EgressRequest,
+        ) -> Result<
+            ironclaw_product_adapters::EgressResponse,
+            ironclaw_product_adapters::ProtocolHttpEgressError,
+        > {
+            self.calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(request);
+            let response = match self.calls().last().map(|request| request.path().as_str()) {
+                Some(SLACK_CONVERSATIONS_OPEN_PATH) => {
+                    br#"{"ok":true,"channel":{"id":"D123"}}"#.to_vec()
+                }
+                _ => br#"{"ok":true}"#.to_vec(),
+            };
+            Ok(ironclaw_product_adapters::EgressResponse::new(
+                200, response,
+            ))
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -97,13 +97,10 @@ impl SlackPairingChallengeHttpNotifier {
         path: &'static str,
         body: Vec<u8>,
     ) -> Result<ironclaw_product_adapters::EgressResponse, SlackPersonalBindingPairingError> {
+        let request = slack_api_request(path, body, self.credential_handle.clone())?;
         let response = self
             .egress
-            .send(slack_api_request(
-                path,
-                body,
-                self.credential_handle.clone(),
-            ))
+            .send(request)
             .await
             .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
         if !(200..300).contains(&response.status()) {
@@ -150,16 +147,18 @@ fn slack_api_request(
     path: &'static str,
     body: Vec<u8>,
     credential_handle: EgressCredentialHandle,
-) -> EgressRequest {
-    let host = DeclaredEgressHost::new(SLACK_API_HOST).expect("static Slack host valid");
+) -> Result<EgressRequest, SlackPersonalBindingPairingError> {
+    let host = DeclaredEgressHost::new(SLACK_API_HOST)
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
     let method = EgressMethod::post();
-    let path = EgressPath::new(path).expect("static Slack API path valid");
+    let path = EgressPath::new(path)
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
     let content_type = EgressHeader::new("content-type", "application/json")
-        .expect("static content-type header valid");
-    EgressRequest::new(host, method, path)
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+    Ok(EgressRequest::new(host, method, path)
         .with_header(content_type)
         .with_body(body)
-        .with_credential_handle(Some(credential_handle))
+        .with_credential_handle(Some(credential_handle)))
 }
 
 fn slack_json_response<T>(
@@ -256,6 +255,51 @@ mod tests {
         );
         assert!(matches!(
             rejected_post.send_pairing_challenge(notification()).await,
+            Err(SlackPersonalBindingPairingError::Backend(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn slack_pairing_notifier_rejects_open_response_without_channel_id() {
+        for body in [
+            br#"{"ok":true}"#.to_vec(),
+            br#"{"ok":true,"channel":{"id":""}}"#.to_vec(),
+        ] {
+            let notifier = SlackPairingChallengeHttpNotifier::new(
+                Arc::new(ScriptedEgress::new([EgressResponse::new(200, body)])),
+                EgressCredentialHandle::new("slack_bot_token").unwrap(),
+            );
+
+            assert!(matches!(
+                notifier.send_pairing_challenge(notification()).await,
+                Err(SlackPersonalBindingPairingError::Backend(_))
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn slack_pairing_notifier_rejects_invalid_and_oversized_slack_responses() {
+        let invalid_json = SlackPairingChallengeHttpNotifier::new(
+            Arc::new(ScriptedEgress::new([EgressResponse::new(
+                200,
+                b"not json".to_vec(),
+            )])),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+        assert!(matches!(
+            invalid_json.send_pairing_challenge(notification()).await,
+            Err(SlackPersonalBindingPairingError::Backend(_))
+        ));
+
+        let oversized = SlackPairingChallengeHttpNotifier::new(
+            Arc::new(ScriptedEgress::new([EgressResponse::new(
+                200,
+                vec![b'{'; SLACK_API_RESPONSE_LIMIT + 1],
+            )])),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+        assert!(matches!(
+            oversized.send_pairing_challenge(notification()).await,
             Err(SlackPersonalBindingPairingError::Backend(_))
         ));
     }

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -1,0 +1,330 @@
+//! Slack API notifier for personal-binding pairing challenges.
+
+use std::sync::Arc;
+
+use ironclaw_product_adapters::{
+    DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod, EgressPath,
+    EgressRequest, ProtocolHttpEgress,
+};
+use ironclaw_slack_v2_adapter::SLACK_API_HOST;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use crate::slack_personal_binding_pairing::{
+    SlackPersonalBindingPairingError, SlackPersonalBindingPairingNotification,
+    SlackPersonalBindingPairingNotifier,
+};
+
+const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
+const SLACK_POST_MESSAGE_PATH: &str = "/api/chat.postMessage";
+const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
+
+pub(crate) struct SlackPairingChallengeHttpNotifier {
+    egress: Arc<dyn ProtocolHttpEgress>,
+    credential_handle: EgressCredentialHandle,
+}
+
+impl SlackPairingChallengeHttpNotifier {
+    pub(crate) fn new(
+        egress: Arc<dyn ProtocolHttpEgress>,
+        credential_handle: EgressCredentialHandle,
+    ) -> Self {
+        Self {
+            egress,
+            credential_handle,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SlackPersonalBindingPairingNotifier for SlackPairingChallengeHttpNotifier {
+    async fn send_pairing_challenge(
+        &self,
+        notification: SlackPersonalBindingPairingNotification,
+    ) -> Result<(), SlackPersonalBindingPairingError> {
+        let channel = self
+            .open_dm_channel(notification.slack_user_id.as_str())
+            .await?;
+        let body = serde_json::to_vec(&SlackPairingPostMessage {
+            channel,
+            text: format!(
+                "Connect this Slack account to Ironclaw by entering code {} in WebChat.",
+                notification.code.as_str()
+            ),
+            mrkdwn: false,
+        })
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        let response = self
+            .send_slack_request(SLACK_POST_MESSAGE_PATH, body)
+            .await?;
+        slack_ok_response("Slack pairing DM", response.body())?;
+        Ok(())
+    }
+}
+
+impl SlackPairingChallengeHttpNotifier {
+    async fn open_dm_channel(
+        &self,
+        slack_user_id: &str,
+    ) -> Result<String, SlackPersonalBindingPairingError> {
+        let body = serde_json::to_vec(&SlackConversationsOpenRequest {
+            users: slack_user_id.to_string(),
+        })
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        let response = self
+            .send_slack_request(SLACK_CONVERSATIONS_OPEN_PATH, body)
+            .await?;
+        let opened: SlackConversationsOpenResponse =
+            slack_json_response("Slack conversations.open", response.body())?;
+        if !opened.ok {
+            return Err(SlackPersonalBindingPairingError::Backend(format!(
+                "Slack rejected conversations.open ({})",
+                opened.error.unwrap_or_else(|| "unknown_error".into())
+            )));
+        }
+        opened
+            .channel
+            .map(|channel| channel.id)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| {
+                SlackPersonalBindingPairingError::Backend(
+                    "Slack conversations.open response did not include a channel id".into(),
+                )
+            })
+    }
+
+    async fn send_slack_request(
+        &self,
+        path: &'static str,
+        body: Vec<u8>,
+    ) -> Result<ironclaw_product_adapters::EgressResponse, SlackPersonalBindingPairingError> {
+        let response = self
+            .egress
+            .send(slack_api_request(
+                path,
+                body,
+                self.credential_handle.clone(),
+            ))
+            .await
+            .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        if !(200..300).contains(&response.status()) {
+            return Err(SlackPersonalBindingPairingError::Backend(format!(
+                "Slack API request {path} failed with HTTP {}",
+                response.status()
+            )));
+        }
+        Ok(response)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SlackConversationsOpenRequest {
+    users: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenResponse {
+    ok: bool,
+    error: Option<String>,
+    channel: Option<SlackConversationsOpenChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenChannel {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackPairingPostMessage {
+    channel: String,
+    text: String,
+    mrkdwn: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackApiResponse {
+    ok: bool,
+    error: Option<String>,
+}
+
+fn slack_api_request(
+    path: &'static str,
+    body: Vec<u8>,
+    credential_handle: EgressCredentialHandle,
+) -> EgressRequest {
+    let host = DeclaredEgressHost::new(SLACK_API_HOST).expect("static Slack host valid");
+    let method = EgressMethod::post();
+    let path = EgressPath::new(path).expect("static Slack API path valid");
+    let content_type = EgressHeader::new("content-type", "application/json")
+        .expect("static content-type header valid");
+    EgressRequest::new(host, method, path)
+        .with_header(content_type)
+        .with_body(body)
+        .with_credential_handle(Some(credential_handle))
+}
+
+fn slack_json_response<T>(
+    label: &'static str,
+    body: &[u8],
+) -> Result<T, SlackPersonalBindingPairingError>
+where
+    T: DeserializeOwned,
+{
+    if body.len() > SLACK_API_RESPONSE_LIMIT {
+        return Err(SlackPersonalBindingPairingError::Backend(format!(
+            "{label} response exceeded body limit"
+        )));
+    }
+    serde_json::from_slice(body).map_err(|error| {
+        SlackPersonalBindingPairingError::Backend(format!(
+            "{label} response was invalid JSON: {error}"
+        ))
+    })
+}
+
+fn slack_ok_response(
+    label: &'static str,
+    body: &[u8],
+) -> Result<(), SlackPersonalBindingPairingError> {
+    let response: SlackApiResponse = slack_json_response(label, body)?;
+    if response.ok {
+        Ok(())
+    } else {
+        Err(SlackPersonalBindingPairingError::Backend(format!(
+            "Slack rejected {label} ({})",
+            response.error.unwrap_or_else(|| "unknown_error".into())
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use ironclaw_product_adapters::{
+        AdapterInstallationId, EgressResponse, ProtocolHttpEgressError,
+    };
+
+    use super::*;
+    use crate::slack_personal_binding_pairing::SlackPersonalBindingPairingCode;
+    use crate::slack_serve::SlackUserId;
+
+    #[tokio::test]
+    async fn slack_pairing_notifier_posts_code_to_slack_user() {
+        let egress = Arc::new(RecordingEgress::default());
+        let notifier = SlackPairingChallengeHttpNotifier::new(
+            egress.clone(),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+
+        notifier
+            .send_pairing_challenge(notification())
+            .await
+            .expect("notification succeeds");
+
+        let calls = egress.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].path().as_str(), SLACK_CONVERSATIONS_OPEN_PATH);
+        let open_body: serde_json::Value = serde_json::from_slice(calls[0].body()).unwrap();
+        assert_eq!(open_body["users"], "U123");
+        assert_eq!(calls[1].path().as_str(), SLACK_POST_MESSAGE_PATH);
+        let post_body: serde_json::Value = serde_json::from_slice(calls[1].body()).unwrap();
+        assert_eq!(post_body["channel"], "D123");
+        assert!(post_body["text"].as_str().unwrap().contains("ABCD1234"));
+    }
+
+    #[tokio::test]
+    async fn slack_pairing_notifier_maps_slack_api_failures_to_backend_errors() {
+        let rejected_open = SlackPairingChallengeHttpNotifier::new(
+            Arc::new(ScriptedEgress::new([EgressResponse::new(
+                200,
+                br#"{"ok":false,"error":"not_allowed"}"#.to_vec(),
+            )])),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+        assert!(matches!(
+            rejected_open.send_pairing_challenge(notification()).await,
+            Err(SlackPersonalBindingPairingError::Backend(_))
+        ));
+
+        let rejected_post = SlackPairingChallengeHttpNotifier::new(
+            Arc::new(ScriptedEgress::new([
+                EgressResponse::new(200, br#"{"ok":true,"channel":{"id":"D123"}}"#.to_vec()),
+                EgressResponse::new(200, br#"{"ok":false,"error":"channel_not_found"}"#.to_vec()),
+            ])),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+        assert!(matches!(
+            rejected_post.send_pairing_challenge(notification()).await,
+            Err(SlackPersonalBindingPairingError::Backend(_))
+        ));
+    }
+
+    fn notification() -> SlackPersonalBindingPairingNotification {
+        SlackPersonalBindingPairingNotification {
+            installation_id: AdapterInstallationId::new("install-alpha").unwrap(),
+            slack_user_id: SlackUserId::new("U123"),
+            code: SlackPersonalBindingPairingCode::new("ABCD1234").unwrap(),
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingEgress {
+        calls: Mutex<Vec<EgressRequest>>,
+    }
+
+    impl RecordingEgress {
+        fn calls(&self) -> Vec<EgressRequest> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ProtocolHttpEgress for RecordingEgress {
+        async fn send(
+            &self,
+            request: EgressRequest,
+        ) -> Result<EgressResponse, ProtocolHttpEgressError> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(request);
+            let response = match self.calls().last().map(|request| request.path().as_str()) {
+                Some(SLACK_CONVERSATIONS_OPEN_PATH) => {
+                    br#"{"ok":true,"channel":{"id":"D123"}}"#.to_vec()
+                }
+                _ => br#"{"ok":true}"#.to_vec(),
+            };
+            Ok(EgressResponse::new(200, response))
+        }
+    }
+
+    struct ScriptedEgress {
+        responses: Mutex<VecDeque<EgressResponse>>,
+    }
+
+    impl ScriptedEgress {
+        fn new(responses: impl IntoIterator<Item = EgressResponse>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into_iter().collect()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ProtocolHttpEgress for ScriptedEgress {
+        async fn send(
+            &self,
+            _request: EgressRequest,
+        ) -> Result<EgressResponse, ProtocolHttpEgressError> {
+            self.responses
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .pop_front()
+                .ok_or(ProtocolHttpEgressError::Timeout)
+        }
+    }
+}

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -238,10 +238,12 @@ pub struct SlackSection {
     pub installation_id: Option<String>,
     /// Slack team id used to select this installation from signed envelopes.
     pub team_id: Option<String>,
-    /// Optional Slack app id. When set, installation matching requires both
-    /// `api_app_id` and `team_id`.
+    /// Slack app id for tenant app-scoped pairing. Required by the
+    /// host-beta personal-binding pairing path.
     pub api_app_id: Option<String>,
-    /// Slack user id allowed to route through this beta installation.
+    /// Optional legacy static Slack user id to map directly to `user_id`.
+    /// Omit this for the pairing-code flow, where unknown Slack actors are
+    /// prompted to bind in WebUI.
     pub slack_user_id: Option<String>,
     /// Reborn user id the configured Slack user maps to. Defaults in the CLI
     /// to the same user as the WebUI env-bearer authenticator.


### PR DESCRIPTION
## Summary
- add Reborn host-beta filesystem-backed Slack personal binding state for identity lookup/bind and pairing challenge issue/get/consume
- wire SlackPairingActorResolver, pairing-code notifier, and WebUI redeem route into ironclaw-reborn serve
- make host-beta Slack user config optional so unknown Slack actors can receive pairing challenges through the tenant app

## Thermo loop
- loops run: 4/5
- fixed CAS single-use consume handling, tenant-scoped Slack egress, base-required get_challenge support, and durable binding CAS reconciliation
- stop condition: no actionable thermo-level issues found

## Validation
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_host -- --nocapture
- cargo fmt --check
- cargo test -p ironclaw_reborn_cli --features slack-v2-host-beta slack_host_beta_config -- --nocapture
- cargo clippy -p ironclaw_reborn_composition --all-targets --features slack-v2-host-beta -- -D warnings
- cargo clippy -p ironclaw_reborn_cli --features slack-v2-host-beta -- -D warnings
- git diff --check
- git diff --cached --check