### PR TITLE
ci: keep Reborn-only PRs out of legacy tests

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -50,8 +50,9 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
 
           if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(src/|crates/|channels-src/|tools-src/|tests/|migrations/|Cargo\.toml$|Cargo\.lock$|Dockerfile$|build\.rs$|scripts/check_no_panics\.py$|scripts/check_gateway_boundaries\.py$|\.github/workflows/code_style\.yml$)'; then
             echo "has_code=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reborn-integration.yml
+++ b/.github/workflows/reborn-integration.yml
@@ -121,7 +121,7 @@ jobs:
             cargo test -p "${{ matrix.package }}" ${feature_flags} --all-targets -- --nocapture
 
   root-reborn-parity-tests:
-    name: Reborn parity tests (${{ matrix.group }})
+    name: Reborn root tests (${{ matrix.partition }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -130,16 +130,12 @@ jobs:
       LLM_USE_CODEX_AUTH: "false"
       OLLAMA_BASE_URL: ""
       OPENAI_API_KEY: ""
+      REBORN_ROOT_TEST_PARTITIONS: 4
+      REBORN_ROOT_TEST_PARTITION: ${{ matrix.partition }}
     strategy:
       fail-fast: true
       matrix:
-        include:
-          - group: scope-isolation
-            tests: "reborn_agent_scope_isolation_parity reborn_direct_chat_user_scope_isolation_parity reborn_wrong_scope_access_isolation_parity"
-          - group: trace-parity
-            tests: "reborn_approval_traces_parity reborn_trace_core_builtin_tools_parity reborn_trace_file_tools_parity"
-          - group: runtime-parity
-            tests: "reborn_minimal_dispatch_parity reborn_response_order_parity reborn_subagent_spawn_e2e"
+        partition: [0, 1, 2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -153,17 +149,39 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: reborn-integration-root-${{ matrix.group }}
+          key: reborn-integration-root-${{ matrix.partition }}
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/reborn-integration' }}
 
-      - name: Run Reborn root parity tests
+      - name: Run Reborn root tests
         run: |
-          for test_name in ${{ matrix.tests }}; do
+          mapfile -t test_names < <(
+            find tests -maxdepth 1 -type f -name 'reborn_*.rs' -print \
+              | sed -E 's#^tests/##; s#\.rs$##' \
+              | sort
+          )
+
+          if [ "${#test_names[@]}" -eq 0 ]; then
+            echo "No Reborn root tests discovered"
+            exit 1
+          fi
+
+          selected=false
+          for index in "${!test_names[@]}"; do
+            if (( index % REBORN_ROOT_TEST_PARTITIONS != REBORN_ROOT_TEST_PARTITION )); then
+              continue
+            fi
+
+            selected=true
+            test_name="${test_names[$index]}"
             echo "::group::cargo test --test ${test_name}"
             timeout --signal=INT --kill-after=30s 12m \
               cargo test --test "${test_name}" -- --nocapture
             echo "::endgroup::"
           done
+
+          if [ "${selected}" != true ]; then
+            echo "No Reborn root tests assigned to partition ${REBORN_ROOT_TEST_PARTITION}"
+          fi
 
   reborn-integration-crate-tests:
     name: Reborn Integration Binary Crate Tests
@@ -185,6 +203,6 @@ jobs:
             exit 1
           fi
           if [[ "${{ needs.root-reborn-parity-tests.result }}" != "success" ]]; then
-            echo "One or more Reborn root parity tests failed"
+            echo "One or more Reborn root tests failed"
             exit 1
           fi

--- a/.github/workflows/reborn-integration.yml
+++ b/.github/workflows/reborn-integration.yml
@@ -153,35 +153,7 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/reborn-integration' }}
 
       - name: Run Reborn root tests
-        run: |
-          mapfile -t test_names < <(
-            find tests -maxdepth 1 -type f -name 'reborn_*.rs' -print \
-              | sed -E 's#^tests/##; s#\.rs$##' \
-              | sort
-          )
-
-          if [ "${#test_names[@]}" -eq 0 ]; then
-            echo "No Reborn root tests discovered"
-            exit 1
-          fi
-
-          selected=false
-          for index in "${!test_names[@]}"; do
-            if (( index % REBORN_ROOT_TEST_PARTITIONS != REBORN_ROOT_TEST_PARTITION )); then
-              continue
-            fi
-
-            selected=true
-            test_name="${test_names[$index]}"
-            echo "::group::cargo test --test ${test_name}"
-            timeout --signal=INT --kill-after=30s 12m \
-              cargo test --test "${test_name}" -- --nocapture
-            echo "::endgroup::"
-          done
-
-          if [ "${selected}" != true ]; then
-            echo "No Reborn root tests assigned to partition ${REBORN_ROOT_TEST_PARTITION}"
-          fi
+        run: scripts/ci/run-reborn-root-partition.sh
 
   reborn-integration-crate-tests:
     name: Reborn Integration Binary Crate Tests

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -61,8 +61,9 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
 
           echo "Changed files:"
           if [ -n "$CHANGED_FILES" ]; then

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -198,35 +198,7 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Run Reborn root tests
-        run: |
-          mapfile -t test_names < <(
-            find tests -maxdepth 1 -type f -name 'reborn_*.rs' -print \
-              | sed -E 's#^tests/##; s#\.rs$##' \
-              | sort
-          )
-
-          if [ "${#test_names[@]}" -eq 0 ]; then
-            echo "No Reborn root tests discovered"
-            exit 1
-          fi
-
-          selected=false
-          for index in "${!test_names[@]}"; do
-            if (( index % REBORN_ROOT_TEST_PARTITIONS != REBORN_ROOT_TEST_PARTITION )); then
-              continue
-            fi
-
-            selected=true
-            test_name="${test_names[$index]}"
-            echo "::group::cargo test --test ${test_name}"
-            timeout --signal=INT --kill-after=30s 12m \
-              cargo test --test "${test_name}" -- --nocapture
-            echo "::endgroup::"
-          done
-
-          if [ "${selected}" != true ]; then
-            echo "No Reborn root tests assigned to partition ${REBORN_ROOT_TEST_PARTITION}"
-          fi
+        run: scripts/ci/run-reborn-root-partition.sh
 
   reborn-tests:
     name: Tests (Reborn)

--- a/.github/workflows/reborn-tests.yml
+++ b/.github/workflows/reborn-tests.yml
@@ -163,7 +163,7 @@ jobs:
             cargo test -p "${{ matrix.package }}" ${feature_flags} --all-targets -- --nocapture
 
   root-reborn-parity-tests:
-    name: Reborn parity tests (${{ matrix.group }})
+    name: Reborn root tests (${{ matrix.partition }})
     needs: changes
     if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_reborn_tests == 'true'
     runs-on: ubuntu-latest
@@ -174,16 +174,12 @@ jobs:
       LLM_USE_CODEX_AUTH: "false"
       OLLAMA_BASE_URL: ""
       OPENAI_API_KEY: ""
+      REBORN_ROOT_TEST_PARTITIONS: 4
+      REBORN_ROOT_TEST_PARTITION: ${{ matrix.partition }}
     strategy:
       fail-fast: true
       matrix:
-        include:
-          - group: scope-isolation
-            tests: "reborn_agent_scope_isolation_parity reborn_direct_chat_user_scope_isolation_parity reborn_wrong_scope_access_isolation_parity"
-          - group: trace-parity
-            tests: "reborn_approval_traces_parity reborn_trace_core_builtin_tools_parity reborn_trace_file_tools_parity"
-          - group: runtime-parity
-            tests: "reborn_minimal_dispatch_parity reborn_response_order_parity reborn_subagent_spawn_e2e"
+        partition: [0, 1, 2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -197,17 +193,39 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: reborn-tests-root-${{ matrix.group }}
+          key: reborn-tests-root-${{ matrix.partition }}
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-      - name: Run Reborn root parity tests
+      - name: Run Reborn root tests
         run: |
-          for test_name in ${{ matrix.tests }}; do
+          mapfile -t test_names < <(
+            find tests -maxdepth 1 -type f -name 'reborn_*.rs' -print \
+              | sed -E 's#^tests/##; s#\.rs$##' \
+              | sort
+          )
+
+          if [ "${#test_names[@]}" -eq 0 ]; then
+            echo "No Reborn root tests discovered"
+            exit 1
+          fi
+
+          selected=false
+          for index in "${!test_names[@]}"; do
+            if (( index % REBORN_ROOT_TEST_PARTITIONS != REBORN_ROOT_TEST_PARTITION )); then
+              continue
+            fi
+
+            selected=true
+            test_name="${test_names[$index]}"
             echo "::group::cargo test --test ${test_name}"
             timeout --signal=INT --kill-after=30s 12m \
               cargo test --test "${test_name}" -- --nocapture
             echo "::endgroup::"
           done
+
+          if [ "${selected}" != true ]; then
+            echo "No Reborn root tests assigned to partition ${REBORN_ROOT_TEST_PARTITION}"
+          fi
 
   reborn-tests:
     name: Tests (Reborn)
@@ -247,6 +265,6 @@ jobs:
           fi
 
           if [[ "${{ needs.root-reborn-parity-tests.result }}" != "success" ]]; then
-            echo "One or more Reborn root parity tests failed: ${{ needs.root-reborn-parity-tests.result }}"
+            echo "One or more Reborn root tests failed: ${{ needs.root-reborn-parity-tests.result }}"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,9 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
 
           echo "Changed files:"
           if [ -n "$CHANGED_FILES" ]; then

--- a/scripts/ci/classify-test-scope.sh
+++ b/scripts/ci/classify-test-scope.sh
@@ -66,7 +66,7 @@ is_shared_test_path() {
 is_reborn_test_path() {
   local path="$1"
   case "$path" in
-    docs/reborn/*|scripts/reborn-e2e-rust.sh|tests/reborn_*|tests/support/reborn/*|tests/e2e/scenarios/test_reborn_*)
+    docs/reborn/*|scripts/reborn-e2e-rust.sh|scripts/ci/run-reborn-root-partition.sh|tests/reborn_*|tests/support/reborn/*|tests/e2e/scenarios/test_reborn_*)
       return 0
       ;;
     crates/ironclaw_architecture/*)

--- a/scripts/ci/classify-test-scope.sh
+++ b/scripts/ci/classify-test-scope.sh
@@ -66,7 +66,7 @@ is_shared_test_path() {
 is_reborn_test_path() {
   local path="$1"
   case "$path" in
-    docs/reborn/*|scripts/reborn-e2e-rust.sh|tests/e2e/scenarios/test_reborn_gateway_smoke.py)
+    docs/reborn/*|scripts/reborn-e2e-rust.sh|tests/reborn_*|tests/support/reborn/*|tests/e2e/scenarios/test_reborn_*)
       return 0
       ;;
     crates/ironclaw_architecture/*)

--- a/scripts/ci/run-reborn-root-partition.sh
+++ b/scripts/ci/run-reborn-root-partition.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+partition_count="${REBORN_ROOT_TEST_PARTITIONS:?REBORN_ROOT_TEST_PARTITIONS must be set}"
+partition_index="${REBORN_ROOT_TEST_PARTITION:?REBORN_ROOT_TEST_PARTITION must be set}"
+
+if ! [[ "${partition_count}" =~ ^[0-9]+$ ]] || [ "${partition_count}" -lt 1 ]; then
+  echo "REBORN_ROOT_TEST_PARTITIONS must be a positive integer; got '${partition_count}'" >&2
+  exit 1
+fi
+
+partition_count_int=$((10#${partition_count}))
+
+if ! [[ "${partition_index}" =~ ^[0-9]+$ ]]; then
+  echo "REBORN_ROOT_TEST_PARTITION must be an integer in [0, ${partition_count_int}); got '${partition_index}'" >&2
+  exit 1
+fi
+
+partition_index_int=$((10#${partition_index}))
+
+if [ "${partition_index_int}" -ge "${partition_count_int}" ]; then
+  echo "REBORN_ROOT_TEST_PARTITION must be an integer in [0, ${partition_count}); got '${partition_index}'" >&2
+  exit 1
+fi
+
+mapfile -t test_names < <(
+  {
+    find tests -maxdepth 1 -type f -name 'reborn_*.rs' -print
+    if [ -f tests/support_unit_tests.rs ]; then
+      printf '%s\n' tests/support_unit_tests.rs
+    fi
+  } \
+    | sed -E 's#^tests/##; s#\.rs$##' \
+    | LC_ALL=C sort
+)
+
+if [ "${#test_names[@]}" -eq 0 ]; then
+  echo "No Reborn root tests discovered" >&2
+  exit 1
+fi
+
+selected=false
+for index in "${!test_names[@]}"; do
+  if (( index % partition_count_int != partition_index_int )); then
+    continue
+  fi
+
+  selected=true
+  test_name="${test_names[$index]}"
+  echo "::group::cargo test --test ${test_name}"
+  timeout --signal=INT --kill-after=30s 12m \
+    cargo test --test "${test_name}" -- --nocapture
+  echo "::endgroup::"
+done
+
+if [ "${selected}" != true ]; then
+  # Empty partitions are valid when the matrix has more partitions than tests
+  # or when the sorted test list leaves a sparse tail for this partition.
+  echo "No Reborn root tests assigned to partition ${partition_index_int} of ${partition_count_int}; passing by design"
+fi

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -89,6 +89,14 @@ has_legacy_tests=false
 has_reborn_tests=true"
 
 assert_scope \
+  "reborn root test runner script" \
+  "scripts/ci/run-reborn-root-partition.sh" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
   "reborn root tests and support" \
   "tests/reborn_qa_smoke_scenarios_e2e.rs
 tests/support/reborn/harness.rs
@@ -97,6 +105,22 @@ tests/e2e/scenarios/test_reborn_gateway_smoke.py" \
 has_core_code=true
 has_legacy_tests=false
 has_reborn_tests=true"
+
+assert_scope \
+  "reborn e2e scenario" \
+  "tests/e2e/scenarios/test_reborn_scope_isolation.py" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "legacy e2e scenario" \
+  "tests/e2e/scenarios/test_live_flow.py" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=false"
 
 assert_scope \
   "mixed legacy and reborn root tests" \

--- a/scripts/ci/test-classify-test-scope.sh
+++ b/scripts/ci/test-classify-test-scope.sh
@@ -89,6 +89,25 @@ has_legacy_tests=false
 has_reborn_tests=true"
 
 assert_scope \
+  "reborn root tests and support" \
+  "tests/reborn_qa_smoke_scenarios_e2e.rs
+tests/support/reborn/harness.rs
+tests/e2e/scenarios/test_reborn_gateway_smoke.py" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=false
+has_reborn_tests=true"
+
+assert_scope \
+  "mixed legacy and reborn root tests" \
+  "tests/e2e_live.rs
+tests/reborn_trace_first_party_tool_coverage.rs" \
+  "docs_only=false
+has_core_code=true
+has_legacy_tests=true
+has_reborn_tests=true"
+
+assert_scope \
   "legacy root runtime" \
   "src/agent/session.rs" \
   "docs_only=false


### PR DESCRIPTION
## Summary
- classify root Reborn tests, Reborn test support, and Reborn E2E scenarios as Reborn scope instead of legacy scope
- make Reborn CI discover all root tests/reborn_*.rs targets dynamically across 4 partitions
- compute PR scope from pull_request.head.sha instead of the synthetic merge ref to avoid stale base merge refs pulling unrelated legacy paths into scope

## Recent PR audit
- #4517, #4506, #4486, #4448, #4394: current Reborn-only diffs had no heavy legacy jobs in latest checks
- #4511, #4493, #4460: heavy legacy jobs shown in latest checks, but those runs predate the #4513 CI split merge at 2026-06-06T08:05:35Z
- #4518: post-split regression. Current diff is Reborn root tests/support only, but the legacy run at 2026-06-06T11:42Z scheduled Tests (all-features), Secret Store Contract Tests, and Hooks Predicate-Backend Parity Tests. This patch covers both the missed Reborn test path rules and the stale synthetic-merge diff source.

## Verification
- scripts/ci/test-classify-test-scope.sh
- ruby -e "require \"yaml\"; %w[.github/workflows/test.yml .github/workflows/reborn-tests.yml .github/workflows/reborn-integration.yml .github/workflows/code_style.yml].each { |path| YAML.load_file(path) }"
- PR #4518 file list classifies as has_legacy_tests=false, has_reborn_tests=true
- root Reborn discovery finds 23 current tests/reborn_*.rs targets across 4 partitions
- git diff --check