### PR TITLE
Add JSON cleaner for formatting and sanitization

### DIFF
--- a/src/tools/src/skills/json_cleaner.rs
+++ b/src/tools/src/skills/json_cleaner.rs
@@ -1,0 +1,40 @@
+use serde_json::{Value, Map};
+use std::fs;
+
+/// IronClaw Custom Skill: Cleans and formats messy or scraped JSON data payloads 
+/// within the agent's sandboxed local workspace filesystem.
+pub fn clean_workspace_json(file_path: &str) -> Result<String, String> {
+    // Read the file securely from the workspace path
+    let data = fs::read_to_string(file_path)
+        .map_err(|e| format!("Failed to read workspace file: {}", e))?;
+        
+    // Parse the data framework into a structural JSON value
+    let mut json_value: Value = serde_json::from_str(&data)
+        .map_err(|e| format!("Invalid JSON syntax or structure: {}", e))?;
+
+    // Execute recursive sanitization if the root item is a JSON object
+    if let Value::Object(ref mut map) = json_value {
+        clean_map(map);
+    }
+
+    // Serialize back into pretty-printed, standardized spacing format
+    let cleaned_data = serde_json::to_string_pretty(&json_value)
+        .map_err(|e| format!("Failed to serialize clean JSON: {}", e))?;
+
+    Ok(cleaned_data)
+}
+
+/// Recursive helper function to strip out null keys and empty strings to optimize context windows
+fn clean_map(map: &mut Map<String, Value>) {
+    map.retain(|_, v| {
+        match v {
+            Value::Null => false, // Strip out nulls
+            Value::String(s) => !s.trim().is_empty(), // Strip out blank text
+            Value::Object(ref mut nested_map) => {
+                clean_map(nested_map);
+                !nested_map.is_empty() // Remove nested maps if they become empty
+            }
+            _ => true, // Keep numbers, booleans, and arrays
+        }
+    });
+}

--- a/src/tools/src/skills/json_cleaner.rs
+++ b/src/tools/src/skills/json_cleaner.rs
@@ -1,11 +1,18 @@
 use serde_json::{Value, Map};
 use std::fs;
+use std::path::Path;
 
 /// IronClaw Custom Skill: Cleans and formats messy or scraped JSON data payloads 
 /// within the agent's sandboxed local workspace filesystem.
 pub fn clean_workspace_json(file_path: &str) -> Result<String, String> {
+    // SECURITY GUARD: Prevent path traversal vulnerabilities
+    let path = Path::new(file_path);
+    if path.components().any(|c| c == std::path::Component::ParentDir) {
+        return Err("Security Error: Path traversal attempt detected. Access denied.".to_string());
+    }
+
     // Read the file securely from the workspace path
-    let data = fs::read_to_string(file_path)
+    let data = fs::read_to_string(path)
         .map_err(|e| format!("Failed to read workspace file: {}", e))?;
         
     // Parse the data framework into a structural JSON value


### PR DESCRIPTION
Implement a JSON cleaner that sanitizes messy JSON data by removing null keys and empty strings, and formats the output.

## Summary

<!-- 2-5 bullet points: what changed and why -->

-

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Reborn Trust-Boundary Checklist

<!-- Required for Reborn/security/runtime/DB changes. Write "N/A" with reason if not relevant. -->

- [ ] Public policy/evidence/trust-bearing types: who can construct them?
- [ ] Untrusted content enters prompts only through an envelope/escaping primitive.
- [ ] Hashes declare purpose; trust/binding/authenticity uses SHA-256/BLAKE3 or separate authenticity check.
- [ ] New/changed status, exit, policy, runtime, or error variants: downstream match sites audited. Command/output:
- [ ] Security/durability `serde(default)` fields fail closed or have migration tests.
- [ ] Queues/maps/buffers/counters have bounds and overflow-safe arithmetic.
- [ ] Driver/operator-visible errors have stable class semantics (`Transient`, `Permanent`, `Misconfigured`, `PolicyDenied` or equivalent).
- [ ] Sandbox/native/host names accurately describe trust boundary.

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
