### PR TITLE
[codex] Add NEAR API key option in WebUI

### DIFF
--- a/crates/ironclaw_llm/src/registry.rs
+++ b/crates/ironclaw_llm/src/registry.rs
@@ -237,6 +237,10 @@ impl SetupHint {
         }
     }
 
+    pub fn accepts_api_key(&self) -> bool {
+        matches!(self, Self::ApiKey { .. } | Self::OpenAiCompatible { .. })
+    }
+
     pub fn secret_name(&self) -> Option<&str> {
         match self {
             Self::ApiKey { secret_name, .. } => Some(secret_name),
@@ -716,6 +720,31 @@ mod tests {
             can_list_models: false,
         };
         assert!(!without.can_list_models());
+    }
+
+    #[test]
+    fn setup_hint_accepts_api_key_marks_key_based_flows() {
+        let api_key = SetupHint::ApiKey {
+            secret_name: "llm_test_api_key".to_string(),
+            key_url: None,
+            display_name: "API Key".to_string(),
+            can_list_models: false,
+            models_filter: None,
+        };
+        let compatible = SetupHint::OpenAiCompatible {
+            secret_name: "llm_compatible_api_key".to_string(),
+            display_name: "Compatible".to_string(),
+            can_list_models: false,
+        };
+        let session = SetupHint::SessionToken {
+            display_name: "Session".to_string(),
+            key_url: None,
+            can_list_models: false,
+        };
+
+        assert!(api_key.accepts_api_key());
+        assert!(compatible.accepts_api_key());
+        assert!(!session.accepts_api_key());
     }
 
     #[test]

--- a/crates/ironclaw_product_workflow/src/reborn_services/llm_config.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/llm_config.rs
@@ -195,6 +195,9 @@ pub struct LlmProviderView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_model: Option<String>,
     pub api_key_required: bool,
+    /// Whether this provider supports API-key auth at all. This can be true
+    /// even when `api_key_required` is false for dual-auth providers.
+    pub accepts_api_key: bool,
     /// Whether an API-key value is stored for this provider (never the value).
     pub api_key_set: bool,
     pub can_list_models: bool,

--- a/crates/ironclaw_reborn_composition/src/llm_config_service.rs
+++ b/crates/ironclaw_reborn_composition/src/llm_config_service.rs
@@ -213,6 +213,10 @@ impl RebornLlmConfigService {
                     .as_ref()
                     .map(|meta| meta.api_key_required)
                     .unwrap_or(false),
+                accepts_api_key: metadata
+                    .as_ref()
+                    .map(|meta| meta.accepts_api_key)
+                    .unwrap_or(false),
                 api_key_set,
                 can_list_models: metadata
                     .as_ref()
@@ -1290,6 +1294,31 @@ mod tests {
             "overlay edits must not make built-ins custom"
         );
         assert!(openai.api_key_set);
+    }
+
+    #[tokio::test]
+    async fn nearai_snapshot_exposes_api_key_as_supported_but_not_required() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        let boot = boot_for_home(&reborn_home);
+        let service = RebornLlmConfigService::new(boot, key_store());
+
+        let snapshot = service.snapshot(caller()).await.expect("snapshot");
+        let nearai = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "nearai")
+            .expect("nearai provider in snapshot");
+
+        assert!(nearai.builtin);
+        assert!(
+            nearai.accepts_api_key,
+            "NEAR AI supports API-key auth in addition to session-token login"
+        );
+        assert!(
+            !nearai.api_key_required,
+            "NEAR AI session-token login means API key is not the only setup path"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/provider_admin.rs
+++ b/crates/ironclaw_reborn_composition/src/provider_admin.rs
@@ -260,6 +260,7 @@ pub struct RebornProviderMetadata {
     pub base_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credential_kind: Option<&'static str>,
+    pub accepts_api_key: bool,
     pub can_list_models: bool,
 }
 
@@ -449,6 +450,11 @@ fn provider_info(
             api_key_required: def.api_key_required,
             base_url: def.default_base_url.clone(),
             credential_kind: def.setup.as_ref().map(|setup| setup.kind()),
+            accepts_api_key: def.api_key_env.is_some()
+                || def
+                    .setup
+                    .as_ref()
+                    .is_some_and(ironclaw_llm::registry::SetupHint::accepts_api_key),
             can_list_models: def
                 .setup
                 .as_ref()

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -558,6 +558,7 @@ fn llm_snapshot(provider_id: &str) -> LlmConfigSnapshot {
             active: true,
             active_model: Some("model-a".to_string()),
             api_key_required: true,
+            accepts_api_key: true,
             api_key_set: true,
             can_list_models: true,
         }],
@@ -1321,6 +1322,8 @@ async fn llm_provider_routes_dispatch_to_facade_methods() {
         .await
         .expect("oneshot");
     assert_eq!(get_response.status(), StatusCode::OK);
+    let get_body = read_json(get_response).await;
+    assert_eq!(get_body["providers"][0]["accepts_api_key"], true);
 
     let upsert_response = router
         .clone()

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
@@ -7,6 +7,7 @@ import { useT } from "../../../lib/i18n.js";
 import {
   adapterLabel,
   isProviderConfigured,
+  providerAcceptsApiKey,
   providerDisplayModel,
   providerEffectiveBaseUrl,
   providerMissingReason,
@@ -32,6 +33,7 @@ export function ProviderCard({
   const baseUrl = providerEffectiveBaseUrl(provider, builtinOverrides);
   const model = providerDisplayModel(provider, builtinOverrides, activeProviderId, selectedModel);
   const missing = providerMissingReason(provider, builtinOverrides);
+  const acceptsApiKey = providerAcceptsApiKey(provider);
   const missingLabel =
     missing === "api_key"
       ? t("llm.missingApiKey")
@@ -55,9 +57,24 @@ export function ProviderCard({
       </span>`;
 
   const isLoginProvider = provider.id === "nearai" || provider.id === "openai_codex";
+  const apiKeyAction =
+    acceptsApiKey && provider.builtin
+      ? html`
+          <${Button}
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled=${isBusy}
+            onClick=${() => onConfigure(provider)}
+          >
+            ${t("llm.addApiKey")}
+          <//>
+        `
+      : null;
   const loginActions =
     !isActive && provider.id === "nearai"
       ? html`
+          ${apiKeyAction}
           <${Button} type="button" variant="secondary" size="sm" disabled=${loginBusy} onClick=${onNearaiWallet}>
             ${t("onboarding.nearWallet")}
           <//>
@@ -75,11 +92,11 @@ export function ProviderCard({
           <//>
         `
       : null;
-  const primaryAction = isActive
-    ? null
-    : isLoginProvider
-    ? loginActions
-    : configured
+  const canUseProvider =
+    !isActive &&
+    configured &&
+    (!isLoginProvider || (provider.id === "nearai" && provider.has_api_key === true));
+  const useAction = canUseProvider
     ? html`
         <${Button}
           type="button"
@@ -91,7 +108,9 @@ export function ProviderCard({
           ${t("llm.use")}
         <//>
       `
-    : html`
+    : null;
+  const setupAction = !configured
+    ? html`
         <${Button}
           type="button"
           variant="secondary"
@@ -101,9 +120,19 @@ export function ProviderCard({
         >
           ${missing === "api_key" ? t("llm.addApiKey") : t("llm.configure")}
         <//>
-      `;
+      `
+    : null;
+  const primaryAction = isActive
+    ? null
+    : useAction || (isLoginProvider ? loginActions : setupAction);
   const showConfigureAction =
-    !isLoginProvider && ((provider.builtin && provider.id !== "bedrock") || !provider.builtin);
+    (!isLoginProvider && ((provider.builtin && provider.id !== "bedrock") || !provider.builtin)) ||
+    (provider.id === "nearai" && acceptsApiKey);
+  const configureLabel = provider.builtin
+    ? provider.id === "nearai" && acceptsApiKey
+      ? t("llm.addApiKey")
+      : t("llm.configure")
+    : t("common.edit");
 
   return html`
     <${Card}
@@ -194,7 +223,7 @@ export function ProviderCard({
                 disabled=${isBusy}
                 onClick=${() => onConfigure(provider)}
               >
-                ${provider.builtin ? t("llm.configure") : t("common.edit")}
+                ${configureLabel}
               <//>
             `}
             ${!provider.builtin &&

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-card.js
@@ -57,6 +57,12 @@ export function ProviderCard({
       </span>`;
 
   const isLoginProvider = provider.id === "nearai" || provider.id === "openai_codex";
+  const hasApiKey = provider.api_key_set === true || provider.has_api_key === true;
+  const configureLabel = provider.builtin
+    ? provider.id === "nearai" && acceptsApiKey && !hasApiKey
+      ? t("llm.addApiKey")
+      : t("llm.configure")
+    : t("common.edit");
   const apiKeyAction =
     acceptsApiKey && provider.builtin
       ? html`
@@ -67,7 +73,7 @@ export function ProviderCard({
             disabled=${isBusy}
             onClick=${() => onConfigure(provider)}
           >
-            ${t("llm.addApiKey")}
+            ${configureLabel}
           <//>
         `
       : null;
@@ -128,11 +134,6 @@ export function ProviderCard({
   const showConfigureAction =
     (!isLoginProvider && ((provider.builtin && provider.id !== "bedrock") || !provider.builtin)) ||
     (provider.id === "nearai" && acceptsApiKey);
-  const configureLabel = provider.builtin
-    ? provider.id === "nearai" && acceptsApiKey
-      ? t("llm.addApiKey")
-      : t("llm.configure")
-    : t("common.edit");
 
   return html`
     <${Card}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
@@ -440,6 +440,7 @@ test("ProviderCard renders login actions instead of generic use for login provid
 test("ProviderCard renders generic use action for NEAR when an API key is configured", () => {
   const calls = [];
   const harness = createProviderCardHarness();
+  harness.state.expanded = true;
 
   const rendered = harness.render({
     activeProviderId: "openai",
@@ -453,6 +454,8 @@ test("ProviderCard renders generic use action for NEAR when an API key is config
   const templateText = collectTemplateText(rendered);
 
   assert.ok(labels.includes("llm.use"));
+  assert.ok(labels.includes("llm.configure"));
+  assert.ok(!labels.includes("llm.addApiKey"));
   assert.ok(!labels.includes("onboarding.nearWallet"));
   assert.ok(!templateText.includes("GitHub"));
 

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
@@ -244,6 +244,7 @@ function createProviderCardHarness() {
     globalThis: {},
     html,
     isProviderConfigured: (provider) => provider.configured !== false,
+    providerAcceptsApiKey: (provider) => provider.accepts_api_key !== false,
     providerDisplayModel: (provider) => provider.default_model || "model",
     providerEffectiveBaseUrl: (provider) => provider.base_url || "https://example.com/v1",
     providerMissingReason: (provider) => provider.missing || "api_key",
@@ -403,18 +404,28 @@ test("ProviderCard actions keep existing callbacks without toggling disclosure",
 });
 
 test("ProviderCard renders login actions instead of generic use for login providers", () => {
+  const calls = [];
   const harness = createProviderCardHarness();
 
   let rendered = harness.render({
     activeProviderId: "openai",
-    provider: builtinProvider("nearai", { adapter: "nearai" }),
+    onConfigure: (provider) => calls.push(["configure", provider.id]),
+    provider: builtinProvider("nearai", { adapter: "nearai", has_api_key: false }),
   });
   let labels = collectScalars(rendered);
   let templateText = collectTemplateText(rendered);
   assert.ok(labels.includes("onboarding.nearWallet"));
+  assert.ok(labels.includes("llm.addApiKey"));
   assert.ok(templateText.includes("GitHub"));
   assert.ok(templateText.includes("Google"));
   assert.ok(!labels.includes("llm.use"));
+  const addKeyButton = findComponentNodes(rendered, "Button").find((node) => {
+    const scalars = collectScalars(node);
+    return scalars.includes("llm.addApiKey") && !scalars.includes("onboarding.nearWallet");
+  });
+  assert.ok(addKeyButton, "expected NEAR API key action");
+  componentProps(addKeyButton, "Button").onClick();
+  assert.deepEqual(calls, [["configure", "nearai"]]);
 
   rendered = harness.render({
     activeProviderId: "openai",
@@ -424,4 +435,27 @@ test("ProviderCard renders login actions instead of generic use for login provid
   templateText = collectTemplateText(rendered);
   assert.ok(labels.includes("onboarding.codexSignIn"));
   assert.ok(!labels.includes("llm.use"));
+});
+
+test("ProviderCard renders generic use action for NEAR when an API key is configured", () => {
+  const calls = [];
+  const harness = createProviderCardHarness();
+
+  const rendered = harness.render({
+    activeProviderId: "openai",
+    onUse: (provider) => calls.push(["use", provider.id]),
+    provider: builtinProvider("nearai", {
+      adapter: "nearai",
+      has_api_key: true,
+    }),
+  });
+  const labels = collectScalars(rendered);
+  const templateText = collectTemplateText(rendered);
+
+  assert.ok(labels.includes("llm.use"));
+  assert.ok(!labels.includes("onboarding.nearWallet"));
+  assert.ok(!templateText.includes("GitHub"));
+
+  firstButtonProps(rendered).onClick();
+  assert.deepEqual(calls, [["use", "nearai"]]);
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.js
@@ -51,6 +51,13 @@ export function providerDefaultModel(provider, overrides) {
   return override.model || provider.env_model || provider.default_model || "";
 }
 
+export function providerAcceptsApiKey(provider) {
+  if (!provider) return false;
+  if (!provider.builtin) return provider.adapter !== "ollama";
+  if (provider.accepts_api_key !== undefined) return provider.accepts_api_key !== false;
+  return provider.api_key_required !== false;
+}
+
 export function isProviderConfigured(provider, overrides) {
   const override = provider.builtin ? overrides[provider.id] || {} : {};
   const needsKey = provider.builtin ? provider.api_key_required !== false : provider.adapter !== "ollama";

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   API_KEY_UNCHANGED,
   groupProvidersByStatus,
+  providerAcceptsApiKey,
   providerStatus,
 } from "./llm-providers.js";
 
@@ -69,6 +70,32 @@ test("providerStatus returns 'setup' when an API key is missing", () => {
 
 test("providerStatus returns 'setup' when a required base URL is missing", () => {
   assert.equal(providerStatus(builtinNeedsBaseUrl("openai"), {}, "nearai"), "setup");
+});
+
+test("providerAcceptsApiKey supports dual-auth NEAR providers", () => {
+  const nearai = builtinReady("nearai", {
+    adapter: "nearai",
+    api_key_required: false,
+    accepts_api_key: true,
+    has_api_key: false,
+  });
+
+  assert.equal(providerAcceptsApiKey(nearai), true);
+});
+
+test("providerAcceptsApiKey rejects missing provider input", () => {
+  assert.equal(providerAcceptsApiKey(null), false);
+  assert.equal(providerAcceptsApiKey(undefined), false);
+});
+
+test("providerAcceptsApiKey honors explicit false", () => {
+  const loginOnly = builtinReady("openai_codex", {
+    adapter: "openai_codex",
+    api_key_required: false,
+    accepts_api_key: false,
+  });
+
+  assert.equal(providerAcceptsApiKey(loginOnly), false);
 });
 
 test("groupProvidersByStatus buckets providers into active/ready/setup", () => {


### PR DESCRIPTION
## Summary
- expose `accepts_api_key` in the WebUI v2 LLM provider snapshot
- mark NEAR AI as API-key-capable while keeping API keys optional for session-token login
- show an `Add API key` action on the NEAR provider card alongside wallet/GitHub/Google login, and switch back to `Configure` once a key exists
- derive API-key capability from typed `SetupHint` metadata instead of credential-kind strings

## Root Cause
NEAR AI is dual-auth: it can use a session token or an API key. The reborn provider snapshot only exposed `api_key_required`, so NEAR correctly reported `api_key_required: false` but the UI had no backend signal that API-key auth was still supported.

## Validation
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/settings/lib/llm-providers.test.mjs crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs`
- `cargo fmt --check`
- `cargo test -p ironclaw_llm setup_hint_accepts_api_key_marks_key_based_flows`
- `cargo test -p ironclaw_webui_v2 --features webui-v2-beta`
- `cargo test -p ironclaw_reborn_composition llm_config_service::tests::nearai_snapshot_exposes_api_key_as_supported_but_not_required --features root-llm-provider`
- `git diff --check`