### PR TITLE
fix(webui-v2): address provider grouping review feedback

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
@@ -28,27 +28,23 @@ export function ProviderCard({
   const baseUrl = providerEffectiveBaseUrl(provider, builtinOverrides);
   const model = providerDisplayModel(provider, builtinOverrides, activeProviderId, selectedModel);
   const missing = providerMissingReason(provider, builtinOverrides);
+  const missingLabel =
+    missing === "api_key"
+      ? t("llm.missingApiKey")
+      : missing === "base_url"
+      ? t("llm.missingBaseUrl")
+      : t("llm.notConfigured");
 
   const [expanded, setExpanded] = React.useState(isActive);
   const toggle = React.useCallback(() => setExpanded((v) => !v), []);
 
   React.useEffect(() => {
-    if (isActive) setExpanded(true);
+    setExpanded(isActive);
   }, [isActive]);
-
-  const onKeyDown = React.useCallback(
-    (event) => {
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-        toggle();
-      }
-    },
-    [toggle]
-  );
 
   const inlineMeta = !configured
     ? html`<span className="font-mono text-[11px] text-[var(--v2-warning-text)]">
-        ${missing === "api_key" ? t("llm.missingApiKey") : t("llm.missingBaseUrl")}
+        ${missingLabel}
       </span>`
     : html`<span className="hidden truncate font-mono text-[11px] text-[var(--v2-text-faint)] sm:inline">
         ${adapterLabel(provider.adapter)} · ${model || provider.default_model || t("llm.none")}
@@ -80,13 +76,11 @@ export function ProviderCard({
         <//>
       `;
 
-  // The row contains action buttons, so it cannot be a native <button>.
-  // Stop action clicks from bubbling to the disclosure row.
-  const stop = React.useCallback((e) => e.stopPropagation(), []);
-
   return html`
     <${Card}
       padding="none"
+      data-testid="llm-provider-card"
+      data-provider-id=${provider.id}
       className=${[
         "transition-colors",
         isActive
@@ -96,44 +90,42 @@ export function ProviderCard({
           : "",
       ].join(" ")}
     >
-      <div
-        role="button"
-        tabIndex=${0}
-        aria-expanded=${expanded}
-        aria-label=${expanded ? t("llm.collapseDetails") : t("llm.expandDetails")}
-        onClick=${toggle}
-        onKeyDown=${onKeyDown}
-        className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 hover:bg-[var(--v2-surface-soft)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-accent)] sm:px-5"
-      >
-        <span
-          className=${[
-            "h-2 w-2 shrink-0 rounded-full",
-            isActive
-              ? "bg-[var(--v2-positive-text)]"
-              : configured
-              ? "bg-[var(--v2-accent)]"
-              : "bg-[var(--v2-warning-text)]",
-          ].join(" ")}
-        />
-        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
-          <span className="min-w-0 truncate text-sm font-semibold text-[var(--v2-text-strong)]">
-            ${provider.name || provider.id}
-          </span>
-          <span className="font-mono text-[11px] text-[var(--v2-text-faint)]">${provider.id}</span>
-          ${isActive && html`<${Badge} tone="positive" label=${t("llm.active")} size="sm" />`}
-          ${provider.builtin && !isActive &&
-          html`<${Badge} tone="muted" label=${t("llm.builtin")} size="sm" />`}
-        </div>
-        <div className="hidden min-w-0 max-w-[280px] truncate sm:block">${inlineMeta}</div>
-        <div
-          className="flex shrink-0 items-center gap-2"
-          onClick=${stop}
-          onKeyDown=${stop}
+      <div className="flex w-full items-stretch hover:bg-[var(--v2-surface-soft)]">
+        <button
+          type="button"
+          aria-expanded=${expanded ? "true" : "false"}
+          aria-label=${expanded ? t("llm.collapseDetails") : t("llm.expandDetails")}
+          data-testid="llm-provider-disclosure"
+          onClick=${toggle}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 px-4 py-3 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-accent)] sm:pl-5 sm:pr-3"
         >
+          <span
+            className=${[
+              "h-2 w-2 shrink-0 rounded-full",
+              isActive
+                ? "bg-[var(--v2-positive-text)]"
+                : configured
+                ? "bg-[var(--v2-accent)]"
+                : "bg-[var(--v2-warning-text)]",
+            ].join(" ")}
+          />
+          <span className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            <span className="min-w-0 truncate text-sm font-semibold text-[var(--v2-text-strong)]">
+              ${provider.name || provider.id}
+            </span>
+            <span className="font-mono text-[11px] text-[var(--v2-text-faint)]">${provider.id}</span>
+            ${isActive && html`<${Badge} tone="positive" label=${t("llm.active")} size="sm" />`}
+            ${provider.builtin && !isActive &&
+            html`<${Badge} tone="muted" label=${t("llm.builtin")} size="sm" />`}
+          </span>
+          <span className="hidden min-w-0 max-w-[280px] truncate sm:block">${inlineMeta}</span>
+        </button>
+        <div className="flex shrink-0 items-center gap-2 py-3 pr-4 sm:pr-5">
           ${primaryAction}
           <button
             type="button"
             onClick=${toggle}
+            data-testid="llm-provider-chevron"
             aria-label=${expanded ? t("llm.collapseDetails") : t("llm.expandDetails")}
             className=${[
               "grid h-7 w-7 place-items-center rounded-md text-[var(--v2-text-faint)] transition-transform hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-text-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-accent)]",
@@ -147,7 +139,7 @@ export function ProviderCard({
 
       ${expanded &&
       html`
-        <div className="border-t border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-4 py-4 sm:px-5">
+        <div data-testid="llm-provider-details" className="border-t border-[var(--v2-panel-border)] bg-[var(--v2-surface-soft)] px-4 py-4 sm:px-5">
           <div className="grid gap-3 text-xs text-[var(--v2-text-muted)] sm:grid-cols-3">
             <div>
               <div className="font-mono uppercase text-[10px] text-[var(--v2-text-faint)]">${t("llm.adapter")}</div>

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
@@ -89,6 +89,17 @@ function valuesAfter(rendered, fragment) {
   }, []);
 }
 
+function deepValuesAfter(root, fragment) {
+  const values = [];
+  visit(root, (node) => {
+    if (!Array.isArray(node.strings) || !Array.isArray(node.values)) return;
+    node.strings.forEach((part, index) => {
+      if (part.includes(fragment)) values.push(node.values[index]);
+    });
+  });
+  return values;
+}
+
 function builtinProvider(id, overrides = {}) {
   return {
     id,
@@ -176,10 +187,20 @@ function groupLabels(rendered) {
   return collectScalars(rendered).filter((value) => PROVIDER_GROUP_LABELS.includes(value));
 }
 
+function depsChanged(previous, next) {
+  if (!previous || !next || previous.length !== next.length) return true;
+  return next.some((value, index) => value !== previous[index]);
+}
+
 function createReactStateStub(state) {
   return {
     useCallback: (fn) => fn,
-    useEffect: (fn) => fn(),
+    useEffect: (fn, deps) => {
+      if (depsChanged(state.effectDeps, deps)) {
+        state.effectDeps = deps ? Array.from(deps) : deps;
+        fn();
+      }
+    },
     useState: (initial) => {
       if (!Object.hasOwn(state, "expanded")) {
         state.expanded = typeof initial === "function" ? initial() : initial;
@@ -250,6 +271,11 @@ test("ProviderManagement groups filtered providers through the render caller", (
   });
 
   assert.deepEqual(groupLabels(rendered), PROVIDER_GROUP_LABELS);
+  assert.deepEqual(deepValuesAfter(rendered, "data-provider-status="), [
+    "active",
+    "ready",
+    "setup",
+  ]);
   assert.deepEqual(
     cardProps.map((props) => props.provider.id),
     ["nearai", "openai", "anthropic"]
@@ -281,27 +307,38 @@ test("ProviderCard disclosure responds to row, keyboard, and chevron controls", 
     });
 
   let rendered = renderOpenAi();
-  assert.equal(valueAfter(rendered, "aria-expanded="), false);
+  assert.equal(valueAfter(rendered, "aria-expanded="), "false");
 
   valueAfter(rendered, "onClick=")();
   assert.equal(harness.state.expanded, true);
 
   rendered = renderOpenAi();
-  assert.equal(valueAfter(rendered, "aria-expanded="), true);
+  assert.equal(valueAfter(rendered, "aria-expanded="), "true");
 
-  let prevented = 0;
-  valueAfter(rendered, "onKeyDown=")({
-    key: "Enter",
-    preventDefault: () => {
-      prevented += 1;
-    },
-  });
-  assert.equal(prevented, 1);
+  valueAfter(rendered, "onClick=")();
   assert.equal(harness.state.expanded, false);
 
   rendered = renderOpenAi();
-  valuesAfter(rendered, "onClick=")[2]();
+  valuesAfter(rendered, "onClick=")[1]();
   assert.equal(harness.state.expanded, true);
+});
+
+test("ProviderCard syncs disclosure state when active provider changes", () => {
+  const harness = createProviderCardHarness();
+  const provider = builtinProvider("openai", { default_model: "gpt" });
+
+  let rendered = harness.render({ provider, activeProviderId: "nearai" });
+  assert.equal(valueAfter(rendered, "aria-expanded="), "false");
+
+  rendered = harness.render({ provider, activeProviderId: "openai" });
+  rendered = harness.render({ provider, activeProviderId: "openai" });
+  assert.equal(valueAfter(rendered, "aria-expanded="), "true");
+  assert.equal(harness.state.expanded, true);
+
+  rendered = harness.render({ provider, activeProviderId: "nearai" });
+  rendered = harness.render({ provider, activeProviderId: "nearai" });
+  assert.equal(valueAfter(rendered, "aria-expanded="), "false");
+  assert.equal(harness.state.expanded, false);
 });
 
 test("ProviderCard actions keep existing callbacks without toggling disclosure", () => {
@@ -312,13 +349,6 @@ test("ProviderCard actions keep existing callbacks without toggling disclosure",
     onUse: (provider) => calls.push(["use", provider.id]),
     provider: builtinProvider("openai", { default_model: "gpt" }),
   });
-  let stopped = 0;
-  valuesAfter(rendered, "onClick=")[1]({
-    stopPropagation: () => {
-      stopped += 1;
-    },
-  });
-  assert.equal(stopped, 1);
 
   firstButtonProps(rendered).onClick();
   assert.deepEqual(calls, [["use", "openai"]]);

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-management.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-management.js
@@ -84,14 +84,19 @@ export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }
                 const items = groups[group.key];
                 if (!items.length) return [];
                 return [
-                  html`<${GroupHeader}
-                    key=${"head-" + group.key}
-                    label=${t(group.labelKey)}
-                    count=${items.length}
-                    dotClass=${group.dotClass}
-                  />`,
                   html`
-                    <div key=${"body-" + group.key} className="mb-3 space-y-2">
+                    <section
+                      key=${group.key}
+                      data-testid="llm-provider-group"
+                      data-provider-status=${group.key}
+                      className="mb-3"
+                    >
+                      <${GroupHeader}
+                        label=${t(group.labelKey)}
+                        count=${items.length}
+                        dotClass=${group.dotClass}
+                      />
+                      <div className="space-y-2">
                       ${items.map(
                         (provider) => html`
                           <${ProviderCard}
@@ -107,7 +112,8 @@ export function ProviderManagement({ settings, gatewayStatus, searchQuery = "" }
                           />
                         `
                       )}
-                    </div>
+                      </div>
+                    </section>
                   `,
                 ];
               })}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
@@ -71,8 +71,10 @@ export function providerStatus(provider, overrides, activeProviderId) {
 
 export function groupProvidersByStatus(providers, overrides, activeProviderId) {
   const buckets = { active: [], ready: [], setup: [] };
+  if (!Array.isArray(providers)) return buckets;
   for (const provider of providers) {
-    buckets[providerStatus(provider, overrides, activeProviderId)].push(provider);
+    const status = providerStatus(provider, overrides, activeProviderId);
+    if (buckets[status]) buckets[status].push(provider);
   }
   return buckets;
 }

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs
@@ -32,6 +32,17 @@ const builtinNeedsKey = (id) => ({
   default_model: "claude",
 });
 
+const builtinNeedsBaseUrl = (id) => ({
+  id,
+  name: id,
+  builtin: true,
+  adapter: "open_ai_completions",
+  api_key_required: false,
+  base_url_required: true,
+  has_api_key: true,
+  default_model: "model-x",
+});
+
 const customReady = (id) => ({
   id,
   name: id,
@@ -54,6 +65,10 @@ test("providerStatus returns 'ready' for configured non-active providers", () =>
 
 test("providerStatus returns 'setup' when an API key is missing", () => {
   assert.equal(providerStatus(builtinNeedsKey("anthropic"), {}, "nearai"), "setup");
+});
+
+test("providerStatus returns 'setup' when a required base URL is missing", () => {
+  assert.equal(providerStatus(builtinNeedsBaseUrl("openai"), {}, "nearai"), "setup");
 });
 
 test("groupProvidersByStatus buckets providers into active/ready/setup", () => {
@@ -117,5 +132,10 @@ test("groupProvidersByStatus honours builtin overrides when classifying", () => 
 
 test("groupProvidersByStatus returns empty arrays for missing buckets, not undefined", () => {
   const groups = groupProvidersByStatus([], {}, null);
+  assert.deepEqual(groups, { active: [], ready: [], setup: [] });
+});
+
+test("groupProvidersByStatus treats non-array input as empty", () => {
+  const groups = groupProvidersByStatus(null, {}, null);
   assert.deepEqual(groups, { active: [], ready: [], setup: [] });
 });


### PR DESCRIPTION
## Summary
- split provider disclosure into native button controls so action buttons are no longer inside a clickable role wrapper
- collapse inactive provider cards and re-expand when the active provider changes
- add robust missing-configuration labels and defensive provider grouping guards
- extend WebUI v2 static tests for base-url setup status, active disclosure sync, and grouped render status hooks

## Validation
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs`
- `node --test crates/ironclaw_webui_v2_static/static/js/**/*.test.mjs`
- `cargo check -p ironclaw_webui_v2_static`
- `git diff --check`

Follow-up for #4477, which was merged before these review fixes could be pushed.