### PR TITLE
Wire Reborn Slack actor/subject journey

### DIFF
--- a/crates/ironclaw_host_runtime/src/egress/host_port.rs
+++ b/crates/ironclaw_host_runtime/src/egress/host_port.rs
@@ -111,8 +111,16 @@ impl HostRuntimeHttpEgressPort {
         let staged_scope = request.request.scope.clone();
         let staged_capability_id = request.request.capability_id.clone();
         let staged_credentials = !request.credentials.is_empty();
-        self.stage_credentials(&mut request.request, request.credentials)
-            .await?;
+        if let Err(error) = self
+            .stage_credentials(&mut request.request, request.credentials)
+            .await
+        {
+            if staged_credentials {
+                self.secret_stager
+                    .discard_secret_material_for_capability(&staged_scope, &staged_capability_id);
+            }
+            return Err(error);
+        }
         let result = self.runtime_http_egress.execute(request.request).await;
         if staged_credentials {
             self.secret_stager

--- a/crates/ironclaw_host_runtime/src/egress/host_port.rs
+++ b/crates/ironclaw_host_runtime/src/egress/host_port.rs
@@ -1,0 +1,455 @@
+use std::sync::Arc;
+
+use ironclaw_capabilities::{
+    CapabilityObligationHandler, CapabilityObligationPhase, CapabilityObligationRequest,
+};
+use ironclaw_host_api::{
+    CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, MountView, Obligation,
+    ResourceEstimate, ResourceScope, RuntimeCredentialInjection, RuntimeCredentialSource,
+    RuntimeCredentialTarget, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+    RuntimeHttpEgressResponse, RuntimeKind, SecretHandle, TrustClass,
+};
+use ironclaw_secrets::SecretMaterial;
+
+use crate::obligations::RuntimeSecretInjectionStore;
+
+/// Canonical host-runtime one-shot secret material staging port.
+///
+/// This is for host-owned adapters that already hold trusted secret material
+/// and need the shared runtime HTTP egress to inject it without exposing the
+/// material through request headers.
+#[derive(Clone)]
+pub struct RuntimeSecretMaterialStager {
+    secret_injection_store: Arc<RuntimeSecretInjectionStore>,
+}
+
+/// Alias for [`ironclaw_host_api::CredentialStageError`].
+pub type RuntimeSecretStageError = ironclaw_host_api::CredentialStageError;
+
+impl RuntimeSecretMaterialStager {
+    pub(crate) fn new(secret_injection_store: Arc<RuntimeSecretInjectionStore>) -> Self {
+        Self {
+            secret_injection_store,
+        }
+    }
+
+    pub async fn stage_secret_material_once(
+        &self,
+        target_scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+    ) -> Result<(), RuntimeSecretStageError> {
+        self.secret_injection_store
+            .insert(target_scope, capability_id, handle, material)
+            .map_err(|_| RuntimeSecretStageError::Backend)
+    }
+
+    fn discard_secret_material_for_capability(
+        &self,
+        target_scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) {
+        if let Err(error) = self
+            .secret_injection_store
+            .discard_for_capability(target_scope, capability_id)
+        {
+            tracing::debug!(
+                error = ?error,
+                capability_id = %capability_id,
+                "host HTTP egress failed to discard staged secret material"
+            );
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HostRuntimeHttpEgressPort {
+    runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+    obligation_handler: Arc<dyn CapabilityObligationHandler>,
+    secret_stager: RuntimeSecretMaterialStager,
+}
+
+pub struct HostRuntimeHttpEgressRequest {
+    pub extension_id: ExtensionId,
+    pub trust: TrustClass,
+    pub request: RuntimeHttpEgressRequest,
+    pub credentials: Vec<HostRuntimeCredentialMaterial>,
+}
+
+pub struct HostRuntimeCredentialMaterial {
+    pub handle: SecretHandle,
+    pub material: SecretMaterial,
+    pub target: RuntimeCredentialTarget,
+    pub required: bool,
+}
+
+impl HostRuntimeHttpEgressPort {
+    pub(crate) fn new(
+        runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+        obligation_handler: Arc<dyn CapabilityObligationHandler>,
+        secret_stager: RuntimeSecretMaterialStager,
+    ) -> Self {
+        Self {
+            runtime_http_egress,
+            obligation_handler,
+            secret_stager,
+        }
+    }
+
+    pub async fn execute(
+        &self,
+        mut request: HostRuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        if !request.request.credential_injections.is_empty() {
+            return Err(RuntimeHttpEgressError::Credential {
+                reason: "host-mediated HTTP egress does not accept caller-provided credential injections"
+                    .to_string(),
+            });
+        }
+        self.authorize_network_egress(&request).await?;
+        let staged_scope = request.request.scope.clone();
+        let staged_capability_id = request.request.capability_id.clone();
+        let staged_credentials = !request.credentials.is_empty();
+        self.stage_credentials(&mut request.request, request.credentials)
+            .await?;
+        let result = self.runtime_http_egress.execute(request.request).await;
+        if staged_credentials {
+            self.secret_stager
+                .discard_secret_material_for_capability(&staged_scope, &staged_capability_id);
+        }
+        result
+    }
+
+    async fn stage_credentials(
+        &self,
+        request: &mut RuntimeHttpEgressRequest,
+        credentials: Vec<HostRuntimeCredentialMaterial>,
+    ) -> Result<(), RuntimeHttpEgressError> {
+        for credential in credentials {
+            self.secret_stager
+                .stage_secret_material_once(
+                    &request.scope,
+                    &request.capability_id,
+                    &credential.handle,
+                    credential.material,
+                )
+                .await
+                .map_err(|_| RuntimeHttpEgressError::Credential {
+                    reason: "host credential material could not be staged".to_string(),
+                })?;
+            request
+                .credential_injections
+                .push(RuntimeCredentialInjection {
+                    handle: credential.handle,
+                    source: RuntimeCredentialSource::StagedObligation {
+                        capability_id: request.capability_id.clone(),
+                    },
+                    target: credential.target,
+                    required: credential.required,
+                });
+        }
+        Ok(())
+    }
+
+    async fn authorize_network_egress(
+        &self,
+        request: &HostRuntimeHttpEgressRequest,
+    ) -> Result<(), RuntimeHttpEgressError> {
+        let context = execution_context_for_host_http_egress(
+            &request.request.scope,
+            request.extension_id.clone(),
+            request.request.runtime,
+            request.trust,
+        )?;
+        let estimate = ResourceEstimate {
+            network_egress_bytes: request.request.network_policy.max_egress_bytes,
+            ..ResourceEstimate::default()
+        };
+        self.obligation_handler
+            .satisfy(CapabilityObligationRequest {
+                phase: CapabilityObligationPhase::Invoke,
+                context: &context,
+                capability_id: &request.request.capability_id,
+                estimate: &estimate,
+                obligations: &[Obligation::ApplyNetworkPolicy {
+                    policy: request.request.network_policy.clone(),
+                }],
+            })
+            .await
+            .map_err(|error| RuntimeHttpEgressError::Request {
+                reason: format!("host network egress policy was not authorized: {error}"),
+                request_bytes: 0,
+                response_bytes: 0,
+            })
+    }
+}
+
+fn execution_context_for_host_http_egress(
+    scope: &ResourceScope,
+    extension_id: ExtensionId,
+    runtime: RuntimeKind,
+    trust: TrustClass,
+) -> Result<ExecutionContext, RuntimeHttpEgressError> {
+    let context = ExecutionContext {
+        invocation_id: scope.invocation_id,
+        correlation_id: ironclaw_host_api::CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: scope.mission_id.clone(),
+        thread_id: scope.thread_id.clone(),
+        extension_id,
+        runtime,
+        trust,
+        grants: CapabilitySet::default(),
+        mounts: MountView::default(),
+        resource_scope: scope.clone(),
+    };
+    context
+        .validate()
+        .map_err(|error| RuntimeHttpEgressError::Credential {
+            reason: format!("invalid host HTTP egress context: {error}"),
+        })?;
+    Ok(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use async_trait::async_trait;
+    use ironclaw_capabilities::{
+        CapabilityObligationError, CapabilityObligationFailureKind, CapabilityObligationRequest,
+    };
+    use ironclaw_host_api::{
+        InvocationId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern,
+        RuntimeHttpEgressResponse, UserId,
+    };
+
+    use super::*;
+
+    struct AllowObligations;
+
+    #[async_trait]
+    impl CapabilityObligationHandler for AllowObligations {
+        async fn satisfy(
+            &self,
+            _request: CapabilityObligationRequest<'_>,
+        ) -> Result<(), CapabilityObligationError> {
+            Ok(())
+        }
+    }
+
+    struct DenyNetworkObligations;
+
+    #[async_trait]
+    impl CapabilityObligationHandler for DenyNetworkObligations {
+        async fn satisfy(
+            &self,
+            _request: CapabilityObligationRequest<'_>,
+        ) -> Result<(), CapabilityObligationError> {
+            Err(CapabilityObligationError::Failed {
+                kind: CapabilityObligationFailureKind::Network,
+            })
+        }
+    }
+
+    struct RecordingRuntimeHttpEgress {
+        calls: AtomicUsize,
+        response: Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError>,
+    }
+
+    impl RecordingRuntimeHttpEgress {
+        fn ok() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                response: Ok(RuntimeHttpEgressResponse {
+                    status: 200,
+                    headers: Vec::new(),
+                    body: Vec::new(),
+                    saved_body: None,
+                    request_bytes: 0,
+                    response_bytes: 0,
+                    redaction_applied: false,
+                }),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                response: Err(RuntimeHttpEgressError::Network {
+                    reason: "network_error".to_string(),
+                    request_bytes: 17,
+                    response_bytes: 0,
+                }),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
+        async fn execute(
+            &self,
+            _request: RuntimeHttpEgressRequest,
+        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.response.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_rejects_caller_provided_credential_injections() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::ok());
+        let port = host_port(egress.clone(), Arc::new(AllowObligations), secret_store());
+        let mut request = host_request();
+        request
+            .request
+            .credential_injections
+            .push(RuntimeCredentialInjection {
+                handle: secret_handle(),
+                source: RuntimeCredentialSource::StagedObligation {
+                    capability_id: capability_id(),
+                },
+                target: RuntimeCredentialTarget::Header {
+                    name: "authorization".to_string(),
+                    prefix: Some("Bearer ".to_string()),
+                },
+                required: true,
+            });
+
+        let error = port
+            .execute(request)
+            .await
+            .expect_err("caller-provided credential injections must be rejected");
+
+        assert!(matches!(error, RuntimeHttpEgressError::Credential { .. }));
+        assert_eq!(egress.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_maps_network_policy_denial_to_request_error() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::ok());
+        let port = host_port(
+            egress.clone(),
+            Arc::new(DenyNetworkObligations),
+            secret_store(),
+        );
+
+        let error = port
+            .execute(host_request())
+            .await
+            .expect_err("policy denial must fail before runtime egress");
+
+        assert!(matches!(error, RuntimeHttpEgressError::Request { .. }));
+        assert_eq!(error.stable_runtime_reason(), "request_denied");
+        assert_eq!(egress.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn host_runtime_http_egress_discards_staged_secret_after_delegate_failure() {
+        let store = secret_store();
+        let egress = Arc::new(RecordingRuntimeHttpEgress::failing());
+        let port = host_port(egress, Arc::new(AllowObligations), Arc::clone(&store));
+        let mut request = host_request();
+        let scope = request.request.scope.clone();
+        let capability_id = request.request.capability_id.clone();
+        let handle = secret_handle();
+        request.credentials.push(HostRuntimeCredentialMaterial {
+            handle: handle.clone(),
+            material: SecretMaterial::from("host-held-token"),
+            target: RuntimeCredentialTarget::Header {
+                name: "authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            required: true,
+        });
+
+        let error = port
+            .execute(request)
+            .await
+            .expect_err("delegate egress failure should bubble");
+
+        assert!(matches!(error, RuntimeHttpEgressError::Network { .. }));
+        assert!(
+            store
+                .take(&scope, &capability_id, &handle)
+                .expect("staged secret store should be readable")
+                .is_none(),
+            "host-staged material should be discarded after delegate failure"
+        );
+    }
+
+    fn host_port(
+        egress: Arc<dyn RuntimeHttpEgress>,
+        obligations: Arc<dyn CapabilityObligationHandler>,
+        store: Arc<RuntimeSecretInjectionStore>,
+    ) -> HostRuntimeHttpEgressPort {
+        HostRuntimeHttpEgressPort::new(egress, obligations, RuntimeSecretMaterialStager::new(store))
+    }
+
+    fn host_request() -> HostRuntimeHttpEgressRequest {
+        HostRuntimeHttpEgressRequest {
+            extension_id: ExtensionId::new("test_extension").expect("extension id"),
+            trust: TrustClass::System,
+            request: RuntimeHttpEgressRequest {
+                runtime: RuntimeKind::FirstParty,
+                scope: scope(),
+                capability_id: capability_id(),
+                method: NetworkMethod::Get,
+                url: "https://api.example.test/v1".to_string(),
+                headers: Vec::new(),
+                body: Vec::new(),
+                network_policy: network_policy(),
+                credential_injections: Vec::new(),
+                response_body_limit: None,
+                save_body_to: None,
+                timeout_ms: None,
+            },
+            credentials: Vec::new(),
+        }
+    }
+
+    fn scope() -> ResourceScope {
+        ResourceScope::local_default(
+            UserId::new("user:test").expect("user id"),
+            InvocationId::new(),
+        )
+        .expect("scope")
+    }
+
+    fn capability_id() -> CapabilityId {
+        CapabilityId::new("test.host_http").expect("capability id")
+    }
+
+    fn secret_handle() -> SecretHandle {
+        SecretHandle::new("host-held-token").expect("secret handle")
+    }
+
+    fn secret_store() -> Arc<RuntimeSecretInjectionStore> {
+        Arc::new(RuntimeSecretInjectionStore::new())
+    }
+
+    fn network_policy() -> NetworkPolicy {
+        NetworkPolicy {
+            allowed_targets: vec![NetworkTargetPattern {
+                scheme: Some(NetworkScheme::Https),
+                host_pattern: "api.example.test".to_string(),
+                port: None,
+            }],
+            deny_private_ip_ranges: true,
+            max_egress_bytes: Some(1024),
+        }
+    }
+}

--- a/crates/ironclaw_host_runtime/src/egress/mod.rs
+++ b/crates/ironclaw_host_runtime/src/egress/mod.rs
@@ -1,4 +1,5 @@
 mod credential;
+mod host_port;
 mod pipeline;
 mod sanitize;
 
@@ -14,6 +15,11 @@ use std::{fmt, sync::Arc};
 
 use crate::obligations::{NetworkObligationPolicyStore, RuntimeSecretInjectionStore};
 use crate::{ToolCallHttpEgress, http_body::RuntimeHttpBodyStore};
+
+pub use host_port::{
+    HostRuntimeCredentialMaterial, HostRuntimeHttpEgressPort, HostRuntimeHttpEgressRequest,
+    RuntimeSecretMaterialStager, RuntimeSecretStageError,
+};
 
 #[derive(Clone)]
 pub struct HostHttpEgressService<N, S> {

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -109,10 +109,11 @@ pub use sandbox_process::{
     RebornScopedSandboxCommandTransport,
 };
 pub use services::{
+    HostRuntimeCredentialMaterial, HostRuntimeHttpEgressPort, HostRuntimeHttpEgressRequest,
     HostRuntimeServices, ProductAuthCredentialStageError, ProductAuthProviderRuntimePorts,
     ProductionEventStoreWiringError, ProductionWiringComponent, ProductionWiringConfig,
     ProductionWiringIssue, ProductionWiringIssueKind, ProductionWiringReport,
-    RegisteredRuntimeHealth,
+    RegisteredRuntimeHealth, RuntimeSecretMaterialStager, RuntimeSecretStageError,
 };
 pub use surface::{CapabilitySurfacePolicy, VisibleCapability, VisibleCapabilityAccess};
 pub use turn_scheduler::{

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -60,7 +60,10 @@ pub use capability_catalog::{
     HotCapabilityCatalog, HotCapabilityRecord, MAX_HOT_PROMPT_BYTES, MAX_HOT_SCHEMA_BYTES,
     publish_hot_capability_catalog,
 };
-pub use egress::HostHttpEgressService;
+pub use egress::{
+    HostHttpEgressService, HostRuntimeCredentialMaterial, HostRuntimeHttpEgressPort,
+    HostRuntimeHttpEgressRequest, RuntimeSecretMaterialStager, RuntimeSecretStageError,
+};
 pub use extension_contracts::{
     default_host_api_contract_registry, default_host_port_catalog,
     discover_extensions_with_default_host_api_contracts,
@@ -109,11 +112,10 @@ pub use sandbox_process::{
     RebornScopedSandboxCommandTransport,
 };
 pub use services::{
-    HostRuntimeCredentialMaterial, HostRuntimeHttpEgressPort, HostRuntimeHttpEgressRequest,
     HostRuntimeServices, ProductAuthCredentialStageError, ProductAuthProviderRuntimePorts,
     ProductionEventStoreWiringError, ProductionWiringComponent, ProductionWiringConfig,
     ProductionWiringIssue, ProductionWiringIssueKind, ProductionWiringReport,
-    RegisteredRuntimeHealth, RuntimeSecretMaterialStager, RuntimeSecretStageError,
+    RegisteredRuntimeHealth,
 };
 pub use surface::{CapabilitySurfacePolicy, VisibleCapability, VisibleCapabilityAccess};
 pub use turn_scheduler::{

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -15,9 +15,7 @@ use ironclaw_approvals::ApprovalResolver;
 use ironclaw_authorization::{
     CapabilityLeaseStore, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
 };
-use ironclaw_capabilities::{
-    CapabilityObligationHandler, CapabilityObligationPhase, CapabilityObligationRequest,
-};
+use ironclaw_capabilities::CapabilityObligationHandler;
 use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
 };
@@ -32,11 +30,8 @@ use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
-    CapabilityDispatcher, CapabilityId, CapabilitySet, DispatchError, ExecutionContext,
-    ExtensionId, MountView, Obligation, ResourceEstimate, ResourceReservationId, ResourceScope,
-    ResourceUsage, RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeCredentialTarget,
-    RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
-    RuntimeHttpEgressResponse, RuntimeKind, SecretHandle, TrustClass,
+    CapabilityDispatcher, CapabilityId, DispatchError, ResourceReservationId, ResourceScope,
+    ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeKind, SecretHandle,
     runtime_policy::{
         DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind, NetworkMode,
         ProcessBackendKind, RuntimeProfile, SecretMode,
@@ -61,7 +56,6 @@ use ironclaw_run_state::{
     InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateApprovalStore, RunStateStore,
 };
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
-use ironclaw_secrets::SecretMaterial;
 use ironclaw_secrets::{
     CredentialAccountStore, CredentialSessionStore, InMemoryCredentialBroker, InMemorySecretStore,
     SecretStore, SecretStoreError,
@@ -86,10 +80,11 @@ use crate::obligations::{
 use crate::{
     BuiltinObligationHandler, CapabilitySurfaceVersion, DefaultHostRuntime,
     FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, HostRuntimeError,
-    InvocationServicesResolutionRequest, InvocationServicesResolver, LocalHostProcessPort,
-    LocalInvocationServicesResolver, PlannerError, ProcessObligationLifecycleStore,
-    RuntimeBackendHealth, RuntimeProcessPort, TenantSandboxProcessPort, ToolCallHttpEgress,
-    TurnRunExecutor, TurnRunScheduler, TurnRunSchedulerConfig, plan_capability,
+    HostRuntimeHttpEgressPort, InvocationServicesResolutionRequest, InvocationServicesResolver,
+    LocalHostProcessPort, LocalInvocationServicesResolver, PlannerError,
+    ProcessObligationLifecycleStore, RuntimeBackendHealth, RuntimeProcessPort,
+    RuntimeSecretMaterialStager, RuntimeSecretStageError, TenantSandboxProcessPort,
+    ToolCallHttpEgress, TurnRunExecutor, TurnRunScheduler, TurnRunSchedulerConfig, plan_capability,
 };
 use process_executor::{HostProcessExecutor, RuntimeDispatchProcessExecutor};
 
@@ -170,183 +165,6 @@ where
     component_types: ProductionComponentTypes,
 }
 
-/// Canonical host-runtime one-shot secret material staging port.
-///
-/// This is for host-owned adapters that already hold trusted secret material
-/// and need the shared runtime HTTP egress to inject it without exposing the
-/// material through request headers.
-#[derive(Clone)]
-pub struct RuntimeSecretMaterialStager {
-    secret_injection_store: Arc<RuntimeSecretInjectionStore>,
-}
-
-/// Alias for [`ironclaw_host_api::CredentialStageError`].
-pub type RuntimeSecretStageError = ironclaw_host_api::CredentialStageError;
-
-impl RuntimeSecretMaterialStager {
-    fn new(secret_injection_store: Arc<RuntimeSecretInjectionStore>) -> Self {
-        Self {
-            secret_injection_store,
-        }
-    }
-
-    pub async fn stage_secret_material_once(
-        &self,
-        target_scope: &ResourceScope,
-        capability_id: &CapabilityId,
-        handle: &SecretHandle,
-        material: SecretMaterial,
-    ) -> Result<(), RuntimeSecretStageError> {
-        self.secret_injection_store
-            .insert(target_scope, capability_id, handle, material)
-            .map_err(|_| RuntimeSecretStageError::Backend)
-    }
-}
-
-#[derive(Clone)]
-pub struct HostRuntimeHttpEgressPort {
-    runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
-    obligation_handler: Arc<dyn CapabilityObligationHandler>,
-    secret_stager: RuntimeSecretMaterialStager,
-}
-
-pub struct HostRuntimeHttpEgressRequest {
-    pub extension_id: ExtensionId,
-    pub trust: TrustClass,
-    pub request: RuntimeHttpEgressRequest,
-    pub credentials: Vec<HostRuntimeCredentialMaterial>,
-}
-
-pub struct HostRuntimeCredentialMaterial {
-    pub handle: SecretHandle,
-    pub material: SecretMaterial,
-    pub target: RuntimeCredentialTarget,
-    pub required: bool,
-}
-
-impl HostRuntimeHttpEgressPort {
-    fn new(
-        runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
-        obligation_handler: Arc<dyn CapabilityObligationHandler>,
-        secret_stager: RuntimeSecretMaterialStager,
-    ) -> Self {
-        Self {
-            runtime_http_egress,
-            obligation_handler,
-            secret_stager,
-        }
-    }
-
-    pub async fn execute(
-        &self,
-        mut request: HostRuntimeHttpEgressRequest,
-    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-        if !request.request.credential_injections.is_empty() {
-            return Err(RuntimeHttpEgressError::Credential {
-                reason: "host-mediated HTTP egress does not accept caller-provided credential injections"
-                    .to_string(),
-            });
-        }
-        self.authorize_network_egress(&request).await?;
-        self.stage_credentials(&mut request.request, request.credentials)
-            .await?;
-        self.runtime_http_egress.execute(request.request).await
-    }
-
-    async fn stage_credentials(
-        &self,
-        request: &mut RuntimeHttpEgressRequest,
-        credentials: Vec<HostRuntimeCredentialMaterial>,
-    ) -> Result<(), RuntimeHttpEgressError> {
-        for credential in credentials {
-            self.secret_stager
-                .stage_secret_material_once(
-                    &request.scope,
-                    &request.capability_id,
-                    &credential.handle,
-                    credential.material,
-                )
-                .await
-                .map_err(|_| RuntimeHttpEgressError::Credential {
-                    reason: "host credential material could not be staged".to_string(),
-                })?;
-            request
-                .credential_injections
-                .push(RuntimeCredentialInjection {
-                    handle: credential.handle,
-                    source: RuntimeCredentialSource::StagedObligation {
-                        capability_id: request.capability_id.clone(),
-                    },
-                    target: credential.target,
-                    required: credential.required,
-                });
-        }
-        Ok(())
-    }
-
-    async fn authorize_network_egress(
-        &self,
-        request: &HostRuntimeHttpEgressRequest,
-    ) -> Result<(), RuntimeHttpEgressError> {
-        let context = execution_context_for_host_http_egress(
-            &request.request.scope,
-            request.extension_id.clone(),
-            request.request.runtime,
-            request.trust,
-        )?;
-        let estimate = ResourceEstimate {
-            network_egress_bytes: request.request.network_policy.max_egress_bytes,
-            ..ResourceEstimate::default()
-        };
-        self.obligation_handler
-            .satisfy(CapabilityObligationRequest {
-                phase: CapabilityObligationPhase::Invoke,
-                context: &context,
-                capability_id: &request.request.capability_id,
-                estimate: &estimate,
-                obligations: &[Obligation::ApplyNetworkPolicy {
-                    policy: request.request.network_policy.clone(),
-                }],
-            })
-            .await
-            .map_err(|error| RuntimeHttpEgressError::Credential {
-                reason: format!("host network egress policy was not authorized: {error}"),
-            })
-    }
-}
-
-fn execution_context_for_host_http_egress(
-    scope: &ResourceScope,
-    extension_id: ExtensionId,
-    runtime: RuntimeKind,
-    trust: TrustClass,
-) -> Result<ExecutionContext, RuntimeHttpEgressError> {
-    let context = ExecutionContext {
-        invocation_id: scope.invocation_id,
-        correlation_id: ironclaw_host_api::CorrelationId::new(),
-        process_id: None,
-        parent_process_id: None,
-        tenant_id: scope.tenant_id.clone(),
-        user_id: scope.user_id.clone(),
-        agent_id: scope.agent_id.clone(),
-        project_id: scope.project_id.clone(),
-        mission_id: scope.mission_id.clone(),
-        thread_id: scope.thread_id.clone(),
-        extension_id,
-        runtime,
-        trust,
-        grants: CapabilitySet::default(),
-        mounts: MountView::default(),
-        resource_scope: scope.clone(),
-    };
-    context
-        .validate()
-        .map_err(|error| RuntimeHttpEgressError::Credential {
-            reason: format!("invalid host HTTP egress context: {error}"),
-        })?;
-    Ok(context)
-}
-
 /// Canonical host-runtime ports used by product-auth provider adapters.
 ///
 /// This intentionally exposes only the already-composed egress, obligation
@@ -360,8 +178,8 @@ pub struct ProductAuthProviderRuntimePorts {
     secret_injection_store: Arc<RuntimeSecretInjectionStore>,
 }
 
-/// The shared type lives in `ironclaw_host_api` so that per-extension staging
-/// traits can use it without a dependency on `ironclaw_host_runtime`.
+/// Alias for [`RuntimeSecretStageError`], which re-exports
+/// [`ironclaw_host_api::CredentialStageError`].
 pub type ProductAuthCredentialStageError = RuntimeSecretStageError;
 
 impl ProductAuthProviderRuntimePorts {

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -15,7 +15,9 @@ use ironclaw_approvals::ApprovalResolver;
 use ironclaw_authorization::{
     CapabilityLeaseStore, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
 };
-use ironclaw_capabilities::CapabilityObligationHandler;
+use ironclaw_capabilities::{
+    CapabilityObligationHandler, CapabilityObligationPhase, CapabilityObligationRequest,
+};
 use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
 };
@@ -30,8 +32,11 @@ use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{
-    CapabilityDispatcher, CapabilityId, DispatchError, ResourceReservationId, ResourceScope,
-    ResourceUsage, RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeKind, SecretHandle,
+    CapabilityDispatcher, CapabilityId, CapabilitySet, DispatchError, ExecutionContext,
+    ExtensionId, MountView, Obligation, ResourceEstimate, ResourceReservationId, ResourceScope,
+    ResourceUsage, RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeCredentialTarget,
+    RuntimeDispatchErrorKind, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+    RuntimeHttpEgressResponse, RuntimeKind, SecretHandle, TrustClass,
     runtime_policy::{
         DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind, NetworkMode,
         ProcessBackendKind, RuntimeProfile, SecretMode,
@@ -56,6 +61,7 @@ use ironclaw_run_state::{
     InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateApprovalStore, RunStateStore,
 };
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
+use ironclaw_secrets::SecretMaterial;
 use ironclaw_secrets::{
     CredentialAccountStore, CredentialSessionStore, InMemoryCredentialBroker, InMemorySecretStore,
     SecretStore, SecretStoreError,
@@ -164,6 +170,183 @@ where
     component_types: ProductionComponentTypes,
 }
 
+/// Canonical host-runtime one-shot secret material staging port.
+///
+/// This is for host-owned adapters that already hold trusted secret material
+/// and need the shared runtime HTTP egress to inject it without exposing the
+/// material through request headers.
+#[derive(Clone)]
+pub struct RuntimeSecretMaterialStager {
+    secret_injection_store: Arc<RuntimeSecretInjectionStore>,
+}
+
+/// Alias for [`ironclaw_host_api::CredentialStageError`].
+pub type RuntimeSecretStageError = ironclaw_host_api::CredentialStageError;
+
+impl RuntimeSecretMaterialStager {
+    fn new(secret_injection_store: Arc<RuntimeSecretInjectionStore>) -> Self {
+        Self {
+            secret_injection_store,
+        }
+    }
+
+    pub async fn stage_secret_material_once(
+        &self,
+        target_scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+        material: SecretMaterial,
+    ) -> Result<(), RuntimeSecretStageError> {
+        self.secret_injection_store
+            .insert(target_scope, capability_id, handle, material)
+            .map_err(|_| RuntimeSecretStageError::Backend)
+    }
+}
+
+#[derive(Clone)]
+pub struct HostRuntimeHttpEgressPort {
+    runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+    obligation_handler: Arc<dyn CapabilityObligationHandler>,
+    secret_stager: RuntimeSecretMaterialStager,
+}
+
+pub struct HostRuntimeHttpEgressRequest {
+    pub extension_id: ExtensionId,
+    pub trust: TrustClass,
+    pub request: RuntimeHttpEgressRequest,
+    pub credentials: Vec<HostRuntimeCredentialMaterial>,
+}
+
+pub struct HostRuntimeCredentialMaterial {
+    pub handle: SecretHandle,
+    pub material: SecretMaterial,
+    pub target: RuntimeCredentialTarget,
+    pub required: bool,
+}
+
+impl HostRuntimeHttpEgressPort {
+    fn new(
+        runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+        obligation_handler: Arc<dyn CapabilityObligationHandler>,
+        secret_stager: RuntimeSecretMaterialStager,
+    ) -> Self {
+        Self {
+            runtime_http_egress,
+            obligation_handler,
+            secret_stager,
+        }
+    }
+
+    pub async fn execute(
+        &self,
+        mut request: HostRuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        if !request.request.credential_injections.is_empty() {
+            return Err(RuntimeHttpEgressError::Credential {
+                reason: "host-mediated HTTP egress does not accept caller-provided credential injections"
+                    .to_string(),
+            });
+        }
+        self.authorize_network_egress(&request).await?;
+        self.stage_credentials(&mut request.request, request.credentials)
+            .await?;
+        self.runtime_http_egress.execute(request.request).await
+    }
+
+    async fn stage_credentials(
+        &self,
+        request: &mut RuntimeHttpEgressRequest,
+        credentials: Vec<HostRuntimeCredentialMaterial>,
+    ) -> Result<(), RuntimeHttpEgressError> {
+        for credential in credentials {
+            self.secret_stager
+                .stage_secret_material_once(
+                    &request.scope,
+                    &request.capability_id,
+                    &credential.handle,
+                    credential.material,
+                )
+                .await
+                .map_err(|_| RuntimeHttpEgressError::Credential {
+                    reason: "host credential material could not be staged".to_string(),
+                })?;
+            request
+                .credential_injections
+                .push(RuntimeCredentialInjection {
+                    handle: credential.handle,
+                    source: RuntimeCredentialSource::StagedObligation {
+                        capability_id: request.capability_id.clone(),
+                    },
+                    target: credential.target,
+                    required: credential.required,
+                });
+        }
+        Ok(())
+    }
+
+    async fn authorize_network_egress(
+        &self,
+        request: &HostRuntimeHttpEgressRequest,
+    ) -> Result<(), RuntimeHttpEgressError> {
+        let context = execution_context_for_host_http_egress(
+            &request.request.scope,
+            request.extension_id.clone(),
+            request.request.runtime,
+            request.trust,
+        )?;
+        let estimate = ResourceEstimate {
+            network_egress_bytes: request.request.network_policy.max_egress_bytes,
+            ..ResourceEstimate::default()
+        };
+        self.obligation_handler
+            .satisfy(CapabilityObligationRequest {
+                phase: CapabilityObligationPhase::Invoke,
+                context: &context,
+                capability_id: &request.request.capability_id,
+                estimate: &estimate,
+                obligations: &[Obligation::ApplyNetworkPolicy {
+                    policy: request.request.network_policy.clone(),
+                }],
+            })
+            .await
+            .map_err(|error| RuntimeHttpEgressError::Credential {
+                reason: format!("host network egress policy was not authorized: {error}"),
+            })
+    }
+}
+
+fn execution_context_for_host_http_egress(
+    scope: &ResourceScope,
+    extension_id: ExtensionId,
+    runtime: RuntimeKind,
+    trust: TrustClass,
+) -> Result<ExecutionContext, RuntimeHttpEgressError> {
+    let context = ExecutionContext {
+        invocation_id: scope.invocation_id,
+        correlation_id: ironclaw_host_api::CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: scope.mission_id.clone(),
+        thread_id: scope.thread_id.clone(),
+        extension_id,
+        runtime,
+        trust,
+        grants: CapabilitySet::default(),
+        mounts: MountView::default(),
+        resource_scope: scope.clone(),
+    };
+    context
+        .validate()
+        .map_err(|error| RuntimeHttpEgressError::Credential {
+            reason: format!("invalid host HTTP egress context: {error}"),
+        })?;
+    Ok(context)
+}
+
 /// Canonical host-runtime ports used by product-auth provider adapters.
 ///
 /// This intentionally exposes only the already-composed egress, obligation
@@ -177,11 +360,9 @@ pub struct ProductAuthProviderRuntimePorts {
     secret_injection_store: Arc<RuntimeSecretInjectionStore>,
 }
 
-/// Alias for [`ironclaw_host_api::CredentialStageError`].
-///
 /// The shared type lives in `ironclaw_host_api` so that per-extension staging
 /// traits can use it without a dependency on `ironclaw_host_runtime`.
-pub type ProductAuthCredentialStageError = ironclaw_host_api::CredentialStageError;
+pub type ProductAuthCredentialStageError = RuntimeSecretStageError;
 
 impl ProductAuthProviderRuntimePorts {
     fn new(
@@ -444,14 +625,39 @@ where
         Arc::clone(&self.registry)
     }
 
+    /// Returns the canonical host-runtime HTTP egress port when configured.
+    pub fn runtime_http_egress(&self) -> Option<Arc<dyn RuntimeHttpEgress>> {
+        runtime_http_egress(&self.runtime_http_egress)
+    }
+
+    /// Returns the canonical host-runtime obligation handler.
+    pub fn obligation_handler(&self) -> Arc<dyn CapabilityObligationHandler> {
+        Arc::new(self.builtin_obligation_handler())
+    }
+
+    /// Returns the canonical host-runtime one-shot secret material stager.
+    pub fn runtime_secret_material_stager(&self) -> RuntimeSecretMaterialStager {
+        RuntimeSecretMaterialStager::new(Arc::clone(&self.secret_injection_store))
+    }
+
+    /// Returns a host-mediated HTTP egress port that owns network-obligation
+    /// authorization and one-shot host-held credential staging.
+    pub fn host_runtime_http_egress_port(&self) -> Option<HostRuntimeHttpEgressPort> {
+        Some(HostRuntimeHttpEgressPort::new(
+            self.runtime_http_egress()?,
+            self.obligation_handler(),
+            self.runtime_secret_material_stager(),
+        ))
+    }
+
     /// Returns the canonical host-runtime egress/obligation ports for
     /// product-auth provider adapters.
     pub fn product_auth_provider_runtime_ports(&self) -> Option<ProductAuthProviderRuntimePorts> {
-        let runtime_http_egress = runtime_http_egress(&self.runtime_http_egress)?;
+        let runtime_http_egress = self.runtime_http_egress()?;
         let secret_store = self.secret_store.clone()?;
         Some(ProductAuthProviderRuntimePorts::new(
             runtime_http_egress,
-            Arc::new(self.builtin_obligation_handler()),
+            self.obligation_handler(),
             secret_store,
             Arc::clone(&self.secret_injection_store),
         ))

--- a/crates/ironclaw_host_runtime/src/services/tests.rs
+++ b/crates/ironclaw_host_runtime/src/services/tests.rs
@@ -24,6 +24,7 @@ use ironclaw_resources::{
 use ironclaw_secrets::{
     InMemorySecretStore, SecretLeaseId, SecretMaterial, SecretStore, SecretStoreError,
 };
+use secrecy::ExposeSecret;
 use serde_json::{Value, json};
 
 use super::{
@@ -139,6 +140,35 @@ async fn product_auth_ports_stage_secret_from_source_scope_into_target_scope() {
             .expect("source scope should remain readable")
             .is_none()
     );
+}
+
+#[tokio::test]
+async fn runtime_secret_material_stager_stages_secret_material_into_target_scope() {
+    let services = test_services()
+        .with_secret_store(Arc::new(InMemorySecretStore::new()))
+        .try_with_host_http_egress(RecordingNetwork::ok())
+        .expect("host HTTP egress should wire with graph secret store");
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    let handle = SecretHandle::new("config-secret").unwrap();
+
+    services
+        .runtime_secret_material_stager()
+        .stage_secret_material_once(
+            &scope,
+            &capability_id,
+            &handle,
+            SecretMaterial::from("config-secret-material"),
+        )
+        .await
+        .expect("runtime stager should stage provided secret material");
+
+    let staged = services
+        .secret_injection_store
+        .take(&scope, &capability_id, &handle)
+        .expect("staged secret should be readable for target scope")
+        .expect("provided material should be staged");
+    assert_eq!(staged.expose_secret(), "config-secret-material");
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
@@ -93,9 +93,13 @@ pub struct ApprovalInteractionScope {
 
 impl ApprovalInteractionScope {
     pub fn from_turn(scope: &TurnScope, actor: &TurnActor) -> Self {
+        let user_id = scope
+            .explicit_owner_user_id()
+            .cloned()
+            .unwrap_or_else(|| actor.user_id.clone());
         Self {
             tenant_id: scope.tenant_id.clone(),
-            user_id: actor.user_id.clone(),
+            user_id,
             agent_id: scope.agent_id.clone(),
             project_id: scope.project_id.clone(),
             thread_id: scope.thread_id.clone(),

--- a/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/approval_interaction/types.rs
@@ -276,11 +276,38 @@ fn display_safe_summary() -> String {
 #[cfg(test)]
 mod tests {
     use ironclaw_host_api::{
-        Action, ApprovalRequest, CapabilityId, CorrelationId, InvocationId, Principal,
-        ResourceEstimate, ThreadId, UserId,
+        Action, AgentId, ApprovalRequest, CapabilityId, CorrelationId, InvocationId, Principal,
+        ProjectId, ResourceEstimate, TenantId, ThreadId, UserId,
     };
 
     use super::*;
+
+    #[test]
+    fn approval_interaction_scope_from_turn_uses_scope_owner_over_actor() {
+        let actor = TurnActor::new(UserId::new("user:actor").unwrap());
+        let owner_user_id = UserId::new("user:subject").unwrap();
+        let thread_id = ThreadId::new("thread:shared").unwrap();
+        let scope = TurnScope::new_with_owner(
+            TenantId::new("tenant:shared").unwrap(),
+            Some(AgentId::new("agent:shared").unwrap()),
+            Some(ProjectId::new("project:shared").unwrap()),
+            thread_id.clone(),
+            Some(owner_user_id.clone()),
+        );
+
+        let interaction_scope = ApprovalInteractionScope::from_turn(&scope, &actor);
+
+        assert_eq!(interaction_scope.user_id, owner_user_id);
+        assert_eq!(interaction_scope.thread_id, thread_id);
+        assert_eq!(
+            interaction_scope.agent_id.as_ref().map(AgentId::as_str),
+            Some("agent:shared")
+        );
+        assert_eq!(
+            interaction_scope.project_id.as_ref().map(ProjectId::as_str),
+            Some("project:shared")
+        );
+    }
 
     #[test]
     fn approval_gate_record_with_status_rejects_scope_without_thread_id() {

--- a/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
@@ -88,9 +88,13 @@ pub struct AuthInteractionScope {
 
 impl AuthInteractionScope {
     pub fn from_turn(scope: &TurnScope, actor: &TurnActor) -> Self {
+        let user_id = scope
+            .explicit_owner_user_id()
+            .cloned()
+            .unwrap_or_else(|| actor.user_id.clone());
         Self {
             tenant_id: scope.tenant_id.clone(),
-            user_id: actor.user_id.clone(),
+            user_id,
             agent_id: scope.agent_id.clone(),
             project_id: scope.project_id.clone(),
             thread_id: scope.thread_id.clone(),

--- a/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/types.rs
@@ -351,3 +351,37 @@ pub(super) fn is_pending_auth_status(status: AuthFlowStatus) -> bool {
 fn display_safe_auth_summary() -> String {
     FALLBACK_AUTH_SUMMARY.to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+
+    use super::*;
+
+    #[test]
+    fn auth_interaction_scope_from_turn_uses_scope_owner_over_actor() {
+        let actor = TurnActor::new(UserId::new("user:actor").unwrap());
+        let owner_user_id = UserId::new("user:subject").unwrap();
+        let thread_id = ThreadId::new("thread:shared").unwrap();
+        let scope = TurnScope::new_with_owner(
+            TenantId::new("tenant:shared").unwrap(),
+            Some(AgentId::new("agent:shared").unwrap()),
+            Some(ProjectId::new("project:shared").unwrap()),
+            thread_id.clone(),
+            Some(owner_user_id.clone()),
+        );
+
+        let interaction_scope = AuthInteractionScope::from_turn(&scope, &actor);
+
+        assert_eq!(interaction_scope.user_id, owner_user_id);
+        assert_eq!(interaction_scope.thread_id, thread_id);
+        assert_eq!(
+            interaction_scope.agent_id.as_ref().map(AgentId::as_str),
+            Some("agent:shared")
+        );
+        assert_eq!(
+            interaction_scope.project_id.as_ref().map(ProjectId::as_str),
+            Some("project:shared")
+        );
+    }
+}

--- a/crates/ironclaw_product_workflow/src/binding.rs
+++ b/crates/ironclaw_product_workflow/src/binding.rs
@@ -107,18 +107,27 @@ impl ResolveBindingRequest {
     }
 }
 
-pub fn binding_creation_policy_for_trigger(
+pub fn binding_profile_for_trigger(
     trigger: ProductTriggerReason,
-) -> ProductConversationBindingCreationPolicy {
+) -> (
+    ProductConversationRouteKind,
+    ProductConversationBindingCreationPolicy,
+) {
     match trigger {
-        ProductTriggerReason::ReplyToBot | ProductTriggerReason::LinkedThreadAction => {
-            ProductConversationBindingCreationPolicy::ExistingOnly
-        }
-        ProductTriggerReason::DirectChat
-        | ProductTriggerReason::BotMention
-        | ProductTriggerReason::BotCommand => {
-            ProductConversationBindingCreationPolicy::CreateAllowed
-        }
+        ProductTriggerReason::DirectChat => (
+            ProductConversationRouteKind::Direct,
+            ProductConversationBindingCreationPolicy::CreateAllowed,
+        ),
+        ProductTriggerReason::BotMention | ProductTriggerReason::BotCommand => (
+            ProductConversationRouteKind::Shared,
+            ProductConversationBindingCreationPolicy::CreateAllowed,
+        ),
+        // Reply/action callbacks refer to a prior bot turn by definition, so
+        // they are shared routes that must already have a conversation binding.
+        ProductTriggerReason::ReplyToBot | ProductTriggerReason::LinkedThreadAction => (
+            ProductConversationRouteKind::Shared,
+            ProductConversationBindingCreationPolicy::ExistingOnly,
+        ),
     }
 }
 
@@ -147,13 +156,7 @@ pub fn route_kind_for_inbound_payload(
 }
 
 fn route_kind_for_trigger(trigger: ProductTriggerReason) -> ProductConversationRouteKind {
-    match trigger {
-        ProductTriggerReason::DirectChat => ProductConversationRouteKind::Direct,
-        ProductTriggerReason::BotMention
-        | ProductTriggerReason::ReplyToBot
-        | ProductTriggerReason::BotCommand
-        | ProductTriggerReason::LinkedThreadAction => ProductConversationRouteKind::Shared,
-    }
+    binding_profile_for_trigger(trigger).0
 }
 
 /// Conversation binding resolution contract. Host implementations wire this to

--- a/crates/ironclaw_product_workflow/src/binding.rs
+++ b/crates/ironclaw_product_workflow/src/binding.rs
@@ -21,6 +21,7 @@ use crate::error::ProductWorkflowError;
 pub struct ResolvedBinding {
     pub tenant_id: TenantId,
     /// Real paired human actor who sent or authorized the external action.
+    #[serde(alias = "user_id")]
     pub actor_user_id: UserId,
     /// User scope whose agent/context/tools/memory execute the turn.
     ///
@@ -36,6 +37,30 @@ pub struct ResolvedBinding {
     /// user-scoped must be completed before entering `InboundTurnService`.
     pub agent_id: Option<AgentId>,
     pub project_id: Option<ProjectId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_binding_accepts_legacy_user_id_actor_field() {
+        let binding: ResolvedBinding = serde_json::from_value(serde_json::json!({
+            "tenant_id": "tenant:legacy",
+            "user_id": "user:legacy-actor",
+            "subject_user_id": "user:legacy-subject",
+            "thread_id": "thread:legacy",
+            "agent_id": "agent:legacy",
+            "project_id": "project:legacy"
+        }))
+        .expect("legacy binding should deserialize");
+
+        assert_eq!(binding.actor_user_id.as_str(), "user:legacy-actor");
+        assert_eq!(
+            binding.subject_user_id.as_ref().map(UserId::as_str),
+            Some("user:legacy-subject")
+        );
+    }
 }
 
 /// Request to resolve external adapter refs into canonical Reborn bindings.

--- a/crates/ironclaw_product_workflow/src/binding.rs
+++ b/crates/ironclaw_product_workflow/src/binding.rs
@@ -20,7 +20,16 @@ use crate::error::ProductWorkflowError;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResolvedBinding {
     pub tenant_id: TenantId,
-    pub user_id: UserId,
+    /// Real paired human actor who sent or authorized the external action.
+    pub actor_user_id: UserId,
+    /// User scope whose agent/context/tools/memory execute the turn.
+    ///
+    /// Direct/personal routes set this to the actor. Shared routes set this to
+    /// the configured team/agent subject when one exists; legacy shared routes
+    /// without an explicit subject remain ownerless until their host route is
+    /// configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_user_id: Option<UserId>,
     pub thread_id: ThreadId,
     /// Required for user-message turn submission because Reborn `ThreadScope`
     /// and `TurnScope` are agent-scoped. Product bindings that are only
@@ -51,6 +60,14 @@ pub enum ProductConversationRouteKind {
     Shared,
 }
 
+/// Whether an inbound user message may create a new product conversation
+/// binding, or must target a conversation that the product has already linked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProductConversationBindingCreationPolicy {
+    CreateAllowed,
+    ExistingOnly,
+}
+
 impl ResolveBindingRequest {
     pub fn from_envelope(envelope: &ProductInboundEnvelope) -> Self {
         Self {
@@ -61,6 +78,21 @@ impl ResolveBindingRequest {
             external_event_id: envelope.external_event_id().clone(),
             route_kind: route_kind_for_inbound_payload(envelope.payload()),
             auth_claim: envelope.auth_claim().clone(),
+        }
+    }
+}
+
+pub fn binding_creation_policy_for_trigger(
+    trigger: ProductTriggerReason,
+) -> ProductConversationBindingCreationPolicy {
+    match trigger {
+        ProductTriggerReason::ReplyToBot | ProductTriggerReason::LinkedThreadAction => {
+            ProductConversationBindingCreationPolicy::ExistingOnly
+        }
+        ProductTriggerReason::DirectChat
+        | ProductTriggerReason::BotMention
+        | ProductTriggerReason::BotCommand => {
+            ProductConversationBindingCreationPolicy::CreateAllowed
         }
     }
 }

--- a/crates/ironclaw_product_workflow/src/conversation_binding.rs
+++ b/crates/ironclaw_product_workflow/src/conversation_binding.rs
@@ -121,6 +121,7 @@ pub struct ProductInstallationScope {
     pub tenant_id: TenantId,
     pub default_agent_id: Option<AgentId>,
     pub default_project_id: Option<ProjectId>,
+    pub default_subject_user_id: Option<UserId>,
     pub actor_binding_policy: ProductActorBindingPolicy,
 }
 
@@ -130,6 +131,7 @@ impl ProductInstallationScope {
             tenant_id,
             default_agent_id: None,
             default_project_id: None,
+            default_subject_user_id: None,
             actor_binding_policy: ProductActorBindingPolicy::default(),
         }
     }
@@ -143,8 +145,14 @@ impl ProductInstallationScope {
             tenant_id,
             default_agent_id: Some(default_agent_id),
             default_project_id,
+            default_subject_user_id: None,
             actor_binding_policy: ProductActorBindingPolicy::default(),
         }
+    }
+
+    pub fn with_default_subject_user_id(mut self, subject_user_id: UserId) -> Self {
+        self.default_subject_user_id = Some(subject_user_id);
+        self
     }
 
     pub fn with_actor_binding_policy(mut self, policy: ProductActorBindingPolicy) -> Self {
@@ -390,7 +398,11 @@ impl ConversationBindingService for ProductConversationBindingService {
             .map_err(map_conversation_error)?;
         ensure_resolved_actor_matches_expected_user(expected_user_id.as_ref(), &resolution)?;
 
-        Ok(resolved_binding_from_resolution(resolution))
+        Ok(resolved_binding_from_resolution(
+            resolution,
+            request.route_kind,
+            installation_scope.default_subject_user_id.as_ref(),
+        ))
     }
 
     async fn lookup_binding(
@@ -411,16 +423,28 @@ impl ConversationBindingService for ProductConversationBindingService {
             .map_err(map_conversation_error)?;
         ensure_resolved_actor_matches_expected_user(expected_user_id.as_ref(), &resolution)?;
 
-        Ok(resolved_binding_from_resolution(resolution))
+        Ok(resolved_binding_from_resolution(
+            resolution,
+            request.route_kind,
+            installation_scope.default_subject_user_id.as_ref(),
+        ))
     }
 }
 
 fn resolved_binding_from_resolution(
     resolution: ironclaw_conversations::ConversationBindingResolution,
+    route_kind: ProductConversationRouteKind,
+    configured_subject_user_id: Option<&UserId>,
 ) -> ResolvedBinding {
+    let actor_user_id = resolution.actor.user_id;
+    let subject_user_id = match route_kind {
+        ProductConversationRouteKind::Direct => Some(actor_user_id.clone()),
+        ProductConversationRouteKind::Shared => configured_subject_user_id.cloned(),
+    };
     ResolvedBinding {
         tenant_id: resolution.tenant_id,
-        user_id: resolution.actor.user_id,
+        actor_user_id,
+        subject_user_id,
         thread_id: resolution.turn_scope.thread_id,
         agent_id: resolution.turn_scope.agent_id,
         project_id: resolution.turn_scope.project_id,

--- a/crates/ironclaw_product_workflow/src/fakes.rs
+++ b/crates/ironclaw_product_workflow/src/fakes.rs
@@ -130,11 +130,17 @@ impl FakeConversationBindingService {
                 .map_err(|e| ProductWorkflowError::BindingResolutionFailed {
                     reason: e.to_string(),
                 })?,
-            user_id: UserId::new(format!("user:{}", request.external_actor_ref.id())).map_err(
-                |e| ProductWorkflowError::BindingResolutionFailed {
+            actor_user_id: UserId::new(format!("user:{}", request.external_actor_ref.id()))
+                .map_err(|e| ProductWorkflowError::BindingResolutionFailed {
                     reason: e.to_string(),
-                },
-            )?,
+                })?,
+            subject_user_id: Some(
+                UserId::new(format!("user:{}", request.external_actor_ref.id())).map_err(|e| {
+                    ProductWorkflowError::BindingResolutionFailed {
+                        reason: e.to_string(),
+                    }
+                })?,
+            ),
             thread_id: ThreadId::new(format!(
                 "thread:{}:{}",
                 request.installation_id.as_str(),
@@ -580,11 +586,16 @@ impl FakeInboundTurnService {
                     reason: e.to_string(),
                 }
             })?,
-            user_id: UserId::new("user:fake").map_err(|e| {
+            actor_user_id: UserId::new("user:fake").map_err(|e| {
                 ProductWorkflowError::BindingResolutionFailed {
                     reason: e.to_string(),
                 }
             })?,
+            subject_user_id: Some(UserId::new("user:fake").map_err(|e| {
+                ProductWorkflowError::BindingResolutionFailed {
+                    reason: e.to_string(),
+                }
+            })?),
             thread_id: ThreadId::new("thread:fake").map_err(|e| {
                 ProductWorkflowError::BindingResolutionFailed {
                     reason: e.to_string(),

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -651,14 +651,18 @@ fn accepted_message_ref(
 fn binding_from_replay(
     replay: &AcceptedInboundMessageReplay,
 ) -> Result<ResolvedBinding, ProductWorkflowError> {
-    let actor_user_id = UserId::new(replay.actor_id.as_deref().ok_or_else(|| {
-        ProductWorkflowError::BindingResolutionFailed {
-            reason: "accepted replay missing actor user id".into(),
+    let actor_user_id = match replay.actor_id.as_deref() {
+        Some(actor_id) => {
+            UserId::new(actor_id).map_err(|e| ProductWorkflowError::BindingResolutionFailed {
+                reason: format!("invalid replay actor user id: {e}"),
+            })?
         }
-    })?)
-    .map_err(|e| ProductWorkflowError::BindingResolutionFailed {
-        reason: format!("invalid replay actor user id: {e}"),
-    })?;
+        None => replay.scope.owner_user_id.clone().ok_or_else(|| {
+            ProductWorkflowError::BindingResolutionFailed {
+                reason: "accepted replay missing actor user id and owner user id".into(),
+            }
+        })?,
+    };
     Ok(ResolvedBinding {
         tenant_id: replay.scope.tenant_id.clone(),
         actor_user_id,
@@ -838,6 +842,31 @@ mod tests {
         assert_eq!(submission.message_id, message_id);
         assert_eq!(submission.source_binding_id, "src:alpha");
         assert_eq!(submission.reply_target_binding_id, "reply:alpha");
+    }
+
+    #[test]
+    fn legacy_replay_without_actor_id_uses_owner_as_actor() {
+        let message_id = ThreadMessageId::new();
+        let mut replay = replay(
+            message_id,
+            MessageStatus::DeferredBusy,
+            Some("src:alpha"),
+            Some("reply:alpha"),
+            None,
+        );
+        replay.actor_id = None;
+
+        let handoff =
+            ProductInboundTurnHandoff::from_replay(replay, "turn-key".to_string(), received_at())
+                .expect("legacy replay handoff");
+
+        let ProductInboundTurnHandoff::NeedsSubmission(submission) = handoff else {
+            panic!("expected legacy replay to require a new turn submission")
+        };
+
+        assert_eq!(submission.binding.actor_user_id, user_id());
+        assert_eq!(submission.binding.subject_user_id, Some(user_id()));
+        assert_eq!(submission.message_id, message_id);
     }
 
     fn policy_request() -> BeforeInboundPolicyRequest {

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -26,9 +26,8 @@ use ironclaw_turns::{
 use uuid::Uuid;
 
 use crate::binding::{
-    ConversationBindingService, ProductConversationBindingCreationPolicy,
-    ProductConversationRouteKind, ResolveBindingRequest, ResolvedBinding,
-    binding_creation_policy_for_trigger,
+    ConversationBindingService, ProductConversationBindingCreationPolicy, ResolveBindingRequest,
+    ResolvedBinding, binding_profile_for_trigger,
 };
 use crate::binding_ref::{
     DEFAULT_BINDING_REF_RAW_MAX_BYTES, bounded_idempotency_key, bounded_reply_target_binding_ref,
@@ -276,16 +275,17 @@ where
                 kind: "non_user_message".into(),
             });
         };
+        let (route_kind, creation_policy) = binding_profile_for_trigger(payload.trigger);
         let binding_request = ResolveBindingRequest {
             adapter_id: envelope.adapter_id().clone(),
             installation_id: envelope.installation_id().clone(),
             external_actor_ref: envelope.external_actor_ref().clone(),
             external_conversation_ref: envelope.external_conversation_ref().clone(),
             external_event_id: envelope.external_event_id().clone(),
-            route_kind: route_kind_for_user_message(payload.trigger),
+            route_kind,
             auth_claim: envelope.auth_claim().clone(),
         };
-        let binding = match binding_creation_policy_for_trigger(payload.trigger) {
+        let binding = match creation_policy {
             ProductConversationBindingCreationPolicy::CreateAllowed => {
                 self.binding_service
                     .resolve_binding(binding_request)
@@ -333,6 +333,7 @@ where
             replay,
             prepared.submit_idempotency_key.clone(),
             envelope.received_at(),
+            Some(prepared),
         )
         .await
         .map(Some)
@@ -392,36 +393,26 @@ where
     }
 }
 
-fn route_kind_for_user_message(
-    trigger: ironclaw_product_adapters::ProductTriggerReason,
-) -> ProductConversationRouteKind {
-    match trigger {
-        ironclaw_product_adapters::ProductTriggerReason::DirectChat => {
-            ProductConversationRouteKind::Direct
-        }
-        ironclaw_product_adapters::ProductTriggerReason::BotMention
-        | ironclaw_product_adapters::ProductTriggerReason::ReplyToBot
-        | ironclaw_product_adapters::ProductTriggerReason::BotCommand
-        | ironclaw_product_adapters::ProductTriggerReason::LinkedThreadAction => {
-            ProductConversationRouteKind::Shared
-        }
-    }
-}
-
 async fn submit_or_replay_accepted_message<T, C>(
     thread_service: &T,
     turn_coordinator: &C,
     replay: AcceptedInboundMessageReplay,
     submit_idempotency_key: String,
     received_at: DateTime<Utc>,
+    prepared: Option<&PreparedUserMessage>,
 ) -> Result<InboundTurnOutcome, ProductWorkflowError>
 where
     T: SessionThreadService,
     C: TurnCoordinator,
 {
-    ProductInboundTurnHandoff::from_replay(replay, submit_idempotency_key, received_at)?
-        .submit_or_replay(thread_service, turn_coordinator)
-        .await
+    ProductInboundTurnHandoff::from_replay_with_prepared(
+        replay,
+        submit_idempotency_key,
+        received_at,
+        prepared,
+    )?
+    .submit_or_replay(thread_service, turn_coordinator)
+    .await
 }
 
 enum ProductInboundTurnHandoff {
@@ -434,12 +425,25 @@ enum ProductInboundTurnHandoff {
 }
 
 impl ProductInboundTurnHandoff {
+    #[cfg(test)]
     fn from_replay(
         replay: AcceptedInboundMessageReplay,
         submit_idempotency_key: String,
         received_at: DateTime<Utc>,
     ) -> Result<Self, ProductWorkflowError> {
-        let binding = binding_from_replay(&replay)?;
+        Self::from_replay_with_prepared(replay, submit_idempotency_key, received_at, None)
+    }
+
+    fn from_replay_with_prepared(
+        replay: AcceptedInboundMessageReplay,
+        submit_idempotency_key: String,
+        received_at: DateTime<Utc>,
+        prepared: Option<&PreparedUserMessage>,
+    ) -> Result<Self, ProductWorkflowError> {
+        let (binding, thread_scope) = match prepared {
+            Some(prepared) => (prepared.binding.clone(), prepared.thread_scope.clone()),
+            None => (binding_from_replay(&replay)?, replay.scope.clone()),
+        };
         let accepted_message_ref = accepted_message_ref(replay.message_id)?;
 
         if replay.status == MessageStatus::Submitted {
@@ -485,7 +489,7 @@ impl ProductInboundTurnHandoff {
 
         Ok(Self::NeedsSubmission(AcceptedProductInboundTurn {
             binding,
-            thread_scope: replay.scope,
+            thread_scope,
             message_id: replay.message_id,
             source_binding_id,
             reply_target_binding_id,
@@ -866,6 +870,58 @@ mod tests {
 
         assert_eq!(submission.binding.actor_user_id, user_id());
         assert_eq!(submission.binding.subject_user_id, Some(user_id()));
+        assert_eq!(submission.message_id, message_id);
+    }
+
+    #[test]
+    fn prepared_replay_uses_fresh_binding_scope_over_persisted_scope() {
+        let message_id = ThreadMessageId::new();
+        let mut replay = replay(
+            message_id,
+            MessageStatus::DeferredBusy,
+            Some("src:alpha"),
+            Some("reply:alpha"),
+            None,
+        );
+        replay.scope.owner_user_id = None;
+        let subject_user_id = UserId::new("user:team-subject").unwrap();
+        let prepared = PreparedUserMessage {
+            binding: ResolvedBinding {
+                tenant_id: tenant_id(),
+                actor_user_id: user_id(),
+                subject_user_id: Some(subject_user_id.clone()),
+                thread_id: thread_id(),
+                agent_id: Some(AgentId::new("agent:alpha").unwrap()),
+                project_id: None,
+            },
+            thread_scope: ThreadScope {
+                tenant_id: tenant_id(),
+                agent_id: AgentId::new("agent:alpha").unwrap(),
+                project_id: None,
+                owner_user_id: Some(subject_user_id.clone()),
+                mission_id: None,
+            },
+            source_binding_id: "src:alpha".to_string(),
+            submit_idempotency_key: "turn-key".to_string(),
+        };
+
+        let handoff = ProductInboundTurnHandoff::from_replay_with_prepared(
+            replay,
+            "turn-key".to_string(),
+            received_at(),
+            Some(&prepared),
+        )
+        .expect("prepared replay handoff");
+
+        let ProductInboundTurnHandoff::NeedsSubmission(submission) = handoff else {
+            panic!("expected prepared replay to require a new turn submission")
+        };
+
+        assert_eq!(
+            submission.binding.subject_user_id,
+            Some(subject_user_id.clone())
+        );
+        assert_eq!(submission.thread_scope.owner_user_id, Some(subject_user_id));
         assert_eq!(submission.message_id, message_id);
     }
 

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+#[cfg(test)]
 use ironclaw_host_api::UserId;
 use ironclaw_product_adapters::{
     ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload, ProductRejection,
@@ -333,7 +334,7 @@ where
             replay,
             prepared.submit_idempotency_key.clone(),
             envelope.received_at(),
-            Some(prepared),
+            prepared,
         )
         .await
         .map(Some)
@@ -399,7 +400,7 @@ async fn submit_or_replay_accepted_message<T, C>(
     replay: AcceptedInboundMessageReplay,
     submit_idempotency_key: String,
     received_at: DateTime<Utc>,
-    prepared: Option<&PreparedUserMessage>,
+    prepared: &PreparedUserMessage,
 ) -> Result<InboundTurnOutcome, ProductWorkflowError>
 where
     T: SessionThreadService,
@@ -431,19 +432,39 @@ impl ProductInboundTurnHandoff {
         submit_idempotency_key: String,
         received_at: DateTime<Utc>,
     ) -> Result<Self, ProductWorkflowError> {
-        Self::from_replay_with_prepared(replay, submit_idempotency_key, received_at, None)
+        let binding = binding_from_replay(&replay)?;
+        let thread_scope = replay.scope.clone();
+        Self::from_replay_parts(
+            replay,
+            submit_idempotency_key,
+            received_at,
+            binding,
+            thread_scope,
+        )
     }
 
     fn from_replay_with_prepared(
         replay: AcceptedInboundMessageReplay,
         submit_idempotency_key: String,
         received_at: DateTime<Utc>,
-        prepared: Option<&PreparedUserMessage>,
+        prepared: &PreparedUserMessage,
     ) -> Result<Self, ProductWorkflowError> {
-        let (binding, thread_scope) = match prepared {
-            Some(prepared) => (prepared.binding.clone(), prepared.thread_scope.clone()),
-            None => (binding_from_replay(&replay)?, replay.scope.clone()),
-        };
+        Self::from_replay_parts(
+            replay,
+            submit_idempotency_key,
+            received_at,
+            prepared.binding.clone(),
+            prepared.thread_scope.clone(),
+        )
+    }
+
+    fn from_replay_parts(
+        replay: AcceptedInboundMessageReplay,
+        submit_idempotency_key: String,
+        received_at: DateTime<Utc>,
+        binding: ResolvedBinding,
+        thread_scope: ThreadScope,
+    ) -> Result<Self, ProductWorkflowError> {
         let accepted_message_ref = accepted_message_ref(replay.message_id)?;
 
         if replay.status == MessageStatus::Submitted {
@@ -652,6 +673,7 @@ fn accepted_message_ref(
     })
 }
 
+#[cfg(test)]
 fn binding_from_replay(
     replay: &AcceptedInboundMessageReplay,
 ) -> Result<ResolvedBinding, ProductWorkflowError> {
@@ -909,7 +931,7 @@ mod tests {
             replay,
             "turn-key".to_string(),
             received_at(),
-            Some(&prepared),
+            &prepared,
         )
         .expect("prepared replay handoff");
 

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -26,8 +26,9 @@ use ironclaw_turns::{
 use uuid::Uuid;
 
 use crate::binding::{
-    ConversationBindingService, ProductConversationRouteKind, ResolveBindingRequest,
-    ResolvedBinding,
+    ConversationBindingService, ProductConversationBindingCreationPolicy,
+    ProductConversationRouteKind, ResolveBindingRequest, ResolvedBinding,
+    binding_creation_policy_for_trigger,
 };
 use crate::binding_ref::{
     DEFAULT_BINDING_REF_RAW_MAX_BYTES, bounded_idempotency_key, bounded_reply_target_binding_ref,
@@ -275,22 +276,28 @@ where
                 kind: "non_user_message".into(),
             });
         };
-        let route_kind = route_kind_for_user_message(payload.trigger);
-        let binding = self
-            .binding_service
-            .resolve_binding(ResolveBindingRequest {
-                adapter_id: envelope.adapter_id().clone(),
-                installation_id: envelope.installation_id().clone(),
-                external_actor_ref: envelope.external_actor_ref().clone(),
-                external_conversation_ref: envelope.external_conversation_ref().clone(),
-                external_event_id: envelope.external_event_id().clone(),
-                route_kind,
-                auth_claim: envelope.auth_claim().clone(),
-            })
-            .await?;
+        let binding_request = ResolveBindingRequest {
+            adapter_id: envelope.adapter_id().clone(),
+            installation_id: envelope.installation_id().clone(),
+            external_actor_ref: envelope.external_actor_ref().clone(),
+            external_conversation_ref: envelope.external_conversation_ref().clone(),
+            external_event_id: envelope.external_event_id().clone(),
+            route_kind: route_kind_for_user_message(payload.trigger),
+            auth_claim: envelope.auth_claim().clone(),
+        };
+        let binding = match binding_creation_policy_for_trigger(payload.trigger) {
+            ProductConversationBindingCreationPolicy::CreateAllowed => {
+                self.binding_service
+                    .resolve_binding(binding_request)
+                    .await?
+            }
+            ProductConversationBindingCreationPolicy::ExistingOnly => {
+                self.binding_service.lookup_binding(binding_request).await?
+            }
+        };
         let source_binding_id = product_source_binding_id(envelope, &binding);
         let submit_idempotency_key = submit_idempotency_key(envelope, &binding);
-        let thread_scope = thread_scope_from_binding(&binding, route_kind)?;
+        let thread_scope = thread_scope_from_binding(&binding)?;
         Ok(PreparedUserMessage {
             binding,
             thread_scope,
@@ -308,7 +315,7 @@ where
             .thread_service
             .replay_accepted_inbound_message(ReplayAcceptedInboundMessageRequest {
                 scope: prepared.thread_scope.clone(),
-                actor_id: prepared.binding.user_id.as_str().to_string(),
+                actor_id: prepared.binding.actor_user_id.as_str().to_string(),
                 source_binding_id: prepared.source_binding_id.clone(),
                 external_event_id: envelope.external_event_id().as_str().to_string(),
             })
@@ -345,7 +352,7 @@ where
             .ensure_thread(EnsureThreadRequest {
                 scope: prepared.thread_scope.clone(),
                 thread_id: Some(prepared.binding.thread_id.clone()),
-                created_by_actor_id: prepared.binding.user_id.as_str().to_string(),
+                created_by_actor_id: prepared.binding.actor_user_id.as_str().to_string(),
                 title: None,
                 metadata_json: None,
             })
@@ -360,7 +367,7 @@ where
             .accept_inbound_message(AcceptInboundMessageRequest {
                 scope: prepared.thread_scope.clone(),
                 thread_id: prepared.binding.thread_id.clone(),
-                actor_id: prepared.binding.user_id.as_str().to_string(),
+                actor_id: prepared.binding.actor_user_id.as_str().to_string(),
                 source_binding_id: Some(prepared.source_binding_id.clone()),
                 reply_target_binding_id: Some(reply_target_binding_id.clone()),
                 external_event_id: Some(envelope.external_event_id().as_str().to_string()),
@@ -542,13 +549,14 @@ impl AcceptedProductInboundTurn {
             idempotency_key_raw,
             received_at,
         } = self;
-        let turn_scope = TurnScope::new(
+        let turn_scope = TurnScope::new_with_owner(
             binding.tenant_id.clone(),
             binding.agent_id.clone(),
             binding.project_id.clone(),
             binding.thread_id.clone(),
+            thread_scope.owner_user_id.clone(),
         );
-        let actor = TurnActor::new(binding.user_id.clone());
+        let actor = TurnActor::new(binding.actor_user_id.clone());
         let source_binding_ref = bounded_source_binding_ref(
             "src",
             &source_binding_id,
@@ -643,20 +651,18 @@ fn accepted_message_ref(
 fn binding_from_replay(
     replay: &AcceptedInboundMessageReplay,
 ) -> Result<ResolvedBinding, ProductWorkflowError> {
-    let user_id = match replay.scope.owner_user_id.clone() {
-        Some(user_id) => user_id,
-        None => UserId::new(replay.actor_id.as_deref().ok_or_else(|| {
-            ProductWorkflowError::BindingResolutionFailed {
-                reason: "accepted replay missing user id".into(),
-            }
-        })?)
-        .map_err(|e| ProductWorkflowError::BindingResolutionFailed {
-            reason: format!("invalid replay user id: {e}"),
-        })?,
-    };
+    let actor_user_id = UserId::new(replay.actor_id.as_deref().ok_or_else(|| {
+        ProductWorkflowError::BindingResolutionFailed {
+            reason: "accepted replay missing actor user id".into(),
+        }
+    })?)
+    .map_err(|e| ProductWorkflowError::BindingResolutionFailed {
+        reason: format!("invalid replay actor user id: {e}"),
+    })?;
     Ok(ResolvedBinding {
         tenant_id: replay.scope.tenant_id.clone(),
-        user_id,
+        actor_user_id,
+        subject_user_id: replay.scope.owner_user_id.clone(),
         thread_id: replay.thread_id.clone(),
         agent_id: Some(replay.scope.agent_id.clone()),
         project_id: replay.scope.project_id.clone(),
@@ -665,22 +671,17 @@ fn binding_from_replay(
 
 fn thread_scope_from_binding(
     binding: &ResolvedBinding,
-    route_kind: ProductConversationRouteKind,
 ) -> Result<ThreadScope, ProductWorkflowError> {
     let Some(agent_id) = binding.agent_id.clone() else {
         return Err(ProductWorkflowError::BindingResolutionFailed {
             reason: "resolved binding missing agent_id required for thread scope".into(),
         });
     };
-    let owner_user_id = match route_kind {
-        ProductConversationRouteKind::Direct => Some(binding.user_id.clone()),
-        ProductConversationRouteKind::Shared => None,
-    };
     Ok(ThreadScope {
         tenant_id: binding.tenant_id.clone(),
         agent_id,
         project_id: binding.project_id.clone(),
-        owner_user_id,
+        owner_user_id: binding.subject_user_id.clone(),
         mission_id: None,
     })
 }
@@ -879,7 +880,7 @@ mod tests {
             message_id,
             sequence: 1,
             status,
-            actor_id: None,
+            actor_id: Some(user_id().as_str().to_string()),
             source_binding_id: source_binding_id.map(str::to_string),
             reply_target_binding_id: reply_target_binding_id.map(str::to_string),
             turn_run_id,

--- a/crates/ironclaw_product_workflow/src/webui_inbound.rs
+++ b/crates/ironclaw_product_workflow/src/webui_inbound.rs
@@ -51,11 +51,12 @@ impl WebUiAuthenticatedCaller {
     }
 
     pub fn turn_scope(&self, thread_id: ThreadId) -> TurnScope {
-        TurnScope::new(
+        TurnScope::new_with_owner(
             self.tenant_id.clone(),
             self.agent_id.clone(),
             self.project_id.clone(),
             thread_id,
+            Some(self.user_id.clone()),
         )
     }
 }

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_auth::{AuthFlowId, CredentialAccountId};
+use ironclaw_host_api::ThreadId;
 use ironclaw_product_adapters::{
     ApprovalDecision, ProductAdapterError, ProductInboundAck, ProductInboundEnvelope,
     ProductInboundPayload, ProductRejection, ProductRejectionKind, ProductWorkflow,
@@ -245,13 +246,8 @@ impl ProductWorkflow for DefaultProductWorkflow {
             projection_thread_id_from_binding(&binding, payload.thread_id_hint.as_deref())?;
 
         Ok(ProjectionSubscriptionRequest {
-            actor: TurnActor::new(binding.user_id.clone()),
-            scope: TurnScope::new(
-                binding.tenant_id.clone(),
-                binding.agent_id.clone(),
-                binding.project_id.clone(),
-                thread_id,
-            ),
+            actor: TurnActor::new(binding.actor_user_id.clone()),
+            scope: turn_scope_for_thread(&binding, thread_id),
             after_cursor: payload.after_cursor.clone(),
         })
     }
@@ -416,7 +412,7 @@ async fn dispatch_approval_resolution(
         .lookup_binding(resolve_binding_request(envelope))
         .await?;
     let scope = turn_scope_from_binding(&binding);
-    let actor = TurnActor::new(binding.user_id.clone());
+    let actor = TurnActor::new(binding.actor_user_id.clone());
     let gate_ref = GateRef::new(payload.gate_ref.clone()).map_err(|_| {
         ProductWorkflowError::ApprovalInteractionRejected {
             kind: ApprovalInteractionRejectionKind::InvalidGateRef,
@@ -455,7 +451,7 @@ async fn dispatch_scoped_approval_resolution(
         .lookup_binding(resolve_binding_request(envelope))
         .await?;
     let scope = turn_scope_from_binding(&binding);
-    let actor = TurnActor::new(binding.user_id.clone());
+    let actor = TurnActor::new(binding.actor_user_id.clone());
     let pending = approval_interaction_service
         .list_pending(ListPendingApprovalsRequest {
             scope: scope.clone(),
@@ -533,7 +529,7 @@ async fn dispatch_auth_resolution(
         .lookup_binding(resolve_binding_request(envelope))
         .await?;
     let scope = turn_scope_from_binding(&binding);
-    let actor = TurnActor::new(binding.user_id.clone());
+    let actor = TurnActor::new(binding.actor_user_id.clone());
     let gate_ref = GateRef::new(payload.auth_request_ref.clone()).map_err(|_| {
         ProductWorkflowError::AuthInteractionRejected {
             kind: AuthInteractionRejectionKind::InvalidGateRef,
@@ -672,11 +668,16 @@ fn interaction_resolution_idempotency_key(
 }
 
 fn turn_scope_from_binding(binding: &ResolvedBinding) -> TurnScope {
-    TurnScope::new(
+    turn_scope_for_thread(binding, binding.thread_id.clone())
+}
+
+fn turn_scope_for_thread(binding: &ResolvedBinding, thread_id: ThreadId) -> TurnScope {
+    TurnScope::new_with_owner(
         binding.tenant_id.clone(),
         binding.agent_id.clone(),
         binding.project_id.clone(),
-        binding.thread_id.clone(),
+        thread_id,
+        binding.subject_user_id.clone(),
     )
 }
 

--- a/crates/ironclaw_product_workflow/tests/inbound_turn_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/inbound_turn_contract.rs
@@ -61,7 +61,7 @@ fn sample_user_message_envelope(event_suffix: &str) -> ProductInboundEnvelope {
     sample_user_message_envelope_with_install_and_text(event_suffix, "install_alpha", "hello world")
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct CapturingTurnCoordinator {
     last_submit: Arc<Mutex<Option<SubmitTurnRequest>>>,
 }
@@ -407,13 +407,25 @@ fn test_safety_context() -> InstructionSafetyContext {
 }
 
 fn binding_with_user(user: &str, thread: &str) -> ironclaw_product_workflow::ResolvedBinding {
+    let user_id = UserId::new(user).expect("valid user");
     ironclaw_product_workflow::ResolvedBinding {
         tenant_id: TenantId::new("tenant:install_alpha").expect("valid tenant"),
-        user_id: UserId::new(user).expect("valid user"),
+        actor_user_id: user_id.clone(),
+        subject_user_id: Some(user_id),
         thread_id: ThreadId::new(thread).expect("valid thread"),
         agent_id: Some(AgentId::new("agent:fake").expect("valid agent")),
         project_id: None,
     }
+}
+
+fn turn_scope_for_binding(binding: &ironclaw_product_workflow::ResolvedBinding) -> TurnScope {
+    TurnScope::new_with_owner(
+        binding.tenant_id.clone(),
+        binding.agent_id.clone(),
+        binding.project_id.clone(),
+        binding.thread_id.clone(),
+        binding.subject_user_id.clone(),
+    )
 }
 
 fn sample_user_message_envelope_with_text(
@@ -427,6 +439,20 @@ fn sample_user_message_envelope_with_install_and_text(
     event_suffix: &str,
     installation_id: &str,
     text: &str,
+) -> ProductInboundEnvelope {
+    sample_user_message_envelope_with_install_text_and_trigger(
+        event_suffix,
+        installation_id,
+        text,
+        ProductTriggerReason::DirectChat,
+    )
+}
+
+fn sample_user_message_envelope_with_install_text_and_trigger(
+    event_suffix: &str,
+    installation_id: &str,
+    text: &str,
+    trigger: ProductTriggerReason,
 ) -> ProductInboundEnvelope {
     let evidence = ProtocolAuthEvidence::test_verified(
         AuthRequirement::SharedSecretHeader {
@@ -447,7 +473,7 @@ fn sample_user_message_envelope_with_install_and_text(
         ExternalActorRef::new("test", "user1", Option::<String>::None).expect("valid"),
         ExternalConversationRef::new(None, "conv1", None, None).expect("valid"),
         ProductInboundPayload::UserMessage(
-            UserMessagePayload::new(text, vec![], ProductTriggerReason::DirectChat).expect("valid"),
+            UserMessagePayload::new(text, vec![], trigger).expect("valid"),
         ),
     )
     .expect("parsed");
@@ -481,7 +507,7 @@ async fn user_message_resolves_binding_persists_message_and_submits_turn() {
                 tenant_id: binding.tenant_id.clone(),
                 agent_id: binding.agent_id.clone().expect("agent id"),
                 project_id: binding.project_id.clone(),
-                owner_user_id: Some(binding.user_id.clone()),
+                owner_user_id: binding.subject_user_id.clone(),
                 mission_id: None,
             },
             thread_id: binding.thread_id.clone(),
@@ -492,6 +518,64 @@ async fn user_message_resolves_binding_persists_message_and_submits_turn() {
     assert_eq!(history.messages[0].content.as_deref(), Some("hello world"));
     assert_eq!(history.messages[0].status, MessageStatus::Submitted);
     assert!(history.messages[0].turn_run_id.is_some());
+}
+
+#[tokio::test]
+async fn shared_user_message_submits_subject_owned_turn_scope() {
+    let binding_service = FakeConversationBindingService::new();
+    let thread_service = InMemorySessionThreadService::default();
+    let coordinator = CapturingTurnCoordinator::default();
+    let service = DefaultInboundTurnService::new(
+        binding_service,
+        thread_service.clone(),
+        coordinator.clone(),
+    );
+    let envelope = sample_user_message_envelope_with_install_text_and_trigger(
+        "shared-turn-owner",
+        "install_alpha",
+        "hello shared channel",
+        ProductTriggerReason::BotMention,
+    );
+
+    let outcome = service
+        .accept_user_message(&envelope)
+        .await
+        .expect("shared route should submit");
+    let binding = match &outcome {
+        InboundTurnOutcome::Submitted { binding, .. } => binding,
+        _ => panic!("expected Submitted, got {outcome:?}"),
+    };
+
+    let submitted = coordinator
+        .last_submit
+        .lock()
+        .expect("captured submit lock")
+        .clone()
+        .expect("turn should be submitted");
+    assert_eq!(
+        submitted.scope.explicit_owner_user_id(),
+        binding.subject_user_id.as_ref()
+    );
+    assert_eq!(submitted.actor.user_id, binding.actor_user_id);
+
+    let history = thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: ThreadScope {
+                tenant_id: binding.tenant_id.clone(),
+                agent_id: binding.agent_id.clone().expect("agent id"),
+                project_id: binding.project_id.clone(),
+                owner_user_id: binding.subject_user_id.clone(),
+                mission_id: None,
+            },
+            thread_id: binding.thread_id.clone(),
+        })
+        .await
+        .expect("shared route history should use the resolved subject");
+    assert_eq!(history.messages.len(), 1);
+    assert_eq!(
+        history.messages[0].content.as_deref(),
+        Some("hello shared channel")
+    );
 }
 
 #[tokio::test]
@@ -522,12 +606,7 @@ async fn user_message_no_profile_submission_uses_planned_reborn_default() {
     };
     let state = store
         .get_run_state(GetRunStateRequest {
-            scope: ironclaw_turns::TurnScope::new(
-                binding.tenant_id,
-                binding.agent_id,
-                binding.project_id,
-                binding.thread_id,
-            ),
+            scope: turn_scope_for_binding(&binding),
             run_id: submitted_run_id,
         })
         .await
@@ -558,7 +637,7 @@ async fn user_message_no_profile_uses_product_live_runtime_and_persists_reply() 
         tenant_id: binding.tenant_id.clone(),
         agent_id: binding.agent_id.clone().expect("agent id"),
         project_id: binding.project_id.clone(),
-        owner_user_id: Some(binding.user_id.clone()),
+        owner_user_id: binding.subject_user_id.clone(),
         mission_id: None,
     };
     let model_route_resolver = Arc::new(
@@ -637,12 +716,7 @@ async fn user_message_no_profile_uses_product_live_runtime_and_persists_reply() 
     else {
         panic!("expected submitted outcome");
     };
-    let turn_scope = TurnScope::new(
-        binding.tenant_id.clone(),
-        binding.agent_id.clone(),
-        binding.project_id.clone(),
-        binding.thread_id.clone(),
-    );
+    let turn_scope = turn_scope_for_binding(&binding);
     let state = match timeout(Duration::from_secs(3), async {
         loop {
             let state = turn_store
@@ -729,7 +803,7 @@ async fn user_message_no_profile_can_cancel_product_live_run_from_product_path()
         tenant_id: binding.tenant_id.clone(),
         agent_id: binding.agent_id.clone().expect("agent id"),
         project_id: binding.project_id.clone(),
-        owner_user_id: Some(binding.user_id.clone()),
+        owner_user_id: binding.subject_user_id.clone(),
         mission_id: None,
     };
     let model_route_resolver = Arc::new(
@@ -822,17 +896,12 @@ async fn user_message_no_profile_can_cancel_product_live_run_from_product_path()
     .await
     .expect("product live run should reach model call");
 
-    let turn_scope = TurnScope::new(
-        binding.tenant_id.clone(),
-        binding.agent_id.clone(),
-        binding.project_id.clone(),
-        binding.thread_id.clone(),
-    );
+    let turn_scope = turn_scope_for_binding(&binding);
     let cancel_response = composition
         .coordinator
         .cancel_run(CancelRunRequest {
             scope: turn_scope.clone(),
-            actor: TurnActor::new(binding.user_id.clone()),
+            actor: TurnActor::new(binding.actor_user_id.clone()),
             run_id: submitted_run_id,
             reason: SanitizedCancelReason::UserRequested,
             idempotency_key: IdempotencyKey::new("idem-product-live-cancel").expect("valid"),
@@ -913,7 +982,7 @@ async fn product_live_runtime_rejects_unretained_cancellation_factory() {
         tenant_id: binding.tenant_id.clone(),
         agent_id: binding.agent_id.clone().expect("agent id"),
         project_id: binding.project_id.clone(),
-        owner_user_id: Some(binding.user_id.clone()),
+        owner_user_id: binding.subject_user_id.clone(),
         mission_id: None,
     };
     let model_route_resolver = Arc::new(
@@ -1002,7 +1071,7 @@ async fn busy_thread_persists_second_message_as_deferred() {
                 tenant_id: binding.tenant_id.clone(),
                 agent_id: binding.agent_id.clone().expect("agent id"),
                 project_id: binding.project_id.clone(),
-                owner_user_id: Some(binding.user_id.clone()),
+                owner_user_id: binding.subject_user_id.clone(),
                 mission_id: None,
             },
             thread_id: binding.thread_id.clone(),
@@ -1050,7 +1119,7 @@ async fn retry_validates_live_binding_before_accepted_message_replay() {
     let InboundTurnOutcome::Submitted { binding, .. } = outcome else {
         panic!("expected submitted retry")
     };
-    assert_eq!(binding.user_id.as_str(), "user:churned");
+    assert_eq!(binding.actor_user_id.as_str(), "user:churned");
     assert_eq!(binding.thread_id.as_str(), "thread:churned");
     assert_eq!(
         binding_handle.resolve_count(),
@@ -1064,7 +1133,7 @@ async fn retry_validates_live_binding_before_accepted_message_replay() {
                 tenant_id: binding.tenant_id.clone(),
                 agent_id: binding.agent_id.clone().expect("agent id"),
                 project_id: binding.project_id.clone(),
-                owner_user_id: Some(binding.user_id.clone()),
+                owner_user_id: binding.subject_user_id.clone(),
                 mission_id: None,
             },
             thread_id: binding.thread_id.clone(),
@@ -1126,7 +1195,7 @@ async fn replay_lookup_is_namespaced_by_installation() {
                 tenant_id: binding.tenant_id.clone(),
                 agent_id: binding.agent_id.clone().expect("agent id"),
                 project_id: binding.project_id.clone(),
-                owner_user_id: Some(binding.user_id.clone()),
+                owner_user_id: binding.subject_user_id.clone(),
                 mission_id: None,
             },
             thread_id: binding.thread_id.clone(),
@@ -1171,7 +1240,7 @@ async fn deferred_busy_retry_resubmits_existing_message() {
                 tenant_id: binding.tenant_id.clone(),
                 agent_id: binding.agent_id.clone().expect("agent id"),
                 project_id: binding.project_id.clone(),
-                owner_user_id: Some(binding.user_id.clone()),
+                owner_user_id: binding.subject_user_id.clone(),
                 mission_id: None,
             },
             thread_id: binding.thread_id.clone(),

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -424,7 +424,8 @@ fn action_dispatch_kind_retains_typed_payload_refs() {
 fn fake_binding() -> ResolvedBinding {
     ResolvedBinding {
         tenant_id: TenantId::new("tenant:fake").expect("valid tenant"),
-        user_id: UserId::new("user:fake").expect("valid user"),
+        actor_user_id: UserId::new("user:fake").expect("valid actor user"),
+        subject_user_id: Some(UserId::new("user:fake").expect("valid subject user")),
         thread_id: ThreadId::new("thread:fake").expect("valid thread"),
         agent_id: Some(AgentId::new("agent:fake").expect("valid agent")),
         project_id: None,
@@ -1542,7 +1543,7 @@ async fn projection_subscription_resolves_through_binding_service() {
         .await
         .expect("projection subscription");
 
-    assert_eq!(subscription.actor.user_id, binding.user_id);
+    assert_eq!(subscription.actor.user_id, binding.actor_user_id);
     assert_eq!(subscription.scope.tenant_id, binding.tenant_id);
     assert_eq!(subscription.scope.agent_id, binding.agent_id);
     assert_eq!(subscription.scope.project_id, binding.project_id);
@@ -2097,6 +2098,14 @@ async fn concrete_product_workflow_accepts_shared_route_participant_on_existing_
     );
     assert_eq!(submissions[0].actor.user_id.as_str(), "user:alice");
     assert_eq!(submissions[1].actor.user_id.as_str(), "user:bob");
+    assert_eq!(
+        submissions[0].scope.explicit_owner_user_id(),
+        Some(&UserId::new("user:team-agent").expect("team subject"))
+    );
+    assert_eq!(
+        submissions[1].scope.explicit_owner_user_id(),
+        Some(&UserId::new("user:team-agent").expect("team subject"))
+    );
 }
 
 #[tokio::test]
@@ -2284,6 +2293,78 @@ async fn concrete_product_workflow_bot_mention_uses_shared_route() {
     assert_eq!(
         binding.route_kinds(),
         vec![ironclaw_product_workflow::ProductConversationRouteKind::Shared]
+    );
+}
+
+#[tokio::test]
+async fn concrete_product_workflow_reply_to_bot_requires_existing_binding() {
+    let conversations = Arc::new(InMemoryConversationServices::default());
+    conversations
+        .pair_external_actor(
+            TenantId::new("tenant:alpha").expect("tenant"),
+            ironclaw_conversations::AdapterKind::new("test_adapter").expect("adapter"),
+            ironclaw_conversations::AdapterInstallationId::new("install_alpha").expect("install"),
+            ironclaw_conversations::ExternalActorRef::new("test", "user1").expect("actor"),
+            UserId::new("user:alice").expect("user"),
+        )
+        .await;
+    let binding = product_binding_service(
+        conversations,
+        vec![(
+            "test_adapter",
+            "install_alpha",
+            "tenant:alpha",
+            "agent:alpha",
+            Some("project:alpha"),
+        )],
+    );
+    let coordinator = Arc::new(RecordingTurnCoordinator::default());
+    let inbound = Arc::new(DefaultInboundTurnService::new(
+        binding.clone(),
+        InMemorySessionThreadService::default(),
+        coordinator.clone(),
+    ));
+    let workflow = DefaultProductWorkflow::new(
+        inbound,
+        Arc::new(InMemoryIdempotencyLedger::new()),
+        Arc::new(binding),
+    );
+
+    let err = workflow
+        .accept_inbound(sample_envelope_with_context(
+            ProductAdapterId::new("test_adapter").expect("adapter"),
+            AdapterInstallationId::new("install_alpha").expect("install"),
+            ExternalEventId::new("evt:random-thread-reply").expect("event"),
+            ExternalActorRef::new("test", "user1", Option::<String>::None).expect("actor"),
+            ExternalConversationRef::new(
+                Some("space1"),
+                "conv1",
+                Some("thread-never-linked"),
+                Some("msg1"),
+            )
+            .expect("conversation"),
+            ProductInboundPayload::UserMessage(
+                UserMessagePayload::new(
+                    "ambient thread reply",
+                    vec![],
+                    ProductTriggerReason::ReplyToBot,
+                )
+                .expect("message"),
+            ),
+        ))
+        .await
+        .expect_err("reply-to-bot requires a pre-existing linked thread");
+
+    assert!(matches!(
+        err,
+        ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::ScopeNotFound,
+            ..
+        }
+    ));
+    assert!(
+        coordinator.submissions().is_empty(),
+        "unlinked Slack thread reply must not submit a turn"
     );
 }
 
@@ -2930,6 +3011,9 @@ fn product_binding_service(
                     TenantId::new(tenant).expect("tenant"),
                     AgentId::new(agent).expect("agent"),
                     project.map(|value| ProjectId::new(value).expect("project")),
+                )
+                .with_default_subject_user_id(
+                    UserId::new("user:team-agent").expect("team subject"),
                 ),
             )
         },

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -2263,6 +2263,61 @@ async fn concrete_product_workflow_keeps_installations_tenant_isolated() {
 }
 
 #[tokio::test]
+async fn shared_route_without_configured_subject_yields_none_subject_user_id() {
+    let tenant_id = TenantId::new("tenant:alpha").expect("tenant");
+    let adapter_kind = ironclaw_conversations::AdapterKind::new("test_adapter").expect("adapter");
+    let installation_id =
+        ironclaw_conversations::AdapterInstallationId::new("install_alpha").expect("install");
+    let conversations = Arc::new(InMemoryConversationServices::default());
+    conversations
+        .pair_external_actor(
+            tenant_id.clone(),
+            adapter_kind,
+            installation_id,
+            ironclaw_conversations::ExternalActorRef::new("test", "user1").expect("actor"),
+            UserId::new("user:alice").expect("user"),
+        )
+        .await;
+    let conversation_port: Arc<dyn ironclaw_conversations::ConversationBindingService> =
+        conversations;
+    let resolver = StaticProductInstallationResolver::new([(
+        ProductInstallationKey::new(
+            ProductAdapterId::new("test_adapter").expect("adapter"),
+            AdapterInstallationId::new("install_alpha").expect("installation"),
+        ),
+        ProductInstallationScope::with_default_scope(
+            tenant_id,
+            AgentId::new("agent:alpha").expect("agent"),
+            Some(ProjectId::new("project:alpha").expect("project")),
+        ),
+    )]);
+    let binding = ProductConversationBindingService::new(conversation_port, resolver);
+    let envelope = sample_envelope_with_payload(
+        "shared-no-subject",
+        ProductInboundPayload::UserMessage(
+            UserMessagePayload::new("hello shared", vec![], ProductTriggerReason::BotMention)
+                .expect("message"),
+        ),
+    );
+
+    let resolved = binding
+        .resolve_binding(ResolveBindingRequest::from_envelope(&envelope))
+        .await
+        .expect("shared binding should resolve without a configured subject");
+
+    assert_eq!(resolved.actor_user_id.as_str(), "user:alice");
+    assert_eq!(resolved.subject_user_id, None);
+    assert_eq!(
+        resolved.agent_id.as_ref().map(AgentId::as_str),
+        Some("agent:alpha")
+    );
+    assert_eq!(
+        resolved.project_id.as_ref().map(ProjectId::as_str),
+        Some("project:alpha")
+    );
+}
+
+#[tokio::test]
 async fn concrete_product_workflow_bot_mention_uses_shared_route() {
     let binding = Arc::new(FakeConversationBindingService::new());
     let coordinator = Arc::new(RecordingTurnCoordinator::default());

--- a/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
+++ b/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
@@ -159,9 +159,11 @@ pub fn capability_call_response(
 impl ProductLiveAgentLoopHarness {
     pub async fn new(config: ProductLiveAgentLoopHarnessConfig) -> Self {
         let binding_service = FakeConversationBindingService::new();
+        let user_id = UserId::new(config.user_id).expect("valid harness user id");
         let binding = ResolvedBinding {
             tenant_id: TenantId::new(config.tenant_id).expect("valid harness tenant id"),
-            user_id: UserId::new(config.user_id).expect("valid harness user id"),
+            actor_user_id: user_id.clone(),
+            subject_user_id: Some(user_id),
             thread_id: ThreadId::new(config.thread_id).expect("valid harness thread id"),
             agent_id: Some(AgentId::new(config.agent_id).expect("valid harness agent id")),
             project_id: None,
@@ -170,7 +172,7 @@ impl ProductLiveAgentLoopHarness {
             tenant_id: binding.tenant_id.clone(),
             agent_id: binding.agent_id.clone().expect("harness agent id"),
             project_id: binding.project_id.clone(),
-            owner_user_id: Some(binding.user_id.clone()),
+            owner_user_id: binding.subject_user_id.clone(),
             mission_id: None,
         };
         let thread_service = InMemorySessionThreadService::default();
@@ -231,7 +233,10 @@ impl ProductLiveAgentLoopHarness {
                     results: Arc::clone(&capability_results),
                     capability_id: harness_capability_id(&capability.capability_id),
                     input: capability.input,
-                    user_id: binding.user_id.clone(),
+                    user_id: binding
+                        .subject_user_id
+                        .clone()
+                        .expect("harness subject user id"),
                     cancellation_factory: cancellation_factory.clone(),
                     model_provider: config.model_provider.clone(),
                     model_id: config.model_id.clone(),
@@ -418,7 +423,7 @@ impl ProductLiveAgentLoopHarness {
             .coordinator
             .cancel_run(CancelRunRequest {
                 scope: self.turn_scope(),
-                actor: TurnActor::new(self.binding.user_id.clone()),
+                actor: TurnActor::new(self.binding.actor_user_id.clone()),
                 run_id,
                 reason: SanitizedCancelReason::UserRequested,
                 idempotency_key: IdempotencyKey::new(format!("idem-harness-cancel-{run_id}"))
@@ -464,11 +469,12 @@ impl ProductLiveAgentLoopHarness {
     }
 
     fn turn_scope(&self) -> TurnScope {
-        TurnScope::new(
+        TurnScope::new_with_owner(
             self.binding.tenant_id.clone(),
             self.binding.agent_id.clone(),
             self.binding.project_id.clone(),
             self.binding.thread_id.clone(),
+            self.binding.subject_user_id.clone(),
         )
     }
 }

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -891,7 +891,11 @@ where
     /// owner-agnostic flows and runs without an actor (background tasks,
     /// triggers) are unaffected.
     fn effective_thread_scope(&self, run_context: &LoopRunContext) -> ThreadScope {
-        crate::thread_scope::ThreadScopeResolver::resolve(&self.thread_scope, run_context.actor())
+        crate::thread_scope::ThreadScopeResolver::resolve_for_turn(
+            &self.thread_scope,
+            &run_context.scope,
+            run_context.actor(),
+        )
     }
 
     fn build_compaction_ports(&self, run_context: &LoopRunContext) -> Arc<dyn LoopCompactionPort> {
@@ -1990,11 +1994,18 @@ fn validate_thread_scope(
     }
     // The thread store keys threads by `owner_user_id` (via the MountView in
     // `ThreadScope::to_resource_scope`), but that axis is not part of the
-    // on-disk thread path, so a wrong owner silently reads an empty subtree
-    // and surfaces as `UnknownThread` deep in the Prompt stage. When the run
-    // carries an authenticated actor and the thread scope declares an owner,
-    // require them to agree so the divergence fails loud here instead.
-    if let (Some(thread_owner), Some(actor)) =
+    // on-disk thread path, so a wrong owner silently reads an empty subtree.
+    // Actor-fallback turns still require owner=actor. Explicit-owner turns
+    // intentionally allow actor/subject divergence for shared Slack/team
+    // routes, but the explicit subject must match the resolved thread owner.
+    if run_context.scope.has_explicit_thread_owner() {
+        if run_context.scope.explicit_owner_user_id().cloned() != thread_scope.owner_user_id {
+            return Err(RebornLoopDriverHostError::ScopeMismatch {
+                reason: "thread scope owner does not match the explicit loop run subject"
+                    .to_string(),
+            });
+        }
+    } else if let (Some(thread_owner), Some(actor)) =
         (thread_scope.owner_user_id.as_ref(), run_context.actor())
         && thread_owner != &actor.user_id
     {

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -1999,7 +1999,7 @@ fn validate_thread_scope(
     // intentionally allow actor/subject divergence for shared Slack/team
     // routes, but the explicit subject must match the resolved thread owner.
     if run_context.scope.has_explicit_thread_owner() {
-        if run_context.scope.explicit_owner_user_id().cloned() != thread_scope.owner_user_id {
+        if run_context.scope.explicit_owner_user_id() != thread_scope.owner_user_id.as_ref() {
             return Err(RebornLoopDriverHostError::ScopeMismatch {
                 reason: "thread scope owner does not match the explicit loop run subject"
                     .to_string(),

--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -247,7 +247,13 @@ where
         // [`ThreadScopeResolver`], so the two cannot drift. The run-state
         // read (for the actor) only runs when the base scope is
         // owner-scoped; an owner-less applier keeps its shared/system slot.
-        if thread_scope.owner_user_id.is_some() {
+        if request.scope.has_explicit_thread_owner() {
+            thread_scope = crate::thread_scope::ThreadScopeResolver::resolve_for_turn(
+                &thread_scope,
+                request.scope,
+                None,
+            );
+        } else if thread_scope.owner_user_id.is_some() {
             let run_state = self
                 .turn_state_store
                 .get_run_state(GetRunStateRequest {
@@ -255,8 +261,9 @@ where
                     run_id: request.run_id,
                 })
                 .await?;
-            thread_scope = crate::thread_scope::ThreadScopeResolver::resolve(
+            thread_scope = crate::thread_scope::ThreadScopeResolver::resolve_for_turn(
                 &thread_scope,
+                request.scope,
                 run_state.actor.as_ref(),
             );
         }

--- a/crates/ironclaw_reborn/src/thread_scope.rs
+++ b/crates/ironclaw_reborn/src/thread_scope.rs
@@ -13,7 +13,7 @@
 //! removes.
 
 use ironclaw_threads::ThreadScope;
-use ironclaw_turns::TurnActor;
+use ironclaw_turns::{TurnActor, TurnScope};
 
 /// Canonical owner-scoping rule for per-caller thread isolation.
 pub(crate) struct ThreadScopeResolver;
@@ -34,6 +34,19 @@ impl ThreadScopeResolver {
             scope.owner_user_id = Some(actor.user_id.clone());
         }
         scope
+    }
+
+    pub(crate) fn resolve_for_turn(
+        base: &ThreadScope,
+        turn_scope: &TurnScope,
+        actor: Option<&TurnActor>,
+    ) -> ThreadScope {
+        if turn_scope.has_explicit_thread_owner() {
+            let mut scope = base.clone();
+            scope.owner_user_id = turn_scope.explicit_owner_user_id().cloned();
+            return scope;
+        }
+        Self::resolve(base, actor)
     }
 }
 
@@ -83,5 +96,22 @@ mod tests {
             resolved.owner_user_id.is_none(),
             "an owner-agnostic base must stay system/shared-scoped"
         );
+    }
+
+    #[test]
+    fn explicit_turn_owner_overrides_actor_rewrite() {
+        let base = scope(Some("runtime-owner"));
+        let turn_scope = TurnScope::new_with_owner(
+            base.tenant_id.clone(),
+            Some(base.agent_id.clone()),
+            base.project_id.clone(),
+            ironclaw_host_api::ThreadId::new("thread").unwrap(),
+            None,
+        );
+
+        let resolved =
+            ThreadScopeResolver::resolve_for_turn(&base, &turn_scope, Some(&actor("alice")));
+
+        assert_eq!(resolved.owner_user_id, None);
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -162,6 +162,9 @@ impl ServeCommand {
             .map(ironclaw_reborn_composition::host_api::ProjectId::new)
             .transpose()
             .map_err(|err| anyhow!("[identity].default_project is invalid: {err}"))?;
+        if let Some(project_id) = default_project_id.clone() {
+            runtime_input = runtime_input.with_default_project_id(project_id);
+        }
         let slack_host_beta_config = crate::commands::serve_slack::resolve_slack_config_for_serve(
             config_file.as_ref().and_then(|file| file.slack.as_ref()),
             &tenant_id,

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -533,7 +533,6 @@ mod tests {
             user_id: Some("invalid\nuser".to_string()),
             signing_secret_env: Some("IRONCLAW_TEST_SLACK_SIGNING_SECRET_INVALID_USER".to_string()),
             bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_INVALID_USER".to_string()),
-            ..Default::default()
         };
 
         let error = resolve_slack_host_beta_config(

--- a/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve_slack.rs
@@ -70,18 +70,8 @@ pub(crate) fn resolve_slack_host_beta_config(
     let api_app_id = required_slack_config_value("api_app_id", &section.api_app_id, config_path)?;
     let slack_user_id = optional_slack_config_value("slack_user_id", &section.slack_user_id)?;
     let mapped_user_id = match optional_slack_config_value("user_id", &section.user_id)? {
-        Some(raw) => {
-            let user_id = ironclaw_reborn_composition::host_api::UserId::new(&raw)
-                .map_err(|err| anyhow!("[slack].user_id `{raw}` is invalid: {err}"))?;
-            if user_id != *default_user_id {
-                anyhow::bail!(
-                    "[slack].user_id `{raw}` must match the Reborn WebUI runtime owner `{default_user_id}`. \
-                     A mismatch makes Slack-originated threads unreadable by the turn runner. \
-                     Remove [slack].user_id or set it to `{default_user_id}`."
-                );
-            }
-            user_id
-        }
+        Some(raw) => ironclaw_reborn_composition::host_api::UserId::new(&raw)
+            .map_err(|err| anyhow!("[slack].user_id `{raw}` is invalid: {err}"))?,
         None => default_user_id.clone(),
     };
 
@@ -460,7 +450,7 @@ mod tests {
 
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
-    fn slack_host_beta_config_rejects_divergent_user_mapping() {
+    fn slack_host_beta_config_accepts_distinct_shared_subject_user() {
         let _lock = env_lock();
         let _signing = EnvGuard::set(
             "IRONCLAW_TEST_SLACK_SIGNING_SECRET_DIVERGENT_USER",
@@ -480,7 +470,7 @@ mod tests {
             bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_DIVERGENT_USER".to_string()),
         };
 
-        let error = resolve_slack_host_beta_config(
+        let resolved = resolve_slack_host_beta_config(
             Some(&section),
             &tenant_id("tenant"),
             &agent_id("agent"),
@@ -488,14 +478,10 @@ mod tests {
             &user_id("web-user"),
             Path::new("/tmp/reborn-config.toml"),
         )
-        .expect_err("Slack user mapping must match the runtime owner");
+        .expect("Slack config should resolve")
+        .expect("Slack should be enabled");
 
-        assert!(
-            error
-                .to_string()
-                .contains("must match the Reborn WebUI runtime owner"),
-            "message: {error}"
-        );
+        assert_eq!(resolved.user_id, user_id("slack-mapped-user"));
     }
 
     #[cfg(feature = "slack-v2-host-beta")]
@@ -532,13 +518,21 @@ mod tests {
     #[cfg(feature = "slack-v2-host-beta")]
     #[test]
     fn slack_host_beta_config_rejects_invalid_user_id_mapping() {
+        let _lock = env_lock();
+        let _signing = EnvGuard::set(
+            "IRONCLAW_TEST_SLACK_SIGNING_SECRET_INVALID_USER",
+            "signing-secret",
+        );
+        let _bot = EnvGuard::set("IRONCLAW_TEST_SLACK_BOT_TOKEN_INVALID_USER", "xoxb-token");
         let section = ironclaw_reborn_config::SlackSection {
             enabled: Some(true),
             installation_id: Some("install-alpha".to_string()),
             team_id: Some("T123".to_string()),
             api_app_id: Some("A123".to_string()),
             slack_user_id: Some("U123".to_string()),
-            user_id: Some("invalid user".to_string()),
+            user_id: Some("invalid\nuser".to_string()),
+            signing_secret_env: Some("IRONCLAW_TEST_SLACK_SIGNING_SECRET_INVALID_USER".to_string()),
+            bot_token_env: Some("IRONCLAW_TEST_SLACK_BOT_TOKEN_INVALID_USER".to_string()),
             ..Default::default()
         };
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -48,8 +48,8 @@ use ironclaw_host_api::{
 #[cfg(feature = "libsql")]
 use ironclaw_host_api::{MountAlias, MountGrant};
 use ironclaw_host_runtime::{
-    CapabilitySurfaceVersion, FirstPartyCapabilityRegistry, HostRuntimeServices,
-    LocalHostProcessPort, ProductAuthProviderRuntimePorts, TriggerCreateHook,
+    CapabilitySurfaceVersion, FirstPartyCapabilityRegistry, HostRuntimeHttpEgressPort,
+    HostRuntimeServices, LocalHostProcessPort, ProductAuthProviderRuntimePorts, TriggerCreateHook,
     builtin_first_party_handlers_with_trigger_create_hook, builtin_first_party_package,
 };
 #[cfg(feature = "libsql")]
@@ -383,6 +383,7 @@ pub(crate) struct RebornLocalRuntimeServices {
     // outside local-dev composition. Tracked in #4091.
     pub(crate) extension_management: Option<Arc<RebornLocalExtensionManagementPort>>,
     pub(crate) runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,
+    pub(crate) host_runtime_http_egress: Option<HostRuntimeHttpEgressPort>,
     pub(crate) skill_mounts: MountView,
     pub(crate) memory_mounts: MountView,
     pub(crate) skill_filesystem: Arc<ScopedFilesystem<LocalDevRootFilesystem>>,
@@ -526,6 +527,8 @@ fn production_config(
 }
 
 async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, RebornBuildError> {
+    #[cfg(all(test, feature = "slack-v2-host-beta"))]
+    let host_runtime_http_egress_for_test = input.host_runtime_http_egress_for_test.clone();
     let RebornBuildInput {
         profile,
         storage,
@@ -788,6 +791,11 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     if let Some(local_runtime) = Arc::get_mut(&mut store_graph.local_runtime) {
         local_runtime.extension_management = Some(Arc::clone(&extension_management));
         local_runtime.runtime_http_egress = Some(product_auth_runtime_ports.runtime_http_egress());
+        let host_runtime_http_egress = services.host_runtime_http_egress_port();
+        #[cfg(all(test, feature = "slack-v2-host-beta"))]
+        let host_runtime_http_egress =
+            host_runtime_http_egress_for_test.unwrap_or(host_runtime_http_egress);
+        local_runtime.host_runtime_http_egress = host_runtime_http_egress;
     } else {
         return Err(RebornBuildError::InvalidConfig {
             reason: "local-dev extension lifecycle facade could not be attached".to_string(),
@@ -915,6 +923,7 @@ fn build_local_dev_store_graph(
         skill_management,
         extension_management: None,
         runtime_http_egress: None,
+        host_runtime_http_egress: None,
         skill_mounts,
         memory_mounts,
         skill_filesystem,
@@ -1012,6 +1021,7 @@ fn build_local_dev_store_graph(
         skill_management,
         extension_management: None,
         runtime_http_egress: None,
+        host_runtime_http_egress: None,
         skill_mounts,
         memory_mounts,
         skill_filesystem,
@@ -1928,6 +1938,8 @@ async fn build_production_shaped(
         required_runtime_backends,
         require_runtime_http_egress,
         require_wasm_credentials,
+        #[cfg(all(test, feature = "slack-v2-host-beta"))]
+            host_runtime_http_egress_for_test: _,
         product_auth_ports,
         oauth_provider_configs,
         oauth_dcr_provider_configs,
@@ -2698,6 +2710,7 @@ mod tests {
             skill_management: Arc::clone(&base_runtime.skill_management),
             extension_management: base_runtime.extension_management.clone(),
             runtime_http_egress: base_runtime.runtime_http_egress.clone(),
+            host_runtime_http_egress: base_runtime.host_runtime_http_egress.clone(),
             skill_mounts: base_runtime.skill_mounts.clone(),
             memory_mounts: base_runtime.memory_mounts.clone(),
             skill_filesystem: Arc::clone(&base_runtime.skill_filesystem),

--- a/crates/ironclaw_reborn_composition/src/input.rs
+++ b/crates/ironclaw_reborn_composition/src/input.rs
@@ -7,6 +7,8 @@ use ironclaw_host_api::runtime_policy::ProcessBackendKind;
 use ironclaw_host_api::runtime_policy::{
     EffectiveRuntimePolicy, FilesystemBackendKind, NetworkMode, SecretMode,
 };
+#[cfg(all(test, feature = "slack-v2-host-beta"))]
+use ironclaw_host_runtime::HostRuntimeHttpEgressPort;
 use ironclaw_host_runtime::{SchedulerTurnRunWakeNotifier, TenantSandboxProcessPort};
 use ironclaw_trust::HostTrustPolicy;
 use secrecy::SecretString;
@@ -152,6 +154,8 @@ pub struct RebornBuildInput {
     pub(crate) required_runtime_backends: Vec<ironclaw_host_api::RuntimeKind>,
     pub(crate) require_runtime_http_egress: bool,
     pub(crate) require_wasm_credentials: bool,
+    #[cfg(all(test, feature = "slack-v2-host-beta"))]
+    pub(crate) host_runtime_http_egress_for_test: Option<Option<HostRuntimeHttpEgressPort>>,
     pub(crate) product_auth_ports: Option<RebornProductAuthServicePorts>,
     pub(crate) oauth_provider_configs: Vec<OAuthProviderBackendConfig>,
     pub(crate) oauth_dcr_provider_configs: Vec<OAuthDcrProviderBackendConfig>,
@@ -394,6 +398,15 @@ impl RebornBuildInput {
         self
     }
 
+    #[cfg(all(test, feature = "slack-v2-host-beta"))]
+    pub(crate) fn with_host_runtime_http_egress_for_test(
+        mut self,
+        egress: Option<HostRuntimeHttpEgressPort>,
+    ) -> Self {
+        self.host_runtime_http_egress_for_test = Some(egress);
+        self
+    }
+
     /// Inject Reborn-native product-auth service ports.
     ///
     /// Production callers should provide durable implementations here. The
@@ -491,6 +504,8 @@ impl RebornBuildInput {
             required_runtime_backends: Vec::new(),
             require_runtime_http_egress: false,
             require_wasm_credentials: false,
+            #[cfg(all(test, feature = "slack-v2-host-beta"))]
+            host_runtime_http_egress_for_test: None,
             product_auth_ports: None,
             oauth_provider_configs: Vec::new(),
             oauth_dcr_provider_configs: Vec::new(),

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -37,8 +37,6 @@ use ironclaw_first_party_extension_ports::{
     FirstPartySkillsExtension, FirstPartySkillsExtensionHandles, SelectableSkillContextSource,
     SkillActivationSelectorConfig, SkillExecutionAdapter,
 };
-#[cfg(all(test, feature = "slack-v2-host-beta"))]
-use ironclaw_host_api::RuntimeHttpEgress;
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AgentId, AuditEnvelope, AuditEventId, AuditStage,
     CapabilityId, CorrelationId, DecisionSummary, EffectKind, InvocationId, ResourceScope,
@@ -581,26 +579,6 @@ impl RebornRuntime {
             Arc::clone(&parts.session),
             crate::LlmKeyStore::new(self.services.secret_store()),
         )))
-    }
-
-    /// Test-only override for the runtime HTTP egress handle that mirrors the
-    /// local runtime service slot populated by build_reborn_runtime.
-    #[cfg(all(test, feature = "slack-v2-host-beta"))]
-    #[allow(dead_code)]
-    /// Test-only mutator for the local runtime HTTP egress binding used by
-    /// production capability policy wiring during runtime construction.
-    pub(crate) fn set_local_runtime_http_egress_for_test(
-        &mut self,
-        runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,
-    ) {
-        let local_runtime = self
-            .services
-            .local_runtime
-            .as_mut()
-            .expect("test runtime must include local runtime services");
-        Arc::get_mut(local_runtime)
-            .expect("test must mutate local runtime services before cloning the service Arc")
-            .runtime_http_egress = runtime_http_egress;
     }
 
     /// Diagnostic id for the no-profile run profile selected by this runtime.
@@ -1321,6 +1299,7 @@ pub async fn build_reborn_runtime(
         trigger_poller,
         poll,
         identity,
+        default_project_id,
         regex_skill_activation_enabled,
         skill_context_source: configured_skill_context_source,
         budget_defaults,
@@ -1396,7 +1375,7 @@ pub async fn build_reborn_runtime(
     let thread_scope = ThreadScope {
         tenant_id,
         agent_id,
-        project_id: None,
+        project_id: default_project_id,
         // Keep local-dev runtime threads aligned with WebUI's owner-scoped
         // facade so both entrypoints drive the same runner/evidence path.
         owner_user_id: Some(actor_user_id.clone()),

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -4876,9 +4876,10 @@ mod tests {
 
         let runtime = build_reborn_runtime(input).await.expect("runtime builds");
         let bundle = build_webui_services(&runtime, None).expect("webui bundle");
+        let webui_user_id = UserId::new("runtime-webui-skill-user").unwrap();
         let caller = WebUiAuthenticatedCaller::new(
             TenantId::new("runtime-webui-skill-tenant").unwrap(),
-            UserId::new("runtime-webui-skill-user").unwrap(),
+            webui_user_id.clone(),
             Some(AgentId::new("runtime-webui-skill-agent").unwrap()),
             None,
         );
@@ -4920,16 +4921,21 @@ mod tests {
         let source = runtime
             .webui_skill_activation_source()
             .expect("webui skill activation source");
+        let turn_scope = TurnScope::new_with_owner(
+            TenantId::new("runtime-webui-skill-tenant").unwrap(),
+            Some(AgentId::new("runtime-webui-skill-agent").unwrap()),
+            None,
+            thread_id.clone(),
+            Some(webui_user_id.clone()),
+        );
         let context = LoopRunContext::new(
-            runtime.turn_scope_for(&thread_id),
+            turn_scope,
             TurnId::new(),
             TurnRunId::new(),
             resolved_run_profile,
         )
         .with_accepted_message_ref(accepted_message_ref)
-        .with_actor(TurnActor::new(
-            UserId::new("runtime-webui-skill-user").unwrap(),
-        ));
+        .with_actor(TurnActor::new(webui_user_id));
         let selected = source
             .load_skill_context_candidates(&context)
             .await

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -745,8 +745,10 @@ fn local_dev_visible_capability_request(
         .grants
         .extend(extension_surface.grants(&extension_id));
     let user_id = run_context
-        .actor()
-        .map(|actor| actor.user_id.clone())
+        .scope
+        .explicit_owner_user_id()
+        .cloned()
+        .or_else(|| run_context.actor().map(|actor| actor.user_id.clone()))
         .unwrap_or_else(|| fallback_user_id.clone());
     let mut context = ExecutionContext::local_default(
         user_id,

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -42,21 +42,21 @@ mod tests {
     use crate::runtime::local_dev_filesystem_skill_context_source;
 
     async fn run_context(label: &str) -> LoopRunContext {
+        run_context_with_scope(TurnScope::new(
+            TenantId::new(format!("tenant-{label}")).expect("tenant id"),
+            Some(AgentId::new(format!("agent-{label}")).expect("agent id")),
+            Some(ProjectId::new(format!("project-{label}")).expect("project id")),
+            ThreadId::new(format!("thread-{label}")).expect("thread id"),
+        ))
+        .await
+    }
+
+    async fn run_context_with_scope(scope: TurnScope) -> LoopRunContext {
         let resolved = InMemoryRunProfileResolver::default()
             .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
             .await
             .expect("profile resolves");
-        LoopRunContext::new(
-            TurnScope::new(
-                TenantId::new(format!("tenant-{label}")).expect("tenant id"),
-                Some(AgentId::new(format!("agent-{label}")).expect("agent id")),
-                Some(ProjectId::new(format!("project-{label}")).expect("project id")),
-                ThreadId::new(format!("thread-{label}")).expect("thread id"),
-            ),
-            TurnId::new(),
-            TurnRunId::new(),
-            resolved,
-        )
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved)
     }
 
     #[tokio::test]
@@ -71,6 +71,30 @@ mod tests {
 
         assert_eq!(request.context.user_id.as_str(), "sso-user");
         assert_eq!(request.context.resource_scope.user_id.as_str(), "sso-user");
+    }
+
+    #[tokio::test]
+    async fn local_dev_visible_capability_request_uses_explicit_subject_for_runtime_scope() {
+        let subject_user_id = UserId::new("team-agent-user").expect("subject user id");
+        let run_context = run_context_with_scope(TurnScope::new_with_owner(
+            TenantId::new("tenant-subject").expect("tenant id"),
+            Some(AgentId::new("agent-subject").expect("agent id")),
+            Some(ProjectId::new("project-subject").expect("project id")),
+            ThreadId::new("thread-subject").expect("thread id"),
+            Some(subject_user_id),
+        ))
+        .await
+        .with_actor(TurnActor::new(
+            UserId::new("slack-sender").expect("actor user id"),
+        ));
+        let fallback_user_id = UserId::new("env-operator").expect("fallback user id");
+        let request = visible_request_for_runtime_scope(&run_context, &fallback_user_id);
+
+        assert_eq!(request.context.user_id.as_str(), "team-agent-user");
+        assert_eq!(
+            request.context.resource_scope.user_id.as_str(),
+            "team-agent-user"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -23,6 +23,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use ironclaw_host_api::ProjectId;
 #[cfg(any(test, feature = "test-support"))]
 use ironclaw_loop_support::HostManagedModelGateway;
 use ironclaw_loop_support::HostSkillContextSource;
@@ -200,6 +201,10 @@ pub struct RebornRuntimeInput {
     pub trigger_poller: TriggerPollerSettings,
     pub poll: PollSettings,
     pub identity: RebornRuntimeIdentity,
+    /// Optional project scope for runtime-owned thread I/O. Channel adapters
+    /// that stamp a project onto inbound turns must set the same project here,
+    /// otherwise the loop host rejects the run before model execution.
+    pub default_project_id: Option<ProjectId>,
     pub regex_skill_activation_enabled: bool,
     pub skill_context_source: Option<Arc<dyn HostSkillContextSource>>,
     /// Pre-resolved budget defaults to seed the model-budget accountant.
@@ -245,6 +250,7 @@ impl RebornRuntimeInput {
             trigger_poller: TriggerPollerSettings::default(),
             poll: PollSettings::default(),
             identity: RebornRuntimeIdentity::default(),
+            default_project_id: None,
             regex_skill_activation_enabled: true,
             skill_context_source: None,
             budget_defaults: None,
@@ -311,6 +317,11 @@ impl RebornRuntimeInput {
 
     pub fn with_identity(mut self, identity: RebornRuntimeIdentity) -> Self {
         self.identity = identity;
+        self
+    }
+
+    pub fn with_default_project_id(mut self, project_id: ProjectId) -> Self {
+        self.default_project_id = Some(project_id);
         self
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -26,10 +26,9 @@ use ironclaw_product_adapters::{
     ProductOutboundPayload, ProtocolHttpEgress,
 };
 use ironclaw_product_workflow::{
-    ConversationBindingService, ProductConversationRouteKind, ProductOutboundDeliveryRequest,
-    ProductOutboundTargetResolver, ProductWorkflowError, ResolveBindingRequest, ResolvedBinding,
+    ConversationBindingService, ProductOutboundDeliveryRequest, ProductOutboundTargetResolver,
+    ProductWorkflowError, ResolveBindingRequest, ResolvedBinding,
     VerifiedProductOutboundTargetMetadata, prepare_and_render_product_outbound,
-    route_kind_for_inbound_payload,
 };
 use ironclaw_threads::{FinalizedAssistantMessageByRunRequest, SessionThreadService, ThreadScope};
 use ironclaw_turns::{
@@ -100,15 +99,14 @@ impl SlackFinalReplyDeliveryObserver {
         let Some(run_id) = submitted_run_id(&ack) else {
             return Ok(());
         };
-        let route_kind = route_kind_for_inbound_payload(envelope.payload());
         let binding = self
             .services
             .binding_service
             .lookup_binding(ResolveBindingRequest::from_envelope(&envelope))
             .await?;
-        let scope = turn_scope_from_binding(&binding)?;
-        let actor = TurnActor::new(binding.user_id.clone());
-        let thread_scope = thread_scope_from_binding(&binding, route_kind)?;
+        let actor = TurnActor::new(binding.actor_user_id.clone());
+        let thread_scope = thread_scope_from_binding(&binding)?;
+        let scope = turn_scope_from_thread_scope(&binding, &thread_scope)?;
         let actionable_state = self.wait_for_actionable(&scope, run_id).await?;
         let (event_kind, payload) = match actionable_state.status {
             TurnStatus::Completed => {
@@ -118,7 +116,6 @@ impl SlackFinalReplyDeliveryObserver {
                 else {
                     tracing::warn!(
                         %run_id,
-                        ?route_kind,
                         "completed Slack run has no finalized assistant message; skipping final reply delivery"
                     );
                     return Ok(());
@@ -397,38 +394,37 @@ fn submitted_run_id(ack: &ProductInboundAck) -> Option<TurnRunId> {
     }
 }
 
-fn turn_scope_from_binding(binding: &ResolvedBinding) -> Result<TurnScope, ProductWorkflowError> {
+fn turn_scope_from_thread_scope(
+    binding: &ResolvedBinding,
+    thread_scope: &ThreadScope,
+) -> Result<TurnScope, ProductWorkflowError> {
     let Some(agent_id) = binding.agent_id.clone() else {
         return Err(ProductWorkflowError::BindingResolutionFailed {
             reason: "resolved binding missing agent_id required for turn scope".to_string(),
         });
     };
-    Ok(TurnScope::new(
+    Ok(TurnScope::new_with_owner(
         binding.tenant_id.clone(),
         Some(agent_id),
         binding.project_id.clone(),
         binding.thread_id.clone(),
+        thread_scope.owner_user_id.clone(),
     ))
 }
 
 fn thread_scope_from_binding(
     binding: &ResolvedBinding,
-    route_kind: ProductConversationRouteKind,
 ) -> Result<ThreadScope, ProductWorkflowError> {
     let Some(agent_id) = binding.agent_id.clone() else {
         return Err(ProductWorkflowError::BindingResolutionFailed {
             reason: "resolved binding missing agent_id required for thread scope".to_string(),
         });
     };
-    let owner_user_id = match route_kind {
-        ProductConversationRouteKind::Direct => Some(binding.user_id.clone()),
-        ProductConversationRouteKind::Shared => None,
-    };
     Ok(ThreadScope {
         tenant_id: binding.tenant_id.clone(),
         agent_id,
         project_id: binding.project_id.clone(),
-        owner_user_id,
+        owner_user_id: binding.subject_user_id.clone(),
         mission_id: None,
     })
 }

--- a/crates/ironclaw_reborn_composition/src/slack_egress.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_egress.rs
@@ -11,9 +11,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern,
-    ResourceScope, RuntimeCredentialTarget, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
-    RuntimeKind, SecretHandle, TrustClass,
+    CapabilityId, ExtensionId, InvocationId, NetworkMethod, NetworkPolicy, NetworkScheme,
+    NetworkTargetPattern, ResourceScope, RuntimeCredentialTarget, RuntimeHttpEgressError,
+    RuntimeHttpEgressRequest, RuntimeKind, SecretHandle, TrustClass,
 };
 use ironclaw_host_runtime::{
     HostRuntimeCredentialMaterial, HostRuntimeHttpEgressPort, HostRuntimeHttpEgressRequest,
@@ -101,7 +101,7 @@ pub struct SlackProtocolHttpEgress {
     host_egress: HostRuntimeHttpEgressPort,
     credentials: Arc<dyn SlackEgressCredentialProvider>,
     policy: EgressPolicy,
-    scope: ResourceScope,
+    scope_template: ResourceScope,
 }
 
 impl SlackProtocolHttpEgress {
@@ -109,13 +109,13 @@ impl SlackProtocolHttpEgress {
         host_egress: HostRuntimeHttpEgressPort,
         credentials: Arc<dyn SlackEgressCredentialProvider>,
         policy: EgressPolicy,
-        scope: ResourceScope,
+        scope_template: ResourceScope,
     ) -> Self {
         Self {
             host_egress,
             credentials,
             policy,
-            scope,
+            scope_template,
         }
     }
 }
@@ -158,6 +158,7 @@ impl ProtocolHttpEgress for SlackProtocolHttpEgress {
         let credentials = self
             .credential_material(request.credential_handle())
             .await?;
+        let scope = self.request_scope();
         let response = self
             .host_egress
             .execute(HostRuntimeHttpEgressRequest {
@@ -165,7 +166,7 @@ impl ProtocolHttpEgress for SlackProtocolHttpEgress {
                 trust: TrustClass::System,
                 request: RuntimeHttpEgressRequest {
                     runtime: RuntimeKind::FirstParty,
-                    scope: self.scope.clone(),
+                    scope,
                     capability_id,
                     method: network_method(request.method().as_str())?,
                     url: format!(
@@ -191,6 +192,12 @@ impl ProtocolHttpEgress for SlackProtocolHttpEgress {
 }
 
 impl SlackProtocolHttpEgress {
+    fn request_scope(&self) -> ResourceScope {
+        let mut scope = self.scope_template.clone();
+        scope.invocation_id = InvocationId::new();
+        scope
+    }
+
     async fn credential_material(
         &self,
         handle: Option<&EgressCredentialHandle>,
@@ -498,6 +505,28 @@ mod tests {
                 "authorization".to_string(),
                 "Bearer xoxb-secret".to_string()
             ))
+        );
+    }
+
+    #[tokio::test]
+    async fn slack_protocol_http_egress_uses_fresh_invocation_scope_per_send() {
+        let (egress, recorded_requests) =
+            slack_egress_with_network(RecordingNetworkHttpEgress::ok());
+
+        egress
+            .send(slack_request(slack_handle()))
+            .await
+            .expect("first Slack egress should succeed");
+        egress
+            .send(slack_request(slack_handle()))
+            .await
+            .expect("second Slack egress should succeed");
+
+        let requests = recorded_requests.lock().expect("network requests lock");
+        assert_eq!(requests.len(), 2);
+        assert_ne!(
+            requests[0].scope.invocation_id, requests[1].scope.invocation_id,
+            "each Slack protocol egress call must stage credentials in a per-request invocation scope"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/slack_egress.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_egress.rs
@@ -3,20 +3,26 @@
 //! The Slack adapter renders only a constrained `EgressRequest` containing the
 //! declared host, origin-form path, headers, body, and opaque credential handle.
 //! This module is the host side: it validates the request against the adapter's
-//! declared egress policy, resolves the opaque handle to a bearer token, injects
-//! authorization, and sends the request through the shared network policy egress.
+//! declared egress policy, resolves the opaque handle to a bearer token, and
+//! delegates authorization plus runtime credential injection to the shared host
+//! HTTP egress port.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    CapabilityId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern, ResourceScope,
-    RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeKind,
+    CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTargetPattern,
+    ResourceScope, RuntimeCredentialTarget, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+    RuntimeKind, SecretHandle, TrustClass,
+};
+use ironclaw_host_runtime::{
+    HostRuntimeCredentialMaterial, HostRuntimeHttpEgressPort, HostRuntimeHttpEgressRequest,
 };
 use ironclaw_product_adapters::{
     EgressCredentialHandle, EgressRequest, EgressResponse, ProtocolHttpEgress,
     ProtocolHttpEgressError, RedactedString,
 };
+use ironclaw_secrets::SecretMaterial;
 use ironclaw_wasm_product_adapters::{EgressPolicy, EgressPolicyError, EgressPolicyTarget};
 use secrecy::{ExposeSecret, SecretString};
 use thiserror::Error;
@@ -92,7 +98,7 @@ impl SlackEgressCredentialProvider for StaticSlackEgressCredentialProvider {
 }
 
 pub struct SlackProtocolHttpEgress {
-    runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+    host_egress: HostRuntimeHttpEgressPort,
     credentials: Arc<dyn SlackEgressCredentialProvider>,
     policy: EgressPolicy,
     scope: ResourceScope,
@@ -100,13 +106,13 @@ pub struct SlackProtocolHttpEgress {
 
 impl SlackProtocolHttpEgress {
     pub fn new(
-        runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+        host_egress: HostRuntimeHttpEgressPort,
         credentials: Arc<dyn SlackEgressCredentialProvider>,
         policy: EgressPolicy,
         scope: ResourceScope,
     ) -> Self {
         Self {
-            runtime_http_egress,
+            host_egress,
             credentials,
             policy,
             scope,
@@ -127,46 +133,55 @@ impl ProtocolHttpEgress for SlackProtocolHttpEgress {
             })
             .map_err(map_egress_policy_error)?;
 
-        let mut headers = request
+        if request
+            .headers()
+            .iter()
+            .any(|header| header.name().eq_ignore_ascii_case("authorization"))
+        {
+            return Err(ProtocolHttpEgressError::PolicyDenied {
+                reason: RedactedString::new(
+                    "Slack adapter requests must use credential handles, not Authorization headers",
+                ),
+            });
+        }
+        let headers = request
             .headers()
             .iter()
             .map(|header| (header.name().to_string(), header.value().to_string()))
             .collect::<Vec<_>>();
-        if let Some(handle) = request.credential_handle() {
-            let credential = self
-                .credentials
-                .resolve_slack_egress_credential(handle)
-                .await
-                .map_err(map_credential_error)?;
-            let authorization = bearer_authorization_value(&credential)?;
-            headers.retain(|(name, _)| !name.eq_ignore_ascii_case("authorization"));
-            headers.push(("authorization".to_string(), authorization));
-        }
 
         let capability_id = CapabilityId::new(SLACK_EGRESS_CAPABILITY_ID).map_err(|error| {
             ProtocolHttpEgressError::PolicyDenied {
                 reason: RedactedString::new(format!("invalid Slack egress capability id: {error}")),
             }
         })?;
+        let credentials = self
+            .credential_material(request.credential_handle())
+            .await?;
         let response = self
-            .runtime_http_egress
-            .execute(RuntimeHttpEgressRequest {
-                runtime: RuntimeKind::FirstParty,
-                scope: self.scope.clone(),
-                capability_id,
-                method: network_method(request.method().as_str())?,
-                url: format!(
-                    "https://{}{}",
-                    request.host().as_str(),
-                    request.path().as_str()
-                ),
-                headers,
-                body: request.body().to_vec(),
-                network_policy: slack_network_policy(request.host().as_str()),
-                credential_injections: Vec::new(),
-                response_body_limit: Some(SLACK_EGRESS_RESPONSE_BODY_LIMIT_BYTES),
-                save_body_to: None,
-                timeout_ms: Some(SLACK_EGRESS_TIMEOUT_MS),
+            .host_egress
+            .execute(HostRuntimeHttpEgressRequest {
+                extension_id: slack_extension_id()?,
+                trust: TrustClass::System,
+                request: RuntimeHttpEgressRequest {
+                    runtime: RuntimeKind::FirstParty,
+                    scope: self.scope.clone(),
+                    capability_id,
+                    method: network_method(request.method().as_str())?,
+                    url: format!(
+                        "https://{}{}",
+                        request.host().as_str(),
+                        request.path().as_str()
+                    ),
+                    headers,
+                    body: request.body().to_vec(),
+                    network_policy: slack_network_policy(request.host().as_str()),
+                    credential_injections: Vec::new(),
+                    response_body_limit: Some(SLACK_EGRESS_RESPONSE_BODY_LIMIT_BYTES),
+                    save_body_to: None,
+                    timeout_ms: Some(SLACK_EGRESS_TIMEOUT_MS),
+                },
+                credentials,
             })
             .await
             .map_err(map_runtime_http_error)?;
@@ -175,16 +190,49 @@ impl ProtocolHttpEgress for SlackProtocolHttpEgress {
     }
 }
 
-fn bearer_authorization_value(
+impl SlackProtocolHttpEgress {
+    async fn credential_material(
+        &self,
+        handle: Option<&EgressCredentialHandle>,
+    ) -> Result<Vec<HostRuntimeCredentialMaterial>, ProtocolHttpEgressError> {
+        let Some(handle) = handle else {
+            return Ok(Vec::new());
+        };
+        let credential = self
+            .credentials
+            .resolve_slack_egress_credential(handle)
+            .await
+            .map_err(map_credential_error)?;
+        validate_bearer_token(&credential)?;
+        let secret_handle = SecretHandle::new(handle.as_str()).map_err(|error| {
+            ProtocolHttpEgressError::PolicyDenied {
+                reason: RedactedString::new(format!(
+                    "invalid Slack egress credential handle: {error}"
+                )),
+            }
+        })?;
+        Ok(vec![HostRuntimeCredentialMaterial {
+            handle: secret_handle,
+            material: SecretMaterial::from(credential.as_bearer_token().to_string()),
+            target: RuntimeCredentialTarget::Header {
+                name: "authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            required: true,
+        }])
+    }
+}
+
+fn validate_bearer_token(
     credential: &SlackEgressCredential,
-) -> Result<String, ProtocolHttpEgressError> {
+) -> Result<(), ProtocolHttpEgressError> {
     let token = credential.as_bearer_token();
     if token.bytes().any(|byte| byte < 0x20 || byte == 0x7f) {
         return Err(ProtocolHttpEgressError::PolicyDenied {
             reason: RedactedString::new("Slack bearer token contains control characters"),
         });
     }
-    Ok(format!("Bearer {token}"))
+    Ok(())
 }
 
 fn slack_network_policy(host: &str) -> NetworkPolicy {
@@ -197,6 +245,12 @@ fn slack_network_policy(host: &str) -> NetworkPolicy {
         deny_private_ip_ranges: true,
         max_egress_bytes: None,
     }
+}
+
+fn slack_extension_id() -> Result<ExtensionId, ProtocolHttpEgressError> {
+    ExtensionId::new("ironclaw_slack").map_err(|error| ProtocolHttpEgressError::PolicyDenied {
+        reason: RedactedString::new(format!("invalid Slack egress extension id: {error}")),
+    })
 }
 
 fn network_method(method: &str) -> Result<NetworkMethod, ProtocolHttpEgressError> {
@@ -269,64 +323,101 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
-    use ironclaw_host_api::{
-        RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED, RuntimeHttpEgressResponse,
-        RuntimeHttpSavedBody,
+    use ironclaw_authorization::GrantAuthorizer;
+    use ironclaw_extensions::ExtensionRegistry;
+    use ironclaw_filesystem::LocalFilesystem;
+    use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
+    use ironclaw_network::{
+        NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
     };
+    use ironclaw_processes::{InMemoryProcessResultStore, InMemoryProcessStore, ProcessServices};
     use ironclaw_product_adapters::{
         DeclaredEgressHost, DeclaredEgressTarget, EgressCredentialHandle, EgressMethod, EgressPath,
     };
+    use ironclaw_resources::InMemoryResourceGovernor;
+    use ironclaw_secrets::InMemorySecretStore;
 
     use super::*;
 
-    #[derive(Default)]
-    struct RecordingRuntimeHttpEgress {
-        requests: Mutex<Vec<RuntimeHttpEgressRequest>>,
+    struct RecordingNetworkHttpEgress {
+        requests: Arc<Mutex<Vec<NetworkHttpRequest>>>,
+        response: Result<NetworkHttpResponse, NetworkHttpError>,
     }
 
-    impl RecordingRuntimeHttpEgress {
-        fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
-            self.requests
-                .lock()
-                .expect("runtime HTTP requests lock")
-                .clone()
+    impl RecordingNetworkHttpEgress {
+        fn ok() -> Self {
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                response: Ok(NetworkHttpResponse {
+                    status: 200,
+                    headers: Vec::new(),
+                    body: br#"{\"ok\":true}"#.to_vec(),
+                    usage: NetworkUsage {
+                        request_bytes: 0,
+                        response_bytes: 11,
+                        resolved_ip: None,
+                    },
+                }),
+            }
+        }
+
+        fn failing(error: NetworkHttpError) -> Self {
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                response: Err(error),
+            }
+        }
+
+        fn requests(&self) -> Arc<Mutex<Vec<NetworkHttpRequest>>> {
+            Arc::clone(&self.requests)
         }
     }
 
     #[async_trait]
-    impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
+    impl NetworkHttpEgress for RecordingNetworkHttpEgress {
         async fn execute(
             &self,
-            request: RuntimeHttpEgressRequest,
-        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+            request: NetworkHttpRequest,
+        ) -> Result<NetworkHttpResponse, NetworkHttpError> {
             self.requests
                 .lock()
-                .expect("runtime HTTP requests lock")
+                .expect("network HTTP requests lock")
                 .push(request);
-            Ok(RuntimeHttpEgressResponse {
-                status: 200,
-                headers: Vec::new(),
-                body: br#"{\"ok\":true}"#.to_vec(),
-                saved_body: None::<RuntimeHttpSavedBody>,
-                request_bytes: 0,
-                response_bytes: 0,
-                redaction_applied: false,
-            })
+            self.response.clone()
         }
     }
 
-    struct FailingRuntimeHttpEgress {
-        error: RuntimeHttpEgressError,
+    fn host_egress_port(
+        network: RecordingNetworkHttpEgress,
+    ) -> (
+        HostRuntimeHttpEgressPort,
+        Arc<Mutex<Vec<NetworkHttpRequest>>>,
+    ) {
+        let requests = network.requests();
+        let services = test_host_runtime_services()
+            .with_secret_store(Arc::new(InMemorySecretStore::new()))
+            .try_with_host_http_egress(network)
+            .expect("host HTTP egress should wire");
+        let port = services
+            .host_runtime_http_egress_port()
+            .expect("host runtime HTTP egress port should be configured");
+        (port, requests)
     }
 
-    #[async_trait]
-    impl RuntimeHttpEgress for FailingRuntimeHttpEgress {
-        async fn execute(
-            &self,
-            _request: RuntimeHttpEgressRequest,
-        ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-            Err(self.error.clone())
-        }
+    fn test_host_runtime_services() -> HostRuntimeServices<
+        LocalFilesystem,
+        InMemoryResourceGovernor,
+        InMemoryProcessStore,
+        InMemoryProcessResultStore,
+    > {
+        HostRuntimeServices::new(
+            Arc::new(ExtensionRegistry::new()),
+            Arc::new(LocalFilesystem::new()),
+            Arc::new(InMemoryResourceGovernor::new()),
+            Arc::new(GrantAuthorizer::new()),
+            ProcessServices::in_memory(),
+            CapabilitySurfaceVersion::new("surface-v1").expect("surface version"),
+        )
     }
 
     fn slack_host() -> DeclaredEgressHost {
@@ -347,65 +438,77 @@ mod tests {
         .with_credential_handle(Some(handle))
     }
 
-    fn slack_egress(runtime_http: Arc<RecordingRuntimeHttpEgress>) -> SlackProtocolHttpEgress {
+    fn slack_egress_with_network(
+        network: RecordingNetworkHttpEgress,
+    ) -> (SlackProtocolHttpEgress, Arc<Mutex<Vec<NetworkHttpRequest>>>) {
+        let (host_egress, requests) = host_egress_port(network);
         let handle = slack_handle();
-        SlackProtocolHttpEgress::new(
-            runtime_http,
+        let egress = SlackProtocolHttpEgress::new(
+            host_egress,
             Arc::new(StaticSlackEgressCredentialProvider::new(
                 handle.clone(),
                 "xoxb-secret",
             )),
             EgressPolicy::new([DeclaredEgressTarget::new(slack_host(), Some(handle))]),
             ResourceScope::system(),
-        )
-    }
-
-    fn slack_egress_with_runtime(
-        runtime_http: Arc<dyn RuntimeHttpEgress>,
-    ) -> SlackProtocolHttpEgress {
-        let handle = slack_handle();
-        SlackProtocolHttpEgress::new(
-            runtime_http,
-            Arc::new(StaticSlackEgressCredentialProvider::new(
-                handle.clone(),
-                "xoxb-secret",
-            )),
-            EgressPolicy::new([DeclaredEgressTarget::new(slack_host(), Some(handle))]),
-            ResourceScope::system(),
-        )
+        );
+        (egress, requests)
     }
 
     #[tokio::test]
-    async fn slack_protocol_http_egress_validates_policy_and_injects_bearer() {
-        let runtime_http = Arc::new(RecordingRuntimeHttpEgress::default());
-        let egress = slack_egress(Arc::clone(&runtime_http));
+    async fn slack_protocol_http_egress_validates_policy_and_host_injects_bearer() {
+        let network = RecordingNetworkHttpEgress::ok();
+        let recorded_requests = network.requests();
+        let (host_egress, _) = host_egress_port(network);
+        let handle = slack_handle();
+        let egress = SlackProtocolHttpEgress::new(
+            host_egress,
+            Arc::new(StaticSlackEgressCredentialProvider::new(
+                handle.clone(),
+                "xoxb-secret",
+            )),
+            EgressPolicy::new([DeclaredEgressTarget::new(
+                slack_host(),
+                Some(handle.clone()),
+            )]),
+            ResourceScope::system(),
+        );
 
         let response = egress
-            .send(slack_request(slack_handle()))
+            .send(slack_request(handle))
             .await
             .expect("slack egress should succeed");
 
         assert_eq!(response.status(), 200);
-        let requests = runtime_http.requests();
+        let requests = recorded_requests.lock().expect("network requests lock");
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].url, "https://slack.com/api/chat.postMessage");
         assert_eq!(requests[0].method, NetworkMethod::Post);
         assert_eq!(requests[0].body, br#"{"channel":"D1","text":"hi"}"#);
-        let auth_headers = requests[0]
-            .headers
-            .iter()
-            .filter(|(name, _)| name.eq_ignore_ascii_case("authorization"))
-            .collect::<Vec<_>>();
-        assert_eq!(auth_headers.len(), 1);
-        assert_eq!(auth_headers[0].1, "Bearer xoxb-secret");
+        assert_eq!(
+            requests[0].policy.allowed_targets[0].host_pattern,
+            "slack.com"
+        );
+        assert_eq!(
+            requests[0]
+                .headers
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case("authorization")),
+            Some(&(
+                "authorization".to_string(),
+                "Bearer xoxb-secret".to_string()
+            ))
+        );
     }
 
     #[tokio::test]
     async fn slack_protocol_http_egress_rejects_control_chars_in_bearer_before_network() {
-        let runtime_http = Arc::new(RecordingRuntimeHttpEgress::default());
+        let network = RecordingNetworkHttpEgress::ok();
+        let recorded_requests = network.requests();
+        let (host_egress, _) = host_egress_port(network);
         let handle = slack_handle();
         let egress = SlackProtocolHttpEgress::new(
-            runtime_http.clone(),
+            host_egress,
             Arc::new(StaticSlackEgressCredentialProvider::new(
                 handle.clone(),
                 "xoxb-secret\r\nX-Injected: true",
@@ -426,15 +529,22 @@ mod tests {
             error,
             ProtocolHttpEgressError::PolicyDenied { .. }
         ));
-        assert!(runtime_http.requests().is_empty());
+        assert!(
+            recorded_requests
+                .lock()
+                .expect("network requests lock")
+                .is_empty()
+        );
     }
 
     #[tokio::test]
     async fn slack_protocol_http_egress_rejects_unknown_handle_before_network() {
-        let runtime_http = Arc::new(RecordingRuntimeHttpEgress::default());
+        let network = RecordingNetworkHttpEgress::ok();
+        let recorded_requests = network.requests();
+        let (host_egress, _) = host_egress_port(network);
         let unknown = EgressCredentialHandle::new("other_token").expect("other handle");
         let egress = SlackProtocolHttpEgress::new(
-            runtime_http.clone(),
+            host_egress,
             Arc::new(StaticSlackEgressCredentialProvider::new(
                 slack_handle(),
                 "xoxb-secret",
@@ -455,23 +565,28 @@ mod tests {
             error,
             ProtocolHttpEgressError::UnknownCredentialHandle { .. }
         ));
-        assert!(runtime_http.requests().is_empty());
+        assert!(
+            recorded_requests
+                .lock()
+                .expect("network requests lock")
+                .is_empty()
+        );
     }
 
     #[tokio::test]
     async fn slack_protocol_http_egress_maps_runtime_http_failures() {
         let cases = [
             (
-                RuntimeHttpEgressError::Request {
+                NetworkHttpError::InvalidUrl {
                     reason: "invalid_url".to_string(),
                     request_bytes: 12,
                     response_bytes: 0,
                 },
                 "request-denied",
-                RuntimeErrorExpectation::PolicyDenied,
+                RuntimeErrorExpectation::Network,
             ),
             (
-                RuntimeHttpEgressError::Network {
+                NetworkHttpError::PolicyDenied {
                     reason: "policy_denied".to_string(),
                     request_bytes: 12,
                     response_bytes: 0,
@@ -480,16 +595,17 @@ mod tests {
                 RuntimeErrorExpectation::PolicyDenied,
             ),
             (
-                RuntimeHttpEgressError::Response {
-                    reason: RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED.to_string(),
+                NetworkHttpError::ResponseBodyLimit {
+                    limit: 65_536,
                     request_bytes: 12,
                     response_bytes: 65_536,
+                    partial_response: None,
                 },
                 "body-limit",
                 RuntimeErrorExpectation::LeakDetected,
             ),
             (
-                RuntimeHttpEgressError::Network {
+                NetworkHttpError::Dns {
                     reason: "dns_failure".to_string(),
                     request_bytes: 12,
                     response_bytes: 0,
@@ -499,11 +615,9 @@ mod tests {
             ),
         ];
 
-        for (runtime_error, label, expectation) in cases {
-            let runtime_http = Arc::new(FailingRuntimeHttpEgress {
-                error: runtime_error,
-            });
-            let egress = slack_egress_with_runtime(runtime_http);
+        for (network_error, label, expectation) in cases {
+            let (egress, _) =
+                slack_egress_with_network(RecordingNetworkHttpEgress::failing(network_error));
             let error = match egress.send(slack_request(slack_handle())).await {
                 Ok(response) => panic!("{label} case should fail, got {response:?}"),
                 Err(error) => error,

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -366,11 +366,11 @@ fn slack_protocol_egress(
             config.bot_token.expose_secret().to_string(),
         )),
         EgressPolicy::new(slack_declared_egress_targets(token_handle)?),
-        slack_egress_scope(config),
+        slack_egress_scope_template(config),
     )))
 }
 
-fn slack_egress_scope(config: &SlackHostBetaConfig) -> ResourceScope {
+fn slack_egress_scope_template(config: &SlackHostBetaConfig) -> ResourceScope {
     ResourceScope {
         tenant_id: config.tenant_id.clone(),
         user_id: config.user_id.clone(),
@@ -935,10 +935,10 @@ mod tests {
     }
 
     #[test]
-    fn slack_egress_scope_uses_configured_tenant_agent_and_project() {
+    fn slack_egress_scope_template_uses_configured_tenant_agent_and_project() {
         let config = config();
 
-        let scope = slack_egress_scope(&config);
+        let scope = slack_egress_scope_template(&config);
 
         assert_eq!(scope.tenant_id, TenantId::new(TENANT).expect("tenant"));
         assert_eq!(scope.user_id, UserId::new(USER).expect("user"));

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -82,7 +82,9 @@ pub struct SlackHostBetaConfig {
     /// tests/config. Tenant app host-beta resolution uses durable personal
     /// bindings and does not require a preselected Slack user.
     pub slack_actor: Option<ExternalActorRef>,
-    /// Host user used as the resource owner for Slack bot-token egress.
+    /// User scope that owns Slack shared-route execution, tools, skills, and
+    /// memory in this beta route. Personal DM routes still use the paired actor
+    /// as the subject.
     pub user_id: UserId,
     pub signing_secret: SecretString,
     pub bot_token: SecretString,
@@ -237,8 +239,9 @@ pub fn build_slack_events_route_mount_with_actor_user_resolver(
     config: SlackHostBetaConfig,
     actor_user_resolver: Arc<dyn ProductActorUserResolver>,
 ) -> Result<PublicRouteMount, SlackHostBetaBuildError> {
-    // The resolver controls inbound Slack actor binding. `config.user_id` still
-    // scopes the host-mediated Slack bot-token egress for this beta route.
+    // The resolver controls inbound Slack actor binding. `config.user_id`
+    // scopes shared Slack channel execution and host-mediated Slack bot-token
+    // egress for this beta route.
     tracing::warn!(
         "Slack host-beta uses in-memory conversation bindings, idempotency ledger, and outbound state; Slack continuity, retry deduplication, and delivery state are lost on process restart"
     );
@@ -262,6 +265,7 @@ pub fn build_slack_events_route_mount_with_actor_user_resolver(
         config.agent_id.clone(),
         config.project_id.clone(),
     )
+    .with_default_subject_user_id(config.user_id.clone())
     .with_actor_user_resolver(actor_user_resolver, actor_pairings);
     let installation_resolver = StaticProductInstallationResolver::new([(
         ProductInstallationKey::new(adapter_id, config.installation_id.clone()),
@@ -351,12 +355,12 @@ fn slack_protocol_egress(
         .local_runtime
         .as_ref()
         .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
-    let runtime_http_egress = local_runtime
-        .runtime_http_egress
+    let host_egress = local_runtime
+        .host_runtime_http_egress
         .clone()
         .ok_or(SlackHostBetaBuildError::RuntimeHttpEgressUnavailable)?;
     Ok(Arc::new(SlackProtocolHttpEgress::new(
-        runtime_http_egress,
+        host_egress,
         Arc::new(StaticSlackEgressCredentialProvider::new(
             token_handle.clone(),
             config.bot_token.expose_secret().to_string(),
@@ -467,18 +471,30 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use hmac::{Hmac, Mac};
     use http_body_util::BodyExt;
-    use ironclaw_host_api::{
-        RuntimeHttpEgress, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    use ironclaw_authorization::GrantAuthorizer;
+    use ironclaw_extensions::ExtensionRegistry;
+    use ironclaw_filesystem::LocalFilesystem;
+    use ironclaw_host_runtime::{
+        CapabilitySurfaceVersion, HostRuntimeHttpEgressPort, HostRuntimeServices,
     };
     use ironclaw_loop_support::{
         HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
         HostManagedModelResponse,
     };
+    use ironclaw_network::{
+        NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
+    };
+    use ironclaw_processes::{InMemoryProcessResultStore, InMemoryProcessStore, ProcessServices};
     use ironclaw_product_workflow::{
         ProductActorUserResolutionRequest, ProductWorkflowError, WebUiAuthenticatedCaller,
     };
+    use ironclaw_resources::InMemoryResourceGovernor;
+    use ironclaw_secrets::InMemorySecretStore;
     use ironclaw_threads::{ListThreadsForScopeRequest, ThreadHistoryRequest, ThreadScope};
-    use ironclaw_turns::run_profile::LoopCapabilityPort;
+    use ironclaw_turns::{
+        GetRunStateRequest, TurnCoordinator, TurnRunId, TurnScope, TurnStatus,
+        run_profile::LoopCapabilityPort,
+    };
     use secrecy::ExposeSecret;
     use tower::ServiceExt;
 
@@ -496,9 +512,9 @@ mod tests {
     const PROJECT: &str = "project:slack-host";
     const USER: &str = "user:slack-host";
     const INSTALLATION: &str = "install_host_beta";
-    const TEAM: &str = "T-HOST";
-    const API_APP: &str = "A-HOST";
-    const SLACK_USER: &str = "U-HOST";
+    const TEAM: &str = "T0HOST";
+    const API_APP: &str = "A0HOST";
+    const SLACK_USER: &str = "U0HOST";
     const SECRET: &str = "host-signing-secret";
 
     type HmacSha256 = Hmac<sha2::Sha256>;
@@ -583,8 +599,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_slack_events_route_mount_fails_when_runtime_http_egress_unavailable() {
-        let (mut runtime, _root) = runtime().await;
-        runtime.set_local_runtime_http_egress_for_test(None);
+        let (runtime, _root) = runtime_with_host_egress_override(Some(None)).await;
 
         let error = match build_slack_events_route_mount(&runtime, config()) {
             Ok(_) => panic!("Slack route requires runtime HTTP egress"),
@@ -600,16 +615,18 @@ mod tests {
 
     #[tokio::test]
     async fn build_slack_events_route_mount_dispatches_signed_event_callback() {
-        let (mut runtime, _root) = runtime().await;
         let egress = Arc::new(RecordingRuntimeHttpEgress::default());
-        runtime.set_local_runtime_http_egress_for_test(Some(egress.clone()));
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
         let mount = build_slack_events_route_mount(&runtime, config()).expect("route builds");
         let body = r#"{
             "type":"event_callback",
-            "team_id":"T-HOST",
-            "api_app_id":"A-HOST",
+            "team_id":"T0HOST",
+            "api_app_id":"A0HOST",
             "event_id":"Ev-host-beta-dispatch",
-            "event":{"type":"message","channel_type":"im","user":"U-HOST","channel":"D-HOST","text":"hello","ts":"1710000000.000010"}
+            "event":{"type":"message","channel_type":"im","user":"U0HOST","channel":"D0HOST","text":"hello","ts":"1710000000.000010"}
         }"#;
         let timestamp = current_unix_timestamp();
 
@@ -633,12 +650,15 @@ mod tests {
             drain.drain().await;
         }
         let history = wait_for_slack_thread_history(&runtime).await;
-        assert_eq!(history.messages.len(), 1);
-        assert_eq!(history.messages[0].content.as_deref(), Some("hello"));
+        let inbound_message = history
+            .messages
+            .iter()
+            .find(|message| message.content.as_deref() == Some("hello"))
+            .expect("inbound Slack message should be recorded");
         assert_eq!(
-            history.messages[0].source_binding_id.as_deref(),
+            inbound_message.source_binding_id.as_deref(),
             Some(
-                "adapter:8:slack_v2;installation:17:install_host_beta;agent:16:agent:slack-host;project:18:project:slack-host;space:6:T-HOST;conversation:6:D-HOST;topic:0:;"
+                "adapter:8:slack_v2;installation:17:install_host_beta;agent:16:agent:slack-host;project:18:project:slack-host;space:6:T0HOST;conversation:6:D0HOST;topic:0:;"
             )
         );
 
@@ -659,6 +679,7 @@ mod tests {
                 source_binding_id: "slack-host-source".to_string(),
                 reply_target_binding_id: "slack-host-reply".to_string(),
             })
+            .with_default_project_id(ProjectId::new(PROJECT).expect("project"))
             .with_model_gateway_override(Arc::new(StaticGateway)),
         )
         .await
@@ -682,9 +703,11 @@ mod tests {
 
     #[tokio::test]
     async fn build_slack_host_beta_mounts_pairs_unknown_slack_actor_then_routes_bound_event() {
-        let (mut runtime, _root) = runtime().await;
         let egress = Arc::new(RecordingRuntimeHttpEgress::default());
-        runtime.set_local_runtime_http_egress_for_test(Some(egress.clone()));
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
         let mounts =
             build_slack_host_beta_mounts(&runtime, config_without_legacy_actor()).expect("mounts");
 
@@ -731,11 +754,124 @@ mod tests {
         }
 
         let history = wait_for_slack_thread_history(&runtime).await;
-        assert_eq!(history.messages.len(), 1);
+        let accepted_message = history
+            .messages
+            .iter()
+            .find(|message| message.content.as_deref() == Some("after pairing"))
+            .expect("accepted Slack message is present");
+        let run_id = TurnRunId::parse(
+            accepted_message
+                .turn_run_id
+                .as_deref()
+                .expect("accepted Slack message should carry submitted run id"),
+        )
+        .expect("valid submitted run id");
+        let run_state = runtime
+            .webui_turn_coordinator()
+            .get_run_state(GetRunStateRequest {
+                scope: TurnScope::new_with_owner(
+                    TenantId::new(TENANT).expect("tenant"),
+                    Some(AgentId::new(AGENT).expect("agent")),
+                    Some(ProjectId::new(PROJECT).expect("project")),
+                    accepted_message.thread_id.clone(),
+                    Some(UserId::new(USER).expect("user")),
+                ),
+                run_id,
+            })
+            .await
+            .expect("read DM run state");
         assert_eq!(
-            history.messages[0].content.as_deref(),
-            Some("after pairing")
+            run_state.status,
+            TurnStatus::Completed,
+            "DM run failed: {:?}",
+            run_state.failure
         );
+        let final_reply = wait_for_slack_post_message(&egress, "ok").await;
+        assert_eq!(final_reply["channel"], "D0HOST");
+        assert_eq!(final_reply["text"], "ok");
+        assert_eq!(final_reply["mrkdwn"], false);
+
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn build_slack_host_beta_mounts_replies_to_channel_app_mention_thread() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
+        let mounts = build_slack_host_beta_mounts(&runtime, config()).expect("mounts");
+
+        let body = app_mention_event_body_with(
+            "Ev-host-beta-channel-mention",
+            "<@U-BOT> help in channel",
+            "1710000000.000040",
+        );
+        post_signed_slack_event(&mounts.events, &body).await;
+        if let Some(drain) = mounts.events.drain.as_ref() {
+            drain.drain().await;
+        }
+
+        let history = wait_for_slack_thread_history_with_owner(
+            &runtime,
+            Some(UserId::new(USER).expect("user")),
+        )
+        .await;
+        let accepted_message = history
+            .messages
+            .iter()
+            .find(|message| message.content.as_deref() == Some("help in channel"))
+            .expect("accepted Slack app mention message is present");
+        let run_id = TurnRunId::parse(
+            accepted_message
+                .turn_run_id
+                .as_deref()
+                .expect("accepted Slack message should carry submitted run id"),
+        )
+        .expect("valid submitted run id");
+        let run_state = runtime
+            .webui_turn_coordinator()
+            .get_run_state(GetRunStateRequest {
+                scope: TurnScope::new_with_owner(
+                    TenantId::new(TENANT).expect("tenant"),
+                    Some(AgentId::new(AGENT).expect("agent")),
+                    Some(ProjectId::new(PROJECT).expect("project")),
+                    accepted_message.thread_id.clone(),
+                    Some(UserId::new(USER).expect("user")),
+                ),
+                run_id,
+            })
+            .await
+            .expect("read channel mention run state");
+        assert_eq!(
+            run_state.status,
+            TurnStatus::Completed,
+            "channel mention run failed: {:?}",
+            run_state.failure
+        );
+        let final_reply = wait_for_slack_post_message(&egress, "ok").await;
+        assert_eq!(final_reply["channel"], "C0HOST");
+        assert_eq!(final_reply["text"], "ok");
+        assert_eq!(final_reply["thread_ts"], "1710000000.000040");
+
+        let thread_reply_body = thread_message_event_body_with(
+            "Ev-host-beta-channel-thread-reply",
+            "follow up without mention",
+            "1710000000.000041",
+            "1710000000.000040",
+        );
+        post_signed_slack_event(&mounts.events, &thread_reply_body).await;
+        if let Some(drain) = mounts.events.drain.as_ref() {
+            drain.drain().await;
+        }
+
+        let final_replies = wait_for_slack_post_messages(&egress, "ok", 2).await;
+        let threaded_reply = final_replies
+            .iter()
+            .find(|body| body["thread_ts"] == "1710000000.000040" && body["channel"] == "C0HOST")
+            .expect("thread follow-up reply should post back to original Slack thread");
+        assert_eq!(threaded_reply["text"], "ok");
 
         runtime.shutdown().await.expect("runtime shuts down");
     }
@@ -754,6 +890,7 @@ mod tests {
                 source_binding_id: "slack-host-source".to_string(),
                 reply_target_binding_id: "slack-host-reply".to_string(),
             })
+            .with_default_project_id(ProjectId::new(PROJECT).expect("project"))
             .with_model_gateway_override(Arc::new(StaticGateway)),
         )
         .await
@@ -892,19 +1029,28 @@ mod tests {
     }
 
     async fn runtime() -> (RebornRuntime, tempfile::TempDir) {
+        runtime_with_host_egress_override(None).await
+    }
+
+    async fn runtime_with_host_egress_override(
+        host_egress_override: Option<Option<HostRuntimeHttpEgressPort>>,
+    ) -> (RebornRuntime, tempfile::TempDir) {
         let root = tempfile::tempdir().expect("tempdir");
+        let mut build_input = RebornBuildInput::local_dev(USER, root.path().join("local-dev"))
+            .with_runtime_policy(local_dev_runtime_policy().expect("local policy"));
+        if let Some(host_egress) = host_egress_override {
+            build_input = build_input.with_host_runtime_http_egress_for_test(host_egress);
+        }
         let runtime = build_reborn_runtime(
-            RebornRuntimeInput::from_services(
-                RebornBuildInput::local_dev(USER, root.path().join("local-dev"))
-                    .with_runtime_policy(local_dev_runtime_policy().expect("local policy")),
-            )
-            .with_identity(RebornRuntimeIdentity {
-                tenant_id: TENANT.to_string(),
-                agent_id: AGENT.to_string(),
-                source_binding_id: "slack-host-source".to_string(),
-                reply_target_binding_id: "slack-host-reply".to_string(),
-            })
-            .with_model_gateway_override(Arc::new(StaticGateway)),
+            RebornRuntimeInput::from_services(build_input)
+                .with_identity(RebornRuntimeIdentity {
+                    tenant_id: TENANT.to_string(),
+                    agent_id: AGENT.to_string(),
+                    source_binding_id: "slack-host-source".to_string(),
+                    reply_target_binding_id: "slack-host-reply".to_string(),
+                })
+                .with_default_project_id(ProjectId::new(PROJECT).expect("project"))
+                .with_model_gateway_override(Arc::new(StaticGateway)),
         )
         .await
         .expect("runtime builds");
@@ -914,13 +1060,21 @@ mod tests {
     async fn wait_for_slack_thread_history(
         runtime: &RebornRuntime,
     ) -> ironclaw_threads::ThreadHistory {
+        wait_for_slack_thread_history_with_owner(runtime, Some(UserId::new(USER).expect("user")))
+            .await
+    }
+
+    async fn wait_for_slack_thread_history_with_owner(
+        runtime: &RebornRuntime,
+        owner_user_id: Option<UserId>,
+    ) -> ironclaw_threads::ThreadHistory {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         let thread_service = runtime.webui_thread_service();
         let scope = ThreadScope {
             tenant_id: TenantId::new(TENANT).expect("tenant"),
             agent_id: AgentId::new(AGENT).expect("agent"),
             project_id: Some(ProjectId::new(PROJECT).expect("project")),
-            owner_user_id: Some(UserId::new(USER).expect("user")),
+            owner_user_id,
             mission_id: None,
         };
         loop {
@@ -966,14 +1120,14 @@ mod tests {
     fn dm_event_body() -> &'static str {
         r#"{
           "type":"event_callback",
-          "team_id":"T-HOST",
-          "api_app_id":"A-HOST",
+          "team_id":"T0HOST",
+          "api_app_id":"A0HOST",
           "event_id":"Ev-host-beta-custom-resolver",
           "event":{
             "type":"message",
             "channel_type":"im",
-            "user":"U-HOST",
-            "channel":"D-HOST",
+            "user":"U0HOST",
+            "channel":"D0HOST",
             "text":"hello",
             "ts":"1710000000.000001"
           }
@@ -990,9 +1144,49 @@ mod tests {
                 "type": "message",
                 "channel_type": "im",
                 "user": SLACK_USER,
-                "channel": "D-HOST",
+                "channel": "D0HOST",
                 "text": text,
                 "ts": ts
+            }
+        })
+        .to_string()
+    }
+
+    fn app_mention_event_body_with(event_id: &str, text: &str, ts: &str) -> String {
+        serde_json::json!({
+            "type": "event_callback",
+            "team_id": TEAM,
+            "api_app_id": API_APP,
+            "event_id": event_id,
+            "event": {
+                "type": "app_mention",
+                "user": SLACK_USER,
+                "channel": "C0HOST",
+                "text": text,
+                "ts": ts
+            }
+        })
+        .to_string()
+    }
+
+    fn thread_message_event_body_with(
+        event_id: &str,
+        text: &str,
+        ts: &str,
+        thread_ts: &str,
+    ) -> String {
+        serde_json::json!({
+            "type": "event_callback",
+            "team_id": TEAM,
+            "api_app_id": API_APP,
+            "event_id": event_id,
+            "event": {
+                "type": "message",
+                "user": SLACK_USER,
+                "channel": "C0HOST",
+                "text": text,
+                "ts": ts,
+                "thread_ts": thread_ts
             }
         })
         .to_string()
@@ -1020,6 +1214,40 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
         panic!("Slack pairing notifier did not post a pairing code");
+    }
+
+    async fn wait_for_slack_post_message(
+        egress: &RecordingRuntimeHttpEgress,
+        expected_text: &str,
+    ) -> serde_json::Value {
+        for _ in 0..80 {
+            if let Some(body) = egress.post_message_body_with_text(expected_text) {
+                return body;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!(
+            "Slack final reply was not posted; recorded egress requests: {:?}",
+            egress.request_bodies()
+        );
+    }
+
+    async fn wait_for_slack_post_messages(
+        egress: &RecordingRuntimeHttpEgress,
+        expected_text: &str,
+        expected_len: usize,
+    ) -> Vec<serde_json::Value> {
+        for _ in 0..80 {
+            let bodies = egress.post_message_bodies_with_text(expected_text);
+            if bodies.len() >= expected_len {
+                return bodies;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!(
+            "expected {expected_len} Slack posts with text {expected_text:?}; recorded egress requests: {:?}",
+            egress.request_bodies()
+        );
     }
 
     #[derive(Debug)]
@@ -1096,17 +1324,17 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingRuntimeHttpEgress {
-        requests: std::sync::Mutex<Vec<RuntimeHttpEgressRequest>>,
+        requests: std::sync::Mutex<Vec<NetworkHttpRequest>>,
     }
 
     #[async_trait]
-    impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
+    impl NetworkHttpEgress for RecordingRuntimeHttpEgress {
         async fn execute(
             &self,
-            request: RuntimeHttpEgressRequest,
-        ) -> Result<RuntimeHttpEgressResponse, ironclaw_host_api::RuntimeHttpEgressError> {
+            request: NetworkHttpRequest,
+        ) -> Result<NetworkHttpResponse, NetworkHttpError> {
             let response = if request.url.contains("/api/conversations.open") {
-                br#"{"ok":true,"channel":{"id":"D-HOST"}}"#.to_vec()
+                br#"{"ok":true,"channel":{"id":"D0HOST"}}"#.to_vec()
             } else {
                 br#"{"ok":true}"#.to_vec()
             };
@@ -1114,19 +1342,70 @@ mod tests {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(request);
-            Ok(RuntimeHttpEgressResponse {
+            Ok(NetworkHttpResponse {
                 status: 200,
                 headers: Vec::new(),
                 body: response,
-                saved_body: None,
-                request_bytes: 0,
-                response_bytes: 0,
-                redaction_applied: false,
+                usage: NetworkUsage {
+                    request_bytes: 0,
+                    response_bytes: 0,
+                    resolved_ip: None,
+                },
             })
         }
     }
 
+    fn host_egress_port_for_test(
+        network: Arc<RecordingRuntimeHttpEgress>,
+    ) -> HostRuntimeHttpEgressPort {
+        test_host_runtime_services()
+            .with_secret_store(Arc::new(InMemorySecretStore::new()))
+            .try_with_host_http_egress(RecordingNetworkHttpEgress(network))
+            .expect("host HTTP egress should wire")
+            .host_runtime_http_egress_port()
+            .expect("host runtime HTTP egress port should be configured")
+    }
+
+    fn test_host_runtime_services() -> HostRuntimeServices<
+        LocalFilesystem,
+        InMemoryResourceGovernor,
+        InMemoryProcessStore,
+        InMemoryProcessResultStore,
+    > {
+        HostRuntimeServices::new(
+            Arc::new(ExtensionRegistry::new()),
+            Arc::new(LocalFilesystem::new()),
+            Arc::new(InMemoryResourceGovernor::new()),
+            Arc::new(GrantAuthorizer::new()),
+            ProcessServices::in_memory(),
+            CapabilitySurfaceVersion::new("surface-v1").expect("surface version"),
+        )
+    }
+
+    struct RecordingNetworkHttpEgress(Arc<RecordingRuntimeHttpEgress>);
+
+    #[async_trait]
+    impl NetworkHttpEgress for RecordingNetworkHttpEgress {
+        async fn execute(
+            &self,
+            request: NetworkHttpRequest,
+        ) -> Result<NetworkHttpResponse, NetworkHttpError> {
+            self.0.execute(request).await
+        }
+    }
+
     impl RecordingRuntimeHttpEgress {
+        fn request_bodies(&self) -> Vec<serde_json::Value> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .filter_map(|request| {
+                    serde_json::from_slice::<serde_json::Value>(&request.body).ok()
+                })
+                .collect()
+        }
+
         fn pairing_code(&self) -> Option<String> {
             self.requests
                 .lock()
@@ -1143,6 +1422,25 @@ mod tests {
                         .and_then(|suffix| suffix.split(" in WebChat").next())
                         .map(str::to_string)
                 })
+        }
+
+        fn post_message_body_with_text(&self, expected_text: &str) -> Option<serde_json::Value> {
+            self.post_message_bodies_with_text(expected_text)
+                .into_iter()
+                .next()
+        }
+
+        fn post_message_bodies_with_text(&self, expected_text: &str) -> Vec<serde_json::Value> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .filter(|request| request.url.contains("/api/chat.postMessage"))
+                .filter_map(|request| {
+                    serde_json::from_slice::<serde_json::Value>(&request.body).ok()
+                })
+                .filter(|body| body["text"].as_str() == Some(expected_text))
+                .collect()
         }
     }
 }

--- a/crates/ironclaw_slack_v2_adapter/src/payload.rs
+++ b/crates/ironclaw_slack_v2_adapter/src/payload.rs
@@ -153,10 +153,12 @@ fn parse_message_event(
 /// Fixed user-message routing strategies in this first slice.
 /// `AppMention`: public channel, strip leading `@mention`, thread fallback to `ts`.
 /// `Dm`: direct-message channel required, keep text verbatim, no thread fallback.
+/// `ThreadReply`: channel thread reply, keep text verbatim, require `thread_ts`.
 #[derive(Debug, Clone, Copy)]
 enum SlackMessageKind {
     AppMention,
     Dm,
+    ThreadReply,
 }
 
 fn try_parse_user_message(
@@ -179,6 +181,9 @@ fn try_parse_user_message(
     {
         return noop_parsed_inbound(event_id, team_id, Some(event));
     }
+    if matches!(kind, SlackMessageKind::ThreadReply) && event.thread_ts.is_none() {
+        return noop_parsed_inbound(event_id, team_id, Some(event));
+    }
     let Some(ts) = event.ts.as_deref() else {
         return noop_parsed_inbound(event_id, team_id, Some(event));
     };
@@ -194,6 +199,11 @@ fn try_parse_user_message(
             raw_text.to_string(),
             event.thread_ts.as_deref(),
             ProductTriggerReason::DirectChat,
+        ),
+        SlackMessageKind::ThreadReply => (
+            raw_text.to_string(),
+            event.thread_ts.as_deref(),
+            ProductTriggerReason::ReplyToBot,
         ),
     };
 
@@ -223,7 +233,7 @@ fn parse_thread_interaction(
         ProductTriggerReason::ReplyToBot,
     )?
     else {
-        return noop_parsed_inbound(event_id, team_id, Some(event));
+        return try_parse_user_message(event_id, team_id, event, SlackMessageKind::ThreadReply);
     };
     Ok(parsed)
 }
@@ -802,6 +812,40 @@ mod tests {
         }));
 
         assert!(matches!(inbound.payload, ProductInboundPayload::NoOp));
+    }
+
+    #[test]
+    fn channel_thread_message_becomes_reply_to_bot_user_message() {
+        let inbound = parse(serde_json::json!({
+            "type": "event_callback",
+            "team_id": "T123",
+            "event_id": "EvThreadReply",
+            "event": {
+                "type": "message",
+                "user": "U123",
+                "channel": "C123",
+                "text": "continue without mentioning the bot",
+                "ts": "1710000000.000011",
+                "thread_ts": "1710000000.000010"
+            }
+        }));
+
+        assert_eq!(inbound.external_conversation_ref.conversation_id(), "C123");
+        assert_eq!(
+            inbound.external_conversation_ref.topic_id(),
+            Some("1710000000.000010")
+        );
+        assert_eq!(
+            inbound.external_conversation_ref.reply_target_message_id(),
+            Some("1710000000.000011")
+        );
+        match inbound.payload {
+            ProductInboundPayload::UserMessage(payload) => {
+                assert_eq!(payload.text, "continue without mentioning the bot");
+                assert_eq!(payload.trigger, ProductTriggerReason::ReplyToBot);
+            }
+            other => panic!("expected user message, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironclaw_turns/src/scope.rs
+++ b/crates/ironclaw_turns/src/scope.rs
@@ -7,6 +7,44 @@ pub struct TurnScope {
     pub agent_id: Option<AgentId>,
     pub project_id: Option<ProjectId>,
     pub thread_id: ThreadId,
+    #[serde(default, skip_serializing_if = "TurnThreadOwner::is_actor_fallback")]
+    pub thread_owner: TurnThreadOwner,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "mode")]
+pub enum TurnThreadOwner {
+    #[default]
+    ActorFallback,
+    #[serde(alias = "explicit")]
+    ExplicitUser {
+        owner_user_id: UserId,
+    },
+    Ownerless,
+}
+
+impl TurnThreadOwner {
+    pub fn explicit(owner_user_id: Option<UserId>) -> Self {
+        match owner_user_id {
+            Some(owner_user_id) => Self::ExplicitUser { owner_user_id },
+            None => Self::Ownerless,
+        }
+    }
+
+    fn is_actor_fallback(&self) -> bool {
+        matches!(self, Self::ActorFallback)
+    }
+
+    pub fn explicit_owner_user_id(&self) -> Option<&UserId> {
+        match self {
+            Self::ExplicitUser { owner_user_id } => Some(owner_user_id),
+            Self::ActorFallback | Self::Ownerless => None,
+        }
+    }
+
+    pub fn is_explicit(&self) -> bool {
+        !self.is_actor_fallback()
+    }
 }
 
 impl TurnScope {
@@ -21,7 +59,32 @@ impl TurnScope {
             agent_id,
             project_id,
             thread_id,
+            thread_owner: TurnThreadOwner::ActorFallback,
         }
+    }
+
+    pub fn new_with_owner(
+        tenant_id: TenantId,
+        agent_id: Option<AgentId>,
+        project_id: Option<ProjectId>,
+        thread_id: ThreadId,
+        owner_user_id: Option<UserId>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            agent_id,
+            project_id,
+            thread_id,
+            thread_owner: TurnThreadOwner::explicit(owner_user_id),
+        }
+    }
+
+    pub fn explicit_owner_user_id(&self) -> Option<&UserId> {
+        self.thread_owner.explicit_owner_user_id()
+    }
+
+    pub fn has_explicit_thread_owner(&self) -> bool {
+        self.thread_owner.is_explicit()
     }
 
     /// Convert into a [`ironclaw_host_api::ResourceScope`] for filesystem
@@ -34,7 +97,9 @@ impl TurnScope {
     pub fn to_resource_scope(&self) -> ironclaw_host_api::ResourceScope {
         let mut scope = ironclaw_host_api::ResourceScope::system();
         scope.tenant_id = self.tenant_id.clone();
-        scope.user_id = UserId::from_trusted(ironclaw_host_api::SYSTEM_RESERVED_ID.to_string());
+        scope.user_id = self.explicit_owner_user_id().cloned().unwrap_or_else(|| {
+            UserId::from_trusted(ironclaw_host_api::SYSTEM_RESERVED_ID.to_string())
+        });
         scope.agent_id = self.agent_id.clone();
         scope.project_id = self.project_id.clone();
         scope.mission_id = None;
@@ -51,5 +116,37 @@ pub struct TurnActor {
 impl TurnActor {
     pub fn new(user_id: UserId) -> Self {
         Self { user_id }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turn_scope_accepts_legacy_explicit_thread_owner_mode() {
+        let scope: TurnScope = serde_json::from_value(serde_json::json!({
+            "tenant_id": "tenant:slack",
+            "agent_id": "agent:slack",
+            "project_id": "project:slack",
+            "thread_id": "thread:slack",
+            "thread_owner": {
+                "mode": "explicit",
+                "owner_user_id": "user:slack-subject"
+            }
+        }))
+        .expect("legacy explicit owner mode should deserialize");
+
+        assert_eq!(
+            scope.explicit_owner_user_id().map(UserId::as_str),
+            Some("user:slack-subject")
+        );
+        assert_eq!(
+            serde_json::to_value(&scope.thread_owner).expect("serialize owner"),
+            serde_json::json!({
+                "mode": "explicit_user",
+                "owner_user_id": "user:slack-subject"
+            })
+        );
     }
 }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -804,11 +804,12 @@ impl RebornBinaryE2EHarness {
             &binding,
             route_kind_for_trigger(initial_trigger),
         )?;
-        let turn_scope = TurnScope::new(
+        let turn_scope = TurnScope::new_with_owner(
             binding.tenant_id.clone(),
             binding.agent_id.clone(),
             binding.project_id.clone(),
             binding.thread_id.clone(),
+            binding.subject_user_id.clone(),
         );
         let thread_harness = if let Some(storage) = shared_storage.as_ref() {
             RebornThreadHarness::filesystem_shared_backend(
@@ -1039,7 +1040,7 @@ impl RebornBinaryE2EHarness {
             binding.project_id.clone(),
             binding.thread_id.clone(),
         );
-        let actor = TurnActor::new(binding.user_id.clone());
+        let actor = TurnActor::new(binding.actor_user_id.clone());
         let ack = self.workflow.accept_inbound(envelope).await?;
         let run_id = match &ack {
             ProductInboundAck::Accepted {
@@ -1090,7 +1091,7 @@ impl RebornBinaryE2EHarness {
     ) -> HarnessResult<()> {
         self.resume_with_gate_as(
             self.turn_scope.clone(),
-            TurnActor::new(self.binding.user_id.clone()),
+            TurnActor::new(self.binding.actor_user_id.clone()),
             run_id,
             gate_ref,
             format!("resume-{run_id}"),
@@ -1128,7 +1129,7 @@ impl RebornBinaryE2EHarness {
     pub async fn cancel_blocked_turn(&self, run_id: TurnRunId) -> HarnessResult<()> {
         self.cancel_run_as(
             self.turn_scope.clone(),
-            TurnActor::new(self.binding.user_id.clone()),
+            TurnActor::new(self.binding.actor_user_id.clone()),
             run_id,
             format!("cancel-{run_id}"),
         )
@@ -2934,7 +2935,7 @@ fn thread_scope_from_binding(binding: &ResolvedBinding) -> HarnessResult<ThreadS
 
 fn thread_scope_from_binding_with_route_kind(
     binding: &ResolvedBinding,
-    route_kind: ProductConversationRouteKind,
+    _route_kind: ProductConversationRouteKind,
 ) -> HarnessResult<ThreadScope> {
     Ok(ThreadScope {
         tenant_id: binding.tenant_id.clone(),
@@ -2943,10 +2944,7 @@ fn thread_scope_from_binding_with_route_kind(
             .clone()
             .ok_or("resolved binding missing agent id")?,
         project_id: binding.project_id.clone(),
-        owner_user_id: match route_kind {
-            ProductConversationRouteKind::Direct => Some(binding.user_id.clone()),
-            ProductConversationRouteKind::Shared => None,
-        },
+        owner_user_id: binding.subject_user_id.clone(),
         mission_id: None,
     })
 }
@@ -2976,9 +2974,13 @@ fn scoped_turns_fs<F>(
 where
     F: RootFilesystem,
 {
+    let owner_user_id = binding
+        .subject_user_id
+        .as_ref()
+        .unwrap_or(&binding.actor_user_id);
     let target = format!(
         "/engine/tenants/{}/users/{}/turns",
-        binding.tenant_id, binding.user_id
+        binding.tenant_id, owner_user_id
     );
     let mounts = MountView::new(vec![MountGrant::new(
         MountAlias::new("/turns").expect("valid turns alias"),

--- a/tests/support/reborn/product_workflow.rs
+++ b/tests/support/reborn/product_workflow.rs
@@ -13,8 +13,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_product_workflow::{
     ActionFingerprintKey, ActionPhase, ConversationBindingService, IdempotencyDecision,
-    IdempotencyLedger, ProductInboundAction, ProductWorkflowError, ResolveBindingRequest,
-    ResolvedBinding,
+    IdempotencyLedger, ProductConversationRouteKind, ProductInboundAction, ProductWorkflowError,
+    ResolveBindingRequest, ResolvedBinding,
 };
 use serde::{Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
@@ -194,9 +194,15 @@ where
             return Ok(stored.binding);
         }
 
+        let actor_user_id = user_id_for_binding(&self.scope.tenant_id, &request)?;
+        let subject_user_id = match request.route_kind {
+            ProductConversationRouteKind::Direct => Some(actor_user_id.clone()),
+            ProductConversationRouteKind::Shared => Some(self.scope.user_id.clone()),
+        };
         let binding = ResolvedBinding {
             tenant_id: self.scope.tenant_id.clone(),
-            user_id: user_id_for_binding(&self.scope.tenant_id, &request)?,
+            actor_user_id,
+            subject_user_id,
             thread_id: thread_id_for_binding(&self.scope, &request)?,
             agent_id: Some(self.agent_id.clone()),
             project_id: self.project_id.clone(),

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -1263,7 +1263,7 @@ mod reborn_support_tests {
             .await
             .expect("tenant-b binding");
         assert_eq!(tenant_b_binding.tenant_id.as_str(), "tenant-b");
-        assert_ne!(tenant_b_binding.user_id, binding.user_id);
+        assert_ne!(tenant_b_binding.actor_user_id, binding.actor_user_id);
         assert_ne!(tenant_b_binding.thread_id, binding.thread_id);
     }
 


### PR DESCRIPTION
## Summary
- split Slack product bindings into actor_user_id and subject_user_id so channel routes execute under the configured subject while preserving the paired Slack sender as actor
- wire Slack host-beta through subject-owned turn/thread scopes, host-runtime egress credential staging, and final reply delivery
- accept plain Slack thread replies as ReplyToBot continuations while keeping ambient channel chatter ignored and requiring an existing thread binding

## Tests
- cargo test -p ironclaw_product_workflow
- cargo test -p ironclaw_slack_v2_adapter
- cargo test -p ironclaw_product_workflow concrete_product_workflow_reply_to_bot_requires_existing_binding
- cargo test -p ironclaw_reborn_composition build_slack_host_beta_mounts_replies_to_channel_app_mention_thread --features webui-v2-beta,slack-v2-host-beta,libsql
- cargo test -p ironclaw_reborn_composition build_slack_host_beta_mounts_pairs_unknown_slack_actor_then_routes_bound_event --features webui-v2-beta,slack-v2-host-beta,libsql
- cargo test -p ironclaw_reborn_composition local_dev_visible_capability_request_uses_explicit_subject_for_runtime_scope --features webui-v2-beta,slack-v2-host-beta,libsql
- cargo test -p ironclaw_reborn_composition slack_egress --features webui-v2-beta,slack-v2-host-beta,libsql
- cargo test -p ironclaw_reborn thread_scope
- cargo test -p ironclaw_reborn_cli slack_host_beta_config --features webui-v2-beta,slack-v2-host-beta
- cargo build -p ironclaw_reborn_cli --features webui-v2-beta,slack-v2-host-beta
- cargo fmt --check
- git diff --check

## Notes
- Slack thread replies still require the Slack app to subscribe to message.channels/message.groups and corresponding history scopes.
- Full cargo test -p ironclaw_host_runtime currently has an unrelated GitHub hot catalog expectation mismatch: github_v2_package_discovers_and_publishes_issue_hot_catalog expects the old three-capability catalog while the manifest exposes the full catalog.
