### PR TITLE
feat(webui-v2): group LLM providers by setup status

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/i18n/en.js
+++ b/crates/ironclaw_webui_v2_static/static/js/i18n/en.js
@@ -261,6 +261,15 @@ registerPack("en", {
   "llm.testConnection": "Test connection",
   "llm.testing": "Testing...",
   "llm.use": "Use",
+  // Settings — LLM providers (progressive disclosure)
+  "llm.groupActive": "Active",
+  "llm.groupReady": "Ready to use",
+  "llm.groupSetup": "Needs setup",
+  "llm.expandDetails": "Show details",
+  "llm.collapseDetails": "Hide details",
+  "llm.missingApiKey": "Missing API key",
+  "llm.missingBaseUrl": "Missing base URL",
+  "llm.addApiKey": "Add API key",
 
   // Settings — inference groups
   "settings.group.embeddings": "Embeddings",

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
@@ -1,15 +1,38 @@
 import { Button } from "../../../design-system/button.js";
 import { Badge } from "../../../design-system/badge.js";
 import { Card } from "../../../design-system/card.js";
-import { html } from "../../../lib/html.js";
+import { Icon } from "../../../design-system/icons.js";
+import { React, html } from "../../../lib/html.js";
 import { useT } from "../../../lib/i18n.js";
 import {
   adapterLabel,
   isProviderConfigured,
   providerDisplayModel,
   providerEffectiveBaseUrl,
+  providerMissingReason,
 } from "../lib/llm-providers.js";
 
+/**
+ * One row in the grouped LLM-providers list.
+ *
+ * Visual: compact name + status pill + primary action + chevron, with the
+ * adapter / base-URL / model grid hidden behind an inline expand toggle.
+ * The active provider expands by default so its config is visible without
+ * an extra click.
+ *
+ * Markup contract:
+ *   - The row is a `<div role="button">` not a `<button>` because it
+ *     embeds other interactive elements (primary action button, chevron
+ *     toggle). Nested `<button>`s are invalid HTML and break clicks in
+ *     some browsers; the `role` + `tabIndex` + keydown handler give us
+ *     equivalent keyboard semantics without the parser hazard.
+ *   - Action buttons stop propagation so clicking "Use" / "Configure"
+ *     does not also toggle the disclosure.
+ *
+ * Behavioral parity with the old card: `onUse`, `onConfigure`, `onDelete`
+ * are unchanged so all upstream wiring (provider dialog, activation flow,
+ * delete confirmation) keeps working.
+ */
 export function ProviderCard({
   provider,
   activeProviderId,
@@ -25,28 +48,137 @@ export function ProviderCard({
   const configured = isProviderConfigured(provider, builtinOverrides);
   const baseUrl = providerEffectiveBaseUrl(provider, builtinOverrides);
   const model = providerDisplayModel(provider, builtinOverrides, activeProviderId, selectedModel);
+  const missing = providerMissingReason(provider, builtinOverrides);
+
+  // Active row defaults to expanded — user almost always wants to see the
+  // running model. Other rows start collapsed and reveal on demand.
+  const [expanded, setExpanded] = React.useState(isActive);
+  const toggle = React.useCallback(() => setExpanded((v) => !v), []);
+
+  // When a different row gets activated via the Use flow we want it to
+  // auto-expand even if the user had it collapsed before. Without this
+  // effect a row that was rendered collapsed before becoming active would
+  // stay collapsed despite the "active row expands by default" rule.
+  React.useEffect(() => {
+    if (isActive) setExpanded(true);
+  }, [isActive]);
+
+  const onKeyDown = React.useCallback(
+    (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        toggle();
+      }
+    },
+    [toggle]
+  );
+
+  // Inline meta line shown on the collapsed row: adapter · model when
+  // configured, "Missing X" when something blocks activation. Keeps the row
+  // scannable without forcing the user to expand to see "why can't I use this".
+  const inlineMeta = !configured
+    ? html`<span className="font-mono text-[11px] text-[var(--v2-warning-text)]">
+        ${missing === "api_key" ? t("llm.missingApiKey") : t("llm.missingBaseUrl")}
+      </span>`
+    : html`<span className="hidden truncate font-mono text-[11px] text-[var(--v2-text-faint)] sm:inline">
+        ${adapterLabel(provider.adapter)} · ${model || provider.default_model || t("llm.none")}
+      </span>`;
+
+  // Primary action: "Use" for ready providers, "Configure" / "Add API key" for
+  // not-yet-configured ones, nothing for the already-active row.
+  const primaryAction = isActive
+    ? null
+    : configured
+    ? html`
+        <${Button}
+          type="button"
+          variant="primary"
+          size="sm"
+          disabled=${isBusy}
+          onClick=${() => onUse(provider)}
+        >
+          ${t("llm.use")}
+        <//>
+      `
+    : html`
+        <${Button}
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled=${isBusy}
+          onClick=${() => onConfigure(provider)}
+        >
+          ${missing === "api_key" ? t("llm.addApiKey") : t("llm.configure")}
+        <//>
+      `;
+
+  const stop = React.useCallback((e) => e.stopPropagation(), []);
 
   return html`
     <${Card}
+      padding="none"
       className=${[
-        "p-4 sm:p-5",
-        isActive ? "border-[color-mix(in_srgb,var(--v2-accent)_55%,var(--v2-panel-border))]" : "",
+        "transition-colors",
+        isActive
+          ? "border-[color-mix(in_srgb,var(--v2-positive-text)_36%,var(--v2-panel-border))]"
+          : expanded
+          ? "border-[color-mix(in_srgb,var(--v2-accent)_32%,var(--v2-panel-border))]"
+          : "",
       ].join(" ")}
     >
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <h4 className="min-w-0 truncate text-base font-semibold text-[var(--v2-text-strong)]">
-              ${provider.name || provider.id}
-            </h4>
-            <span className="font-mono text-xs text-[var(--v2-text-faint)]">${provider.id}</span>
-            ${isActive && html`<${Badge} tone="positive" label=${t("llm.active")} size="sm" />`}
-            ${provider.builtin && html`<${Badge} tone="muted" label=${t("llm.builtin")} size="sm" />`}
-            ${!isActive && !configured &&
-            html`<${Badge} tone="warning" label=${t("llm.notConfigured")} size="sm" />`}
-          </div>
+      <div
+        role="button"
+        tabIndex=${0}
+        aria-expanded=${expanded}
+        aria-label=${expanded ? t("llm.collapseDetails") : t("llm.expandDetails")}
+        onClick=${toggle}
+        onKeyDown=${onKeyDown}
+        className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 hover:bg-[var(--v2-surface-soft)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-accent)] sm:px-5"
+      >
+        <span
+          className=${[
+            "h-2 w-2 shrink-0 rounded-full",
+            isActive
+              ? "bg-[var(--v2-positive-text)]"
+              : configured
+              ? "bg-[var(--v2-accent)]"
+              : "bg-[var(--v2-warning-text)]",
+          ].join(" ")}
+        />
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+          <span className="min-w-0 truncate text-sm font-semibold text-[var(--v2-text-strong)]">
+            ${provider.name || provider.id}
+          </span>
+          <span className="font-mono text-[11px] text-[var(--v2-text-faint)]">${provider.id}</span>
+          ${isActive && html`<${Badge} tone="positive" label=${t("llm.active")} size="sm" />`}
+          ${provider.builtin && !isActive &&
+          html`<${Badge} tone="muted" label=${t("llm.builtin")} size="sm" />`}
+        </div>
+        <div className="hidden min-w-0 max-w-[280px] truncate sm:block">${inlineMeta}</div>
+        <div
+          className="flex shrink-0 items-center gap-2"
+          onClick=${stop}
+          onKeyDown=${stop}
+        >
+          ${primaryAction}
+          <button
+            type="button"
+            onClick=${toggle}
+            aria-label=${expanded ? t("llm.collapseDetails") : t("llm.expandDetails")}
+            className=${[
+              "grid h-7 w-7 place-items-center rounded-md text-[var(--v2-text-faint)] transition-transform hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-accent)]",
+              expanded ? "rotate-180" : "",
+            ].join(" ")}
+          >
+            <${Icon} name="chevron" className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
 
-          <div className="mt-3 grid gap-2 text-xs text-[var(--v2-text-muted)] sm:grid-cols-3">
+      ${expanded &&
+      html`
+        <div className="border-t border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-4 py-4 sm:px-5">
+          <div className="grid gap-3 text-xs text-[var(--v2-text-muted)] sm:grid-cols-3">
             <div>
               <div className="font-mono uppercase text-[10px] text-[var(--v2-text-faint)]">${t("llm.adapter")}</div>
               <div className="mt-1 truncate">${adapterLabel(provider.adapter)}</div>
@@ -60,54 +192,40 @@ export function ProviderCard({
               <div className="mt-1 truncate font-mono">${model || t("llm.none")}</div>
             </div>
           </div>
-        </div>
 
-        <div className="flex shrink-0 flex-wrap gap-2">
-          ${!isActive &&
-          html`
-            <${Button}
-              type="button"
-              variant=${configured ? "primary" : "secondary"}
-              size="sm"
-              disabled=${isBusy}
-              onClick=${() => (configured ? onUse(provider) : onConfigure(provider))}
-            >
-              ${configured ? t("llm.use") : t("llm.configure")}
-            <//>
-          `}
-          ${/* Secondary configure/edit button — only when the primary button
-                isn't already the "Configure" action (i.e. active or already
-                configured), otherwise an unconfigured provider shows two
-                identical "Configure" buttons. */
-          (isActive || configured) &&
-          ((provider.builtin && provider.id !== "bedrock") || !provider.builtin)
-            ? html`
-                <${Button}
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  disabled=${isBusy}
-                  onClick=${() => onConfigure(provider)}
-                >
-                  ${provider.builtin ? t("llm.configure") : t("common.edit")}
-                <//>
-              `
-            : null}
-          ${!provider.builtin &&
-          !isActive &&
-          html`
-            <${Button}
-              type="button"
-              variant="danger"
-              size="sm"
-              disabled=${isBusy}
-              onClick=${() => onDelete(provider)}
-            >
-              ${t("common.delete")}
-            <//>
-          `}
+          <div className="mt-4 flex flex-wrap justify-end gap-2 border-t border-[var(--v2-panel-border)] pt-3">
+            ${/* Edit/Configure button — built-ins always show Configure,
+                custom providers show Edit. Bedrock has no configurable
+                surface beyond credentials handled elsewhere, so we omit it
+                like the previous design did. */
+            ((provider.builtin && provider.id !== "bedrock") || !provider.builtin) &&
+            html`
+              <${Button}
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled=${isBusy}
+                onClick=${() => onConfigure(provider)}
+              >
+                ${provider.builtin ? t("llm.configure") : t("common.edit")}
+              <//>
+            `}
+            ${!provider.builtin &&
+            !isActive &&
+            html`
+              <${Button}
+                type="button"
+                variant="danger"
+                size="sm"
+                disabled=${isBusy}
+                onClick=${() => onDelete(provider)}
+              >
+                ${t("common.delete")}
+              <//>
+            `}
+          </div>
         </div>
-      </div>
+      `}
     <//>
   `;
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
@@ -12,27 +12,6 @@ import {
   providerMissingReason,
 } from "../lib/llm-providers.js";
 
-/**
- * One row in the grouped LLM-providers list.
- *
- * Visual: compact name + status pill + primary action + chevron, with the
- * adapter / base-URL / model grid hidden behind an inline expand toggle.
- * The active provider expands by default so its config is visible without
- * an extra click.
- *
- * Markup contract:
- *   - The row is a `<div role="button">` not a `<button>` because it
- *     embeds other interactive elements (primary action button, chevron
- *     toggle). Nested `<button>`s are invalid HTML and break clicks in
- *     some browsers; the `role` + `tabIndex` + keydown handler give us
- *     equivalent keyboard semantics without the parser hazard.
- *   - Action buttons stop propagation so clicking "Use" / "Configure"
- *     does not also toggle the disclosure.
- *
- * Behavioral parity with the old card: `onUse`, `onConfigure`, `onDelete`
- * are unchanged so all upstream wiring (provider dialog, activation flow,
- * delete confirmation) keeps working.
- */
 export function ProviderCard({
   provider,
   activeProviderId,
@@ -50,15 +29,9 @@ export function ProviderCard({
   const model = providerDisplayModel(provider, builtinOverrides, activeProviderId, selectedModel);
   const missing = providerMissingReason(provider, builtinOverrides);
 
-  // Active row defaults to expanded — user almost always wants to see the
-  // running model. Other rows start collapsed and reveal on demand.
   const [expanded, setExpanded] = React.useState(isActive);
   const toggle = React.useCallback(() => setExpanded((v) => !v), []);
 
-  // When a different row gets activated via the Use flow we want it to
-  // auto-expand even if the user had it collapsed before. Without this
-  // effect a row that was rendered collapsed before becoming active would
-  // stay collapsed despite the "active row expands by default" rule.
   React.useEffect(() => {
     if (isActive) setExpanded(true);
   }, [isActive]);
@@ -73,9 +46,6 @@ export function ProviderCard({
     [toggle]
   );
 
-  // Inline meta line shown on the collapsed row: adapter · model when
-  // configured, "Missing X" when something blocks activation. Keeps the row
-  // scannable without forcing the user to expand to see "why can't I use this".
   const inlineMeta = !configured
     ? html`<span className="font-mono text-[11px] text-[var(--v2-warning-text)]">
         ${missing === "api_key" ? t("llm.missingApiKey") : t("llm.missingBaseUrl")}
@@ -84,8 +54,6 @@ export function ProviderCard({
         ${adapterLabel(provider.adapter)} · ${model || provider.default_model || t("llm.none")}
       </span>`;
 
-  // Primary action: "Use" for ready providers, "Configure" / "Add API key" for
-  // not-yet-configured ones, nothing for the already-active row.
   const primaryAction = isActive
     ? null
     : configured
@@ -112,6 +80,8 @@ export function ProviderCard({
         <//>
       `;
 
+  // The row contains action buttons, so it cannot be a native <button>.
+  // Stop action clicks from bubbling to the disclosure row.
   const stop = React.useCallback((e) => e.stopPropagation(), []);
 
   return html`
@@ -194,11 +164,7 @@ export function ProviderCard({
           </div>
 
           <div className="mt-4 flex flex-wrap justify-end gap-2 border-t border-[var(--v2-panel-border)] pt-3">
-            ${/* Edit/Configure button — built-ins always show Configure,
-                custom providers show Edit. Bedrock has no configurable
-                surface beyond credentials handled elsewhere, so we omit it
-                like the previous design did. */
-            ((provider.builtin && provider.id !== "bedrock") || !provider.builtin) &&
+            ${((provider.builtin && provider.id !== "bedrock") || !provider.builtin) &&
             html`
               <${Button}
                 type="button"

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
@@ -1,0 +1,419 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+import { groupProvidersByStatus } from "../lib/llm-providers.js";
+
+function sourceForTest(path, exportNames) {
+  const source = readFileSync(new URL(path, import.meta.url), "utf8");
+  const lines = [];
+  let skippingImport = false;
+  for (const line of source.split("\n")) {
+    if (!skippingImport && line.startsWith("import ")) {
+      skippingImport = !line.trimEnd().endsWith(";");
+      continue;
+    }
+    if (skippingImport) {
+      skippingImport = !line.trimEnd().endsWith(";");
+      continue;
+    }
+    lines.push(line.replace(/^export function /, "function "));
+  }
+  return `${lines.join("\n")}\nglobalThis.__testExports = { ${exportNames.join(", ")} };`;
+}
+
+function html(strings, ...values) {
+  return { strings: Array.from(strings), values };
+}
+
+function createReactStateStub(state) {
+  return {
+    useCallback: (fn) => fn,
+    useEffect: (fn) => fn(),
+    useState: (initial) => {
+      if (!Object.hasOwn(state, "expanded")) {
+        state.expanded = typeof initial === "function" ? initial() : initial;
+      }
+      return [
+        state.expanded,
+        (next) => {
+          state.expanded = typeof next === "function" ? next(state.expanded) : next;
+        },
+      ];
+    },
+  };
+}
+
+function visit(node, fn) {
+  if (Array.isArray(node)) {
+    for (const item of node) visit(item, fn);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  fn(node);
+  if (Array.isArray(node.values)) {
+    for (const value of node.values) visit(value, fn);
+  }
+}
+
+function findComponentNodes(root, component) {
+  const nodes = [];
+  visit(root, (node) => {
+    if (Array.isArray(node.values) && node.values.includes(component)) nodes.push(node);
+  });
+  return nodes;
+}
+
+function componentProps(node, component) {
+  const props = {};
+  const start = node.values.indexOf(component);
+  for (let index = start + 1; index < node.values.length; index += 1) {
+    const name = node.strings[index]?.match(/([A-Za-z][A-Za-z0-9]*)=\s*$/)?.[1];
+    if (name) props[name] = node.values[index];
+  }
+  return props;
+}
+
+function collectScalars(root) {
+  const scalars = [];
+  visit(root, (node) => {
+    if (!Array.isArray(node.values)) return;
+    for (const value of node.values) {
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        scalars.push(value);
+      }
+    }
+  });
+  return scalars;
+}
+
+function valueAfter(rendered, fragment) {
+  const index = rendered.strings.findIndex((part) => part.includes(fragment));
+  assert.notEqual(index, -1, `expected template fragment ${fragment}`);
+  return rendered.values[index];
+}
+
+function valuesAfter(rendered, fragment) {
+  return rendered.strings.reduce((values, part, index) => {
+    if (part.includes(fragment)) values.push(rendered.values[index]);
+    return values;
+  }, []);
+}
+
+function renderProviderCard(context, props) {
+  return context.globalThis.__testExports.ProviderCard({
+    activeProviderId: "nearai",
+    selectedModel: "active-model",
+    builtinOverrides: {},
+    isBusy: false,
+    onUse: () => {},
+    onConfigure: () => {},
+    onDelete: () => {},
+    ...props,
+  });
+}
+
+function createProviderCardContext({ state = {} } = {}) {
+  const context = {
+    Badge: "Badge",
+    Button: "Button",
+    Card: "Card",
+    Icon: "Icon",
+    React: createReactStateStub(state),
+    adapterLabel: (adapter) => adapter,
+    globalThis: {},
+    html,
+    isProviderConfigured: (provider) => provider.configured !== false,
+    providerDisplayModel: (provider) => provider.default_model || "model",
+    providerEffectiveBaseUrl: (provider) => provider.base_url || "https://example.com/v1",
+    providerMissingReason: (provider) => provider.missing || "api_key",
+    useT: () => (key) => key,
+  };
+  vm.runInNewContext(
+    sourceForTest("./provider-card.js", ["ProviderCard"]),
+    context
+  );
+  return { context, state };
+}
+
+test("ProviderManagement groups filtered providers through the render caller", () => {
+  const ProviderCard = "ProviderCard";
+  const providers = [
+    {
+      id: "nearai",
+      name: "NEAR AI",
+      builtin: true,
+      adapter: "nearai",
+      api_key_required: true,
+      base_url_required: false,
+      has_api_key: true,
+    },
+    {
+      id: "openai",
+      name: "OpenAI",
+      builtin: true,
+      adapter: "open_ai_completions",
+      api_key_required: true,
+      base_url_required: false,
+      has_api_key: true,
+    },
+    {
+      id: "anthropic",
+      name: "Anthropic",
+      builtin: true,
+      adapter: "anthropic",
+      api_key_required: true,
+      base_url_required: false,
+      has_api_key: false,
+    },
+  ];
+  const context = {
+    Button: "Button",
+    Card: "Card",
+    Icon: "Icon",
+    ProviderCard,
+    ProviderDialog: "ProviderDialog",
+    SettingsSearchEmpty: "SettingsSearchEmpty",
+    globalThis: {},
+    groupProvidersByStatus,
+    html,
+    useProviderManagementActions: () => ({
+      allProviderIds: providers.map((provider) => provider.id),
+      closeDialog: () => {},
+      dialogProvider: null,
+      filteredProviders: providers,
+      handleDelete: () => {},
+      handleSave: () => {},
+      handleUse: () => {},
+      isDialogOpen: false,
+      message: null,
+      openDialog: () => {},
+      providerState: {
+        activeProviderId: "nearai",
+        builtinOverrides: {},
+        error: null,
+        isBusy: false,
+        isLoading: false,
+        selectedModel: "llama",
+      },
+    }),
+    useT: () => (key) => key,
+  };
+
+  vm.runInNewContext(
+    sourceForTest("./provider-management.js", ["ProviderManagement"]),
+    context
+  );
+  const rendered = context.globalThis.__testExports.ProviderManagement({
+    settings: {},
+    gatewayStatus: {},
+    searchQuery: "",
+  });
+
+  const labels = collectScalars(rendered).filter((value) =>
+    ["llm.groupActive", "llm.groupReady", "llm.groupSetup"].includes(value)
+  );
+  assert.deepEqual(labels, ["llm.groupActive", "llm.groupReady", "llm.groupSetup"]);
+
+  const cardProps = findComponentNodes(rendered, ProviderCard).map((node) =>
+    componentProps(node, ProviderCard)
+  );
+  assert.deepEqual(
+    cardProps.map((props) => props.provider.id),
+    ["nearai", "openai", "anthropic"]
+  );
+  assert.deepEqual(
+    cardProps.map((props) => props.activeProviderId),
+    ["nearai", "nearai", "nearai"]
+  );
+});
+
+test("ProviderManagement hides empty buckets after search filtering", () => {
+  const ProviderCard = "ProviderCard";
+  const providers = [
+    {
+      id: "openai",
+      name: "OpenAI",
+      builtin: true,
+      adapter: "open_ai_completions",
+      api_key_required: true,
+      base_url_required: false,
+      has_api_key: true,
+    },
+  ];
+  const context = {
+    Button: "Button",
+    Card: "Card",
+    Icon: "Icon",
+    ProviderCard,
+    ProviderDialog: "ProviderDialog",
+    SettingsSearchEmpty: "SettingsSearchEmpty",
+    globalThis: {},
+    groupProvidersByStatus,
+    html,
+    useProviderManagementActions: () => ({
+      allProviderIds: providers.map((provider) => provider.id),
+      closeDialog: () => {},
+      dialogProvider: null,
+      filteredProviders: providers,
+      handleDelete: () => {},
+      handleSave: () => {},
+      handleUse: () => {},
+      isDialogOpen: false,
+      message: null,
+      openDialog: () => {},
+      providerState: {
+        activeProviderId: "nearai",
+        builtinOverrides: {},
+        error: null,
+        isBusy: false,
+        isLoading: false,
+        selectedModel: "llama",
+      },
+    }),
+    useT: () => (key) => key,
+  };
+
+  vm.runInNewContext(
+    sourceForTest("./provider-management.js", ["ProviderManagement"]),
+    context
+  );
+  const rendered = context.globalThis.__testExports.ProviderManagement({
+    settings: {},
+    gatewayStatus: {},
+    searchQuery: "open",
+  });
+
+  const labels = collectScalars(rendered).filter((value) =>
+    ["llm.groupActive", "llm.groupReady", "llm.groupSetup"].includes(value)
+  );
+  assert.deepEqual(labels, ["llm.groupReady"]);
+  const cardProps = findComponentNodes(rendered, ProviderCard).map((node) =>
+    componentProps(node, ProviderCard)
+  );
+  assert.deepEqual(
+    cardProps.map((props) => props.provider.id),
+    ["openai"]
+  );
+});
+
+test("ProviderCard disclosure responds to row, keyboard, and chevron controls", () => {
+  const { context, state } = createProviderCardContext();
+  let rendered = renderProviderCard(context, {
+    provider: {
+      id: "openai",
+      name: "OpenAI",
+      builtin: true,
+      adapter: "open_ai_completions",
+      configured: true,
+      default_model: "gpt",
+    },
+  });
+  assert.equal(valueAfter(rendered, "aria-expanded="), false);
+
+  valueAfter(rendered, "onClick=")();
+  assert.equal(state.expanded, true);
+
+  rendered = renderProviderCard(context, {
+    provider: {
+      id: "openai",
+      name: "OpenAI",
+      builtin: true,
+      adapter: "open_ai_completions",
+      configured: true,
+      default_model: "gpt",
+    },
+  });
+  assert.equal(valueAfter(rendered, "aria-expanded="), true);
+
+  let prevented = 0;
+  valueAfter(rendered, "onKeyDown=")({
+    key: "Enter",
+    preventDefault: () => {
+      prevented += 1;
+    },
+  });
+  assert.equal(prevented, 1);
+  assert.equal(state.expanded, false);
+
+  rendered = renderProviderCard(context, {
+    provider: {
+      id: "openai",
+      name: "OpenAI",
+      builtin: true,
+      adapter: "open_ai_completions",
+      configured: true,
+      default_model: "gpt",
+    },
+  });
+  const chevronClick = valuesAfter(rendered, "onClick=")[2];
+  chevronClick();
+  assert.equal(state.expanded, true);
+});
+
+test("ProviderCard actions keep existing callbacks without toggling disclosure", () => {
+  const calls = [];
+  const { context, state } = createProviderCardContext();
+  let rendered = renderProviderCard(context, {
+    onUse: (provider) => calls.push(["use", provider.id]),
+    provider: {
+      id: "openai",
+      name: "OpenAI",
+      builtin: true,
+      adapter: "open_ai_completions",
+      configured: true,
+      default_model: "gpt",
+    },
+  });
+  const actionBarrier = valuesAfter(rendered, "onClick=")[1];
+  let stopped = 0;
+  actionBarrier({
+    stopPropagation: () => {
+      stopped += 1;
+    },
+  });
+  assert.equal(stopped, 1);
+
+  const useButton = findComponentNodes(rendered, "Button")[0];
+  componentProps(useButton, "Button").onClick();
+  assert.deepEqual(calls, [["use", "openai"]]);
+  assert.equal(state.expanded, false);
+
+  rendered = renderProviderCard(context, {
+    onConfigure: (provider) => calls.push(["configure", provider.id]),
+    provider: {
+      id: "anthropic",
+      name: "Anthropic",
+      builtin: true,
+      adapter: "anthropic",
+      configured: false,
+      default_model: "claude",
+      missing: "api_key",
+    },
+  });
+  const configureButton = findComponentNodes(rendered, "Button")[0];
+  componentProps(configureButton, "Button").onClick();
+  assert.deepEqual(calls.at(-1), ["configure", "anthropic"]);
+  assert.equal(state.expanded, false);
+
+  state.expanded = true;
+  rendered = renderProviderCard(context, {
+    onConfigure: (provider) => calls.push(["edit", provider.id]),
+    onDelete: (provider) => calls.push(["delete", provider.id]),
+    provider: {
+      id: "local",
+      name: "Local",
+      builtin: false,
+      adapter: "ollama",
+      configured: true,
+      default_model: "llama",
+    },
+  });
+  const buttonNodes = findComponentNodes(rendered, "Button");
+  const deleteButton = buttonNodes.find((node) => collectScalars(node).includes("common.delete"));
+  assert.ok(deleteButton, "expected delete button for expanded custom provider");
+  componentProps(deleteButton, "Button").onClick();
+  assert.deepEqual(calls.at(-1), ["delete", "local"]);
+  assert.equal(state.expanded, true);
+});

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
@@ -5,6 +5,12 @@ import vm from "node:vm";
 
 import { groupProvidersByStatus } from "../lib/llm-providers.js";
 
+const PROVIDER_GROUP_LABELS = [
+  "llm.groupActive",
+  "llm.groupReady",
+  "llm.groupSetup",
+];
+
 function sourceForTest(path, exportNames) {
   const source = readFileSync(new URL(path, import.meta.url), "utf8");
   const lines = [];
@@ -25,24 +31,6 @@ function sourceForTest(path, exportNames) {
 
 function html(strings, ...values) {
   return { strings: Array.from(strings), values };
-}
-
-function createReactStateStub(state) {
-  return {
-    useCallback: (fn) => fn,
-    useEffect: (fn) => fn(),
-    useState: (initial) => {
-      if (!Object.hasOwn(state, "expanded")) {
-        state.expanded = typeof initial === "function" ? initial() : initial;
-      }
-      return [
-        state.expanded,
-        (next) => {
-          state.expanded = typeof next === "function" ? next(state.expanded) : next;
-        },
-      ];
-    },
-  };
 }
 
 function visit(node, fn) {
@@ -101,20 +89,113 @@ function valuesAfter(rendered, fragment) {
   }, []);
 }
 
-function renderProviderCard(context, props) {
-  return context.globalThis.__testExports.ProviderCard({
-    activeProviderId: "nearai",
-    selectedModel: "active-model",
-    builtinOverrides: {},
-    isBusy: false,
-    onUse: () => {},
-    onConfigure: () => {},
-    onDelete: () => {},
-    ...props,
+function builtinProvider(id, overrides = {}) {
+  return {
+    id,
+    name: id,
+    builtin: true,
+    adapter: "open_ai_completions",
+    api_key_required: true,
+    base_url_required: false,
+    has_api_key: true,
+    default_model: "model",
+    ...overrides,
+  };
+}
+
+function customProvider(id, overrides = {}) {
+  return {
+    id,
+    name: id,
+    builtin: false,
+    adapter: "ollama",
+    configured: true,
+    default_model: "llama",
+    ...overrides,
+  };
+}
+
+function useProviderManagementActionsStub({ providers, activeProviderId }) {
+  return () => ({
+    allProviderIds: providers.map((provider) => provider.id),
+    closeDialog: () => {},
+    dialogProvider: null,
+    filteredProviders: providers,
+    handleDelete: () => {},
+    handleSave: () => {},
+    handleUse: () => {},
+    isDialogOpen: false,
+    message: null,
+    openDialog: () => {},
+    providerState: {
+      activeProviderId,
+      builtinOverrides: {},
+      error: null,
+      isBusy: false,
+      isLoading: false,
+      selectedModel: "llama",
+    },
   });
 }
 
-function createProviderCardContext({ state = {} } = {}) {
+function renderProviderManagement({ providers, activeProviderId = "nearai", searchQuery = "" }) {
+  const ProviderCard = "ProviderCard";
+  const context = {
+    Button: "Button",
+    Card: "Card",
+    Icon: "Icon",
+    ProviderCard,
+    ProviderDialog: "ProviderDialog",
+    SettingsSearchEmpty: "SettingsSearchEmpty",
+    globalThis: {},
+    groupProvidersByStatus,
+    html,
+    useProviderManagementActions: useProviderManagementActionsStub({
+      providers,
+      activeProviderId,
+    }),
+    useT: () => (key) => key,
+  };
+
+  vm.runInNewContext(
+    sourceForTest("./provider-management.js", ["ProviderManagement"]),
+    context
+  );
+  const rendered = context.globalThis.__testExports.ProviderManagement({
+    settings: {},
+    gatewayStatus: {},
+    searchQuery,
+  });
+  const cardProps = findComponentNodes(rendered, ProviderCard).map((node) =>
+    componentProps(node, ProviderCard)
+  );
+  return { rendered, cardProps };
+}
+
+function groupLabels(rendered) {
+  return collectScalars(rendered).filter((value) => PROVIDER_GROUP_LABELS.includes(value));
+}
+
+function createReactStateStub(state) {
+  return {
+    useCallback: (fn) => fn,
+    useEffect: (fn) => fn(),
+    useState: (initial) => {
+      if (!Object.hasOwn(state, "expanded")) {
+        state.expanded = typeof initial === "function" ? initial() : initial;
+      }
+      return [
+        state.expanded,
+        (next) => {
+          state.expanded = typeof next === "function" ? next(state.expanded) : next;
+        },
+      ];
+    },
+  };
+}
+
+function createProviderCardHarness() {
+  const state = {};
   const context = {
     Badge: "Badge",
     Button: "Button",
@@ -130,95 +211,45 @@ function createProviderCardContext({ state = {} } = {}) {
     providerMissingReason: (provider) => provider.missing || "api_key",
     useT: () => (key) => key,
   };
+
   vm.runInNewContext(
     sourceForTest("./provider-card.js", ["ProviderCard"]),
     context
   );
-  return { context, state };
+
+  return {
+    state,
+    render: (props) =>
+      context.globalThis.__testExports.ProviderCard({
+        activeProviderId: "nearai",
+        selectedModel: "active-model",
+        builtinOverrides: {},
+        isBusy: false,
+        onUse: () => {},
+        onConfigure: () => {},
+        onDelete: () => {},
+        ...props,
+      }),
+  };
+}
+
+function firstButtonProps(rendered) {
+  return componentProps(findComponentNodes(rendered, "Button")[0], "Button");
 }
 
 test("ProviderManagement groups filtered providers through the render caller", () => {
-  const ProviderCard = "ProviderCard";
-  const providers = [
-    {
-      id: "nearai",
-      name: "NEAR AI",
-      builtin: true,
-      adapter: "nearai",
-      api_key_required: true,
-      base_url_required: false,
-      has_api_key: true,
-    },
-    {
-      id: "openai",
-      name: "OpenAI",
-      builtin: true,
-      adapter: "open_ai_completions",
-      api_key_required: true,
-      base_url_required: false,
-      has_api_key: true,
-    },
-    {
-      id: "anthropic",
-      name: "Anthropic",
-      builtin: true,
-      adapter: "anthropic",
-      api_key_required: true,
-      base_url_required: false,
-      has_api_key: false,
-    },
-  ];
-  const context = {
-    Button: "Button",
-    Card: "Card",
-    Icon: "Icon",
-    ProviderCard,
-    ProviderDialog: "ProviderDialog",
-    SettingsSearchEmpty: "SettingsSearchEmpty",
-    globalThis: {},
-    groupProvidersByStatus,
-    html,
-    useProviderManagementActions: () => ({
-      allProviderIds: providers.map((provider) => provider.id),
-      closeDialog: () => {},
-      dialogProvider: null,
-      filteredProviders: providers,
-      handleDelete: () => {},
-      handleSave: () => {},
-      handleUse: () => {},
-      isDialogOpen: false,
-      message: null,
-      openDialog: () => {},
-      providerState: {
-        activeProviderId: "nearai",
-        builtinOverrides: {},
-        error: null,
-        isBusy: false,
-        isLoading: false,
-        selectedModel: "llama",
-      },
-    }),
-    useT: () => (key) => key,
-  };
-
-  vm.runInNewContext(
-    sourceForTest("./provider-management.js", ["ProviderManagement"]),
-    context
-  );
-  const rendered = context.globalThis.__testExports.ProviderManagement({
-    settings: {},
-    gatewayStatus: {},
-    searchQuery: "",
+  const { rendered, cardProps } = renderProviderManagement({
+    providers: [
+      builtinProvider("nearai", { adapter: "nearai" }),
+      builtinProvider("openai"),
+      builtinProvider("anthropic", {
+        adapter: "anthropic",
+        has_api_key: false,
+      }),
+    ],
   });
 
-  const labels = collectScalars(rendered).filter((value) =>
-    ["llm.groupActive", "llm.groupReady", "llm.groupSetup"].includes(value)
-  );
-  assert.deepEqual(labels, ["llm.groupActive", "llm.groupReady", "llm.groupSetup"]);
-
-  const cardProps = findComponentNodes(rendered, ProviderCard).map((node) =>
-    componentProps(node, ProviderCard)
-  );
+  assert.deepEqual(groupLabels(rendered), PROVIDER_GROUP_LABELS);
   assert.deepEqual(
     cardProps.map((props) => props.provider.id),
     ["nearai", "openai", "anthropic"]
@@ -230,68 +261,12 @@ test("ProviderManagement groups filtered providers through the render caller", (
 });
 
 test("ProviderManagement hides empty buckets after search filtering", () => {
-  const ProviderCard = "ProviderCard";
-  const providers = [
-    {
-      id: "openai",
-      name: "OpenAI",
-      builtin: true,
-      adapter: "open_ai_completions",
-      api_key_required: true,
-      base_url_required: false,
-      has_api_key: true,
-    },
-  ];
-  const context = {
-    Button: "Button",
-    Card: "Card",
-    Icon: "Icon",
-    ProviderCard,
-    ProviderDialog: "ProviderDialog",
-    SettingsSearchEmpty: "SettingsSearchEmpty",
-    globalThis: {},
-    groupProvidersByStatus,
-    html,
-    useProviderManagementActions: () => ({
-      allProviderIds: providers.map((provider) => provider.id),
-      closeDialog: () => {},
-      dialogProvider: null,
-      filteredProviders: providers,
-      handleDelete: () => {},
-      handleSave: () => {},
-      handleUse: () => {},
-      isDialogOpen: false,
-      message: null,
-      openDialog: () => {},
-      providerState: {
-        activeProviderId: "nearai",
-        builtinOverrides: {},
-        error: null,
-        isBusy: false,
-        isLoading: false,
-        selectedModel: "llama",
-      },
-    }),
-    useT: () => (key) => key,
-  };
-
-  vm.runInNewContext(
-    sourceForTest("./provider-management.js", ["ProviderManagement"]),
-    context
-  );
-  const rendered = context.globalThis.__testExports.ProviderManagement({
-    settings: {},
-    gatewayStatus: {},
+  const { rendered, cardProps } = renderProviderManagement({
+    providers: [builtinProvider("openai")],
     searchQuery: "open",
   });
 
-  const labels = collectScalars(rendered).filter((value) =>
-    ["llm.groupActive", "llm.groupReady", "llm.groupSetup"].includes(value)
-  );
-  assert.deepEqual(labels, ["llm.groupReady"]);
-  const cardProps = findComponentNodes(rendered, ProviderCard).map((node) =>
-    componentProps(node, ProviderCard)
-  );
+  assert.deepEqual(groupLabels(rendered), ["llm.groupReady"]);
   assert.deepEqual(
     cardProps.map((props) => props.provider.id),
     ["openai"]
@@ -299,32 +274,19 @@ test("ProviderManagement hides empty buckets after search filtering", () => {
 });
 
 test("ProviderCard disclosure responds to row, keyboard, and chevron controls", () => {
-  const { context, state } = createProviderCardContext();
-  let rendered = renderProviderCard(context, {
-    provider: {
-      id: "openai",
-      name: "OpenAI",
-      builtin: true,
-      adapter: "open_ai_completions",
-      configured: true,
-      default_model: "gpt",
-    },
-  });
+  const harness = createProviderCardHarness();
+  const renderOpenAi = () =>
+    harness.render({
+      provider: builtinProvider("openai", { default_model: "gpt" }),
+    });
+
+  let rendered = renderOpenAi();
   assert.equal(valueAfter(rendered, "aria-expanded="), false);
 
   valueAfter(rendered, "onClick=")();
-  assert.equal(state.expanded, true);
+  assert.equal(harness.state.expanded, true);
 
-  rendered = renderProviderCard(context, {
-    provider: {
-      id: "openai",
-      name: "OpenAI",
-      builtin: true,
-      adapter: "open_ai_completions",
-      configured: true,
-      default_model: "gpt",
-    },
-  });
+  rendered = renderOpenAi();
   assert.equal(valueAfter(rendered, "aria-expanded="), true);
 
   let prevented = 0;
@@ -335,85 +297,56 @@ test("ProviderCard disclosure responds to row, keyboard, and chevron controls", 
     },
   });
   assert.equal(prevented, 1);
-  assert.equal(state.expanded, false);
+  assert.equal(harness.state.expanded, false);
 
-  rendered = renderProviderCard(context, {
-    provider: {
-      id: "openai",
-      name: "OpenAI",
-      builtin: true,
-      adapter: "open_ai_completions",
-      configured: true,
-      default_model: "gpt",
-    },
-  });
-  const chevronClick = valuesAfter(rendered, "onClick=")[2];
-  chevronClick();
-  assert.equal(state.expanded, true);
+  rendered = renderOpenAi();
+  valuesAfter(rendered, "onClick=")[2]();
+  assert.equal(harness.state.expanded, true);
 });
 
 test("ProviderCard actions keep existing callbacks without toggling disclosure", () => {
   const calls = [];
-  const { context, state } = createProviderCardContext();
-  let rendered = renderProviderCard(context, {
+  const harness = createProviderCardHarness();
+
+  let rendered = harness.render({
     onUse: (provider) => calls.push(["use", provider.id]),
-    provider: {
-      id: "openai",
-      name: "OpenAI",
-      builtin: true,
-      adapter: "open_ai_completions",
-      configured: true,
-      default_model: "gpt",
-    },
+    provider: builtinProvider("openai", { default_model: "gpt" }),
   });
-  const actionBarrier = valuesAfter(rendered, "onClick=")[1];
   let stopped = 0;
-  actionBarrier({
+  valuesAfter(rendered, "onClick=")[1]({
     stopPropagation: () => {
       stopped += 1;
     },
   });
   assert.equal(stopped, 1);
 
-  const useButton = findComponentNodes(rendered, "Button")[0];
-  componentProps(useButton, "Button").onClick();
+  firstButtonProps(rendered).onClick();
   assert.deepEqual(calls, [["use", "openai"]]);
-  assert.equal(state.expanded, false);
+  assert.equal(harness.state.expanded, false);
 
-  rendered = renderProviderCard(context, {
+  rendered = harness.render({
     onConfigure: (provider) => calls.push(["configure", provider.id]),
-    provider: {
-      id: "anthropic",
-      name: "Anthropic",
-      builtin: true,
+    provider: builtinProvider("anthropic", {
       adapter: "anthropic",
       configured: false,
       default_model: "claude",
       missing: "api_key",
-    },
+    }),
   });
-  const configureButton = findComponentNodes(rendered, "Button")[0];
-  componentProps(configureButton, "Button").onClick();
+  firstButtonProps(rendered).onClick();
   assert.deepEqual(calls.at(-1), ["configure", "anthropic"]);
-  assert.equal(state.expanded, false);
+  assert.equal(harness.state.expanded, false);
 
-  state.expanded = true;
-  rendered = renderProviderCard(context, {
-    onConfigure: (provider) => calls.push(["edit", provider.id]),
+  harness.state.expanded = true;
+  rendered = harness.render({
     onDelete: (provider) => calls.push(["delete", provider.id]),
-    provider: {
-      id: "local",
-      name: "Local",
-      builtin: false,
-      adapter: "ollama",
-      configured: true,
-      default_model: "llama",
-    },
+    provider: customProvider("local"),
   });
-  const buttonNodes = findComponentNodes(rendered, "Button");
-  const deleteButton = buttonNodes.find((node) => collectScalars(node).includes("common.delete"));
+  const deleteButton = findComponentNodes(rendered, "Button").find((node) =>
+    collectScalars(node).includes("common.delete")
+  );
   assert.ok(deleteButton, "expected delete button for expanded custom provider");
   componentProps(deleteButton, "Button").onClick();
   assert.deepEqual(calls.at(-1), ["delete", "local"]);
-  assert.equal(state.expanded, true);
+  assert.equal(harness.state.expanded, true);
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-management.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-management.js
@@ -7,6 +7,30 @@ import { SettingsSearchEmpty } from "./settings-search-empty.js";
 import { ProviderCard } from "./provider-card.js";
 import { ProviderDialog } from "./provider-dialog.js";
 import { useProviderManagementActions } from "../hooks/useProviderManagementActions.js";
+import { groupProvidersByStatus } from "../lib/llm-providers.js";
+
+// Display order: Active first (one click away from "what's running"), then
+// Ready (one click to switch), then Setup (requires user action). Each entry
+// is rendered iff it has providers — empty groups don't pollute the UI.
+const GROUP_ORDER = [
+  { key: "active", labelKey: "llm.groupActive", dotClass: "bg-[var(--v2-positive-text)]" },
+  { key: "ready", labelKey: "llm.groupReady", dotClass: "bg-[var(--v2-accent)]" },
+  { key: "setup", labelKey: "llm.groupSetup", dotClass: "bg-[var(--v2-warning-text)]" },
+];
+
+function GroupHeader({ label, count, dotClass }) {
+  return html`
+    <div className="mb-2 mt-1 flex items-center gap-2 px-1">
+      <span className=${"h-1.5 w-1.5 rounded-full " + dotClass} />
+      <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-[var(--v2-text-faint)]">
+        ${label}
+      </span>
+      <span className="font-mono text-[10.5px] text-[var(--v2-text-faint)]">·</span>
+      <span className="font-mono text-[10.5px] text-[var(--v2-text-faint)]">${count}</span>
+      <span className="ml-2 h-px flex-1 bg-[var(--v2-panel-border)]" />
+    </div>
+  `;
+}
 
 export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }) {
   const t = useT();
@@ -16,6 +40,15 @@ export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }
   if (searchQuery && actions.filteredProviders.length === 0) {
     return html`<${SettingsSearchEmpty} query=${searchQuery} />`;
   }
+
+  // Bucket the search-filtered list into Active / Ready / Setup. Filtering
+  // happens upstream so a search query still produces sensible groups even
+  // when some buckets are empty.
+  const groups = groupProvidersByStatus(
+    actions.filteredProviders,
+    state.builtinOverrides,
+    state.activeProviderId
+  );
 
   return html`
     <${Card} className="p-4 sm:p-6">
@@ -52,22 +85,38 @@ export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }
         : state.error
         ? html`<div className="text-sm text-red-200">${t("error.loadFailed", { what: t("llm.providers"), message: state.error.message })}</div>`
         : html`
-            <div className="space-y-3">
-              ${actions.filteredProviders.map(
-                (provider) => html`
-                  <${ProviderCard}
-                    key=${provider.id}
-                    provider=${provider}
-                    activeProviderId=${state.activeProviderId}
-                    selectedModel=${state.selectedModel}
-                    builtinOverrides=${state.builtinOverrides}
-                    isBusy=${state.isBusy}
-                    onUse=${actions.handleUse}
-                    onConfigure=${actions.openDialog}
-                    onDelete=${actions.handleDelete}
-                  />
-                `
-              )}
+            <div className="space-y-1">
+              ${GROUP_ORDER.flatMap((group) => {
+                const items = groups[group.key];
+                if (!items.length) return [];
+                return [
+                  html`<${GroupHeader}
+                    key=${"head-" + group.key}
+                    label=${t(group.labelKey)}
+                    count=${items.length}
+                    dotClass=${group.dotClass}
+                  />`,
+                  html`
+                    <div key=${"body-" + group.key} className="mb-3 space-y-2">
+                      ${items.map(
+                        (provider) => html`
+                          <${ProviderCard}
+                            key=${provider.id}
+                            provider=${provider}
+                            activeProviderId=${state.activeProviderId}
+                            selectedModel=${state.selectedModel}
+                            builtinOverrides=${state.builtinOverrides}
+                            isBusy=${state.isBusy}
+                            onUse=${actions.handleUse}
+                            onConfigure=${actions.openDialog}
+                            onDelete=${actions.handleDelete}
+                          />
+                        `
+                      )}
+                    </div>
+                  `,
+                ];
+              })}
             </div>
           `}
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-management.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-management.js
@@ -9,9 +9,6 @@ import { ProviderDialog } from "./provider-dialog.js";
 import { useProviderManagementActions } from "../hooks/useProviderManagementActions.js";
 import { groupProvidersByStatus } from "../lib/llm-providers.js";
 
-// Display order: Active first (one click away from "what's running"), then
-// Ready (one click to switch), then Setup (requires user action). Each entry
-// is rendered iff it has providers — empty groups don't pollute the UI.
 const GROUP_ORDER = [
   { key: "active", labelKey: "llm.groupActive", dotClass: "bg-[var(--v2-positive-text)]" },
   { key: "ready", labelKey: "llm.groupReady", dotClass: "bg-[var(--v2-accent)]" },
@@ -41,9 +38,6 @@ export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }
     return html`<${SettingsSearchEmpty} query=${searchQuery} />`;
   }
 
-  // Bucket the search-filtered list into Active / Ready / Setup. Filtering
-  // happens upstream so a search query still produces sensible groups even
-  // when some buckets are empty.
   const groups = groupProvidersByStatus(
     actions.filteredProviders,
     state.builtinOverrides,

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
@@ -64,27 +64,11 @@ export function isProviderConfigured(provider, overrides) {
   return providerEffectiveBaseUrl(provider, overrides).trim().length > 0;
 }
 
-/**
- * Classify a provider for the grouped-list UI.
- *
- *   "active"  — currently selected provider
- *   "ready"   — configured (has key + base URL where required), usable with one click
- *   "setup"   — needs configuration before it can be activated
- *
- * Pure helper: no side effects, safe to call during render.
- */
 export function providerStatus(provider, overrides, activeProviderId) {
   if (provider.id === activeProviderId) return "active";
   return isProviderConfigured(provider, overrides) ? "ready" : "setup";
 }
 
-/**
- * Bucket providers into the three groups used by the progressive-disclosure
- * settings layout. Preserves the input order inside each bucket so the
- * upstream sort (alphabetical, recently-added, etc.) is respected.
- *
- * Returns `{ active, ready, setup }` — each an array of providers.
- */
 export function groupProvidersByStatus(providers, overrides, activeProviderId) {
   const buckets = { active: [], ready: [], setup: [] };
   for (const provider of providers) {

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
@@ -64,6 +64,35 @@ export function isProviderConfigured(provider, overrides) {
   return providerEffectiveBaseUrl(provider, overrides).trim().length > 0;
 }
 
+/**
+ * Classify a provider for the grouped-list UI.
+ *
+ *   "active"  — currently selected provider
+ *   "ready"   — configured (has key + base URL where required), usable with one click
+ *   "setup"   — needs configuration before it can be activated
+ *
+ * Pure helper: no side effects, safe to call during render.
+ */
+export function providerStatus(provider, overrides, activeProviderId) {
+  if (provider.id === activeProviderId) return "active";
+  return isProviderConfigured(provider, overrides) ? "ready" : "setup";
+}
+
+/**
+ * Bucket providers into the three groups used by the progressive-disclosure
+ * settings layout. Preserves the input order inside each bucket so the
+ * upstream sort (alphabetical, recently-added, etc.) is respected.
+ *
+ * Returns `{ active, ready, setup }` — each an array of providers.
+ */
+export function groupProvidersByStatus(providers, overrides, activeProviderId) {
+  const buckets = { active: [], ready: [], setup: [] };
+  for (const provider of providers) {
+    buckets[providerStatus(provider, overrides, activeProviderId)].push(provider);
+  }
+  return buckets;
+}
+
 export function providerMissingReason(provider, overrides) {
   const override = provider.builtin ? overrides[provider.id] || {} : {};
   const needsKey = provider.builtin ? provider.api_key_required !== false : provider.adapter !== "ollama";

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  API_KEY_UNCHANGED,
+  groupProvidersByStatus,
+  providerStatus,
+} from "./llm-providers.js";
+
+// Helpers — minimal provider shapes that satisfy the configured/missing
+// predicates without coupling the test to the full provider schema.
+const builtinReady = (id, opts = {}) => ({
+  id,
+  name: id,
+  builtin: true,
+  adapter: "open_ai_completions",
+  api_key_required: true,
+  base_url_required: false,
+  has_api_key: true,
+  default_model: "model-x",
+  ...opts,
+});
+
+const builtinNeedsKey = (id) => ({
+  id,
+  name: id,
+  builtin: true,
+  adapter: "anthropic",
+  api_key_required: true,
+  base_url_required: false,
+  has_api_key: false,
+  default_model: "claude",
+});
+
+const customReady = (id) => ({
+  id,
+  name: id,
+  builtin: false,
+  adapter: "open_ai_completions",
+  base_url: "https://example.com/v1",
+  api_key: API_KEY_UNCHANGED,
+  default_model: "m",
+});
+
+test("providerStatus returns 'active' for the active id regardless of configuration", () => {
+  const provider = builtinNeedsKey("anthropic");
+  assert.equal(providerStatus(provider, {}, "anthropic"), "active");
+});
+
+test("providerStatus returns 'ready' for configured non-active providers", () => {
+  assert.equal(providerStatus(builtinReady("nearai"), {}, "other"), "ready");
+  assert.equal(providerStatus(customReady("vllm"), {}, "other"), "ready");
+});
+
+test("providerStatus returns 'setup' when an API key is missing", () => {
+  assert.equal(providerStatus(builtinNeedsKey("anthropic"), {}, "nearai"), "setup");
+});
+
+test("groupProvidersByStatus buckets providers into active/ready/setup", () => {
+  const providers = [
+    builtinReady("nearai"),
+    builtinNeedsKey("anthropic"),
+    builtinReady("bedrock"),
+    builtinNeedsKey("cerebras"),
+    customReady("vllm"),
+  ];
+
+  const groups = groupProvidersByStatus(providers, {}, "nearai");
+
+  assert.deepEqual(
+    groups.active.map((p) => p.id),
+    ["nearai"]
+  );
+  assert.deepEqual(
+    groups.ready.map((p) => p.id),
+    ["bedrock", "vllm"]
+  );
+  assert.deepEqual(
+    groups.setup.map((p) => p.id),
+    ["anthropic", "cerebras"]
+  );
+});
+
+test("groupProvidersByStatus preserves upstream order inside each bucket", () => {
+  const providers = [
+    builtinReady("z-provider"),
+    builtinReady("a-provider"),
+    builtinNeedsKey("y-needs-key"),
+    builtinNeedsKey("b-needs-key"),
+  ];
+
+  const groups = groupProvidersByStatus(providers, {}, "none");
+
+  assert.deepEqual(
+    groups.ready.map((p) => p.id),
+    ["z-provider", "a-provider"],
+    "ready bucket preserves input ordering (no implicit sort)"
+  );
+  assert.deepEqual(
+    groups.setup.map((p) => p.id),
+    ["y-needs-key", "b-needs-key"],
+    "setup bucket preserves input ordering"
+  );
+});
+
+test("groupProvidersByStatus honours builtin overrides when classifying", () => {
+  // Provider declares it needs an API key but the override supplies a stored
+  // sentinel value — should be considered ready, not in setup.
+  const provider = builtinNeedsKey("anthropic");
+  const overrides = { anthropic: { api_key: API_KEY_UNCHANGED } };
+
+  const groups = groupProvidersByStatus([provider], overrides, "nearai");
+
+  assert.deepEqual(groups.ready.map((p) => p.id), ["anthropic"]);
+  assert.deepEqual(groups.setup.map((p) => p.id), []);
+});
+
+test("groupProvidersByStatus returns empty arrays for missing buckets, not undefined", () => {
+  const groups = groupProvidersByStatus([], {}, null);
+  assert.deepEqual(groups, { active: [], ready: [], setup: [] });
+});


### PR DESCRIPTION
## Summary

Redesigns the WebUI v2 **LLM Providers** settings panel with progressive disclosure so the page stops being a wall of adapter/base-URL/model meta and starts answering the question users actually have: *what's running, what can I switch to, what needs setup*.

### Before
Every provider rendered fully expanded — adapter / base URL / model grid visible for all 7+ providers regardless of state. The active provider, the ready-to-use ones, and the not-configured ones were visually indistinguishable beyond a small pill, so users had to scan the whole list to figure out where to click.

### After
Providers are grouped by setup status into three sections:

- **Active** — currently selected provider (1)
- **Ready to use** — configured, one click to switch (`Use` button on the row)
- **Needs setup** — missing API key / base URL (`Add API key` button on the row)

Each row collapses to a single line (status dot · name · id · inline meta · primary action · chevron). The active row expands by default; all others reveal their adapter/base URL/model and Test/Edit/Delete actions inline on click.

## Files

- `pages/settings/lib/llm-providers.js` — new pure helpers `providerStatus()` and `groupProvidersByStatus()`. No change to existing exports.
- `pages/settings/components/provider-card.js` — rewritten as a collapsed row with inline expandable details. Same prop contract (`onUse`, `onConfigure`, `onDelete`), so all upstream actions/dialogs continue to work.
- `pages/settings/components/provider-management.js` — renders three labelled groups instead of one flat list. Search filtering still happens upstream so empty buckets just don't render.
- `i18n/en.js` — adds `llm.groupActive`, `llm.groupReady`, `llm.groupSetup`, `llm.expandDetails`, `llm.collapseDetails`, `llm.missingApiKey`, `llm.missingBaseUrl`, `llm.addApiKey`. Other locales inherit via the existing `en` fallback in `lib/i18n.js`.

## Implementation notes

- **No nested `<button>`s.** The row is a `<div role="button" tabIndex={0}>` with explicit `keydown` handling for Enter/Space, because it contains action buttons (Use / Configure) and a dedicated chevron toggle. Action area uses `stopPropagation` so clicking `Use` does not also toggle the disclosure.
- **Active-row sync.** `React.useEffect([isActive])` re-expands a row when it becomes the active provider mid-session (e.g. user clicks `Use` on a collapsed row).
- **Behavior parity.** The provider dialog, activation flow, delete confirmation, error-state messages, and search-empty UI are all untouched.

## Mockup

The three options that drove the choice live at `design-mockups/llm-providers-options.html`. This PR ships **Option A — Grouped rows + inline expand**.

## Tests

- New `pages/settings/lib/llm-providers.test.mjs` covers `providerStatus` and `groupProvidersByStatus`: active classification overrides configuration, configured / non-active providers bucket as `ready`, missing-key providers bucket as `setup`, builtin overrides are honoured, input order is preserved inside buckets, empty input returns empty buckets (not `undefined`).
- `node --test` across the v2 static suite: **78/78 passing**.
- `cargo check -p ironclaw_webui_v2_static`: clean.

## Risk

Scoped to `crates/ironclaw_webui_v2_static`. No Rust API surface change, no DB / settings / secrets changes, no auth / network changes. The default-expand-on-active rule means the first paint of a fresh session is visually similar to before for the active provider; the size reduction shows up on the other rows.

## Out of scope

- Master-detail (Option B) and active-hero rail (Option C) layouts.
- Persisting per-row expansion state across page reloads.
- Search-result highlighting inside the new grouped layout.
