### PR TITLE
[codex] Deduplicate Google OAuth setup rows

### DIFF
--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -176,9 +176,12 @@ fn credential_requirements(
             let provider = provider.as_str().to_string();
             let setup = credential_setup(setup);
             if let Some(seen) = groups.iter_mut().find(|seen| {
-                seen.handle == handle && seen.provider == provider && seen.setup == setup
+                seen.handle == handle
+                    && seen.provider == provider
+                    && can_merge_credential_setup(&seen.setup, &setup)
             }) {
                 seen.required |= requirement.required;
+                merge_credential_setup(&mut seen.setup, setup);
                 continue;
             }
             groups.push(CredentialRequirementGroup {
@@ -209,6 +212,39 @@ fn credential_requirements(
             }
         })
         .collect()
+}
+
+fn can_merge_credential_setup(
+    existing: &LifecycleExtensionCredentialSetup,
+    candidate: &LifecycleExtensionCredentialSetup,
+) -> bool {
+    matches!(
+        (existing, candidate),
+        (
+            LifecycleExtensionCredentialSetup::ManualToken,
+            LifecycleExtensionCredentialSetup::ManualToken
+        ) | (
+            LifecycleExtensionCredentialSetup::OAuth { .. },
+            LifecycleExtensionCredentialSetup::OAuth { .. }
+        )
+    )
+}
+
+fn merge_credential_setup(
+    existing: &mut LifecycleExtensionCredentialSetup,
+    candidate: LifecycleExtensionCredentialSetup,
+) {
+    if let (
+        LifecycleExtensionCredentialSetup::OAuth { scopes: existing },
+        LifecycleExtensionCredentialSetup::OAuth { scopes: candidate },
+    ) = (existing, candidate)
+    {
+        for scope in candidate {
+            if !existing.iter().any(|seen| seen == &scope) {
+                existing.push(scope);
+            }
+        }
+    }
 }
 
 struct CredentialRequirementGroup {
@@ -1572,14 +1608,16 @@ mod tests {
     }
 
     #[test]
-    fn bundled_gsuite_wasm_credentials_declare_oauth_setup() {
+    fn bundled_google_credentials_project_single_oauth_setup_per_account() {
         let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
 
         for extension_id in [
+            "google-calendar",
             "google-docs",
             "google-drive",
             "google-sheets",
             "google-slides",
+            "gmail",
         ] {
             let package_ref =
                 LifecyclePackageRef::new(LifecyclePackageKind::Extension, extension_id).unwrap();
@@ -1592,7 +1630,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             let mut credential_count = 0;
-            let mut capability_scope_sets: Vec<Vec<String>> = Vec::new();
+            let mut expected_setup_scopes: Vec<String> = Vec::new();
             for capability in &package.package.manifest.capabilities {
                 for credential in &capability.runtime_credentials {
                     let RuntimeCredentialRequirementSource::ProductAuthAccount { provider, setup } =
@@ -1616,8 +1654,10 @@ mod tests {
                         "{extension_id} capability {} OAuth setup scopes should match requested provider scopes",
                         capability.id
                     );
-                    if !capability_scope_sets.iter().any(|seen| seen == scopes) {
-                        capability_scope_sets.push(scopes.clone());
+                    for scope in scopes {
+                        if !expected_setup_scopes.iter().any(|seen| seen == scope) {
+                            expected_setup_scopes.push(scope.clone());
+                        }
                     }
                     credential_count += 1;
                 }
@@ -1625,27 +1665,17 @@ mod tests {
 
             assert_eq!(
                 google_requirements.len(),
-                capability_scope_sets.len(),
-                "{extension_id} lifecycle setup should keep distinct OAuth scope sets separate"
+                1,
+                "{extension_id} lifecycle setup should show one Google OAuth request per account"
             );
+            let requirement = google_requirements[0];
+            let LifecycleExtensionCredentialSetup::OAuth { scopes } = &requirement.setup else {
+                panic!("{extension_id} should expose Google OAuth setup");
+            };
             assert_eq!(
-                google_requirements
-                    .iter()
-                    .map(|requirement| requirement.name.as_str())
-                    .collect::<HashSet<_>>()
-                    .len(),
-                google_requirements.len(),
-                "{extension_id} lifecycle setup should give split OAuth requirements unique names"
+                scopes, &expected_setup_scopes,
+                "{extension_id} lifecycle setup should request the union of capability OAuth scopes once"
             );
-            for requirement in google_requirements {
-                let LifecycleExtensionCredentialSetup::OAuth { scopes } = &requirement.setup else {
-                    panic!("{extension_id} should expose Google OAuth setup");
-                };
-                assert!(
-                    capability_scope_sets.iter().any(|seen| seen == scopes),
-                    "{extension_id} lifecycle setup should request only operation-level OAuth scopes; got {scopes:?}",
-                );
-            }
             assert!(
                 credential_count > 0,
                 "{extension_id} should declare runtime credentials"

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -240,7 +240,7 @@ fn merge_credential_setup(
     ) = (existing, candidate)
     {
         for scope in candidate {
-            if !existing.iter().any(|seen| seen == &scope) {
+            if !existing.contains(&scope) {
                 existing.push(scope);
             }
         }
@@ -1655,7 +1655,7 @@ mod tests {
                         capability.id
                     );
                     for scope in scopes {
-                        if !expected_setup_scopes.iter().any(|seen| seen == scope) {
+                        if !expected_setup_scopes.contains(scope) {
                             expected_setup_scopes.push(scope.clone());
                         }
                     }

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -40,7 +40,7 @@ use ironclaw_first_party_extension_ports::{
     FirstPartySkillsExtension, FirstPartySkillsExtensionHandles, SelectableSkillContextSource,
     SkillActivationSelectorConfig, SkillExecutionAdapter,
 };
-#[cfg(test)]
+#[cfg(all(test, feature = "slack-v2-host-beta"))]
 use ironclaw_host_api::RuntimeHttpEgress;
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AgentId, AuditEnvelope, AuditEventId, AuditStage,
@@ -510,7 +510,7 @@ impl RebornRuntime {
         &self.services
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "slack-v2-host-beta"))]
     pub(crate) fn set_local_runtime_http_egress_for_test(
         &mut self,
         runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -3886,7 +3886,7 @@ mod tests {
             )
             .await
             .expect("google setup extension lifecycle projection");
-        assert_eq!(google_setup.secrets.len(), 2);
+        assert_eq!(google_setup.secrets.len(), 1);
         let google_oauth_setups = google_setup
             .secrets
             .iter()
@@ -3910,12 +3910,11 @@ mod tests {
                 .iter()
                 .map(|(_, scopes)| scopes.clone())
                 .collect::<Vec<_>>(),
-            vec![
-                vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()],
-                vec![GOOGLE_CALENDAR_EVENTS_SCOPE.to_string()],
-            ]
+            vec![vec![
+                GOOGLE_CALENDAR_READONLY_SCOPE.to_string(),
+                GOOGLE_CALENDAR_EVENTS_SCOPE.to_string(),
+            ]]
         );
-        assert_ne!(google_oauth_setups[0].0, google_oauth_setups[1].0);
         let google_setup_json =
             serde_json::to_value(&google_setup.secrets[0]).expect("serialize setup secret");
         assert_eq!(google_setup_json["setup"]["kind"], "oauth");


### PR DESCRIPTION
## Summary
- Merge same-handle Google OAuth setup requirements into a single setup row with the union of required scopes
- Update bundled Google/Gmail lifecycle coverage to assert one OAuth setup request per account
- Update the WebUI setup projection test to match the single-row setup contract
- Gate the Slack beta test-only egress helper to the feature surface that uses it, keeping default clippy clean

## Root Cause
Gmail declares one runtime credential per capability, with distinct scope sets for read, send, and modify operations. The lifecycle setup projection grouped OAuth requirements by exact setup payload, so the browser rendered three separate Google authorization rows for the same Gmail account.

## Validation
- cargo test -p ironclaw_reborn_composition bundled_google_credentials_project_single_oauth_setup_per_account
- cargo test -p ironclaw_reborn_composition local_dev_webui_bundle_uses_local_lifecycle_facade_for_setup_extension
- cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings
- cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta build_slack_events_route_mount_fails_when_runtime_http_egress_unavailable
- cargo fmt
- git diff --check
