### PR TITLE
[codex] Fix Reborn Google OAuth callbacks

### DIFF
--- a/crates/ironclaw_auth/src/oauth.rs
+++ b/crates/ironclaw_auth/src/oauth.rs
@@ -590,9 +590,6 @@ pub fn parse_google_callback_scopes(
     raw.split([' ', ','])
         .filter(|scope| !scope.is_empty())
         .map(|scope| {
-            if !is_allowed_google_scope(scope) {
-                return Err(AuthProductError::MalformedCallback);
-            }
             ProviderScope::new(scope.to_string()).map_err(|_| AuthProductError::MalformedCallback)
         })
         .collect::<Result<Vec<_>, _>>()
@@ -732,5 +729,24 @@ mod tests {
             assert!(is_allowed_google_scope(scope), "{scope} must be allowed");
             assert!(parse_google_requested_scopes(&[scope.to_string()]).is_ok());
         }
+    }
+
+    #[test]
+    fn google_callback_scope_parser_accepts_provider_returned_extras() {
+        let scopes = parse_google_callback_scopes(Some(&format!(
+            "openid email profile {GOOGLE_GMAIL_READONLY_SCOPE}"
+        )))
+        .expect("callback scopes")
+        .expect("present callback scopes");
+
+        assert_eq!(
+            scopes,
+            vec![
+                ProviderScope::new("openid").unwrap(),
+                ProviderScope::new("email").unwrap(),
+                ProviderScope::new("profile").unwrap(),
+                ProviderScope::new(GOOGLE_GMAIL_READONLY_SCOPE).unwrap(),
+            ]
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_serve/oauth.rs
@@ -402,19 +402,24 @@ pub(super) async fn google_oauth_callback_handler(
                 return Err(error);
             }
         };
+    let requested_scopes = callback_state.requested_scopes();
     let callback_scopes = match parse_google_callback_scopes(query.scopes.as_deref()) {
-        Ok(callback_scopes) => {
-            callback_scopes.unwrap_or_else(|| callback_state.requested_scopes().to_vec())
+        Ok(Some(callback_scopes)) => {
+            if let Err(error) = validate_google_callback_includes_requested_scopes(
+                &callback_scopes,
+                requested_scopes,
+            ) {
+                state.remove_pkce_verifier(flow_id);
+                return Err(error);
+            }
+            requested_scopes.to_vec()
         }
+        Ok(None) => requested_scopes.to_vec(),
         Err(error) => {
             state.remove_pkce_verifier(flow_id);
             return Err(ProductAuthRouteFailure::from(error));
         }
     };
-    if callback_scopes.is_empty() {
-        state.remove_pkce_verifier(flow_id);
-        return Err(ProductAuthRouteFailure::malformed_callback());
-    }
     let authorization_code_hash = authorization_code_hash(code.expose_secret())?;
     let pkce_verifier_hash = pkce_verifier_hash(pkce_verifier.expose_secret())?;
 
@@ -456,6 +461,20 @@ pub(super) async fn google_oauth_callback_handler(
     };
 
     Ok(oauth_callback_response(&headers, response))
+}
+
+fn validate_google_callback_includes_requested_scopes(
+    callback_scopes: &[ProviderScope],
+    requested_scopes: &[ProviderScope],
+) -> Result<(), ProductAuthRouteFailure> {
+    if callback_scopes.is_empty()
+        || !requested_scopes
+            .iter()
+            .all(|requested| callback_scopes.iter().any(|scope| scope == requested))
+    {
+        return Err(ProductAuthRouteFailure::malformed_callback());
+    }
+    Ok(())
 }
 
 fn oauth_callback_response(headers: &HeaderMap, response: RebornOAuthCallbackResponse) -> Response {

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -211,11 +211,6 @@ struct DurableCapabilityDisplayPreviewSink {
     thread_scope: ThreadScope,
 }
 
-enum DurableDisplayPreviewAppend {
-    Attached(ThreadMessageId),
-    NotAttached,
-}
-
 impl Default for LocalDevCapabilityIo {
     fn default() -> Self {
         Self::new(Arc::new(CapabilityDisplayPreviewStore::default()))
@@ -263,9 +258,9 @@ impl LocalDevCapabilityIo {
         run_context: &LoopRunContext,
         invocation_id: InvocationId,
         capability_id: &CapabilityId,
-    ) -> Result<DurableDisplayPreviewAppend, AgentLoopHostError> {
+    ) -> Option<ThreadMessageId> {
         let Some(durable_previews) = &self.durable_previews else {
-            return Ok(DurableDisplayPreviewAppend::NotAttached);
+            return None;
         };
         let Some(record) = self.display_previews.record_for_invocation(invocation_id) else {
             tracing::debug!(
@@ -273,7 +268,7 @@ impl LocalDevCapabilityIo {
                 capability_id = capability_id.as_str(),
                 "capability display preview record missing after result staging"
             );
-            return Ok(DurableDisplayPreviewAppend::NotAttached);
+            return None;
         };
         let preview =
             match CapabilityDisplayPreviewEnvelope::new(CapabilityDisplayPreviewEnvelopeInput {
@@ -299,7 +294,7 @@ impl LocalDevCapabilityIo {
                         error,
                         "capability display preview envelope validation failed"
                     );
-                    return Err(capability_io_error());
+                    return None;
                 }
             };
         let message = match durable_previews
@@ -320,10 +315,10 @@ impl LocalDevCapabilityIo {
                     error = %error,
                     "capability display preview durable append failed; continuing with staged capability result"
                 );
-                return Ok(DurableDisplayPreviewAppend::NotAttached);
+                return None;
             }
         };
-        Ok(DurableDisplayPreviewAppend::Attached(message.message_id))
+        Some(message.message_id)
     }
 }
 
@@ -508,9 +503,9 @@ impl LoopCapabilityResultWriter for LocalDevCapabilityIo {
             },
             display_preview.as_ref(),
         );
-        if let DurableDisplayPreviewAppend::Attached(message_id) = self
+        if let Some(message_id) = self
             .try_append_durable_display_preview(run_context, invocation_id, capability_id)
-            .await?
+            .await
         {
             self.display_previews
                 .attach_timeline_message_id(invocation_id, message_id);

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -24,7 +24,7 @@ use ironclaw_loop_support::{
 use ironclaw_threads::{
     AppendCapabilityDisplayPreviewRequest, CapabilityDisplayPreviewEnvelope,
     CapabilityDisplayPreviewEnvelopeInput, CapabilityDisplayPreviewStatus, SessionThreadService,
-    ThreadScope,
+    ThreadMessageId, ThreadScope,
 };
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use ironclaw_turns::{
@@ -211,6 +211,11 @@ struct DurableCapabilityDisplayPreviewSink {
     thread_scope: ThreadScope,
 }
 
+enum DurableDisplayPreviewAppend {
+    Attached(ThreadMessageId),
+    NotAttached,
+}
+
 impl Default for LocalDevCapabilityIo {
     fn default() -> Self {
         Self::new(Arc::new(CapabilityDisplayPreviewStore::default()))
@@ -253,14 +258,14 @@ impl LocalDevCapabilityIo {
             .map(|results| results.get(result_ref).cloned())
     }
 
-    async fn append_durable_display_preview(
+    async fn try_append_durable_display_preview(
         &self,
         run_context: &LoopRunContext,
         invocation_id: InvocationId,
         capability_id: &CapabilityId,
-    ) -> Result<(), AgentLoopHostError> {
+    ) -> Result<DurableDisplayPreviewAppend, AgentLoopHostError> {
         let Some(durable_previews) = &self.durable_previews else {
-            return Ok(());
+            return Ok(DurableDisplayPreviewAppend::NotAttached);
         };
         let Some(record) = self.display_previews.record_for_invocation(invocation_id) else {
             tracing::debug!(
@@ -268,7 +273,7 @@ impl LocalDevCapabilityIo {
                 capability_id = capability_id.as_str(),
                 "capability display preview record missing after result staging"
             );
-            return Ok(());
+            return Ok(DurableDisplayPreviewAppend::NotAttached);
         };
         let preview =
             match CapabilityDisplayPreviewEnvelope::new(CapabilityDisplayPreviewEnvelopeInput {
@@ -297,7 +302,7 @@ impl LocalDevCapabilityIo {
                     return Err(capability_io_error());
                 }
             };
-        let message = durable_previews
+        let message = match durable_previews
             .thread_service
             .append_capability_display_preview(AppendCapabilityDisplayPreviewRequest {
                 scope: durable_previews.thread_scope.clone(),
@@ -306,18 +311,19 @@ impl LocalDevCapabilityIo {
                 preview,
             })
             .await
-            .map_err(|error| {
+        {
+            Ok(message) => message,
+            Err(error) => {
                 tracing::debug!(
                     invocation_id = %invocation_id,
                     capability_id = capability_id.as_str(),
                     error = %error,
-                    "capability display preview durable append failed"
+                    "capability display preview durable append failed; continuing with staged capability result"
                 );
-                capability_io_error()
-            })?;
-        self.display_previews
-            .attach_timeline_message_id(invocation_id, message.message_id);
-        Ok(())
+                return Ok(DurableDisplayPreviewAppend::NotAttached);
+            }
+        };
+        Ok(DurableDisplayPreviewAppend::Attached(message.message_id))
     }
 }
 
@@ -502,8 +508,13 @@ impl LoopCapabilityResultWriter for LocalDevCapabilityIo {
             },
             display_preview.as_ref(),
         );
-        self.append_durable_display_preview(run_context, invocation_id, capability_id)
-            .await?;
+        if let DurableDisplayPreviewAppend::Attached(message_id) = self
+            .try_append_durable_display_preview(run_context, invocation_id, capability_id)
+            .await?
+        {
+            self.display_previews
+                .attach_timeline_message_id(invocation_id, message_id);
+        }
         Ok(result_ref)
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -462,7 +462,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn capability_io_fails_result_when_durable_preview_append_fails() {
+    async fn capability_io_keeps_result_when_durable_preview_append_fails() {
         let run_context = run_context("durable-preview-failure").await;
         let thread_scope = ThreadScope {
             tenant_id: run_context.scope.tenant_id.clone(),
@@ -488,7 +488,7 @@ mod tests {
         let invocation_id = InvocationId::new();
 
         let capability_id = CapabilityId::new("builtin.echo").expect("capability id");
-        let error = capability_io
+        let result_ref = capability_io
             .write_capability_result(CapabilityResultWrite {
                 run_context: &run_context,
                 input_ref: &input_ref,
@@ -498,9 +498,14 @@ mod tests {
                 display_preview: None,
             })
             .await
-            .expect_err("missing thread rejects durable preview append");
+            .expect("missing thread does not reject staged capability result");
 
-        assert_eq!(error.kind, AgentLoopHostErrorKind::Internal);
+        assert_eq!(
+            capability_io
+                .result_output(result_ref.as_str())
+                .expect("staged result reads"),
+            Some(serde_json::json!({"content": "hello"}))
+        );
         let preview_record = display_previews
             .record_for_invocation(invocation_id)
             .expect("live preview record was staged before durable append");

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
@@ -100,6 +100,58 @@ impl AuthProviderClient for FailingProviderClient {
 }
 
 #[derive(Debug, Default)]
+struct RecordingProviderClient {
+    exchanged_scopes: Mutex<Vec<Vec<String>>>,
+}
+
+impl RecordingProviderClient {
+    fn exchanged_scopes(&self) -> Vec<Vec<String>> {
+        self.exchanged_scopes
+            .lock()
+            .expect("exchanged scopes lock")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl AuthProviderClient for RecordingProviderClient {
+    async fn exchange_callback(
+        &self,
+        _context: OAuthProviderExchangeContext,
+        request: OAuthProviderCallbackRequest,
+    ) -> Result<OAuthProviderExchange, AuthProductError> {
+        let scopes = request
+            .scopes
+            .iter()
+            .map(|scope| scope.as_str().to_string())
+            .collect::<Vec<_>>();
+        self.exchanged_scopes
+            .lock()
+            .expect("exchanged scopes lock")
+            .push(scopes);
+        Ok(OAuthProviderExchange {
+            provider: request.provider,
+            account_label: request.account_label,
+            authorization_code_hash: request.authorization_code_hash,
+            pkce_verifier_hash: request.pkce_verifier_hash,
+            access_secret: SecretHandle::new("recorded-google-access").expect("secret handle"),
+            refresh_secret: Some(
+                SecretHandle::new("recorded-google-refresh").expect("secret handle"),
+            ),
+            scopes: request.scopes,
+            account_id: None,
+        })
+    }
+
+    async fn refresh_token(
+        &self,
+        _request: OAuthProviderRefreshRequest,
+    ) -> Result<OAuthProviderRefresh, AuthProductError> {
+        Err(AuthProductError::RefreshFailed)
+    }
+}
+
+#[derive(Debug, Default)]
 struct SubmitFailingManualTokenInteractions {
     interaction_id: AuthInteractionId,
     abandoned: Mutex<Vec<(AuthProductScope, AuthInteractionId)>>,
@@ -356,6 +408,34 @@ fn build_app_with_google_oauth() -> (axum::Router, Arc<RecordingAuthDispatcher>)
     let dispatcher = Arc::new(RecordingAuthDispatcher::default());
     let product_auth = Arc::new(RebornProductAuthServices::from_shared(
         Arc::new(InMemoryAuthProductServices::new()),
+        dispatcher.clone(),
+    ));
+    (
+        build_app_with_product_auth_service_and_config(
+            product_auth,
+            Some(google_oauth_route_config()),
+        ),
+        dispatcher,
+    )
+}
+
+fn build_app_with_google_oauth_provider(
+    provider_client: Arc<dyn AuthProviderClient>,
+) -> (axum::Router, Arc<RecordingAuthDispatcher>) {
+    let dispatcher = Arc::new(RecordingAuthDispatcher::default());
+    let shared = Arc::new(InMemoryAuthProductServices::new());
+    let flow_manager: Arc<dyn AuthFlowManager> = shared.clone();
+    let interaction_service: Arc<dyn AuthInteractionService> = shared.clone();
+    let credential_setup_service: Arc<dyn CredentialSetupService> = shared.clone();
+    let credential_account_service: Arc<dyn CredentialAccountService> = shared.clone();
+    let cleanup_service: Arc<dyn SecretCleanupService> = shared;
+    let product_auth = Arc::new(RebornProductAuthServices::new(
+        flow_manager,
+        interaction_service,
+        credential_setup_service,
+        credential_account_service,
+        provider_client,
+        cleanup_service,
         dispatcher.clone(),
     ));
     (
@@ -1232,6 +1312,38 @@ async fn product_auth_google_oauth_callback_completes_setup_flow() {
     assert_eq!(callback_json["flow_id"], start_json["flow_id"]);
     assert_eq!(callback_json["status"], "completed");
     assert_eq!(dispatcher.events().len(), 1);
+}
+
+#[tokio::test]
+async fn product_auth_google_oauth_callback_accepts_provider_extra_scopes_without_overclaiming() {
+    let provider_client = Arc::new(RecordingProviderClient::default());
+    let (app, dispatcher) = build_app_with_google_oauth_provider(provider_client.clone());
+    let (start_json, state) = start_google_oauth_flow(&app).await;
+    let scopes = format!(
+        "openid%20email%20profile%20{GOOGLE_GMAIL_READONLY_SCOPE}%20{GOOGLE_CALENDAR_READONLY_SCOPE}"
+    );
+
+    let callback_response = app
+        .oneshot(callback_request(format!(
+            "/api/reborn/product-auth/oauth/google/callback?state={state}&code=google-auth-code&scope={scopes}"
+        )))
+        .await
+        .expect("oneshot");
+
+    assert_eq!(callback_response.status(), StatusCode::OK);
+    let callback_body = read_body_string(callback_response).await;
+    let callback_json: serde_json::Value =
+        serde_json::from_str(&callback_body).expect("callback json");
+    assert_eq!(callback_json["flow_id"], start_json["flow_id"]);
+    assert_eq!(callback_json["status"], "completed");
+    assert_eq!(dispatcher.events().len(), 1);
+    assert_eq!(
+        provider_client.exchanged_scopes(),
+        vec![vec![
+            GOOGLE_GMAIL_READONLY_SCOPE.to_string(),
+            GOOGLE_CALENDAR_READONLY_SCOPE.to_string()
+        ]]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Accept Google OAuth callback scope metadata such as `openid email profile` while requiring the originally requested Google API scopes.
- Keep Reborn product-auth exchanges scoped to the requested Gmail/Calendar scopes instead of forwarding provider callback extras.
- Treat durable capability display-preview append failures as best-effort so a missing timeline thread does not fail an otherwise successful capability call.

## Root Cause
Google can return additional OAuth scope metadata during callback handling. The route rejected those callbacks as malformed. After that was fixed, a secondary display-preview append failure for an unknown thread was still being escalated into `HostUnavailable { stage: Capability }` even though the capability result had already been staged.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_auth google_callback_scope_parser_accepts_provider_returned_extras -- --nocapture`
- `cargo test -p ironclaw_auth google_oauth -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --lib capability_io_ -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features webui-v2-beta --test webui_v2_product_auth product_auth_google_oauth_callback -- --nocapture`

Note: a broader non-`--lib` `ironclaw_reborn_composition` test run hit local linker disk exhaustion (`ld: write() failed, errno=28`) with only ~182MiB free.