### PR TITLE
feat(reborn): split ProductWorkflow into submit/read/subscribe doors

### DIFF
--- a/crates/ironclaw_product_adapters/src/fakes.rs
+++ b/crates/ironclaw_product_adapters/src/fakes.rs
@@ -14,7 +14,10 @@ use crate::error::ProductAdapterError;
 use crate::external::ExternalEventId;
 use crate::inbound::{ProductInboundAck, ProductInboundEnvelope, ProductRejection};
 use crate::outbound::{ProductOutboundEnvelope, ProjectionCursor};
-use crate::projection::{ProjectionStream, ProjectionSubscriptionRequest};
+use crate::projection::{
+    ProductProjectionReadInput, ProductProjectionSubscribeInput, ProjectionReadRequest,
+    ProjectionStream, ProjectionSubscriptionRequest,
+};
 use crate::workflow::ProductWorkflow;
 
 pub struct FakeProductWorkflow {
@@ -27,7 +30,10 @@ struct FakeProductWorkflowState {
     outcomes_by_event: HashMap<EventDedupeKey, ProductInboundAck>,
     accepted_envelopes: Vec<ProductInboundEnvelope>,
     seen_envelopes: Vec<ProductInboundEnvelope>,
+    read_inputs: Vec<ProductProjectionReadInput>,
+    subscribe_inputs: Vec<ProductProjectionSubscribeInput>,
     fail_with: Option<ProductAdapterError>,
+    projection_read_resolution: Option<ProjectionReadRequest>,
     projection_resolution: Option<ProjectionSubscriptionRequest>,
 }
 
@@ -56,6 +62,11 @@ impl FakeProductWorkflow {
         state.fail_with = Some(error);
     }
 
+    pub fn program_projection_read_resolution(&self, request: ProjectionReadRequest) {
+        let mut state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
+        state.projection_read_resolution = Some(request);
+    }
+
     pub fn program_projection_resolution(&self, request: ProjectionSubscriptionRequest) {
         let mut state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
         state.projection_resolution = Some(request);
@@ -74,6 +85,16 @@ impl FakeProductWorkflow {
         let state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
         state.seen_envelopes.clone()
     }
+
+    pub fn read_inputs(&self) -> Vec<ProductProjectionReadInput> {
+        let state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
+        state.read_inputs.clone()
+    }
+
+    pub fn subscribe_inputs(&self) -> Vec<ProductProjectionSubscribeInput> {
+        let state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
+        state.subscribe_inputs.clone()
+    }
 }
 
 impl Default for FakeProductWorkflow {
@@ -84,7 +105,7 @@ impl Default for FakeProductWorkflow {
 
 #[async_trait]
 impl ProductWorkflow for FakeProductWorkflow {
-    async fn accept_inbound(
+    async fn submit_inbound(
         &self,
         envelope: ProductInboundEnvelope,
     ) -> Result<ProductInboundAck, ProductAdapterError> {
@@ -127,11 +148,32 @@ impl ProductWorkflow for FakeProductWorkflow {
         Ok(outcome)
     }
 
-    async fn resolve_projection_subscription(
+    async fn read_projection(
         &self,
-        _envelope: ProductInboundEnvelope,
+        request: ProductProjectionReadInput,
+    ) -> Result<ProjectionReadRequest, ProductAdapterError> {
+        let mut state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state.read_inputs.push(request);
+        state
+            .projection_read_resolution
+            .clone()
+            .ok_or(ProductAdapterError::Internal {
+                detail: crate::RedactedString::new("projection read resolution not programmed"),
+            })
+    }
+
+    async fn subscribe_projection(
+        &self,
+        request: ProductProjectionSubscribeInput,
     ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError> {
-        let state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
+        let mut state = self.state.lock().expect("fake state lock poisoned"); // safety: test-support fake state; poisoned mutex means another test already panicked;
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state.subscribe_inputs.push(request);
         state
             .projection_resolution
             .clone()

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -406,6 +406,48 @@ fn validate_auth_resolution_result(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectionReadPayload {
+    pub thread_id_hint: Option<String>,
+    pub after_cursor: Option<ProjectionCursor>,
+    pub limit: Option<u16>,
+}
+
+impl ProjectionReadPayload {
+    pub fn new(
+        thread_id_hint: Option<String>,
+        after_cursor: Option<ProjectionCursor>,
+        limit: Option<u16>,
+    ) -> Result<Self, ProductAdapterError> {
+        if let Some(hint) = &thread_id_hint {
+            validate_token_string("thread id hint", hint, THREAD_HINT_MAX_BYTES)?;
+        }
+        Ok(Self {
+            thread_id_hint,
+            after_cursor,
+            limit,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct ProjectionReadPayloadWire {
+    thread_id_hint: Option<String>,
+    after_cursor: Option<ProjectionCursor>,
+    limit: Option<u16>,
+}
+
+impl<'de> Deserialize<'de> for ProjectionReadPayload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ProjectionReadPayloadWire::deserialize(deserializer)?;
+        Self::new(wire.thread_id_hint, wire.after_cursor, wire.limit)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProjectionSubscriptionPayload {
     pub thread_id_hint: Option<String>,
     pub after_cursor: Option<ProjectionCursor>,
@@ -440,6 +482,12 @@ impl<'de> Deserialize<'de> for ProjectionSubscriptionPayload {
         let wire = ProjectionSubscriptionPayloadWire::deserialize(deserializer)?;
         Self::new(wire.thread_id_hint, wire.after_cursor).map_err(serde::de::Error::custom)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ProductControlActionPayload {
+    CancelRun { run_id: TurnRunId },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -501,7 +549,9 @@ pub enum ProductInboundPayload {
     ApprovalResolution(ApprovalResolutionPayload),
     ScopedApprovalResolution(ScopedApprovalResolutionPayload),
     AuthResolution(AuthResolutionPayload),
+    ProjectionRead(ProjectionReadPayload),
     SubscriptionRequest(ProjectionSubscriptionPayload),
+    ControlAction(ProductControlActionPayload),
     LinkedThreadAction(LinkedThreadActionPayload),
     NoOp,
 }

--- a/crates/ironclaw_product_adapters/src/lib.rs
+++ b/crates/ironclaw_product_adapters/src/lib.rs
@@ -44,9 +44,10 @@ pub use identity::{AdapterInstallationId, ProductAdapterId, ProductSurfaceKind};
 pub use inbound::{
     ApprovalDecision, ApprovalResolutionPayload, AuthResolutionPayload, AuthResolutionResult,
     InboundCommandPayload, InboundRetryDisposition, LinkedThreadActionPayload,
-    ParsedProductInbound, ProductCommandResultPayload, ProductInboundAck, ProductInboundEnvelope,
-    ProductInboundPayload, ProductRejection, ProductRejectionDisposition, ProductRejectionKind,
-    ProductSlashCommandParseError, ProductTriggerReason, ProjectionSubscriptionPayload,
+    ParsedProductInbound, ProductCommandResultPayload, ProductControlActionPayload,
+    ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload, ProductRejection,
+    ProductRejectionDisposition, ProductRejectionKind, ProductSlashCommandParseError,
+    ProductTriggerReason, ProjectionReadPayload, ProjectionSubscriptionPayload,
     ScopedApprovalResolutionPayload, TrustedInboundContext, UserMessagePayload,
     parse_product_slash_command,
 };
@@ -61,6 +62,9 @@ pub use outbound::{
     ProductRenderOutcome, ProductSynchronousResponse, ProductWorkSummaryPhase, ProgressKind,
     ProgressUpdateView, ProjectionCursor,
 };
-pub use projection::{ProjectionStream, ProjectionSubscriptionRequest};
+pub use projection::{
+    ProductProjectionReadInput, ProductProjectionSubject, ProductProjectionSubscribeInput,
+    ProjectionReadRequest, ProjectionStream, ProjectionSubscriptionRequest,
+};
 pub use redaction::{REDACTED_PLACEHOLDER, RedactedDebug, RedactedString};
 pub use workflow::ProductWorkflow;

--- a/crates/ironclaw_product_adapters/src/projection.rs
+++ b/crates/ironclaw_product_adapters/src/projection.rs
@@ -1,11 +1,140 @@
-//! Projection subscription contract.
+//! Projection read/subscription contracts.
 
 use async_trait::async_trait;
 use ironclaw_turns::{TurnActor, TurnScope};
 use serde::{Deserialize, Serialize};
 
+use crate::auth::VerifiedAuthClaim;
 use crate::error::ProductAdapterError;
+use crate::external::{ExternalActorRef, ExternalConversationRef, ExternalEventId};
+use crate::identity::{AdapterInstallationId, ProductAdapterId};
+use crate::inbound::{ProductInboundEnvelope, ProductInboundPayload};
 use crate::outbound::{ProductOutboundEnvelope, ProjectionCursor};
+use crate::redaction::RedactedString;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductProjectionReadInput {
+    pub subject: ProductProjectionSubject,
+    pub thread_id_hint: Option<String>,
+    pub after_cursor: Option<ProjectionCursor>,
+    pub limit: Option<u16>,
+}
+
+impl ProductProjectionReadInput {
+    pub fn new(
+        subject: ProductProjectionSubject,
+        thread_id_hint: Option<String>,
+        after_cursor: Option<ProjectionCursor>,
+        limit: Option<u16>,
+    ) -> Self {
+        Self {
+            subject,
+            thread_id_hint,
+            after_cursor,
+            limit,
+        }
+    }
+
+    pub fn from_inbound_envelope(
+        envelope: &ProductInboundEnvelope,
+    ) -> Result<Self, ProductAdapterError> {
+        let ProductInboundPayload::ProjectionRead(payload) = envelope.payload() else {
+            return Err(ProductAdapterError::MalformedInboundPayload {
+                reason: RedactedString::new(
+                    "projection read resolution requires projection_read payload",
+                ),
+            });
+        };
+        Ok(Self {
+            subject: ProductProjectionSubject::from_inbound_envelope(envelope),
+            thread_id_hint: payload.thread_id_hint.clone(),
+            after_cursor: payload.after_cursor.clone(),
+            limit: payload.limit,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductProjectionSubscribeInput {
+    pub subject: ProductProjectionSubject,
+    pub thread_id_hint: Option<String>,
+    pub after_cursor: Option<ProjectionCursor>,
+}
+
+impl ProductProjectionSubscribeInput {
+    pub fn new(
+        subject: ProductProjectionSubject,
+        thread_id_hint: Option<String>,
+        after_cursor: Option<ProjectionCursor>,
+    ) -> Self {
+        Self {
+            subject,
+            thread_id_hint,
+            after_cursor,
+        }
+    }
+
+    pub fn from_inbound_envelope(
+        envelope: &ProductInboundEnvelope,
+    ) -> Result<Self, ProductAdapterError> {
+        let ProductInboundPayload::SubscriptionRequest(payload) = envelope.payload() else {
+            return Err(ProductAdapterError::MalformedInboundPayload {
+                reason: RedactedString::new(
+                    "projection subscription resolution requires subscription_request payload",
+                ),
+            });
+        };
+        Ok(Self {
+            subject: ProductProjectionSubject::from_inbound_envelope(envelope),
+            thread_id_hint: payload.thread_id_hint.clone(),
+            after_cursor: payload.after_cursor.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProductProjectionSubject {
+    /// Adapter/channel style request: ProductWorkflow resolves canonical
+    /// actor/scope/thread from verified installation + external refs.
+    AdapterExternalRefs {
+        adapter_id: ProductAdapterId,
+        installation_id: AdapterInstallationId,
+        external_event_id: ExternalEventId,
+        external_actor_ref: ExternalActorRef,
+        external_conversation_ref: ExternalConversationRef,
+        auth_claim: VerifiedAuthClaim,
+    },
+
+    /// API/projection style request: caller has already resolved an opaque
+    /// product/API id such as OpenAI `resp_*` into canonical Reborn metadata.
+    /// ProductWorkflow remains the facade door, but does not own that mapping.
+    CanonicalProjection { actor: TurnActor, scope: TurnScope },
+}
+
+impl ProductProjectionSubject {
+    pub fn from_inbound_envelope(envelope: &ProductInboundEnvelope) -> Self {
+        Self::AdapterExternalRefs {
+            adapter_id: envelope.adapter_id().clone(),
+            installation_id: envelope.installation_id().clone(),
+            external_event_id: envelope.external_event_id().clone(),
+            external_actor_ref: envelope.external_actor_ref().clone(),
+            external_conversation_ref: envelope.external_conversation_ref().clone(),
+            auth_claim: envelope.auth_claim().clone(),
+        }
+    }
+
+    pub fn canonical(actor: TurnActor, scope: TurnScope) -> Self {
+        Self::CanonicalProjection { actor, scope }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProjectionReadRequest {
+    pub actor: TurnActor,
+    pub scope: TurnScope,
+    pub after_cursor: Option<ProjectionCursor>,
+    pub limit: Option<u16>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProjectionSubscriptionRequest {

--- a/crates/ironclaw_product_adapters/src/workflow.rs
+++ b/crates/ironclaw_product_adapters/src/workflow.rs
@@ -1,28 +1,97 @@
 //! ProductWorkflow facade contract.
+//!
+//! Product surfaces must choose the ProductWorkflow door that matches their
+//! effect boundary:
+//!
+//! | Product/API behavior | ProductWorkflow door |
+//! | --- | --- |
+//! | Create chat completion / response | [`ProductWorkflow::submit_inbound`] |
+//! | Retrieve current response/projection | [`ProductWorkflow::read_projection`] |
+//! | Stream response/projection events | [`ProductWorkflow::subscribe_projection`] |
+//! | Cancel response/run | [`ProductWorkflow::submit_inbound`] with a typed control payload |
+//!
+//! The OpenAI-compatible layer may resolve opaque `resp_*` identifiers into
+//! canonical Reborn projection metadata before calling the projection doors, but
+//! route handlers should not fabricate inbound envelopes or bypass this facade to
+//! call projection internals directly.
 
 use async_trait::async_trait;
 
 use crate::error::ProductAdapterError;
 use crate::inbound::{ProductInboundAck, ProductInboundEnvelope};
-use crate::projection::ProjectionSubscriptionRequest;
+use crate::projection::{
+    ProductProjectionReadInput, ProductProjectionSubscribeInput, ProjectionReadRequest,
+    ProjectionSubscriptionRequest,
+};
+use crate::redaction::RedactedString;
 
 #[async_trait]
 pub trait ProductWorkflow: Send + Sync {
-    /// Accept a mutating product action into the ProductWorkflow submit path.
+    /// Submit a mutating product action into the ProductWorkflow submit/control
+    /// path.
     ///
-    /// This entrypoint is for payloads that can create messages, runs,
-    /// command/gate/auth outcomes, or other durable side effects. Projection
-    /// read/subscribe requests must use [`Self::resolve_projection_subscription`]
-    /// and must not create mutating ProductInboundAction ledger rows.
-    async fn accept_inbound(
+    /// This door is for payloads that can create messages, runs,
+    /// command/gate/auth outcomes, mission work, typed control actions, or other
+    /// durable side effects. Projection read/subscribe requests must use the
+    /// projection doors and must not create mutating ProductInboundAction ledger
+    /// rows.
+    async fn submit_inbound(
         &self,
         envelope: ProductInboundEnvelope,
     ) -> Result<ProductInboundAck, ProductAdapterError>;
 
-    /// Resolve an adapter-level projection subscription request into the
+    /// Resolve a ProductWorkflow-facing projection read/fetch request into the
+    /// canonical actor/scope/cursor/window used by projection services.
+    ///
+    /// This door accepts typed projection input rather than requiring callers to
+    /// fabricate a full inbound envelope. API routes may call it after resolving
+    /// opaque product ids into canonical Reborn projection metadata.
+    async fn read_projection(
+        &self,
+        _request: ProductProjectionReadInput,
+    ) -> Result<ProjectionReadRequest, ProductAdapterError> {
+        Err(ProductAdapterError::Internal {
+            detail: RedactedString::new(
+                "projection read is not supported by this ProductWorkflow implementation",
+            ),
+        })
+    }
+
+    /// Resolve a ProductWorkflow-facing projection subscription request into the
     /// canonical actor/scope/cursor used by [`crate::ProjectionStream`].
+    ///
+    /// This door accepts typed projection input rather than requiring callers to
+    /// fabricate a full inbound envelope. API routes may call it after resolving
+    /// opaque product ids into canonical Reborn projection metadata.
+    async fn subscribe_projection(
+        &self,
+        _request: ProductProjectionSubscribeInput,
+    ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError> {
+        Err(ProductAdapterError::Internal {
+            detail: RedactedString::new(
+                "projection subscription is not supported by this ProductWorkflow implementation",
+            ),
+        })
+    }
+
+    /// Compatibility wrapper for existing callers. New adapter/API wiring should
+    /// call [`Self::submit_inbound`] explicitly.
+    async fn accept_inbound(
+        &self,
+        envelope: ProductInboundEnvelope,
+    ) -> Result<ProductInboundAck, ProductAdapterError> {
+        self.submit_inbound(envelope).await
+    }
+
+    /// Compatibility wrapper for legacy adapter-level subscription callers. New
+    /// code should pass typed projection input to [`Self::subscribe_projection`].
     async fn resolve_projection_subscription(
         &self,
         envelope: ProductInboundEnvelope,
-    ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError>;
+    ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError> {
+        self.subscribe_projection(ProductProjectionSubscribeInput::from_inbound_envelope(
+            &envelope,
+        )?)
+        .await
+    }
 }

--- a/crates/ironclaw_product_adapters/tests/product_adapter_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/product_adapter_contract.rs
@@ -275,7 +275,7 @@ async fn workflow_returns_programmed_outcomes() {
 }
 
 #[tokio::test]
-async fn workflow_fake_records_read_and_subscribe_doors_separately() {
+async fn workflow_fake_records_submit_read_and_subscribe_doors_separately() {
     let workflow = FakeProductWorkflow::new();
     let actor = TurnActor::new(ironclaw_host_api::UserId::new("user:alice").expect("valid"));
     let scope = TurnScope::new(
@@ -326,6 +326,15 @@ async fn workflow_fake_records_read_and_subscribe_doors_separately() {
     assert_eq!(workflow.read_inputs(), vec![read_input]);
     assert_eq!(workflow.subscribe_inputs(), vec![subscribe_input]);
     assert_eq!(workflow.accepted_count(), 0);
+
+    let submit = workflow
+        .submit_inbound(sample_envelope("update:projection-doors"))
+        .await
+        .expect("submit");
+    assert!(matches!(submit, ProductInboundAck::Accepted { .. }));
+    assert_eq!(workflow.accepted_count(), 1);
+    assert_eq!(workflow.read_inputs().len(), 1);
+    assert_eq!(workflow.subscribe_inputs().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_adapters/tests/product_adapter_contract.rs
+++ b/crates/ironclaw_product_adapters/tests/product_adapter_contract.rs
@@ -11,13 +11,15 @@ use ironclaw_product_adapters::{
     ParsedProductInbound, ProductAdapterCapabilities, ProductAdapterError, ProductAdapterId,
     ProductAttachmentDescriptor, ProductAttachmentKind, ProductCapabilityFlag, ProductInboundAck,
     ProductInboundEnvelope, ProductInboundPayload, ProductOutboundEnvelope, ProductOutboundPayload,
-    ProductOutboundTarget, ProductProjectionItem, ProductProjectionState, ProductRejection,
-    ProductRejectionKind, ProductSurfaceKind, ProductTriggerReason, ProductWorkflow,
-    ProjectionCursor, ProjectionStream, ProjectionSubscriptionRequest, ProtocolAuthEvidence,
-    ProtocolHttpEgress, ProtocolHttpEgressError, REDACTED_PLACEHOLDER, RedactedDebug,
-    RedactedString, TrustedInboundContext, UserMessagePayload,
+    ProductOutboundTarget, ProductProjectionItem, ProductProjectionReadInput,
+    ProductProjectionState, ProductProjectionSubject, ProductProjectionSubscribeInput,
+    ProductRejection, ProductRejectionKind, ProductSurfaceKind, ProductTriggerReason,
+    ProductWorkflow, ProjectionCursor, ProjectionReadRequest, ProjectionStream,
+    ProjectionSubscriptionRequest, ProtocolAuthEvidence, ProtocolHttpEgress,
+    ProtocolHttpEgressError, REDACTED_PLACEHOLDER, RedactedDebug, RedactedString,
+    TrustedInboundContext, UserMessagePayload,
 };
-use ironclaw_turns::{AcceptedMessageRef, ReplyTargetBindingRef, TurnRunId};
+use ironclaw_turns::{AcceptedMessageRef, ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
 
 const FORBIDDEN_DEPENDENCIES: &[&str] = &[
     "ironclaw_dispatcher",
@@ -270,6 +272,60 @@ async fn workflow_returns_programmed_outcomes() {
         .await
         .expect("reject");
     assert!(matches!(reject_ack, ProductInboundAck::Rejected(_)));
+}
+
+#[tokio::test]
+async fn workflow_fake_records_read_and_subscribe_doors_separately() {
+    let workflow = FakeProductWorkflow::new();
+    let actor = TurnActor::new(ironclaw_host_api::UserId::new("user:alice").expect("valid"));
+    let scope = TurnScope::new(
+        ironclaw_host_api::TenantId::new("tenant:alpha").expect("valid"),
+        None,
+        None,
+        ironclaw_host_api::ThreadId::new("thread:alpha").expect("valid"),
+    );
+    let read_cursor = ProjectionCursor::new("cursor:read").expect("valid");
+    let subscribe_cursor = ProjectionCursor::new("cursor:subscribe").expect("valid");
+    let read_request = ProjectionReadRequest {
+        actor: actor.clone(),
+        scope: scope.clone(),
+        after_cursor: Some(read_cursor.clone()),
+        limit: Some(10),
+    };
+    let subscribe_request = ProjectionSubscriptionRequest {
+        actor: actor.clone(),
+        scope: scope.clone(),
+        after_cursor: Some(subscribe_cursor.clone()),
+    };
+    workflow.program_projection_read_resolution(read_request.clone());
+    workflow.program_projection_resolution(subscribe_request.clone());
+
+    let read_input = ProductProjectionReadInput::new(
+        ProductProjectionSubject::canonical(actor.clone(), scope.clone()),
+        None,
+        Some(read_cursor),
+        Some(10),
+    );
+    let subscribe_input = ProductProjectionSubscribeInput::new(
+        ProductProjectionSubject::canonical(actor, scope),
+        None,
+        Some(subscribe_cursor),
+    );
+
+    let read = workflow
+        .read_projection(read_input.clone())
+        .await
+        .expect("read");
+    let subscription = workflow
+        .subscribe_projection(subscribe_input.clone())
+        .await
+        .expect("subscribe");
+
+    assert_eq!(read, read_request);
+    assert_eq!(subscription, subscribe_request);
+    assert_eq!(workflow.read_inputs(), vec![read_input]);
+    assert_eq!(workflow.subscribe_inputs(), vec![subscribe_input]);
+    assert_eq!(workflow.accepted_count(), 0);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/src/action.rs
+++ b/crates/ironclaw_product_workflow/src/action.rs
@@ -185,7 +185,9 @@ pub enum ActionDispatchKind {
     ApprovalResolution { gate_ref: LoopGateRef },
     ScopedApprovalResolution,
     AuthResolution { auth_request_ref: AuthRequestRef },
+    ProjectionRead,
     ProjectionSubscription,
+    ControlAction,
     LinkedThreadAction { action_id: LinkedThreadActionId },
     Rejected { kind: ProductRejectionKind },
     NoOp,
@@ -214,7 +216,9 @@ impl ActionDispatchKind {
                 auth_request_ref: AuthRequestRef::new(res.auth_request_ref.clone())
                     .map_err(|reason| ProductWorkflowError::TurnSubmissionRejected { reason })?,
             }),
+            ProductInboundPayload::ProjectionRead(_) => Ok(Self::ProjectionRead),
             ProductInboundPayload::SubscriptionRequest(_) => Ok(Self::ProjectionSubscription),
+            ProductInboundPayload::ControlAction(_) => Ok(Self::ControlAction),
             ProductInboundPayload::LinkedThreadAction(lta) => Ok(Self::LinkedThreadAction {
                 action_id: LinkedThreadActionId::new(lta.action_id.clone())
                     .map_err(|reason| ProductWorkflowError::TurnSubmissionRejected { reason })?,

--- a/crates/ironclaw_product_workflow/src/binding.rs
+++ b/crates/ironclaw_product_workflow/src/binding.rs
@@ -149,7 +149,9 @@ pub fn route_kind_for_inbound_payload(
             .source_trigger
             .map(route_kind_for_trigger)
             .unwrap_or(ProductConversationRouteKind::Direct),
-        ProductInboundPayload::SubscriptionRequest(_)
+        ProductInboundPayload::ProjectionRead(_)
+        | ProductInboundPayload::SubscriptionRequest(_)
+        | ProductInboundPayload::ControlAction(_)
         | ProductInboundPayload::LinkedThreadAction(_)
         | ProductInboundPayload::NoOp => ProductConversationRouteKind::Direct,
     }

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -10,8 +10,10 @@ use ironclaw_auth::{AuthFlowId, CredentialAccountId};
 use ironclaw_host_api::ThreadId;
 use ironclaw_product_adapters::{
     ApprovalDecision, ExternalConversationRef, ProductAdapterError, ProductInboundAck,
-    ProductInboundEnvelope, ProductInboundPayload, ProductRejection, ProductRejectionKind,
-    ProductWorkflow, ProductWorkflowRejectionKind, ProjectionSubscriptionRequest, RedactedString,
+    ProductInboundEnvelope, ProductInboundPayload, ProductProjectionReadInput,
+    ProductProjectionSubject, ProductProjectionSubscribeInput, ProductRejection,
+    ProductRejectionKind, ProductWorkflow, ProductWorkflowRejectionKind, ProjectionReadRequest,
+    ProjectionSubscriptionRequest, RedactedString,
 };
 use ironclaw_turns::{
     AcceptedMessageRef, AdmissionRejectionReason, GateRef, IdempotencyKey, TurnActor, TurnError,
@@ -122,20 +124,21 @@ impl DefaultProductWorkflow {
 
 #[async_trait]
 impl ProductWorkflow for DefaultProductWorkflow {
-    async fn accept_inbound(
+    async fn submit_inbound(
         &self,
         envelope: ProductInboundEnvelope,
     ) -> Result<ProductInboundAck, ProductAdapterError> {
         if matches!(
             envelope.payload(),
-            ProductInboundPayload::SubscriptionRequest(_)
+            ProductInboundPayload::ProjectionRead(_)
+                | ProductInboundPayload::SubscriptionRequest(_)
         ) {
             return Err(ProductAdapterError::WorkflowRejected {
                 kind: ProductWorkflowRejectionKind::InvalidRequest,
                 status_code: 400,
                 retryable: false,
                 reason: RedactedString::new(
-                    "subscription_request must be resolved through resolve_projection_subscription",
+                    "projection read/subscribe requests must use ProductWorkflow projection doors",
                 ),
             });
         }
@@ -243,29 +246,45 @@ impl ProductWorkflow for DefaultProductWorkflow {
         }
     }
 
-    async fn resolve_projection_subscription(
+    async fn read_projection(
         &self,
-        envelope: ProductInboundEnvelope,
+        request: ProductProjectionReadInput,
+    ) -> Result<ProjectionReadRequest, ProductAdapterError> {
+        let ProductProjectionReadInput {
+            subject,
+            thread_id_hint,
+            after_cursor,
+            limit,
+        } = request;
+        let (actor, scope) =
+            resolve_projection_subject(&*self.binding_service, &subject, thread_id_hint.as_deref())
+                .await?;
+
+        Ok(ProjectionReadRequest {
+            actor,
+            scope,
+            after_cursor,
+            limit,
+        })
+    }
+
+    async fn subscribe_projection(
+        &self,
+        request: ProductProjectionSubscribeInput,
     ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError> {
-        let ProductInboundPayload::SubscriptionRequest(payload) = envelope.payload() else {
-            return Err(ProductAdapterError::MalformedInboundPayload {
-                reason: RedactedString::new(
-                    "projection subscription resolution requires subscription_request payload",
-                ),
-            });
-        };
-        let binding = self
-            .binding_service
-            .lookup_binding(resolve_binding_request(&envelope))
-            .await
-            .map_err(ProductAdapterError::from)?;
-        let thread_id =
-            projection_thread_id_from_binding(&binding, payload.thread_id_hint.as_deref())?;
+        let ProductProjectionSubscribeInput {
+            subject,
+            thread_id_hint,
+            after_cursor,
+        } = request;
+        let (actor, scope) =
+            resolve_projection_subject(&*self.binding_service, &subject, thread_id_hint.as_deref())
+                .await?;
 
         Ok(ProjectionSubscriptionRequest {
-            actor: TurnActor::new(binding.actor_user_id.clone()),
-            scope: turn_scope_for_thread(&binding, thread_id),
-            after_cursor: payload.after_cursor.clone(),
+            actor,
+            scope,
+            after_cursor,
         })
     }
 }
@@ -287,6 +306,45 @@ struct DispatchPorts<'a> {
 
 fn resolve_binding_request(envelope: &ProductInboundEnvelope) -> ResolveBindingRequest {
     ResolveBindingRequest::from_envelope(envelope)
+}
+
+async fn resolve_projection_subject(
+    binding_service: &dyn ConversationBindingService,
+    subject: &ProductProjectionSubject,
+    thread_id_hint: Option<&str>,
+) -> Result<(TurnActor, TurnScope), ProductAdapterError> {
+    match subject {
+        ProductProjectionSubject::AdapterExternalRefs {
+            adapter_id,
+            installation_id,
+            external_event_id,
+            external_actor_ref,
+            external_conversation_ref,
+            auth_claim,
+        } => {
+            let binding = binding_service
+                .lookup_binding(ResolveBindingRequest {
+                    adapter_id: adapter_id.clone(),
+                    installation_id: installation_id.clone(),
+                    external_actor_ref: external_actor_ref.clone(),
+                    external_conversation_ref: external_conversation_ref.clone(),
+                    external_event_id: external_event_id.clone(),
+                    route_kind: ProductConversationRouteKind::Direct,
+                    auth_claim: auth_claim.clone(),
+                })
+                .await
+                .map_err(ProductAdapterError::from)?;
+            let thread_id = projection_thread_id_from_binding(&binding, thread_id_hint)?;
+            Ok((
+                TurnActor::new(binding.actor_user_id.clone()),
+                turn_scope_for_thread(&binding, thread_id),
+            ))
+        }
+        ProductProjectionSubject::CanonicalProjection { actor, scope } => {
+            validate_projection_thread_hint(&scope.thread_id, thread_id_hint)?;
+            Ok((actor.clone(), scope.clone()))
+        }
+    }
 }
 
 async fn lookup_interaction_binding(
@@ -331,24 +389,32 @@ fn projection_thread_id_from_binding(
     binding: &ResolvedBinding,
     thread_id_hint: Option<&str>,
 ) -> Result<ironclaw_host_api::ThreadId, ProductAdapterError> {
+    validate_projection_thread_hint(&binding.thread_id, thread_id_hint)?;
+    Ok(binding.thread_id.clone())
+}
+
+fn validate_projection_thread_hint(
+    expected_thread_id: &ThreadId,
+    thread_id_hint: Option<&str>,
+) -> Result<(), ProductAdapterError> {
     if let Some(thread_id_hint) = thread_id_hint {
-        let hinted = ironclaw_host_api::ThreadId::new(thread_id_hint).map_err(|_| {
+        let hinted = ThreadId::new(thread_id_hint).map_err(|_| {
             ProductAdapterError::MalformedInboundPayload {
                 reason: RedactedString::new("invalid thread_id_hint"),
             }
         })?;
-        if hinted != binding.thread_id {
+        if &hinted != expected_thread_id {
             return Err(ProductAdapterError::WorkflowRejected {
                 kind: ProductWorkflowRejectionKind::InvalidRequest,
                 status_code: 400,
                 retryable: false,
                 reason: RedactedString::new(
-                    "thread_id_hint does not match resolved conversation binding",
+                    "thread_id_hint does not match resolved projection thread",
                 ),
             });
         }
     }
-    Ok(binding.thread_id.clone())
+    Ok(())
 }
 
 async fn dispatch_payload(
@@ -438,11 +504,25 @@ async fn dispatch_payload(
             )
             .await
         }
+        ProductInboundPayload::ProjectionRead(_) => {
+            Err(ProductWorkflowError::UnsupportedActionKind {
+                kind: "projection_read".into(),
+            })
+        }
         ProductInboundPayload::SubscriptionRequest(_) => {
             Err(ProductWorkflowError::UnsupportedActionKind {
                 kind: "subscription_request".into(),
             })
         }
+        ProductInboundPayload::ControlAction(_) => Ok(DispatchedAction {
+            ack: ProductInboundAck::Rejected(ProductRejection::permanent(
+                ProductRejectionKind::InvalidRequest,
+                "control action is not supported by this ProductWorkflow implementation",
+            )),
+            dispatch_kind: ActionDispatchKind::Rejected {
+                kind: ProductRejectionKind::InvalidRequest,
+            },
+        }),
         ProductInboundPayload::LinkedThreadAction(_) => {
             Err(ProductWorkflowError::UnsupportedActionKind {
                 kind: "linked_thread_action".into(),

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -43,8 +43,8 @@ use ironclaw_threads::InMemorySessionThreadService;
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
     GetRunStateRequest, LoopGateRef, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,
-    RunProfileVersion, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnCoordinator,
-    TurnError, TurnId, TurnRunId, TurnRunState, TurnScope, TurnStatus,
+    RunProfileVersion, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
+    TurnCoordinator, TurnError, TurnId, TurnRunId, TurnRunState, TurnScope, TurnStatus,
 };
 
 fn sample_envelope(event_suffix: &str) -> ProductInboundEnvelope {

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -13,9 +13,11 @@ use ironclaw_product_adapters::{
     AdapterInstallationId, ApprovalDecision, ApprovalResolutionPayload, AuthRequirement,
     AuthResolutionPayload, AuthResolutionResult, ExternalActorRef, ExternalConversationRef,
     ExternalEventId, InboundCommandPayload, LinkedThreadActionPayload, ParsedProductInbound,
-    ProductAdapterError, ProductAdapterId, ProductInboundAck, ProductInboundEnvelope,
-    ProductInboundPayload, ProductRejection, ProductRejectionDisposition, ProductRejectionKind,
-    ProductTriggerReason, ProductWorkflow, ProductWorkflowRejectionKind, ProjectionCursor,
+    ProductAdapterError, ProductAdapterId, ProductControlActionPayload, ProductInboundAck,
+    ProductInboundEnvelope, ProductInboundPayload, ProductProjectionReadInput,
+    ProductProjectionSubject, ProductProjectionSubscribeInput, ProductRejection,
+    ProductRejectionDisposition, ProductRejectionKind, ProductTriggerReason, ProductWorkflow,
+    ProductWorkflowRejectionKind, ProjectionCursor, ProjectionReadPayload,
     ProjectionSubscriptionPayload, ProtocolAuthEvidence, ScopedApprovalResolutionPayload,
     TrustedInboundContext, UserMessagePayload,
 };
@@ -1598,6 +1600,33 @@ async fn noop_returns_noop_ack() {
 }
 
 #[tokio::test]
+async fn typed_cancel_control_action_uses_submit_door_without_command_text() {
+    let (workflow, inbound, ledger) = build_workflow();
+    let envelope = sample_envelope_with_payload(
+        "typed-cancel-control",
+        ProductInboundPayload::ControlAction(ProductControlActionPayload::CancelRun {
+            run_id: TurnRunId::new(),
+        }),
+    );
+
+    let ack = workflow
+        .submit_inbound(envelope)
+        .await
+        .expect("typed control action returns product-safe ack");
+
+    assert!(matches!(
+        ack,
+        ProductInboundAck::Rejected(ProductRejection {
+            kind: ProductRejectionKind::InvalidRequest,
+            disposition: ProductRejectionDisposition::Permanent,
+            ..
+        })
+    ));
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 1);
+}
+
+#[tokio::test]
 async fn subscription_request_via_accept_inbound_rejects_before_mutating_ledger() {
     let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
     let envelope = sample_envelope_with_payload(
@@ -1629,6 +1658,109 @@ async fn subscription_request_via_accept_inbound_rejects_before_mutating_ledger(
 }
 
 #[tokio::test]
+async fn projection_read_via_submit_inbound_rejects_before_mutating_ledger() {
+    let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
+    let envelope = sample_envelope_with_payload(
+        "projection-read-wrong-entrypoint",
+        ProductInboundPayload::ProjectionRead(
+            ProjectionReadPayload::new(None, None, Some(25)).expect("valid read"),
+        ),
+    );
+
+    let err = workflow
+        .submit_inbound(envelope)
+        .await
+        .expect_err("projection reads use the read projection door, not submit_inbound");
+
+    assert!(matches!(
+        err,
+        ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::InvalidRequest,
+            status_code: 400,
+            retryable: false,
+            ..
+        }
+    ));
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(binding_service.resolve_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+}
+
+#[tokio::test]
+async fn projection_read_resolves_external_refs_through_read_door() {
+    let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
+    let binding = fake_binding();
+    let cursor = ProjectionCursor::new("cursor:projection-read-1").expect("valid cursor");
+    let envelope = sample_envelope_with_payload(
+        "projection-read-1",
+        ProductInboundPayload::ProjectionRead(
+            ProjectionReadPayload::new(
+                Some(binding.thread_id.as_str().to_string()),
+                Some(cursor.clone()),
+                Some(50),
+            )
+            .expect("valid read"),
+        ),
+    );
+    binding_service.program_binding(envelope.source_binding_key(), binding.clone());
+    let input = ProductProjectionReadInput::from_inbound_envelope(&envelope).expect("read input");
+
+    let read = workflow
+        .read_projection(input)
+        .await
+        .expect("projection read");
+
+    assert_eq!(read.actor.user_id, binding.actor_user_id);
+    assert_eq!(read.scope.tenant_id, binding.tenant_id);
+    assert_eq!(read.scope.agent_id, binding.agent_id);
+    assert_eq!(read.scope.project_id, binding.project_id);
+    assert_eq!(read.scope.thread_id, binding.thread_id);
+    assert_eq!(read.after_cursor, Some(cursor));
+    assert_eq!(read.limit, Some(50));
+    assert_eq!(binding_service.resolve_count(), 1);
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+}
+
+#[tokio::test]
+async fn projection_read_accepts_canonical_subject_without_inbound_envelope() {
+    let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
+    let binding = fake_binding();
+    let actor = TurnActor::new(binding.actor_user_id.clone());
+    let scope = TurnScope::new(
+        binding.tenant_id.clone(),
+        binding.agent_id.clone(),
+        binding.project_id.clone(),
+        binding.thread_id.clone(),
+    );
+    let cursor = ProjectionCursor::new("cursor:canonical-read").expect("valid cursor");
+
+    let read = workflow
+        .read_projection(ProductProjectionReadInput::new(
+            ProductProjectionSubject::canonical(actor.clone(), scope.clone()),
+            Some(binding.thread_id.as_str().to_string()),
+            Some(cursor.clone()),
+            Some(10),
+        ))
+        .await
+        .expect("canonical projection read");
+
+    assert_eq!(read.actor, actor);
+    assert_eq!(read.scope, scope);
+    assert_eq!(read.after_cursor, Some(cursor));
+    assert_eq!(read.limit, Some(10));
+    assert_eq!(binding_service.resolve_count(), 0);
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+}
+
+#[tokio::test]
 async fn projection_subscription_resolves_through_binding_service() {
     let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
     let binding = fake_binding();
@@ -1645,8 +1777,10 @@ async fn projection_subscription_resolves_through_binding_service() {
     );
     binding_service.program_binding(envelope.source_binding_key(), binding.clone());
 
+    let input =
+        ProductProjectionSubscribeInput::from_inbound_envelope(&envelope).expect("subscribe input");
     let subscription = workflow
-        .resolve_projection_subscription(envelope)
+        .subscribe_projection(input)
         .await
         .expect("projection subscription");
 
@@ -1657,6 +1791,38 @@ async fn projection_subscription_resolves_through_binding_service() {
     assert_eq!(subscription.scope.thread_id, binding.thread_id);
     assert_eq!(subscription.after_cursor, Some(cursor));
     assert_eq!(binding_service.resolve_count(), 1);
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+}
+
+#[tokio::test]
+async fn projection_subscription_accepts_canonical_subject_without_inbound_envelope() {
+    let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
+    let binding = fake_binding();
+    let actor = TurnActor::new(binding.actor_user_id.clone());
+    let scope = TurnScope::new(
+        binding.tenant_id.clone(),
+        binding.agent_id.clone(),
+        binding.project_id.clone(),
+        binding.thread_id.clone(),
+    );
+    let cursor = ProjectionCursor::new("cursor:canonical-subscribe").expect("valid cursor");
+
+    let subscription = workflow
+        .subscribe_projection(ProductProjectionSubscribeInput::new(
+            ProductProjectionSubject::canonical(actor.clone(), scope.clone()),
+            Some(binding.thread_id.as_str().to_string()),
+            Some(cursor.clone()),
+        ))
+        .await
+        .expect("canonical projection subscription");
+
+    assert_eq!(subscription.actor, actor);
+    assert_eq!(subscription.scope, scope);
+    assert_eq!(subscription.after_cursor, Some(cursor));
+    assert_eq!(binding_service.resolve_count(), 0);
     assert_eq!(inbound.accepted_count(), 0);
     assert_eq!(ledger.settled_count(), 0);
     assert_eq!(ledger.in_flight_count(), 0);

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -1658,6 +1658,36 @@ async fn subscription_request_via_accept_inbound_rejects_before_mutating_ledger(
 }
 
 #[tokio::test]
+async fn subscription_request_via_submit_inbound_rejects_before_mutating_ledger() {
+    let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
+    let envelope = sample_envelope_with_payload(
+        "projection-subscribe-wrong-submit-door",
+        ProductInboundPayload::SubscriptionRequest(
+            ProjectionSubscriptionPayload::new(None, None).expect("valid subscription"),
+        ),
+    );
+
+    let err = workflow.submit_inbound(envelope).await.expect_err(
+        "projection subscriptions use the subscribe projection door, not submit_inbound",
+    );
+
+    assert!(matches!(
+        err,
+        ProductAdapterError::WorkflowRejected {
+            kind: ProductWorkflowRejectionKind::InvalidRequest,
+            status_code: 400,
+            retryable: false,
+            ..
+        }
+    ));
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(binding_service.resolve_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 0);
+}
+
+#[tokio::test]
 async fn projection_read_via_submit_inbound_rejects_before_mutating_ledger() {
     let (workflow, inbound, ledger, binding_service) = build_workflow_with_binding();
     let envelope = sample_envelope_with_payload(

--- a/crates/ironclaw_reborn_composition/src/slack_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_serve.rs
@@ -624,7 +624,7 @@ mod tests {
 
     #[async_trait]
     impl ironclaw_product_adapters::ProductWorkflow for AckWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {

--- a/crates/ironclaw_wasm_product_adapters/src/runner.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/runner.rs
@@ -385,7 +385,7 @@ impl NativeProductAdapterRunner {
         let (envelope, _permit) = self.prepare_inbound_envelope(body, &evidence).await?;
         let workflow = Arc::clone(&self.workflow);
         let mut workflow_task =
-            tokio::spawn(async move { workflow.accept_inbound(envelope).await });
+            tokio::spawn(async move { workflow.submit_inbound(envelope).await });
         let ack = match tokio::time::timeout(self.config.workflow_timeout, &mut workflow_task).await
         {
             Ok(Ok(result)) => result?,
@@ -579,7 +579,7 @@ mod tests {
     }
 
     /// Helper for workflow stubs: `resolve_projection_subscription` is never
-    /// exercised by the runner tests (the runner only invokes `accept_inbound`),
+    /// exercised by the runner tests (the runner only invokes `submit_inbound`),
     /// but the trait requires it. Return a deterministic adapter-shape error
     /// so accidental calls fail loudly.
     fn projection_subscription_unimplemented() -> ProductAdapterError {
@@ -594,7 +594,7 @@ mod tests {
 
     #[async_trait]
     impl ProductWorkflow for AckWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {
@@ -613,7 +613,7 @@ mod tests {
 
     #[async_trait]
     impl ProductWorkflow for RetryableRejectedWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {
@@ -637,7 +637,7 @@ mod tests {
 
     #[async_trait]
     impl ProductWorkflow for RecordingWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {
@@ -660,7 +660,7 @@ mod tests {
 
     #[async_trait]
     impl ProductWorkflow for PendingWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {
@@ -679,7 +679,7 @@ mod tests {
 
     #[async_trait]
     impl ProductWorkflow for PanicWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {
@@ -701,7 +701,7 @@ mod tests {
 
     #[async_trait]
     impl ProductWorkflow for BlockingWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {

--- a/crates/ironclaw_wasm_product_adapters/src/runner_immediate_ack.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/runner_immediate_ack.rs
@@ -95,7 +95,7 @@ impl NativeProductAdapterRunner {
             // resource owner to abort. Workflows that open DB/network resources
             // must make their own futures cancellation-safe at await points.
             let workflow_result =
-                tokio::time::timeout(workflow_timeout, workflow.accept_inbound(workflow_envelope))
+                tokio::time::timeout(workflow_timeout, workflow.submit_inbound(workflow_envelope))
                     .await;
             match workflow_result {
                 Ok(Ok(ack)) => {
@@ -252,7 +252,7 @@ mod tests {
 
     #[async_trait]
     impl ironclaw_product_adapters::ProductWorkflow for AckWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {
@@ -278,7 +278,7 @@ mod tests {
 
     #[async_trait]
     impl ironclaw_product_adapters::ProductWorkflow for BlockingWorkflow {
-        async fn accept_inbound(
+        async fn submit_inbound(
             &self,
             _envelope: ProductInboundEnvelope,
         ) -> Result<ProductInboundAck, ProductAdapterError> {

--- a/docs/reborn/2026-05-28-slack-product-adapter-mvp-completion-plan.md
+++ b/docs/reborn/2026-05-28-slack-product-adapter-mvp-completion-plan.md
@@ -141,7 +141,7 @@ async fn slack_events_handler(request: HttpRequest) -> HttpResponse {
 
     spawn_reborn_task(async move {
         let parsed = slack_adapter.parse_inbound(verified_context, request.body).await?;
-        product_workflow.accept_inbound(parsed).await?;
+        product_workflow.submit_inbound(parsed).await?;
     });
 
     ack

--- a/docs/reborn/contracts/product-adapters.md
+++ b/docs/reborn/contracts/product-adapters.md
@@ -28,10 +28,21 @@ protocol event (webhook / cookie / bearer / cli)
   -> host verifies protocol auth (mints ProtocolAuthEvidence::Verified)
   -> ProductAdapter::parse_inbound(raw_payload, evidence)
        -> ProductInboundEnvelope (or None for ambient/no-op events)
-  -> ProductWorkflow::accept_inbound(envelope)
+  -> ProductWorkflow::submit_inbound(envelope)
        -> ConversationBindingService -> SessionThreadService -> TurnCoordinator
   -> ProductInboundAck (Accepted / DeferredBusy / Rejected / Duplicate / NoOp)
   -> protocol layer maps ack to status code
+
+projection read / fetch
+  -> caller resolves any opaque product/API id into canonical Reborn metadata
+  -> ProductWorkflow::read_projection(ProductProjectionReadInput)
+       -> ProjectionReadRequest
+
+projection stream / subscription
+  -> ProductWorkflow::subscribe_projection(ProductProjectionSubscribeInput)
+       -> ProjectionSubscriptionRequest
+  -> ProjectionStream::drain(request)
+       -> ProductOutboundEnvelope(s)
 
 projection update
   -> ProductOutboundEnvelope (FinalReply / Progress / GatePrompt / ...)
@@ -87,7 +98,28 @@ projection update
 - `auth_evidence: ProtocolAuthEvidence`
 - `received_at: DateTime<Utc>`
 - `payload: ProductInboundPayload` — UserMessage / Command /
-  ApprovalResolution / AuthResolution / SubscriptionRequest / NoOp.
+  ApprovalResolution / ScopedApprovalResolution / AuthResolution /
+  ProjectionRead / SubscriptionRequest / ControlAction / LinkedThreadAction /
+  NoOp.
+
+`ProductWorkflow` has three effect-boundary doors:
+
+- `submit_inbound(ProductInboundEnvelope)` for mutating submit/control actions:
+  user messages, commands, approval/auth resolutions, linked-thread actions,
+  typed control actions, and no-op acknowledgements. Projection reads and
+  projection subscriptions must not be submitted through this mutating path.
+- `read_projection(ProductProjectionReadInput)` for non-mutating projection
+  reads/fetches. Callers may provide adapter external refs for workflow binding
+  resolution or already-canonicalized actor/scope metadata after resolving an
+  opaque product/API id outside ProductWorkflow.
+- `subscribe_projection(ProductProjectionSubscribeInput)` for non-mutating
+  projection subscriptions. Legacy `resolve_projection_subscription(...)` is a
+  compatibility wrapper that converts the old envelope shape into typed
+  subscribe input.
+
+`accept_inbound(...)` remains a compatibility wrapper around `submit_inbound(...)`.
+New host/adapter/API wiring should call the specific door that matches the
+operation's effect boundary.
 
 `ProductInboundEnvelope` does not model host-internal trigger or scheduler
 ingress. Synthetic trusted trigger ingress is handled by the conversation-owned


### PR DESCRIPTION
Refs #4488
Parent: #3280
Related: #4484, #4459, #3281, #3266, #3286

## Summary

- Split `ProductWorkflow` into three first-class effect-boundary doors:
  - `submit_inbound(ProductInboundEnvelope)` for mutating submit/control actions.
  - `read_projection(ProductProjectionReadInput)` for non-mutating projection reads.
  - `subscribe_projection(ProductProjectionSubscribeInput)` for non-mutating projection subscriptions.
- Keep compatibility wrappers:
  - `accept_inbound(...)` delegates to `submit_inbound(...)`.
  - `resolve_projection_subscription(...)` converts the legacy envelope shape into typed subscribe input.
- Add typed projection inputs that support both:
  - adapter external refs resolved by ProductWorkflow binding lookup;
  - already-canonicalized actor/scope metadata for API routes after opaque-id mapping, e.g. OpenAI `resp_*` lookup outside ProductWorkflow.
- Add distinct `ProjectionReadRequest` vs `ProjectionSubscriptionRequest`; read is no longer modeled as subscribe.
- Add `ProjectionReadPayload` and a typed `ProductControlActionPayload::CancelRun` submit/control seam so cancel is not represented as slash-command text.
- Move native WASM adapter runners to call `submit_inbound` directly instead of the compatibility `accept_inbound` wrapper.
- Extend fakes/tests so submit/read/subscribe side effects are observable independently.

## OpenAI-compatible effect-path matrix

| Behavior | ProductWorkflow door |
| --- | --- |
| create chat completion / response | `submit_inbound` |
| retrieve response / projection | opaque-id mapping outside ProductWorkflow, then `read_projection` |
| stream response/projection events | `submit_inbound` + `subscribe_projection` |
| cancel response/run | opaque-id mapping outside ProductWorkflow, then `submit_inbound` with typed control/cancel payload |

ProductWorkflow does not store, parse, or depend on OpenAI-specific `resp_*` ids.

## Boundary

This PR intentionally does not implement EventStreamManager internals (#3281), outbound/subscription policy (#3266), OpenAI `response_id` storage/mapping, SSE rendering, full command matrix (#3286), or full runtime cancel execution. It lands the ProductWorkflow facade seam those follow-ups should target.

## Validation

- `cargo fmt --all`
- `cargo clippy -p ironclaw_product_adapters --features test-support --all-targets -- -D warnings`

## Reviewer question

@hanakannzashi does this concrete three-door facade plus flexible projection-door input shape match what you need for future OpenAI-compatible create/retrieve/stream/cancel wiring? In particular, please confirm whether the typed `CancelRun` submit/control payload seam is enough for upcoming route wiring, with actual opaque `resp_*` mapping and runtime cancel execution remaining outside this PR.
