### PR TITLE
fix(reborn): guard ProductWorkflow projection entrypoint

### DIFF
--- a/crates/ironclaw_product_adapters/src/workflow.rs
+++ b/crates/ironclaw_product_adapters/src/workflow.rs
@@ -8,6 +8,12 @@ use crate::projection::ProjectionSubscriptionRequest;
 
 #[async_trait]
 pub trait ProductWorkflow: Send + Sync {
+    /// Accept a mutating product action into the ProductWorkflow submit path.
+    ///
+    /// This entrypoint is for payloads that can create messages, runs,
+    /// command/gate/auth outcomes, or other durable side effects. Projection
+    /// read/subscribe requests must use [`Self::resolve_projection_subscription`]
+    /// and must not create mutating ProductInboundAction ledger rows.
     async fn accept_inbound(
         &self,
         envelope: ProductInboundEnvelope,

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -123,6 +123,20 @@ impl ProductWorkflow for DefaultProductWorkflow {
         &self,
         envelope: ProductInboundEnvelope,
     ) -> Result<ProductInboundAck, ProductAdapterError> {
+        if matches!(
+            envelope.payload(),
+            ProductInboundPayload::SubscriptionRequest(_)
+        ) {
+            return Err(ProductAdapterError::WorkflowRejected {
+                kind: ProductWorkflowRejectionKind::InvalidRequest,
+                status_code: 400,
+                retryable: false,
+                reason: RedactedString::new(
+                    "subscription_request must be resolved through resolve_projection_subscription",
+                ),
+            });
+        }
+
         let source_binding_key =
             SourceBindingKey::new(envelope.source_binding_key()).map_err(|reason| {
                 ProductAdapterError::from(ProductWorkflowError::BindingResolutionFailed { reason })

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -1522,6 +1522,37 @@ async fn noop_returns_noop_ack() {
 }
 
 #[tokio::test]
+async fn subscription_request_via_accept_inbound_rejects_before_mutating_ledger() {
+    let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
+    let envelope = sample_envelope_with_payload(
+        "projection-wrong-entrypoint",
+        ProductInboundPayload::SubscriptionRequest(
+            ProjectionSubscriptionPayload::new(None, None).expect("valid subscription"),
+        ),
+    );
+
+    let err = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("subscription requests use the projection resolver, not accept_inbound");
+
+    assert!(matches!(
+        err,
+        ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::InvalidRequest,
+            status_code: 400,
+            retryable: false,
+            ..
+        }
+    ));
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(binding_service.resolve_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+}
+
+#[tokio::test]
 async fn projection_subscription_resolves_through_binding_service() {
     let (workflow, inbound, _ledger, binding_service) = build_workflow_with_binding();
     let binding = fake_binding();

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -1554,7 +1554,7 @@ async fn subscription_request_via_accept_inbound_rejects_before_mutating_ledger(
 
 #[tokio::test]
 async fn projection_subscription_resolves_through_binding_service() {
-    let (workflow, inbound, _ledger, binding_service) = build_workflow_with_binding();
+    let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
     let binding = fake_binding();
     let cursor = ProjectionCursor::new("cursor:projection-1").expect("valid cursor");
     let envelope = sample_envelope_with_payload(
@@ -1582,6 +1582,9 @@ async fn projection_subscription_resolves_through_binding_service() {
     assert_eq!(subscription.after_cursor, Some(cursor));
     assert_eq!(binding_service.resolve_count(), 1);
     assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Refs #4483
Parent: #3280
Related: #4459, #3281, #3266

## Summary

- Reject `SubscriptionRequest` at the mutating `ProductWorkflow::accept_inbound` entrypoint before idempotency ledger begin/replay.
- Return a product-safe wrong-entrypoint rejection (`InvalidRequest`, 400 semantics, non-retryable) directing callers to `resolve_projection_subscription`.
- Document that `accept_inbound` is the mutating submit path and projection read/subscribe requests must not create mutating ProductInboundAction ledger rows.
- Add caller-level ProductWorkflow coverage proving the wrong-door subscription request does not call inbound turn handling, binding resolution, or the mutating ledger.

## Boundary

This is intentionally the narrow #3280 unblock slice for the OpenAI-compatible wiring boundary. It does not implement EventStreamManager behavior (#3281), outbound/subscription policy (#3266), OpenAI `response_id` mapping, SSE translation, full cancel/control-action semantics, or command matrix behavior (#3286).

## Question for OpenAI-compatible API wiring

Is this submit-vs-projection boundary enough for the next #4459 follow-up wiring slice, or do you need a separate typed ProductWorkflow cancel/control-action seam immediately for `POST /responses/{response_id}/cancel`?

## Validation

- `cargo fmt --all`
