### PR TITLE
ci: skip hooks parity for Reborn-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,7 +238,7 @@ jobs:
   hooks-parity-tests:
     name: Hooks Predicate-Backend Parity Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_core_code == 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_legacy_tests == 'true' && needs.changes.outputs.has_core_code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:


### PR DESCRIPTION
## Summary
- gate Hooks Predicate-Backend Parity Tests on `has_legacy_tests`
- keep the legacy roll-up behavior unchanged for shared and legacy-scoped changes

## Verification
- `scripts/ci/test-classify-test-scope.sh`
- `git diff --check`

`actionlint` is not installed locally, so workflow validation was limited to the targeted YAML condition edit.