### PR TITLE
[codex] Pair trigger creator during trigger create

### DIFF
--- a/crates/ironclaw_conversations/src/inbound.rs
+++ b/crates/ironclaw_conversations/src/inbound.rs
@@ -444,7 +444,10 @@ mod tests {
     use async_trait::async_trait;
     use chrono::{TimeZone, Utc};
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
-    use ironclaw_triggers::TrustedTriggerFireSubmitOutcome;
+    use ironclaw_triggers::{
+        TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
+        TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TrustedTriggerFireSubmitOutcome,
+    };
     use ironclaw_turns::{
         AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, CancelRunRequest,
         CancelRunResponse, EventCursor, GetRunStateRequest, ReplyTargetBindingRef,
@@ -774,7 +777,7 @@ mod tests {
                 reason: "empty".to_string(),
             },
             InboundTurnError::BindingRequired {
-                adapter_kind: "trigger".to_string(),
+                adapter_kind: TRIGGER_TRUSTED_ADAPTER_KIND.to_string(),
                 external_actor_id: "actor".to_string(),
             },
             InboundTurnError::AccessDenied {
@@ -891,15 +894,15 @@ mod tests {
     }
 
     fn trigger_adapter() -> AdapterKind {
-        AdapterKind::new("trigger").unwrap()
+        AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).unwrap()
     }
 
     fn trigger_installation() -> AdapterInstallationId {
-        AdapterInstallationId::new("reborn-trigger-poller").unwrap()
+        AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID).unwrap()
     }
 
     fn external_actor(value: &str) -> ExternalActorRef {
-        ExternalActorRef::new("user", value).unwrap()
+        ExternalActorRef::new(TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, value).unwrap()
     }
 
     fn user(value: &str) -> UserId {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -59,6 +59,7 @@ pub use time::TIME_CAPABILITY_ID;
 pub use trigger_management::TriggerManagementClock;
 pub use trigger_management::{
     TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID,
+    TriggerCreateHook,
 };
 
 pub const BUILTIN_FIRST_PARTY_PROVIDER: &str = "builtin";
@@ -193,6 +194,21 @@ pub fn builtin_first_party_handlers(
 ) -> Result<FirstPartyCapabilityRegistry, HostApiError> {
     let mut registry = builtin_first_party_base_registry()?;
     trigger_management::insert_handlers(&mut registry, trigger_repository)?;
+    Ok(registry)
+}
+
+/// Create handlers for all built-in first-party capabilities using an
+/// explicitly composed trigger repository and trigger-create lifecycle hook.
+pub fn builtin_first_party_handlers_with_trigger_create_hook(
+    trigger_repository: Arc<dyn ironclaw_triggers::TriggerRepository>,
+    trigger_create_hook: Arc<dyn TriggerCreateHook>,
+) -> Result<FirstPartyCapabilityRegistry, HostApiError> {
+    let mut registry = builtin_first_party_base_registry()?;
+    trigger_management::insert_handlers_with_create_hook(
+        &mut registry,
+        trigger_repository,
+        trigger_create_hook,
+    )?;
     Ok(registry)
 }
 

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -238,14 +238,25 @@ async fn create_trigger(
         created_at: now,
     };
     record.validate().map_err(trigger_input_error)?;
-    create_hook
-        .before_trigger_persisted(&record)
-        .await
-        .map_err(|error| trigger_create_hook_error("before_trigger_persisted", error))?;
     repository
         .upsert_trigger(record.clone())
         .await
         .map_err(|error| trigger_repository_error("upsert_trigger", error))?;
+    if let Err(error) = create_hook.before_trigger_persisted(&record).await {
+        let hook_error = trigger_create_hook_error("before_trigger_persisted", error);
+        if let Err(remove_error) = repository
+            .remove_trigger(record.tenant_id.clone(), record.trigger_id)
+            .await
+        {
+            tracing::warn!(
+                trigger_id = %record.trigger_id,
+                error_kind = "trigger_create_rollback_failed",
+                "failed to remove trigger after create hook failure"
+            );
+            return Err(trigger_repository_error("remove_trigger", remove_error));
+        }
+        return Err(hook_error);
+    }
     Ok(json!({
         "trigger": trigger_output(&record),
     }))

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -123,7 +123,7 @@ trait TriggerManagementClock: Send + Sync {
 
 #[async_trait]
 pub trait TriggerCreateHook: Send + Sync {
-    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError>;
+    async fn after_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError>;
 }
 
 #[derive(Debug)]
@@ -131,7 +131,7 @@ struct NoopTriggerCreateHook;
 
 #[async_trait]
 impl TriggerCreateHook for NoopTriggerCreateHook {
-    async fn before_trigger_persisted(&self, _record: &TriggerRecord) -> Result<(), TriggerError> {
+    async fn after_trigger_persisted(&self, _record: &TriggerRecord) -> Result<(), TriggerError> {
         Ok(())
     }
 }
@@ -242,18 +242,18 @@ async fn create_trigger(
         .upsert_trigger(record.clone())
         .await
         .map_err(|error| trigger_repository_error("upsert_trigger", error))?;
-    if let Err(error) = create_hook.before_trigger_persisted(&record).await {
-        let hook_error = trigger_create_hook_error("before_trigger_persisted", error);
+    if let Err(error) = create_hook.after_trigger_persisted(&record).await {
+        let hook_error = trigger_create_hook_error("after_trigger_persisted", error);
         if let Err(remove_error) = repository
             .remove_trigger(record.tenant_id.clone(), record.trigger_id)
             .await
         {
             tracing::warn!(
                 trigger_id = %record.trigger_id,
+                %remove_error,
                 error_kind = "trigger_create_rollback_failed",
                 "failed to remove trigger after create hook failure"
             );
-            return Err(trigger_repository_error("remove_trigger", remove_error));
         }
         return Err(hook_error);
     }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -248,12 +248,10 @@ async fn create_trigger(
             .remove_trigger(record.tenant_id.clone(), record.trigger_id)
             .await
         {
-            tracing::warn!(
-                trigger_id = %record.trigger_id,
-                %remove_error,
-                error_kind = "trigger_create_rollback_failed",
-                "failed to remove trigger after create hook failure"
-            );
+            return Err(trigger_create_rollback_error(
+                "remove_trigger",
+                remove_error,
+            ));
         }
         return Err(hook_error);
     }
@@ -379,6 +377,23 @@ fn trigger_create_hook_error(
         "trigger management capability create hook failed"
     );
     FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
+}
+
+fn trigger_create_rollback_error(
+    repository_operation: &'static str,
+    error: TriggerError,
+) -> FirstPartyCapabilityError {
+    tracing::warn!(
+        runtime_dispatch_error_kind = %RuntimeDispatchErrorKind::Backend,
+        repository_operation,
+        trigger_error_kind = trigger_error_kind(&error),
+        error_kind = "trigger_create_rollback_failed",
+        "trigger management capability create hook rollback failed"
+    );
+    FirstPartyCapabilityError::with_safe_summary(
+        RuntimeDispatchErrorKind::Backend,
+        "trigger create rollback failed after hook error",
+    )
 }
 
 fn trigger_error_kind(error: &TriggerError) -> &'static str {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -60,10 +60,19 @@ pub(super) fn insert_handlers(
     registry: &mut FirstPartyCapabilityRegistry,
     repository: Arc<dyn TriggerRepository>,
 ) -> Result<(), HostApiError> {
+    insert_handlers_with_create_hook(registry, repository, Arc::new(NoopTriggerCreateHook))
+}
+
+pub(super) fn insert_handlers_with_create_hook(
+    registry: &mut FirstPartyCapabilityRegistry,
+    repository: Arc<dyn TriggerRepository>,
+    create_hook: Arc<dyn TriggerCreateHook>,
+) -> Result<(), HostApiError> {
     insert_trigger_handlers(
         registry,
         Arc::new(TriggerManagementToolHandler {
             repository,
+            create_hook,
             clock: Arc::new(SystemTriggerManagementClock),
         }),
     )
@@ -77,7 +86,11 @@ pub(super) fn insert_handlers_with_clock(
 ) -> Result<(), HostApiError> {
     insert_trigger_handlers(
         registry,
-        Arc::new(TriggerManagementToolHandler { repository, clock }),
+        Arc::new(TriggerManagementToolHandler {
+            repository,
+            create_hook: Arc::new(NoopTriggerCreateHook),
+            clock,
+        }),
     )
 }
 
@@ -108,6 +121,21 @@ trait TriggerManagementClock: Send + Sync {
     fn now(&self) -> DateTime<Utc>;
 }
 
+#[async_trait]
+pub trait TriggerCreateHook: Send + Sync {
+    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError>;
+}
+
+#[derive(Debug)]
+struct NoopTriggerCreateHook;
+
+#[async_trait]
+impl TriggerCreateHook for NoopTriggerCreateHook {
+    async fn before_trigger_persisted(&self, _record: &TriggerRecord) -> Result<(), TriggerError> {
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 struct SystemTriggerManagementClock;
 
@@ -119,6 +147,7 @@ impl TriggerManagementClock for SystemTriggerManagementClock {
 
 struct TriggerManagementToolHandler {
     repository: Arc<dyn TriggerRepository>,
+    create_hook: Arc<dyn TriggerCreateHook>,
     clock: Arc<dyn TriggerManagementClock>,
 }
 
@@ -134,6 +163,7 @@ impl FirstPartyCapabilityHandler for TriggerManagementToolHandler {
             TRIGGER_CREATE_CAPABILITY_ID => {
                 create_trigger(
                     &*self.repository,
+                    &*self.create_hook,
                     &request.scope,
                     request.input,
                     self.clock.now(),
@@ -179,6 +209,7 @@ struct TriggerListInput {
 
 async fn create_trigger(
     repository: &dyn TriggerRepository,
+    create_hook: &dyn TriggerCreateHook,
     scope: &ResourceScope,
     input: Value,
     now: DateTime<Utc>,
@@ -207,6 +238,10 @@ async fn create_trigger(
         created_at: now,
     };
     record.validate().map_err(trigger_input_error)?;
+    create_hook
+        .before_trigger_persisted(&record)
+        .await
+        .map_err(|error| trigger_create_hook_error("before_trigger_persisted", error))?;
     repository
         .upsert_trigger(record.clone())
         .await
@@ -318,6 +353,19 @@ fn trigger_repository_error(
         repository_operation,
         trigger_error_kind = trigger_error_kind(&error),
         "trigger management capability repository operation failed"
+    );
+    FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
+}
+
+fn trigger_create_hook_error(
+    hook_operation: &'static str,
+    error: TriggerError,
+) -> FirstPartyCapabilityError {
+    tracing::debug!(
+        runtime_dispatch_error_kind = %RuntimeDispatchErrorKind::Backend,
+        hook_operation,
+        trigger_error_kind = trigger_error_kind(&error),
+        "trigger management capability create hook failed"
     );
     FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
 }

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -78,7 +78,8 @@ pub use first_party_tools::{
     READ_FILE_CAPABILITY_ID, SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID,
     SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID,
     TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID,
-    TRIGGER_REMOVE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
+    TRIGGER_REMOVE_CAPABILITY_ID, TriggerCreateHook, WRITE_FILE_CAPABILITY_ID,
+    builtin_first_party_handlers, builtin_first_party_handlers_with_trigger_create_hook,
     builtin_first_party_package,
 };
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -318,9 +318,9 @@ async fn builtin_trigger_create_stamps_caller_scope_and_persists_record() {
 }
 
 #[tokio::test]
-async fn builtin_trigger_create_runs_create_hook_before_persistence() {
+async fn builtin_trigger_create_runs_create_hook_after_persistence() {
     let repository = Arc::new(InMemoryTriggerRepository::default());
-    let hook = Arc::new(RecordingTriggerCreateHook::default());
+    let hook = Arc::new(PersistedRecordTriggerCreateHook::new(repository.clone()));
     let runtime = runtime_with_trigger_repository_and_create_hook(repository.clone(), hook.clone());
     let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
 
@@ -360,7 +360,7 @@ async fn builtin_trigger_create_runs_create_hook_before_persistence() {
 }
 
 #[tokio::test]
-async fn builtin_trigger_create_maps_create_hook_error_to_backend_before_persistence() {
+async fn builtin_trigger_create_maps_create_hook_error_to_backend_and_rolls_back_record() {
     let repository = Arc::new(InMemoryTriggerRepository::default());
     let runtime = runtime_with_trigger_repository_and_create_hook(
         repository.clone(),
@@ -5315,20 +5315,36 @@ where
     .host_runtime_for_local_testing()
 }
 
-#[derive(Debug, Default)]
-struct RecordingTriggerCreateHook {
+struct PersistedRecordTriggerCreateHook {
+    repository: Arc<InMemoryTriggerRepository>,
     records: std::sync::Mutex<Vec<TriggerRecord>>,
 }
 
-impl RecordingTriggerCreateHook {
+impl PersistedRecordTriggerCreateHook {
+    fn new(repository: Arc<InMemoryTriggerRepository>) -> Self {
+        Self {
+            repository,
+            records: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
     fn records(&self) -> Vec<TriggerRecord> {
         self.records.lock().unwrap().clone()
     }
 }
 
 #[async_trait]
-impl TriggerCreateHook for RecordingTriggerCreateHook {
+impl TriggerCreateHook for PersistedRecordTriggerCreateHook {
     async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+        let persisted = self
+            .repository
+            .get_trigger(record.tenant_id.clone(), record.trigger_id)
+            .await
+            .expect("trigger lookup succeeds");
+        assert_eq!(
+            persisted.as_ref().map(|record| record.trigger_id),
+            Some(record.trigger_id)
+        );
         self.records.lock().unwrap().push(record.clone());
         Ok(())
     }

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -34,8 +34,9 @@ use ironclaw_host_runtime::{
     SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID,
     SPAWN_SUBAGENT_CAPABILITY_ID, SandboxCommandTransport, SurfaceKind, TIME_CAPABILITY_ID,
     TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID,
-    TenantSandboxProcessPort, VisibleCapabilityAccess, VisibleCapabilityRequest,
-    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
+    TenantSandboxProcessPort, TriggerCreateHook, VisibleCapabilityAccess, VisibleCapabilityRequest,
+    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
+    builtin_first_party_handlers_with_trigger_create_hook, builtin_first_party_package,
 };
 #[cfg(feature = "test-support")]
 use ironclaw_host_runtime::{
@@ -48,7 +49,8 @@ use ironclaw_network::{
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount};
 use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_triggers::{
-    InMemoryTriggerRepository, MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerRepository,
+    InMemoryTriggerRepository, MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerError,
+    TriggerRecord, TriggerRepository,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -313,6 +315,80 @@ async fn builtin_trigger_create_stamps_caller_scope_and_persists_record() {
     assert_eq!(records[0].creator_user_id, context.resource_scope.user_id);
     assert_eq!(records[0].agent_id, context.resource_scope.agent_id);
     assert_eq!(records[0].project_id, context.resource_scope.project_id);
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_runs_create_hook_before_persistence() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let hook = Arc::new(RecordingTriggerCreateHook::default());
+    let runtime = runtime_with_trigger_repository_and_create_hook(repository.clone(), hook.clone());
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+
+    invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Hooked trigger",
+            "prompt": "Pair trigger creator",
+            "cron": "0 8 * * *"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    let hooked_records = hook.records();
+    assert_eq!(hooked_records.len(), 1);
+    assert_eq!(hooked_records[0].name, "Hooked trigger");
+    assert_eq!(hooked_records[0].prompt, "Pair trigger creator");
+    assert_eq!(
+        hooked_records[0].creator_user_id,
+        context.resource_scope.user_id
+    );
+    assert_eq!(hooked_records[0].agent_id, context.resource_scope.agent_id);
+    assert_eq!(
+        hooked_records[0].project_id,
+        context.resource_scope.project_id
+    );
+
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].trigger_id, hooked_records[0].trigger_id);
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_maps_create_hook_error_to_backend_before_persistence() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_trigger_repository_and_create_hook(
+        repository.clone(),
+        Arc::new(FailingTriggerCreateHook),
+    );
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+
+    let error = invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Hook failure",
+            "prompt": "Do not persist this trigger",
+            "cron": "0 8 * * *"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::Backend);
+    assert!(
+        repository
+            .list_triggers(context.resource_scope.tenant_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[tokio::test]
@@ -5164,6 +5240,32 @@ fn runtime_with_trigger_repository(repository: Arc<dyn TriggerRepository>) -> im
     )
 }
 
+fn runtime_with_trigger_repository_and_create_hook(
+    trigger_repository: Arc<dyn TriggerRepository>,
+    trigger_create_hook: Arc<dyn TriggerCreateHook>,
+) -> impl HostRuntime {
+    HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(
+        builtin_first_party_handlers_with_trigger_create_hook(
+            trigger_repository,
+            trigger_create_hook,
+        )
+        .unwrap(),
+    ))
+    .with_runtime_http_egress(Arc::new(RecordingRuntimeHttpEgress::default()))
+    .with_audit_sink(Arc::new(InMemoryAuditSink::new()))
+    .with_runtime_policy(local_dev_policy())
+    .with_trust_policy(Arc::new(trust_policy()))
+    .host_runtime_for_local_testing()
+}
+
 #[cfg(feature = "test-support")]
 fn runtime_with_trigger_repository_and_clock(
     trigger_repository: Arc<dyn TriggerRepository>,
@@ -5211,6 +5313,37 @@ where
     .with_runtime_policy(policy)
     .with_trust_policy(Arc::new(trust_policy()))
     .host_runtime_for_local_testing()
+}
+
+#[derive(Debug, Default)]
+struct RecordingTriggerCreateHook {
+    records: std::sync::Mutex<Vec<TriggerRecord>>,
+}
+
+impl RecordingTriggerCreateHook {
+    fn records(&self) -> Vec<TriggerRecord> {
+        self.records.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl TriggerCreateHook for RecordingTriggerCreateHook {
+    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+        self.records.lock().unwrap().push(record.clone());
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FailingTriggerCreateHook;
+
+#[async_trait]
+impl TriggerCreateHook for FailingTriggerCreateHook {
+    async fn before_trigger_persisted(&self, _record: &TriggerRecord) -> Result<(), TriggerError> {
+        Err(TriggerError::Backend {
+            reason: "hook unavailable".to_string(),
+        })
+    }
 }
 
 #[derive(Debug)]

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -392,6 +392,40 @@ async fn builtin_trigger_create_maps_create_hook_error_to_backend_and_rolls_back
 }
 
 #[tokio::test]
+async fn builtin_trigger_create_preserves_hook_error_when_rollback_fails() {
+    let repository = Arc::new(RemoveFailingTriggerRepository::default());
+    let runtime = runtime_with_trigger_repository_and_create_hook(
+        repository.clone(),
+        Arc::new(FailingTriggerCreateHook),
+    );
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+
+    let error = invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Rollback failure",
+            "prompt": "Keep the hook failure as the user-visible cause",
+            "cron": "0 8 * * *"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::Backend);
+    assert_eq!(repository.remove_attempts(), 1);
+    assert_eq!(
+        repository
+            .list_triggers(context.resource_scope.tenant_id)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn builtin_trigger_create_rejects_sub_minute_schedule_before_persistence() {
     let repository = Arc::new(InMemoryTriggerRepository::default());
     let runtime = runtime_with_trigger_repository(repository.clone());
@@ -5335,7 +5369,7 @@ impl PersistedRecordTriggerCreateHook {
 
 #[async_trait]
 impl TriggerCreateHook for PersistedRecordTriggerCreateHook {
-    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+    async fn after_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
         let persisted = self
             .repository
             .get_trigger(record.tenant_id.clone(), record.trigger_id)
@@ -5355,7 +5389,7 @@ struct FailingTriggerCreateHook;
 
 #[async_trait]
 impl TriggerCreateHook for FailingTriggerCreateHook {
-    async fn before_trigger_persisted(&self, _record: &TriggerRecord) -> Result<(), TriggerError> {
+    async fn after_trigger_persisted(&self, _record: &TriggerRecord) -> Result<(), TriggerError> {
         Err(TriggerError::Backend {
             reason: "hook unavailable".to_string(),
         })
@@ -5375,9 +5409,153 @@ impl TriggerManagementClock for FixedTriggerClock {
 
 struct FailingTriggerRepository;
 
+#[derive(Default)]
+struct RemoveFailingTriggerRepository {
+    inner: InMemoryTriggerRepository,
+    remove_attempts: std::sync::Mutex<usize>,
+}
+
+impl RemoveFailingTriggerRepository {
+    fn remove_attempts(&self) -> usize {
+        *self.remove_attempts.lock().unwrap()
+    }
+}
+
 fn trigger_backend_error() -> ironclaw_triggers::TriggerError {
     ironclaw_triggers::TriggerError::Backend {
         reason: "test backend failure".to_string(),
+    }
+}
+
+#[async_trait]
+impl TriggerRepository for RemoveFailingTriggerRepository {
+    async fn upsert_trigger(
+        &self,
+        record: ironclaw_triggers::TriggerRecord,
+    ) -> Result<(), ironclaw_triggers::TriggerError> {
+        self.inner.upsert_trigger(record).await
+    }
+
+    async fn get_trigger(
+        &self,
+        tenant_id: TenantId,
+        trigger_id: ironclaw_triggers::TriggerId,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.get_trigger(tenant_id, trigger_id).await
+    }
+
+    async fn list_triggers(
+        &self,
+        tenant_id: TenantId,
+    ) -> Result<Vec<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.list_triggers(tenant_id).await
+    }
+
+    async fn list_scoped_triggers(
+        &self,
+        tenant_id: TenantId,
+        creator_user_id: UserId,
+        agent_id: Option<AgentId>,
+        project_id: Option<ProjectId>,
+        limit: usize,
+    ) -> Result<Vec<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner
+            .list_scoped_triggers(tenant_id, creator_user_id, agent_id, project_id, limit)
+            .await
+    }
+
+    async fn remove_trigger(
+        &self,
+        _tenant_id: TenantId,
+        _trigger_id: ironclaw_triggers::TriggerId,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        *self.remove_attempts.lock().unwrap() += 1;
+        Err(trigger_backend_error())
+    }
+
+    async fn remove_scoped_trigger(
+        &self,
+        tenant_id: TenantId,
+        creator_user_id: UserId,
+        agent_id: Option<AgentId>,
+        project_id: Option<ProjectId>,
+        trigger_id: ironclaw_triggers::TriggerId,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner
+            .remove_scoped_trigger(tenant_id, creator_user_id, agent_id, project_id, trigger_id)
+            .await
+    }
+
+    async fn list_due_triggers(
+        &self,
+        now: Timestamp,
+        limit: usize,
+    ) -> Result<Vec<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.list_due_triggers(now, limit).await
+    }
+
+    async fn list_active_triggers(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.list_active_triggers(limit).await
+    }
+
+    async fn list_active_triggers_after(
+        &self,
+        after: Option<ironclaw_triggers::ActiveTriggerScanCursor>,
+        limit: usize,
+    ) -> Result<Vec<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.list_active_triggers_after(after, limit).await
+    }
+
+    async fn claim_due_fire(
+        &self,
+        request: ironclaw_triggers::ClaimDueFireRequest,
+    ) -> Result<ironclaw_triggers::ClaimDueFireOutcome, ironclaw_triggers::TriggerError> {
+        self.inner.claim_due_fire(request).await
+    }
+
+    async fn mark_fire_accepted(
+        &self,
+        request: ironclaw_triggers::FireAcceptedRequest,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.mark_fire_accepted(request).await
+    }
+
+    async fn mark_fire_replayed(
+        &self,
+        request: ironclaw_triggers::FireReplayedRequest,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.mark_fire_replayed(request).await
+    }
+
+    async fn mark_fire_retryable_failed(
+        &self,
+        request: ironclaw_triggers::FireRetryableFailedRequest,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.mark_fire_retryable_failed(request).await
+    }
+
+    async fn mark_fire_permanently_failed(
+        &self,
+        request: ironclaw_triggers::FirePermanentFailedRequest,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.mark_fire_permanently_failed(request).await
+    }
+
+    async fn mark_fire_terminally_failed(
+        &self,
+        request: ironclaw_triggers::FireTerminalFailedRequest,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.mark_fire_terminally_failed(request).await
+    }
+
+    async fn clear_active_fire(
+        &self,
+        request: ironclaw_triggers::ClearActiveFireRequest,
+    ) -> Result<Option<ironclaw_triggers::TriggerRecord>, ironclaw_triggers::TriggerError> {
+        self.inner.clear_active_fire(request).await
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -29,14 +29,15 @@ use ironclaw_host_runtime::{
     GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HTTP_SAVE_CAPABILITY_ID, HostRuntime,
     HostRuntimeServices, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID, MEMORY_READ_CAPABILITY_ID,
     MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID, MEMORY_WRITE_CAPABILITY_ID,
-    READ_FILE_CAPABILITY_ID, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
-    RuntimeFailureKind, RuntimeProcessError, RuntimeProcessPort, SHELL_CAPABILITY_ID,
-    SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID,
-    SPAWN_SUBAGENT_CAPABILITY_ID, SandboxCommandTransport, SurfaceKind, TIME_CAPABILITY_ID,
-    TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID, TRIGGER_REMOVE_CAPABILITY_ID,
-    TenantSandboxProcessPort, TriggerCreateHook, VisibleCapabilityAccess, VisibleCapabilityRequest,
-    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers,
-    builtin_first_party_handlers_with_trigger_create_hook, builtin_first_party_package,
+    READ_FILE_CAPABILITY_ID, RuntimeCapabilityFailure, RuntimeCapabilityOutcome,
+    RuntimeCapabilityRequest, RuntimeFailureKind, RuntimeProcessError, RuntimeProcessPort,
+    SHELL_CAPABILITY_ID, SKILL_INSTALL_CAPABILITY_ID, SKILL_LIST_CAPABILITY_ID,
+    SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID, SandboxCommandTransport, SurfaceKind,
+    TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID,
+    TRIGGER_REMOVE_CAPABILITY_ID, TenantSandboxProcessPort, TriggerCreateHook,
+    VisibleCapabilityAccess, VisibleCapabilityRequest, WRITE_FILE_CAPABILITY_ID,
+    builtin_first_party_handlers, builtin_first_party_handlers_with_trigger_create_hook,
+    builtin_first_party_package,
 };
 #[cfg(feature = "test-support")]
 use ironclaw_host_runtime::{
@@ -392,7 +393,7 @@ async fn builtin_trigger_create_maps_create_hook_error_to_backend_and_rolls_back
 }
 
 #[tokio::test]
-async fn builtin_trigger_create_preserves_hook_error_when_rollback_fails() {
+async fn builtin_trigger_create_surfaces_rollback_error_when_cleanup_fails() {
     let repository = Arc::new(RemoveFailingTriggerRepository::default());
     let runtime = runtime_with_trigger_repository_and_create_hook(
         repository.clone(),
@@ -400,20 +401,23 @@ async fn builtin_trigger_create_preserves_hook_error_when_rollback_fails() {
     );
     let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
 
-    let error = invoke_with_context(
+    let failure = invoke_failure_with_context(
         &runtime,
         TRIGGER_CREATE_CAPABILITY_ID,
         json!({
             "name": "Rollback failure",
-            "prompt": "Keep the hook failure as the user-visible cause",
+            "prompt": "Surface the rollback failure as the user-visible cause",
             "cron": "0 8 * * *"
         }),
         context.clone(),
     )
-    .await
-    .unwrap_err();
+    .await;
 
-    assert_eq!(error, RuntimeFailureKind::Backend);
+    assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+    assert_eq!(
+        failure.safe_summary().as_deref(),
+        Some("trigger create rollback failed after hook error")
+    );
     assert_eq!(repository.remove_attempts(), 1);
     assert_eq!(
         repository
@@ -5237,6 +5241,28 @@ async fn invoke_with_context<R: HostRuntime + ?Sized>(
     match outcome {
         RuntimeCapabilityOutcome::Completed(completed) => Ok(completed.output),
         RuntimeCapabilityOutcome::Failed(failure) => Err(failure.kind),
+        other => panic!("unexpected capability outcome: {other:?}"),
+    }
+}
+
+async fn invoke_failure_with_context<R: HostRuntime + ?Sized>(
+    runtime: &R,
+    capability: &str,
+    input: Value,
+    context: ExecutionContext,
+) -> RuntimeCapabilityFailure {
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            capability_id(capability),
+            ResourceEstimate::default(),
+            input,
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => failure,
         other => panic!("unexpected capability outcome: {other:?}"),
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -17,6 +17,8 @@ use ironclaw_conversations::InMemoryConversationServices;
 use ironclaw_conversations::{
     AdapterInstallationId, AdapterKind, ConversationActorPairingService, ExternalActorRef,
 };
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_conversations::{InboundTurnError, RebornFilesystemConversationServices};
 #[cfg(feature = "libsql")]
 use ironclaw_events::{DurableAuditLog, DurableEventLog};
 #[cfg(not(feature = "libsql"))]
@@ -123,6 +125,12 @@ use crate::{
 };
 
 pub(crate) type LocalDevRootFilesystem = CompositeRootFilesystem;
+
+struct LocalDevRootFilesystemBundle {
+    filesystem: Arc<LocalDevRootFilesystem>,
+    #[cfg(feature = "libsql")]
+    database: Arc<libsql::Database>,
+}
 
 type LocalDevWorkspaceFilesystems = (
     Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
@@ -330,6 +338,8 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) trigger_repository: Arc<dyn TriggerRepository>,
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     pub(crate) trigger_conversation_services: InMemoryConversationServices,
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    trigger_conversation_services: tokio::sync::OnceCell<RebornFilesystemConversationServices>,
     pub(crate) checkpoint_state_store: Arc<dyn CheckpointStateStore>,
     pub(crate) loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
     pub(crate) thread_service: Arc<dyn SessionThreadService>,
@@ -389,6 +399,21 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) audit_log: Arc<dyn DurableAuditLog>,
 }
 
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+impl RebornLocalRuntimeServices {
+    pub(crate) async fn durable_trigger_conversation_services(
+        &self,
+    ) -> Result<RebornFilesystemConversationServices, InboundTurnError> {
+        let filesystem = Arc::clone(&self.subagent_goal_filesystem);
+        self.trigger_conversation_services
+            .get_or_try_init(|| async move {
+                RebornFilesystemConversationServices::new(filesystem).await
+            })
+            .await
+            .cloned()
+    }
+}
+
 struct RebornLocalDevStoreGraph {
     run_state: Arc<LocalDevRunStateStore>,
     approval_requests: Arc<LocalDevApprovalRequestStore>,
@@ -397,6 +422,17 @@ struct RebornLocalDevStoreGraph {
     local_runtime: Arc<RebornLocalRuntimeServices>,
     resource_governor: Arc<LocalDevResourceGovernor>,
     process_services: LocalDevProcessServices,
+    trigger_repository: Arc<dyn TriggerRepository>,
+}
+
+struct RebornLocalDevStoreGraphInput {
+    filesystem: Arc<LocalDevRootFilesystem>,
+    owner_user_id: UserId,
+    skill_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    workspace_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
+    workspace_mounts: MountView,
+    local_dev_storage_root: PathBuf,
+    default_system_prompt_path: PathBuf,
     trigger_repository: Arc<dyn TriggerRepository>,
 }
 
@@ -554,8 +590,14 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         }
     })?;
     crate::bundled_skills::ensure_bundled_reborn_skills_installed(&root).await?;
-    let filesystem =
+    let filesystem_bundle =
         build_local_dev_root_filesystem(&root, &workspace_root, host_home_root.as_ref()).await?;
+    let filesystem = filesystem_bundle.filesystem;
+    #[cfg(feature = "libsql")]
+    let trigger_repository =
+        local_dev_trigger_repository(Arc::clone(&filesystem_bundle.database)).await?;
+    #[cfg(not(feature = "libsql"))]
+    let trigger_repository = local_dev_trigger_repository();
     let (skill_filesystem, workspace_filesystem, runtime_workspace_mounts) =
         build_workspace_filesystems(
             Arc::clone(&filesystem),
@@ -569,15 +611,16 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     let owner_user_id = UserId::new(owner_id).map_err(|error| RebornBuildError::InvalidConfig {
         reason: error.to_string(),
     })?;
-    let mut store_graph = build_local_dev_store_graph(
-        Arc::clone(&filesystem),
+    let mut store_graph = build_local_dev_store_graph(RebornLocalDevStoreGraphInput {
+        filesystem: Arc::clone(&filesystem),
         owner_user_id,
         skill_filesystem,
         workspace_filesystem,
-        runtime_workspace_mounts,
-        root.clone(),
+        workspace_mounts: runtime_workspace_mounts,
+        local_dev_storage_root: root.clone(),
         default_system_prompt_path,
-    )?;
+        trigger_repository,
+    })?;
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> = Arc::new(
         DefaultTurnCoordinator::new(Arc::clone(&store_graph.turn_state)),
@@ -591,12 +634,6 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     let secret_store: Arc<dyn SecretStore> = local_dev_secret_store.clone();
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     let secret_store: Arc<dyn SecretStore> = Arc::new(ironclaw_secrets::InMemorySecretStore::new());
-    let trigger_create_hook = local_dev_trigger_create_hook(&store_graph.local_runtime);
-    let mut first_party_registry = builtin_first_party_registry_with_trigger_create_hook(
-        Arc::clone(&store_graph.trigger_repository),
-        trigger_create_hook,
-    )?;
-
     let local_dev_trust_policy = Arc::new(local_dev_first_party_trust_policy()?);
     let local_dev_trust_invalidation_bus = Arc::new(ironclaw_trust::InvalidationBus::new());
     let mut services = HostRuntimeServices::new(
@@ -696,22 +733,6 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
             product_auth.runtime_credential_account_selection_service(),
         ),
     ));
-    register_bundled_gsuite_first_party_handlers(
-        &mut first_party_registry,
-        product_auth.credential_account_service(),
-        product_auth.credential_account_record_source(),
-        Arc::new(ProductAuthRuntimeGsuiteCredentialStager::new(
-            product_auth_runtime_ports.clone(),
-        )),
-    )
-    .map_err(|error| RebornBuildError::InvalidConfig {
-        reason: format!("GSuite first-party handlers are invalid: {error}"),
-    })?;
-    register_bundled_web_access_first_party_handlers(&mut first_party_registry).map_err(
-        |error| RebornBuildError::InvalidConfig {
-            reason: format!("web access first-party handlers are invalid: {error}"),
-        },
-    )?;
     let mut available_extensions = AvailableExtensionCatalog::from_filesystem_root(
         filesystem.as_ref(),
         &VirtualPath::new("/system/extensions")?,
@@ -762,22 +783,41 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         extension_lifecycle_service,
         active_extensions,
     ));
-    insert_extension_lifecycle_handlers(
-        &mut first_party_registry,
-        Arc::clone(&extension_management),
-    )
-    .map_err(|error| RebornBuildError::InvalidConfig {
-        reason: format!("local-dev extension lifecycle handlers are invalid: {error}"),
-    })?;
-    services = services.with_first_party_capabilities(Arc::new(first_party_registry));
     if let Some(local_runtime) = Arc::get_mut(&mut store_graph.local_runtime) {
-        local_runtime.extension_management = Some(extension_management);
+        local_runtime.extension_management = Some(Arc::clone(&extension_management));
         local_runtime.runtime_http_egress = Some(product_auth_runtime_ports.runtime_http_egress());
     } else {
         return Err(RebornBuildError::InvalidConfig {
             reason: "local-dev extension lifecycle facade could not be attached".to_string(),
         });
     }
+    let trigger_create_hook = local_dev_trigger_create_hook(&store_graph.local_runtime);
+    let mut first_party_registry = builtin_first_party_registry_with_trigger_create_hook(
+        Arc::clone(&store_graph.trigger_repository),
+        trigger_create_hook,
+    )?;
+    register_bundled_gsuite_first_party_handlers(
+        &mut first_party_registry,
+        product_auth.credential_account_service(),
+        product_auth.credential_account_record_source(),
+        Arc::new(ProductAuthRuntimeGsuiteCredentialStager::new(
+            product_auth_runtime_ports.clone(),
+        )),
+    )
+    .map_err(|error| RebornBuildError::InvalidConfig {
+        reason: format!("GSuite first-party handlers are invalid: {error}"),
+    })?;
+    register_bundled_web_access_first_party_handlers(&mut first_party_registry).map_err(
+        |error| RebornBuildError::InvalidConfig {
+            reason: format!("web access first-party handlers are invalid: {error}"),
+        },
+    )?;
+    insert_extension_lifecycle_handlers(&mut first_party_registry, extension_management).map_err(
+        |error| RebornBuildError::InvalidConfig {
+            reason: format!("local-dev extension lifecycle handlers are invalid: {error}"),
+        },
+    )?;
+    services = services.with_first_party_capabilities(Arc::new(first_party_registry));
 
     let host_runtime: Arc<dyn ironclaw_host_runtime::HostRuntime> =
         Arc::new(services.host_runtime_for_local_testing());
@@ -797,14 +837,18 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
 
 #[cfg(feature = "libsql")]
 fn build_local_dev_store_graph(
-    filesystem: Arc<LocalDevRootFilesystem>,
-    owner_user_id: UserId,
-    skill_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
-    workspace_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
-    workspace_mounts: MountView,
-    local_dev_storage_root: PathBuf,
-    default_system_prompt_path: PathBuf,
+    input: RebornLocalDevStoreGraphInput,
 ) -> Result<RebornLocalDevStoreGraph, RebornBuildError> {
+    let RebornLocalDevStoreGraphInput {
+        filesystem,
+        owner_user_id,
+        skill_filesystem,
+        workspace_filesystem,
+        workspace_mounts,
+        local_dev_storage_root,
+        default_system_prompt_path,
+        trigger_repository,
+    } = input;
     let scoped_filesystem = local_dev_scoped_filesystem(Arc::clone(&filesystem));
     let event_log = local_dev_event_log(Arc::clone(&filesystem))?;
     let audit_log = local_dev_audit_log(Arc::clone(&filesystem))?;
@@ -848,7 +892,6 @@ fn build_local_dev_store_graph(
             }
         })?;
     let skill_management = build_local_skill_management_port(owner_user_id, filesystem)?;
-    let trigger_repository = local_dev_trigger_repository();
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
@@ -856,6 +899,8 @@ fn build_local_dev_store_graph(
         trigger_repository: Arc::clone(&trigger_repository),
         #[cfg(not(any(feature = "libsql", feature = "postgres")))]
         trigger_conversation_services,
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        trigger_conversation_services: tokio::sync::OnceCell::new(),
         checkpoint_state_store,
         loop_checkpoint_store,
         thread_service,
@@ -897,14 +942,18 @@ fn build_local_dev_store_graph(
 
 #[cfg(not(feature = "libsql"))]
 fn build_local_dev_store_graph(
-    filesystem: Arc<LocalDevRootFilesystem>,
-    owner_user_id: UserId,
-    skill_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
-    workspace_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
-    workspace_mounts: MountView,
-    local_dev_storage_root: PathBuf,
-    default_system_prompt_path: PathBuf,
+    input: RebornLocalDevStoreGraphInput,
 ) -> Result<RebornLocalDevStoreGraph, RebornBuildError> {
+    let RebornLocalDevStoreGraphInput {
+        filesystem,
+        owner_user_id,
+        skill_filesystem,
+        workspace_filesystem,
+        workspace_mounts,
+        local_dev_storage_root,
+        default_system_prompt_path,
+        trigger_repository,
+    } = input;
     #[cfg(feature = "postgres")]
     let subagent_goal_filesystem = local_dev_scoped_filesystem(Arc::clone(&filesystem));
     let event_log = local_dev_event_log(Arc::clone(&filesystem))?;
@@ -938,7 +987,6 @@ fn build_local_dev_store_graph(
             }
         })?;
     let skill_management = build_local_skill_management_port(owner_user_id, filesystem)?;
-    let trigger_repository = local_dev_trigger_repository();
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     let trigger_conversation_services = local_dev_trigger_conversation_services();
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
@@ -948,6 +996,8 @@ fn build_local_dev_store_graph(
         trigger_repository: Arc::clone(&trigger_repository),
         #[cfg(not(any(feature = "libsql", feature = "postgres")))]
         trigger_conversation_services,
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        trigger_conversation_services: tokio::sync::OnceCell::new(),
         checkpoint_state_store,
         loop_checkpoint_store,
         thread_service,
@@ -988,6 +1038,21 @@ fn build_local_dev_store_graph(
     })
 }
 
+#[cfg(feature = "libsql")]
+async fn local_dev_trigger_repository(
+    database: Arc<libsql::Database>,
+) -> Result<Arc<dyn TriggerRepository>, RebornBuildError> {
+    let repository = ironclaw_triggers::LibSqlTriggerRepository::new(database);
+    repository
+        .run_migrations()
+        .await
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("local-dev trigger repository migrations failed: {error}"),
+        })?;
+    Ok(Arc::new(repository))
+}
+
+#[cfg(not(feature = "libsql"))]
 fn local_dev_trigger_repository() -> Arc<dyn TriggerRepository> {
     Arc::new(ironclaw_triggers::InMemoryTriggerRepository::default())
 }
@@ -998,13 +1063,13 @@ fn local_dev_trigger_conversation_services() -> InMemoryConversationServices {
 }
 
 fn local_dev_trigger_create_hook(
-    local_runtime: &RebornLocalRuntimeServices,
+    local_runtime: &Arc<RebornLocalRuntimeServices>,
 ) -> Arc<dyn TriggerCreateHook> {
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     {
-        Arc::new(FilesystemTriggerCreatorPairingHook::new(Arc::clone(
-            &local_runtime.subagent_goal_filesystem,
-        )))
+        Arc::new(LocalRuntimeTriggerCreatorPairingHook {
+            runtime: Arc::clone(local_runtime),
+        })
     }
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     {
@@ -1028,17 +1093,34 @@ impl TriggerCreateHook for InMemoryTriggerCreatorPairingHook {
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-struct FilesystemTriggerCreatorPairingHook<F>
+struct LocalRuntimeTriggerCreatorPairingHook {
+    runtime: Arc<RebornLocalRuntimeServices>,
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[async_trait::async_trait]
+impl TriggerCreateHook for LocalRuntimeTriggerCreatorPairingHook {
+    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+        let conversations = self
+            .runtime
+            .durable_trigger_conversation_services()
+            .await
+            .map_err(trigger_pairing_error)?;
+        pair_trigger_creator(&conversations, record).await
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+struct ScopedFilesystemTriggerCreatorPairingHook<F>
 where
     F: RootFilesystem + 'static,
 {
     filesystem: Arc<ScopedFilesystem<F>>,
-    conversations:
-        tokio::sync::OnceCell<ironclaw_conversations::RebornFilesystemConversationServices>,
+    conversations: tokio::sync::OnceCell<RebornFilesystemConversationServices>,
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-impl<F> FilesystemTriggerCreatorPairingHook<F>
+impl<F> ScopedFilesystemTriggerCreatorPairingHook<F>
 where
     F: RootFilesystem + 'static,
 {
@@ -1052,7 +1134,7 @@ where
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 #[async_trait::async_trait]
-impl<F> TriggerCreateHook for FilesystemTriggerCreatorPairingHook<F>
+impl<F> TriggerCreateHook for ScopedFilesystemTriggerCreatorPairingHook<F>
 where
     F: RootFilesystem + 'static,
 {
@@ -1061,12 +1143,13 @@ where
         let conversations = self
             .conversations
             .get_or_try_init(|| async move {
-                ironclaw_conversations::RebornFilesystemConversationServices::new(filesystem)
+                RebornFilesystemConversationServices::new(filesystem)
                     .await
                     .map_err(trigger_pairing_error)
             })
-            .await?;
-        pair_trigger_creator(conversations, record).await
+            .await
+            .cloned()?;
+        pair_trigger_creator(&conversations, record).await
     }
 }
 
@@ -1136,7 +1219,7 @@ async fn build_local_dev_root_filesystem(
     root: &Path,
     workspace_root: &Path,
     host_home_root: Option<&LocalDevHostHomeRoot>,
-) -> Result<Arc<LocalDevRootFilesystem>, RebornBuildError> {
+) -> Result<LocalDevRootFilesystemBundle, RebornBuildError> {
     let db_path = root.join("reborn-local-dev.db");
     let db = Arc::new(
         libsql::Builder::new_local(&db_path)
@@ -1146,7 +1229,7 @@ async fn build_local_dev_root_filesystem(
                 reason: format!("local-dev libSQL database could not be opened: {error}"),
             })?,
     );
-    let database = Arc::new(LibSqlRootFilesystem::new(db));
+    let database = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&db)));
     database.run_migrations().await?;
 
     let local = Arc::new(local_dev_project_filesystem(
@@ -1181,7 +1264,10 @@ async fn build_local_dev_root_filesystem(
         database,
     )?;
     mount_local_dev_project_roots(&mut root, local)?;
-    Ok(Arc::new(root))
+    Ok(LocalDevRootFilesystemBundle {
+        filesystem: Arc::new(root),
+        database: db,
+    })
 }
 
 #[cfg(not(feature = "libsql"))]
@@ -1189,7 +1275,7 @@ async fn build_local_dev_root_filesystem(
     root: &Path,
     workspace_root: &Path,
     host_home_root: Option<&LocalDevHostHomeRoot>,
-) -> Result<Arc<LocalDevRootFilesystem>, RebornBuildError> {
+) -> Result<LocalDevRootFilesystemBundle, RebornBuildError> {
     let local = Arc::new(local_dev_project_filesystem(
         root,
         workspace_root,
@@ -1201,7 +1287,9 @@ async fn build_local_dev_root_filesystem(
     let mut composite = CompositeRootFilesystem::new();
     mount_local_dev_memory_root(&mut composite, Arc::new(InMemoryBackend::new()))?;
     mount_local_dev_project_roots(&mut composite, local)?;
-    Ok(Arc::new(composite))
+    Ok(LocalDevRootFilesystemBundle {
+        filesystem: Arc::new(composite),
+    })
 }
 
 fn local_dev_project_filesystem(
@@ -2218,7 +2306,7 @@ where
         oauth_dcr_provider_configs,
     } = context;
     let secret_store: Arc<dyn SecretStore> = stores.secret_credentials.secret_store.clone();
-    let trigger_create_hook = Arc::new(FilesystemTriggerCreatorPairingHook::new(Arc::clone(
+    let trigger_create_hook = Arc::new(ScopedFilesystemTriggerCreatorPairingHook::new(Arc::clone(
         &stores.scoped_filesystem,
     )));
     let mut first_party_registry = builtin_first_party_registry_with_trigger_create_hook(
@@ -2716,7 +2804,7 @@ mod tests {
         .expect("local-dev filesystem rebuild");
         let rebuilt_secret_store = build_local_dev_secret_store(
             &local_dev_root,
-            local_dev_scoped_filesystem(rebuilt_filesystem),
+            local_dev_scoped_filesystem(rebuilt_filesystem.filesystem),
         )
         .expect("local-dev secret store rebuild");
         let lease = rebuilt_secret_store

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1107,7 +1107,9 @@ impl TriggerCreateHook for LocalRuntimeTriggerCreatorPairingHook {
             .runtime
             .durable_trigger_conversation_services()
             .await
-            .map_err(trigger_pairing_error)?;
+            .map_err(|error| {
+                trigger_pairing_error(TriggerPairingFailureSource::ConversationInit, error)
+            })?;
         pair_trigger_creator(&conversations, record).await
     }
 }
@@ -1147,7 +1149,9 @@ where
             .get_or_try_init(|| async move {
                 RebornFilesystemConversationServices::new(filesystem)
                     .await
-                    .map_err(trigger_pairing_error)
+                    .map_err(|error| {
+                        trigger_pairing_error(TriggerPairingFailureSource::ConversationInit, error)
+                    })
             })
             .await
             .cloned()?;
@@ -1159,16 +1163,18 @@ async fn pair_trigger_creator(
     pairing: &dyn ConversationActorPairingService,
     record: &TriggerRecord,
 ) -> Result<(), TriggerError> {
-    let adapter_kind =
-        AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).map_err(trigger_pairing_error)?;
+    let adapter_kind = AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).map_err(|error| {
+        trigger_pairing_error(TriggerPairingFailureSource::TypedIdentity, error)
+    })?;
     let adapter_installation_id =
-        AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
-            .map_err(trigger_pairing_error)?;
+        AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID).map_err(|error| {
+            trigger_pairing_error(TriggerPairingFailureSource::TypedIdentity, error)
+        })?;
     let external_actor_ref = ExternalActorRef::new(
         TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
         record.creator_user_id.as_str(),
     )
-    .map_err(trigger_pairing_error)?;
+    .map_err(|error| trigger_pairing_error(TriggerPairingFailureSource::TypedIdentity, error))?;
     pairing
         .pair_external_actor(
             record.tenant_id.clone(),
@@ -1178,12 +1184,34 @@ async fn pair_trigger_creator(
             record.creator_user_id.clone(),
         )
         .await
-        .map_err(trigger_pairing_error)
+        .map_err(|error| trigger_pairing_error(TriggerPairingFailureSource::ActorPairing, error))
 }
 
-fn trigger_pairing_error(_error: impl std::fmt::Display) -> TriggerError {
+enum TriggerPairingFailureSource {
+    TypedIdentity,
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    ConversationInit,
+    ActorPairing,
+}
+
+impl TriggerPairingFailureSource {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::TypedIdentity => "typed_identity",
+            #[cfg(any(feature = "libsql", feature = "postgres"))]
+            Self::ConversationInit => "conversation_init",
+            Self::ActorPairing => "actor_pairing",
+        }
+    }
+}
+
+fn trigger_pairing_error(
+    source: TriggerPairingFailureSource,
+    _error: impl std::fmt::Display,
+) -> TriggerError {
     tracing::debug!(
         error_kind = "pairing_failure",
+        error_source = source.as_str(),
         "trigger creator actor pairing failed"
     );
     TriggerError::Backend {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1089,7 +1089,7 @@ struct InMemoryTriggerCreatorPairingHook {
 #[cfg(not(any(feature = "libsql", feature = "postgres")))]
 #[async_trait::async_trait]
 impl TriggerCreateHook for InMemoryTriggerCreatorPairingHook {
-    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+    async fn after_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
         pair_trigger_creator(&self.conversations, record).await
     }
 }
@@ -1102,7 +1102,7 @@ struct LocalRuntimeTriggerCreatorPairingHook {
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 #[async_trait::async_trait]
 impl TriggerCreateHook for LocalRuntimeTriggerCreatorPairingHook {
-    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+    async fn after_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
         let conversations = self
             .runtime
             .durable_trigger_conversation_services()
@@ -1140,7 +1140,7 @@ impl<F> TriggerCreateHook for ScopedFilesystemTriggerCreatorPairingHook<F>
 where
     F: RootFilesystem + 'static,
 {
-    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+    async fn after_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
         let filesystem = Arc::clone(&self.filesystem);
         let conversations = self
             .conversations
@@ -2623,8 +2623,7 @@ mod tests {
     }
 
     #[cfg(any(feature = "libsql", feature = "postgres"))]
-    #[tokio::test]
-    async fn durable_trigger_conversation_services_propagates_init_error() {
+    async fn local_runtime_with_failing_trigger_conversations() -> Arc<RebornLocalRuntimeServices> {
         let local_dev_root = tempfile::tempdir().expect("tempdir");
         let owner_user_id = "pairing-owner";
         let services = build_reborn_services(RebornBuildInput::local_dev(
@@ -2692,6 +2691,13 @@ mod tests {
             event_log: Arc::clone(&base_runtime.event_log),
             audit_log: Arc::clone(&base_runtime.audit_log),
         });
+        runtime
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[tokio::test]
+    async fn durable_trigger_conversation_services_propagates_init_error() {
+        let runtime = local_runtime_with_failing_trigger_conversations().await;
 
         let error = match runtime.durable_trigger_conversation_services().await {
             Ok(_) => panic!("conversation service init should fail"),
@@ -2702,6 +2708,25 @@ mod tests {
             error,
             ironclaw_conversations::InboundTurnError::DurableState { .. }
         ));
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[tokio::test]
+    async fn local_runtime_trigger_create_hook_maps_conversation_init_error_to_backend() {
+        let hook = LocalRuntimeTriggerCreatorPairingHook {
+            runtime: local_runtime_with_failing_trigger_conversations().await,
+        };
+        let record = trigger_record_for_pairing_test();
+
+        let error = hook
+            .after_trigger_persisted(&record)
+            .await
+            .expect_err("conversation init failure should surface as trigger backend error");
+
+        let TriggerError::Backend { reason } = error else {
+            panic!("expected backend trigger error");
+        };
+        assert_eq!(reason, "trigger creator actor pairing failed");
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -70,7 +70,10 @@ use ironclaw_threads::FilesystemSessionThreadService;
 #[cfg(not(feature = "libsql"))]
 use ironclaw_threads::InMemorySessionThreadService;
 use ironclaw_threads::SessionThreadService;
-use ironclaw_triggers::{TriggerError, TriggerRecord, TriggerRepository};
+use ironclaw_triggers::{
+    TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
+    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerError, TriggerRecord, TriggerRepository,
+};
 use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 #[cfg(feature = "libsql")]
 use ironclaw_turns::FilesystemTurnStateStore;
@@ -846,8 +849,6 @@ fn build_local_dev_store_graph(
         })?;
     let skill_management = build_local_skill_management_port(owner_user_id, filesystem)?;
     let trigger_repository = local_dev_trigger_repository();
-    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-    let trigger_conversation_services = InMemoryConversationServices::default();
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
@@ -939,7 +940,7 @@ fn build_local_dev_store_graph(
     let skill_management = build_local_skill_management_port(owner_user_id, filesystem)?;
     let trigger_repository = local_dev_trigger_repository();
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
-    let trigger_conversation_services = InMemoryConversationServices::default();
+    let trigger_conversation_services = local_dev_trigger_conversation_services();
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
@@ -989,6 +990,11 @@ fn build_local_dev_store_graph(
 
 fn local_dev_trigger_repository() -> Arc<dyn TriggerRepository> {
     Arc::new(ironclaw_triggers::InMemoryTriggerRepository::default())
+}
+
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
+fn local_dev_trigger_conversation_services() -> InMemoryConversationServices {
+    InMemoryConversationServices::default()
 }
 
 fn local_dev_trigger_create_hook(
@@ -1051,14 +1057,13 @@ where
     F: RootFilesystem + 'static,
 {
     async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+        let filesystem = Arc::clone(&self.filesystem);
         let conversations = self
             .conversations
-            .get_or_try_init(|| async {
-                ironclaw_conversations::RebornFilesystemConversationServices::new(Arc::clone(
-                    &self.filesystem,
-                ))
-                .await
-                .map_err(trigger_pairing_error)
+            .get_or_try_init(|| async move {
+                ironclaw_conversations::RebornFilesystemConversationServices::new(filesystem)
+                    .await
+                    .map_err(trigger_pairing_error)
             })
             .await?;
         pair_trigger_creator(conversations, record).await
@@ -1069,11 +1074,16 @@ async fn pair_trigger_creator(
     pairing: &dyn ConversationActorPairingService,
     record: &TriggerRecord,
 ) -> Result<(), TriggerError> {
-    let adapter_kind = AdapterKind::new("trigger").map_err(trigger_pairing_error)?;
+    let adapter_kind =
+        AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).map_err(trigger_pairing_error)?;
     let adapter_installation_id =
-        AdapterInstallationId::new("reborn-trigger-poller").map_err(trigger_pairing_error)?;
-    let external_actor_ref = ExternalActorRef::new("user", record.creator_user_id.as_str())
-        .map_err(trigger_pairing_error)?;
+        AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+            .map_err(trigger_pairing_error)?;
+    let external_actor_ref = ExternalActorRef::new(
+        TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
+        record.creator_user_id.as_str(),
+    )
+    .map_err(trigger_pairing_error)?;
     pairing
         .pair_external_actor(
             record.tenant_id.clone(),
@@ -1087,8 +1097,9 @@ async fn pair_trigger_creator(
 }
 
 fn trigger_pairing_error(error: impl std::fmt::Display) -> TriggerError {
+    tracing::debug!(%error, "trigger creator actor pairing failed");
     TriggerError::Backend {
-        reason: format!("trigger creator actor pairing failed: {error}"),
+        reason: "trigger creator actor pairing failed".to_string(),
     }
 }
 
@@ -2414,7 +2425,7 @@ mod tests {
         ExecutionContext, ExtensionId, GrantConstraints, InvocationId, MountAlias, MountGrant,
         NetworkPolicy, NetworkScheme, NetworkTargetPattern, Principal, ResourceEstimate,
         ResourceScope, RuntimeCredentialAccountProviderId, RuntimeCredentialRequirementSource,
-        RuntimeKind, ScopedPath, SecretHandle, TrustClass, UserId, VirtualPath,
+        RuntimeKind, ScopedPath, SecretHandle, TenantId, TrustClass, UserId, VirtualPath,
     };
     use ironclaw_host_runtime::{
         MEMORY_SEARCH_CAPABILITY_ID, MEMORY_TREE_CAPABILITY_ID, MEMORY_WRITE_CAPABILITY_ID,
@@ -2430,6 +2441,62 @@ mod tests {
     use crate::{
         extension_lifecycle::ExtensionActivationMode, runtime::SKILL_ACTIVATE_CAPABILITY_ID,
     };
+
+    struct FailingConversationActorPairingService;
+
+    #[async_trait::async_trait]
+    impl ConversationActorPairingService for FailingConversationActorPairingService {
+        async fn pair_external_actor(
+            &self,
+            _tenant_id: TenantId,
+            _adapter_kind: AdapterKind,
+            _adapter_installation_id: AdapterInstallationId,
+            _external_actor_ref: ExternalActorRef,
+            _user_id: UserId,
+        ) -> Result<(), ironclaw_conversations::InboundTurnError> {
+            Err(ironclaw_conversations::InboundTurnError::DurableState {
+                reason: "raw durable store error".to_string(),
+            })
+        }
+    }
+
+    fn trigger_record_for_pairing_test() -> TriggerRecord {
+        TriggerRecord {
+            trigger_id: ironclaw_triggers::TriggerId::new(),
+            tenant_id: TenantId::new("pairing-test-tenant").expect("tenant id"),
+            creator_user_id: UserId::new("pairing-test-user").expect("user id"),
+            agent_id: None,
+            project_id: None,
+            name: "pairing test".to_string(),
+            source: ironclaw_triggers::TriggerSourceKind::Schedule,
+            schedule: ironclaw_triggers::TriggerSchedule::cron("* * * * *")
+                .expect("valid cron expression"),
+            completion_policy: ironclaw_triggers::TriggerCompletionPolicy::Recurring,
+            prompt: "pairing test prompt".to_string(),
+            state: ironclaw_triggers::TriggerState::Scheduled,
+            next_run_at: chrono::Utc::now(),
+            last_run_at: None,
+            last_fired_slot: None,
+            last_status: None,
+            active_fire_slot: None,
+            active_run_ref: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn pair_trigger_creator_maps_pairing_failure_to_sanitized_backend_error() {
+        let record = trigger_record_for_pairing_test();
+
+        let error = pair_trigger_creator(&FailingConversationActorPairingService, &record)
+            .await
+            .expect_err("pairing failure should surface");
+
+        let TriggerError::Backend { reason } = error else {
+            panic!("expected backend trigger error");
+        };
+        assert_eq!(reason, "trigger creator actor pairing failed");
+    }
 
     #[tokio::test]
     async fn local_dev_services_include_repl_runtime_substrate() {

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -1,3 +1,4 @@
+// arch-exempt: large_file, needs Reborn composition helper extraction, plan #4469
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -1181,7 +1182,10 @@ async fn pair_trigger_creator(
 }
 
 fn trigger_pairing_error(_error: impl std::fmt::Display) -> TriggerError {
-    tracing::debug!("trigger creator actor pairing failed");
+    tracing::debug!(
+        error_kind = "pairing_failure",
+        "trigger creator actor pairing failed"
+    );
     TriggerError::Backend {
         reason: "trigger creator actor pairing failed".to_string(),
     }
@@ -2508,8 +2512,10 @@ mod tests {
         CredentialOwnership, GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_GMAIL_SEND_SCOPE,
         NewCredentialAccount, ProviderScope,
     };
+    use ironclaw_filesystem::FilesystemError;
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
     use ironclaw_filesystem::{
-        DirEntry, FileStat, FilesystemError, FilesystemOperation, RootFilesystem, VersionedEntry,
+        DirEntry, FileStat, FilesystemOperation, RootFilesystem, VersionedEntry,
     };
     use ironclaw_host_api::{
         CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
@@ -2619,17 +2625,75 @@ mod tests {
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     #[tokio::test]
     async fn durable_trigger_conversation_services_propagates_init_error() {
-        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(
-            Arc::new(FailingConversationStateFilesystem),
-            MountView::new(vec![MountGrant::new(
-                MountAlias::new("/conversations").expect("mount alias"),
-                VirtualPath::new("/conversations").expect("virtual path"),
-                MountPermissions::read_write_list_delete(),
-            )])
-            .expect("mount view"),
-        ));
+        let local_dev_root = tempfile::tempdir().expect("tempdir");
+        let owner_user_id = "pairing-owner";
+        let services = build_reborn_services(RebornBuildInput::local_dev(
+            owner_user_id,
+            local_dev_root.path().join("local-dev"),
+        ))
+        .await
+        .expect("local-dev services build");
 
-        let error = match RebornFilesystemConversationServices::new(filesystem).await {
+        let base_runtime = services.local_runtime.expect("local runtime");
+        let mut failing_root = CompositeRootFilesystem::new();
+        failing_root
+            .mount(
+                local_dev_mount_descriptor(
+                    "/conversations",
+                    "failing-conversation-state",
+                    BackendKind::Custom("test".to_string()),
+                    StorageClass::StructuredRecords,
+                    ContentKind::StructuredRecord,
+                    IndexPolicy::NotIndexed,
+                    BackendCapabilities::default(),
+                )
+                .expect("mount descriptor"),
+                Arc::new(FailingConversationStateFilesystem),
+            )
+            .expect("mount failing backend");
+        let runtime = Arc::new(RebornLocalRuntimeServices {
+            approval_requests: Arc::clone(&base_runtime.approval_requests),
+            capability_leases: Arc::clone(&base_runtime.capability_leases),
+            turn_state: Arc::clone(&base_runtime.turn_state),
+            trigger_repository: Arc::clone(&base_runtime.trigger_repository),
+            #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+            trigger_conversation_services: base_runtime.trigger_conversation_services.clone(),
+            #[cfg(any(feature = "libsql", feature = "postgres"))]
+            trigger_conversation_services: tokio::sync::OnceCell::new(),
+            checkpoint_state_store: Arc::clone(&base_runtime.checkpoint_state_store),
+            loop_checkpoint_store: Arc::clone(&base_runtime.loop_checkpoint_store),
+            thread_service: Arc::clone(&base_runtime.thread_service),
+            resource_governor: Arc::clone(&base_runtime.resource_governor),
+            budget_event_sink: Arc::clone(&base_runtime.budget_event_sink),
+            in_memory_budget_event_sink: Arc::clone(&base_runtime.in_memory_budget_event_sink),
+            broadcast_budget_event_sink: Arc::clone(&base_runtime.broadcast_budget_event_sink),
+            budget_gate_store: Arc::clone(&base_runtime.budget_gate_store),
+            skill_management: Arc::clone(&base_runtime.skill_management),
+            extension_management: base_runtime.extension_management.clone(),
+            runtime_http_egress: base_runtime.runtime_http_egress.clone(),
+            skill_mounts: base_runtime.skill_mounts.clone(),
+            memory_mounts: base_runtime.memory_mounts.clone(),
+            skill_filesystem: Arc::clone(&base_runtime.skill_filesystem),
+            workspace_filesystem: Arc::clone(&base_runtime.workspace_filesystem),
+            #[cfg(feature = "slack-v2-host-beta")]
+            host_state_filesystem: Arc::clone(&base_runtime.host_state_filesystem),
+            subagent_goal_filesystem: Arc::new(ScopedFilesystem::with_fixed_view(
+                Arc::new(failing_root),
+                MountView::new(vec![MountGrant::new(
+                    MountAlias::new("/conversations").expect("mount alias"),
+                    VirtualPath::new("/conversations").expect("virtual path"),
+                    MountPermissions::read_write_list_delete(),
+                )])
+                .expect("mount view"),
+            )),
+            workspace_mounts: base_runtime.workspace_mounts.clone(),
+            local_dev_storage_root: base_runtime.local_dev_storage_root.clone(),
+            default_system_prompt_path: base_runtime.default_system_prompt_path.clone(),
+            event_log: Arc::clone(&base_runtime.event_log),
+            audit_log: Arc::clone(&base_runtime.audit_log),
+        });
+
+        let error = match runtime.durable_trigger_conversation_services().await {
             Ok(_) => panic!("conversation service init should fail"),
             Err(error) => error,
         };

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2678,7 +2678,7 @@ mod tests {
                 Arc::new(FailingConversationStateFilesystem),
             )
             .expect("mount failing backend");
-        let runtime = Arc::new(RebornLocalRuntimeServices {
+        Arc::new(RebornLocalRuntimeServices {
             approval_requests: Arc::clone(&base_runtime.approval_requests),
             capability_leases: Arc::clone(&base_runtime.capability_leases),
             turn_state: Arc::clone(&base_runtime.turn_state),
@@ -2718,8 +2718,7 @@ mod tests {
             default_system_prompt_path: base_runtime.default_system_prompt_path.clone(),
             event_log: Arc::clone(&base_runtime.event_log),
             audit_log: Arc::clone(&base_runtime.audit_log),
-        });
-        runtime
+        })
     }
 
     #[cfg(any(feature = "libsql", feature = "postgres"))]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -12,6 +12,11 @@ use ironclaw_authorization::FilesystemCapabilityLeaseStore;
 use ironclaw_authorization::GrantAuthorizer;
 #[cfg(not(feature = "libsql"))]
 use ironclaw_authorization::InMemoryCapabilityLeaseStore;
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
+use ironclaw_conversations::InMemoryConversationServices;
+use ironclaw_conversations::{
+    AdapterInstallationId, AdapterKind, ConversationActorPairingService, ExternalActorRef,
+};
 #[cfg(feature = "libsql")]
 use ironclaw_events::{DurableAuditLog, DurableEventLog};
 #[cfg(not(feature = "libsql"))]
@@ -41,8 +46,8 @@ use ironclaw_host_api::{
 use ironclaw_host_api::{MountAlias, MountGrant};
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, FirstPartyCapabilityRegistry, HostRuntimeServices,
-    LocalHostProcessPort, ProductAuthProviderRuntimePorts, builtin_first_party_handlers,
-    builtin_first_party_package,
+    LocalHostProcessPort, ProductAuthProviderRuntimePorts, TriggerCreateHook,
+    builtin_first_party_handlers_with_trigger_create_hook, builtin_first_party_package,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_loop_support::FilesystemCheckpointStateStore;
@@ -65,7 +70,7 @@ use ironclaw_threads::FilesystemSessionThreadService;
 #[cfg(not(feature = "libsql"))]
 use ironclaw_threads::InMemorySessionThreadService;
 use ironclaw_threads::SessionThreadService;
-use ironclaw_triggers::TriggerRepository;
+use ironclaw_triggers::{TriggerError, TriggerRecord, TriggerRepository};
 use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 #[cfg(feature = "libsql")]
 use ironclaw_turns::FilesystemTurnStateStore;
@@ -320,6 +325,8 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) capability_leases: Arc<LocalDevCapabilityLeaseStore>,
     pub(crate) turn_state: Arc<LocalDevTurnStateStore>,
     pub(crate) trigger_repository: Arc<dyn TriggerRepository>,
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    pub(crate) trigger_conversation_services: InMemoryConversationServices,
     pub(crate) checkpoint_state_store: Arc<dyn CheckpointStateStore>,
     pub(crate) loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
     pub(crate) thread_service: Arc<dyn SessionThreadService>,
@@ -581,8 +588,11 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     let secret_store: Arc<dyn SecretStore> = local_dev_secret_store.clone();
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     let secret_store: Arc<dyn SecretStore> = Arc::new(ironclaw_secrets::InMemorySecretStore::new());
-    let mut first_party_registry =
-        builtin_first_party_registry(Arc::clone(&store_graph.trigger_repository))?;
+    let trigger_create_hook = local_dev_trigger_create_hook(&store_graph.local_runtime);
+    let mut first_party_registry = builtin_first_party_registry_with_trigger_create_hook(
+        Arc::clone(&store_graph.trigger_repository),
+        trigger_create_hook,
+    )?;
 
     let local_dev_trust_policy = Arc::new(local_dev_first_party_trust_policy()?);
     let local_dev_trust_invalidation_bus = Arc::new(ironclaw_trust::InvalidationBus::new());
@@ -836,11 +846,15 @@ fn build_local_dev_store_graph(
         })?;
     let skill_management = build_local_skill_management_port(owner_user_id, filesystem)?;
     let trigger_repository = local_dev_trigger_repository();
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    let trigger_conversation_services = InMemoryConversationServices::default();
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
         turn_state: Arc::clone(&turn_state),
         trigger_repository: Arc::clone(&trigger_repository),
+        #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+        trigger_conversation_services,
         checkpoint_state_store,
         loop_checkpoint_store,
         thread_service,
@@ -924,11 +938,15 @@ fn build_local_dev_store_graph(
         })?;
     let skill_management = build_local_skill_management_port(owner_user_id, filesystem)?;
     let trigger_repository = local_dev_trigger_repository();
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    let trigger_conversation_services = InMemoryConversationServices::default();
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
         turn_state: Arc::clone(&turn_state),
         trigger_repository: Arc::clone(&trigger_repository),
+        #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+        trigger_conversation_services,
         checkpoint_state_store,
         loop_checkpoint_store,
         thread_service,
@@ -971,6 +989,107 @@ fn build_local_dev_store_graph(
 
 fn local_dev_trigger_repository() -> Arc<dyn TriggerRepository> {
     Arc::new(ironclaw_triggers::InMemoryTriggerRepository::default())
+}
+
+fn local_dev_trigger_create_hook(
+    local_runtime: &RebornLocalRuntimeServices,
+) -> Arc<dyn TriggerCreateHook> {
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    {
+        Arc::new(FilesystemTriggerCreatorPairingHook::new(Arc::clone(
+            &local_runtime.subagent_goal_filesystem,
+        )))
+    }
+    #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+    {
+        Arc::new(InMemoryTriggerCreatorPairingHook {
+            conversations: local_runtime.trigger_conversation_services.clone(),
+        })
+    }
+}
+
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
+struct InMemoryTriggerCreatorPairingHook {
+    conversations: InMemoryConversationServices,
+}
+
+#[cfg(not(any(feature = "libsql", feature = "postgres")))]
+#[async_trait::async_trait]
+impl TriggerCreateHook for InMemoryTriggerCreatorPairingHook {
+    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+        pair_trigger_creator(&self.conversations, record).await
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+struct FilesystemTriggerCreatorPairingHook<F>
+where
+    F: RootFilesystem + 'static,
+{
+    filesystem: Arc<ScopedFilesystem<F>>,
+    conversations:
+        tokio::sync::OnceCell<ironclaw_conversations::RebornFilesystemConversationServices>,
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+impl<F> FilesystemTriggerCreatorPairingHook<F>
+where
+    F: RootFilesystem + 'static,
+{
+    fn new(filesystem: Arc<ScopedFilesystem<F>>) -> Self {
+        Self {
+            filesystem,
+            conversations: tokio::sync::OnceCell::new(),
+        }
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[async_trait::async_trait]
+impl<F> TriggerCreateHook for FilesystemTriggerCreatorPairingHook<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn before_trigger_persisted(&self, record: &TriggerRecord) -> Result<(), TriggerError> {
+        let conversations = self
+            .conversations
+            .get_or_try_init(|| async {
+                ironclaw_conversations::RebornFilesystemConversationServices::new(Arc::clone(
+                    &self.filesystem,
+                ))
+                .await
+                .map_err(trigger_pairing_error)
+            })
+            .await?;
+        pair_trigger_creator(conversations, record).await
+    }
+}
+
+async fn pair_trigger_creator(
+    pairing: &dyn ConversationActorPairingService,
+    record: &TriggerRecord,
+) -> Result<(), TriggerError> {
+    let adapter_kind = AdapterKind::new("trigger").map_err(trigger_pairing_error)?;
+    let adapter_installation_id =
+        AdapterInstallationId::new("reborn-trigger-poller").map_err(trigger_pairing_error)?;
+    let external_actor_ref = ExternalActorRef::new("user", record.creator_user_id.as_str())
+        .map_err(trigger_pairing_error)?;
+    pairing
+        .pair_external_actor(
+            record.tenant_id.clone(),
+            adapter_kind,
+            adapter_installation_id,
+            external_actor_ref,
+            record.creator_user_id.clone(),
+        )
+        .await
+        .map_err(trigger_pairing_error)
+}
+
+fn trigger_pairing_error(error: impl std::fmt::Display) -> TriggerError {
+    TriggerError::Backend {
+        reason: format!("trigger creator actor pairing failed: {error}"),
+    }
 }
 
 struct BudgetSinks {
@@ -1498,14 +1617,14 @@ fn builtin_extension_registry() -> Result<ExtensionRegistry, RebornBuildError> {
     Ok(registry)
 }
 
-fn builtin_first_party_registry(
+fn builtin_first_party_registry_with_trigger_create_hook(
     trigger_repository: Arc<dyn TriggerRepository>,
+    trigger_create_hook: Arc<dyn TriggerCreateHook>,
 ) -> Result<FirstPartyCapabilityRegistry, RebornBuildError> {
-    builtin_first_party_handlers(trigger_repository).map_err(|error| {
-        RebornBuildError::InvalidConfig {
+    builtin_first_party_handlers_with_trigger_create_hook(trigger_repository, trigger_create_hook)
+        .map_err(|error| RebornBuildError::InvalidConfig {
             reason: format!("built-in first-party handlers are invalid: {error}"),
-        }
-    })
+        })
 }
 
 fn local_dev_builtin_extension_registry() -> Result<ExtensionRegistry, RebornBuildError> {
@@ -2088,7 +2207,13 @@ where
         oauth_dcr_provider_configs,
     } = context;
     let secret_store: Arc<dyn SecretStore> = stores.secret_credentials.secret_store.clone();
-    let mut first_party_registry = builtin_first_party_registry(trigger_repository)?;
+    let trigger_create_hook = Arc::new(FilesystemTriggerCreatorPairingHook::new(Arc::clone(
+        &stores.scoped_filesystem,
+    )));
+    let mut first_party_registry = builtin_first_party_registry_with_trigger_create_hook(
+        trigger_repository,
+        trigger_create_hook,
+    )?;
     let product_auth_filesystem = Arc::clone(&stores.scoped_filesystem);
     let services = HostRuntimeServices::new(
         Arc::new(builtin_extension_registry()?),
@@ -3124,7 +3249,7 @@ mod tests {
         assert!(ids.contains(&TRIGGER_LIST_CAPABILITY_ID));
         assert!(ids.contains(&TRIGGER_REMOVE_CAPABILITY_ID));
 
-        let registry = builtin_first_party_registry(Arc::new(
+        let registry = ironclaw_host_runtime::builtin_first_party_handlers(Arc::new(
             ironclaw_triggers::InMemoryTriggerRepository::default(),
         ))
         .expect("built-in handlers build");

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -31,8 +31,6 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_conversations::RebornFilesystemConversationServices;
 use ironclaw_events::{DurableAuditLog, DurableEventLog, InMemoryAuditSink, RuntimeEvent};
 use ironclaw_first_party_extension_ports::{
     FirstPartySkillsExtension, FirstPartySkillsExtensionHandles, SelectableSkillContextSource,
@@ -275,13 +273,12 @@ async fn build_trigger_poller_services(
     let authorizer = Arc::new(TrustedTenantTriggerFireAuthorizer::new(tenant_id));
     #[cfg(any(feature = "libsql", feature = "postgres"))]
     {
-        let conversations = RebornFilesystemConversationServices::new(Arc::clone(
-            &local_runtime.subagent_goal_filesystem,
-        ))
-        .await
-        .map_err(|error| RebornRuntimeError::InvalidArgument {
-            reason: format!("trigger conversation services unavailable: {error}"),
-        })?;
+        let conversations = local_runtime
+            .durable_trigger_conversation_services()
+            .await
+            .map_err(|error| RebornRuntimeError::InvalidArgument {
+                reason: format!("trigger conversation services unavailable: {error}"),
+            })?;
         #[cfg(any(test, feature = "test-support"))]
         let pairing_service: Arc<
             dyn ironclaw_conversations::ConversationActorPairingService,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -31,8 +31,6 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-#[cfg(not(any(feature = "libsql", feature = "postgres")))]
-use ironclaw_conversations::InMemoryConversationServices;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_conversations::RebornFilesystemConversationServices;
 use ironclaw_events::{DurableAuditLog, DurableEventLog, InMemoryAuditSink, RuntimeEvent};
@@ -308,8 +306,7 @@ async fn build_trigger_poller_services(
     }
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     {
-        let _ = local_runtime;
-        let conversations = InMemoryConversationServices::default();
+        let conversations = local_runtime.trigger_conversation_services.clone();
         #[cfg(any(test, feature = "test-support"))]
         let pairing_service: Arc<
             dyn ironclaw_conversations::ConversationActorPairingService,

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -20,6 +20,7 @@
 //! property that satisfies the "narrow Reborn public surface" requirement
 //! pinned by `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`.
 
+// arch-exempt: large_file, needs Reborn runtime helper extraction, plan #4471
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -395,12 +395,14 @@ mod tests {
         UpdateAssistantDraftRequest, UpdateThreadGoalRequest, UpdateToolResultReferenceRequest,
     };
     use ironclaw_triggers::{
-        InMemoryTriggerRepository, ScheduleTriggerSourceProvider, TriggerActiveRunLookup,
-        TriggerActiveRunState, TriggerActiveRunStateRequest, TriggerCompletionPolicy, TriggerError,
-        TriggerFire, TriggerFireIdentity, TriggerId, TriggerInboundContentRef,
-        TriggerMaterializedPrompt, TriggerPollerFailureReason, TriggerPollerFireOutcome,
-        TriggerPollerWorker, TriggerPollerWorkerConfig, TriggerPollerWorkerDeps, TriggerRecord,
-        TriggerRepository, TriggerSchedule, TriggerSourceKind, TriggerState,
+        InMemoryTriggerRepository, ScheduleTriggerSourceProvider,
+        TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
+        TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerActiveRunLookup, TriggerActiveRunState,
+        TriggerActiveRunStateRequest, TriggerCompletionPolicy, TriggerError, TriggerFire,
+        TriggerFireIdentity, TriggerId, TriggerInboundContentRef, TriggerMaterializedPrompt,
+        TriggerPollerFailureReason, TriggerPollerFireOutcome, TriggerPollerWorker,
+        TriggerPollerWorkerConfig, TriggerPollerWorkerDeps, TriggerRecord, TriggerRepository,
+        TriggerSchedule, TriggerSourceKind, TriggerState,
     };
     use ironclaw_turns::{
         AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, CancelRunRequest,
@@ -1104,9 +1106,14 @@ mod tests {
         conversations
             .pair_external_actor(
                 tenant_id.clone(),
-                AdapterKind::new("trigger").expect("adapter kind"),
-                AdapterInstallationId::new("reborn-trigger-poller").expect("installation id"),
-                ExternalActorRef::new("user", creator_user_id.as_str()).expect("actor ref"),
+                AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("adapter kind"),
+                AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                    .expect("installation id"),
+                ExternalActorRef::new(
+                    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
+                    creator_user_id.as_str(),
+                )
+                .expect("actor ref"),
                 creator_user_id.clone(),
             )
             .await;
@@ -1236,9 +1243,14 @@ mod tests {
         conversations
             .pair_external_actor(
                 tenant_id.clone(),
-                AdapterKind::new("trigger").expect("adapter kind"),
-                AdapterInstallationId::new("reborn-trigger-poller").expect("installation id"),
-                ExternalActorRef::new("user", creator_user_id.as_str()).expect("actor ref"),
+                AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("adapter kind"),
+                AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                    .expect("installation id"),
+                ExternalActorRef::new(
+                    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
+                    creator_user_id.as_str(),
+                )
+                .expect("actor ref"),
                 creator_user_id.clone(),
             )
             .await;
@@ -1384,9 +1396,14 @@ mod tests {
         conversations
             .pair_external_actor(
                 tenant_id.clone(),
-                AdapterKind::new("trigger").expect("adapter kind"),
-                AdapterInstallationId::new("reborn-trigger-poller").expect("installation id"),
-                ExternalActorRef::new("user", creator_user_id.as_str()).expect("actor ref"),
+                AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("adapter kind"),
+                AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                    .expect("installation id"),
+                ExternalActorRef::new(
+                    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
+                    creator_user_id.as_str(),
+                )
+                .expect("actor ref"),
                 creator_user_id.clone(),
             )
             .await;
@@ -1495,9 +1512,14 @@ mod tests {
         conversations
             .pair_external_actor(
                 tenant_id.clone(),
-                AdapterKind::new("trigger").expect("adapter kind"),
-                AdapterInstallationId::new("reborn-trigger-poller").expect("installation id"),
-                ExternalActorRef::new("user", creator_user_id.as_str()).expect("actor ref"),
+                AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("adapter kind"),
+                AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                    .expect("installation id"),
+                ExternalActorRef::new(
+                    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE,
+                    creator_user_id.as_str(),
+                )
+                .expect("actor ref"),
                 creator_user_id.clone(),
             )
             .await;

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -333,6 +333,21 @@ async fn libsql_db_at(path: impl AsRef<std::path::Path>) -> Arc<libsql::Database
     )
 }
 
+#[cfg(feature = "libsql")]
+async fn libsql_trigger_record_count(db: &libsql::Database) -> i64 {
+    let conn = db.connect().expect("connect libsql db");
+    let mut rows = conn
+        .query("SELECT COUNT(*) FROM trigger_records", ())
+        .await
+        .expect("trigger table exists");
+    let row = rows
+        .next()
+        .await
+        .expect("read trigger table count row")
+        .expect("trigger table count row");
+    row.get(0).expect("trigger count")
+}
+
 #[cfg(feature = "postgres")]
 async fn postgres_pool_or_skip() -> Option<(
     testcontainers_modules::testcontainers::ContainerAsync<
@@ -1034,6 +1049,9 @@ async fn local_dev_services_dispatch_trigger_management_through_composed_runtime
         .as_str()
         .expect("created trigger id")
         .to_string();
+
+    let local_dev_db = libsql_db_at(dir.path().join("reborn-local-dev.db")).await;
+    assert_eq!(libsql_trigger_record_count(&local_dev_db).await, 1);
 
     let listed = invoke_trigger_management(
         runtime,

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -17,7 +17,14 @@ use ironclaw_host_api::runtime_policy::{
     ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
     NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
 };
-use ironclaw_host_api::{AgentId, TenantId, UserId};
+use ironclaw_host_api::{
+    AgentId, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
+    ExecutionContext, ExtensionId, GrantConstraints, MountView, NetworkPolicy, Principal,
+    ResourceEstimate, RuntimeKind, TenantId, TrustClass, UserId,
+};
+use ironclaw_host_runtime::{
+    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, TRIGGER_CREATE_CAPABILITY_ID,
+};
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
     HostManagedModelResponse,
@@ -30,6 +37,8 @@ use ironclaw_triggers::{
     TriggerCompletionPolicy, TriggerId, TriggerPollerWorkerConfig, TriggerRecord,
     TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use serde_json::{Value, json};
 use tokio::sync::Mutex as TokioMutex;
 
 const TENANT: &str = "trigger-e2e-tenant";
@@ -141,6 +150,82 @@ async fn build_runtime_with(
         );
 
     build_reborn_runtime(input).await.expect("runtime builds")
+}
+
+async fn invoke_trigger_create(runtime: &RebornRuntime, input: Value) -> Value {
+    let host_runtime = runtime
+        .services()
+        .host_runtime
+        .as_deref()
+        .expect("runtime exposes host runtime");
+    let outcome = host_runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            trigger_management_execution_context(),
+            CapabilityId::new(TRIGGER_CREATE_CAPABILITY_ID).expect("capability id"),
+            ResourceEstimate::default(),
+            input,
+            trigger_management_trust_decision(),
+        ))
+        .await
+        .expect("trigger create invocation completes");
+    let RuntimeCapabilityOutcome::Completed(completed) = outcome else {
+        panic!("expected trigger create to complete, got {outcome:?}");
+    };
+    completed.output
+}
+
+fn trigger_management_execution_context() -> ExecutionContext {
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let agent_id = AgentId::new(AGENT).expect("agent id");
+    let extension_id = ExtensionId::new("trigger-e2e-caller").expect("extension id");
+    let mut context = ExecutionContext::local_default(
+        user_id.clone(),
+        extension_id.clone(),
+        RuntimeKind::FirstParty,
+        TrustClass::UserTrusted,
+        CapabilitySet {
+            grants: vec![CapabilityGrant {
+                id: CapabilityGrantId::new(),
+                capability: CapabilityId::new(TRIGGER_CREATE_CAPABILITY_ID).expect("capability id"),
+                grantee: Principal::Extension(extension_id),
+                issued_by: Principal::HostRuntime,
+                constraints: GrantConstraints {
+                    allowed_effects: vec![
+                        EffectKind::DispatchCapability,
+                        EffectKind::ExternalWrite,
+                    ],
+                    mounts: MountView::default(),
+                    network: NetworkPolicy::default(),
+                    secrets: Vec::new(),
+                    resource_ceiling: None,
+                    expires_at: None,
+                    max_invocations: None,
+                },
+            }],
+        },
+        MountView::default(),
+    )
+    .expect("execution context");
+    context.tenant_id = tenant_id.clone();
+    context.agent_id = Some(agent_id.clone());
+    context.project_id = None;
+    context.resource_scope.tenant_id = tenant_id;
+    context.resource_scope.agent_id = Some(agent_id);
+    context.resource_scope.project_id = None;
+    context
+}
+
+fn trigger_management_trust_decision() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::user_trusted(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::ExternalWrite],
+            max_resource_ceiling: None,
+        },
+        provenance: TrustProvenance::AdminConfig,
+        evaluated_at: Utc::now(),
+    }
 }
 
 #[tokio::test]
@@ -301,6 +386,133 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
         final_record.last_status,
         Some(TriggerRunStatus::Ok),
         "CompleteAfterFirstFire policy: last_status should be Ok after fire — record: {final_record:?}",
+    );
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_pairs_creator_and_poller_submits_turn() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(TokioMutex::new(Vec::new())),
+    });
+
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings {
+            enabled: true,
+            worker: TriggerPollerWorkerConfig {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
+            startup_jitter_max: Duration::ZERO,
+            tick_jitter_max: Duration::ZERO,
+        },
+    )
+    .await;
+
+    let created = invoke_trigger_create(
+        &runtime,
+        json!({
+            "name": "trigger-e2e-created-by-tool",
+            "prompt": TRIGGER_PROMPT,
+            "cron": "* * * * *"
+        }),
+    )
+    .await;
+    assert_eq!(
+        created["trigger"]["name"],
+        json!("trigger-e2e-created-by-tool")
+    );
+    assert_eq!(created["trigger"]["state"], json!("scheduled"));
+    assert_eq!(created["trigger"]["completion_policy"], json!("recurring"));
+    assert!(created["trigger"]["last_status"].is_null());
+    assert!(created["trigger"]["prompt"].is_null());
+    assert!(created["trigger"]["tenant_id"].is_null());
+    assert!(created["trigger"]["creator_user_id"].is_null());
+
+    let repo = runtime
+        .trigger_repository()
+        .expect("local-dev runtime exposes trigger repository");
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let trigger_id = TriggerId::parse(
+        created["trigger"]["trigger_id"]
+            .as_str()
+            .expect("created trigger id"),
+    )
+    .expect("valid trigger id");
+
+    let mut record = repo
+        .get_trigger(tenant_id.clone(), trigger_id)
+        .await
+        .expect("get created trigger")
+        .expect("created trigger persisted");
+    assert_eq!(record.prompt, TRIGGER_PROMPT);
+    assert_eq!(record.creator_user_id, user_id);
+    assert_eq!(record.name, "trigger-e2e-created-by-tool");
+
+    let original_next_run_at = record.next_run_at;
+    record.next_run_at = Utc::now() - chrono::Duration::seconds(120);
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("make created trigger due");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut record_was_mutated = false;
+    let mut prompt_seen = false;
+
+    while Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let current = repo
+            .get_trigger(tenant_id.clone(), trigger_id)
+            .await
+            .expect("get trigger")
+            .expect("record present");
+
+        let mutated = current.last_fired_slot.is_some()
+            || current.last_run_at.is_some()
+            || current.last_status.is_some()
+            || current.active_fire_slot.is_some();
+
+        if mutated {
+            record_was_mutated = true;
+            let contents = recording_gateway.captured_message_contents().await;
+            if contents
+                .iter()
+                .any(|content| content.contains(TRIGGER_PROMPT))
+            {
+                prompt_seen = true;
+            }
+        }
+
+        if record_was_mutated && prompt_seen {
+            break;
+        }
+    }
+
+    let settled = wait_for_settled(&repo, &tenant_id, trigger_id, Duration::from_secs(5), |r| {
+        r.last_fired_slot.is_some() && r.next_run_at > original_next_run_at
+    })
+    .await;
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    let captured_contents = recording_gateway.captured_message_contents().await;
+    assert!(
+        record_was_mutated,
+        "poller did not mutate trigger created through builtin.trigger_create — record: {settled:?}",
+    );
+    assert!(
+        prompt_seen,
+        "LLM gateway never received trigger prompt for builtin-created trigger — \
+         captured_messages: {captured_contents:?}"
+    );
+    assert_eq!(settled.last_status, Some(TriggerRunStatus::Ok));
+    assert!(
+        settled.last_run_at.is_some(),
+        "builtin-created trigger should record last_run_at after poller fire"
     );
 }
 

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -29,7 +29,11 @@ mod postgres;
 mod trusted_submit;
 mod worker;
 
-pub use trusted_submit::{TriggerMaterializedPrompt, TriggerTrustedInboundBinding};
+pub use trusted_submit::{
+    TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
+    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerMaterializedPrompt,
+    TriggerTrustedInboundBinding,
+};
 
 const MIN_FIRE_CADENCE: Duration = Duration::from_secs(60);
 const MAX_DUE_TRIGGER_POLL_LIMIT: usize = 128;

--- a/crates/ironclaw_triggers/src/trusted_submit.rs
+++ b/crates/ironclaw_triggers/src/trusted_submit.rs
@@ -1,5 +1,9 @@
 use crate::{TriggerFire, TriggerInboundContentRef};
 
+pub const TRIGGER_TRUSTED_ADAPTER_KIND: &str = "trigger";
+pub const TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID: &str = "reborn-trigger-poller";
+pub const TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE: &str = "user";
+
 /// Canonical conversation identity for a trusted trigger fire.
 ///
 /// Composition computes this once while materializing the trigger prompt, uses
@@ -20,9 +24,9 @@ pub struct TriggerTrustedInboundBinding {
 impl TriggerTrustedInboundBinding {
     pub fn for_fire(fire: &TriggerFire) -> Self {
         Self {
-            adapter_kind: "trigger".to_string(),
-            adapter_installation_id: "reborn-trigger-poller".to_string(),
-            external_actor_namespace: "user".to_string(),
+            adapter_kind: TRIGGER_TRUSTED_ADAPTER_KIND.to_string(),
+            adapter_installation_id: TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID.to_string(),
+            external_actor_namespace: TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE.to_string(),
             external_actor_id: fire.creator_user_id.as_str().to_string(),
             external_conversation_id: format!("trigger-{}", fire.identity.trigger_id()),
             route_thread_id: fire.identity.route_thread_id().as_str().to_string(),

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -13,9 +13,11 @@ use crate::{
     ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire,
     ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
     FireRetryableFailedRequest, FireTerminalFailedRequest, InMemoryTriggerRepository,
-    TriggerCompletionPolicy, TriggerError, TriggerFire, TriggerId, TriggerInboundContentRef,
-    TriggerMaterializedPrompt, TriggerPromptMaterializer, TriggerRecord, TriggerRepository,
-    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerSourceProvider, TriggerState,
+    TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
+    TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerCompletionPolicy, TriggerError, TriggerFire,
+    TriggerId, TriggerInboundContentRef, TriggerMaterializedPrompt, TriggerPromptMaterializer,
+    TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind,
+    TriggerSourceProvider, TriggerState,
 };
 
 fn ts(seconds: i64) -> Timestamp {
@@ -250,12 +252,18 @@ async fn tick_processes_one_due_trigger_happy_path() {
     assert_eq!(fire.agent_id, record.agent_id);
     assert_eq!(fire.project_id, record.project_id);
     assert_eq!(content_ref.as_str(), "content:trigger-fire");
-    assert_eq!(trusted_inbound_binding.adapter_kind(), "trigger");
+    assert_eq!(
+        trusted_inbound_binding.adapter_kind(),
+        TRIGGER_TRUSTED_ADAPTER_KIND
+    );
     assert_eq!(
         trusted_inbound_binding.adapter_installation_id(),
-        "reborn-trigger-poller"
+        TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID
     );
-    assert_eq!(trusted_inbound_binding.external_actor_namespace(), "user");
+    assert_eq!(
+        trusted_inbound_binding.external_actor_namespace(),
+        TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE
+    );
     assert_eq!(
         trusted_inbound_binding.external_actor_id(),
         record.creator_user_id.as_str()

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -324,8 +324,21 @@ The trigger system must expose `trigger_create`, `trigger_list`, and `trigger_re
   persists the trigger. This pairing is composition-owned trigger management
   wiring; trigger repositories remain storage-only, and the poller must still
   fail closed for records whose creator actor was not paired.
+- `trigger_create` pairs the creator before persisting the trigger record. This
+  intentionally fails closed before storage if the actor pairing cannot be
+  established, instead of storing a trigger that the poller cannot fire. A
+  pairing that remains after a later trigger-record write failure is reusable
+  creator-scoped authorization state, not a trigger-specific fire gate.
+- Durable local-dev composition must share the same trigger conversation
+  services between `trigger_create` pairing and trigger-poller fire submission.
+  The shared service preserves the conversation store's mutation lock across
+  both paths and avoids racing optimistic durable-state writes.
 - `trigger_list` is caller-scoped and surfaces the current schedule state plus `last_status`.
 - `trigger_remove` is caller-scoped delete.
+- Local-dev builds compiled with `libsql` store trigger records in the
+  local-dev libSQL database (`reborn-local-dev.db`) through the same
+  `TriggerRepository` contract used by production libSQL. Local-dev builds
+  without `libsql` keep the existing in-memory repository behavior.
 
 Exact wiring of the capability registry and handler dependencies may land in later implementation PRs, but the capability names and semantics are frozen here.
 

--- a/docs/reborn/contracts/triggers.md
+++ b/docs/reborn/contracts/triggers.md
@@ -319,7 +319,11 @@ messages directly.
 
 The trigger system must expose `trigger_create`, `trigger_list`, and `trigger_remove` as first-party Reborn capabilities.
 
-- `trigger_create` validates the schedule, captures caller scope, and persists the trigger.
+- `trigger_create` validates the schedule, captures caller scope, pairs the
+  caller as the host-trusted synthetic trigger actor used by the poller, and
+  persists the trigger. This pairing is composition-owned trigger management
+  wiring; trigger repositories remain storage-only, and the poller must still
+  fail closed for records whose creator actor was not paired.
 - `trigger_list` is caller-scoped and surfaces the current schedule state plus `last_status`.
 - `trigger_remove` is caller-scoped delete.
 


### PR DESCRIPTION
## Summary

- add a trigger-create lifecycle hook so `builtin.trigger_create` can run composition-owned side effects before persistence
- wire Reborn composition to pair the creator as the synthetic `trigger/reborn-trigger-poller` actor for local-dev and durable production builds
- reuse shared trigger conversation services in non-durable poller wiring, and cache filesystem conversation services for durable trigger-create pairing
- add caller-level and poller e2e coverage, plus update the trigger contract

## Testing

- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools builtin_trigger_create`
- `cargo test -p ironclaw_reborn_composition --test trigger_poller_e2e --features test-support`
- `cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --features test-support --test trigger_poller_e2e -- -D warnings`
- `cargo clippy -p ironclaw_reborn_composition --features libsql --lib -- -D warnings`

## Notes

PR #4436 overlaps `runtime.rs`, `trigger_poller_e2e.rs`, and trigger docs. If #4436 lands first, this branch will likely need a small test helper adjustment to use `enabled_with_tenant_scoped_authorizer_for_test()`, but the trigger-create pairing hook itself remains valid.
