### PR TITLE
[codex] Guide extension install retries to activation

### DIFF
--- a/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
+++ b/crates/ironclaw_reborn_composition/src/extension_lifecycle_capabilities.rs
@@ -60,7 +60,7 @@ fn manifests() -> Result<Vec<CapabilityManifest>, ExtensionError> {
         )?,
         lifecycle_manifest(
             EXTENSION_INSTALL_CAPABILITY_ID,
-            "Install a locally available Reborn extension into durable local-dev lifecycle state",
+            "Install a locally available Reborn extension into durable local-dev lifecycle state. If install fails because the extension is already installed, use builtin.extension_activate instead.",
             vec![EffectKind::ReadFilesystem, EffectKind::WriteFilesystem],
             PermissionMode::Ask,
         )?,
@@ -262,6 +262,14 @@ mod tests {
 
         let install = descriptor_for(&surface, EXTENSION_INSTALL_CAPABILITY_ID);
         assert_eq!(install.default_permission, PermissionMode::Ask);
+        assert!(
+            install.description.contains("already installed")
+                && install
+                    .description
+                    .contains(EXTENSION_ACTIVATE_CAPABILITY_ID),
+            "extension_install description should route already-installed failures to activation: {}",
+            install.description
+        );
         assert_eq!(
             install.parameters_schema["required"],
             serde_json::json!(["extension_id"])


### PR DESCRIPTION
## Summary

- Update the model-visible `builtin.extension_install` description to route already-installed failures to `builtin.extension_activate`.
- Add a regression assertion that the visible install descriptor includes both the already-installed cue and activation capability id.

## Root Cause

When an extension was installed but inactive, a failed install attempt exposed no model-visible guidance to switch to activation, so the agent could keep retrying install until loop prevention stopped the run.

## Validation

- `cargo fmt --check`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test -p ironclaw_reborn_composition extension_lifecycle_capabilities`
