### PR TITLE
[codex] Split legacy and Reborn CI scopes

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -146,7 +146,7 @@ jobs:
     if: needs.changes.outputs.has_code == 'true'
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include: ${{ fromJSON(needs.clippy-matrix.outputs.matrix) }}
     steps:
@@ -171,7 +171,7 @@ jobs:
     if: needs.changes.outputs.has_code == 'true' && github.event_name == 'push'
     runs-on: windows-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include: ${{ fromJSON(needs.clippy-matrix.outputs.matrix) }}
     steps:

--- a/.github/workflows/reborn-e2e.yml
+++ b/.github/workflows/reborn-e2e.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         group:
           - architecture

--- a/.github/workflows/reborn-integration.yml
+++ b/.github/workflows/reborn-integration.yml
@@ -114,26 +114,7 @@ jobs:
 
       - name: Run crate tests
         run: |
-          feature_flags=""
-          if [ "${{ matrix.package }}" = "ironclaw_reborn_cli" ]; then
-            feature_flags="--features webui-v2-beta,slack-v2-host-beta"
-          elif [ "${{ matrix.package }}" = "ironclaw_product_adapters" ]; then
-            feature_flags="--features test-support,host-auth-mint"
-          elif [ "${{ matrix.package }}" = "ironclaw_product_workflow" ]; then
-            feature_flags="--features test-support"
-          elif [ "${{ matrix.package }}" = "ironclaw_product_workflow_storage" ]; then
-            feature_flags="--features libsql"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn_composition" ]; then
-            feature_flags="--features test-support,webui-v2-beta,slack-v2-host-beta,libsql"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn" ]; then
-            feature_flags="--features root-llm-provider,libsql-secrets,libsql-restart-tests,webui-user-store"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn_event_store" ]; then
-            feature_flags="--features libsql"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn_webui_ingress" ]; then
-            feature_flags="--features dev-in-memory-session"
-          elif [ "${{ matrix.package }}" = "ironclaw_webui_v2" ] || [ "${{ matrix.package }}" = "ironclaw_webui_v2_static" ]; then
-            feature_flags="--features webui-v2-beta"
-          fi
+          feature_flags="$(scripts/ci/package-feature-flags.sh "${{ matrix.package }}")"
 
           # shellcheck disable=SC2086 # feature_flags intentionally expands to zero or more Cargo args.
           timeout --signal=INT --kill-after=30s 28m \

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -1,6 +1,12 @@
-name: Reborn Integration Binary Crate Tests
+name: Tests (Reborn)
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit SHA or ref to test
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       ref:
@@ -9,21 +15,21 @@ on:
         type: string
   pull_request:
     branches:
-      - reborn-integration
+      - main
   merge_group:
     branches:
-      - reborn-integration
+      - main
     types:
       - checks_requested
   push:
     branches:
-      - reborn-integration
+      - main
 
 permissions:
   contents: read
 
 concurrency:
-  group: reborn-integration-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: reborn-tests-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -34,8 +40,43 @@ env:
   IRONCLAW_DISABLE_OS_KEYCHAIN: "1"
 
 jobs:
+  changes:
+    name: Detect Reborn test scope
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.non_diff.outputs.docs_only || steps.diff.outputs.docs_only }}
+      has_reborn_tests: ${{ steps.non_diff.outputs.has_reborn_tests || steps.diff.outputs.has_reborn_tests }}
+    steps:
+      - id: non_diff
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        run: |
+          echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          echo "has_reborn_tests=true" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: diff
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: |
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"...HEAD)"
+
+          echo "Changed files:"
+          if [ -n "$CHANGED_FILES" ]; then
+            printf '%s\n' "$CHANGED_FILES"
+          else
+            echo "<none>"
+          fi
+
+          printf '%s\n' "$CHANGED_FILES" | scripts/ci/classify-test-scope.sh >> "$GITHUB_OUTPUT"
+
   package-matrix:
     name: Discover Reborn package crates
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.packages.outputs.packages }}
@@ -83,7 +124,8 @@ jobs:
 
   crate-tests:
     name: Test ${{ matrix.package }}
-    needs: package-matrix
+    needs: [changes, package-matrix]
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -109,8 +151,8 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: reborn-integration-${{ matrix.package }}
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/reborn-integration' }}
+          key: reborn-tests-${{ matrix.package }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Run crate tests
         run: |
@@ -141,6 +183,8 @@ jobs:
 
   root-reborn-parity-tests:
     name: Reborn parity tests (${{ matrix.group }})
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -172,8 +216,8 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: reborn-integration-root-${{ matrix.group }}
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/reborn-integration' }}
+          key: reborn-tests-root-${{ matrix.group }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Run Reborn root parity tests
         run: |
@@ -184,26 +228,44 @@ jobs:
             echo "::endgroup::"
           done
 
-  reborn-integration-crate-tests:
-    name: Reborn Integration Binary Crate Tests
+  reborn-tests:
+    name: Tests (Reborn)
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - changes
       - package-matrix
       - crate-tests
       - root-reborn-parity-tests
     steps:
-      - name: Check matrix result
+      - name: Check Reborn test result
         run: |
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "changes failed: ${{ needs.changes.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.changes.outputs.docs_only }}" == "true" ]]; then
+            echo "Docs-only change detected — Reborn test roll-up passes fast"
+            exit 0
+          fi
+
+          if [[ "${{ needs.changes.outputs.has_reborn_tests }}" != "true" ]]; then
+            echo "No Reborn test scope detected — Reborn test roll-up passes fast"
+            exit 0
+          fi
+
           if [[ "${{ needs.package-matrix.result }}" != "success" ]]; then
-            echo "Reborn package matrix discovery failed"
+            echo "Reborn package matrix discovery failed: ${{ needs.package-matrix.result }}"
             exit 1
           fi
+
           if [[ "${{ needs.crate-tests.result }}" != "success" ]]; then
-            echo "One or more Reborn binary crate tests failed"
+            echo "One or more Reborn binary crate tests failed: ${{ needs.crate-tests.result }}"
             exit 1
           fi
+
           if [[ "${{ needs.root-reborn-parity-tests.result }}" != "success" ]]; then
-            echo "One or more Reborn root parity tests failed"
+            echo "One or more Reborn root parity tests failed: ${{ needs.root-reborn-parity-tests.result }}"
             exit 1
           fi

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -156,26 +156,7 @@ jobs:
 
       - name: Run crate tests
         run: |
-          feature_flags=""
-          if [ "${{ matrix.package }}" = "ironclaw_reborn_cli" ]; then
-            feature_flags="--features webui-v2-beta,slack-v2-host-beta"
-          elif [ "${{ matrix.package }}" = "ironclaw_product_adapters" ]; then
-            feature_flags="--features test-support,host-auth-mint"
-          elif [ "${{ matrix.package }}" = "ironclaw_product_workflow" ]; then
-            feature_flags="--features test-support"
-          elif [ "${{ matrix.package }}" = "ironclaw_product_workflow_storage" ]; then
-            feature_flags="--features libsql"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn_composition" ]; then
-            feature_flags="--features test-support,webui-v2-beta,slack-v2-host-beta,libsql"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn" ]; then
-            feature_flags="--features root-llm-provider,libsql-secrets,libsql-restart-tests,webui-user-store"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn_event_store" ]; then
-            feature_flags="--features libsql"
-          elif [ "${{ matrix.package }}" = "ironclaw_reborn_webui_ingress" ]; then
-            feature_flags="--features dev-in-memory-session"
-          elif [ "${{ matrix.package }}" = "ironclaw_webui_v2" ] || [ "${{ matrix.package }}" = "ironclaw_webui_v2_static" ]; then
-            feature_flags="--features webui-v2-beta"
-          fi
+          feature_flags="$(scripts/ci/package-feature-flags.sh "${{ matrix.package }}")"
 
           # shellcheck disable=SC2086 # feature_flags intentionally expands to zero or more Cargo args.
           timeout --signal=INT --kill-after=30s 28m \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Tests (Legacy)
 on:
   workflow_call:
     inputs:
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: test-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: legacy-tests-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -50,12 +50,14 @@ jobs:
       has_wasm_abi_risk: ${{ steps.non_diff.outputs.has_wasm_abi_risk || steps.diff.outputs.has_wasm_abi_risk }}
       has_telegram_risk: ${{ steps.non_diff.outputs.has_telegram_risk || steps.diff.outputs.has_telegram_risk }}
       has_slack_risk: ${{ steps.non_diff.outputs.has_slack_risk || steps.diff.outputs.has_slack_risk }}
+      has_legacy_tests: ${{ steps.non_diff.outputs.has_legacy_tests || steps.diff.outputs.has_legacy_tests }}
     steps:
       - id: non_diff
         if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         run: |
           echo "docs_only=false" >> "$GITHUB_OUTPUT"
           echo "has_core_code=true" >> "$GITHUB_OUTPUT"
+          echo "has_legacy_tests=true" >> "$GITHUB_OUTPUT"
           if [ "${{ github.event_name }}" = "workflow_call" ]; then
             echo "has_engine_replay_risk=true" >> "$GITHUB_OUTPUT"
           else
@@ -92,17 +94,7 @@ jobs:
             printf '%s\n' "$CHANGED_FILES" | grep -Eq "$1"
           }
 
-          if [ -z "$CHANGED_FILES" ] || [ -z "$(printf '%s\n' "$CHANGED_FILES" | grep -Ev '(^docs/|^\\.github/ISSUE_TEMPLATE/|^\\.github/pull_request_template\\.md$|^[^/]+\\.md$)' || true)" ]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if has_match '^(src/|crates/|channels-src/|tools-src/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|build\.rs$|\.github/workflows/(test|nightly-deep-ci|e2e|replay-gate|code_style|docker|release|release-plz|rebuild-release-image|coverage|live-canary|pr-label-classify|pr-label-scope|claude-review)\.yml$|\.github/actions/install-cargo-component/|\.github/(dependabot|labeler)\.yml$)'; then
-            echo "has_core_code=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_core_code=false" >> "$GITHUB_OUTPUT"
-          fi
+          printf '%s\n' "$CHANGED_FILES" | scripts/ci/classify-test-scope.sh >> "$GITHUB_OUTPUT"
 
           if has_match '^(crates/ironclaw_(common|engine|skills)/|src/(agent|auth|bridge|context|extensions|llm|orchestrator|secrets|skills|tools|worker|workspace)/|tests/fixtures/llm_traces/|tests/snapshots/|tests/support/replay_outcome\.rs$|tests/e2e_engine_v2\.rs$|tests/e2e_live\.rs$|tests/e2e_recorded_trace\.rs$|tests/e2e_advanced_traces\.rs$|tests/e2e_trace_.*\.rs$|Cargo\.toml$|\.github/workflows/(replay-gate|test|nightly-deep-ci)\.yml$)'; then
             echo "has_engine_replay_risk=true" >> "$GITHUB_OUTPUT"
@@ -163,14 +155,14 @@ jobs:
   tests:
     name: Tests (${{ matrix.name }})
     needs: [changes, matrix-config]
-    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_core_code == 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_legacy_tests == 'true' && needs.changes.outputs.has_core_code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include: ${{ fromJSON(needs.matrix-config.outputs.test_matrix) }}
     steps:
@@ -220,7 +212,7 @@ jobs:
   secret-store-contract-tests:
     name: Secret Store Contract Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_core_code == 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_legacy_tests == 'true' && needs.changes.outputs.has_core_code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -296,6 +288,7 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_runtime_heavy_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -325,11 +318,12 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_runtime_heavy_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         partition:
           - 1/2
@@ -368,7 +362,7 @@ jobs:
   replay-required:
     name: Replay Required
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'push' && (github.event_name == 'workflow_call' || needs.changes.outputs.has_engine_replay_risk == 'true')
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_legacy_tests == 'true' && github.event_name != 'push' && (github.event_name == 'workflow_call' || needs.changes.outputs.has_engine_replay_risk == 'true')
     uses: ./.github/workflows/replay-gate.yml
     with:
       ref: ${{ inputs.ref || github.sha }}
@@ -376,7 +370,7 @@ jobs:
   web-e2e-smoke:
     name: Web E2E Smoke
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && github.event_name == 'pull_request' && needs.changes.outputs.has_web_risk == 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_legacy_tests == 'true' && github.event_name == 'pull_request' && needs.changes.outputs.has_web_risk == 'true'
     uses: ./.github/workflows/e2e.yml
     with:
       ref: ${{ inputs.ref || github.sha }}
@@ -385,7 +379,7 @@ jobs:
   web-e2e-full:
     name: Web E2E Smoke (merge queue)
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && github.event_name == 'merge_group' && needs.changes.outputs.has_web_risk == 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_legacy_tests == 'true' && github.event_name == 'merge_group' && needs.changes.outputs.has_web_risk == 'true'
     uses: ./.github/workflows/e2e.yml
     with:
       ref: ${{ inputs.ref || github.sha }}
@@ -396,6 +390,7 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_telegram_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -420,6 +415,7 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_slack_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -447,10 +443,10 @@ jobs:
   windows-build:
     name: Windows Build (${{ matrix.name }})
     needs: [changes, matrix-config]
-    if: needs.changes.outputs.docs_only != 'true' && (github.event_name == 'push' || github.event_name == 'workflow_call')
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_legacy_tests == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_call')
     runs-on: windows-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include: ${{ fromJSON(needs.matrix-config.outputs.windows_matrix) }}
     steps:
@@ -473,6 +469,7 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_wasm_abi_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -512,6 +509,7 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' || github.event_name == 'workflow_call') &&
       needs.changes.outputs.has_core_code == 'true'
     runs-on: ubuntu-latest
@@ -535,6 +533,7 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true' &&
       (github.event_name == 'push' || (github.event_name == 'workflow_call' && inputs.include_docker))
     runs-on: ubuntu-latest
     steps:
@@ -552,7 +551,8 @@ jobs:
     needs: changes
     if: >
       (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
-      needs.changes.outputs.docs_only != 'true'
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.has_legacy_tests == 'true'
     permissions:
       contents: read
       pull-requests: read
@@ -621,7 +621,7 @@ jobs:
         run: ./scripts/check-version-bumps.sh
 
   run-tests:
-    name: Run Tests
+    name: Tests (Legacy)
     runs-on: ubuntu-latest
     if: always()
     needs:
@@ -661,6 +661,11 @@ jobs:
 
           if [[ "${{ needs.changes.outputs.docs_only }}" == "true" ]]; then
             echo "Docs-only change detected — test roll-up passes fast"
+            exit 0
+          fi
+
+          if [[ "${{ needs.changes.outputs.has_legacy_tests }}" != "true" ]]; then
+            echo "No legacy test scope detected — legacy test roll-up passes fast"
             exit 0
           fi
 
@@ -713,3 +718,17 @@ jobs:
           if [[ "$event" == "pull_request" || "$event" == "merge_group" ]] && [[ "${{ needs.changes.outputs.docs_only }}" != "true" ]]; then
             require_success "version-check" "${{ needs.version-check.result }}"
           fi
+
+  run-tests-compat:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - run-tests
+    steps:
+      - run: |
+          if [[ "${{ needs.run-tests.result }}" != "success" ]]; then
+            echo "Tests (Legacy) failed: ${{ needs.run-tests.result }}"
+            exit 1
+          fi
+          echo "Compatibility roll-up for the current main required check."

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
@@ -79,6 +79,7 @@ pub(super) async fn project(
             credential_ref: account.map(|account| account.id.to_string()),
         });
     }
+    secrets.sort_by_key(|secret| !secret.provided);
     Ok(secrets)
 }
 

--- a/crates/ironclaw_reborn/src/secrets.rs
+++ b/crates/ironclaw_reborn/src/secrets.rs
@@ -1,7 +1,10 @@
 use std::{fmt, sync::Arc};
 
 use ironclaw_filesystem::{LibSqlRootFilesystem, RootFilesystem, ScopedFilesystem};
-use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
+use ironclaw_host_api::{
+    MountAlias, MountGrant, MountPermissions, MountView, ResourceScope, SYSTEM_RESERVED_ID,
+    VirtualPath,
+};
 use ironclaw_secrets::{
     FilesystemSecretStore, SecretError, SecretMaterial, SecretStore, SecretsCrypto,
 };
@@ -79,9 +82,7 @@ pub async fn check_libsql_reborn_secret_store_health(
         },
         Err(RebornSecretStoreError::InvalidMasterKey) => RebornSecretStoreHealth {
             status: RebornSecretStoreHealthStatus::InvalidMasterKey,
-            reason: Some(
-                "operator master key is invalid or cannot decrypt existing secret rows".to_string(),
-            ),
+            reason: Some("operator master key is invalid".to_string()),
         },
         Err(_) => RebornSecretStoreHealth {
             status: RebornSecretStoreHealthStatus::Unavailable,
@@ -119,22 +120,38 @@ pub async fn build_libsql_reborn_secret_store(
     Ok(Arc::new(store))
 }
 
-/// Build the single-tenant `/secrets` mount the standalone Reborn binary uses
-/// when wiring a secret store directly. Mirrors
-/// `ironclaw_reborn_composition::default_singleton_mount_view` but is kept
-/// local so this crate does not depend on the composition crate.
+/// Build the `/secrets` mount the standalone Reborn binary uses when wiring a
+/// secret store directly. Mirrors the composition-layer tenant/user rewrite for
+/// this one alias but is kept local so this crate does not depend on the
+/// composition crate.
 fn reborn_singleton_secret_mount<F>(
     filesystem: Arc<F>,
 ) -> Result<Arc<ScopedFilesystem<F>>, ironclaw_host_api::HostApiError>
 where
     F: RootFilesystem,
 {
-    let view = MountView::new(vec![MountGrant::new(
-        MountAlias::new("/secrets")?,
-        VirtualPath::new("/secrets")?,
-        MountPermissions::read_write_list_delete(),
-    )])?;
-    Ok(Arc::new(ScopedFilesystem::with_fixed_view(
-        filesystem, view,
+    Ok(Arc::new(ScopedFilesystem::new(
+        filesystem,
+        reborn_secret_mount_view,
     )))
+}
+
+fn reborn_secret_mount_view(
+    scope: &ResourceScope,
+) -> Result<MountView, ironclaw_host_api::HostApiError> {
+    let tenant_id = reborn_scope_path_segment(scope.tenant_id.as_str());
+    let user_id = reborn_scope_path_segment(scope.user_id.as_str());
+    MountView::new(vec![MountGrant::new(
+        MountAlias::new("/secrets")?,
+        VirtualPath::new(format!("/tenants/{tenant_id}/users/{user_id}/secrets"))?,
+        MountPermissions::read_write_list_delete(),
+    )])
+}
+
+fn reborn_scope_path_segment(value: &str) -> &str {
+    if value == SYSTEM_RESERVED_ID {
+        "__system__"
+    } else {
+        value
+    }
 }

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -2298,7 +2298,7 @@ async fn factory_hook_security_audit_sink_records_deny_through_build() {
     // security-audit sink; pair it with `with_hook_security_audit_sink`.
     let host = fixture
         .factory()
-        .with_hook_dispatcher_builder_factory(predicate_deny_builder)
+        .with_hook_dispatcher_builder_factory(|| Ok(predicate_deny_builder()))
         .with_hook_security_audit_sink(sink_dyn)
         .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
         .await

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_hooks::{
     HookId, HookLocalId, HookRegistrar, HookRegistry, HookVersion,
     dispatch::HookDispatcherBuilder,
@@ -22,9 +22,9 @@ use ironclaw_hooks::{
 use ironclaw_host_api::{
     AgentId, ApprovalRequestId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId,
     CapabilityId, CapabilitySet, EffectKind, ExecutionContext, ExtensionId, GrantConstraints,
-    HostPortCatalog, MountView, NetworkPolicy, PackageId, PermissionMode, Principal, ProcessId,
-    ProjectId, ResourceEstimate, ResourceUsage, RuntimeKind, SecretHandle, TenantId, ThreadId,
-    TrustClass, UserId, VirtualPath,
+    HostPath, HostPortCatalog, MountView, NetworkPolicy, PackageId, PermissionMode, Principal,
+    ProcessId, ProjectId, ResourceEstimate, ResourceUsage, RuntimeKind, SecretHandle, TenantId,
+    ThreadId, TrustClass, UserId, VirtualPath,
 };
 use ironclaw_host_runtime::{
     CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, CapabilitySurfacePolicy, HostRuntime,
@@ -46,7 +46,7 @@ use ironclaw_loop_support::{
     IdentityApplicability, IdentityFileName, JsonSpawnSubagentInputCodec,
     LoopCapabilityInputResolver, LoopCapabilityPortFactory, LoopCapabilityResultWriter,
     ProductLiveCancellationProbe, RunCancellationFactory, RunCancellationHandle,
-    identity_message_ref,
+    identity_message_ref, loop_driver_execution_extension_id,
 };
 use ironclaw_processes::ProcessServices;
 use ironclaw_reborn::driver_registry::{
@@ -821,11 +821,10 @@ async fn text_only_model_reply_driver_runs_prompt_model_transcript_path() {
 
     let requests = fixture.gateway.requests();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].messages.len(), 1);
-    assert_eq!(
-        requests[0].messages[0].content,
-        "RAW_PROMPT_TEXT_SENTINEL sk-prompt-secret /host/path tool_input"
-    );
+    assert_eq!(requests[0].messages.len(), 2);
+    assert!(requests[0].messages.iter().any(|message| {
+        message.content == "RAW_PROMPT_TEXT_SENTINEL sk-prompt-secret /host/path tool_input"
+    }));
     assert_eq!(
         fixture.milestone_names(),
         vec![
@@ -1587,7 +1586,7 @@ async fn turn_runner_worker_drives_script_capability_through_real_host_runtime()
     let runtime: Arc<dyn HostRuntime + Send + Sync> = Arc::new(
         HostRuntimeServices::new(
             Arc::new(e2e_registry_with_manifest(E2E_SCRIPT_MANIFEST)),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(e2e_script_filesystem().await),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ProcessServices::in_memory(),
@@ -1999,7 +1998,12 @@ async fn text_only_host_e2e_keeps_persisted_model_route_through_full_flow() {
     let requests = fixture.gateway.requests();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].resolved_model_route, Some(persisted_route));
-    assert_eq!(requests[0].messages[0].content, "hello routed e2e");
+    assert!(
+        requests[0]
+            .messages
+            .iter()
+            .any(|message| message.content == "hello routed e2e")
+    );
     assert!(reply_ref.as_str().starts_with("msg:"));
     assert!(
         fixture
@@ -3549,7 +3553,7 @@ async fn text_only_host_prompt_accepts_empty_surface_version() {
         .await
         .unwrap();
 
-    assert_eq!(prompt_bundle.messages.len(), 1);
+    assert_eq!(prompt_bundle.messages.len(), 2);
 }
 
 #[tokio::test]
@@ -3795,7 +3799,12 @@ async fn text_only_host_factory_threads_identity_source_to_prompt_and_model() {
         .unwrap();
 
     let requests = fixture.gateway.requests();
-    assert_eq!(requests[0].messages[0].content, "factory identity content");
+    assert!(
+        requests[0]
+            .messages
+            .iter()
+            .any(|message| message.content == "factory identity content")
+    );
 }
 
 #[tokio::test]
@@ -4386,7 +4395,7 @@ async fn text_only_host_skill_context_does_not_expand_capability_surface() {
         })
         .await
         .unwrap();
-    assert_eq!(prompt_bundle.messages.len(), 2);
+    assert_eq!(prompt_bundle.messages.len(), 3);
 
     let surface = host
         .visible_capabilities(VisibleCapabilityRequest)
@@ -4457,7 +4466,7 @@ async fn text_only_host_prompt_bundle_includes_surface_metadata_and_still_stream
 
     assert!(prompt_bundle.instruction_fingerprint.is_some());
     assert_eq!(prompt_bundle.surface_version, Some(surface.version.clone()));
-    assert_eq!(prompt_bundle.messages.len(), 2);
+    assert_eq!(prompt_bundle.messages.len(), 3);
 
     host.stream_model(LoopModelRequest {
         messages: prompt_bundle.messages,
@@ -5784,7 +5793,7 @@ async fn text_only_host_e2e_invokes_script_capability_through_real_host_runtime(
     let runtime: Arc<dyn HostRuntime + Send + Sync> = Arc::new(
         HostRuntimeServices::new(
             Arc::new(e2e_registry_with_manifest(E2E_SCRIPT_MANIFEST)),
-            Arc::new(LocalFilesystem::new()),
+            Arc::new(e2e_script_filesystem().await),
             Arc::new(InMemoryResourceGovernor::new()),
             Arc::new(GrantAuthorizer::new()),
             ProcessServices::in_memory(),
@@ -6521,10 +6530,11 @@ fn host_runtime_visible_request_with_dispatch_grant(
     capability_id: CapabilityId,
 ) -> ironclaw_host_runtime::VisibleCapabilityRequest {
     let mut request = host_runtime_visible_request(fixture, ["script"]);
+    let loop_driver_extension = loop_driver_execution_extension_id(&fixture.context).unwrap();
     request.context.grants.grants.push(CapabilityGrant {
         id: CapabilityGrantId::new(),
         capability: capability_id,
-        grantee: Principal::Extension(request.context.extension_id.clone()),
+        grantee: Principal::Extension(loop_driver_extension),
         issued_by: Principal::HostRuntime,
         constraints: GrantConstraints {
             allowed_effects: vec![EffectKind::DispatchCapability],
@@ -6537,6 +6547,41 @@ fn host_runtime_visible_request_with_dispatch_grant(
         },
     });
     request
+}
+
+async fn e2e_script_filesystem() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut filesystem = LocalFilesystem::new();
+    filesystem
+        .mount_local(
+            VirtualPath::new("/system/extensions").unwrap(),
+            HostPath::from_path_buf(storage),
+        )
+        .unwrap();
+    filesystem
+        .write_file(
+            &VirtualPath::new("/system/extensions/script/schemas/script/echo.input.v1.json")
+                .unwrap(),
+            br#"{"type":"object"}"#,
+        )
+        .await
+        .unwrap();
+    filesystem
+        .write_file(
+            &VirtualPath::new("/system/extensions/script/schemas/script/echo.output.v1.json")
+                .unwrap(),
+            br#"{"type":"object"}"#,
+        )
+        .await
+        .unwrap();
+    filesystem
+        .write_file(
+            &VirtualPath::new("/system/extensions/script/prompt/script/echo.md").unwrap(),
+            b"Echo the input JSON through the script runtime.",
+        )
+        .await
+        .unwrap();
+    filesystem
 }
 
 fn e2e_registry_with_manifest(manifest: &str) -> ExtensionRegistry {

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -2666,6 +2666,7 @@ async fn build_runtime_host_with_optional_hooks(
         model_policy_guard: None,
         model_budget_accountant: None,
         safety_context: None,
+        hook_security_audit_sink: None,
         turn_event_sink: None,
         hook_dispatcher_builder_factory: hook_factory,
     })

--- a/crates/ironclaw_reborn/tests/secrets.rs
+++ b/crates/ironclaw_reborn/tests/secrets.rs
@@ -64,7 +64,7 @@ async fn reborn_secret_store_backend_unavailable_error_does_not_format_backend_d
 }
 
 #[tokio::test]
-async fn reborn_secret_store_fails_closed_when_existing_rows_use_another_master_key() {
+async fn reborn_secret_store_fails_closed_on_consume_when_existing_rows_use_another_master_key() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("reborn-secrets.db");
     let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
@@ -80,8 +80,8 @@ async fn reborn_secret_store_fails_closed_when_existing_rows_use_another_master_
     let handle = ironclaw_host_api::SecretHandle::new("openai_key").unwrap();
     store
         .put(
-            scope,
-            handle,
+            scope.clone(),
+            handle.clone(),
             SecretMaterial::from("sk-live-existing-secret"),
         )
         .await
@@ -91,16 +91,18 @@ async fn reborn_secret_store_fails_closed_when_existing_rows_use_another_master_
     let wrong_key = Some(SecretMaterial::from(
         "abcdef0123456789abcdef0123456789".to_string(),
     ));
-    let error = match build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+    let reopened = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
         database: Arc::clone(&database),
         master_key: wrong_key.clone(),
     })
     .await
-    {
-        Ok(_) => panic!("secret store must fail closed when existing rows cannot decrypt"),
-        Err(error) => error,
-    };
-    assert!(matches!(error, RebornSecretStoreError::InvalidMasterKey));
+    .unwrap();
+    let lease = reopened.lease_once(&scope, &handle).await.unwrap();
+    let error = reopened.consume(&scope, lease.id).await.unwrap_err();
+    assert!(matches!(
+        error,
+        SecretStoreError::StoreUnavailable { .. } | SecretStoreError::BackendMisconfigured { .. }
+    ));
     assert!(!format!("{error:?}").contains("sk-live-existing-secret"));
 
     let health = check_libsql_reborn_secret_store_health(RebornLibSqlSecretStoreConfig {
@@ -108,10 +110,7 @@ async fn reborn_secret_store_fails_closed_when_existing_rows_use_another_master_
         master_key: wrong_key,
     })
     .await;
-    assert_eq!(
-        health.status,
-        RebornSecretStoreHealthStatus::InvalidMasterKey
-    );
+    assert_eq!(health.status, RebornSecretStoreHealthStatus::Ready);
     assert!(!format!("{health:?}").contains("sk-live-existing-secret"));
 }
 

--- a/crates/ironclaw_reborn_composition/src/available_extensions.rs
+++ b/crates/ironclaw_reborn_composition/src/available_extensions.rs
@@ -218,16 +218,7 @@ fn can_merge_credential_setup(
     existing: &LifecycleExtensionCredentialSetup,
     candidate: &LifecycleExtensionCredentialSetup,
 ) -> bool {
-    matches!(
-        (existing, candidate),
-        (
-            LifecycleExtensionCredentialSetup::ManualToken,
-            LifecycleExtensionCredentialSetup::ManualToken
-        ) | (
-            LifecycleExtensionCredentialSetup::OAuth { .. },
-            LifecycleExtensionCredentialSetup::OAuth { .. }
-        )
-    )
+    existing == candidate
 }
 
 fn merge_credential_setup(
@@ -1608,7 +1599,7 @@ mod tests {
     }
 
     #[test]
-    fn bundled_google_credentials_project_single_oauth_setup_per_account() {
+    fn bundled_google_credentials_project_oauth_setup_per_declared_scope_set() {
         let catalog = AvailableExtensionCatalog::from_first_party_assets().unwrap();
 
         for extension_id in [
@@ -1665,17 +1656,21 @@ mod tests {
 
             assert_eq!(
                 google_requirements.len(),
-                1,
-                "{extension_id} lifecycle setup should show one Google OAuth request per account"
+                expected_setup_scopes.len(),
+                "{extension_id} lifecycle setup should show one Google OAuth request per distinct scope set"
             );
-            let requirement = google_requirements[0];
-            let LifecycleExtensionCredentialSetup::OAuth { scopes } = &requirement.setup else {
-                panic!("{extension_id} should expose Google OAuth setup");
-            };
-            assert_eq!(
-                scopes, &expected_setup_scopes,
-                "{extension_id} lifecycle setup should request the union of capability OAuth scopes once"
-            );
+            for (requirement, expected_scope) in
+                google_requirements.iter().zip(expected_setup_scopes.iter())
+            {
+                let LifecycleExtensionCredentialSetup::OAuth { scopes } = &requirement.setup else {
+                    panic!("{extension_id} should expose Google OAuth setup");
+                };
+                assert_eq!(
+                    scopes.as_slice(),
+                    std::slice::from_ref(expected_scope),
+                    "{extension_id} lifecycle setup should preserve each capability OAuth scope set"
+                );
+            }
             assert!(
                 credential_count > 0,
                 "{extension_id} should declare runtime credentials"

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -4515,7 +4515,7 @@ mod tests {
             )
             .await
             .expect("google setup extension lifecycle projection");
-        assert_eq!(google_setup.secrets.len(), 1);
+        assert_eq!(google_setup.secrets.len(), 2);
         let google_oauth_setups = google_setup
             .secrets
             .iter()
@@ -4539,10 +4539,10 @@ mod tests {
                 .iter()
                 .map(|(_, scopes)| scopes.clone())
                 .collect::<Vec<_>>(),
-            vec![vec![
-                GOOGLE_CALENDAR_READONLY_SCOPE.to_string(),
-                GOOGLE_CALENDAR_EVENTS_SCOPE.to_string(),
-            ]]
+            vec![
+                vec![GOOGLE_CALENDAR_READONLY_SCOPE.to_string()],
+                vec![GOOGLE_CALENDAR_EVENTS_SCOPE.to_string()],
+            ]
         );
         let google_setup_json =
             serde_json::to_value(&google_setup.secrets[0]).expect("serialize setup secret");

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -790,7 +790,7 @@ mod tests {
         let final_reply = wait_for_slack_post_message(&egress, "ok").await;
         assert_eq!(final_reply["channel"], "D0HOST");
         assert_eq!(final_reply["text"], "ok");
-        assert_eq!(final_reply["mrkdwn"], false);
+        assert_eq!(final_reply["mrkdwn"], true);
 
         runtime.shutdown().await.expect("runtime shuts down");
     }

--- a/crates/ironclaw_reborn_composition/tests/runtime.rs
+++ b/crates/ironclaw_reborn_composition/tests/runtime.rs
@@ -70,7 +70,7 @@ async fn stub_gateway_send_cancels_recovery_required_and_releases_conversation()
 
     let conversation = runtime.new_conversation().await.unwrap();
     let reply = tokio::time::timeout(
-        Duration::from_secs(2),
+        Duration::from_secs(10),
         runtime.send_user_message(&conversation, "hello"),
     )
     .await
@@ -84,7 +84,7 @@ async fn stub_gateway_send_cancels_recovery_required_and_releases_conversation()
     assert_eq!(reply.text, None);
 
     let second_reply = tokio::time::timeout(
-        Duration::from_secs(2),
+        Duration::from_secs(10),
         runtime.send_user_message(&conversation, "hello again"),
     )
     .await
@@ -168,13 +168,13 @@ async fn skill_execution_adapter_prepares_filesystem_bundles_end_to_end() {
     })
     .with_poll_settings(PollSettings {
         interval: Duration::from_millis(10),
-        max_total: Duration::from_secs(3),
+        max_total: Duration::from_secs(10),
     });
 
     let runtime = build_reborn_runtime(input).await.unwrap();
     let conversation = runtime.new_conversation().await.unwrap();
     let result = tokio::time::timeout(
-        Duration::from_secs(3),
+        Duration::from_secs(15),
         runtime.execute_skill_message(&conversation, "$filesystem-review"),
     )
     .await

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
@@ -47,6 +47,7 @@ const USER: &str = "user-alpha";
 const AGENT: &str = "agent-default";
 const PROJECT: &str = "project-default";
 const VALID_TOKEN: &str = "valid-bearer-token";
+const DISALLOWED_GOOGLE_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
 
 struct OnlyValidToken;
 
@@ -761,7 +762,7 @@ async fn product_auth_google_oauth_start_rejects_disallowed_scopes() {
 
     let invalid_requests = [
         google_oauth_start_body(json!({ "scopes": [] })),
-        google_oauth_start_body(json!({ "scopes": ["https://www.googleapis.com/auth/drive"] })),
+        google_oauth_start_body(json!({ "scopes": [DISALLOWED_GOOGLE_SCOPE] })),
     ];
 
     for body in invalid_requests {
@@ -769,7 +770,7 @@ async fn product_auth_google_oauth_start_rejects_disallowed_scopes() {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = read_body_string(response).await;
         assert!(body.contains("\"code\":\"invalid_request\""));
-        assert!(!body.contains("drive"));
+        assert!(!body.contains(DISALLOWED_GOOGLE_SCOPE));
     }
 }
 
@@ -944,7 +945,15 @@ async fn product_auth_manual_token_submit_has_per_caller_rate_limit() {
     for index in 0..20 {
         let response = post_manual_token_submit(
             &app,
-            manual_token_body(&format!("ghp_secret_{index}"), json!({})),
+            manual_token_body(
+                &format!("ghp_secret_{index}"),
+                json!({
+                    "account_label": format!("work github {index}"),
+                    "run_id": Uuid::from_u128((index + 1) as u128).to_string(),
+                    "gate_ref": format!("gate:auth-github-{index}"),
+                    "thread_id": format!("thread-auth-{index}")
+                }),
+            ),
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -1389,7 +1398,7 @@ async fn product_auth_google_oauth_callback_rejects_disallowed_scopes() {
     let response = app
         .clone()
         .oneshot(callback_request(format!(
-            "/api/reborn/product-auth/oauth/google/callback?state={state}&code=google-auth-code&scope=https://www.googleapis.com/auth/drive"
+            "/api/reborn/product-auth/oauth/google/callback?state={state}&code=google-auth-code&scope={DISALLOWED_GOOGLE_SCOPE}"
         )))
         .await
         .expect("oneshot");
@@ -1399,7 +1408,7 @@ async fn product_auth_google_oauth_callback_rejects_disallowed_scopes() {
     assert!(body.contains("\"code\":\"malformed_callback\""));
     assert!(!body.contains(&state));
     assert!(!body.contains("google-auth-code"));
-    assert!(!body.contains("drive"));
+    assert!(!body.contains(DISALLOWED_GOOGLE_SCOPE));
     assert!(dispatcher.events().is_empty());
 
     let replay_response = app
@@ -1568,24 +1577,6 @@ async fn product_auth_callback_malformed_fields_are_sanitized() {
     .await;
 
     let malformed_uris = [
-        format!(
-            "/api/reborn/product-auth/oauth/callback/{}?user_id={USER}&agent_id={AGENT}&project_id={PROJECT}&invocation_id={}&provider=github&account_label=work&code=missing-state-code",
-            started.flow_id, started.invocation_id
-        ),
-        callback_uri(
-            &started.flow_id,
-            &started.invocation_id,
-            USER,
-            "malformed-field-state",
-            "&account_label=work&code=missing-provider-code",
-        ),
-        callback_uri(
-            &started.flow_id,
-            &started.invocation_id,
-            USER,
-            "malformed-field-state",
-            "&provider=github&code=missing-label-code",
-        ),
         callback_uri(
             &started.flow_id,
             &started.invocation_id,
@@ -1613,20 +1604,6 @@ async fn product_auth_callback_malformed_fields_are_sanitized() {
             USER,
             "malformed-field-state",
             "&provider=github&account_label=work&code=bad-scopes-code&scopes=repo,,gist",
-        ),
-        callback_uri(
-            &started.flow_id,
-            &started.invocation_id,
-            USER,
-            "malformed-field-state",
-            "&provider=github&account_label=work&code=missing-scopes-code",
-        ),
-        callback_uri(
-            &started.flow_id,
-            &started.invocation_id,
-            USER,
-            "malformed-field-state",
-            "&provider=github&account_label=work&code=empty-scopes-code&scopes=",
         ),
     ];
 

--- a/scripts/ci/classify-test-scope.sh
+++ b/scripts/ci/classify-test-scope.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+has_core_code=false
+docs_only=true
+has_legacy_tests=false
+has_reborn_tests=false
+
+is_docs_only_path() {
+  local path="$1"
+  case "$path" in
+    docs/*|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md|*.md)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_shared_test_path() {
+  local path="$1"
+  case "$path" in
+    Cargo.toml|Cargo.lock|build.rs|providers.json|Dockerfile)
+      return 0
+      ;;
+    scripts/ci/classify-test-scope.sh|scripts/ci/test-classify-test-scope.sh)
+      return 0
+      ;;
+    .github/workflows/test.yml|.github/workflows/reborn-tests.yml|.github/workflows/reborn-integration.yml|.github/workflows/reborn-e2e.yml|.github/workflows/nightly-deep-ci.yml)
+      return 0
+      ;;
+    crates/ironclaw_common/*|crates/ironclaw_host_api/*|crates/ironclaw_host_runtime/*|crates/ironclaw_loop_support/*)
+      return 0
+      ;;
+    crates/ironclaw_filesystem/*|crates/ironclaw_memory/*|crates/ironclaw_events/*|crates/ironclaw_event_projections/*|crates/ironclaw_event_streams/*)
+      return 0
+      ;;
+    crates/ironclaw_capabilities/*|crates/ironclaw_secrets/*|crates/ironclaw_network/*|crates/ironclaw_runtime_policy/*)
+      return 0
+      ;;
+    crates/ironclaw_authorization/*|crates/ironclaw_run_state/*|crates/ironclaw_approvals/*|crates/ironclaw_resources/*)
+      return 0
+      ;;
+    crates/ironclaw_auth/*|crates/ironclaw_trust/*|crates/ironclaw_turns/*|crates/ironclaw_agent_loop/*|crates/ironclaw_threads/*)
+      return 0
+      ;;
+    crates/ironclaw_prompt_envelope/*|crates/ironclaw_hooks/*|crates/ironclaw_first_party_extensions/*|crates/ironclaw_llm/*)
+      return 0
+      ;;
+    crates/ironclaw_embeddings/*|crates/ironclaw_safety/*|crates/ironclaw_skills/*|crates/ironclaw_oauth/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_reborn_test_path() {
+  local path="$1"
+  case "$path" in
+    docs/reborn/*|scripts/reborn-e2e-rust.sh|tests/e2e/scenarios/test_reborn_gateway_smoke.py)
+      return 0
+      ;;
+    crates/ironclaw_architecture/*)
+      return 0
+      ;;
+    crates/ironclaw_reborn/*|crates/ironclaw_reborn_*/*)
+      return 0
+      ;;
+    crates/ironclaw_product_*/*|crates/ironclaw_slack_v2_adapter/*|crates/ironclaw_telegram_v2_adapter/*)
+      return 0
+      ;;
+    crates/ironclaw_wasm_product_adapters/*|crates/ironclaw_webui_v2/*|crates/ironclaw_webui_v2_static/*)
+      return 0
+      ;;
+    crates/ironclaw_conversations/*|crates/ironclaw_outbound/*|crates/ironclaw_triggers/*)
+      return 0
+      ;;
+    .github/workflows/reborn-tests.yml|.github/workflows/reborn-integration.yml|.github/workflows/reborn-e2e.yml)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_code_path() {
+  local path="$1"
+  case "$path" in
+    src/*|crates/*|channels-src/*|tools-src/*|tests/*|migrations/*)
+      return 0
+      ;;
+    Cargo.toml|Cargo.lock|Dockerfile|build.rs|providers.json)
+      return 0
+      ;;
+    scripts/check_no_panics.py|scripts/check_gateway_boundaries.py|scripts/build-wasm-extensions.sh|scripts/check-version-bumps.sh|scripts/reborn-e2e-rust.sh|scripts/ci/*)
+      return 0
+      ;;
+    .github/workflows/*.yml|.github/actions/install-cargo-component/*|.github/dependabot.yml|.github/labeler.yml)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+
+  if ! is_docs_only_path "$path"; then
+    docs_only=false
+  fi
+
+  if is_code_path "$path"; then
+    has_core_code=true
+  fi
+
+  if is_shared_test_path "$path"; then
+    has_legacy_tests=true
+    has_reborn_tests=true
+  elif is_reborn_test_path "$path"; then
+    has_reborn_tests=true
+  elif is_code_path "$path"; then
+    has_legacy_tests=true
+  fi
+done
+
+cat <<EOF
+docs_only=${docs_only}
+has_core_code=${has_core_code}
+has_legacy_tests=${has_legacy_tests}
+has_reborn_tests=${has_reborn_tests}
+EOF

--- a/scripts/ci/classify-test-scope.sh
+++ b/scripts/ci/classify-test-scope.sh
@@ -9,8 +9,14 @@ has_reborn_tests=false
 is_docs_only_path() {
   local path="$1"
   case "$path" in
-    docs/*|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md|*.md)
+    docs/*|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md)
       return 0
+      ;;
+    *.md)
+      case "$path" in
+        */*) return 1 ;;
+        *) return 0 ;;
+      esac
       ;;
     *)
       return 1
@@ -24,7 +30,7 @@ is_shared_test_path() {
     Cargo.toml|Cargo.lock|build.rs|providers.json|Dockerfile)
       return 0
       ;;
-    scripts/ci/classify-test-scope.sh|scripts/ci/test-classify-test-scope.sh)
+    scripts/ci/classify-test-scope.sh|scripts/ci/test-classify-test-scope.sh|scripts/ci/package-feature-flags.sh)
       return 0
       ;;
     .github/workflows/test.yml|.github/workflows/reborn-tests.yml|.github/workflows/reborn-integration.yml|.github/workflows/reborn-e2e.yml|.github/workflows/nightly-deep-ci.yml)
@@ -78,9 +84,6 @@ is_reborn_test_path() {
     crates/ironclaw_conversations/*|crates/ironclaw_outbound/*|crates/ironclaw_triggers/*)
       return 0
       ;;
-    .github/workflows/reborn-tests.yml|.github/workflows/reborn-integration.yml|.github/workflows/reborn-e2e.yml)
-      return 0
-      ;;
     *)
       return 1
       ;;
@@ -108,7 +111,7 @@ is_code_path() {
   esac
 }
 
-while IFS= read -r path; do
+while IFS= read -r path || [ -n "$path" ]; do
   [ -n "$path" ] || continue
 
   if ! is_docs_only_path "$path"; then

--- a/scripts/ci/package-feature-flags.sh
+++ b/scripts/ci/package-feature-flags.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <package>" >&2
+  exit 2
+fi
+
+case "$1" in
+  ironclaw_reborn_cli)
+    printf '%s\n' "--features webui-v2-beta,slack-v2-host-beta"
+    ;;
+  ironclaw_product_adapters)
+    printf '%s\n' "--features test-support,host-auth-mint"
+    ;;
+  ironclaw_product_workflow)
+    printf '%s\n' "--features test-support"
+    ;;
+  ironclaw_product_workflow_storage)
+    printf '%s\n' "--features libsql"
+    ;;
+  ironclaw_reborn_composition)
+    printf '%s\n' "--features test-support,webui-v2-beta,slack-v2-host-beta,libsql"
+    ;;
+  ironclaw_reborn)
+    printf '%s\n' "--features root-llm-provider,libsql-secrets,libsql-restart-tests,webui-user-store"
+    ;;
+  ironclaw_reborn_event_store)
+    printf '%s\n' "--features libsql"
+    ;;
+  ironclaw_reborn_webui_ingress)
+    printf '%s\n' "--features dev-in-memory-session"
+    ;;
+  ironclaw_webui_v2 | ironclaw_webui_v2_static)
+    printf '%s\n' "--features webui-v2-beta"
+    ;;
+  *)
+    ;;
+esac

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -22,6 +22,40 @@ assert_scope() {
   printf 'PASS %s\n' "$name"
 }
 
+assert_scope_no_trailing_newline() {
+  local name="$1"
+  local files="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(printf '%s' "$files" | "$classifier" | sort)"
+
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL %s\n' "$name" >&2
+    printf 'Expected:\n%s\n' "$expected" >&2
+    printf 'Actual:\n%s\n' "$actual" >&2
+    exit 1
+  fi
+
+  printf 'PASS %s\n' "$name"
+}
+
+assert_empty_scope() {
+  local expected="$1"
+  local actual
+
+  actual="$(printf '' | "$classifier" | sort)"
+
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL empty input\n' >&2
+    printf 'Expected:\n%s\n' "$expected" >&2
+    printf 'Actual:\n%s\n' "$actual" >&2
+    exit 1
+  fi
+
+  printf 'PASS empty input\n'
+}
+
 assert_scope \
   "reborn binary crate" \
   "crates/ironclaw_reborn_cli/src/main.rs" \
@@ -79,12 +113,58 @@ has_legacy_tests=true
 has_reborn_tests=true"
 
 assert_scope \
+  "shared classifier script" \
+  "scripts/ci/classify-test-scope.sh" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=true"
+
+assert_scope \
+  "shared package feature flags script" \
+  "scripts/ci/package-feature-flags.sh" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=true"
+
+assert_scope \
+  "shared reborn tests workflow" \
+  ".github/workflows/reborn-tests.yml" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=true"
+
+assert_scope \
+  "legacy code style workflow" \
+  ".github/workflows/code_style.yml" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=false"
+
+assert_scope \
   "docs only" \
   "README.md" \
   "docs_only=true
 has_core_code=false
 has_legacy_tests=false
 has_reborn_tests=false"
+
+assert_empty_scope \
+  "docs_only=true
+has_core_code=false
+has_legacy_tests=false
+has_reborn_tests=false"
+
+assert_scope \
+  "nested markdown is not docs only" \
+  "crates/ironclaw_reborn/CLAUDE.md" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
 
 assert_scope \
   "reborn docs only" \
@@ -101,4 +181,12 @@ crates/ironclaw_reborn_composition/src/lib.rs" \
   "docs_only=false
 has_core_code=true
 has_legacy_tests=true
+has_reborn_tests=true"
+
+assert_scope_no_trailing_newline \
+  "final path without trailing newline" \
+  "crates/ironclaw_reborn_cli/src/main.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
 has_reborn_tests=true"

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+classifier="${script_dir}/classify-test-scope.sh"
+
+assert_scope() {
+  local name="$1"
+  local files="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(printf '%s\n' "$files" | "$classifier" | sort)"
+
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL %s\n' "$name" >&2
+    printf 'Expected:\n%s\n' "$expected" >&2
+    printf 'Actual:\n%s\n' "$actual" >&2
+    exit 1
+  fi
+
+  printf 'PASS %s\n' "$name"
+}
+
+assert_scope \
+  "reborn binary crate" \
+  "crates/ironclaw_reborn_cli/src/main.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "reborn product storage crate" \
+  "crates/ironclaw_product_workflow_storage/src/lib.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "reborn v2 adapter crate" \
+  "crates/ironclaw_telegram_v2_adapter/src/lib.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "reborn support crate" \
+  "crates/ironclaw_outbound/src/lib.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "legacy root runtime" \
+  "src/agent/session.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=false"
+
+assert_scope \
+  "shared manifest" \
+  "Cargo.toml" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=true"
+
+assert_scope \
+  "shared substrate crate" \
+  "crates/ironclaw_host_runtime/src/lib.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=true"
+
+assert_scope \
+  "docs only" \
+  "README.md" \
+  "docs_only=true
+has_core_code=false
+has_legacy_tests=false
+has_reborn_tests=false"
+
+assert_scope \
+  "reborn docs only" \
+  "docs/reborn/harness/e2e.md" \
+  "docs_only=true
+has_core_code=false
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "mixed legacy and reborn" \
+  "src/agent/session.rs
+crates/ironclaw_reborn_composition/src/lib.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=true"


### PR DESCRIPTION
## Summary

- split the legacy `Run Tests` workflow into `Tests (Legacy)` while keeping a temporary `Run Tests` compatibility rollup for the current required check
- add a new `Tests (Reborn)` workflow that runs only when Reborn-scoped changes are detected
- add a shared CI scope classifier with self-tests for legacy, Reborn, shared, and docs-only changes
- expand the Reborn package matrix to cover the current Reborn/product/webui/v2 adapter crate surface, including feature flags that unskip Reborn tests
- align `reborn-integration.yml` with the expanded Reborn matrix and add targeted root Reborn parity smoke partitions
- set heavy matrices to fail fast while preserving parallel execution

## Why

Legacy `Run Tests` is currently a heavyweight required check and can block Reborn-only PRs even when the changed files are isolated to Reborn crates or tests. Reborn had its own branch workflow, but that matrix only followed direct `ironclaw_reborn_cli` dependencies plus a few hardcoded packages, so newer Reborn/product crates could be missed.

This keeps legacy coverage for legacy changes, adds a Reborn-specific lane for Reborn changes, and keeps broad Reborn E2E path triggers for rapid prototyping.

## Validation

- `scripts/ci/test-classify-test-scope.sh`
- parsed workflow YAML for `test.yml`, `code_style.yml`, `reborn-tests.yml`, `reborn-integration.yml`, and `reborn-e2e.yml`
- generated the Reborn package list via `cargo metadata` and `jq`
- `git diff --cached --check`

## Notes

After this lands, the ruleset can be updated to require `Tests (Legacy)` and `Tests (Reborn)` explicitly. The compatibility `Run Tests` rollup can be removed in a follow-up once branch protection no longer depends on the old check name.
