### PR TITLE
[codex] Fix Slack auth resume final delivery

### DIFF
--- a/crates/ironclaw_product_workflow/src/auth_continuation.rs
+++ b/crates/ironclaw_product_workflow/src/auth_continuation.rs
@@ -9,14 +9,13 @@ use std::sync::Arc;
 
 use ironclaw_auth::{AuthContinuationEvent, AuthContinuationRef, AuthProductError};
 use ironclaw_turns::{
-    GateRef, IdempotencyKey, ResumeTurnPrecondition, ResumeTurnRequest, TurnActor, TurnCoordinator,
-    TurnError, TurnErrorCategory, TurnRunId, TurnScope,
+    GateRef, GetRunStateRequest, IdempotencyKey, ResumeTurnPrecondition, ResumeTurnRequest,
+    TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnScope,
 };
 use uuid::Uuid;
 
 use crate::binding_ref::{
     AUTH_CONTINUATION_BINDING_REF_RAW_MAX_BYTES, binding_ref_segment, bounded_idempotency_key,
-    bounded_reply_target_binding_ref, bounded_source_binding_ref,
 };
 use crate::{AuthContinuationRejectionKind, ProductWorkflowError};
 
@@ -76,9 +75,23 @@ impl ProductAuthTurnGateResumeDispatcher {
             });
         };
 
-        let scope = turn_scope_from_auth_event(&event)?;
-        let actor = TurnActor::new(event.scope.resource.user_id.clone());
         let run_id = parse_turn_run_id(turn_run_ref.as_str())?;
+        let scope = turn_scope_from_auth_event(&event)?;
+        let state = self
+            .turn_coordinator
+            .get_run_state(GetRunStateRequest {
+                scope: scope.clone(),
+                run_id,
+            })
+            .await
+            .map_err(map_auth_resume_error)?;
+        let actor = state
+            .actor
+            .ok_or(ProductWorkflowError::AuthContinuationRejected {
+                kind: AuthContinuationRejectionKind::UnauthorizedBlockedGate,
+            })?;
+        let source_binding_ref = state.source_binding_ref;
+        let reply_target_binding_ref = state.reply_target_binding_ref;
         let gate_resolution_ref = parse_gate_ref(gate_ref.as_str())?;
         let binding_id = auth_continuation_binding_id(event.flow_id, &run_id, gate_ref.as_str());
         let idempotency_key = idempotency_key_for_binding(&binding_id)?;
@@ -89,18 +102,8 @@ impl ProductAuthTurnGateResumeDispatcher {
                 actor,
                 run_id,
                 gate_resolution_ref,
-                source_binding_ref: bounded_source_binding_ref(
-                    "auth-continuation-src",
-                    &binding_id,
-                    AUTH_CONTINUATION_BINDING_REF_RAW_MAX_BYTES,
-                )
-                .map_err(binding_ref_error)?,
-                reply_target_binding_ref: bounded_reply_target_binding_ref(
-                    "auth-continuation-reply",
-                    &binding_id,
-                    AUTH_CONTINUATION_BINDING_REF_RAW_MAX_BYTES,
-                )
-                .map_err(binding_ref_error)?,
+                source_binding_ref,
+                reply_target_binding_ref,
                 idempotency_key,
                 precondition: ResumeTurnPrecondition::BlockedAuthGate,
             })
@@ -253,11 +256,12 @@ fn turn_scope_from_auth_event(
             kind: AuthContinuationRejectionKind::MissingThreadScope,
         });
     };
-    Ok(TurnScope::new(
+    Ok(TurnScope::new_with_owner(
         event.scope.resource.tenant_id.clone(),
         event.scope.resource.agent_id.clone(),
         event.scope.resource.project_id.clone(),
         thread_id,
+        Some(event.scope.resource.user_id.clone()),
     ))
 }
 
@@ -284,12 +288,6 @@ fn idempotency_key_for_binding(binding_id: &str) -> Result<IdempotencyKey, Produ
     .map_err(|_| ProductWorkflowError::AuthContinuationRejected {
         kind: AuthContinuationRejectionKind::InvalidIdempotencyKey,
     })
-}
-
-fn binding_ref_error(_reason: String) -> ProductWorkflowError {
-    ProductWorkflowError::AuthContinuationRejected {
-        kind: AuthContinuationRejectionKind::InvalidBindingRef,
-    }
 }
 
 #[cfg(test)]
@@ -372,6 +370,12 @@ mod tests {
                 .expect("state lock")
                 .clone()
                 .ok_or(TurnError::ScopeNotFound)?;
+            if state.scope != request.scope {
+                return Err(TurnError::ScopeNotFound);
+            }
+            if state.actor.as_ref() != Some(&request.actor) {
+                return Err(TurnError::Unauthorized);
+            }
             if let Some(required) = request.precondition.required_status()
                 && state.status != required
             {
@@ -415,21 +419,33 @@ mod tests {
 
         async fn get_run_state(
             &self,
-            _request: GetRunStateRequest,
+            request: GetRunStateRequest,
         ) -> Result<TurnRunState, TurnError> {
-            self.state
+            let state = self
+                .state
                 .lock()
                 .expect("state lock")
                 .clone()
-                .ok_or(TurnError::ScopeNotFound)
+                .ok_or(TurnError::ScopeNotFound)?;
+            if state.scope != request.scope || state.run_id != request.run_id {
+                return Err(TurnError::ScopeNotFound);
+            }
+            Ok(state)
         }
     }
 
     fn scoped_event(continuation: AuthContinuationRef) -> AuthContinuationEvent {
+        scoped_event_for_owner("alice", continuation)
+    }
+
+    fn scoped_event_for_owner(
+        owner_user_id: &str,
+        continuation: AuthContinuationRef,
+    ) -> AuthContinuationEvent {
         let thread_id = ThreadId::new("thread-auth").unwrap();
         let resource = ResourceScope {
             tenant_id: TenantId::new("tenant-auth").unwrap(),
-            user_id: UserId::new("alice").unwrap(),
+            user_id: UserId::new(owner_user_id).unwrap(),
             agent_id: Some(AgentId::new("agent-auth").unwrap()),
             project_id: Some(ProjectId::new("project-auth").unwrap()),
             mission_id: None,
@@ -447,14 +463,25 @@ mod tests {
     }
 
     fn run_state(run_id: TurnRunId, status: TurnStatus, gate_ref: Option<&str>) -> TurnRunState {
+        run_state_for_actor_owner(run_id, status, gate_ref, "alice", "alice")
+    }
+
+    fn run_state_for_actor_owner(
+        run_id: TurnRunId,
+        status: TurnStatus,
+        gate_ref: Option<&str>,
+        actor_user_id: &str,
+        owner_user_id: &str,
+    ) -> TurnRunState {
         TurnRunState {
-            scope: TurnScope::new(
+            scope: TurnScope::new_with_owner(
                 TenantId::new("tenant-auth").unwrap(),
                 Some(AgentId::new("agent-auth").unwrap()),
                 Some(ProjectId::new("project-auth").unwrap()),
                 ThreadId::new("thread-auth").unwrap(),
+                Some(UserId::new(owner_user_id).unwrap()),
             ),
-            actor: Some(TurnActor::new(UserId::new("alice").unwrap())),
+            actor: Some(TurnActor::new(UserId::new(actor_user_id).unwrap())),
             turn_id: TurnId::new(),
             run_id,
             status,
@@ -504,6 +531,15 @@ mod tests {
         );
         assert_eq!(resumes[0].actor.user_id.as_str(), "alice");
         assert_eq!(resumes[0].scope.thread_id.as_str(), "thread-auth");
+        assert_eq!(resumes[0].source_binding_ref.as_str(), "source-auth");
+        assert_eq!(resumes[0].reply_target_binding_ref.as_str(), "reply-auth");
+        assert_eq!(
+            resumes[0]
+                .scope
+                .explicit_owner_user_id()
+                .map(UserId::as_str),
+            Some("alice")
+        );
         assert!(
             resumes[0]
                 .idempotency_key
@@ -514,6 +550,46 @@ mod tests {
         assert!(resumes[0].idempotency_key.as_str().contains("flow:"));
         assert!(resumes[0].idempotency_key.as_str().contains("run:"));
         assert!(resumes[0].idempotency_key.as_str().contains("gate:"));
+    }
+
+    #[tokio::test]
+    async fn turn_gate_continuation_uses_subject_scope_and_original_actor() {
+        let coordinator = Arc::new(RecordingTurnCoordinator::default());
+        let dispatcher = ProductAuthTurnGateResumeDispatcher::new(coordinator.clone());
+        let run_id = TurnRunId::new();
+        coordinator.set_state(run_state_for_actor_owner(
+            run_id,
+            TurnStatus::BlockedAuth,
+            Some("gate:auth"),
+            "alice",
+            "team-agent",
+        ));
+        let event = scoped_event_for_owner(
+            "team-agent",
+            AuthContinuationRef::TurnGateResume {
+                turn_run_ref: TurnRunRef::new(run_id.to_string()).unwrap(),
+                gate_ref: AuthGateRef::new("gate:auth").unwrap(),
+            },
+        );
+
+        let resumed_run_id = dispatcher
+            .dispatch_turn_gate_resume(event)
+            .await
+            .expect("dispatch");
+
+        assert_eq!(resumed_run_id, run_id);
+        let resumes = coordinator.resumes();
+        assert_eq!(resumes.len(), 1);
+        assert_eq!(resumes[0].actor.user_id.as_str(), "alice");
+        assert_eq!(resumes[0].source_binding_ref.as_str(), "source-auth");
+        assert_eq!(resumes[0].reply_target_binding_ref.as_str(), "reply-auth");
+        assert_eq!(
+            resumes[0]
+                .scope
+                .explicit_owner_user_id()
+                .map(UserId::as_str),
+            Some("team-agent")
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_product_workflow/src/auth_interaction/gate_ref.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/gate_ref.rs
@@ -1,10 +1,4 @@
-use ironclaw_turns::{GateRef, ReplyTargetBindingRef, SourceBindingRef};
-
-use super::{AuthInteractionRejectionKind, auth_rejected};
-use crate::binding_ref::{
-    DEFAULT_BINDING_REF_RAW_MAX_BYTES, bounded_reply_target_binding_ref, bounded_source_binding_ref,
-};
-use crate::error::ProductWorkflowError;
+use ironclaw_turns::GateRef;
 
 const AUTH_GATE_REF: &str = "gate:auth";
 const AUTH_GATE_PREFIX: &str = "gate:auth-";
@@ -15,28 +9,6 @@ pub fn is_auth_gate_ref(gate_ref: &GateRef) -> bool {
     value == AUTH_GATE_REF
         || value.starts_with(AUTH_GATE_PREFIX)
         || value.starts_with(HOOK_AUTH_GATE_PREFIX)
-}
-
-pub(crate) fn auth_source_binding_ref(
-    binding_id: &str,
-) -> Result<SourceBindingRef, ProductWorkflowError> {
-    bounded_source_binding_ref(
-        "auth-interaction-src",
-        binding_id,
-        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
-    )
-    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
-}
-
-pub(crate) fn auth_reply_binding_ref(
-    binding_id: &str,
-) -> Result<ReplyTargetBindingRef, ProductWorkflowError> {
-    bounded_reply_target_binding_ref(
-        "auth-interaction-reply",
-        binding_id,
-        DEFAULT_BINDING_REF_RAW_MAX_BYTES,
-    )
-    .map_err(|_| auth_rejected(AuthInteractionRejectionKind::InvalidBindingRef))
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_product_workflow/src/auth_interaction/mod.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/mod.rs
@@ -9,7 +9,6 @@ mod service;
 mod types;
 
 pub use gate_ref::is_auth_gate_ref;
-pub(super) use gate_ref::{auth_reply_binding_ref, auth_source_binding_ref};
 pub(crate) use service::RejectingAuthInteractionService;
 pub use service::{
     AuthInteractionReadModel, AuthInteractionService, DefaultAuthInteractionService,

--- a/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
+++ b/crates/ironclaw_product_workflow/src/auth_interaction/service.rs
@@ -6,8 +6,8 @@ use ironclaw_auth::{
     CredentialAccountId, CredentialSelectionInput,
 };
 use ironclaw_turns::{
-    CancelRunRequest, GateRef, ResumeTurnPrecondition, ResumeTurnRequest, SanitizedCancelReason,
-    TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
+    CancelRunRequest, GateRef, GetRunStateRequest, ResumeTurnPrecondition, ResumeTurnRequest,
+    SanitizedCancelReason, TurnCoordinator, TurnError, TurnErrorCategory, TurnRunId, TurnStatus,
 };
 
 use super::types::is_pending_auth_status;
@@ -15,9 +15,7 @@ use super::{
     AuthGateRecord, AuthInteractionDecision, AuthInteractionRejectionKind, AuthInteractionScope,
     ListPendingAuthInteractionsRequest, ListPendingAuthInteractionsResponse,
     ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, auth_rejected,
-    auth_reply_binding_ref, auth_source_binding_ref,
 };
-use crate::binding_ref::binding_ref_segment;
 use crate::error::ProductWorkflowError;
 use crate::gate_state::{BlockedGateState, BlockedGateStateError, blocked_gate_state};
 
@@ -159,7 +157,14 @@ impl DefaultAuthInteractionService {
             }
         };
         validate_completion_ref(&gate, completion)?;
-        let binding_id = auth_interaction_binding_id(gate.flow().id, &run_id, gate.gate_ref());
+        let state = self
+            .turn_coordinator
+            .get_run_state(GetRunStateRequest {
+                scope: request.scope.clone(),
+                run_id,
+            })
+            .await
+            .map_err(map_auth_resume_error)?;
         let response = self
             .turn_coordinator
             .resume_turn(ResumeTurnRequest {
@@ -168,8 +173,8 @@ impl DefaultAuthInteractionService {
                 run_id,
                 gate_resolution_ref: request.gate_ref,
                 precondition: ResumeTurnPrecondition::BlockedAuthGate,
-                source_binding_ref: auth_source_binding_ref(&binding_id)?,
-                reply_target_binding_ref: auth_reply_binding_ref(&binding_id)?,
+                source_binding_ref: state.source_binding_ref,
+                reply_target_binding_ref: state.reply_target_binding_ref,
                 idempotency_key: request.idempotency_key,
             })
             .await
@@ -394,20 +399,6 @@ fn validate_completion_ref(
             Ok(())
         }
     }
-}
-
-fn auth_interaction_binding_id(
-    flow_id: ironclaw_auth::AuthFlowId,
-    run_id: &TurnRunId,
-    gate_ref: &GateRef,
-) -> String {
-    format!(
-        "{}{}{}{}",
-        binding_ref_segment("surface", "auth-interaction"),
-        binding_ref_segment("flow", &flow_id.to_string()),
-        binding_ref_segment("run", &run_id.to_string()),
-        binding_ref_segment("gate", gate_ref.as_str())
-    )
 }
 
 fn map_auth_product_error(error: AuthProductError) -> ProductWorkflowError {

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -9,9 +9,9 @@ use async_trait::async_trait;
 use ironclaw_auth::{AuthFlowId, CredentialAccountId};
 use ironclaw_host_api::ThreadId;
 use ironclaw_product_adapters::{
-    ApprovalDecision, ProductAdapterError, ProductInboundAck, ProductInboundEnvelope,
-    ProductInboundPayload, ProductRejection, ProductRejectionKind, ProductWorkflow,
-    ProductWorkflowRejectionKind, ProjectionSubscriptionRequest, RedactedString,
+    ApprovalDecision, ExternalConversationRef, ProductAdapterError, ProductInboundAck,
+    ProductInboundEnvelope, ProductInboundPayload, ProductRejection, ProductRejectionKind,
+    ProductWorkflow, ProductWorkflowRejectionKind, ProjectionSubscriptionRequest, RedactedString,
 };
 use ironclaw_turns::{
     AcceptedMessageRef, AdmissionRejectionReason, GateRef, IdempotencyKey, TurnActor, TurnError,
@@ -30,7 +30,10 @@ use crate::auth_interaction::{
     AuthInteractionDecision, AuthInteractionRejectionKind, AuthInteractionService,
     RejectingAuthInteractionService, ResolveAuthInteractionRequest, ResolveAuthInteractionResponse,
 };
-use crate::binding::{ConversationBindingService, ResolveBindingRequest, ResolvedBinding};
+use crate::binding::{
+    ConversationBindingService, ProductConversationRouteKind, ResolveBindingRequest,
+    ResolvedBinding,
+};
 use crate::binding_ref::{
     DEFAULT_BINDING_REF_RAW_MAX_BYTES, binding_ref_segment, bounded_idempotency_key,
 };
@@ -272,6 +275,44 @@ fn resolve_binding_request(envelope: &ProductInboundEnvelope) -> ResolveBindingR
     ResolveBindingRequest::from_envelope(envelope)
 }
 
+async fn lookup_interaction_binding(
+    envelope: &ProductInboundEnvelope,
+    binding_service: &dyn ConversationBindingService,
+) -> Result<ResolvedBinding, ProductWorkflowError> {
+    let request = resolve_binding_request(envelope);
+    match binding_service.lookup_binding(request.clone()).await {
+        Ok(binding) => Ok(binding),
+        Err(ProductWorkflowError::BindingRequired { .. })
+            if can_fallback_to_direct_base_binding(&request) =>
+        {
+            binding_service
+                .lookup_binding(direct_base_binding_request(request)?)
+                .await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn can_fallback_to_direct_base_binding(request: &ResolveBindingRequest) -> bool {
+    request.route_kind == ProductConversationRouteKind::Direct
+        && request.external_conversation_ref.topic_id().is_some()
+}
+
+fn direct_base_binding_request(
+    mut request: ResolveBindingRequest,
+) -> Result<ResolveBindingRequest, ProductWorkflowError> {
+    request.external_conversation_ref = ExternalConversationRef::new(
+        request.external_conversation_ref.space_id(),
+        request.external_conversation_ref.conversation_id(),
+        None,
+        request.external_conversation_ref.reply_target_message_id(),
+    )
+    .map_err(|error| ProductWorkflowError::InvalidBindingRequest {
+        reason: error.to_string(),
+    })?;
+    Ok(request)
+}
+
 fn projection_thread_id_from_binding(
     binding: &ResolvedBinding,
     thread_id_hint: Option<&str>,
@@ -408,9 +449,7 @@ async fn dispatch_approval_resolution(
     approval_interaction_service: &dyn ApprovalInteractionService,
 ) -> Result<DispatchedAction, ProductWorkflowError> {
     let decision = approval_interaction_decision(payload.decision)?;
-    let binding = binding_service
-        .lookup_binding(resolve_binding_request(envelope))
-        .await?;
+    let binding = lookup_interaction_binding(envelope, binding_service).await?;
     let scope = turn_scope_from_binding(&binding);
     let actor = TurnActor::new(binding.actor_user_id.clone());
     let gate_ref = GateRef::new(payload.gate_ref.clone()).map_err(|_| {
@@ -447,9 +486,7 @@ async fn dispatch_scoped_approval_resolution(
     approval_interaction_service: &dyn ApprovalInteractionService,
 ) -> Result<DispatchedAction, ProductWorkflowError> {
     let decision = approval_interaction_decision(payload.decision)?;
-    let binding = binding_service
-        .lookup_binding(resolve_binding_request(envelope))
-        .await?;
+    let binding = lookup_interaction_binding(envelope, binding_service).await?;
     let scope = turn_scope_from_binding(&binding);
     let actor = TurnActor::new(binding.actor_user_id.clone());
     let pending = approval_interaction_service
@@ -525,9 +562,7 @@ async fn dispatch_auth_resolution(
         }
         ironclaw_product_adapters::AuthResolutionResult::Denied => AuthInteractionDecision::Deny,
     };
-    let binding = binding_service
-        .lookup_binding(resolve_binding_request(envelope))
-        .await?;
+    let binding = lookup_interaction_binding(envelope, binding_service).await?;
     let scope = turn_scope_from_binding(&binding);
     let actor = TurnActor::new(binding.actor_user_id.clone());
     let gate_ref = GateRef::new(payload.auth_request_ref.clone()).map_err(|_| {

--- a/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/auth_interaction_contract.rs
@@ -523,6 +523,8 @@ async fn credential_provided_resumes_completed_auth_gate() {
         resumes[0].precondition,
         ResumeTurnPrecondition::BlockedAuthGate
     );
+    assert_eq!(resumes[0].source_binding_ref.as_str(), "src:auth");
+    assert_eq!(resumes[0].reply_target_binding_ref.as_str(), "reply:auth");
 }
 
 #[tokio::test]
@@ -581,6 +583,8 @@ async fn credential_selection_completes_pending_auth_gate_before_resume() {
         resumes[0].precondition,
         ResumeTurnPrecondition::BlockedAuthGate
     );
+    assert_eq!(resumes[0].source_binding_ref.as_str(), "src:auth");
+    assert_eq!(resumes[0].reply_target_binding_ref.as_str(), "reply:auth");
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -779,6 +779,82 @@ async fn auth_callback_and_denied_payloads_route_through_auth_interaction_servic
 }
 
 #[tokio::test]
+async fn auth_deny_from_threaded_direct_prompt_uses_base_direct_binding() {
+    let conversations = Arc::new(InMemoryConversationServices::default());
+    conversations
+        .pair_external_actor(
+            TenantId::new("tenant:alpha").expect("tenant"),
+            ironclaw_conversations::AdapterKind::new("test_adapter").expect("adapter"),
+            ironclaw_conversations::AdapterInstallationId::new("install_alpha")
+                .expect("installation"),
+            ironclaw_conversations::ExternalActorRef::new("test", "user1").expect("actor"),
+            UserId::new("user:alice").expect("user"),
+        )
+        .await;
+    let binding = product_binding_service(
+        conversations,
+        vec![(
+            "test_adapter",
+            "install_alpha",
+            "tenant:alpha",
+            "agent:alpha",
+            Some("project:alpha"),
+        )],
+    );
+    let base_envelope = sample_envelope_with_context(
+        ProductAdapterId::new("test_adapter").expect("adapter"),
+        AdapterInstallationId::new("install_alpha").expect("installation"),
+        ExternalEventId::new("evt:seed-direct").expect("event"),
+        ExternalActorRef::new("test", "user1", None::<String>).expect("actor"),
+        ExternalConversationRef::new(None, "conv1", None, None).expect("conversation"),
+        ProductInboundPayload::UserMessage(
+            UserMessagePayload::new("needs auth", vec![], ProductTriggerReason::DirectChat)
+                .expect("message"),
+        ),
+    );
+    let base_binding = binding
+        .resolve_binding(ResolveBindingRequest::from_envelope(&base_envelope))
+        .await
+        .expect("seed base direct conversation binding");
+    let gate_ref = GateRef::new("gate:auth-direct-thread").expect("auth gate");
+    let auth_service = Arc::new(RecordingAuthInteractionService::new(
+        gate_ref.clone(),
+        TurnRunId::new(),
+    ));
+    let workflow = DefaultProductWorkflow::new(
+        Arc::new(FakeInboundTurnService::new()),
+        Arc::new(InMemoryIdempotencyLedger::new()),
+        Arc::new(binding),
+    )
+    .with_auth_interaction_service(auth_service.clone());
+    let threaded_deny = sample_envelope_with_context(
+        ProductAdapterId::new("test_adapter").expect("adapter"),
+        AdapterInstallationId::new("install_alpha").expect("installation"),
+        ExternalEventId::new("evt:threaded-auth-deny").expect("event"),
+        ExternalActorRef::new("test", "user1", None::<String>).expect("actor"),
+        ExternalConversationRef::new(None, "conv1", Some("prompt-thread-ts"), Some("reply-ts"))
+            .expect("conversation"),
+        ProductInboundPayload::AuthResolution(
+            AuthResolutionPayload::new(gate_ref.as_str(), AuthResolutionResult::Denied)
+                .expect("auth payload")
+                .with_source_trigger(ProductTriggerReason::DirectChat),
+        ),
+    );
+
+    let ack = workflow
+        .accept_inbound(threaded_deny)
+        .await
+        .expect("threaded direct auth deny should use base binding");
+
+    assert!(matches!(ack, ProductInboundAck::Accepted { .. }));
+    let resolutions = auth_service.resolutions();
+    assert_eq!(resolutions.len(), 1);
+    assert_eq!(resolutions[0].gate_ref, gate_ref);
+    assert_eq!(resolutions[0].decision, AuthInteractionDecision::Deny);
+    assert_eq!(resolutions[0].scope.thread_id, base_binding.thread_id);
+}
+
+#[tokio::test]
 async fn approval_resolution_idempotency_key_is_stable_for_same_external_event() {
     let gate_ref = approval_gate_ref(ApprovalRequestId::new()).expect("approval gate ref");
     let build = || {

--- a/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
@@ -16,11 +16,11 @@ use ironclaw_host_api::{
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
 use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_turns::{
-    AcceptedMessageRef, BlockedReason, CancelRunRequest, CancelRunResponse, GetRunStateRequest,
-    IdempotencyKey, LoopCheckpointStateRef, ReplyTargetBindingRef, RunProfileRequest,
-    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCheckpointId,
-    TurnCoordinator, TurnError, TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope,
-    TurnStatus,
+    AcceptedMessageRef, BlockedReason, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
+    GetRunStateRequest, IdempotencyKey, LoopCheckpointStateRef, ReplyTargetBindingRef,
+    RunProfileId, RunProfileRequest, RunProfileVersion, SourceBindingRef, SubmitTurnRequest,
+    SubmitTurnResponse, TurnActor, TurnCheckpointId, TurnCoordinator, TurnError, TurnId,
+    TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
     runner::{BlockRunRequest, ClaimRunRequest, TurnRunTransitionPort},
 };
 use secrecy::SecretString;
@@ -59,8 +59,30 @@ impl TurnCoordinator for ErrorTurnCoordinator {
         panic!("cancel_run is not used by auth continuation error mapping tests");
     }
 
-    async fn get_run_state(&self, _request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
-        panic!("get_run_state is not used by auth continuation error mapping tests");
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        Ok(auth_error_mapping_run_state(&request))
+    }
+}
+
+fn auth_error_mapping_run_state(request: &GetRunStateRequest) -> TurnRunState {
+    TurnRunState {
+        scope: request.scope.clone(),
+        actor: Some(TurnActor::new(UserId::new("alice").unwrap())), // safety: fixed test user id literal is valid.
+        turn_id: TurnId::new(),
+        run_id: request.run_id,
+        status: TurnStatus::BlockedAuth,
+        accepted_message_ref: AcceptedMessageRef::new("message-auth-error").unwrap(), // safety: fixed test binding literal is valid.
+        source_binding_ref: SourceBindingRef::new("source-auth-error").unwrap(), // safety: fixed test binding literal is valid.
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-auth-error").unwrap(), // safety: fixed test binding literal is valid.
+        resolved_run_profile_id: RunProfileId::default_profile(),
+        resolved_run_profile_version: RunProfileVersion::new(1),
+        resolved_model_route: None,
+        received_at: Utc::now(),
+        checkpoint_id: None,
+        gate_ref: Some(GateRef::new("gate:auth-error").unwrap()), // safety: fixed test gate literal is valid.
+        credential_requirements: Vec::new(),
+        failure: None,
+        event_cursor: EventCursor::default(),
     }
 }
 
@@ -258,12 +280,9 @@ async fn local_dev_oauth_turn_gate_callback_resumes_default_turn_coordinator() {
         .expect("run state");
     assert_eq!(state.status, TurnStatus::Queued);
     assert_eq!(state.gate_ref, None);
-    assert!(
-        state
-            .source_binding_ref
-            .as_str()
-            .starts_with("auth-continuation-src:")
-    );
+    assert_eq!(state.source_binding_ref.as_str(), "source-auth-callback"); // safety: verifies fixed test binding literal is preserved.
+    let reply_binding_ref = state.reply_target_binding_ref.as_str();
+    assert_eq!(reply_binding_ref, "reply-auth-callback"); // safety: verifies fixed test binding literal is preserved.
 }
 
 #[tokio::test]
@@ -534,11 +553,12 @@ async fn oauth_callback_continuation_dispatch_maps_turn_error_categories() {
 
 #[cfg(test)]
 fn turn_scope() -> TurnScope {
-    TurnScope::new(
+    TurnScope::new_with_owner(
         TenantId::new("tenant-auth").unwrap(),
         Some(AgentId::new("agent-auth").unwrap()),
         Some(ProjectId::new("project-auth").unwrap()),
         ThreadId::new("thread-auth").unwrap(),
+        Some(UserId::new("alice").unwrap()), // safety: fixed test user id literal is valid.
     )
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/auth_interaction.rs
@@ -11,9 +11,7 @@ use ironclaw_product_workflow::{
     ListPendingAuthInteractionsResponse, ProductWorkflowError, ResolveAuthInteractionRequest,
     ResolveAuthInteractionResponse,
 };
-use ironclaw_turns::{
-    GateRef, TurnActor, TurnPersistenceSnapshot, TurnRunId, TurnRunRecord, TurnScope, TurnStatus,
-};
+use ironclaw_turns::{GateRef, TurnPersistenceSnapshot, TurnRunId, TurnScope, TurnStatus};
 
 use crate::factory::LocalDevTurnStateStore;
 
@@ -77,7 +75,6 @@ impl LocalDevAuthInteractionReadModel {
         scope: &AuthInteractionScope,
     ) -> Result<Vec<BlockedAuthRun>, ProductWorkflowError> {
         let turn_scope = turn_scope_for_interaction(scope);
-        let actor = TurnActor::new(scope.user_id.clone());
         let snapshot = self.snapshot().await?;
         let mut runs = snapshot
             .runs
@@ -86,7 +83,6 @@ impl LocalDevAuthInteractionReadModel {
                 run.scope == turn_scope
                     && run.status == TurnStatus::BlockedAuth
                     && run.gate_ref.is_some()
-                    && snapshot_run_actor_matches(&snapshot, run, &actor)
             })
             .filter_map(|run| {
                 run.gate_ref.clone().map(|gate_ref| BlockedAuthRun {
@@ -105,7 +101,6 @@ impl LocalDevAuthInteractionReadModel {
         gate_ref: &GateRef,
     ) -> Result<Option<TurnRunId>, ProductWorkflowError> {
         let turn_scope = turn_scope_for_interaction(scope);
-        let actor = TurnActor::new(scope.user_id.clone());
         let snapshot = self.snapshot().await?;
         let active = snapshot
             .runs
@@ -114,7 +109,6 @@ impl LocalDevAuthInteractionReadModel {
                 run.scope == turn_scope
                     && run.status == TurnStatus::BlockedAuth
                     && run.gate_ref.as_ref() == Some(gate_ref)
-                    && snapshot_run_actor_matches(&snapshot, run, &actor)
             })
             .map(|run| run.run_id);
         if active.is_some() {
@@ -136,11 +130,7 @@ impl LocalDevAuthInteractionReadModel {
                 snapshot
                     .runs
                     .iter()
-                    .find(|run| {
-                        run.run_id == checkpoint.run_id
-                            && run.scope == turn_scope
-                            && snapshot_run_actor_matches(&snapshot, run, &actor)
-                    })
+                    .find(|run| run.run_id == checkpoint.run_id && run.scope == turn_scope)
                     .map(|run| run.run_id)
             })
             .collect::<Vec<_>>();
@@ -274,23 +264,13 @@ impl AuthInteractionReadModel for LocalDevAuthInteractionReadModel {
 }
 
 fn turn_scope_for_interaction(scope: &AuthInteractionScope) -> TurnScope {
-    TurnScope::new(
+    TurnScope::new_with_owner(
         scope.tenant_id.clone(),
         scope.agent_id.clone(),
         scope.project_id.clone(),
         scope.thread_id.clone(),
+        Some(scope.user_id.clone()),
     )
-}
-
-fn snapshot_run_actor_matches(
-    snapshot: &TurnPersistenceSnapshot,
-    run: &TurnRunRecord,
-    actor: &TurnActor,
-) -> bool {
-    snapshot
-        .turns
-        .iter()
-        .any(|turn| turn.turn_id == run.turn_id && turn.scope == run.scope && turn.actor == *actor)
 }
 
 fn auth_read_model_unavailable() -> ProductWorkflowError {

--- a/crates/ironclaw_reborn_composition/src/runtime/tests/auth_interaction.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/tests/auth_interaction.rs
@@ -13,7 +13,7 @@ use ironclaw_host_api::runtime_policy::{
     ApprovalPolicy, AuditMode, DeploymentMode, EffectiveRuntimePolicy, FilesystemBackendKind,
     NetworkMode, ProcessBackendKind, RuntimeProfile, SecretMode,
 };
-use ironclaw_host_api::{InvocationId, ResourceScope};
+use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
     HostManagedModelResponse,
@@ -61,11 +61,13 @@ async fn local_dev_runtime_auth_interactions_use_flow_record_source() {
     .await
     .expect("runtime builds");
     let conversation = runtime.new_conversation().await.expect("conversation");
-    let scope = TurnScope::new(
+    let subject_user_id = UserId::new("team-agent-user").expect("subject user id");
+    let scope = TurnScope::new_with_owner(
         runtime.thread_scope.tenant_id.clone(),
         Some(runtime.thread_scope.agent_id.clone()),
         runtime.thread_scope.project_id.clone(),
         conversation.0,
+        Some(subject_user_id.clone()),
     );
     let actor = TurnActor::new(runtime.actor_user_id.clone());
     let gate_ref = GateRef::new("gate:runtime-auth-read-model").expect("gate");
@@ -84,7 +86,7 @@ async fn local_dev_runtime_auth_interactions_use_flow_record_source() {
     assert_eq!(pending.auth_interactions.len(), 1);
     let view = &pending.auth_interactions[0];
     assert_eq!(view.scope.tenant_id, scope.tenant_id);
-    assert_eq!(view.scope.user_id, actor.user_id);
+    assert_eq!(view.scope.user_id, subject_user_id);
     assert_eq!(view.scope.thread_id, scope.thread_id);
     assert_eq!(view.run_id, run_id);
     assert_eq!(view.auth_request_ref, gate_ref);
@@ -282,7 +284,10 @@ fn auth_scope_for_turn(scope: &TurnScope, actor: &TurnActor) -> AuthProductScope
     AuthProductScope::new(
         ResourceScope {
             tenant_id: scope.tenant_id.clone(),
-            user_id: actor.user_id.clone(),
+            user_id: scope
+                .explicit_owner_user_id()
+                .cloned()
+                .unwrap_or_else(|| actor.user_id.clone()),
             agent_id: scope.agent_id.clone(),
             project_id: scope.project_id.clone(),
             mission_id: None,

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -34,8 +34,8 @@ use ironclaw_product_workflow::{
 };
 use ironclaw_threads::{FinalizedAssistantMessageByRunRequest, SessionThreadService, ThreadScope};
 use ironclaw_turns::{
-    GetRunStateRequest, ReplyTargetBindingRef, TurnActor, TurnCoordinator, TurnRunId, TurnScope,
-    TurnStatus,
+    GetRunStateRequest, ReplyTargetBindingRef, TurnActor, TurnCoordinator, TurnRunId, TurnRunState,
+    TurnScope, TurnStatus,
 };
 use ironclaw_wasm_product_adapters::ImmediateAckWorkflowObserver;
 use serde::{Deserialize, Serialize};
@@ -50,7 +50,16 @@ const SLACK_API_HOST: &str = "slack.com";
 const SLACK_BOT_TOKEN_HANDLE: &str = "slack_bot_token";
 const SLACK_WORKING_MESSAGE: &str = "Ironclaw is thinking...";
 
-type BlockedActionableMarker = (TurnStatus, Option<String>);
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BlockedActionableMarker {
+    status: TurnStatus,
+    gate_ref: Option<String>,
+}
+
+struct SlackActionableNotification {
+    event_kind: RunNotificationEventKind,
+    payload: ProductOutboundPayload,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlackFinalReplyDeliverySettings {
@@ -132,139 +141,38 @@ impl SlackFinalReplyDeliveryObserver {
                     &mut working_message,
                 )
                 .await?;
-            let (event_kind, payload, next_blocked_marker) = match actionable_state.status {
-                TurnStatus::Completed => {
-                    let Some(text) = self
-                        .read_latest_assistant_text(&thread_scope, &binding, run_id)
-                        .await?
-                    else {
-                        tracing::warn!(
-                            %run_id,
-                            "completed Slack run has no finalized assistant message; skipping final reply delivery"
-                        );
-                        return Ok(());
-                    };
-                    (
-                        RunNotificationEventKind::FinalReplyReady,
-                        ProductOutboundPayload::FinalReply(FinalReplyView {
-                            turn_run_id: run_id,
-                            text,
-                            generated_at: Utc::now(),
-                        }),
-                        None,
-                    )
-                }
-                TurnStatus::BlockedApproval => {
-                    self.delete_slack_message_if_present(working_message.take())
-                        .await;
-                    let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
-                        tracing::warn!(
-                            %run_id,
-                            "Slack run is blocked on approval without a gate ref; skipping approval prompt delivery"
-                        );
-                        return Ok(());
-                    };
-                    (
-                        RunNotificationEventKind::ApprovalNeeded,
-                        ProductOutboundPayload::GatePrompt(GatePromptView {
-                            turn_run_id: run_id,
-                            gate_ref: gate_ref.as_str().to_string(),
-                            headline: "Approval needed".to_string(),
-                            body: "A step in the workflow requires your approval to resume."
-                                .to_string(),
-                        }),
-                        blocked_actionable_marker(&actionable_state),
-                    )
-                }
-                TurnStatus::BlockedAuth => {
-                    self.delete_slack_message_if_present(working_message.take())
-                        .await;
-                    let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
-                        tracing::warn!(
-                            %run_id,
-                            "Slack run is blocked on auth without a gate ref; skipping auth prompt delivery"
-                        );
-                        return Ok(());
-                    };
-                    let view = slack_auth_prompt_view(
-                        &envelope,
-                        auth_prompt_view_for_blocked_auth(
-                            &binding.actor_user_id,
-                            &scope,
-                            run_id,
-                            gate_ref.as_str(),
-                            "Authenticate to continue this run.".to_string(),
-                            &actionable_state.credential_requirements,
-                            self.services.auth_challenges.as_deref(),
-                        )
-                        .await?,
-                    );
-                    (
-                        RunNotificationEventKind::AuthRequired,
-                        ProductOutboundPayload::AuthPrompt(view),
-                        blocked_actionable_marker(&actionable_state),
-                    )
-                }
-                _ => return Ok(()),
+            if matches!(
+                actionable_state.status,
+                TurnStatus::BlockedApproval | TurnStatus::BlockedAuth
+            ) {
+                self.delete_slack_message_if_present(working_message.take())
+                    .await;
+            }
+            let Some(notification) = self
+                .notification_for_actionable_state(
+                    &envelope,
+                    &binding,
+                    &thread_scope,
+                    &scope,
+                    run_id,
+                    &actionable_state,
+                )
+                .await?
+            else {
+                return Ok(());
             };
-            let reply_target = actionable_state.reply_target_binding_ref.clone();
-            let target_authority = ObservedSlackReplyTargetAuthority {
-                scope: scope.clone(),
-                actor: actor.clone(),
-                expected_target: reply_target.clone(),
-                external_conversation_ref: envelope.external_conversation_ref().clone(),
-                external_actor_ref: Some(envelope.external_actor_ref().clone()),
-            };
-            let projection_access_policy = AllowNoProjectionAccess;
-            let outbound_policy = OutboundPolicyService::new(
-                self.services.outbound_store.as_ref(),
-                &projection_access_policy,
-                &target_authority,
-            );
-            let projection_id = slack_run_notification_projection_id(run_id, event_kind);
-            let projection_ref = ProjectionUpdateRef::new(projection_id.clone())
-                .map_err(|reason| SlackFinalReplyDeliveryError::InvalidProjectionRef { reason })?;
-            let delivery = ironclaw_outbound::PrepareCommunicationDeliveryRequest {
-                resolution_request: CommunicationDeliveryResolutionRequest {
-                    scope: scope.clone(),
-                    actor: actor.clone(),
-                    modality: CommunicationModality::Text,
-                    intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
-                        event_kind,
-                        origin: RunNotificationOrigin::LiveSourceRoute {
-                            source_route: SourceRouteContext {
-                                reply_target_binding_ref: reply_target,
-                            },
-                        },
-                    }),
-                },
-                turn_run_id: Some(run_id),
-                projection_ref,
-                attempted_at: Utc::now(),
-            };
-            let tracked_egress = TrackingSlackPostEgress::new(self.services.egress.clone());
-            let _outcome = prepare_and_render_product_outbound(
-                &outbound_policy,
-                self.services.communication_preferences.as_ref(),
-                &target_authority,
-                ProductOutboundDeliveryRequest {
-                    delivery,
-                    payload,
-                    projection_cursor: ironclaw_product_adapters::ProjectionCursor::new(
-                        projection_id,
-                    )
-                    .map_err(|error| {
-                        SlackFinalReplyDeliveryError::InvalidProjectionRef {
-                            reason: error.to_string(),
-                        }
-                    })?,
-                    adapter: self.services.adapter.as_ref(),
-                    egress: &tracked_egress,
-                    delivery_sink: self.services.delivery_sink.as_ref(),
-                },
-            )
-            .await?;
-            let posted_messages = tracked_egress.take_posted_messages();
+            let next_blocked_marker = blocked_actionable_marker(&actionable_state);
+            let event_kind = notification.event_kind;
+            let posted_messages = self
+                .deliver_run_notification(
+                    &envelope,
+                    &scope,
+                    &actor,
+                    run_id,
+                    &actionable_state,
+                    notification,
+                )
+                .await?;
 
             let Some(marker) = next_blocked_marker else {
                 self.delete_slack_message_if_present(working_message.take())
@@ -281,6 +189,155 @@ impl SlackFinalReplyDeliveryObserver {
         }
     }
 
+    async fn notification_for_actionable_state(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        binding: &ResolvedBinding,
+        thread_scope: &ThreadScope,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        state: &TurnRunState,
+    ) -> Result<Option<SlackActionableNotification>, SlackFinalReplyDeliveryError> {
+        let notification = match state.status {
+            TurnStatus::Completed => {
+                let Some(text) = self
+                    .read_latest_assistant_text(thread_scope, binding, run_id)
+                    .await?
+                else {
+                    tracing::warn!(
+                        %run_id,
+                        "completed Slack run has no finalized assistant message; skipping final reply delivery"
+                    );
+                    return Ok(None);
+                };
+                SlackActionableNotification {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    payload: ProductOutboundPayload::FinalReply(FinalReplyView {
+                        turn_run_id: run_id,
+                        text,
+                        generated_at: Utc::now(),
+                    }),
+                }
+            }
+            TurnStatus::BlockedApproval => {
+                let Some(gate_ref) = state.gate_ref.as_ref() else {
+                    tracing::warn!(
+                        %run_id,
+                        "Slack run is blocked on approval without a gate ref; skipping approval prompt delivery"
+                    );
+                    return Ok(None);
+                };
+                SlackActionableNotification {
+                    event_kind: RunNotificationEventKind::ApprovalNeeded,
+                    payload: ProductOutboundPayload::GatePrompt(GatePromptView {
+                        turn_run_id: run_id,
+                        gate_ref: gate_ref.as_str().to_string(),
+                        headline: "Approval needed".to_string(),
+                        body: "A step in the workflow requires your approval to resume."
+                            .to_string(),
+                    }),
+                }
+            }
+            TurnStatus::BlockedAuth => {
+                let Some(gate_ref) = state.gate_ref.as_ref() else {
+                    tracing::warn!(
+                        %run_id,
+                        "Slack run is blocked on auth without a gate ref; skipping auth prompt delivery"
+                    );
+                    return Ok(None);
+                };
+                let view = slack_auth_prompt_view(
+                    envelope,
+                    auth_prompt_view_for_blocked_auth(
+                        &binding.actor_user_id,
+                        scope,
+                        run_id,
+                        gate_ref.as_str(),
+                        "Authenticate to continue this run.".to_string(),
+                        &state.credential_requirements,
+                        self.services.auth_challenges.as_deref(),
+                    )
+                    .await?,
+                );
+                SlackActionableNotification {
+                    event_kind: RunNotificationEventKind::AuthRequired,
+                    payload: ProductOutboundPayload::AuthPrompt(view),
+                }
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(notification))
+    }
+
+    async fn deliver_run_notification(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        scope: &TurnScope,
+        actor: &TurnActor,
+        run_id: TurnRunId,
+        state: &TurnRunState,
+        notification: SlackActionableNotification,
+    ) -> Result<Vec<PostedSlackMessage>, SlackFinalReplyDeliveryError> {
+        let SlackActionableNotification {
+            event_kind,
+            payload,
+        } = notification;
+        let reply_target = state.reply_target_binding_ref.clone();
+        let target_authority = ObservedSlackReplyTargetAuthority {
+            scope: scope.clone(),
+            actor: actor.clone(),
+            expected_target: reply_target.clone(),
+            external_conversation_ref: envelope.external_conversation_ref().clone(),
+            external_actor_ref: Some(envelope.external_actor_ref().clone()),
+        };
+        let projection_access_policy = AllowNoProjectionAccess;
+        let outbound_policy = OutboundPolicyService::new(
+            self.services.outbound_store.as_ref(),
+            &projection_access_policy,
+            &target_authority,
+        );
+        let projection_id = slack_run_notification_projection_id(run_id, event_kind);
+        let projection_ref = ProjectionUpdateRef::new(projection_id.clone())
+            .map_err(|reason| SlackFinalReplyDeliveryError::InvalidProjectionRef { reason })?;
+        let delivery = ironclaw_outbound::PrepareCommunicationDeliveryRequest {
+            resolution_request: CommunicationDeliveryResolutionRequest {
+                scope: scope.clone(),
+                actor: actor.clone(),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind,
+                    origin: RunNotificationOrigin::LiveSourceRoute {
+                        source_route: SourceRouteContext {
+                            reply_target_binding_ref: reply_target,
+                        },
+                    },
+                }),
+            },
+            turn_run_id: Some(run_id),
+            projection_ref,
+            attempted_at: Utc::now(),
+        };
+        let tracked_egress = TrackingSlackPostEgress::new(self.services.egress.clone());
+        let _outcome = prepare_and_render_product_outbound(
+            &outbound_policy,
+            self.services.communication_preferences.as_ref(),
+            &target_authority,
+            ProductOutboundDeliveryRequest {
+                delivery,
+                payload,
+                projection_cursor: ironclaw_product_adapters::ProjectionCursor::new(projection_id)
+                    .map_err(|error| SlackFinalReplyDeliveryError::InvalidProjectionRef {
+                        reason: error.to_string(),
+                    })?,
+                adapter: self.services.adapter.as_ref(),
+                egress: &tracked_egress,
+                delivery_sink: self.services.delivery_sink.as_ref(),
+            },
+        )
+        .await?;
+        Ok(tracked_egress.take_posted_messages())
+    }
+
     async fn wait_for_actionable(
         &self,
         scope: &TurnScope,
@@ -288,7 +345,7 @@ impl SlackFinalReplyDeliveryObserver {
         delivered_blocked_marker: Option<&BlockedActionableMarker>,
         envelope: &ProductInboundEnvelope,
         working_message: &mut Option<PostedSlackMessage>,
-    ) -> Result<ironclaw_turns::TurnRunState, SlackFinalReplyDeliveryError> {
+    ) -> Result<TurnRunState, SlackFinalReplyDeliveryError> {
         let start = Instant::now();
         let mut poll_interval = self.settings.poll_interval;
         loop {
@@ -575,17 +632,15 @@ fn posted_slack_message_from_response(body: &[u8]) -> Option<PostedSlackMessage>
     })
 }
 
-fn blocked_actionable_marker(
-    state: &ironclaw_turns::TurnRunState,
-) -> Option<BlockedActionableMarker> {
+fn blocked_actionable_marker(state: &TurnRunState) -> Option<BlockedActionableMarker> {
     match state.status {
-        TurnStatus::BlockedApproval | TurnStatus::BlockedAuth => Some((
-            state.status,
-            state
+        TurnStatus::BlockedApproval | TurnStatus::BlockedAuth => Some(BlockedActionableMarker {
+            status: state.status,
+            gate_ref: state
                 .gate_ref
                 .as_ref()
                 .map(|gate| gate.as_str().to_string()),
-        )),
+        }),
         _ => None,
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -49,6 +49,7 @@ const SLACK_RUN_POLL_JITTER_BUCKETS: u32 = 5;
 const SLACK_API_HOST: &str = "slack.com";
 const SLACK_BOT_TOKEN_HANDLE: &str = "slack_bot_token";
 const SLACK_WORKING_MESSAGE: &str = "Ironclaw is thinking...";
+const SLACK_AUTH_CANCELED_MESSAGE: &str = "Authentication canceled.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BlockedActionableMarker {
@@ -117,6 +118,15 @@ impl SlackFinalReplyDeliveryObserver {
         envelope: ProductInboundEnvelope,
         ack: ProductInboundAck,
     ) -> Result<(), SlackFinalReplyDeliveryError> {
+        if is_accepted_auth_denial(&envelope, &ack) {
+            post_slack_message(
+                self.services.egress.as_ref(),
+                envelope.external_conversation_ref(),
+                SLACK_AUTH_CANCELED_MESSAGE,
+            )
+            .await?;
+            return Ok(());
+        }
         if !should_deliver_after_ack(&envelope, &ack) {
             return Ok(());
         }
@@ -818,6 +828,18 @@ fn should_deliver_after_ack(envelope: &ProductInboundEnvelope, ack: &ProductInbo
         ProductInboundPayload::ScopedApprovalResolution(payload)
             if payload.decision == ironclaw_product_adapters::ApprovalDecision::Deny
     )
+}
+
+fn is_accepted_auth_denial(envelope: &ProductInboundEnvelope, ack: &ProductInboundAck) -> bool {
+    submitted_run_id(ack).is_some()
+        && matches!(
+            envelope.payload(),
+            ProductInboundPayload::AuthResolution(payload)
+                if matches!(
+                    &payload.result,
+                    ironclaw_product_adapters::AuthResolutionResult::Denied
+                )
+        )
 }
 
 fn turn_scope_from_thread_scope(

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -117,6 +117,9 @@ impl SlackFinalReplyDeliveryObserver {
         envelope: ProductInboundEnvelope,
         ack: ProductInboundAck,
     ) -> Result<(), SlackFinalReplyDeliveryError> {
+        if !should_deliver_after_ack(&envelope, &ack) {
+            return Ok(());
+        }
         let Some(run_id) = submitted_run_id(&ack) else {
             return Ok(());
         };
@@ -795,6 +798,28 @@ fn submitted_run_id(ack: &ProductInboundAck) -> Option<TurnRunId> {
     }
 }
 
+fn should_deliver_after_ack(envelope: &ProductInboundEnvelope, ack: &ProductInboundAck) -> bool {
+    if submitted_run_id(ack).is_none() {
+        return false;
+    }
+    !matches!(
+        envelope.payload(),
+        ProductInboundPayload::AuthResolution(payload)
+            if matches!(
+                &payload.result,
+                ironclaw_product_adapters::AuthResolutionResult::Denied
+            )
+    ) && !matches!(
+        envelope.payload(),
+        ProductInboundPayload::ApprovalResolution(payload)
+            if payload.decision == ironclaw_product_adapters::ApprovalDecision::Deny
+    ) && !matches!(
+        envelope.payload(),
+        ProductInboundPayload::ScopedApprovalResolution(payload)
+            if payload.decision == ironclaw_product_adapters::ApprovalDecision::Deny
+    )
+}
+
 fn turn_scope_from_thread_scope(
     binding: &ResolvedBinding,
     thread_scope: &ThreadScope,
@@ -828,4 +853,83 @@ fn thread_scope_from_binding(
         owner_user_id: binding.subject_user_id.clone(),
         mission_id: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_product_adapters::{
+        AdapterInstallationId, AuthRequirement, ExternalActorRef, ExternalConversationRef,
+        ExternalEventId, ParsedProductInbound, ProtocolAuthEvidence, TrustedInboundContext,
+    };
+    use ironclaw_turns::AcceptedMessageRef;
+
+    fn accepted_ack() -> ProductInboundAck {
+        ProductInboundAck::Accepted {
+            accepted_message_ref: AcceptedMessageRef::new("slack:test-message")
+                .expect("accepted message ref"),
+            submitted_run_id: TurnRunId::new(),
+        }
+    }
+
+    fn envelope(payload: ProductInboundPayload) -> ProductInboundEnvelope {
+        let adapter_id =
+            ironclaw_product_adapters::ProductAdapterId::new("slack_v2").expect("adapter");
+        let installation_id = AdapterInstallationId::new("install_alpha").expect("installation");
+        let evidence = ProtocolAuthEvidence::test_verified(
+            AuthRequirement::SharedSecretHeader {
+                header_name: "X-Slack-Signature".to_string(),
+            },
+            installation_id.as_str(),
+        );
+        let context = TrustedInboundContext::from_verified_evidence(
+            adapter_id,
+            installation_id,
+            Utc::now(),
+            &evidence,
+        )
+        .expect("trusted context");
+        let parsed = ParsedProductInbound::new(
+            ExternalEventId::new("evt:test").expect("event"),
+            ExternalActorRef::new("slack_user", "U123", None::<String>).expect("actor"),
+            ExternalConversationRef::new(Some("T123"), "D123", None, None).expect("conversation"),
+            payload,
+        )
+        .expect("parsed inbound");
+        ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("envelope")
+    }
+
+    #[test]
+    fn auth_denial_ack_does_not_enter_slack_delivery_loop() {
+        let payload = ProductInboundPayload::AuthResolution(
+            ironclaw_product_adapters::AuthResolutionPayload::new(
+                "gate:auth-test",
+                ironclaw_product_adapters::AuthResolutionResult::Denied,
+            )
+            .expect("auth resolution"),
+        );
+
+        assert!(!should_deliver_after_ack(
+            &envelope(payload),
+            &accepted_ack()
+        ));
+    }
+
+    #[test]
+    fn auth_completion_ack_still_enters_slack_delivery_loop() {
+        let payload = ProductInboundPayload::AuthResolution(
+            ironclaw_product_adapters::AuthResolutionPayload::new(
+                "gate:auth-test",
+                ironclaw_product_adapters::AuthResolutionResult::CallbackCompleted {
+                    callback_ref: ironclaw_auth::AuthFlowId::new().to_string(),
+                },
+            )
+            .expect("auth resolution"),
+        );
+
+        assert!(should_deliver_after_ack(
+            &envelope(payload),
+            &accepted_ack()
+        ));
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -45,6 +45,8 @@ use crate::auth_prompt::auth_prompt_view_for_blocked_auth;
 const MAX_SLACK_RUN_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const SLACK_RUN_POLL_JITTER_BUCKETS: u32 = 5;
 
+type BlockedActionableMarker = (TurnStatus, Option<String>);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SlackFinalReplyDeliverySettings {
     pub poll_interval: Duration,
@@ -112,134 +114,151 @@ impl SlackFinalReplyDeliveryObserver {
         let actor = TurnActor::new(binding.actor_user_id.clone());
         let thread_scope = thread_scope_from_binding(&binding)?;
         let scope = turn_scope_from_thread_scope(&binding, &thread_scope)?;
-        let actionable_state = self.wait_for_actionable(&scope, run_id).await?;
-        let (event_kind, payload) = match actionable_state.status {
-            TurnStatus::Completed => {
-                let Some(text) = self
-                    .read_latest_assistant_text(&thread_scope, &binding, run_id)
-                    .await?
-                else {
-                    tracing::warn!(
-                        %run_id,
-                        "completed Slack run has no finalized assistant message; skipping final reply delivery"
-                    );
-                    return Ok(());
-                };
-                (
-                    RunNotificationEventKind::FinalReplyReady,
-                    ProductOutboundPayload::FinalReply(FinalReplyView {
-                        turn_run_id: run_id,
-                        text,
-                        generated_at: Utc::now(),
-                    }),
-                )
-            }
-            TurnStatus::BlockedApproval => {
-                let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
-                    tracing::warn!(
-                        %run_id,
-                        "Slack run is blocked on approval without a gate ref; skipping approval prompt delivery"
-                    );
-                    return Ok(());
-                };
-                (
-                    RunNotificationEventKind::ApprovalNeeded,
-                    ProductOutboundPayload::GatePrompt(GatePromptView {
-                        turn_run_id: run_id,
-                        gate_ref: gate_ref.as_str().to_string(),
-                        headline: "Approval needed".to_string(),
-                        body: "A step in the workflow requires your approval to proceed."
-                            .to_string(),
-                    }),
-                )
-            }
-            TurnStatus::BlockedAuth => {
-                let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
-                    tracing::warn!(
-                        %run_id,
-                        "Slack run is blocked on auth without a gate ref; skipping auth prompt delivery"
-                    );
-                    return Ok(());
-                };
-                let view = slack_auth_prompt_view(
-                    &envelope,
-                    auth_prompt_view_for_blocked_auth(
-                        &binding.actor_user_id,
-                        &scope,
-                        run_id,
-                        gate_ref.as_str(),
-                        "Authenticate to continue this run.".to_string(),
-                        &actionable_state.credential_requirements,
-                        self.services.auth_challenges.as_deref(),
+        let mut delivered_blocked_marker = None;
+        loop {
+            let actionable_state = self
+                .wait_for_actionable(&scope, run_id, delivered_blocked_marker.as_ref())
+                .await?;
+            let (event_kind, payload, next_blocked_marker) = match actionable_state.status {
+                TurnStatus::Completed => {
+                    let Some(text) = self
+                        .read_latest_assistant_text(&thread_scope, &binding, run_id)
+                        .await?
+                    else {
+                        tracing::warn!(
+                            %run_id,
+                            "completed Slack run has no finalized assistant message; skipping final reply delivery"
+                        );
+                        return Ok(());
+                    };
+                    (
+                        RunNotificationEventKind::FinalReplyReady,
+                        ProductOutboundPayload::FinalReply(FinalReplyView {
+                            turn_run_id: run_id,
+                            text,
+                            generated_at: Utc::now(),
+                        }),
+                        None,
                     )
-                    .await?,
-                );
-                (
-                    RunNotificationEventKind::AuthRequired,
-                    ProductOutboundPayload::AuthPrompt(view),
-                )
-            }
-            _ => return Ok(()),
-        };
-        let reply_target = actionable_state.reply_target_binding_ref.clone();
-        let target_authority = ObservedSlackReplyTargetAuthority {
-            scope: scope.clone(),
-            actor: actor.clone(),
-            expected_target: reply_target.clone(),
-            external_conversation_ref: envelope.external_conversation_ref().clone(),
-            external_actor_ref: Some(envelope.external_actor_ref().clone()),
-        };
-        let projection_access_policy = AllowNoProjectionAccess;
-        let outbound_policy = OutboundPolicyService::new(
-            self.services.outbound_store.as_ref(),
-            &projection_access_policy,
-            &target_authority,
-        );
-        let projection_id = format!("slack-final-reply:{run_id}");
-        let projection_ref = ProjectionUpdateRef::new(projection_id.clone())
-            .map_err(|reason| SlackFinalReplyDeliveryError::InvalidProjectionRef { reason })?;
-        let delivery = ironclaw_outbound::PrepareCommunicationDeliveryRequest {
-            resolution_request: CommunicationDeliveryResolutionRequest {
+                }
+                TurnStatus::BlockedApproval => {
+                    let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
+                        tracing::warn!(
+                            %run_id,
+                            "Slack run is blocked on approval without a gate ref; skipping approval prompt delivery"
+                        );
+                        return Ok(());
+                    };
+                    (
+                        RunNotificationEventKind::ApprovalNeeded,
+                        ProductOutboundPayload::GatePrompt(GatePromptView {
+                            turn_run_id: run_id,
+                            gate_ref: gate_ref.as_str().to_string(),
+                            headline: "Approval needed".to_string(),
+                            body: "A step in the workflow requires your approval to resume."
+                                .to_string(),
+                        }),
+                        blocked_actionable_marker(&actionable_state),
+                    )
+                }
+                TurnStatus::BlockedAuth => {
+                    let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
+                        tracing::warn!(
+                            %run_id,
+                            "Slack run is blocked on auth without a gate ref; skipping auth prompt delivery"
+                        );
+                        return Ok(());
+                    };
+                    let view = slack_auth_prompt_view(
+                        &envelope,
+                        auth_prompt_view_for_blocked_auth(
+                            &binding.actor_user_id,
+                            &scope,
+                            run_id,
+                            gate_ref.as_str(),
+                            "Authenticate to continue this run.".to_string(),
+                            &actionable_state.credential_requirements,
+                            self.services.auth_challenges.as_deref(),
+                        )
+                        .await?,
+                    );
+                    (
+                        RunNotificationEventKind::AuthRequired,
+                        ProductOutboundPayload::AuthPrompt(view),
+                        blocked_actionable_marker(&actionable_state),
+                    )
+                }
+                _ => return Ok(()),
+            };
+            let reply_target = actionable_state.reply_target_binding_ref.clone();
+            let target_authority = ObservedSlackReplyTargetAuthority {
                 scope: scope.clone(),
                 actor: actor.clone(),
-                modality: CommunicationModality::Text,
-                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
-                    event_kind,
-                    origin: RunNotificationOrigin::LiveSourceRoute {
-                        source_route: SourceRouteContext {
-                            reply_target_binding_ref: reply_target,
+                expected_target: reply_target.clone(),
+                external_conversation_ref: envelope.external_conversation_ref().clone(),
+                external_actor_ref: Some(envelope.external_actor_ref().clone()),
+            };
+            let projection_access_policy = AllowNoProjectionAccess;
+            let outbound_policy = OutboundPolicyService::new(
+                self.services.outbound_store.as_ref(),
+                &projection_access_policy,
+                &target_authority,
+            );
+            let projection_id = slack_run_notification_projection_id(run_id, event_kind);
+            let projection_ref = ProjectionUpdateRef::new(projection_id.clone())
+                .map_err(|reason| SlackFinalReplyDeliveryError::InvalidProjectionRef { reason })?;
+            let delivery = ironclaw_outbound::PrepareCommunicationDeliveryRequest {
+                resolution_request: CommunicationDeliveryResolutionRequest {
+                    scope: scope.clone(),
+                    actor: actor.clone(),
+                    modality: CommunicationModality::Text,
+                    intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                        event_kind,
+                        origin: RunNotificationOrigin::LiveSourceRoute {
+                            source_route: SourceRouteContext {
+                                reply_target_binding_ref: reply_target,
+                            },
                         },
-                    },
-                }),
-            },
-            turn_run_id: Some(run_id),
-            projection_ref,
-            attempted_at: Utc::now(),
-        };
-        let _outcome = prepare_and_render_product_outbound(
-            &outbound_policy,
-            self.services.communication_preferences.as_ref(),
-            &target_authority,
-            ProductOutboundDeliveryRequest {
-                delivery,
-                payload,
-                projection_cursor: ironclaw_product_adapters::ProjectionCursor::new(projection_id)
-                    .map_err(|error| SlackFinalReplyDeliveryError::InvalidProjectionRef {
-                        reason: error.to_string(),
+                    }),
+                },
+                turn_run_id: Some(run_id),
+                projection_ref,
+                attempted_at: Utc::now(),
+            };
+            let _outcome = prepare_and_render_product_outbound(
+                &outbound_policy,
+                self.services.communication_preferences.as_ref(),
+                &target_authority,
+                ProductOutboundDeliveryRequest {
+                    delivery,
+                    payload,
+                    projection_cursor: ironclaw_product_adapters::ProjectionCursor::new(
+                        projection_id,
+                    )
+                    .map_err(|error| {
+                        SlackFinalReplyDeliveryError::InvalidProjectionRef {
+                            reason: error.to_string(),
+                        }
                     })?,
-                adapter: self.services.adapter.as_ref(),
-                egress: self.services.egress.as_ref(),
-                delivery_sink: self.services.delivery_sink.as_ref(),
-            },
-        )
-        .await?;
-        Ok(())
+                    adapter: self.services.adapter.as_ref(),
+                    egress: self.services.egress.as_ref(),
+                    delivery_sink: self.services.delivery_sink.as_ref(),
+                },
+            )
+            .await?;
+
+            let Some(marker) = next_blocked_marker else {
+                return Ok(());
+            };
+            delivered_blocked_marker = Some(marker);
+        }
     }
 
     async fn wait_for_actionable(
         &self,
         scope: &TurnScope,
         run_id: TurnRunId,
+        delivered_blocked_marker: Option<&BlockedActionableMarker>,
     ) -> Result<ironclaw_turns::TurnRunState, SlackFinalReplyDeliveryError> {
         let start = Instant::now();
         let mut poll_interval = self.settings.poll_interval;
@@ -252,11 +271,11 @@ impl SlackFinalReplyDeliveryObserver {
                     run_id,
                 })
                 .await?;
-            if state.status.is_terminal()
-                || matches!(
-                    state.status,
-                    TurnStatus::BlockedApproval | TurnStatus::BlockedAuth
-                )
+            if state.status.is_terminal() {
+                return Ok(state);
+            }
+            if let Some(marker) = blocked_actionable_marker(&state)
+                && Some(&marker) != delivered_blocked_marker
             {
                 return Ok(state);
             }
@@ -287,6 +306,36 @@ impl SlackFinalReplyDeliveryObserver {
             .await?
             .and_then(|message| message.content))
     }
+}
+
+fn blocked_actionable_marker(
+    state: &ironclaw_turns::TurnRunState,
+) -> Option<BlockedActionableMarker> {
+    match state.status {
+        TurnStatus::BlockedApproval | TurnStatus::BlockedAuth => Some((
+            state.status,
+            state
+                .gate_ref
+                .as_ref()
+                .map(|gate| gate.as_str().to_string()),
+        )),
+        _ => None,
+    }
+}
+
+fn slack_run_notification_projection_id(
+    run_id: TurnRunId,
+    event_kind: RunNotificationEventKind,
+) -> String {
+    let suffix = match event_kind {
+        RunNotificationEventKind::FinalReplyReady => "final",
+        RunNotificationEventKind::ProgressUpdate => "progress",
+        RunNotificationEventKind::ApprovalNeeded => "approval",
+        RunNotificationEventKind::AuthRequired => "auth",
+        RunNotificationEventKind::RunBlocked => "blocked",
+        RunNotificationEventKind::DeliveryStatus => "delivery-status",
+    };
+    format!("slack-run-notification:{suffix}:{run_id}")
 }
 
 fn slack_auth_prompt_view(

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -21,9 +21,9 @@ use ironclaw_outbound::{
     RunNotificationOrigin, SourceRouteContext, ValidatedReplyTargetBinding,
 };
 use ironclaw_product_adapters::{
-    DeclaredEgressHost, EgressCredentialHandle, EgressMethod, EgressPath, EgressRequest,
-    EgressResponse, ExternalActorRef, ExternalConversationRef, FinalReplyView, GatePromptView,
-    OutboundDeliverySink, ProductAdapter, ProductAdapterError, ProductInboundAck,
+    DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod, EgressPath,
+    EgressRequest, EgressResponse, ExternalActorRef, ExternalConversationRef, FinalReplyView,
+    GatePromptView, OutboundDeliverySink, ProductAdapter, ProductAdapterError, ProductInboundAck,
     ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductTriggerReason,
     ProtocolHttpEgress, ProtocolHttpEgressError,
 };
@@ -559,6 +559,7 @@ fn slack_web_api_request(
         EgressMethod::post(),
         EgressPath::new(path)?,
     )
+    .with_header(EgressHeader::new("content-type", "application/json")?)
     .with_body(body)
     .with_credential_handle(Some(EgressCredentialHandle::new(SLACK_BOT_TOKEN_HANDLE)?)))
 }

--- a/crates/ironclaw_reborn_composition/src/slack_delivery.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_delivery.rs
@@ -8,7 +8,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -21,10 +21,11 @@ use ironclaw_outbound::{
     RunNotificationOrigin, SourceRouteContext, ValidatedReplyTargetBinding,
 };
 use ironclaw_product_adapters::{
-    ExternalActorRef, ExternalConversationRef, FinalReplyView, GatePromptView,
+    DeclaredEgressHost, EgressCredentialHandle, EgressMethod, EgressPath, EgressRequest,
+    EgressResponse, ExternalActorRef, ExternalConversationRef, FinalReplyView, GatePromptView,
     OutboundDeliverySink, ProductAdapter, ProductAdapterError, ProductInboundAck,
     ProductInboundEnvelope, ProductInboundPayload, ProductOutboundPayload, ProductTriggerReason,
-    ProtocolHttpEgress,
+    ProtocolHttpEgress, ProtocolHttpEgressError,
 };
 use ironclaw_product_workflow::{
     ConversationBindingService, ProductOutboundDeliveryRequest, ProductOutboundTargetResolver,
@@ -37,6 +38,7 @@ use ironclaw_turns::{
     TurnStatus,
 };
 use ironclaw_wasm_product_adapters::ImmediateAckWorkflowObserver;
+use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
 use crate::AuthChallengeProvider;
@@ -44,6 +46,9 @@ use crate::auth_prompt::auth_prompt_view_for_blocked_auth;
 
 const MAX_SLACK_RUN_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const SLACK_RUN_POLL_JITTER_BUCKETS: u32 = 5;
+const SLACK_API_HOST: &str = "slack.com";
+const SLACK_BOT_TOKEN_HANDLE: &str = "slack_bot_token";
+const SLACK_WORKING_MESSAGE: &str = "Ironclaw is thinking...";
 
 type BlockedActionableMarker = (TurnStatus, Option<String>);
 
@@ -115,9 +120,17 @@ impl SlackFinalReplyDeliveryObserver {
         let thread_scope = thread_scope_from_binding(&binding)?;
         let scope = turn_scope_from_thread_scope(&binding, &thread_scope)?;
         let mut delivered_blocked_marker = None;
+        let mut working_message = None;
+        let mut messages_to_delete_after_final = Vec::new();
         loop {
             let actionable_state = self
-                .wait_for_actionable(&scope, run_id, delivered_blocked_marker.as_ref())
+                .wait_for_actionable(
+                    &scope,
+                    run_id,
+                    delivered_blocked_marker.as_ref(),
+                    &envelope,
+                    &mut working_message,
+                )
                 .await?;
             let (event_kind, payload, next_blocked_marker) = match actionable_state.status {
                 TurnStatus::Completed => {
@@ -142,6 +155,8 @@ impl SlackFinalReplyDeliveryObserver {
                     )
                 }
                 TurnStatus::BlockedApproval => {
+                    self.delete_slack_message_if_present(working_message.take())
+                        .await;
                     let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
                         tracing::warn!(
                             %run_id,
@@ -162,6 +177,8 @@ impl SlackFinalReplyDeliveryObserver {
                     )
                 }
                 TurnStatus::BlockedAuth => {
+                    self.delete_slack_message_if_present(working_message.take())
+                        .await;
                     let Some(gate_ref) = actionable_state.gate_ref.as_ref() else {
                         tracing::warn!(
                             %run_id,
@@ -225,6 +242,7 @@ impl SlackFinalReplyDeliveryObserver {
                 projection_ref,
                 attempted_at: Utc::now(),
             };
+            let tracked_egress = TrackingSlackPostEgress::new(self.services.egress.clone());
             let _outcome = prepare_and_render_product_outbound(
                 &outbound_policy,
                 self.services.communication_preferences.as_ref(),
@@ -241,15 +259,24 @@ impl SlackFinalReplyDeliveryObserver {
                         }
                     })?,
                     adapter: self.services.adapter.as_ref(),
-                    egress: self.services.egress.as_ref(),
+                    egress: &tracked_egress,
                     delivery_sink: self.services.delivery_sink.as_ref(),
                 },
             )
             .await?;
+            let posted_messages = tracked_egress.take_posted_messages();
 
             let Some(marker) = next_blocked_marker else {
+                self.delete_slack_message_if_present(working_message.take())
+                    .await;
+                for message in messages_to_delete_after_final {
+                    self.delete_slack_message(message).await;
+                }
                 return Ok(());
             };
+            if event_kind == RunNotificationEventKind::AuthRequired {
+                messages_to_delete_after_final.extend(posted_messages);
+            }
             delivered_blocked_marker = Some(marker);
         }
     }
@@ -259,6 +286,8 @@ impl SlackFinalReplyDeliveryObserver {
         scope: &TurnScope,
         run_id: TurnRunId,
         delivered_blocked_marker: Option<&BlockedActionableMarker>,
+        envelope: &ProductInboundEnvelope,
+        working_message: &mut Option<PostedSlackMessage>,
     ) -> Result<ironclaw_turns::TurnRunState, SlackFinalReplyDeliveryError> {
         let start = Instant::now();
         let mut poll_interval = self.settings.poll_interval;
@@ -281,6 +310,9 @@ impl SlackFinalReplyDeliveryObserver {
             }
             if start.elapsed() >= self.settings.max_wait {
                 return Err(SlackFinalReplyDeliveryError::RunWaitTimedOut { run_id });
+            }
+            if working_message.is_none() && blocked_actionable_marker(&state).is_none() {
+                *working_message = self.post_slack_working_message(envelope).await;
             }
             tokio::time::sleep(jittered_poll_interval(poll_interval, &run_id)).await;
             poll_interval = poll_interval
@@ -306,6 +338,240 @@ impl SlackFinalReplyDeliveryObserver {
             .await?
             .and_then(|message| message.content))
     }
+
+    async fn post_slack_working_message(
+        &self,
+        envelope: &ProductInboundEnvelope,
+    ) -> Option<PostedSlackMessage> {
+        match post_slack_message(
+            self.services.egress.as_ref(),
+            envelope.external_conversation_ref(),
+            SLACK_WORKING_MESSAGE,
+        )
+        .await
+        {
+            Ok(message) => Some(message),
+            Err(error) => {
+                tracing::warn!(
+                    target = "ironclaw::reborn::slack_delivery",
+                    error = %error,
+                    "failed to post Slack working indicator"
+                );
+                None
+            }
+        }
+    }
+
+    async fn delete_slack_message_if_present(&self, message: Option<PostedSlackMessage>) {
+        if let Some(message) = message {
+            self.delete_slack_message(message).await;
+        }
+    }
+
+    async fn delete_slack_message(&self, message: PostedSlackMessage) {
+        if let Err(error) = delete_slack_message(self.services.egress.as_ref(), &message).await {
+            tracing::warn!(
+                target = "ironclaw::reborn::slack_delivery",
+                error = %error,
+                "failed to delete Slack prompt/status message"
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PostedSlackMessage {
+    channel: String,
+    ts: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatPostMessageRequest<'a> {
+    channel: &'a str,
+    text: &'a str,
+    mrkdwn: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread_ts: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatDeleteRequest<'a> {
+    channel: &'a str,
+    ts: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackMessageResponse {
+    ok: bool,
+    channel: Option<String>,
+    ts: Option<String>,
+    error: Option<String>,
+}
+
+struct TrackingSlackPostEgress {
+    inner: Arc<dyn ProtocolHttpEgress>,
+    posted_messages: Arc<Mutex<Vec<PostedSlackMessage>>>,
+}
+
+impl TrackingSlackPostEgress {
+    fn new(inner: Arc<dyn ProtocolHttpEgress>) -> Self {
+        Self {
+            inner,
+            posted_messages: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn take_posted_messages(&self) -> Vec<PostedSlackMessage> {
+        std::mem::take(
+            &mut *self
+                .posted_messages
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
+    }
+}
+
+#[async_trait]
+impl ProtocolHttpEgress for TrackingSlackPostEgress {
+    async fn send(
+        &self,
+        request: EgressRequest,
+    ) -> Result<EgressResponse, ProtocolHttpEgressError> {
+        let captures_posted_message = request.path().as_str() == "/api/chat.postMessage";
+        let response = self.inner.send(request).await?;
+        if captures_posted_message
+            && let Some(message) = posted_slack_message_from_response(response.body())
+        {
+            self.posted_messages
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(message);
+        }
+        Ok(response)
+    }
+}
+
+async fn post_slack_message(
+    egress: &dyn ProtocolHttpEgress,
+    conversation: &ExternalConversationRef,
+    text: &str,
+) -> Result<PostedSlackMessage, SlackFinalReplyDeliveryError> {
+    let body = ChatPostMessageRequest {
+        channel: conversation.conversation_id(),
+        text,
+        mrkdwn: false,
+        thread_ts: conversation.topic_id(),
+    };
+    let response = egress
+        .send(slack_web_api_request(
+            "/api/chat.postMessage",
+            serde_json::to_vec(&body).map_err(|error| {
+                SlackFinalReplyDeliveryError::SlackWebApi {
+                    reason: error.to_string(),
+                }
+            })?,
+        )?)
+        .await
+        .map_err(|error| SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: error.to_string(),
+        })?;
+    if !(200..300).contains(&response.status()) {
+        return Err(SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: format!("Slack chat.postMessage returned HTTP {}", response.status()),
+        });
+    }
+    let parsed: SlackMessageResponse =
+        serde_json::from_slice(response.body()).map_err(|error| {
+            SlackFinalReplyDeliveryError::SlackWebApi {
+                reason: format!("Slack chat.postMessage response was not JSON: {error}"),
+            }
+        })?;
+    if !parsed.ok {
+        return Err(SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: format!(
+                "Slack chat.postMessage failed: {}",
+                parsed.error.unwrap_or_else(|| "unknown_error".to_string())
+            ),
+        });
+    }
+    let Some(channel) = parsed.channel else {
+        return Err(SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: "Slack chat.postMessage response missing channel".to_string(),
+        });
+    };
+    let Some(ts) = parsed.ts else {
+        return Err(SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: "Slack chat.postMessage response missing ts".to_string(),
+        });
+    };
+    Ok(PostedSlackMessage { channel, ts })
+}
+
+async fn delete_slack_message(
+    egress: &dyn ProtocolHttpEgress,
+    message: &PostedSlackMessage,
+) -> Result<(), SlackFinalReplyDeliveryError> {
+    let body = ChatDeleteRequest {
+        channel: &message.channel,
+        ts: &message.ts,
+    };
+    let response = egress
+        .send(slack_web_api_request(
+            "/api/chat.delete",
+            serde_json::to_vec(&body).map_err(|error| {
+                SlackFinalReplyDeliveryError::SlackWebApi {
+                    reason: error.to_string(),
+                }
+            })?,
+        )?)
+        .await
+        .map_err(|error| SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: error.to_string(),
+        })?;
+    if !(200..300).contains(&response.status()) {
+        return Err(SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: format!("Slack chat.delete returned HTTP {}", response.status()),
+        });
+    }
+    let parsed: SlackMessageResponse =
+        serde_json::from_slice(response.body()).map_err(|error| {
+            SlackFinalReplyDeliveryError::SlackWebApi {
+                reason: format!("Slack chat.delete response was not JSON: {error}"),
+            }
+        })?;
+    if !parsed.ok {
+        return Err(SlackFinalReplyDeliveryError::SlackWebApi {
+            reason: format!(
+                "Slack chat.delete failed: {}",
+                parsed.error.unwrap_or_else(|| "unknown_error".to_string())
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn slack_web_api_request(
+    path: &'static str,
+    body: Vec<u8>,
+) -> Result<EgressRequest, ProductAdapterError> {
+    Ok(EgressRequest::new(
+        DeclaredEgressHost::new(SLACK_API_HOST)?,
+        EgressMethod::post(),
+        EgressPath::new(path)?,
+    )
+    .with_body(body)
+    .with_credential_handle(Some(EgressCredentialHandle::new(SLACK_BOT_TOKEN_HANDLE)?)))
+}
+
+fn posted_slack_message_from_response(body: &[u8]) -> Option<PostedSlackMessage> {
+    let parsed: SlackMessageResponse = serde_json::from_slice(body).ok()?;
+    if !parsed.ok {
+        return None;
+    }
+    Some(PostedSlackMessage {
+        channel: parsed.channel?,
+        ts: parsed.ts?,
+    })
 }
 
 fn blocked_actionable_marker(
@@ -398,6 +664,8 @@ enum SlackFinalReplyDeliveryError {
     Outbound(#[from] ironclaw_product_workflow::ProductOutboundDeliveryError),
     #[error("adapter failed: {0}")]
     Adapter(#[from] ProductAdapterError),
+    #[error("Slack Web API helper failed: {reason}")]
+    SlackWebApi { reason: String },
     #[error("outbound policy failed: {0}")]
     OutboundPolicy(#[from] OutboundError),
     #[error("run {run_id} did not finish before Slack delivery timeout")]

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -26,12 +26,14 @@ use ironclaw_product_adapters::{
 };
 use ironclaw_product_workflow::{
     ApprovalInteractionActionView, ApprovalInteractionDecision, ApprovalInteractionScope,
-    ApprovalInteractionService, DefaultInboundTurnService, DefaultProductWorkflow,
-    InMemoryIdempotencyLedger, ListPendingApprovalsRequest, ListPendingApprovalsResponse,
-    PendingApprovalInteractionView, ProductActorUserResolver, ProductConversationBindingService,
-    ProductInstallationKey, ProductInstallationScope, ProductWorkflowError,
-    ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
-    StaticProductActorUserResolver, StaticProductInstallationResolver,
+    ApprovalInteractionService, AuthInteractionDecision, AuthInteractionService,
+    DefaultInboundTurnService, DefaultProductWorkflow, InMemoryIdempotencyLedger,
+    ListPendingApprovalsRequest, ListPendingApprovalsResponse, ListPendingAuthInteractionsRequest,
+    ListPendingAuthInteractionsResponse, PendingApprovalInteractionView, ProductActorUserResolver,
+    ProductConversationBindingService, ProductInstallationKey, ProductInstallationScope,
+    ProductWorkflowError, ResolveApprovalInteractionRequest, ResolveApprovalInteractionResponse,
+    ResolveAuthInteractionRequest, ResolveAuthInteractionResponse, StaticProductActorUserResolver,
+    StaticProductInstallationResolver,
 };
 use ironclaw_slack_v2_adapter::{
     SLACK_USER_ACTOR_KIND, SlackV2Adapter, SlackV2AdapterConfig,
@@ -87,6 +89,7 @@ struct Harness {
     egress: RecordingEgress,
     coordinator: Arc<RecordingTurnCoordinator>,
     approvals: Arc<RecordingApprovalInteractionService>,
+    auths: Arc<RecordingAuthInteractionService>,
 }
 
 type HmacSha256 = Hmac<sha2::Sha256>;
@@ -237,6 +240,7 @@ async fn build_harness_with_actor_user_resolver_and_auth_challenges(
         coordinator.clone(),
         threads.clone(),
     ));
+    let auths = Arc::new(RecordingAuthInteractionService::new(coordinator.clone()));
 
     let inbound = Arc::new(DefaultInboundTurnService::new(
         binding.clone(),
@@ -249,7 +253,8 @@ async fn build_harness_with_actor_user_resolver_and_auth_challenges(
             Arc::new(InMemoryIdempotencyLedger::new()),
             Arc::new(binding.clone()),
         )
-        .with_approval_interaction_service(approvals.clone()),
+        .with_approval_interaction_service(approvals.clone())
+        .with_auth_interaction_service(auths.clone()),
     );
 
     let runner = Arc::new(NativeProductAdapterRunner::with_config(
@@ -309,6 +314,7 @@ async fn build_harness_with_actor_user_resolver_and_auth_challenges(
         egress,
         coordinator: Arc::new(coordinator),
         approvals,
+        auths,
     }
 }
 
@@ -624,6 +630,38 @@ async fn slack_approval_reply_resumes_and_delivers_final_reply() {
     assert_eq!(approvals[0].gate_ref.as_str(), GATE);
 }
 
+#[tokio::test]
+async fn slack_thread_auth_deny_with_bot_mention_cancels_auth_gate_without_agent_turn() {
+    let harness = build_harness(TurnMode::BlockAuth).await;
+
+    let first = harness
+        .post_event(app_mention_message("Ev-auth-cancel-start", "needs auth"))
+        .await;
+    assert_eq!(first.status(), StatusCode::OK); // safety: Slack E2E route assertion.
+    harness.drain().await;
+    assert_eq!(harness.slack_messages().len(), 1); // safety: Slack E2E delivery assertion.
+
+    let second = harness
+        .post_event(thread_message_event(
+            "Ev-auth-cancel",
+            "<@UBOT> auth deny gate:auth-slack",
+            "1710000000.000009",
+        ))
+        .await;
+
+    assert_eq!(second.status(), StatusCode::OK); // safety: Slack E2E route assertion.
+    harness.drain().await;
+
+    let auths = harness.auths.requests();
+    assert_eq!(auths.len(), 1); // safety: Slack E2E auth routing assertion.
+    assert_eq!(auths[0].decision, AuthInteractionDecision::Deny); // safety: length asserted above.
+    assert_eq!(auths[0].gate_ref.as_str(), AUTH_GATE); // safety: length asserted above.
+    let submitted_turn_count = harness.coordinator.submitted_turn_count();
+    assert_eq!(submitted_turn_count, 1); // safety: Slack E2E turn routing assertion.
+    let slack_message_count = harness.slack_messages().len();
+    assert_eq!(slack_message_count, 1); // safety: Slack E2E delivery assertion.
+}
+
 #[derive(Debug, Clone)]
 enum TurnMode {
     Complete { assistant_text: String },
@@ -643,6 +681,7 @@ struct RecordingTurnState {
     runs: std::collections::HashMap<TurnRunId, TurnRunState>,
     active_run_id: Option<TurnRunId>,
     blocked_run_id: Option<TurnRunId>,
+    submitted_turn_count: usize,
 }
 
 impl RecordingTurnCoordinator {
@@ -652,6 +691,7 @@ impl RecordingTurnCoordinator {
                 runs: std::collections::HashMap::new(),
                 active_run_id: None,
                 blocked_run_id: None,
+                submitted_turn_count: 0,
             })),
             threads,
             mode,
@@ -670,6 +710,35 @@ impl RecordingTurnCoordinator {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .active_run_id
+    }
+
+    fn submitted_turn_count(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .submitted_turn_count
+    }
+
+    async fn cancel_blocked_run(&self) -> Result<TurnRunId, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let run_id =
+            state
+                .blocked_run_id
+                .ok_or_else(|| ProductWorkflowError::TurnResumeRejected {
+                    reason: "missing blocked run".into(),
+                })?;
+        let run = state.runs.get_mut(&run_id).ok_or_else(|| {
+            ProductWorkflowError::TurnResumeRejected {
+                reason: "missing blocked run state".into(),
+            }
+        })?;
+        run.status = TurnStatus::Cancelled;
+        run.gate_ref = None;
+        state.blocked_run_id = None;
+        Ok(run_id)
     }
 
     async fn complete_run(
@@ -834,6 +903,7 @@ impl TurnCoordinator for RecordingTurnCoordinator {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.submitted_turn_count += 1;
         state.active_run_id = Some(run_id);
         if matches!(
             status,
@@ -1025,6 +1095,69 @@ impl ApprovalInteractionService for RecordingApprovalInteractionService {
     }
 }
 
+struct RecordingAuthInteractionService {
+    coordinator: RecordingTurnCoordinator,
+    requests: Mutex<Vec<ResolveAuthInteractionRequest>>,
+}
+
+impl RecordingAuthInteractionService {
+    fn new(coordinator: RecordingTurnCoordinator) -> Self {
+        Self {
+            coordinator,
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn requests(&self) -> Vec<ResolveAuthInteractionRequest> {
+        self.requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+#[async_trait]
+impl AuthInteractionService for RecordingAuthInteractionService {
+    async fn list_pending(
+        &self,
+        _request: ListPendingAuthInteractionsRequest,
+    ) -> Result<ListPendingAuthInteractionsResponse, ProductWorkflowError> {
+        Ok(ListPendingAuthInteractionsResponse {
+            auth_interactions: Vec::new(),
+        })
+    }
+
+    async fn resolve(
+        &self,
+        request: ResolveAuthInteractionRequest,
+    ) -> Result<ResolveAuthInteractionResponse, ProductWorkflowError> {
+        self.requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(request.clone());
+        let run_id = self.coordinator.cancel_blocked_run().await?;
+        Ok(match request.decision {
+            AuthInteractionDecision::Deny => {
+                ResolveAuthInteractionResponse::Canceled(CancelRunResponse {
+                    run_id,
+                    status: TurnStatus::Cancelled,
+                    event_cursor: EventCursor::default(),
+                    already_terminal: false,
+                    actor: None,
+                })
+            }
+            AuthInteractionDecision::CredentialProvided { .. }
+            | AuthInteractionDecision::CallbackCompleted { .. } => {
+                ResolveAuthInteractionResponse::Resumed(ResumeTurnResponse {
+                    run_id,
+                    status: TurnStatus::Queued,
+                    event_cursor: EventCursor::default(),
+                })
+            }
+        })
+    }
+}
+
 #[derive(Clone, Default)]
 struct RecordingEgress {
     requests: Arc<Mutex<Vec<EgressRequest>>>,
@@ -1160,6 +1293,20 @@ fn dm_message(event_id: &'static str, text: &'static str) -> &'static str {
 fn app_mention_message(event_id: &'static str, text: &'static str) -> &'static str {
     match (event_id, text) {
         ("Ev-auth-channel", "needs auth") => APP_MENTION_AUTH,
+        ("Ev-auth-cancel-start", "needs auth") => APP_MENTION_AUTH_CANCEL_START,
+        _ => panic!("unknown fixture"),
+    }
+}
+
+fn thread_message_event(
+    event_id: &'static str,
+    text: &'static str,
+    thread_ts: &'static str,
+) -> &'static str {
+    match (event_id, text, thread_ts) {
+        ("Ev-auth-cancel", "<@UBOT> auth deny gate:auth-slack", "1710000000.000009") => {
+            THREAD_AUTH_CANCEL_WITH_MENTION
+        }
         _ => panic!("unknown fixture"),
     }
 }
@@ -1244,4 +1391,20 @@ const APP_MENTION_AUTH: &str = r#"{
   "api_app_id":"A-slack",
   "event_id":"Ev-auth-channel",
   "event":{"type":"app_mention","user":"U123","channel":"C123","text":"<@UBOT> needs auth","ts":"1710000000.000008"}
+}"#;
+
+const APP_MENTION_AUTH_CANCEL_START: &str = r#"{
+  "type":"event_callback",
+  "team_id":"T-A",
+  "api_app_id":"A-slack",
+  "event_id":"Ev-auth-cancel-start",
+  "event":{"type":"app_mention","user":"U123","channel":"C123","text":"<@UBOT> needs auth","ts":"1710000000.000009"}
+}"#;
+
+const THREAD_AUTH_CANCEL_WITH_MENTION: &str = r#"{
+  "type":"event_callback",
+  "team_id":"T-A",
+  "api_app_id":"A-slack",
+  "event_id":"Ev-auth-cancel",
+  "event":{"type":"message","user":"U123","channel":"C123","text":"<@UBOT> auth deny gate:auth-slack","ts":"1710000000.000010","thread_ts":"1710000000.000009"}
 }"#;

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -1055,6 +1055,16 @@ impl ProtocolHttpEgress for RecordingEgress {
 }
 
 fn slack_response_for_request(request: &EgressRequest) -> EgressResponse {
+    if request.path().as_str().starts_with("/api/chat.") {
+        assert!(
+            request
+                .headers()
+                .iter()
+                .any(|header| header.name() == "content-type"
+                    && header.value() == "application/json"),
+            "Slack chat Web API helpers must send JSON content type"
+        );
+    }
     if request.path().as_str() == "/api/chat.postMessage" {
         let body: serde_json::Value =
             serde_json::from_slice(request.body()).expect("Slack post body is JSON");

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -85,6 +85,7 @@ struct Harness {
     mount: PublicRouteMount,
     state: SlackEventsRouteState,
     egress: RecordingEgress,
+    coordinator: Arc<RecordingTurnCoordinator>,
     approvals: Arc<RecordingApprovalInteractionService>,
 }
 
@@ -263,7 +264,7 @@ async fn build_harness_with_actor_user_resolver_and_auth_challenges(
         SlackFinalReplyDeliveryServices {
             binding_service: Arc::new(binding),
             thread_service: Arc::new(threads),
-            turn_coordinator: Arc::new(coordinator),
+            turn_coordinator: Arc::new(coordinator.clone()),
             outbound_store,
             communication_preferences: preferences,
             adapter,
@@ -294,6 +295,7 @@ async fn build_harness_with_actor_user_resolver_and_auth_challenges(
         mount,
         state,
         egress,
+        coordinator: Arc::new(coordinator),
         approvals,
     }
 }
@@ -478,6 +480,51 @@ async fn slack_channel_auth_prompt_omits_setup_link_after_immediate_ack() {
 }
 
 #[tokio::test]
+async fn slack_dm_delivers_final_reply_after_auth_completes_outside_slack() {
+    let auth_provider = Arc::new(FakeAuthChallengeProvider::default());
+    let auth_challenges: Arc<dyn AuthChallengeProvider> = auth_provider.clone();
+    let harness = build_harness_with_actor_user_resolver_and_auth_challenges(
+        TurnMode::BlockAuth,
+        static_personal_actor_user_resolver(),
+        Some(auth_challenges),
+    )
+    .await;
+
+    let response = harness
+        .post_event(dm_message("Ev-auth", "needs auth"))
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    for _ in 0..80 {
+        if harness.slack_messages().len() == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["channel"], CHANNEL);
+    assert!(
+        messages[0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("Authentication required"))
+    );
+
+    harness
+        .coordinator
+        .complete_blocked_run("authenticated and finished")
+        .await
+        .expect("complete auth-blocked run");
+    harness.drain().await;
+
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[1]["channel"], CHANNEL);
+    assert_eq!(messages[1]["text"], "authenticated and finished");
+    auth_provider.assert_single_call();
+}
+
+#[tokio::test]
 async fn slack_approval_reply_resumes_and_delivers_final_reply() {
     let harness = build_harness(TurnMode::BlockApproval).await;
 
@@ -558,6 +605,21 @@ impl RecordingTurnCoordinator {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let (reply_target_binding_ref, accepted_message_ref) = state
+            .runs
+            .get(&run_id)
+            .map(|run| {
+                (
+                    run.reply_target_binding_ref.clone(),
+                    run.accepted_message_ref.clone(),
+                )
+            })
+            .unwrap_or_else(|| {
+                (
+                    ReplyTargetBindingRef::new("slack:reply-target").expect("reply target"), // safety: static test reply target is valid.
+                    AcceptedMessageRef::new("slack:approval-reply").expect("accepted ref"), // safety: static test accepted ref is valid.
+                )
+            });
         state.runs.insert(
             run_id,
             turn_state(
@@ -566,11 +628,39 @@ impl RecordingTurnCoordinator {
                 run_id,
                 TurnStatus::Completed,
                 None,
-                ReplyTargetBindingRef::new("slack:reply-target").expect("reply target"), // safety: static test reply target is valid.
-                AcceptedMessageRef::new("slack:approval-reply").expect("accepted ref"), // safety: static test accepted ref is valid.
+                reply_target_binding_ref,
+                accepted_message_ref,
             ),
         );
         Ok(())
+    }
+
+    async fn complete_blocked_run(&self, text: &str) -> Result<(), ProductWorkflowError> {
+        let (scope, actor, run_id) = {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let run_id =
+                state
+                    .blocked_run_id
+                    .ok_or_else(|| ProductWorkflowError::TurnResumeRejected {
+                        reason: "missing blocked run".into(),
+                    })?;
+            let run = state.runs.get(&run_id).ok_or_else(|| {
+                ProductWorkflowError::TurnResumeRejected {
+                    reason: "missing blocked run state".into(),
+                }
+            })?;
+            let actor =
+                run.actor
+                    .clone()
+                    .ok_or_else(|| ProductWorkflowError::TurnResumeRejected {
+                        reason: "missing blocked run actor".into(),
+                    })?;
+            (run.scope.clone(), actor, run_id)
+        };
+        self.complete_run(scope, actor, run_id, text).await
     }
 }
 
@@ -634,7 +724,10 @@ impl TurnCoordinator for RecordingTurnCoordinator {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if status == TurnStatus::BlockedApproval {
+        if matches!(
+            status,
+            TurnStatus::BlockedApproval | TurnStatus::BlockedAuth
+        ) {
             state.blocked_run_id = Some(run_id);
         }
         state.runs.insert(run_id, run_state);

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -662,6 +662,38 @@ async fn slack_thread_auth_deny_with_bot_mention_cancels_auth_gate_without_agent
     assert_eq!(slack_message_count, 1); // safety: Slack E2E delivery assertion.
 }
 
+#[tokio::test]
+async fn slack_dm_thread_auth_deny_cancels_base_dm_auth_gate_without_agent_turn() {
+    let harness = build_harness(TurnMode::BlockAuth).await;
+
+    let first = harness
+        .post_event(dm_message("Ev-auth", "needs auth"))
+        .await;
+    assert_eq!(first.status(), StatusCode::OK); // safety: Slack E2E route assertion.
+    harness.drain().await;
+    assert_eq!(harness.slack_messages().len(), 1); // safety: Slack E2E delivery assertion.
+
+    let second = harness
+        .post_event(thread_message_event(
+            "Ev-dm-auth-cancel",
+            "auth deny gate:auth-slack",
+            "1710000001.123456",
+        ))
+        .await;
+
+    assert_eq!(second.status(), StatusCode::OK); // safety: Slack E2E route assertion.
+    harness.drain().await;
+
+    let auths = harness.auths.requests();
+    assert_eq!(auths.len(), 1); // safety: Slack E2E auth routing assertion.
+    assert_eq!(auths[0].decision, AuthInteractionDecision::Deny); // safety: length asserted above.
+    assert_eq!(auths[0].gate_ref.as_str(), AUTH_GATE); // safety: length asserted above.
+    let submitted_turn_count = harness.coordinator.submitted_turn_count();
+    assert_eq!(submitted_turn_count, 1); // safety: Slack E2E turn routing assertion.
+    let slack_message_count = harness.slack_messages().len();
+    assert_eq!(slack_message_count, 1); // safety: Slack E2E delivery assertion.
+}
+
 #[derive(Debug, Clone)]
 enum TurnMode {
     Complete { assistant_text: String },
@@ -1307,6 +1339,9 @@ fn thread_message_event(
         ("Ev-auth-cancel", "<@UBOT> auth deny gate:auth-slack", "1710000000.000009") => {
             THREAD_AUTH_CANCEL_WITH_MENTION
         }
+        ("Ev-dm-auth-cancel", "auth deny gate:auth-slack", "1710000001.123456") => {
+            DM_THREAD_AUTH_CANCEL
+        }
         _ => panic!("unknown fixture"),
     }
 }
@@ -1407,4 +1442,12 @@ const THREAD_AUTH_CANCEL_WITH_MENTION: &str = r#"{
   "api_app_id":"A-slack",
   "event_id":"Ev-auth-cancel",
   "event":{"type":"message","user":"U123","channel":"C123","text":"<@UBOT> auth deny gate:auth-slack","ts":"1710000000.000010","thread_ts":"1710000000.000009"}
+}"#;
+
+const DM_THREAD_AUTH_CANCEL: &str = r#"{
+  "type":"event_callback",
+  "team_id":"T-A",
+  "api_app_id":"A-slack",
+  "event_id":"Ev-dm-auth-cancel",
+  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"auth deny gate:auth-slack","ts":"1710000001.123457","thread_ts":"1710000001.123456"}
 }"#;

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -166,6 +166,18 @@ impl Harness {
         self.egress
             .requests()
             .into_iter()
+            .filter(|request| request.path().as_str() == "/api/chat.postMessage")
+            .map(|request| {
+                serde_json::from_slice(request.body()).expect("Slack JSON body") // safety: Slack adapter emits JSON request bodies in this test.
+            })
+            .collect()
+    }
+
+    fn slack_deletes(&self) -> Vec<serde_json::Value> {
+        self.egress
+            .requests()
+            .into_iter()
+            .filter(|request| request.path().as_str() == "/api/chat.delete")
             .map(|request| {
                 serde_json::from_slice(request.body()).expect("Slack JSON body") // safety: Slack adapter emits JSON request bodies in this test.
             })
@@ -422,6 +434,7 @@ async fn slack_dm_delivers_approval_prompt_after_immediate_ack() {
             .as_str()
             .is_some_and(|text| text.contains("approve` or `deny"))
     );
+    assert!(harness.slack_deletes().is_empty());
 }
 
 #[tokio::test]
@@ -448,6 +461,7 @@ async fn slack_dm_delivers_auth_prompt_with_setup_link_after_immediate_ack() {
     let text = messages[0]["text"].as_str().expect("Slack message text");
     assert!(text.contains("Authentication required"));
     assert!(text.contains("Setup link: https://provider.example/oauth"));
+    assert!(harness.slack_deletes().is_empty());
     auth_provider.assert_single_call();
 }
 
@@ -477,6 +491,7 @@ async fn slack_channel_auth_prompt_omits_setup_link_after_immediate_ack() {
     assert!(text.contains("Authentication required"));
     assert!(!text.contains("Setup link:"));
     assert!(!text.contains("https://provider.example/oauth"));
+    assert!(harness.slack_deletes().is_empty());
 }
 
 #[tokio::test]
@@ -512,16 +527,70 @@ async fn slack_dm_delivers_final_reply_after_auth_completes_outside_slack() {
 
     harness
         .coordinator
-        .complete_blocked_run("authenticated and finished")
+        .resume_blocked_run_to_running()
         .await
-        .expect("complete auth-blocked run");
+        .expect("resume auth-blocked run");
+    for _ in 0..80 {
+        if harness.slack_messages().len() == 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[1]["channel"], CHANNEL);
+    assert_eq!(messages[1]["text"], "Ironclaw is thinking...");
+
+    harness
+        .coordinator
+        .complete_active_run("authenticated and finished")
+        .await
+        .expect("complete resumed auth run");
+    harness.drain().await;
+
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 3);
+    assert_eq!(messages[2]["channel"], CHANNEL);
+    assert_eq!(messages[2]["text"], "authenticated and finished");
+    let deletes = harness.slack_deletes();
+    assert_eq!(deletes.len(), 2);
+    assert_eq!(deletes[0]["channel"], CHANNEL);
+    assert_eq!(deletes[1]["channel"], CHANNEL);
+    auth_provider.assert_single_call();
+}
+
+#[tokio::test]
+async fn slack_dm_posts_working_indicator_and_deletes_it_after_final_reply() {
+    let harness = build_harness(TurnMode::Running).await;
+
+    let response = harness.post_event(dm_message("Ev-working", "think")).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    for _ in 0..80 {
+        if harness.slack_messages().len() == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["channel"], CHANNEL);
+    assert_eq!(messages[0]["text"], "Ironclaw is thinking...");
+
+    harness
+        .coordinator
+        .complete_active_run("done thinking")
+        .await
+        .expect("complete running turn");
     harness.drain().await;
 
     let messages = harness.slack_messages();
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[1]["channel"], CHANNEL);
-    assert_eq!(messages[1]["text"], "authenticated and finished");
-    auth_provider.assert_single_call();
+    assert_eq!(messages[1]["text"], "done thinking");
+    let deletes = harness.slack_deletes();
+    assert_eq!(deletes.len(), 1);
+    assert_eq!(deletes[0]["channel"], CHANNEL);
 }
 
 #[tokio::test]
@@ -558,6 +627,7 @@ async fn slack_approval_reply_resumes_and_delivers_final_reply() {
 #[derive(Debug, Clone)]
 enum TurnMode {
     Complete { assistant_text: String },
+    Running,
     BlockApproval,
     BlockAuth,
 }
@@ -571,6 +641,7 @@ struct RecordingTurnCoordinator {
 
 struct RecordingTurnState {
     runs: std::collections::HashMap<TurnRunId, TurnRunState>,
+    active_run_id: Option<TurnRunId>,
     blocked_run_id: Option<TurnRunId>,
 }
 
@@ -579,6 +650,7 @@ impl RecordingTurnCoordinator {
         Self {
             state: Arc::new(Mutex::new(RecordingTurnState {
                 runs: std::collections::HashMap::new(),
+                active_run_id: None,
                 blocked_run_id: None,
             })),
             threads,
@@ -591,6 +663,13 @@ impl RecordingTurnCoordinator {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .blocked_run_id
+    }
+
+    fn active_run_id(&self) -> Option<TurnRunId> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .active_run_id
     }
 
     async fn complete_run(
@@ -635,30 +714,60 @@ impl RecordingTurnCoordinator {
         Ok(())
     }
 
-    async fn complete_blocked_run(&self, text: &str) -> Result<(), ProductWorkflowError> {
-        let (scope, actor, run_id) = {
+    async fn resume_blocked_run_to_running(&self) -> Result<(), ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let run_id =
+            state
+                .blocked_run_id
+                .ok_or_else(|| ProductWorkflowError::TurnResumeRejected {
+                    reason: "missing blocked run".into(),
+                })?;
+        let run = state.runs.get_mut(&run_id).ok_or_else(|| {
+            ProductWorkflowError::TurnResumeRejected {
+                reason: "missing blocked run state".into(),
+            }
+        })?;
+        run.status = TurnStatus::Running;
+        run.gate_ref = None;
+        state.active_run_id = Some(run_id);
+        state.blocked_run_id = None;
+        Ok(())
+    }
+
+    async fn complete_active_run(&self, text: &str) -> Result<(), ProductWorkflowError> {
+        let run_id =
+            self.active_run_id()
+                .ok_or_else(|| ProductWorkflowError::TurnResumeRejected {
+                    reason: "missing active run".into(),
+                })?;
+        self.complete_existing_run(run_id, text).await
+    }
+
+    async fn complete_existing_run(
+        &self,
+        run_id: TurnRunId,
+        text: &str,
+    ) -> Result<(), ProductWorkflowError> {
+        let (scope, actor) = {
             let state = self
                 .state
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let run_id =
-                state
-                    .blocked_run_id
-                    .ok_or_else(|| ProductWorkflowError::TurnResumeRejected {
-                        reason: "missing blocked run".into(),
-                    })?;
             let run = state.runs.get(&run_id).ok_or_else(|| {
                 ProductWorkflowError::TurnResumeRejected {
-                    reason: "missing blocked run state".into(),
+                    reason: "missing run state".into(),
                 }
             })?;
             let actor =
                 run.actor
                     .clone()
                     .ok_or_else(|| ProductWorkflowError::TurnResumeRejected {
-                        reason: "missing blocked run actor".into(),
+                        reason: "missing run actor".into(),
                     })?;
-            (run.scope.clone(), actor, run_id)
+            (run.scope.clone(), actor)
         };
         self.complete_run(scope, actor, run_id, text).await
     }
@@ -689,6 +798,7 @@ impl TurnCoordinator for RecordingTurnCoordinator {
                 })?;
                 TurnStatus::Completed
             }
+            TurnMode::Running => TurnStatus::Running,
             TurnMode::BlockApproval => TurnStatus::BlockedApproval,
             TurnMode::BlockAuth => TurnStatus::BlockedAuth,
         };
@@ -724,6 +834,7 @@ impl TurnCoordinator for RecordingTurnCoordinator {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.active_run_id = Some(run_id);
         if matches!(
             status,
             TurnStatus::BlockedApproval | TurnStatus::BlockedAuth
@@ -934,12 +1045,41 @@ impl ProtocolHttpEgress for RecordingEgress {
         &self,
         request: EgressRequest,
     ) -> Result<EgressResponse, ProtocolHttpEgressError> {
+        let response = slack_response_for_request(&request);
         self.requests
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .push(request);
-        Ok(EgressResponse::new(200, br#"{"ok":true}"#.to_vec()))
+        Ok(response)
     }
+}
+
+fn slack_response_for_request(request: &EgressRequest) -> EgressResponse {
+    if request.path().as_str() == "/api/chat.postMessage" {
+        let body: serde_json::Value =
+            serde_json::from_slice(request.body()).expect("Slack post body is JSON");
+        let channel = body["channel"].as_str().unwrap_or("DTEST");
+        let ts_seed = stable_slack_test_ts(request.body());
+        return EgressResponse::new(
+            200,
+            serde_json::json!({
+                "ok": true,
+                "channel": channel,
+                "ts": ts_seed,
+            })
+            .to_string()
+            .into_bytes(),
+        );
+    }
+    EgressResponse::new(200, br#"{"ok":true}"#.to_vec())
+}
+
+fn stable_slack_test_ts(body: &[u8]) -> String {
+    let mut hash = 0_u64;
+    for byte in body {
+        hash = hash.wrapping_mul(31).wrapping_add(u64::from(*byte));
+    }
+    format!("1710000001.{:06}", hash % 1_000_000)
 }
 
 #[derive(Default)]
@@ -993,6 +1133,7 @@ fn dm_message(event_id: &'static str, text: &'static str) -> &'static str {
         ("Ev-forged", "hello") => DM_FORGED,
         ("Ev-identity", "hello") => DM_IDENTITY,
         ("Ev-auth", "needs auth") => DM_AUTH,
+        ("Ev-working", "think") => DM_WORKING,
         _ => panic!("unknown fixture"),
     }
 }
@@ -1068,6 +1209,14 @@ const DM_AUTH: &str = r#"{
   "api_app_id":"A-slack",
   "event_id":"Ev-auth",
 	  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"needs auth","ts":"1710000000.000007"}
+	}"#;
+
+const DM_WORKING: &str = r#"{
+  "type":"event_callback",
+  "team_id":"T-A",
+  "api_app_id":"A-slack",
+  "event_id":"Ev-working",
+	  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"think","ts":"1710000000.000009"}
 	}"#;
 
 const APP_MENTION_AUTH: &str = r#"{

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -676,7 +676,7 @@ async fn slack_dm_thread_auth_deny_cancels_base_dm_auth_gate_without_agent_turn(
     let second = harness
         .post_event(thread_message_event(
             "Ev-dm-auth-cancel",
-            "auth deny gate:auth-slack",
+            "`auth deny gate:auth-slack`",
             "1710000001.123456",
         ))
         .await;
@@ -1339,7 +1339,7 @@ fn thread_message_event(
         ("Ev-auth-cancel", "<@UBOT> auth deny gate:auth-slack", "1710000000.000009") => {
             THREAD_AUTH_CANCEL_WITH_MENTION
         }
-        ("Ev-dm-auth-cancel", "auth deny gate:auth-slack", "1710000001.123456") => {
+        ("Ev-dm-auth-cancel", "`auth deny gate:auth-slack`", "1710000001.123456") => {
             DM_THREAD_AUTH_CANCEL
         }
         _ => panic!("unknown fixture"),
@@ -1449,5 +1449,5 @@ const DM_THREAD_AUTH_CANCEL: &str = r#"{
   "team_id":"T-A",
   "api_app_id":"A-slack",
   "event_id":"Ev-dm-auth-cancel",
-  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"auth deny gate:auth-slack","ts":"1710000001.123457","thread_ts":"1710000001.123456"}
+  "event":{"type":"message","channel_type":"im","user":"U123","channel":"D123","text":"`auth deny gate:auth-slack`","ts":"1710000001.123457","thread_ts":"1710000001.123456"}
 }"#;

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -658,8 +658,11 @@ async fn slack_thread_auth_deny_with_bot_mention_cancels_auth_gate_without_agent
     assert_eq!(auths[0].gate_ref.as_str(), AUTH_GATE); // safety: length asserted above.
     let submitted_turn_count = harness.coordinator.submitted_turn_count();
     assert_eq!(submitted_turn_count, 1); // safety: Slack E2E turn routing assertion.
-    let slack_message_count = harness.slack_messages().len();
-    assert_eq!(slack_message_count, 1); // safety: Slack E2E delivery assertion.
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 2); // safety: Slack E2E delivery assertion.
+    assert_eq!(messages[1]["channel"], "C123");
+    assert_eq!(messages[1]["thread_ts"], "1710000000.000009");
+    assert_eq!(messages[1]["text"], "Authentication canceled.");
 }
 
 #[tokio::test]
@@ -690,8 +693,11 @@ async fn slack_dm_thread_auth_deny_cancels_base_dm_auth_gate_without_agent_turn(
     assert_eq!(auths[0].gate_ref.as_str(), AUTH_GATE); // safety: length asserted above.
     let submitted_turn_count = harness.coordinator.submitted_turn_count();
     assert_eq!(submitted_turn_count, 1); // safety: Slack E2E turn routing assertion.
-    let slack_message_count = harness.slack_messages().len();
-    assert_eq!(slack_message_count, 1); // safety: Slack E2E delivery assertion.
+    let messages = harness.slack_messages();
+    assert_eq!(messages.len(), 2); // safety: Slack E2E delivery assertion.
+    assert_eq!(messages[1]["channel"], CHANNEL);
+    assert_eq!(messages[1]["thread_ts"], "1710000001.123456");
+    assert_eq!(messages[1]["text"], "Authentication canceled.");
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve/e2e_tests.rs
@@ -1056,18 +1056,27 @@ impl ProtocolHttpEgress for RecordingEgress {
 
 fn slack_response_for_request(request: &EgressRequest) -> EgressResponse {
     if request.path().as_str().starts_with("/api/chat.") {
-        assert!(
-            request
-                .headers()
-                .iter()
-                .any(|header| header.name() == "content-type"
-                    && header.value() == "application/json"),
-            "Slack chat Web API helpers must send JSON content type"
-        );
+        let has_json_content_type = request
+            .headers()
+            .iter()
+            .any(|header| header.name() == "content-type" && header.value() == "application/json");
+        if !has_json_content_type {
+            return EgressResponse::new(
+                200,
+                br#"{"ok":false,"error":"missing_post_type"}"#.to_vec(),
+            );
+        }
     }
     if request.path().as_str() == "/api/chat.postMessage" {
-        let body: serde_json::Value =
-            serde_json::from_slice(request.body()).expect("Slack post body is JSON");
+        let body: serde_json::Value = match serde_json::from_slice(request.body()) {
+            Ok(body) => body,
+            Err(_) => {
+                return EgressResponse::new(
+                    200,
+                    br#"{"ok":false,"error":"invalid_json"}"#.to_vec(),
+                );
+            }
+        };
         let channel = body["channel"].as_str().unwrap_or("DTEST");
         let ts_seed = stable_slack_test_ts(request.body());
         return EgressResponse::new(

--- a/crates/ironclaw_slack_v2_adapter/src/adapter.rs
+++ b/crates/ironclaw_slack_v2_adapter/src/adapter.rs
@@ -622,7 +622,7 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(&calls[0].body).expect("body json");
         assert_eq!(body["channel"], "C123");
         assert_eq!(body["text"], "hello Slack");
-        assert_eq!(body["mrkdwn"], false);
+        assert_eq!(body["mrkdwn"], true);
         assert_eq!(body["thread_ts"], "1710000000.000001");
         assert!(matches!(
             sink.statuses().as_slice(),

--- a/crates/ironclaw_slack_v2_adapter/src/payload.rs
+++ b/crates/ironclaw_slack_v2_adapter/src/payload.rs
@@ -345,6 +345,8 @@ fn parse_interaction_resolution(
     source_trigger: ProductTriggerReason,
 ) -> Result<Option<ProductInboundPayload>, SlackPayloadParseError> {
     let text = strip_leading_slack_mentions(text);
+    let text = strip_wrapping_inline_code(text);
+    let text = strip_leading_slack_mentions(text);
     let mut parts = text.split_whitespace();
     let Some(first) = parts.next() else {
         return Ok(None);
@@ -384,6 +386,14 @@ fn parse_interaction_resolution(
         }
         _ => Ok(None),
     }
+}
+
+fn strip_wrapping_inline_code(text: &str) -> &str {
+    let mut rest = text.trim();
+    while rest.len() >= 2 && rest.starts_with('`') && rest.ends_with('`') {
+        rest = rest[1..rest.len() - 1].trim();
+    }
+    rest
 }
 
 fn strip_leading_slack_mentions(text: &str) -> &str {
@@ -934,6 +944,34 @@ mod tests {
                 "user": "U123",
                 "channel": "C123",
                 "text": "<@UBOT> auth deny gate:auth-slack",
+                "ts": "1710000000.000011",
+                "thread_ts": "1710000000.000010"
+            }
+        }));
+
+        match inbound.payload {
+            ProductInboundPayload::AuthResolution(payload) => {
+                assert_eq!(payload.auth_request_ref, "gate:auth-slack");
+                assert_eq!(
+                    payload.source_trigger,
+                    Some(ProductTriggerReason::ReplyToBot)
+                );
+            }
+            other => panic!("expected auth resolution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn channel_thread_backticked_auth_deny_reply_becomes_auth_resolution() {
+        let inbound = parse(serde_json::json!({
+            "type": "event_callback",
+            "team_id": "T123",
+            "event_id": "EvThreadBacktickedAuthDeny",
+            "event": {
+                "type": "message",
+                "user": "U123",
+                "channel": "C123",
+                "text": "`auth deny gate:auth-slack`",
                 "ts": "1710000000.000011",
                 "thread_ts": "1710000000.000010"
             }

--- a/crates/ironclaw_slack_v2_adapter/src/payload.rs
+++ b/crates/ironclaw_slack_v2_adapter/src/payload.rs
@@ -344,6 +344,7 @@ fn parse_interaction_resolution(
     text: &str,
     source_trigger: ProductTriggerReason,
 ) -> Result<Option<ProductInboundPayload>, SlackPayloadParseError> {
+    let text = strip_leading_slack_mentions(text);
     let mut parts = text.split_whitespace();
     let Some(first) = parts.next() else {
         return Ok(None);
@@ -382,6 +383,19 @@ fn parse_interaction_resolution(
             }
         }
         _ => Ok(None),
+    }
+}
+
+fn strip_leading_slack_mentions(text: &str) -> &str {
+    let mut rest = text.trim_start();
+    loop {
+        let Some(after_open) = rest.strip_prefix("<@") else {
+            return rest;
+        };
+        let Some((_mention, after_close)) = after_open.split_once('>') else {
+            return rest;
+        };
+        rest = after_close.trim_start();
     }
 }
 
@@ -878,6 +892,62 @@ mod tests {
                 );
             }
             other => panic!("expected approval resolution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn channel_thread_auth_deny_reply_becomes_auth_resolution() {
+        let inbound = parse(serde_json::json!({
+            "type": "event_callback",
+            "team_id": "T123",
+            "event_id": "EvThreadAuthDeny",
+            "event": {
+                "type": "message",
+                "user": "U123",
+                "channel": "C123",
+                "text": "auth deny gate:auth-slack",
+                "ts": "1710000000.000011",
+                "thread_ts": "1710000000.000010"
+            }
+        }));
+
+        match inbound.payload {
+            ProductInboundPayload::AuthResolution(payload) => {
+                assert_eq!(payload.auth_request_ref, "gate:auth-slack");
+                assert_eq!(
+                    payload.source_trigger,
+                    Some(ProductTriggerReason::ReplyToBot)
+                );
+            }
+            other => panic!("expected auth resolution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn channel_thread_mentioned_auth_deny_reply_becomes_auth_resolution() {
+        let inbound = parse(serde_json::json!({
+            "type": "event_callback",
+            "team_id": "T123",
+            "event_id": "EvThreadMentionAuthDeny",
+            "event": {
+                "type": "message",
+                "user": "U123",
+                "channel": "C123",
+                "text": "<@UBOT> auth deny gate:auth-slack",
+                "ts": "1710000000.000011",
+                "thread_ts": "1710000000.000010"
+            }
+        }));
+
+        match inbound.payload {
+            ProductInboundPayload::AuthResolution(payload) => {
+                assert_eq!(payload.auth_request_ref, "gate:auth-slack");
+                assert_eq!(
+                    payload.source_trigger,
+                    Some(ProductTriggerReason::ReplyToBot)
+                );
+            }
+            other => panic!("expected auth resolution, got {other:?}"),
         }
     }
 

--- a/crates/ironclaw_slack_v2_adapter/src/render.rs
+++ b/crates/ironclaw_slack_v2_adapter/src/render.rs
@@ -51,7 +51,12 @@ pub fn render_final_reply(
     view: &FinalReplyView,
     credential_handle: EgressCredentialHandle,
 ) -> Result<EgressRequest, SlackRenderError> {
-    render_text_message(target, view.text.clone(), credential_handle)
+    render_text_message(
+        target,
+        render_slack_mrkdwn(&view.text),
+        true,
+        credential_handle,
+    )
 }
 
 pub fn render_gate_prompt(
@@ -67,6 +72,7 @@ pub fn render_gate_prompt(
             view.body,
             gate_prompt_reply_instruction(target, &view.gate_ref)
         ),
+        false,
         credential_handle,
     )
 }
@@ -86,7 +92,7 @@ pub fn render_auth_prompt(
         text.push_str("\n\nSetup link: ");
         text.push_str(url);
     }
-    render_text_message(target, text, credential_handle)
+    render_text_message(target, text, false, credential_handle)
 }
 
 fn gate_prompt_reply_instruction(target: &ProductOutboundTarget, gate_ref: &str) -> String {
@@ -119,13 +125,14 @@ fn requires_app_mention(target: &ProductOutboundTarget) -> bool {
 fn render_text_message(
     target: &ProductOutboundTarget,
     text: String,
+    mrkdwn: bool,
     credential_handle: EgressCredentialHandle,
 ) -> Result<EgressRequest, SlackRenderError> {
     let reply = slack_reply_target(target)?;
     let body = ChatPostMessageRequest {
         channel: reply.channel,
         text,
-        mrkdwn: false,
+        mrkdwn,
         thread_ts: reply.thread_ts,
     };
     let body_bytes = serde_json::to_vec(&body).map_err(|err| SlackRenderError::Serialization {
@@ -137,6 +144,126 @@ fn render_text_message(
         body_bytes,
         credential_handle,
     ))
+}
+
+fn render_slack_mrkdwn(markdown: &str) -> String {
+    let mut rendered = String::with_capacity(markdown.len());
+    let lines = markdown.lines().collect::<Vec<_>>();
+    let mut index = 0;
+    while index < lines.len() {
+        if is_markdown_table_separator(lines[index]) {
+            index += 1;
+            continue;
+        }
+        let line = lines[index];
+        let converted = if is_markdown_table_row(line) {
+            render_table_row(line)
+        } else {
+            render_slack_mrkdwn_line(line)
+        };
+        rendered.push_str(&converted);
+        if index + 1 < lines.len() {
+            rendered.push('\n');
+        }
+        index += 1;
+    }
+    rendered
+}
+
+fn render_slack_mrkdwn_line(line: &str) -> String {
+    let line = strip_heading_marker(line);
+    let line = convert_markdown_links(line);
+    convert_markdown_bold(&line)
+}
+
+fn strip_heading_marker(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('#') {
+        return line;
+    }
+    let hash_count = trimmed.chars().take_while(|ch| *ch == '#').count();
+    if !(1..=6).contains(&hash_count) {
+        return line;
+    }
+    let rest = &trimmed[hash_count..];
+    let Some(rest) = rest.strip_prefix(' ') else {
+        return line;
+    };
+    rest
+}
+
+fn convert_markdown_links(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    while index < line.len() {
+        if bytes[index] == b'['
+            && let Some(label_end_rel) = line[index + 1..].find(']')
+        {
+            let label_end = index + 1 + label_end_rel;
+            if line[label_end..].starts_with("](")
+                && let Some(url_end_rel) = line[label_end + 2..].find(')')
+            {
+                let label = &line[index + 1..label_end];
+                let url_end = label_end + 2 + url_end_rel;
+                let url = &line[label_end + 2..url_end];
+                if is_safe_slack_link_url(url) {
+                    out.push('<');
+                    out.push_str(url);
+                    out.push('|');
+                    out.push_str(label);
+                    out.push('>');
+                    index = url_end + 1;
+                    continue;
+                }
+            }
+        }
+        let Some(ch) = line[index..].chars().next() else {
+            break;
+        };
+        out.push(ch);
+        index += ch.len_utf8();
+    }
+    out
+}
+
+fn is_safe_slack_link_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
+}
+
+fn convert_markdown_bold(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    for (index, part) in line.split("**").enumerate() {
+        if index > 0 {
+            out.push('*');
+        }
+        out.push_str(part);
+    }
+    out
+}
+
+fn is_markdown_table_row(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('|') && trimmed.ends_with('|') && trimmed.matches('|').count() >= 2
+}
+
+fn is_markdown_table_separator(line: &str) -> bool {
+    if !is_markdown_table_row(line) {
+        return false;
+    }
+    line.trim().trim_matches('|').split('|').all(|cell| {
+        let cell = cell.trim();
+        !cell.is_empty() && cell.chars().all(|ch| matches!(ch, '-' | ':' | ' '))
+    })
+}
+
+fn render_table_row(line: &str) -> String {
+    line.trim()
+        .trim_matches('|')
+        .split('|')
+        .map(|cell| render_slack_mrkdwn_line(cell.trim()))
+        .collect::<Vec<_>>()
+        .join(" | ")
 }
 
 #[derive(Debug, Serialize)]
@@ -218,8 +345,31 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(request.body()).expect("body json");
         assert_eq!(body["channel"], "C123");
         assert_eq!(body["text"], "hello Slack");
-        assert_eq!(body["mrkdwn"], false);
+        assert_eq!(body["mrkdwn"], true);
         assert_eq!(body["thread_ts"], "1710000000.000001");
+    }
+
+    #[test]
+    fn final_reply_renders_common_markdown_as_slack_mrkdwn() {
+        let view = FinalReplyView {
+            turn_run_id: TurnRunId::new(),
+            text: "Here are your top Notion docs:\n\n### Top Priority Docs\n\n1. **NEAR AI Engineering Weekly Updates** ([link](https://www.notion.com/p/abc))\n   - \"Multi tenancy for migrating from Railway => top priority\"\n\n| Doc | Highlight |\n|---|---|\n| **Priority Agents** | Priority Agents |"
+                .to_string(),
+            generated_at: Utc::now(),
+        };
+
+        let request = render_final_reply(&target("C123", None), &view, handle()).expect("render");
+        let body: serde_json::Value = serde_json::from_slice(request.body()).expect("body json");
+
+        assert_eq!(body["mrkdwn"], true);
+        let text = body["text"].as_str().expect("text");
+        assert!(text.contains("Top Priority Docs"));
+        assert!(!text.contains("###"));
+        assert!(text.contains("*NEAR AI Engineering Weekly Updates*"));
+        assert!(text.contains("<https://www.notion.com/p/abc|link>"));
+        assert!(!text.contains("|---|---|"));
+        assert!(text.contains("Doc | Highlight"));
+        assert!(text.contains("*Priority Agents* | Priority Agents"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep the Slack final-reply observer alive after auth/approval prompts so it can deliver the final reply when the same run later completes
- preserve original turn source/reply bindings when auth continuation or WebUI auth resolution resumes a blocked run
- post a temporary `Ironclaw is thinking...` Slack status message while a Slack-originated run is queued/running, then delete it before prompt/final delivery
- delete Slack auth prompt messages after auth completes and the final reply is delivered
- add regressions for Slack auth completion outside Slack, thinking-message cleanup, and auth-resume delivery binding preservation

## Root Cause
Slack immediate-ACK delivery treated `BlockedAuth` as the observer's final actionable state. It sent the Slack auth prompt and then stopped watching. When OAuth completed through WebUI/callback, the run resumed and produced the answer, but no Slack observer remained to post it back to the channel.

There was also a retargeting bug: auth resume paths replaced the original Slack reply binding with synthetic auth bindings. That could make a resumed run lose the original Slack channel/thread delivery target.

## Follow-up
Opened #4491 to replace the temporary status message with Slack's AI streaming Web API (`chat.startStream`, `chat.appendStream`, `chat.stopStream`).

## Validation
- `cargo fmt --check`
- `git diff --check`
- `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
- `cargo test -p ironclaw_reborn_composition slack_serve::e2e_tests --features slack-v2-host-beta`
- `cargo test -p ironclaw_reborn_composition local_dev_runtime_auth_interactions_use_flow_record_source --features slack-v2-host-beta`
- `cargo test -p ironclaw_product_workflow turn_gate_continuation --tests`
- `cargo test -p ironclaw_product_workflow --test auth_interaction_contract`
