### PR TITLE
Add outbound target registry follow-up

### DIFF
--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -41,6 +41,18 @@ impl CommunicationPreferenceRecord {
     }
 }
 
+/// Transform the currently stored communication preference record.
+///
+/// Repository implementations may invoke this callback more than once when
+/// retrying compare-and-swap conflicts. Callers must keep the callback
+/// deterministic and free of external side effects.
+pub type CommunicationPreferenceUpdate = Box<
+    dyn FnMut(
+            Option<CommunicationPreferenceRecord>,
+        ) -> Result<CommunicationPreferenceRecord, OutboundError>
+        + Send,
+>;
+
 /// Store for durable tenant/user communication delivery preferences.
 #[async_trait]
 pub trait CommunicationPreferenceRepository: Send + Sync {
@@ -53,4 +65,10 @@ pub trait CommunicationPreferenceRepository: Send + Sync {
         &self,
         key: CommunicationPreferenceKey,
     ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError>;
+
+    async fn update_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+        update: CommunicationPreferenceUpdate,
+    ) -> Result<CommunicationPreferenceRecord, OutboundError>;
 }

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -50,9 +50,10 @@ use crate::validation::{
 };
 use crate::{
     AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
-    OutboundDeliveryId, OutboundError, OutboundStateStore, ProjectionSubscriptionId,
-    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    CommunicationPreferenceRepository, CommunicationPreferenceUpdate,
+    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError,
+    OutboundStateStore, ProjectionSubscriptionId, ProjectionSubscriptionRecord,
+    ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
 };
 
 /// Maximum number of compare-and-swap retries on a read-then-write path
@@ -232,19 +233,12 @@ where
             .await?
             .map(|(value, _)| value))
     }
-}
 
-#[async_trait]
-impl<F> CommunicationPreferenceRepository for FilesystemOutboundStateStore<F>
-where
-    F: RootFilesystem,
-{
-    async fn put_communication_preference(
+    async fn write_communication_preference_with_cas(
         &self,
-        record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
-        validate_communication_preference(&record)?;
-        let key = record.key();
+        key: CommunicationPreferenceKey,
+        mut update: CommunicationPreferenceUpdate,
+    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
         let path = communication_preference_path(&key)?;
         let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
         for _ in 0..MAX_CAS_RETRIES {
@@ -262,18 +256,41 @@ where
             {
                 return Err(OutboundError::Backend);
             }
+            let record = update(existing)?;
+            validate_communication_preference(&record)?;
+            if record.key() != key {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference update key mismatch",
+                });
+            }
             self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
                 .await?;
             match self
                 .put_json(&resource_scope, &path, &record, &record.tenant_id, cas)
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(()) => return Ok(record),
                 Err(OutboundError::CasConflict) => continue,
                 Err(error) => return Err(error),
             }
         }
         Err(OutboundError::Backend)
+    }
+}
+
+#[async_trait]
+impl<F> CommunicationPreferenceRepository for FilesystemOutboundStateStore<F>
+where
+    F: RootFilesystem,
+{
+    async fn put_communication_preference(
+        &self,
+        record: CommunicationPreferenceRecord,
+    ) -> Result<(), OutboundError> {
+        let key = record.key();
+        self.write_communication_preference_with_cas(key, Box::new(move |_| Ok(record.clone())))
+            .await?;
+        Ok(())
     }
 
     async fn load_communication_preference(
@@ -292,6 +309,15 @@ where
             return Err(OutboundError::Backend);
         }
         Ok(Some(record))
+    }
+
+    async fn update_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+        update: CommunicationPreferenceUpdate,
+    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+        self.write_communication_preference_with_cas(key, update)
+            .await
     }
 }
 

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -241,6 +241,8 @@ where
     ) -> Result<CommunicationPreferenceRecord, OutboundError> {
         let path = communication_preference_path(&key)?;
         let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
+        self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
+            .await?;
         for _ in 0..MAX_CAS_RETRIES {
             let (cas, existing) = match self
                 .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
@@ -263,8 +265,6 @@ where
                     reason: "communication preference update key mismatch",
                 });
             }
-            self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
-                .await?;
             match self
                 .put_json(&resource_scope, &path, &record, &record.tenant_id, cas)
                 .await

--- a/crates/ironclaw_outbound/src/lib.rs
+++ b/crates/ironclaw_outbound/src/lib.rs
@@ -19,6 +19,7 @@ mod validation;
 
 pub use communication_preferences::{
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
+    CommunicationPreferenceUpdate,
 };
 pub use delivery_resolution::{
     CommunicationDeliveryCandidate, CommunicationDeliveryIntent, CommunicationDeliveryKind,

--- a/crates/ironclaw_outbound/src/memory.rs
+++ b/crates/ironclaw_outbound/src/memory.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Mutex;
+use std::task::{Context, Poll};
 
 use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
@@ -19,6 +22,24 @@ use crate::{
     OutboundStateStore, ProjectionSubscriptionId, ProjectionSubscriptionRecord,
     ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
 };
+
+const MAX_CAS_RETRIES: usize = 5;
+
+struct YieldOnce(bool);
+
+impl Future for YieldOnce {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.0 {
+            Poll::Ready(())
+        } else {
+            self.0 = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct InMemoryOutboundStateStore {
@@ -115,7 +136,7 @@ impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
         key: CommunicationPreferenceKey,
         mut update: CommunicationPreferenceUpdate,
     ) -> Result<CommunicationPreferenceRecord, OutboundError> {
-        loop {
+        for _ in 0..MAX_CAS_RETRIES {
             let existing = {
                 let state = self.lock_state()?;
                 state.communication_preferences.get(&key).cloned()
@@ -127,14 +148,23 @@ impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
                     reason: "communication preference update key mismatch",
                 });
             }
-            let mut state = self.lock_state()?;
-            if state.communication_preferences.get(&key).cloned() == existing {
-                state
-                    .communication_preferences
-                    .insert(record.key(), record.clone());
+            let updated = {
+                let mut state = self.lock_state()?;
+                if state.communication_preferences.get(&key).cloned() == existing {
+                    state
+                        .communication_preferences
+                        .insert(record.key(), record.clone());
+                    true
+                } else {
+                    false
+                }
+            };
+            if updated {
                 return Ok(record);
             }
+            YieldOnce(false).await;
         }
+        Err(OutboundError::Backend)
     }
 }
 

--- a/crates/ironclaw_outbound/src/memory.rs
+++ b/crates/ironclaw_outbound/src/memory.rs
@@ -14,9 +14,10 @@ use crate::validation::{
 };
 use crate::{
     AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
-    OutboundDeliveryId, OutboundError, OutboundStateStore, ProjectionSubscriptionId,
-    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    CommunicationPreferenceRepository, CommunicationPreferenceUpdate,
+    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError,
+    OutboundStateStore, ProjectionSubscriptionId, ProjectionSubscriptionRecord,
+    ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
 };
 
 #[derive(Default)]
@@ -107,6 +108,33 @@ impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
     ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
         let state = self.lock_state()?;
         Ok(state.communication_preferences.get(&key).cloned())
+    }
+
+    async fn update_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+        mut update: CommunicationPreferenceUpdate,
+    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+        loop {
+            let existing = {
+                let state = self.lock_state()?;
+                state.communication_preferences.get(&key).cloned()
+            };
+            let record = update(existing.clone())?;
+            validate_communication_preference(&record)?;
+            if record.key() != key {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference update key mismatch",
+                });
+            }
+            let mut state = self.lock_state()?;
+            if state.communication_preferences.get(&key).cloned() == existing {
+                state
+                    .communication_preferences
+                    .insert(record.key(), record.clone());
+                return Ok(record);
+            }
+        }
     }
 }
 

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -225,6 +225,14 @@ mod tests {
         ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
             Err(OutboundError::Backend)
         }
+
+        async fn update_communication_preference(
+            &self,
+            _key: CommunicationPreferenceKey,
+            _update: crate::CommunicationPreferenceUpdate,
+        ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+            Err(OutboundError::Backend)
+        }
     }
 
     #[tokio::test]

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -883,6 +883,14 @@ impl CommunicationPreferenceRepository for BackendErrorPreferenceRepository {
     ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
         Err(OutboundError::Backend)
     }
+
+    async fn update_communication_preference(
+        &self,
+        _key: CommunicationPreferenceKey,
+        _update: CommunicationPreferenceUpdate,
+    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+        Err(OutboundError::Backend)
+    }
 }
 
 #[derive(Default)]

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
@@ -47,6 +48,9 @@ async fn in_memory_defaults_policy_progress_opt_in_and_subscription_scope() {
     let store = InMemoryOutboundStateStore::default();
     communication_preferences_are_tenant_user_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
+    communication_preference_atomic_update_preserves_existing_slots(&store).await;
+    communication_preference_update_propagates_update_error_without_writing(&store).await;
+    communication_preference_update_rejects_invalid_or_mismatched_record(&store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
     subscription_ids_are_scoped_not_global(&store).await;
@@ -67,7 +71,11 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     let store = build_outbound_store_for_backend(Arc::clone(&backend));
     communication_preferences_are_tenant_user_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
+    communication_preference_atomic_update_preserves_existing_slots(&store).await;
+    communication_preference_update_propagates_update_error_without_writing(&store).await;
+    communication_preference_update_rejects_invalid_or_mismatched_record(&store).await;
     filesystem_store_retries_communication_preference_put_through_cas_conflict(&backend).await;
+    filesystem_store_retries_communication_preference_update_through_cas_conflict(&backend).await;
     filesystem_store_rejects_mismatched_communication_preference_identity(&backend, &store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
@@ -200,6 +208,157 @@ where
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 }
 
+async fn communication_preference_atomic_update_preserves_existing_slots<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound-atomic").unwrap();
+    let user_id = UserId::new("user-outbound-atomic").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        tenant_id,
+        user_id,
+        final_reply_target: Some(reply_ref("reply-pref-atomic-final")),
+        progress_target: Some(reply_ref("reply-pref-atomic-progress")),
+        approval_prompt_target: Some(reply_ref("reply-pref-atomic-approval")),
+        auth_prompt_target: Some(reply_ref("reply-pref-atomic-auth")),
+        default_modality: Some(CommunicationModality::Voice),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-atomic-updater").unwrap(),
+    };
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+
+    let updated = store
+        .update_communication_preference(
+            key.clone(),
+            Box::new(move |existing| {
+                let existing = existing.expect("existing communication preference");
+                Ok(CommunicationPreferenceRecord {
+                    final_reply_target: Some(reply_ref("reply-pref-atomic-final-updated")),
+                    updated_at: now(),
+                    updated_by: UserId::new("user-outbound-atomic-updater-2").unwrap(),
+                    ..existing
+                })
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated.final_reply_target,
+        Some(reply_ref("reply-pref-atomic-final-updated"))
+    );
+    assert_eq!(updated.progress_target, record.progress_target);
+    assert_eq!(
+        updated.approval_prompt_target,
+        record.approval_prompt_target
+    );
+    assert_eq!(updated.auth_prompt_target, record.auth_prompt_target);
+    assert_eq!(updated.default_modality, record.default_modality);
+    assert_eq!(
+        store.load_communication_preference(key).await.unwrap(),
+        Some(updated)
+    );
+}
+
+async fn communication_preference_update_propagates_update_error_without_writing<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound-update-error").unwrap();
+    let user_id = UserId::new("user-outbound-update-error").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        tenant_id,
+        user_id,
+        final_reply_target: Some(reply_ref("reply-pref-update-error-final")),
+        progress_target: Some(reply_ref("reply-pref-update-error-progress")),
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-update-error-updater").unwrap(),
+    };
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+
+    let result = store
+        .update_communication_preference(
+            key.clone(),
+            Box::new(|_| Err(OutboundError::AccessDenied)),
+        )
+        .await;
+
+    assert!(matches!(result, Err(OutboundError::AccessDenied)));
+    assert_eq!(
+        store.load_communication_preference(key).await.unwrap(),
+        Some(record)
+    );
+}
+
+async fn communication_preference_update_rejects_invalid_or_mismatched_record<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound-update-invalid").unwrap();
+    let user_id = UserId::new("user-outbound-update-invalid").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        tenant_id,
+        user_id,
+        final_reply_target: Some(reply_ref("reply-pref-update-invalid-final")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-update-invalid-updater").unwrap(),
+    };
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+
+    let invalid_result = store
+        .update_communication_preference(
+            key.clone(),
+            Box::new(|existing| {
+                let mut record = existing.expect("existing communication preference");
+                record.updated_by = UserId::from_trusted(String::new());
+                Ok(record)
+            }),
+        )
+        .await;
+    assert!(matches!(
+        invalid_result,
+        Err(OutboundError::InvalidRequest { .. })
+    ));
+
+    let mismatch_result = store
+        .update_communication_preference(
+            key.clone(),
+            Box::new(|existing| {
+                let mut record = existing.expect("existing communication preference");
+                record.user_id = UserId::new("user-outbound-update-invalid-other").unwrap();
+                Ok(record)
+            }),
+        )
+        .await;
+    assert!(matches!(
+        mismatch_result,
+        Err(OutboundError::InvalidRequest { .. })
+    ));
+    assert_eq!(
+        store.load_communication_preference(key).await.unwrap(),
+        Some(record)
+    );
+}
+
 async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     backend: &Arc<InMemoryBackend>,
     store: &FilesystemOutboundStateStore<InMemoryBackend>,
@@ -312,6 +471,74 @@ async fn filesystem_store_retries_communication_preference_put_through_cas_confl
         Some(record)
     );
     assert_eq!(racing.injected_count().await, 1);
+}
+
+async fn filesystem_store_retries_communication_preference_update_through_cas_conflict(
+    backend: &Arc<InMemoryBackend>,
+) {
+    let racing = Arc::new(VersionRacingBackend::new(Arc::clone(backend)));
+    let store =
+        FilesystemOutboundStateStore::new(build_scoped_fs(Arc::clone(&racing), TEST_OUTBOUND_ROOT));
+    let tenant_id = TenantId::new("tenant-outbound-update-cas").unwrap();
+    let user_id = UserId::new("user-outbound-update-cas").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        tenant_id,
+        user_id,
+        final_reply_target: Some(reply_ref("reply-pref-update-cas")),
+        progress_target: Some(reply_ref("reply-pref-update-cas-progress")),
+        approval_prompt_target: Some(reply_ref("reply-pref-update-cas-approval")),
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Voice),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-update-cas").unwrap(),
+    };
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+    racing
+        .arm(
+            &format!("{TEST_OUTBOUND_ROOT}/communication-preferences/"),
+            1,
+        )
+        .await;
+
+    let update_calls = Arc::new(AtomicUsize::new(0));
+    let calls = Arc::clone(&update_calls);
+    let updated = store
+        .update_communication_preference(
+            key.clone(),
+            Box::new(move |existing| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let existing = existing.expect("existing communication preference");
+                Ok(CommunicationPreferenceRecord {
+                    final_reply_target: Some(reply_ref("reply-pref-update-cas-final-updated")),
+                    updated_at: now(),
+                    updated_by: UserId::new("tenant-admin-outbound-update-cas-2").unwrap(),
+                    ..existing
+                })
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated.final_reply_target,
+        Some(reply_ref("reply-pref-update-cas-final-updated"))
+    );
+    assert_eq!(updated.progress_target, record.progress_target);
+    assert_eq!(
+        updated.approval_prompt_target,
+        record.approval_prompt_target
+    );
+    assert_eq!(updated.default_modality, record.default_modality);
+    assert_eq!(racing.injected_count().await, 1);
+    assert_eq!(update_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        store.load_communication_preference(key).await.unwrap(),
+        Some(updated)
+    );
 }
 
 async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateStore) {

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -49,6 +49,7 @@ async fn in_memory_defaults_policy_progress_opt_in_and_subscription_scope() {
     communication_preferences_are_tenant_user_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
     communication_preference_atomic_update_preserves_existing_slots(&store).await;
+    communication_preference_update_inserts_absent_record(&store).await;
     communication_preference_update_propagates_update_error_without_writing(&store).await;
     communication_preference_update_rejects_invalid_or_mismatched_record(&store).await;
     durable_policy_subscription_delivery_flow(&store).await;
@@ -72,6 +73,7 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     communication_preferences_are_tenant_user_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
     communication_preference_atomic_update_preserves_existing_slots(&store).await;
+    communication_preference_update_inserts_absent_record(&store).await;
     communication_preference_update_propagates_update_error_without_writing(&store).await;
     communication_preference_update_rejects_invalid_or_mismatched_record(&store).await;
     filesystem_store_retries_communication_preference_put_through_cas_conflict(&backend).await;
@@ -261,6 +263,48 @@ where
     assert_eq!(
         store.load_communication_preference(key).await.unwrap(),
         Some(updated)
+    );
+}
+
+async fn communication_preference_update_inserts_absent_record<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound-update-absent").unwrap();
+    let user_id = UserId::new("user-outbound-update-absent").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        tenant_id,
+        user_id,
+        final_reply_target: Some(reply_ref("reply-pref-update-absent-final")),
+        progress_target: Some(reply_ref("reply-pref-update-absent-progress")),
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-update-absent").unwrap(),
+    };
+    let update_calls = Arc::new(AtomicUsize::new(0));
+    let calls = Arc::clone(&update_calls);
+    let callback_record = record.clone();
+
+    let updated = store
+        .update_communication_preference(
+            key.clone(),
+            Box::new(move |existing| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                assert!(existing.is_none());
+                Ok(callback_record.clone())
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated, record);
+    assert_eq!(update_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        store.load_communication_preference(key).await.unwrap(),
+        Some(record)
     );
 }
 

--- a/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
@@ -163,6 +163,22 @@ impl CommunicationPreferenceRepository for FakePreferenceRepository {
             .get(&key)
             .cloned())
     }
+
+    async fn update_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+        mut update: ironclaw_outbound::CommunicationPreferenceUpdate,
+    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+        let existing = self.load_communication_preference(key.clone()).await?;
+        let record = update(existing)?;
+        if record.key() != key {
+            return Err(OutboundError::InvalidRequest {
+                reason: "communication preference update key mismatch",
+            });
+        }
+        self.put_communication_preference(record.clone()).await?;
+        Ok(record)
+    }
 }
 
 #[derive(Default)]
@@ -249,6 +265,16 @@ impl CommunicationPreferenceRepository for StatusFailingOutboundStore {
         key: CommunicationPreferenceKey,
     ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
         self.inner.load_communication_preference(key).await
+    }
+
+    async fn update_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+        update: ironclaw_outbound::CommunicationPreferenceUpdate,
+    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+        self.inner
+            .update_communication_preference(key, update)
+            .await
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -183,6 +183,7 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             .map(|entry| entry.reply_target_binding_ref.clone());
         let tenant_id = caller.tenant_id.clone();
         let user_id = caller.user_id.clone();
+        let updated_at = Utc::now();
         let updated = self
             .preferences
             .update_communication_preference(
@@ -204,7 +205,7 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
                         default_modality: existing
                             .as_ref()
                             .and_then(|record| record.default_modality),
-                        updated_at: Utc::now(),
+                        updated_at,
                         updated_by: user_id.clone(),
                     })
                 }),

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -24,29 +24,56 @@ pub(crate) struct OutboundDeliveryTargetEntry {
 }
 
 #[async_trait]
-pub(crate) trait OutboundDeliveryTargetInventory: Send + Sync {
+pub(crate) trait OutboundDeliveryTargetProvider: Send + Sync {
     async fn list_outbound_delivery_targets(
         &self,
         caller: &WebUiAuthenticatedCaller,
     ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError>;
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct EmptyOutboundDeliveryTargetInventory;
+pub(crate) struct OutboundDeliveryTargetRegistry {
+    providers: Vec<Arc<dyn OutboundDeliveryTargetProvider>>,
+}
+
+impl std::fmt::Debug for OutboundDeliveryTargetRegistry {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OutboundDeliveryTargetRegistry")
+            .field("providers", &self.providers.len())
+            .finish()
+    }
+}
+
+impl OutboundDeliveryTargetRegistry {
+    pub(crate) fn empty() -> Self {
+        Self {
+            providers: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_providers(providers: Vec<Arc<dyn OutboundDeliveryTargetProvider>>) -> Self {
+        Self { providers }
+    }
+}
 
 #[async_trait]
-impl OutboundDeliveryTargetInventory for EmptyOutboundDeliveryTargetInventory {
+impl OutboundDeliveryTargetProvider for OutboundDeliveryTargetRegistry {
     async fn list_outbound_delivery_targets(
         &self,
-        _caller: &WebUiAuthenticatedCaller,
+        caller: &WebUiAuthenticatedCaller,
     ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        Ok(Vec::new())
+        let mut targets = Vec::new();
+        for provider in &self.providers {
+            targets.extend(provider.list_outbound_delivery_targets(caller).await?);
+        }
+        Ok(targets)
     }
 }
 
 pub(crate) struct RebornOutboundPreferencesFacade {
     preferences: Arc<dyn CommunicationPreferenceRepository>,
-    targets: Arc<dyn OutboundDeliveryTargetInventory>,
+    targets: Arc<dyn OutboundDeliveryTargetProvider>,
 }
 
 impl std::fmt::Debug for RebornOutboundPreferencesFacade {
@@ -54,7 +81,7 @@ impl std::fmt::Debug for RebornOutboundPreferencesFacade {
         formatter
             .debug_struct("RebornOutboundPreferencesFacade")
             .field("preferences", &"Arc<dyn CommunicationPreferenceRepository>")
-            .field("targets", &"Arc<dyn OutboundDeliveryTargetInventory>")
+            .field("targets", &"Arc<dyn OutboundDeliveryTargetProvider>")
             .finish()
     }
 }
@@ -62,7 +89,7 @@ impl std::fmt::Debug for RebornOutboundPreferencesFacade {
 impl RebornOutboundPreferencesFacade {
     pub(crate) fn new(
         preferences: Arc<dyn CommunicationPreferenceRepository>,
-        targets: Arc<dyn OutboundDeliveryTargetInventory>,
+        targets: Arc<dyn OutboundDeliveryTargetProvider>,
     ) -> Self {
         Self {
             preferences,
@@ -151,41 +178,47 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
         request: RebornSetOutboundPreferencesRequest,
     ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
         let key = Self::key(&caller);
-        let existing = self
-            .preferences
-            .load_communication_preference(key)
-            .await
-            .map_err(map_outbound_repository_error)?;
         let resolved_final_reply_target = match request.final_reply_target_id.as_ref() {
             Some(target_id) => Some(self.resolve_final_reply_target(&caller, target_id).await?),
             None => None,
         };
+        let final_reply_target = resolved_final_reply_target
+            .as_ref()
+            .map(|entry| entry.reply_target_binding_ref.clone());
+        let final_reply_target_summary =
+            resolved_final_reply_target.map(|entry| entry.summary.clone());
         let now = Utc::now();
-        let record = CommunicationPreferenceRecord {
-            tenant_id: caller.tenant_id.clone(),
-            user_id: caller.user_id.clone(),
-            final_reply_target: resolved_final_reply_target
-                .as_ref()
-                .map(|entry| entry.reply_target_binding_ref.clone()),
-            progress_target: existing
-                .as_ref()
-                .and_then(|record| record.progress_target.clone()),
-            approval_prompt_target: existing
-                .as_ref()
-                .and_then(|record| record.approval_prompt_target.clone()),
-            auth_prompt_target: existing
-                .as_ref()
-                .and_then(|record| record.auth_prompt_target.clone()),
-            default_modality: existing.as_ref().and_then(|record| record.default_modality),
-            updated_at: now,
-            updated_by: caller.user_id.clone(),
-        };
+        let tenant_id = caller.tenant_id.clone();
+        let user_id = caller.user_id.clone();
         self.preferences
-            .put_communication_preference(record)
+            .update_communication_preference(
+                key,
+                Box::new(move |existing| {
+                    Ok(CommunicationPreferenceRecord {
+                        tenant_id: tenant_id.clone(),
+                        user_id: user_id.clone(),
+                        final_reply_target: final_reply_target.clone(),
+                        progress_target: existing
+                            .as_ref()
+                            .and_then(|record| record.progress_target.clone()),
+                        approval_prompt_target: existing
+                            .as_ref()
+                            .and_then(|record| record.approval_prompt_target.clone()),
+                        auth_prompt_target: existing
+                            .as_ref()
+                            .and_then(|record| record.auth_prompt_target.clone()),
+                        default_modality: existing
+                            .as_ref()
+                            .and_then(|record| record.default_modality),
+                        updated_at: now,
+                        updated_by: user_id.clone(),
+                    })
+                }),
+            )
             .await
             .map_err(map_outbound_repository_error)?;
         Ok(RebornOutboundPreferencesResponse {
-            final_reply_target: resolved_final_reply_target.map(|entry| entry.summary),
+            final_reply_target: final_reply_target_summary,
             default_modality: RebornOutboundDeliveryModality::Text,
         })
     }
@@ -290,7 +323,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl OutboundDeliveryTargetInventory for FakeTargetInventory {
+    impl OutboundDeliveryTargetProvider for FakeTargetInventory {
         async fn list_outbound_delivery_targets(
             &self,
             caller: &WebUiAuthenticatedCaller,
@@ -308,7 +341,7 @@ mod tests {
     struct FailingTargetInventory;
 
     #[async_trait]
-    impl OutboundDeliveryTargetInventory for FailingTargetInventory {
+    impl OutboundDeliveryTargetProvider for FailingTargetInventory {
         async fn list_outbound_delivery_targets(
             &self,
             _caller: &WebUiAuthenticatedCaller,
@@ -341,6 +374,14 @@ mod tests {
         ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
             Err(OutboundError::Backend)
         }
+
+        async fn update_communication_preference(
+            &self,
+            _key: CommunicationPreferenceKey,
+            _update: ironclaw_outbound::CommunicationPreferenceUpdate,
+        ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+            Err(OutboundError::Backend)
+        }
     }
 
     struct PutFailingPreferenceRepository;
@@ -359,6 +400,20 @@ mod tests {
             _key: CommunicationPreferenceKey,
         ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
             Ok(None)
+        }
+
+        async fn update_communication_preference(
+            &self,
+            key: CommunicationPreferenceKey,
+            mut update: ironclaw_outbound::CommunicationPreferenceUpdate,
+        ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+            let record = update(None)?;
+            if record.key() != key {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference update key mismatch",
+                });
+            }
+            Err(OutboundError::Backend)
         }
     }
 
@@ -695,6 +750,89 @@ mod tests {
         assert!(response.next_cursor.is_none());
     }
 
+    #[tokio::test]
+    async fn target_registry_aggregates_channel_neutral_providers_for_default_selection() {
+        let store = Arc::new(InMemoryOutboundStateStore::default());
+        let slack_provider = Arc::new(FakeTargetInventory::default());
+        slack_provider.insert(
+            "user-alpha",
+            target_entry_for_channel(
+                "slack-alpha",
+                "slack",
+                "Slack DM",
+                "reply:slack-alpha",
+                true,
+            ),
+        );
+        let telegram_provider = Arc::new(FakeTargetInventory::default());
+        telegram_provider.insert(
+            "user-alpha",
+            target_entry_for_channel(
+                "telegram-alpha",
+                "telegram",
+                "Telegram chat",
+                "reply:telegram-alpha",
+                true,
+            ),
+        );
+        let registry = Arc::new(OutboundDeliveryTargetRegistry::from_providers(vec![
+            slack_provider,
+            telegram_provider,
+        ]));
+        let facade = RebornOutboundPreferencesFacade::new(store.clone(), registry);
+
+        let listed = facade
+            .list_outbound_delivery_targets(caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect("target list");
+        assert_eq!(
+            listed
+                .targets
+                .iter()
+                .map(|entry| entry.target.channel.as_str())
+                .collect::<Vec<_>>(),
+            vec!["slack", "telegram"]
+        );
+
+        facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target_id("telegram-alpha")),
+                },
+            )
+            .await
+            .expect("set target from second provider");
+        let stored = store
+            .load_communication_preference(CommunicationPreferenceKey::new(
+                tenant("tenant-alpha"),
+                user("user-alpha"),
+            ))
+            .await
+            .expect("load stored record")
+            .expect("stored record");
+        assert_eq!(
+            stored
+                .final_reply_target
+                .as_ref()
+                .map(|target| target.as_str()),
+            Some("reply:telegram-alpha")
+        );
+    }
+
+    #[tokio::test]
+    async fn target_registry_propagates_provider_failure() {
+        let registry =
+            OutboundDeliveryTargetRegistry::from_providers(vec![Arc::new(FailingTargetInventory)]);
+
+        let error = registry
+            .list_outbound_delivery_targets(&caller("tenant-alpha", "user-alpha"))
+            .await
+            .expect_err("provider failure");
+
+        assert_unavailable_backend_error(error);
+    }
+
     #[test]
     fn repository_error_mapping_distinguishes_authority_conflict_and_backend_errors() {
         for invalid_request_error in [
@@ -740,12 +878,28 @@ mod tests {
         reply_target: &str,
         final_replies: bool,
     ) -> OutboundDeliveryTargetEntry {
+        target_entry_for_channel(
+            target_id_value,
+            "slack",
+            "Slack DM",
+            reply_target,
+            final_replies,
+        )
+    }
+
+    fn target_entry_for_channel(
+        target_id_value: &str,
+        channel: &str,
+        display_name: &str,
+        reply_target: &str,
+        final_replies: bool,
+    ) -> OutboundDeliveryTargetEntry {
         OutboundDeliveryTargetEntry {
             summary: RebornOutboundDeliveryTargetSummary::new(
                 target_id(target_id_value),
-                "slack",
-                "Slack DM",
-                Some("Slack direct message".to_string()),
+                channel,
+                display_name,
+                Some(format!("{display_name} direct message")),
             )
             .expect("valid target summary"),
             capabilities: RebornOutboundDeliveryTargetCapabilities {

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
+use futures::future::try_join_all;
 use ironclaw_outbound::{
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
     OutboundError,
@@ -45,14 +46,7 @@ impl std::fmt::Debug for OutboundDeliveryTargetRegistry {
 }
 
 impl OutboundDeliveryTargetRegistry {
-    pub(crate) fn empty() -> Self {
-        Self {
-            providers: Vec::new(),
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn from_providers(providers: Vec<Arc<dyn OutboundDeliveryTargetProvider>>) -> Self {
+    pub(crate) fn new(providers: Vec<Arc<dyn OutboundDeliveryTargetProvider>>) -> Self {
         Self { providers }
     }
 }
@@ -63,11 +57,13 @@ impl OutboundDeliveryTargetProvider for OutboundDeliveryTargetRegistry {
         &self,
         caller: &WebUiAuthenticatedCaller,
     ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        let mut targets = Vec::new();
-        for provider in &self.providers {
-            targets.extend(provider.list_outbound_delivery_targets(caller).await?);
-        }
-        Ok(targets)
+        let target_groups = try_join_all(
+            self.providers
+                .iter()
+                .map(|provider| provider.list_outbound_delivery_targets(caller)),
+        )
+        .await?;
+        Ok(target_groups.into_iter().flatten().collect())
     }
 }
 
@@ -151,7 +147,7 @@ impl RebornOutboundPreferencesFacade {
 
     /// Invariant: `WebUiAuthenticatedCaller` must come from the authenticated
     /// product/session boundary, never from request-body tenant/user fields.
-    /// This key and target-inventory scope intentionally share the same
+    /// This key and target-provider scope intentionally share the same
     /// verified caller identity.
     fn key(caller: &WebUiAuthenticatedCaller) -> CommunicationPreferenceKey {
         CommunicationPreferenceKey::new(caller.tenant_id.clone(), caller.user_id.clone())
@@ -185,12 +181,10 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
         let final_reply_target = resolved_final_reply_target
             .as_ref()
             .map(|entry| entry.reply_target_binding_ref.clone());
-        let final_reply_target_summary =
-            resolved_final_reply_target.map(|entry| entry.summary.clone());
-        let now = Utc::now();
         let tenant_id = caller.tenant_id.clone();
         let user_id = caller.user_id.clone();
-        self.preferences
+        let updated = self
+            .preferences
             .update_communication_preference(
                 key,
                 Box::new(move |existing| {
@@ -210,17 +204,14 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
                         default_modality: existing
                             .as_ref()
                             .and_then(|record| record.default_modality),
-                        updated_at: now,
+                        updated_at: Utc::now(),
                         updated_by: user_id.clone(),
                     })
                 }),
             )
             .await
             .map_err(map_outbound_repository_error)?;
-        Ok(RebornOutboundPreferencesResponse {
-            final_reply_target: final_reply_target_summary,
-            default_modality: RebornOutboundDeliveryModality::Text,
-        })
+        self.response_for_record(&caller, Some(&updated)).await
     }
 
     async fn list_outbound_delivery_targets(
@@ -307,11 +298,11 @@ mod tests {
     use super::*;
 
     #[derive(Default)]
-    struct FakeTargetInventory {
+    struct FakeTargetProvider {
         by_user: Mutex<HashMap<String, Vec<OutboundDeliveryTargetEntry>>>,
     }
 
-    impl FakeTargetInventory {
+    impl FakeTargetProvider {
         fn insert(&self, user_id: &str, entry: OutboundDeliveryTargetEntry) {
             self.by_user
                 .lock()
@@ -323,7 +314,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl OutboundDeliveryTargetProvider for FakeTargetInventory {
+    impl OutboundDeliveryTargetProvider for FakeTargetProvider {
         async fn list_outbound_delivery_targets(
             &self,
             caller: &WebUiAuthenticatedCaller,
@@ -338,10 +329,10 @@ mod tests {
         }
     }
 
-    struct FailingTargetInventory;
+    struct FailingTargetProvider;
 
     #[async_trait]
-    impl OutboundDeliveryTargetProvider for FailingTargetInventory {
+    impl OutboundDeliveryTargetProvider for FailingTargetProvider {
         async fn list_outbound_delivery_targets(
             &self,
             _caller: &WebUiAuthenticatedCaller,
@@ -420,8 +411,8 @@ mod tests {
     #[tokio::test]
     async fn get_preferences_projects_stored_final_target_for_authenticated_user() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
-        let inventory = Arc::new(FakeTargetInventory::default());
-        inventory.insert(
+        let provider = Arc::new(FakeTargetProvider::default());
+        provider.insert(
             "user-alpha",
             target_entry("slack-alpha", "reply:slack-alpha", true),
         );
@@ -432,7 +423,7 @@ mod tests {
             Some(reply_ref("reply:slack-alpha")),
         )
         .await;
-        let facade = RebornOutboundPreferencesFacade::new(store, inventory);
+        let facade = RebornOutboundPreferencesFacade::new(store, provider);
 
         let response = facade
             .get_outbound_preferences(caller("tenant-alpha", "user-alpha"))
@@ -455,9 +446,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_preferences_returns_none_when_stored_target_not_in_inventory() {
+    async fn get_preferences_returns_none_when_stored_target_not_in_provider() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
-        let inventory = Arc::new(FakeTargetInventory::default());
+        let provider = Arc::new(FakeTargetProvider::default());
         seed_record(
             store.as_ref(),
             "tenant-alpha",
@@ -465,7 +456,7 @@ mod tests {
             Some(reply_ref("reply:slack-alpha")),
         )
         .await;
-        let facade = RebornOutboundPreferencesFacade::new(store, inventory);
+        let facade = RebornOutboundPreferencesFacade::new(store, provider);
 
         let response = facade
             .get_outbound_preferences(caller("tenant-alpha", "user-alpha"))
@@ -479,7 +470,7 @@ mod tests {
     async fn get_preferences_maps_backend_read_error_to_unavailable() {
         let facade = RebornOutboundPreferencesFacade::new(
             Arc::new(LoadFailingPreferenceRepository),
-            Arc::new(FakeTargetInventory::default()),
+            Arc::new(FakeTargetProvider::default()),
         );
 
         let error = facade
@@ -493,12 +484,12 @@ mod tests {
     #[tokio::test]
     async fn set_preferences_validates_target_id_before_writing_reply_target() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
-        let inventory = Arc::new(FakeTargetInventory::default());
-        inventory.insert(
+        let provider = Arc::new(FakeTargetProvider::default());
+        provider.insert(
             "user-alpha",
             target_entry("slack-alpha", "reply:slack-alpha", true),
         );
-        let facade = RebornOutboundPreferencesFacade::new(store.clone(), inventory);
+        let facade = RebornOutboundPreferencesFacade::new(store.clone(), provider);
 
         let response = facade
             .set_outbound_preferences(
@@ -549,14 +540,14 @@ mod tests {
 
     #[tokio::test]
     async fn set_preferences_maps_backend_write_error_to_unavailable() {
-        let inventory = Arc::new(FakeTargetInventory::default());
-        inventory.insert(
+        let provider = Arc::new(FakeTargetProvider::default());
+        provider.insert(
             "user-alpha",
             target_entry("slack-alpha", "reply:slack-alpha", true),
         );
         let facade = RebornOutboundPreferencesFacade::new(
             Arc::new(PutFailingPreferenceRepository),
-            inventory,
+            provider,
         );
 
         let error = facade
@@ -574,14 +565,14 @@ mod tests {
 
     #[tokio::test]
     async fn set_preferences_maps_backend_read_error_before_resolving_target() {
-        let inventory = Arc::new(FakeTargetInventory::default());
-        inventory.insert(
+        let provider = Arc::new(FakeTargetProvider::default());
+        provider.insert(
             "user-alpha",
             target_entry("slack-alpha", "reply:slack-alpha", true),
         );
         let facade = RebornOutboundPreferencesFacade::new(
             Arc::new(LoadFailingPreferenceRepository),
-            inventory,
+            provider,
         );
 
         let error = facade
@@ -600,8 +591,8 @@ mod tests {
     #[tokio::test]
     async fn set_preferences_with_none_target_on_new_user_creates_empty_record() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
-        let inventory = Arc::new(FakeTargetInventory::default());
-        let facade = RebornOutboundPreferencesFacade::new(store.clone(), inventory);
+        let provider = Arc::new(FakeTargetProvider::default());
+        let facade = RebornOutboundPreferencesFacade::new(store.clone(), provider);
 
         let response = facade
             .set_outbound_preferences(
@@ -630,7 +621,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn target_inventory_errors_are_propagated_by_get_set_and_list() {
+    async fn target_provider_errors_are_propagated_by_get_set_and_list() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
         seed_record(
             store.as_ref(),
@@ -639,12 +630,12 @@ mod tests {
             Some(reply_ref("reply:slack-alpha")),
         )
         .await;
-        let facade = RebornOutboundPreferencesFacade::new(store, Arc::new(FailingTargetInventory));
+        let facade = RebornOutboundPreferencesFacade::new(store, Arc::new(FailingTargetProvider));
 
         let get_error = facade
             .get_outbound_preferences(caller("tenant-alpha", "user-alpha"))
             .await
-            .expect_err("get target inventory failure");
+            .expect_err("get target provider failure");
         assert_unavailable_backend_error(get_error);
 
         let set_error = facade
@@ -655,20 +646,20 @@ mod tests {
                 },
             )
             .await
-            .expect_err("set target inventory failure");
+            .expect_err("set target provider failure");
         assert_unavailable_backend_error(set_error);
 
         let list_error = facade
             .list_outbound_delivery_targets(caller("tenant-alpha", "user-alpha"))
             .await
-            .expect_err("list target inventory failure");
+            .expect_err("list target provider failure");
         assert_unavailable_backend_error(list_error);
     }
 
     #[tokio::test]
     async fn clear_preferences_preserves_non_final_slots() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
-        let inventory = Arc::new(FakeTargetInventory::default());
+        let provider = Arc::new(FakeTargetProvider::default());
         seed_record(
             store.as_ref(),
             "tenant-alpha",
@@ -676,7 +667,7 @@ mod tests {
             Some(reply_ref("reply:slack-alpha")),
         )
         .await;
-        let facade = RebornOutboundPreferencesFacade::new(store.clone(), inventory);
+        let facade = RebornOutboundPreferencesFacade::new(store.clone(), provider);
 
         let response = facade
             .set_outbound_preferences(
@@ -725,20 +716,20 @@ mod tests {
     #[tokio::test]
     async fn list_targets_is_scoped_to_caller_and_final_reply_capability() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
-        let inventory = Arc::new(FakeTargetInventory::default());
-        inventory.insert(
+        let provider = Arc::new(FakeTargetProvider::default());
+        provider.insert(
             "user-alpha",
             target_entry("slack-alpha", "reply:slack-alpha", true),
         );
-        inventory.insert(
+        provider.insert(
             "user-alpha",
             target_entry("slack-progress", "reply:slack-progress", false),
         );
-        inventory.insert(
+        provider.insert(
             "user-bravo",
             target_entry("slack-bravo", "reply:slack-bravo", true),
         );
-        let facade = RebornOutboundPreferencesFacade::new(store, inventory);
+        let facade = RebornOutboundPreferencesFacade::new(store, provider);
 
         let response = facade
             .list_outbound_delivery_targets(caller("tenant-alpha", "user-alpha"))
@@ -753,7 +744,7 @@ mod tests {
     #[tokio::test]
     async fn target_registry_aggregates_channel_neutral_providers_for_default_selection() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
-        let slack_provider = Arc::new(FakeTargetInventory::default());
+        let slack_provider = Arc::new(FakeTargetProvider::default());
         slack_provider.insert(
             "user-alpha",
             target_entry_for_channel(
@@ -764,7 +755,7 @@ mod tests {
                 true,
             ),
         );
-        let telegram_provider = Arc::new(FakeTargetInventory::default());
+        let telegram_provider = Arc::new(FakeTargetProvider::default());
         telegram_provider.insert(
             "user-alpha",
             target_entry_for_channel(
@@ -775,7 +766,7 @@ mod tests {
                 true,
             ),
         );
-        let registry = Arc::new(OutboundDeliveryTargetRegistry::from_providers(vec![
+        let registry = Arc::new(OutboundDeliveryTargetRegistry::new(vec![
             slack_provider,
             telegram_provider,
         ]));
@@ -822,8 +813,7 @@ mod tests {
 
     #[tokio::test]
     async fn target_registry_propagates_provider_failure() {
-        let registry =
-            OutboundDeliveryTargetRegistry::from_providers(vec![Arc::new(FailingTargetInventory)]);
+        let registry = OutboundDeliveryTargetRegistry::new(vec![Arc::new(FailingTargetProvider)]);
 
         let error = registry
             .list_outbound_delivery_targets(&caller("tenant-alpha", "user-alpha"))
@@ -899,7 +889,7 @@ mod tests {
                 target_id(target_id_value),
                 channel,
                 display_name,
-                Some(format!("{display_name} direct message")),
+                Some(display_name.to_string()),
             )
             .expect("valid target summary"),
             capabilities: RebornOutboundDeliveryTargetCapabilities {

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -141,7 +141,7 @@ pub(crate) fn build_webui_services_with_connectable_channels(
         // until then this product-neutral facade exposes no targets.
         api = api.with_outbound_preferences_facade(Arc::new(RebornOutboundPreferencesFacade::new(
             Arc::clone(&local_runtime.outbound_preferences),
-            Arc::new(OutboundDeliveryTargetRegistry::empty()),
+            Arc::new(OutboundDeliveryTargetRegistry::new(vec![])),
         )));
     }
     if let Some(connectable_channels) = connectable_channels {

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -17,7 +17,7 @@ use crate::{
     lifecycle::{
         RebornLocalLifecycleFacade, RebornLocalSkillManagementError, RebornLocalSkillManagementPort,
     },
-    outbound_preferences::{EmptyOutboundDeliveryTargetInventory, RebornOutboundPreferencesFacade},
+    outbound_preferences::{OutboundDeliveryTargetRegistry, RebornOutboundPreferencesFacade},
     webui_extension_credentials::ProductAuthExtensionCredentialSetup,
 };
 
@@ -137,11 +137,11 @@ pub(crate) fn build_webui_services_with_connectable_channels(
         api = api.with_automation_product_facade(automation_facade);
     }
     if let Some(local_runtime) = &services.local_runtime {
-        // GitHub PR #4537 carry-forward tracks the Slack delivery target
-        // bridge; until then this product-neutral facade exposes no targets.
+        // GitHub PR #4537 carry-forward tracks real product target providers;
+        // until then this product-neutral facade exposes no targets.
         api = api.with_outbound_preferences_facade(Arc::new(RebornOutboundPreferencesFacade::new(
             Arc::clone(&local_runtime.outbound_preferences),
-            Arc::new(EmptyOutboundDeliveryTargetInventory),
+            Arc::new(OutboundDeliveryTargetRegistry::empty()),
         )));
     }
     if let Some(connectable_channels) = connectable_channels {

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -852,12 +852,16 @@ Carry-forward API and repository follow-ups from GitHub PR #4537 review:
   `unavailable` while preserving the existing `final_reply_target:
   Option<RebornOutboundDeliveryTargetSummary>` field. A tagged target-state DTO
   is cleaner but should be evaluated as a larger API contract change.
-- Add an atomic update operation to `CommunicationPreferenceRepository` before
-  depending on concurrent preference updates for production behavior. The fix
-  belongs in the repository/store contract so in-memory and filesystem-backed
-  stores re-read and re-apply the update under their own lock/CAS semantics. Do
-  not paper over this with a composition-local facade mutex; that would only
-  serialize one process and one facade instance.
+- Harden `CommunicationPreferenceRepository` read-modify-write semantics before
+  depending on concurrent preference updates for production delivery behavior.
+  PR #4558 added the repository update surface and bounded in-memory retries,
+  but byte-only filesystem roots can still reject `Version`/`Absent` CAS and
+  fall back to `CasExpectation::Any`. The next backend-hardening slice must make
+  communication preference updates fail closed on CAS-less roots, use a scoped
+  backend lock/transaction, or change the filesystem fallback contract so stale
+  preference writes cannot drop another writer's slots. Do not paper over this
+  with a composition-local facade mutex; that would only serialize one process
+  and one facade instance.
 - Decide whether local-dev builds with the `postgres` feature should move
   outbound preferences, and possibly the broader non-libSQL local-dev store
   graph, to filesystem-backed persistence. Do not switch only this one

--- a/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
+++ b/docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md
@@ -792,6 +792,23 @@ Expected size: less than 1000 lines; split into config and lifecycle if needed.
 
 ### PR 19 — Trigger Delivery Integration Fast-Follow
 
+Phase 3 entrypoint after PR #4537 merged to `main`:
+
+- Start from the composition-owned outbound preferences facade and shared
+  `CommunicationPreferenceRepository`; do not reintroduce a WebUI-specific
+  backend contract for default delivery settings.
+- Add product outbound targets through a generic composition-owned provider
+  registry backed by the shared preference repository. Slack should become the
+  first registered provider, not a Slack-specific bridge in the backend; later
+  outbound channels must be able to plug into the same provider contract.
+- Keep non-text modalities, stale-target UI/API status, repository-level
+  atomic preference updates, and local-dev filesystem persistence as explicit
+  follow-up decisions unless the phase is scoped to one of those contracts.
+- For external trigger result delivery, the required flow remains
+  `RunNotificationOrigin::Triggered` or `TriggeredFromSourceRoute` ->
+  `OutboundResolutionEngine` -> `OutboundPolicyService` -> ready Reborn
+  product-adapter outbound path.
+
 Only after delivery-resolution PRs are merged and a concrete adapter path is
 ready, connect trigger-origin final reply delivery:
 
@@ -813,12 +830,13 @@ Carry-forward finding from the default outbound preference service slice:
 Phase 2 composes a WebUI-usable `OutboundPreferencesProductFacade` backed by
 `RebornLocalRuntimeServices::outbound_preferences`, but Slack host-beta final
 reply delivery still constructs its own outbound state store inside
-`slack_host_beta.rs`. Before PR 19 claims Slack end-to-end delivery, the Slack
-integration must bridge this split by exposing Slack delivery targets through
-the composition-owned target inventory and making Slack final-reply delivery
-read the same communication preference repository used by the default outbound
-preference API. Do not encode WebUI rendering assumptions in this bridge; the
-API must remain usable by any authenticated product surface.
+`slack_host_beta.rs`. Before PR 19 claims Slack end-to-end delivery, add a
+channel-neutral outbound target provider registry in composition, then register
+Slack as the first provider. That provider must expose only product targets it
+can validate at send time and Slack final-reply delivery must read the same
+communication preference repository used by the default outbound preference
+API. Do not encode WebUI rendering assumptions in this provider path; the API
+must remain usable by any authenticated product surface.
 
 Carry-forward API and repository follow-ups from GitHub PR #4537 review:
 


### PR DESCRIPTION
## Summary

- add an atomic communication-preference update contract with in-memory locking and filesystem CAS retry implementations
- add a channel-neutral outbound delivery target provider registry for composition-owned target discovery
- wire the WebUI outbound preferences facade through the generic registry while keeping the backend product-surface-neutral
- carry forward Slack/trigger delivery follow-up constraints in the plan doc

## Review follow-up included

- made preference updates a required repository method instead of a lossy default load/put implementation
- documented retry semantics for update callbacks
- moved in-memory update callbacks outside the store mutex
- shared the filesystem preference CAS write path
- added repository contract coverage for update errors, invalid records, key mismatches, slot preservation, and CAS retry
- collapsed duplicate provider/inventory traits into one provider/composite abstraction

## Deferred

- I did not add a composition-level filesystem CAS conflict harness. The CAS behavior is covered at the outbound repository contract, and the composition facade now depends on that repository contract rather than owning filesystem retry policy.

## Verification

- `cargo test -p ironclaw_outbound --test outbound_state_store_contract`
- `cargo test -p ironclaw_reborn_composition outbound_preferences -- --nocapture`
- `cargo test -p ironclaw_product_workflow --test outbound_delivery_contract`
- `cargo clippy -p ironclaw_outbound -p ironclaw_reborn_composition -p ironclaw_product_workflow --tests -- -D warnings`
- `git diff --check`
