### PR TITLE
feat(reborn): add outbound preference facade

### DIFF
--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -54,6 +54,11 @@ use ironclaw_host_runtime::{
 };
 #[cfg(feature = "libsql")]
 use ironclaw_loop_support::FilesystemCheckpointStateStore;
+use ironclaw_outbound::CommunicationPreferenceRepository;
+#[cfg(feature = "libsql")]
+use ironclaw_outbound::FilesystemOutboundStateStore;
+#[cfg(not(feature = "libsql"))]
+use ironclaw_outbound::InMemoryOutboundStateStore;
 use ironclaw_processes::ProcessServices;
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
 use ironclaw_resources::InMemoryResourceGovernor;
@@ -343,6 +348,7 @@ pub(crate) struct RebornLocalRuntimeServices {
     pub(crate) capability_leases: Arc<LocalDevCapabilityLeaseStore>,
     pub(crate) turn_state: Arc<LocalDevTurnStateStore>,
     pub(crate) trigger_repository: Arc<dyn TriggerRepository>,
+    pub(crate) outbound_preferences: Arc<dyn CommunicationPreferenceRepository>,
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     pub(crate) trigger_conversation_services: InMemoryConversationServices,
     #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -947,11 +953,13 @@ fn build_local_dev_store_graph(
     let host_state_filesystem = local_dev_slack_host_state_filesystem(Arc::clone(&filesystem));
     let skill_management =
         build_local_skill_management_port(owner_user_id, Arc::clone(&filesystem))?;
+    let outbound_preferences = local_dev_outbound_preferences(Arc::clone(&filesystem));
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
         turn_state: Arc::clone(&turn_state),
         trigger_repository: Arc::clone(&trigger_repository),
+        outbound_preferences,
         #[cfg(not(any(feature = "libsql", feature = "postgres")))]
         trigger_conversation_services,
         #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1052,11 +1060,13 @@ fn build_local_dev_store_graph(
         build_local_skill_management_port(owner_user_id, Arc::clone(&filesystem))?;
     #[cfg(not(any(feature = "libsql", feature = "postgres")))]
     let trigger_conversation_services = local_dev_trigger_conversation_services();
+    let outbound_preferences = local_dev_outbound_preferences(Arc::clone(&filesystem));
     let local_runtime = Arc::new(RebornLocalRuntimeServices {
         approval_requests: Arc::clone(&approval_requests),
         capability_leases: Arc::clone(&capability_leases),
         turn_state: Arc::clone(&turn_state),
         trigger_repository: Arc::clone(&trigger_repository),
+        outbound_preferences,
         #[cfg(not(any(feature = "libsql", feature = "postgres")))]
         trigger_conversation_services,
         #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -1622,6 +1632,22 @@ fn local_dev_scoped_filesystem(
     filesystem: Arc<LocalDevRootFilesystem>,
 ) -> Arc<ScopedFilesystem<LocalDevRootFilesystem>> {
     crate::wrap_scoped(filesystem)
+}
+
+#[cfg(feature = "libsql")]
+fn local_dev_outbound_preferences(
+    filesystem: Arc<LocalDevRootFilesystem>,
+) -> Arc<dyn CommunicationPreferenceRepository> {
+    Arc::new(FilesystemOutboundStateStore::new(
+        local_dev_scoped_filesystem(filesystem),
+    ))
+}
+
+#[cfg(not(feature = "libsql"))]
+fn local_dev_outbound_preferences(
+    _filesystem: Arc<LocalDevRootFilesystem>,
+) -> Arc<dyn CommunicationPreferenceRepository> {
+    Arc::new(InMemoryOutboundStateStore::default())
 }
 
 #[cfg(all(
@@ -2764,6 +2790,7 @@ mod tests {
             capability_leases: Arc::clone(&base_runtime.capability_leases),
             turn_state: Arc::clone(&base_runtime.turn_state),
             trigger_repository: Arc::clone(&base_runtime.trigger_repository),
+            outbound_preferences: Arc::clone(&base_runtime.outbound_preferences),
             #[cfg(not(any(feature = "libsql", feature = "postgres")))]
             trigger_conversation_services: base_runtime.trigger_conversation_services.clone(),
             #[cfg(any(feature = "libsql", feature = "postgres"))]

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -63,6 +63,7 @@ mod oauth_dcr;
 mod oauth_dcr_protocol;
 mod oauth_gate;
 mod oauth_provider_client;
+mod outbound_preferences;
 mod product_auth_durable;
 mod product_auth_providers;
 mod product_auth_runtime_credentials;

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -171,7 +171,7 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             updated_by: caller.user_id.clone(),
         };
         self.preferences
-            .put_communication_preference(record.clone())
+            .put_communication_preference(record)
             .await
             .map_err(map_outbound_repository_error)?;
         Ok(RebornOutboundPreferencesResponse {

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_outbound::{
-    CommunicationModality, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, OutboundError,
+    CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
+    OutboundError,
 };
 use ironclaw_product_workflow::{
     OutboundPreferencesProductFacade, RebornOutboundDeliveryModality,
@@ -47,6 +47,16 @@ impl OutboundDeliveryTargetInventory for EmptyOutboundDeliveryTargetInventory {
 pub(crate) struct RebornOutboundPreferencesFacade {
     preferences: Arc<dyn CommunicationPreferenceRepository>,
     targets: Arc<dyn OutboundDeliveryTargetInventory>,
+}
+
+impl std::fmt::Debug for RebornOutboundPreferencesFacade {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RebornOutboundPreferencesFacade")
+            .field("preferences", &"Arc<dyn CommunicationPreferenceRepository>")
+            .field("targets", &"Arc<dyn OutboundDeliveryTargetInventory>")
+            .finish()
+    }
 }
 
 impl RebornOutboundPreferencesFacade {
@@ -136,19 +146,17 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             .load_communication_preference(key)
             .await
             .map_err(map_outbound_repository_error)?;
-        let final_reply_target = match request.final_reply_target_id.as_ref() {
-            Some(target_id) => Some(
-                self.resolve_final_reply_target(&caller, target_id)
-                    .await?
-                    .reply_target_binding_ref,
-            ),
+        let resolved_final_reply_target = match request.final_reply_target_id.as_ref() {
+            Some(target_id) => Some(self.resolve_final_reply_target(&caller, target_id).await?),
             None => None,
         };
         let now = Utc::now();
         let record = CommunicationPreferenceRecord {
             tenant_id: caller.tenant_id.clone(),
             user_id: caller.user_id.clone(),
-            final_reply_target,
+            final_reply_target: resolved_final_reply_target
+                .as_ref()
+                .map(|entry| entry.reply_target_binding_ref.clone()),
             progress_target: existing
                 .as_ref()
                 .and_then(|record| record.progress_target.clone()),
@@ -158,10 +166,7 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             auth_prompt_target: existing
                 .as_ref()
                 .and_then(|record| record.auth_prompt_target.clone()),
-            default_modality: existing
-                .as_ref()
-                .and_then(|record| record.default_modality)
-                .or(Some(CommunicationModality::Text)),
+            default_modality: existing.as_ref().and_then(|record| record.default_modality),
             updated_at: now,
             updated_by: caller.user_id.clone(),
         };
@@ -169,7 +174,10 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             .put_communication_preference(record.clone())
             .await
             .map_err(map_outbound_repository_error)?;
-        self.response_for_record(&caller, Some(&record)).await
+        Ok(RebornOutboundPreferencesResponse {
+            final_reply_target: resolved_final_reply_target.map(|entry| entry.summary),
+            default_modality: RebornOutboundDeliveryModality::Text,
+        })
     }
 
     async fn list_outbound_delivery_targets(
@@ -209,7 +217,6 @@ fn map_outbound_repository_error(error: OutboundError) -> RebornServicesError {
     match error {
         OutboundError::InvalidRequest { .. }
         | OutboundError::SubscriptionScopeMismatch
-        | OutboundError::AccessDenied
         | OutboundError::DeliveryNotFound => RebornServicesError {
             code: RebornServicesErrorCode::InvalidRequest,
             kind: RebornServicesErrorKind::Validation,
@@ -218,16 +225,30 @@ fn map_outbound_repository_error(error: OutboundError) -> RebornServicesError {
             field: None,
             validation_code: None,
         },
-        OutboundError::Backend | OutboundError::Serialization | OutboundError::CasConflict => {
-            RebornServicesError {
-                code: RebornServicesErrorCode::Unavailable,
-                kind: RebornServicesErrorKind::ServiceUnavailable,
-                status_code: 503,
-                retryable: true,
-                field: None,
-                validation_code: None,
-            }
-        }
+        OutboundError::AccessDenied => RebornServicesError {
+            code: RebornServicesErrorCode::Forbidden,
+            kind: RebornServicesErrorKind::ParticipantDenied,
+            status_code: 403,
+            retryable: false,
+            field: None,
+            validation_code: None,
+        },
+        OutboundError::CasConflict => RebornServicesError {
+            code: RebornServicesErrorCode::Conflict,
+            kind: RebornServicesErrorKind::Conflict,
+            status_code: 409,
+            retryable: false,
+            field: None,
+            validation_code: None,
+        },
+        OutboundError::Backend | OutboundError::Serialization => RebornServicesError {
+            code: RebornServicesErrorCode::Unavailable,
+            kind: RebornServicesErrorKind::ServiceUnavailable,
+            status_code: 503,
+            retryable: true,
+            field: None,
+            validation_code: None,
+        },
     }
 }
 
@@ -236,7 +257,9 @@ mod tests {
     use std::{collections::HashMap, sync::Mutex};
 
     use ironclaw_host_api::{TenantId, UserId};
-    use ironclaw_outbound::{CommunicationPreferenceRepository, InMemoryOutboundStateStore};
+    use ironclaw_outbound::{
+        CommunicationModality, CommunicationPreferenceRepository, InMemoryOutboundStateStore,
+    };
 
     use super::*;
 
@@ -269,6 +292,44 @@ mod tests {
                 .get(caller.user_id.as_str())
                 .cloned()
                 .unwrap_or_default())
+        }
+    }
+
+    struct LoadFailingPreferenceRepository;
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for LoadFailingPreferenceRepository {
+        async fn put_communication_preference(
+            &self,
+            _record: CommunicationPreferenceRecord,
+        ) -> Result<(), OutboundError> {
+            Ok(())
+        }
+
+        async fn load_communication_preference(
+            &self,
+            _key: CommunicationPreferenceKey,
+        ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+            Err(OutboundError::Backend)
+        }
+    }
+
+    struct PutFailingPreferenceRepository;
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for PutFailingPreferenceRepository {
+        async fn put_communication_preference(
+            &self,
+            _record: CommunicationPreferenceRecord,
+        ) -> Result<(), OutboundError> {
+            Err(OutboundError::Backend)
+        }
+
+        async fn load_communication_preference(
+            &self,
+            _key: CommunicationPreferenceKey,
+        ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+            Ok(None)
         }
     }
 
@@ -307,6 +368,42 @@ mod tests {
             .await
             .expect("other user preferences");
         assert!(other_user.final_reply_target.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_preferences_returns_none_when_stored_target_not_in_inventory() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        let inventory = Arc::new(FakeTargetInventory::default());
+        seed_record(
+            store.as_ref(),
+            "tenant-alpha",
+            "user-alpha",
+            Some(reply_ref("reply:slack-alpha")),
+        )
+        .await;
+        let facade = RebornOutboundPreferencesFacade::new(store, inventory);
+
+        let response = facade
+            .get_outbound_preferences(caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect("preferences response");
+
+        assert!(response.final_reply_target.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_preferences_maps_backend_read_error_to_unavailable() {
+        let facade = RebornOutboundPreferencesFacade::new(
+            Arc::new(LoadFailingPreferenceRepository),
+            Arc::new(FakeTargetInventory::default()),
+        );
+
+        let error = facade
+            .get_outbound_preferences(caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect_err("backend read failure");
+
+        assert_unavailable_backend_error(error);
     }
 
     #[tokio::test]
@@ -351,6 +448,7 @@ mod tests {
                 .map(|target| target.as_str()),
             Some("reply:slack-alpha")
         );
+        assert!(stored.default_modality.is_none());
 
         let error = facade
             .set_outbound_preferences(
@@ -363,6 +461,31 @@ mod tests {
             .expect_err("reject unknown target");
         assert_eq!(error.code, RebornServicesErrorCode::NotFound);
         assert_eq!(error.field.as_deref(), Some("final_reply_target_id"));
+    }
+
+    #[tokio::test]
+    async fn set_preferences_maps_backend_write_error_to_unavailable() {
+        let inventory = Arc::new(FakeTargetInventory::default());
+        inventory.insert(
+            "user-alpha",
+            target_entry("slack-alpha", "reply:slack-alpha", true),
+        );
+        let facade = RebornOutboundPreferencesFacade::new(
+            Arc::new(PutFailingPreferenceRepository),
+            inventory,
+        );
+
+        let error = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target_id("slack-alpha")),
+                },
+            )
+            .await
+            .expect_err("backend write failure");
+
+        assert_unavailable_backend_error(error);
     }
 
     #[tokio::test]
@@ -448,6 +571,31 @@ mod tests {
         assert_eq!(response.targets.len(), 1);
         assert_eq!(response.targets[0].target.target_id.as_str(), "slack-alpha");
         assert!(response.next_cursor.is_none());
+    }
+
+    #[test]
+    fn repository_error_mapping_distinguishes_authority_conflict_and_backend_errors() {
+        let access_denied = map_outbound_repository_error(OutboundError::AccessDenied);
+        assert_eq!(access_denied.code, RebornServicesErrorCode::Forbidden);
+        assert_eq!(
+            access_denied.kind,
+            RebornServicesErrorKind::ParticipantDenied
+        );
+        assert_eq!(access_denied.status_code, 403);
+        assert!(!access_denied.retryable);
+
+        let cas_conflict = map_outbound_repository_error(OutboundError::CasConflict);
+        assert_eq!(cas_conflict.code, RebornServicesErrorCode::Conflict);
+        assert_eq!(cas_conflict.kind, RebornServicesErrorKind::Conflict);
+        assert_eq!(cas_conflict.status_code, 409);
+        assert!(!cas_conflict.retryable);
+    }
+
+    fn assert_unavailable_backend_error(error: RebornServicesError) {
+        assert_eq!(error.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(error.kind, RebornServicesErrorKind::ServiceUnavailable);
+        assert_eq!(error.status_code, 503);
+        assert!(error.retryable);
     }
 
     fn target_entry(

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -295,6 +295,25 @@ mod tests {
         }
     }
 
+    struct FailingTargetInventory;
+
+    #[async_trait]
+    impl OutboundDeliveryTargetInventory for FailingTargetInventory {
+        async fn list_outbound_delivery_targets(
+            &self,
+            _caller: &WebUiAuthenticatedCaller,
+        ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+            Err(RebornServicesError {
+                code: RebornServicesErrorCode::Unavailable,
+                kind: RebornServicesErrorKind::ServiceUnavailable,
+                status_code: 503,
+                retryable: true,
+                field: None,
+                validation_code: None,
+            })
+        }
+    }
+
     struct LoadFailingPreferenceRepository;
 
     #[async_trait]
@@ -486,6 +505,67 @@ mod tests {
             .expect_err("backend write failure");
 
         assert_unavailable_backend_error(error);
+    }
+
+    #[tokio::test]
+    async fn set_preferences_maps_backend_read_error_before_resolving_target() {
+        let inventory = Arc::new(FakeTargetInventory::default());
+        inventory.insert(
+            "user-alpha",
+            target_entry("slack-alpha", "reply:slack-alpha", true),
+        );
+        let facade = RebornOutboundPreferencesFacade::new(
+            Arc::new(LoadFailingPreferenceRepository),
+            inventory,
+        );
+
+        let error = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target_id("slack-alpha")),
+                },
+            )
+            .await
+            .expect_err("backend read failure");
+
+        assert_unavailable_backend_error(error);
+    }
+
+    #[tokio::test]
+    async fn target_inventory_errors_are_propagated_by_get_set_and_list() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        seed_record(
+            store.as_ref(),
+            "tenant-alpha",
+            "user-alpha",
+            Some(reply_ref("reply:slack-alpha")),
+        )
+        .await;
+        let facade = RebornOutboundPreferencesFacade::new(store, Arc::new(FailingTargetInventory));
+
+        let get_error = facade
+            .get_outbound_preferences(caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect_err("get target inventory failure");
+        assert_unavailable_backend_error(get_error);
+
+        let set_error = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target_id("slack-alpha")),
+                },
+            )
+            .await
+            .expect_err("set target inventory failure");
+        assert_unavailable_backend_error(set_error);
+
+        let list_error = facade
+            .list_outbound_delivery_targets(caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect_err("list target inventory failure");
+        assert_unavailable_backend_error(list_error);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -91,13 +91,11 @@ impl RebornOutboundPreferencesFacade {
         caller: &WebUiAuthenticatedCaller,
         target: &ReplyTargetBindingRef,
     ) -> Result<Option<RebornOutboundDeliveryTargetSummary>, RebornServicesError> {
-        let targets = self.targets.list_outbound_delivery_targets(caller).await?;
-        Ok(targets
-            .into_iter()
-            .find(|entry| {
-                entry.capabilities.final_replies
-                    && entry.reply_target_binding_ref.as_str() == target.as_str()
+        Ok(self
+            .find_target_entry(caller, |entry| {
+                entry.reply_target_binding_ref.as_str() == target.as_str()
             })
+            .await?
             .map(|entry| entry.summary))
     }
 
@@ -106,16 +104,28 @@ impl RebornOutboundPreferencesFacade {
         caller: &WebUiAuthenticatedCaller,
         target_id: &RebornOutboundDeliveryTargetId,
     ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
-        let targets = self.targets.list_outbound_delivery_targets(caller).await?;
-        targets
-            .into_iter()
-            .find(|entry| {
-                entry.capabilities.final_replies
-                    && entry.summary.target_id.as_str() == target_id.as_str()
-            })
-            .ok_or_else(outbound_target_not_found)
+        self.find_target_entry(caller, |entry| {
+            entry.summary.target_id.as_str() == target_id.as_str()
+        })
+        .await?
+        .ok_or_else(outbound_target_not_found)
     }
 
+    async fn find_target_entry(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        predicate: impl Fn(&OutboundDeliveryTargetEntry) -> bool,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        let targets = self.targets.list_outbound_delivery_targets(caller).await?;
+        Ok(targets
+            .into_iter()
+            .find(|entry| entry.capabilities.final_replies && predicate(entry)))
+    }
+
+    /// Invariant: `WebUiAuthenticatedCaller` must come from the authenticated
+    /// product/session boundary, never from request-body tenant/user fields.
+    /// This key and target-inventory scope intentionally share the same
+    /// verified caller identity.
     fn key(caller: &WebUiAuthenticatedCaller) -> CommunicationPreferenceKey {
         CommunicationPreferenceKey::new(caller.tenant_id.clone(), caller.user_id.clone())
     }
@@ -533,6 +543,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_preferences_with_none_target_on_new_user_creates_empty_record() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        let inventory = Arc::new(FakeTargetInventory::default());
+        let facade = RebornOutboundPreferencesFacade::new(store.clone(), inventory);
+
+        let response = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-new"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: None,
+                },
+            )
+            .await
+            .expect("new-user clear");
+
+        assert!(response.final_reply_target.is_none());
+        let stored = store
+            .load_communication_preference(CommunicationPreferenceKey::new(
+                tenant("tenant-alpha"),
+                user("user-new"),
+            ))
+            .await
+            .expect("load stored record")
+            .expect("stored record");
+        assert!(stored.final_reply_target.is_none());
+        assert!(stored.progress_target.is_none());
+        assert!(stored.approval_prompt_target.is_none());
+        assert!(stored.auth_prompt_target.is_none());
+        assert!(stored.default_modality.is_none());
+    }
+
+    #[tokio::test]
     async fn target_inventory_errors_are_propagated_by_get_set_and_list() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
         seed_record(
@@ -655,6 +697,18 @@ mod tests {
 
     #[test]
     fn repository_error_mapping_distinguishes_authority_conflict_and_backend_errors() {
+        for invalid_request_error in [
+            OutboundError::InvalidRequest { reason: "bad" },
+            OutboundError::SubscriptionScopeMismatch,
+            OutboundError::DeliveryNotFound,
+        ] {
+            let mapped = map_outbound_repository_error(invalid_request_error);
+            assert_eq!(mapped.code, RebornServicesErrorCode::InvalidRequest);
+            assert_eq!(mapped.kind, RebornServicesErrorKind::Validation);
+            assert_eq!(mapped.status_code, 400);
+            assert!(!mapped.retryable);
+        }
+
         let access_denied = map_outbound_repository_error(OutboundError::AccessDenied);
         assert_eq!(access_denied.code, RebornServicesErrorCode::Forbidden);
         assert_eq!(
@@ -669,6 +723,9 @@ mod tests {
         assert_eq!(cas_conflict.kind, RebornServicesErrorKind::Conflict);
         assert_eq!(cas_conflict.status_code, 409);
         assert!(!cas_conflict.retryable);
+
+        let serialization = map_outbound_repository_error(OutboundError::Serialization);
+        assert_unavailable_backend_error(serialization);
     }
 
     fn assert_unavailable_backend_error(error: RebornServicesError) {

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -1,0 +1,516 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_outbound::{
+    CommunicationModality, CommunicationPreferenceKey, CommunicationPreferenceRecord,
+    CommunicationPreferenceRepository, OutboundError,
+};
+use ironclaw_product_workflow::{
+    OutboundPreferencesProductFacade, RebornOutboundDeliveryModality,
+    RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
+    RebornOutboundDeliveryTargetListResponse, RebornOutboundDeliveryTargetOption,
+    RebornOutboundDeliveryTargetSummary, RebornOutboundPreferencesResponse, RebornServicesError,
+    RebornServicesErrorCode, RebornServicesErrorKind, RebornSetOutboundPreferencesRequest,
+    WebUiAuthenticatedCaller,
+};
+use ironclaw_turns::ReplyTargetBindingRef;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OutboundDeliveryTargetEntry {
+    pub(crate) summary: RebornOutboundDeliveryTargetSummary,
+    pub(crate) capabilities: RebornOutboundDeliveryTargetCapabilities,
+    pub(crate) reply_target_binding_ref: ReplyTargetBindingRef,
+}
+
+#[async_trait]
+pub(crate) trait OutboundDeliveryTargetInventory: Send + Sync {
+    async fn list_outbound_delivery_targets(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError>;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct EmptyOutboundDeliveryTargetInventory;
+
+#[async_trait]
+impl OutboundDeliveryTargetInventory for EmptyOutboundDeliveryTargetInventory {
+    async fn list_outbound_delivery_targets(
+        &self,
+        _caller: &WebUiAuthenticatedCaller,
+    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        Ok(Vec::new())
+    }
+}
+
+pub(crate) struct RebornOutboundPreferencesFacade {
+    preferences: Arc<dyn CommunicationPreferenceRepository>,
+    targets: Arc<dyn OutboundDeliveryTargetInventory>,
+}
+
+impl RebornOutboundPreferencesFacade {
+    pub(crate) fn new(
+        preferences: Arc<dyn CommunicationPreferenceRepository>,
+        targets: Arc<dyn OutboundDeliveryTargetInventory>,
+    ) -> Self {
+        Self {
+            preferences,
+            targets,
+        }
+    }
+
+    async fn response_for_record(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        record: Option<&CommunicationPreferenceRecord>,
+    ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
+        let final_reply_target = match record.and_then(|record| record.final_reply_target.as_ref())
+        {
+            Some(target) => self.summary_for_reply_target(caller, target).await?,
+            None => None,
+        };
+        Ok(RebornOutboundPreferencesResponse {
+            final_reply_target,
+            default_modality: RebornOutboundDeliveryModality::Text,
+        })
+    }
+
+    async fn summary_for_reply_target(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target: &ReplyTargetBindingRef,
+    ) -> Result<Option<RebornOutboundDeliveryTargetSummary>, RebornServicesError> {
+        let targets = self.targets.list_outbound_delivery_targets(caller).await?;
+        Ok(targets
+            .into_iter()
+            .find(|entry| {
+                entry.capabilities.final_replies
+                    && entry.reply_target_binding_ref.as_str() == target.as_str()
+            })
+            .map(|entry| entry.summary))
+    }
+
+    async fn resolve_final_reply_target(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target_id: &RebornOutboundDeliveryTargetId,
+    ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
+        let targets = self.targets.list_outbound_delivery_targets(caller).await?;
+        targets
+            .into_iter()
+            .find(|entry| {
+                entry.capabilities.final_replies
+                    && entry.summary.target_id.as_str() == target_id.as_str()
+            })
+            .ok_or_else(outbound_target_not_found)
+    }
+
+    fn key(caller: &WebUiAuthenticatedCaller) -> CommunicationPreferenceKey {
+        CommunicationPreferenceKey::new(caller.tenant_id.clone(), caller.user_id.clone())
+    }
+}
+
+#[async_trait]
+impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
+    async fn get_outbound_preferences(
+        &self,
+        caller: WebUiAuthenticatedCaller,
+    ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
+        let record = self
+            .preferences
+            .load_communication_preference(Self::key(&caller))
+            .await
+            .map_err(map_outbound_repository_error)?;
+        self.response_for_record(&caller, record.as_ref()).await
+    }
+
+    async fn set_outbound_preferences(
+        &self,
+        caller: WebUiAuthenticatedCaller,
+        request: RebornSetOutboundPreferencesRequest,
+    ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
+        let key = Self::key(&caller);
+        let existing = self
+            .preferences
+            .load_communication_preference(key)
+            .await
+            .map_err(map_outbound_repository_error)?;
+        let final_reply_target = match request.final_reply_target_id.as_ref() {
+            Some(target_id) => Some(
+                self.resolve_final_reply_target(&caller, target_id)
+                    .await?
+                    .reply_target_binding_ref,
+            ),
+            None => None,
+        };
+        let now = Utc::now();
+        let record = CommunicationPreferenceRecord {
+            tenant_id: caller.tenant_id.clone(),
+            user_id: caller.user_id.clone(),
+            final_reply_target,
+            progress_target: existing
+                .as_ref()
+                .and_then(|record| record.progress_target.clone()),
+            approval_prompt_target: existing
+                .as_ref()
+                .and_then(|record| record.approval_prompt_target.clone()),
+            auth_prompt_target: existing
+                .as_ref()
+                .and_then(|record| record.auth_prompt_target.clone()),
+            default_modality: existing
+                .as_ref()
+                .and_then(|record| record.default_modality)
+                .or(Some(CommunicationModality::Text)),
+            updated_at: now,
+            updated_by: caller.user_id.clone(),
+        };
+        self.preferences
+            .put_communication_preference(record.clone())
+            .await
+            .map_err(map_outbound_repository_error)?;
+        self.response_for_record(&caller, Some(&record)).await
+    }
+
+    async fn list_outbound_delivery_targets(
+        &self,
+        caller: WebUiAuthenticatedCaller,
+    ) -> Result<RebornOutboundDeliveryTargetListResponse, RebornServicesError> {
+        let targets = self
+            .targets
+            .list_outbound_delivery_targets(&caller)
+            .await?
+            .into_iter()
+            .filter(|entry| entry.capabilities.final_replies)
+            .map(|entry| RebornOutboundDeliveryTargetOption {
+                target: entry.summary,
+                capabilities: entry.capabilities,
+            })
+            .collect();
+        Ok(RebornOutboundDeliveryTargetListResponse {
+            targets,
+            next_cursor: None,
+        })
+    }
+}
+
+fn outbound_target_not_found() -> RebornServicesError {
+    RebornServicesError {
+        code: RebornServicesErrorCode::NotFound,
+        kind: RebornServicesErrorKind::NotFound,
+        status_code: 404,
+        retryable: false,
+        field: Some("final_reply_target_id".to_string()),
+        validation_code: None,
+    }
+}
+
+fn map_outbound_repository_error(error: OutboundError) -> RebornServicesError {
+    match error {
+        OutboundError::InvalidRequest { .. }
+        | OutboundError::SubscriptionScopeMismatch
+        | OutboundError::AccessDenied
+        | OutboundError::DeliveryNotFound => RebornServicesError {
+            code: RebornServicesErrorCode::InvalidRequest,
+            kind: RebornServicesErrorKind::Validation,
+            status_code: 400,
+            retryable: false,
+            field: None,
+            validation_code: None,
+        },
+        OutboundError::Backend | OutboundError::Serialization | OutboundError::CasConflict => {
+            RebornServicesError {
+                code: RebornServicesErrorCode::Unavailable,
+                kind: RebornServicesErrorKind::ServiceUnavailable,
+                status_code: 503,
+                retryable: true,
+                field: None,
+                validation_code: None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Mutex};
+
+    use ironclaw_host_api::{TenantId, UserId};
+    use ironclaw_outbound::{CommunicationPreferenceRepository, InMemoryOutboundStateStore};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeTargetInventory {
+        by_user: Mutex<HashMap<String, Vec<OutboundDeliveryTargetEntry>>>,
+    }
+
+    impl FakeTargetInventory {
+        fn insert(&self, user_id: &str, entry: OutboundDeliveryTargetEntry) {
+            self.by_user
+                .lock()
+                .expect("lock")
+                .entry(user_id.to_string())
+                .or_default()
+                .push(entry);
+        }
+    }
+
+    #[async_trait]
+    impl OutboundDeliveryTargetInventory for FakeTargetInventory {
+        async fn list_outbound_delivery_targets(
+            &self,
+            caller: &WebUiAuthenticatedCaller,
+        ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+            Ok(self
+                .by_user
+                .lock()
+                .expect("lock")
+                .get(caller.user_id.as_str())
+                .cloned()
+                .unwrap_or_default())
+        }
+    }
+
+    #[tokio::test]
+    async fn get_preferences_projects_stored_final_target_for_authenticated_user() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        let inventory = Arc::new(FakeTargetInventory::default());
+        inventory.insert(
+            "user-alpha",
+            target_entry("slack-alpha", "reply:slack-alpha", true),
+        );
+        seed_record(
+            store.as_ref(),
+            "tenant-alpha",
+            "user-alpha",
+            Some(reply_ref("reply:slack-alpha")),
+        )
+        .await;
+        let facade = RebornOutboundPreferencesFacade::new(store, inventory);
+
+        let response = facade
+            .get_outbound_preferences(caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect("preferences response");
+
+        assert_eq!(
+            response
+                .final_reply_target
+                .as_ref()
+                .map(|target| target.target_id.as_str()),
+            Some("slack-alpha")
+        );
+
+        let other_user = facade
+            .get_outbound_preferences(caller("tenant-alpha", "user-bravo"))
+            .await
+            .expect("other user preferences");
+        assert!(other_user.final_reply_target.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_preferences_validates_target_id_before_writing_reply_target() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        let inventory = Arc::new(FakeTargetInventory::default());
+        inventory.insert(
+            "user-alpha",
+            target_entry("slack-alpha", "reply:slack-alpha", true),
+        );
+        let facade = RebornOutboundPreferencesFacade::new(store.clone(), inventory);
+
+        let response = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target_id("slack-alpha")),
+                },
+            )
+            .await
+            .expect("set valid target");
+
+        assert_eq!(
+            response
+                .final_reply_target
+                .as_ref()
+                .map(|target| target.target_id.as_str()),
+            Some("slack-alpha")
+        );
+        let stored = store
+            .load_communication_preference(CommunicationPreferenceKey::new(
+                tenant("tenant-alpha"),
+                user("user-alpha"),
+            ))
+            .await
+            .expect("load stored record")
+            .expect("stored record");
+        assert_eq!(
+            stored
+                .final_reply_target
+                .as_ref()
+                .map(|target| target.as_str()),
+            Some("reply:slack-alpha")
+        );
+
+        let error = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target_id("slack-missing")),
+                },
+            )
+            .await
+            .expect_err("reject unknown target");
+        assert_eq!(error.code, RebornServicesErrorCode::NotFound);
+        assert_eq!(error.field.as_deref(), Some("final_reply_target_id"));
+    }
+
+    #[tokio::test]
+    async fn clear_preferences_preserves_non_final_slots() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        let inventory = Arc::new(FakeTargetInventory::default());
+        seed_record(
+            store.as_ref(),
+            "tenant-alpha",
+            "user-alpha",
+            Some(reply_ref("reply:slack-alpha")),
+        )
+        .await;
+        let facade = RebornOutboundPreferencesFacade::new(store.clone(), inventory);
+
+        let response = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: None,
+                },
+            )
+            .await
+            .expect("clear target");
+
+        assert!(response.final_reply_target.is_none());
+        let stored = store
+            .load_communication_preference(CommunicationPreferenceKey::new(
+                tenant("tenant-alpha"),
+                user("user-alpha"),
+            ))
+            .await
+            .expect("load stored record")
+            .expect("stored record");
+        assert!(stored.final_reply_target.is_none());
+        assert_eq!(
+            stored
+                .progress_target
+                .as_ref()
+                .map(|target| target.as_str()),
+            Some("reply:progress")
+        );
+        assert_eq!(
+            stored
+                .approval_prompt_target
+                .as_ref()
+                .map(|target| target.as_str()),
+            Some("reply:approval")
+        );
+        assert_eq!(
+            stored
+                .auth_prompt_target
+                .as_ref()
+                .map(|target| target.as_str()),
+            Some("reply:auth")
+        );
+        assert_eq!(stored.default_modality, Some(CommunicationModality::Voice));
+    }
+
+    #[tokio::test]
+    async fn list_targets_is_scoped_to_caller_and_final_reply_capability() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        let inventory = Arc::new(FakeTargetInventory::default());
+        inventory.insert(
+            "user-alpha",
+            target_entry("slack-alpha", "reply:slack-alpha", true),
+        );
+        inventory.insert(
+            "user-alpha",
+            target_entry("slack-progress", "reply:slack-progress", false),
+        );
+        inventory.insert(
+            "user-bravo",
+            target_entry("slack-bravo", "reply:slack-bravo", true),
+        );
+        let facade = RebornOutboundPreferencesFacade::new(store, inventory);
+
+        let response = facade
+            .list_outbound_delivery_targets(caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect("target list");
+
+        assert_eq!(response.targets.len(), 1);
+        assert_eq!(response.targets[0].target.target_id.as_str(), "slack-alpha");
+        assert!(response.next_cursor.is_none());
+    }
+
+    fn target_entry(
+        target_id_value: &str,
+        reply_target: &str,
+        final_replies: bool,
+    ) -> OutboundDeliveryTargetEntry {
+        OutboundDeliveryTargetEntry {
+            summary: RebornOutboundDeliveryTargetSummary::new(
+                target_id(target_id_value),
+                "slack",
+                "Slack DM",
+                Some("Slack direct message".to_string()),
+            )
+            .expect("valid target summary"),
+            capabilities: RebornOutboundDeliveryTargetCapabilities {
+                final_replies,
+                gate_prompts: true,
+                auth_prompts: true,
+            },
+            reply_target_binding_ref: reply_ref(reply_target),
+        }
+    }
+
+    async fn seed_record(
+        store: &dyn CommunicationPreferenceRepository,
+        tenant_id: &str,
+        user_id: &str,
+        final_reply_target: Option<ReplyTargetBindingRef>,
+    ) {
+        store
+            .put_communication_preference(CommunicationPreferenceRecord {
+                tenant_id: tenant(tenant_id),
+                user_id: user(user_id),
+                final_reply_target,
+                progress_target: Some(reply_ref("reply:progress")),
+                approval_prompt_target: Some(reply_ref("reply:approval")),
+                auth_prompt_target: Some(reply_ref("reply:auth")),
+                default_modality: Some(CommunicationModality::Voice),
+                updated_at: Utc::now(),
+                updated_by: user(user_id),
+            })
+            .await
+            .expect("seed communication preference");
+    }
+
+    fn caller(tenant_id: &str, user_id: &str) -> WebUiAuthenticatedCaller {
+        WebUiAuthenticatedCaller::new(tenant(tenant_id), user(user_id), None, None)
+    }
+
+    fn tenant(value: &str) -> TenantId {
+        TenantId::new(value).expect("valid tenant")
+    }
+
+    fn user(value: &str) -> UserId {
+        UserId::new(value).expect("valid user")
+    }
+
+    fn reply_ref(value: &str) -> ReplyTargetBindingRef {
+        ReplyTargetBindingRef::new(value).expect("valid reply target")
+    }
+
+    fn target_id(value: &str) -> RebornOutboundDeliveryTargetId {
+        RebornOutboundDeliveryTargetId::new(value).expect("valid target id")
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2522,10 +2522,10 @@ mod tests {
     use ironclaw_product_workflow::{
         LifecyclePackageKind, LifecyclePackageRef, LifecyclePhase, LifecycleProductPayload,
         LifecycleReadinessBlocker, RebornExtensionCredentialSetup, RebornServicesErrorCode,
-        RebornServicesErrorKind, RebornStreamEventsRequest, RebornSubmitTurnResponse,
-        WebUiAuthenticatedCaller, WebUiCreateThreadRequest, WebUiListAutomationsRequest,
-        WebUiResolveGateRequest, WebUiSendMessageRequest, WebUiSetupExtensionRequest,
-        approval_gate_ref,
+        RebornServicesErrorKind, RebornSetOutboundPreferencesRequest, RebornStreamEventsRequest,
+        RebornSubmitTurnResponse, WebUiAuthenticatedCaller, WebUiCreateThreadRequest,
+        WebUiListAutomationsRequest, WebUiResolveGateRequest, WebUiSendMessageRequest,
+        WebUiSetupExtensionRequest, approval_gate_ref,
     };
     use ironclaw_run_state::ApprovalRequestStore;
     use ironclaw_skills::SkillTrust;
@@ -4721,6 +4721,63 @@ mod tests {
             )),
             "local webui bundle must not fall back to the default unwired facade"
         );
+
+        runtime.shutdown().await.expect("runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn local_dev_webui_bundle_exposes_outbound_preferences_facade() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let gateway = Arc::new(RecordingGateway {
+            reply: "webui outbound ok".to_string(),
+            requests: Arc::new(StdMutex::new(Vec::new())),
+        });
+        let input = RebornRuntimeInput::from_services(
+            RebornBuildInput::local_dev(
+                "runtime-webui-outbound-owner",
+                root.path().join("local-dev"),
+            )
+            .with_runtime_policy(local_dev_runtime_policy()),
+        )
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-webui-outbound-tenant".to_string(),
+            agent_id: "runtime-webui-outbound-agent".to_string(),
+            source_binding_id: "runtime-webui-outbound-source".to_string(),
+            reply_target_binding_id: "runtime-webui-outbound-reply".to_string(),
+        })
+        .with_poll_settings(PollSettings {
+            interval: Duration::from_millis(10),
+            max_total: Duration::from_secs(3),
+        })
+        .with_model_gateway_override(gateway);
+
+        let runtime = build_reborn_runtime(input).await.expect("runtime builds");
+        let bundle = build_webui_services(&runtime, None).expect("webui bundle");
+        let caller = WebUiAuthenticatedCaller::new(
+            TenantId::new("runtime-webui-outbound-tenant").unwrap(),
+            UserId::new("runtime-webui-outbound-owner").unwrap(),
+            Some(AgentId::new("runtime-webui-outbound-agent").unwrap()),
+            None,
+        );
+
+        let cleared = bundle
+            .api
+            .set_outbound_preferences(
+                caller.clone(),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: None,
+                },
+            )
+            .await
+            .expect("outbound preference clear uses composed facade");
+        assert!(cleared.final_reply_target.is_none());
+
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(caller)
+            .await
+            .expect("outbound target listing uses composed facade");
+        assert!(targets.targets.is_empty());
 
         runtime.shutdown().await.expect("runtime shutdown");
     }

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -122,6 +122,8 @@ pub(crate) fn build_webui_services_with_connectable_channels(
         api = api.with_automation_product_facade(automation_facade);
     }
     if let Some(local_runtime) = &services.local_runtime {
+        // PR 19 wires Slack delivery targets through this inventory; until then
+        // the facade exposes an empty target list for product-neutral clients.
         api = api.with_outbound_preferences_facade(Arc::new(RebornOutboundPreferencesFacade::new(
             Arc::clone(&local_runtime.outbound_preferences),
             Arc::new(EmptyOutboundDeliveryTargetInventory),

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -122,8 +122,8 @@ pub(crate) fn build_webui_services_with_connectable_channels(
         api = api.with_automation_product_facade(automation_facade);
     }
     if let Some(local_runtime) = &services.local_runtime {
-        // PR 19 wires Slack delivery targets through this inventory; until then
-        // the facade exposes an empty target list for product-neutral clients.
+        // GitHub PR #4537 carry-forward tracks the Slack delivery target
+        // bridge; until then this product-neutral facade exposes no targets.
         api = api.with_outbound_preferences_facade(Arc::new(RebornOutboundPreferencesFacade::new(
             Arc::clone(&local_runtime.outbound_preferences),
             Arc::new(EmptyOutboundDeliveryTargetInventory),

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -8,7 +8,9 @@ use ironclaw_product_workflow::{
 
 use crate::{
     RebornBuildError, RebornProductAuthServices, RebornReadiness, RebornRuntime,
-    RebornWebuiAutomationFacade, lifecycle::RebornLocalLifecycleFacade,
+    RebornWebuiAutomationFacade,
+    lifecycle::RebornLocalLifecycleFacade,
+    outbound_preferences::{EmptyOutboundDeliveryTargetInventory, RebornOutboundPreferencesFacade},
     webui_extension_credentials::ProductAuthExtensionCredentialSetup,
 };
 
@@ -118,6 +120,12 @@ pub(crate) fn build_webui_services_with_connectable_channels(
     }
     if let Some(automation_facade) = automation_facade {
         api = api.with_automation_product_facade(automation_facade);
+    }
+    if let Some(local_runtime) = &services.local_runtime {
+        api = api.with_outbound_preferences_facade(Arc::new(RebornOutboundPreferencesFacade::new(
+            Arc::clone(&local_runtime.outbound_preferences),
+            Arc::new(EmptyOutboundDeliveryTargetInventory),
+        )));
     }
     if let Some(connectable_channels) = connectable_channels {
         api = api.with_connectable_channels_facade(connectable_channels);

--- a/crates/ironclaw_threads/src/tool_result_reference.rs
+++ b/crates/ironclaw_threads/src/tool_result_reference.rs
@@ -408,10 +408,7 @@ fn validate_model_observation_value(value: &serde_json::Value) -> Result<(), Str
 }
 
 fn validate_model_observation_text(value: &str) -> Result<(), String> {
-    if value
-        .chars()
-        .any(|character| is_disallowed_control_character(character))
-    {
+    if value.chars().any(is_disallowed_control_character) {
         return Err("model observation must not contain NUL/control characters".to_string());
     }
     let lower = value.to_ascii_lowercase();

--- a/crates/ironclaw_turns/src/run_profile/model_observation.rs
+++ b/crates/ironclaw_turns/src/run_profile/model_observation.rs
@@ -274,10 +274,7 @@ fn validate_text_len(value: &str, label: &'static str, max: usize) -> Result<(),
     if value.len() > max {
         return Err(format!("{label} exceeds {max} bytes"));
     }
-    if value
-        .chars()
-        .any(|character| is_disallowed_control_character(character))
-    {
+    if value.chars().any(is_disallowed_control_character) {
         return Err(format!("{label} must not contain NUL/control characters"));
     }
     Ok(())

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -820,6 +820,27 @@ read the same communication preference repository used by the default outbound
 preference API. Do not encode WebUI rendering assumptions in this bridge; the
 API must remain usable by any authenticated product surface.
 
+Carry-forward API and repository follow-ups from PR 4537 review:
+
+- Expand `RebornOutboundDeliveryModality` in a dedicated product API follow-up
+  before surfacing non-text outbound defaults. The outbound repository already
+  supports `Text`, `Voice`, `Image`, `Mixed`, and `Unknown`, while the current
+  WebUI/product response DTO intentionally exposes only `Text`. Do not add a
+  partial mapper in composition until the public enum and serde contract are
+  deliberately expanded.
+- Add a product-safe stale-target representation before treating missing
+  inventory matches as first-class UI state. The preferred low-churn shape is a
+  sibling status field that can distinguish `none_configured` from
+  `unavailable` while preserving the existing `final_reply_target:
+  Option<RebornOutboundDeliveryTargetSummary>` field. A tagged target-state DTO
+  is cleaner but should be evaluated as a larger API contract change.
+- Add an atomic update operation to `CommunicationPreferenceRepository` before
+  depending on concurrent preference updates for production behavior. The fix
+  belongs in the repository/store contract so in-memory and filesystem-backed
+  stores re-read and re-apply the update under their own lock/CAS semantics. Do
+  not paper over this with a composition-local facade mutex; that would only
+  serialize one process and one facade instance.
+
 If concrete Reborn product egress is not ready, leave this as fast-follow and
 ship trigger V1 as local persisted threads only.
 

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -809,6 +809,17 @@ ready, connect trigger-origin final reply delivery:
 - validate with `OutboundPolicyService`.
 - send only through Reborn product-adapter outbound paths that are ready.
 
+Carry-forward finding from the default outbound preference service slice:
+Phase 2 composes a WebUI-usable `OutboundPreferencesProductFacade` backed by
+`RebornLocalRuntimeServices::outbound_preferences`, but Slack host-beta final
+reply delivery still constructs its own outbound state store inside
+`slack_host_beta.rs`. Before PR 19 claims Slack end-to-end delivery, the Slack
+integration must bridge this split by exposing Slack delivery targets through
+the composition-owned target inventory and making Slack final-reply delivery
+read the same communication preference repository used by the default outbound
+preference API. Do not encode WebUI rendering assumptions in this bridge; the
+API must remain usable by any authenticated product surface.
+
 If concrete Reborn product egress is not ready, leave this as fast-follow and
 ship trigger V1 as local persisted threads only.
 

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -820,7 +820,7 @@ read the same communication preference repository used by the default outbound
 preference API. Do not encode WebUI rendering assumptions in this bridge; the
 API must remain usable by any authenticated product surface.
 
-Carry-forward API and repository follow-ups from PR 4537 review:
+Carry-forward API and repository follow-ups from GitHub PR #4537 review:
 
 - Expand `RebornOutboundDeliveryModality` in a dedicated product API follow-up
   before surfacing non-text outbound defaults. The outbound repository already

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -840,6 +840,12 @@ Carry-forward API and repository follow-ups from GitHub PR #4537 review:
   stores re-read and re-apply the update under their own lock/CAS semantics. Do
   not paper over this with a composition-local facade mutex; that would only
   serialize one process and one facade instance.
+- Decide whether local-dev builds with the `postgres` feature should move
+  outbound preferences, and possibly the broader non-libSQL local-dev store
+  graph, to filesystem-backed persistence. Do not switch only this one
+  preference store casually: the current non-`libsql` local-dev graph still uses
+  in-memory run, thread, checkpoint, and event stores, while production
+  PostgreSQL already routes durable state through `PostgresRootFilesystem`.
 
 If concrete Reborn product egress is not ready, leave this as fast-follow and
 ship trigger V1 as local persisted threads only.


### PR DESCRIPTION
## Summary

- Add a composition-owned outbound preferences facade for WebUI/product workflow callers
- Wire local runtime outbound preference storage into WebUI service composition
- Add caller-level coverage that the WebUI bundle exposes the outbound preferences facade
- Record the Slack integration follow-up: Slack target inventory and final-reply delivery must share the same preference repository before claiming Slack e2e delivery

## Verification

- `cargo test -p ironclaw_reborn_composition outbound_preferences -- --nocapture`
- `cargo test -p ironclaw_reborn_composition local_dev_webui_bundle_exposes_outbound_preferences_facade -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features libsql --no-run`
- `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings -A clippy::redundant_closure`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `git diff --check`

## Follow-up

- Slack host-beta still constructs its own outbound state store. PR 19 must bridge that split by exposing Slack delivery targets through composition-owned target inventory and making Slack final-reply delivery read the same communication preference repository used by this API.
