### PR TITLE
[codex] Add NEAR onboarding setup menu

### DIFF
--- a/crates/ironclaw_webui_v2_static/static/js/i18n/en.js
+++ b/crates/ironclaw_webui_v2_static/static/js/i18n/en.js
@@ -266,7 +266,7 @@ registerPack("en", {
   "onboarding.ready": "Ready",
   "onboarding.moreInSettings": "Need a different provider? Configure any of them in",
   "onboarding.providerNearai": "NEAR AI",
-  "onboarding.providerNearaiDesc": "Free hosted models. Sign in with GitHub or Google.",
+  "onboarding.providerNearaiDesc": "Free hosted models. Use an API key or SSO.",
   "onboarding.providerCodex": "ChatGPT subscription",
   "onboarding.providerCodexDesc": "Use your existing ChatGPT Plus or Pro plan.",
   "onboarding.providerOpenai": "OpenAI API",

--- a/crates/ironclaw_webui_v2_static/static/js/pages/onboarding/onboarding-page.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/onboarding/onboarding-page.js
@@ -5,6 +5,7 @@ import { useT } from "../../lib/i18n.js";
 import { Badge } from "../../design-system/badge.js";
 import { Button } from "../../design-system/button.js";
 import { Card } from "../../design-system/card.js";
+import { Icon } from "../../design-system/icons.js";
 import { ProviderDialog } from "../settings/components/provider-dialog.js";
 import { ProviderLoginStatus } from "../settings/components/provider-login-status.js";
 import { useProviderManagementActions } from "../settings/hooks/useProviderManagementActions.js";
@@ -26,28 +27,100 @@ const FEATURED = [
   { id: "ollama", auth: "key", nameKey: "onboarding.providerOllama", descKey: "onboarding.providerOllamaDesc" },
 ];
 
+function NearAiSetupMenu({ provider, isBusy, login, t, onSetUp }) {
+  const [open, setOpen] = React.useState(false);
+  const ref = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const onDoc = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const menuItems = [
+    {
+      id: "api-key",
+      label: t("llm.addApiKey"),
+      disabled: isBusy,
+      run: () => onSetUp(provider),
+    },
+    {
+      id: "near-wallet",
+      label: t("onboarding.nearWallet"),
+      disabled: login.nearaiBusy,
+      run: login.startNearaiWallet,
+    },
+    {
+      id: "github",
+      label: "GitHub",
+      disabled: login.nearaiBusy,
+      run: () => login.startNearai("github"),
+    },
+    {
+      id: "google",
+      label: "Google",
+      disabled: login.nearaiBusy,
+      run: () => login.startNearai("google"),
+    },
+  ];
+
+  return html`
+    <div ref=${ref} className="relative shrink-0">
+      <${Button}
+        type="button"
+        variant="primary"
+        size="sm"
+        className="gap-1.5"
+        aria-haspopup="true"
+        aria-expanded=${open ? "true" : "false"}
+        onClick=${() => setOpen((v) => !v)}
+      >
+        ${t("onboarding.setUp")}
+        <${Icon} name="chevron" className="h-3.5 w-3.5" />
+      <//>
+      ${open &&
+      html`
+        <div
+          role="menu"
+          className="absolute right-0 top-10 z-20 min-w-[176px] rounded-[10px] border border-[var(--v2-panel-border)] bg-[var(--v2-surface)] p-1 shadow-[0_20px_40px_-20px_rgba(0,0,0,0.7)]"
+        >
+          ${menuItems.map(
+            (item) => html`
+              <button
+                key=${item.id}
+                type="button"
+                role="menuitem"
+                disabled=${item.disabled}
+                onClick=${() => {
+                  setOpen(false);
+                  item.run();
+                }}
+                className="flex w-full items-center rounded-[7px] px-2.5 py-1.5 text-left text-[13px] text-[var(--v2-text)] hover:bg-[var(--v2-surface-soft)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                ${item.label}
+              </button>
+            `
+          )}
+        </div>
+      `}
+    </div>
+  `;
+}
+
 // One provider row: logo + name/subtitle on the left, the auth action(s) on the
 // right. Stacks vertically on mobile (actions wrap onto their own line) and sits
 // on a single line from `sm` up.
 function FeaturedProviderRow({ entry, provider, configured, isBusy, login, t, onUse, onSetUp }) {
   const name = t(entry.nameKey);
 
-  // Login-based providers (NEAR AI, Codex) always show their sign-in actions —
-  // never a "Use" button. The session/OAuth login is the only way to activate
-  // them, so a separate "Use" would be a dead end.
+  // Login-based providers keep their setup entrypoints visible because they
+  // activate through provider-owned auth flows rather than a generic "Use".
   let actions;
   if (entry.auth === "nearai") {
-    actions = html`
-      <${Button} type="button" variant="secondary" size="sm" disabled=${login.nearaiBusy} onClick=${login.startNearaiWallet}>
-        ${t("onboarding.nearWallet")}
-      <//>
-      <${Button} type="button" variant="secondary" size="sm" disabled=${login.nearaiBusy} onClick=${() => login.startNearai("github")}>
-        GitHub
-      <//>
-      <${Button} type="button" variant="secondary" size="sm" disabled=${login.nearaiBusy} onClick=${() => login.startNearai("google")}>
-        Google
-      <//>
-    `;
+    actions = html`<${NearAiSetupMenu} provider=${provider} isBusy=${isBusy} login=${login} t=${t} onSetUp=${onSetUp} />`;
   } else if (entry.auth === "codex") {
     actions = html`
       <${Button} type="button" variant="secondary" size="sm" disabled=${login.codexBusy} onClick=${login.startCodex}>

--- a/crates/ironclaw_webui_v2_static/static/js/pages/onboarding/onboarding-page.js
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/onboarding/onboarding-page.js
@@ -30,14 +30,22 @@ const FEATURED = [
 function NearAiSetupMenu({ provider, isBusy, login, t, onSetUp }) {
   const [open, setOpen] = React.useState(false);
   const ref = React.useRef(null);
+  const setupBusy = isBusy || login.nearaiBusy;
 
   React.useEffect(() => {
     if (!open) return undefined;
     const onDoc = (event) => {
       if (ref.current && !ref.current.contains(event.target)) setOpen(false);
     };
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") setOpen(false);
+    };
     document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKeyDown);
+    };
   }, [open]);
 
   const menuItems = [
@@ -76,6 +84,7 @@ function NearAiSetupMenu({ provider, isBusy, login, t, onSetUp }) {
         className="gap-1.5"
         aria-haspopup="true"
         aria-expanded=${open ? "true" : "false"}
+        disabled=${setupBusy}
         onClick=${() => setOpen((v) => !v)}
       >
         ${t("onboarding.setUp")}

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
@@ -232,6 +232,29 @@ function createReactStateStub(state) {
   };
 }
 
+function createReactMenuStateStub(state) {
+  return {
+    useEffect: (fn, deps) => {
+      if (depsChanged(state.effectDeps, deps)) {
+        state.effectDeps = deps ? Array.from(deps) : deps;
+        fn();
+      }
+    },
+    useRef: () => ({ current: null }),
+    useState: (initial) => {
+      if (!Object.hasOwn(state, "open")) {
+        state.open = typeof initial === "function" ? initial() : initial;
+      }
+      return [
+        state.open,
+        (next) => {
+          state.open = typeof next === "function" ? next(state.open) : next;
+        },
+      ];
+    },
+  };
+}
+
 function createProviderCardHarness() {
   const state = {};
   const context = {
@@ -271,6 +294,45 @@ function createProviderCardHarness() {
         onNearaiWallet: () => {},
         onCodexLogin: () => {},
         loginBusy: false,
+        ...props,
+      }),
+  };
+}
+
+function createNearAiSetupMenuHarness() {
+  const state = {};
+  const calls = [];
+  const context = {
+    Button: "Button",
+    Icon: "Icon",
+    React: createReactMenuStateStub(state),
+    document: {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    },
+    globalThis: {},
+    html,
+  };
+
+  vm.runInNewContext(
+    sourceForTest("../../onboarding/onboarding-page.js", ["NearAiSetupMenu"]),
+    context
+  );
+
+  return {
+    calls,
+    state,
+    render: (props = {}) =>
+      context.globalThis.__testExports.NearAiSetupMenu({
+        provider: builtinProvider("nearai", { adapter: "nearai" }),
+        isBusy: false,
+        login: {
+          nearaiBusy: false,
+          startNearai: (provider) => calls.push(["sso", provider]),
+          startNearaiWallet: () => calls.push(["wallet"]),
+        },
+        t: (key) => key,
+        onSetUp: (provider) => calls.push(["configure", provider.id]),
         ...props,
       }),
   };
@@ -461,4 +523,36 @@ test("ProviderCard renders generic use action for NEAR when an API key is config
 
   firstButtonProps(rendered).onClick();
   assert.deepEqual(calls, [["use", "nearai"]]);
+});
+
+test("NearAiSetupMenu keeps NEAR onboarding SSO choices behind setup dropdown", () => {
+  const harness = createNearAiSetupMenuHarness();
+
+  let rendered = harness.render();
+  assert.equal(valueAfter(rendered, "aria-expanded="), "false");
+  let labels = collectScalars(rendered);
+  assert.ok(labels.includes("onboarding.setUp"));
+  assert.ok(!labels.includes("llm.addApiKey"));
+  assert.ok(!labels.includes("onboarding.nearWallet"));
+  assert.ok(!labels.includes("GitHub"));
+
+  firstButtonProps(rendered).onClick();
+  assert.equal(harness.state.open, true);
+
+  rendered = harness.render();
+  assert.equal(valueAfter(rendered, "aria-expanded="), "true");
+  labels = collectScalars(rendered);
+  assert.ok(labels.includes("llm.addApiKey"));
+  assert.ok(labels.includes("onboarding.nearWallet"));
+  assert.ok(labels.includes("GitHub"));
+  assert.ok(labels.includes("Google"));
+
+  deepValuesAfter(rendered, "onClick=")[1]();
+  assert.deepEqual(harness.calls, [["configure", "nearai"]]);
+  assert.equal(harness.state.open, false);
+
+  firstButtonProps(harness.render()).onClick();
+  rendered = harness.render();
+  deepValuesAfter(rendered, "onClick=")[3]();
+  assert.deepEqual(harness.calls.at(-1), ["sso", "github"]);
 });

--- a/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
+++ b/crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs
@@ -307,8 +307,13 @@ function createNearAiSetupMenuHarness() {
     Icon: "Icon",
     React: createReactMenuStateStub(state),
     document: {
-      addEventListener: () => {},
-      removeEventListener: () => {},
+      addEventListener: (type, handler) => {
+        state.listeners ??= {};
+        state.listeners[type] = handler;
+      },
+      removeEventListener: (type, handler) => {
+        if (state.listeners?.[type] === handler) delete state.listeners[type];
+      },
     },
     globalThis: {},
     html,
@@ -530,6 +535,7 @@ test("NearAiSetupMenu keeps NEAR onboarding SSO choices behind setup dropdown", 
 
   let rendered = harness.render();
   assert.equal(valueAfter(rendered, "aria-expanded="), "false");
+  assert.equal(firstButtonProps(rendered).disabled, false);
   let labels = collectScalars(rendered);
   assert.ok(labels.includes("onboarding.setUp"));
   assert.ok(!labels.includes("llm.addApiKey"));
@@ -541,6 +547,7 @@ test("NearAiSetupMenu keeps NEAR onboarding SSO choices behind setup dropdown", 
 
   rendered = harness.render();
   assert.equal(valueAfter(rendered, "aria-expanded="), "true");
+  assert.equal(typeof harness.state.listeners.keydown, "function");
   labels = collectScalars(rendered);
   assert.ok(labels.includes("llm.addApiKey"));
   assert.ok(labels.includes("onboarding.nearWallet"));
@@ -555,4 +562,35 @@ test("NearAiSetupMenu keeps NEAR onboarding SSO choices behind setup dropdown", 
   rendered = harness.render();
   deepValuesAfter(rendered, "onClick=")[3]();
   assert.deepEqual(harness.calls.at(-1), ["sso", "github"]);
+});
+
+test("NearAiSetupMenu disables setup trigger while setup or login is busy", () => {
+  const harness = createNearAiSetupMenuHarness();
+
+  assert.equal(firstButtonProps(harness.render({ isBusy: true })).disabled, true);
+  assert.equal(
+    firstButtonProps(
+      harness.render({
+        login: {
+          nearaiBusy: true,
+          startNearai: () => {},
+          startNearaiWallet: () => {},
+        },
+      })
+    ).disabled,
+    true
+  );
+});
+
+test("NearAiSetupMenu closes the setup dropdown on Escape", () => {
+  const harness = createNearAiSetupMenuHarness();
+
+  firstButtonProps(harness.render()).onClick();
+  harness.render();
+
+  harness.state.listeners.keydown({ key: "Enter" });
+  assert.equal(harness.state.open, true);
+
+  harness.state.listeners.keydown({ key: "Escape" });
+  assert.equal(harness.state.open, false);
 });

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -123,6 +123,10 @@ with the running assistant (not during the wizard). The `## First-Run Bootstrap`
 prompt on first run. Once the agent writes a profile via `memory_write` and deletes
 `BOOTSTRAP.md`, the block stops injecting.
 
+**Web UI onboarding** (`/onboarding` in WebUI v2) presents a curated provider
+picker for first-run browser users. NEAR AI setup offers both API-key entry and
+SSO; SSO choices (NEAR Wallet, GitHub, Google) are kept behind the setup menu.
+
 ---
 
 ### Step 1: Database Connection


### PR DESCRIPTION
## Summary
- Replace the onboarding NEAR AI row's always-visible SSO buttons with a single Set up dropdown.
- Add API-key setup as the first NEAR onboarding choice, followed by NEAR Wallet, GitHub, and Google SSO.
- Update onboarding copy/docs and add regression coverage for the dropdown behavior.

## Validation
- `node --test crates/ironclaw_webui_v2_static/static/js/pages/settings/components/provider-components.test.mjs`
- `node --test $(rg --files crates/ironclaw_webui_v2_static/static/js | rg \\.test\.mjs$\)`\n- `cargo fmt --check`\n- `cargo test -p ironclaw_webui_v2 --features webui-v2-beta`\n- `git diff --check`