### PR TITLE
[codex] Add Reborn startup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 </p>
 
 <p align="center">
+  <a href="#ironclaw-reborn-quick-start">Reborn Quick Start</a> •
   <a href="#philosophy">Philosophy</a> •
   <a href="#features">Features</a> •
   <a href="#installation">Installation</a> •
@@ -35,6 +36,299 @@
 </p>
 
 ---
+
+## IronClaw Reborn Quick Start
+
+IronClaw Reborn is the standalone runtime on the `reborn-integration` branch.
+It uses the separate `ironclaw-reborn` binary from the
+`ironclaw_reborn_cli` package and a separate Reborn state root. It does not use
+the legacy `ironclaw` state directory as its config root.
+
+For the older `ironclaw` binary, see [Installation](#installation) and
+[Legacy IronClaw Usage](#legacy-ironclaw-usage).
+
+### Build or run the binary
+
+From the repo root:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
+```
+
+Or build it first:
+
+```bash
+cargo build -p ironclaw_reborn_cli --bin ironclaw-reborn
+./target/debug/ironclaw-reborn --help
+```
+
+The default Reborn home is `$HOME/.ironclaw/reborn`. Override it with an
+absolute path when you want isolated state:
+
+```bash
+export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path
+```
+
+`config path` and `doctor` are safe diagnostics; they report the resolved home,
+profile, `config.toml`, `providers.json`, and `v1_state: not-used`.
+
+### Configure the model route
+
+The CLI-native way to configure Reborn's default model route is:
+
+```bash
+export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models set-provider openai --model gpt-5-mini
+```
+
+That writes `$IRONCLAW_REBORN_HOME/config.toml` with `[llm.default]` and the
+provider's credential env-var name. Check it with:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models list openai
+```
+
+For OpenAI, set the secret value in the environment before starting:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run --message "hello"
+```
+
+Omit `--message` or use `repl` for an interactive stdin session:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- repl
+```
+
+### `config.toml` shape
+
+`config init` creates editable starter files:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config init
+```
+
+It writes:
+
+- `$IRONCLAW_REBORN_HOME/config.toml`
+- `$IRONCLAW_REBORN_HOME/providers.json`
+
+A minimal configured model route looks like:
+
+```toml
+[llm.default]
+provider_id = "openai"
+model = "gpt-5-mini"
+api_key_env = "OPENAI_API_KEY"
+```
+
+`config.toml` may also include optional sections such as `[boot]`,
+`[identity]`, `[runner]`, and `[skills]`; `config init` writes commented
+guidance for the supported fields.
+
+Important: `api_key_env` is the name of an environment variable, not the secret
+itself. Reborn rejects inline secret-shaped values in `config.toml` and
+`providers.json`.
+
+Once `[llm.default]` exists, that config selects the provider. `LLM_BACKEND` is
+only an env fallback when no default LLM slot is configured. To switch providers
+after writing config, use `models set-provider <provider>` or edit
+`[llm.default].provider_id`.
+
+### Env-only model selection
+
+If `$IRONCLAW_REBORN_HOME/config.toml` is absent or has no `[llm.default]`,
+Reborn can resolve the LLM from environment variables:
+
+```bash
+export IRONCLAW_REBORN_HOME="$PWD/.reborn-env-only"
+export LLM_BACKEND=openai
+export OPENAI_API_KEY="sk-..."
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run --message "hello"
+```
+
+Common provider env vars:
+
+| Provider | Selector | Required env |
+| --- | --- | --- |
+| OpenAI | `LLM_BACKEND=openai` | `OPENAI_API_KEY`; optional `OPENAI_MODEL`, `OPENAI_BASE_URL` |
+| Anthropic | `LLM_BACKEND=anthropic` | `ANTHROPIC_API_KEY`; optional `ANTHROPIC_MODEL`, `ANTHROPIC_BASE_URL` |
+| OpenAI-compatible | `LLM_BACKEND=openai_compatible` | `LLM_BASE_URL`; optional `LLM_API_KEY`, `LLM_MODEL` |
+| OpenRouter | `LLM_BACKEND=openrouter` | `OPENROUTER_API_KEY`; optional `OPENROUTER_MODEL` |
+| Ollama | `LLM_BACKEND=ollama` | no key; optional `OLLAMA_BASE_URL`, `OLLAMA_MODEL` |
+| Codex auth | `LLM_BACKEND=openai_codex` | `LLM_USE_CODEX_AUTH=true` or `CODEX_AUTH_PATH`; optional `OPENAI_CODEX_MODEL` |
+
+Use `models list <provider>` to see the exact provider metadata compiled into
+the current branch.
+
+### Startup variables
+
+| Variable | Purpose |
+| --- | --- |
+| `IRONCLAW_REBORN_HOME` | Absolute Reborn state root. Defaults to `$HOME/.ironclaw/reborn`. The resolver rejects unsafe paths and v1 state-root aliases such as `$HOME/.ironclaw`. |
+| `IRONCLAW_REBORN_PROFILE` | Boot profile selector. Supported values: `local-dev`, `local-dev-yolo`, `production`, `migration-dry-run`. |
+| `IRONCLAW_REBORN_LOG` | Tracing filter for the Reborn binary, for example `debug,ironclaw_reborn=trace`. |
+
+`run` and `repl` currently support `local-dev` and `local-dev-yolo` runtime
+composition. `local-dev-yolo` grants trusted-laptop host access and must be
+confirmed explicitly:
+
+```bash
+export IRONCLAW_REBORN_PROFILE=local-dev-yolo
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- repl --confirm-host-access
+```
+
+### WebUI service
+
+The Reborn WebUI is compiled behind the `webui-v2-beta` Cargo feature. Build or
+run the binary with that feature to enable the `serve` command:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- serve --help
+cargo build -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn
+```
+
+The WebUI listener defaults to `127.0.0.1:3000`. The service requires an
+env-bearer token and a user id at startup. It also needs the model route from
+the earlier section, including that provider's credential env var:
+
+```bash
+export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
+export OPENAI_API_KEY="sk-..." # or the required env var for your configured provider
+export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"
+export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"
+
+cargo run -q -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- serve
+```
+
+Equivalent `config.toml` listener configuration:
+
+```toml
+[webui]
+listen_host = "127.0.0.1"
+listen_port = 3000
+env_token_var = "IRONCLAW_REBORN_WEBUI_TOKEN"
+env_user_id_var = "IRONCLAW_REBORN_WEBUI_USER_ID"
+allowed_origins = ["http://127.0.0.1:3000", "http://localhost:3000"]
+canonical_host = "127.0.0.1:3000"
+```
+
+`env_token_var` and `env_user_id_var` are env-var names. Keep the actual token
+and user id in the environment.
+
+Required WebUI env vars:
+
+| Variable | Purpose |
+| --- | --- |
+| `IRONCLAW_REBORN_WEBUI_TOKEN` | Bearer token for WebUI requests. If SSO is enabled, this also signs sessions and must be at least 32 bytes. |
+| `IRONCLAW_REBORN_WEBUI_USER_ID` | Reborn owner/user id for env-bearer requests. If `[identity].default_owner` is configured, it must match this value. |
+
+Optional WebUI SSO env vars:
+
+| Variable | Purpose |
+| --- | --- |
+| `IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID` | Enables Google SSO when set. |
+| `IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET` | Required when Google SSO is enabled. |
+| `IRONCLAW_REBORN_WEBUI_GOOGLE_ALLOWED_HD` | Optional Google hosted-domain restriction. |
+| `IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_ID` | Enables GitHub SSO when set. |
+| `IRONCLAW_REBORN_WEBUI_GITHUB_CLIENT_SECRET` | Required when GitHub SSO is enabled. |
+| `IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS` | Required when any SSO provider is enabled. Comma-separated verified email domains. |
+| `IRONCLAW_REBORN_WEBUI_BASE_URL` | Public base URL used for OAuth callbacks. Non-loopback deployments must use `https://`. |
+| `IRONCLAW_REBORN_WEBUI_OAUTH_HTTP_TIMEOUT_SECS` | Optional OAuth HTTP timeout override. |
+
+For Google SSO, create a Google OAuth web client and register the Reborn WebUI
+redirect URI as:
+
+```text
+{IRONCLAW_REBORN_WEBUI_BASE_URL}/auth/callback/google
+```
+
+For example, with `IRONCLAW_REBORN_WEBUI_BASE_URL=https://ironclaw.example.com`,
+the authorized redirect URI in Google Cloud is:
+
+```text
+https://ironclaw.example.com/auth/callback/google
+```
+
+Do not include a trailing slash in `IRONCLAW_REBORN_WEBUI_BASE_URL`; Reborn
+trims it before building callback URLs. If the base URL is omitted, Reborn uses
+the actual listener address, such as `http://127.0.0.1:3000`, which is suitable
+only for loopback/local OAuth testing. Public or non-loopback SSO deployments
+must set an `https://` base URL.
+
+Complete Google SSO startup env:
+
+```bash
+export IRONCLAW_REBORN_HOME="/var/lib/ironclaw-reborn"
+export IRONCLAW_REBORN_PROFILE=local-dev
+export OPENAI_API_KEY="sk-..." # or the required env var for your configured provider
+export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"
+export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"
+export IRONCLAW_REBORN_WEBUI_BASE_URL="https://ironclaw.example.com"
+export IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS="example.com,team.example.com"
+export IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_ID="..."
+export IRONCLAW_REBORN_WEBUI_GOOGLE_CLIENT_SECRET="..."
+
+cargo run -q -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- serve --host 0.0.0.0 --port 3000
+```
+
+`IRONCLAW_REBORN_WEBUI_ALLOWED_EMAIL_DOMAINS` is the actual admission
+allowlist. Google `hd` is only an optional provider-side hosted-domain hint; do
+not rely on it instead of the Reborn allowed-domain list. `IRONCLAW_REBORN_HOME`
+selects the state/config root for this service. `IRONCLAW_REBORN_PROFILE`
+defaults to `local-dev`; `local-dev-yolo` grants trusted-laptop host access and
+cannot be served on a non-loopback host.
+
+Use `serve --host <ip> --port <port>` to override the listener from the CLI.
+Binding to a non-loopback host is production-sensitive. `local-dev-yolo` serve
+mode also requires `--confirm-host-access` and refuses non-loopback hosts.
+
+### Slack service
+
+Slack support is compiled behind the `slack-v2-host-beta` Cargo feature. That
+feature includes `webui-v2-beta`, so Slack runs on the same `serve` command:
+
+```bash
+export IRONCLAW_REBORN_HOME="$PWD/.reborn-home"
+export OPENAI_API_KEY="sk-..." # or the required env var for your configured provider
+export IRONCLAW_REBORN_WEBUI_TOKEN="$(openssl rand -hex 32)"
+export IRONCLAW_REBORN_WEBUI_USER_ID="reborn-cli"
+export IRONCLAW_REBORN_SLACK_SIGNING_SECRET="..."
+export IRONCLAW_REBORN_SLACK_BOT_TOKEN="xoxb-..."
+
+cargo run -q -p ironclaw_reborn_cli --features slack-v2-host-beta --bin ironclaw-reborn -- serve
+```
+
+Slack env vars alone do not enable Slack. Add a `[slack]` section to
+`config.toml`:
+
+```toml
+[slack]
+enabled = true
+installation_id = "install-alpha"
+team_id = "T123"
+api_app_id = "A123"
+# slack_user_id = "U123" # optional legacy static user mapping
+# user_id = "reborn-cli" # defaults to the WebUI authenticated user
+signing_secret_env = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET"
+bot_token_env = "IRONCLAW_REBORN_SLACK_BOT_TOKEN"
+```
+
+Required Slack settings and env vars:
+
+| Name | Purpose |
+| --- | --- |
+| `[slack].enabled = true` | Mounts the Slack route during `serve`. |
+| `[slack].installation_id` | Stable local installation id. |
+| `[slack].team_id` | Slack workspace/team id. |
+| `[slack].api_app_id` | Slack app id. |
+| `IRONCLAW_REBORN_SLACK_SIGNING_SECRET` | Slack request signing secret, or the env var named by `[slack].signing_secret_env`. |
+| `IRONCLAW_REBORN_SLACK_BOT_TOKEN` | Slack bot token, or the env var named by `[slack].bot_token_env`. |
+
+More detailed command notes live in [`docs/reborn-binary.md`](docs/reborn-binary.md).
 
 ## Philosophy
 
@@ -293,7 +587,7 @@ External content passes through multiple security layers:
 | **Workspace** | Persistent memory with hybrid search |
 | **Safety Layer** | Prompt injection defense and content sanitization |
 
-## Usage
+## Legacy IronClaw Usage
 
 Engine v2 is opt-in right now. If you want to run the new engine instead of the legacy agent loop, start IronClaw with `ENGINE_V2=true`. See [Engine v2 architecture](docs/internal/engine-v2-architecture.md#enabling-engine-v2) for more details.
 


### PR DESCRIPTION
## Summary

- Add a root README quick start for the `ironclaw-reborn` binary on `reborn-integration`.
- Document model configuration via `models set-provider`, env-only provider fallback, and `config.toml` shape.
- Document WebUI and Slack startup feature flags, required env vars, Google SSO redirect URI, allowed email domains, Reborn home, and profile behavior.

## Validation

- `git diff --check -- README.md`
- `cargo run -q -p ironclaw_reborn_cli --features webui-v2-beta --bin ironclaw-reborn -- serve --help`
- `cargo run -q -p ironclaw_reborn_cli --features slack-v2-host-beta --bin ironclaw-reborn -- serve --help`