### PR TITLE
[codex] Silence local filesystem not-found debug noise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,6 +4370,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "tracing-test",
  "uuid",
 ]
 

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -32,4 +32,5 @@ tracing = "0.1"
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -542,23 +542,67 @@ fn io_error(
     operation: FilesystemOperation,
     error: std::io::Error,
 ) -> FilesystemError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        return FilesystemError::NotFound { path, operation };
+    }
+
     tracing::debug!(
         virtual_path = path.as_str(),
         %operation,
         error = %error,
         "local filesystem backend error"
     );
-    if error.kind() == std::io::ErrorKind::NotFound {
-        FilesystemError::NotFound { path, operation }
-    } else {
-        FilesystemError::Backend {
-            path,
-            operation,
-            reason: error.kind().to_string(),
-        }
+    FilesystemError::Backend {
+        path,
+        operation,
+        reason: error.kind().to_string(),
     }
 }
 
 fn io_reason(error: std::io::Error) -> String {
     error.kind().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn missing_local_paths_do_not_log_backend_error() {
+        let storage = tempdir().unwrap();
+        let mut root = LocalFilesystem::new();
+        root.mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let read_error = root
+            .read_file(&VirtualPath::new("/projects/missing.txt").unwrap())
+            .await
+            .unwrap_err();
+        let stat_error = root
+            .stat(&VirtualPath::new("/projects/also-missing.txt").unwrap())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(read_error, FilesystemError::NotFound { .. }));
+        assert!(matches!(stat_error, FilesystemError::NotFound { .. }));
+        assert!(!logs_contain("local filesystem backend error"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn non_not_found_io_error_logs_backend_error() {
+        let error = io_error(
+            VirtualPath::new("/projects/secret.txt").unwrap(),
+            FilesystemOperation::ReadFile,
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        );
+
+        assert!(matches!(error, FilesystemError::Backend { .. }));
+        assert!(logs_contain("local filesystem backend error"));
+    }
 }


### PR DESCRIPTION
## Summary

- Stop the local filesystem backend from logging expected `NotFound` misses as `local filesystem backend error`.
- Keep debug logging for real non-`NotFound` backend failures.
- Add traced regression coverage through `LocalFilesystem::read_file` and `LocalFilesystem::stat`, plus a non-`NotFound` logging assertion.

## Root Cause

`io_error` emitted the backend-error debug log before converting `std::io::ErrorKind::NotFound` into the typed `FilesystemError::NotFound`. Optional existence probes for skill metadata and setup markers were therefore showing up as noisy backend errors even though callers handled absence normally.

## Validation

- `cargo fmt --check -p ironclaw_filesystem`
- `cargo test -p ironclaw_filesystem local::tests`
- `cargo test -p ironclaw_filesystem`
- `cargo test -p ironclaw_filesystem --all-features`
- `cargo check -p ironclaw_filesystem --no-default-features --features libsql`
- `cargo check -p ironclaw_filesystem --no-default-features --features postgres`
- `git diff --check`
