### PR TITLE
[codex] Fix memory_write null target handling

### DIFF
--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -484,21 +484,8 @@ fn normalize_optional_null_sentinels(request: &mut FirstPartyCapabilityRequest) 
     object.retain(|key, value| {
         !(declared.contains(key.as_str())
             && !required.contains(key)
-            && (value.as_str() == Some("null") || value.is_null())
-            && !preserve_optional_null_sentinel(
-                request.capability_id.as_str(),
-                key.as_str(),
-                value,
-            ))
+            && (value.as_str() == Some("null") || value.is_null()))
     });
-}
-
-fn preserve_optional_null_sentinel(
-    capability_id: &str,
-    key: &str,
-    value: &serde_json::Value,
-) -> bool {
-    capability_id == MEMORY_WRITE_CAPABILITY_ID && key == "target" && value.is_null()
 }
 
 fn resource_profile() -> Option<ResourceProfile> {

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -1418,7 +1418,7 @@ async fn memory_write_rejects_traversal_paths() {
 #[tokio::test]
 async fn memory_write_rejects_non_string_target() {
     let runtime = runtime_with_filesystem(InMemoryBackend::new());
-    for target in [json!(null), json!(42), json!(true)] {
+    for target in [json!(42), json!(true)] {
         let failure = invoke_with_context(
             &runtime,
             MEMORY_WRITE_CAPABILITY_ID,
@@ -1435,6 +1435,33 @@ async fn memory_write_rejects_non_string_target() {
         .unwrap_err();
         assert_eq!(failure, RuntimeFailureKind::InvalidInput);
     }
+}
+
+#[tokio::test]
+async fn memory_write_treats_null_target_as_omitted() {
+    let runtime = runtime_with_filesystem(InMemoryBackend::new());
+    let output = invoke_with_context(
+        &runtime,
+        MEMORY_WRITE_CAPABILITY_ID,
+        json!({
+            "target": null,
+            "content": "null target should use the default daily log"
+        }),
+        execution_context_with_mounts(
+            [MEMORY_WRITE_CAPABILITY_ID],
+            memory_mounts(MountPermissions::read_write_list_delete()),
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(output["status"], json!("written"));
+    assert_eq!(output["append"], json!(true));
+    assert!(
+        output["path"]
+            .as_str()
+            .is_some_and(|path| path.starts_with("daily/") && path.ends_with(".md")),
+        "null target should default to today's daily log, got {output:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -1,6 +1,9 @@
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicUsize, Ordering},
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use async_trait::async_trait;


### PR DESCRIPTION
## Summary

- Treat optional JSON `null` sentinels as absent for `memory_write.target`, matching the shared first-party built-in null-sentinel policy.
- Add caller-level coverage that `target: null` defaults to the daily log while non-string targets like numbers and booleans still fail as invalid input.

## Root Cause

OpenAI strict tool schema shaping can make optional tool fields nullable. The first-party runtime already strips optional null sentinels before dispatch, but `memory_write.target = null` had a special preservation exception. That let `null` reach `parse_write_command`, where non-string targets are rejected, so valid model calls that meant “use the default target” failed with `invalid_input`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_host_runtime memory_write_treats_null_target_as_omitted -- --nocapture`
- `cargo test -p ironclaw_host_runtime memory_write_rejects_non_string_target -- --nocapture`
- `cargo test -p ironclaw_host_runtime memory_capabilities_write_read_tree_and_search_native_reborn_memory -- --nocapture`
- `cargo test -p ironclaw_host_runtime builtin_time_tolerates_null_string_sentinels_in_optional_fields -- --nocapture`