### PR TITLE
fix(hooks): record MCP direct-lease denials in SecurityAuditSink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4665,6 +4665,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
+ "ironclaw_events",
  "ironclaw_extensions",
  "ironclaw_host_api",
  "ironclaw_resources",

--- a/crates/ironclaw_mcp/Cargo.toml
+++ b/crates/ironclaw_mcp/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 futures-util = "0.3"
+ironclaw_events = { path = "../ironclaw_events" }
 ironclaw_extensions = { path = "../ironclaw_extensions" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_resources = { path = "../ironclaw_resources" }

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -476,9 +476,15 @@ where
     }
 
     /// Attach a payload-free security audit sink for MCP boundary decisions.
+    ///
+    /// Accepts an `Option` so callers can pass an optional sink directly without
+    /// guarding the call behind an `if let Some(..)` branch. Passing `None` is a
+    /// no-op that leaves any previously configured sink untouched.
     #[must_use]
-    pub fn with_security_audit_sink(mut self, sink: Arc<dyn SecurityAuditSink>) -> Self {
-        self.security_audit_sink = Some(sink);
+    pub fn with_security_audit_sink(mut self, sink: Option<Arc<dyn SecurityAuditSink>>) -> Self {
+        if let Some(sink) = sink {
+            self.security_audit_sink = Some(sink);
+        }
         self
     }
 

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -16,6 +16,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures_util::FutureExt as _;
+use ironclaw_events::{SecurityAuditEvent, SecurityAuditSink, SecurityBoundary, SecurityDecision};
 use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, ResourceEstimate, ResourceReservation,
@@ -30,6 +31,7 @@ use thiserror::Error;
 
 const STREAMABLE_HTTP_MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 const MCP_PROTOCOL_VERSION_HEADER: &str = "MCP-Protocol-Version";
+pub const MCP_DIRECT_LEASE_DENY_CODE: &str = "mcp_direct_lease_deny";
 
 /// Host-owned MCP adapter limits.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -381,6 +383,7 @@ pub struct McpHostHttpClient<H, P> {
     http: H,
     planner: P,
     state: Arc<McpHostHttpClientState>,
+    security_audit_sink: Option<Arc<dyn SecurityAuditSink>>,
 }
 
 #[derive(Debug)]
@@ -400,7 +403,6 @@ struct McpHostHttpSessionCleanup {
 
 struct PlannedMcpJsonRpc {
     id: Option<u64>,
-    method: McpJsonRpcMethod,
     url: String,
     policy_headers: Vec<(String, String)>,
     body: Vec<u8>,
@@ -469,11 +471,45 @@ where
                 next_id: AtomicU64::new(1),
                 sessions: Mutex::new(HashMap::new()),
             }),
+            security_audit_sink: None,
         }
+    }
+
+    /// Attach a payload-free security audit sink for MCP boundary decisions.
+    #[must_use]
+    pub fn with_security_audit_sink(mut self, sink: Arc<dyn SecurityAuditSink>) -> Self {
+        self.security_audit_sink = Some(sink);
+        self
     }
 
     fn next_request_id(&self) -> u64 {
         self.state.next_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn record_direct_lease_rejection(&self, request: &McpClientRequest) {
+        if let Some(sink) = self.security_audit_sink.as_ref() {
+            sink.record(
+                SecurityAuditEvent::new(
+                    SecurityBoundary::McpDirectLease,
+                    SecurityDecision::Blocked,
+                    MCP_DIRECT_LEASE_DENY_CODE,
+                )
+                .with_capability_id(request.capability_id.clone())
+                .with_scope(request.scope.clone()),
+            );
+        }
+    }
+
+    fn reject_direct_lease_credential_injections(
+        &self,
+        request: &McpClientRequest,
+        credential_injections: &[RuntimeCredentialInjection],
+    ) -> Result<(), McpClientError> {
+        if credential_injections_contain_secret_store_lease(credential_injections) {
+            self.record_direct_lease_rejection(request);
+            return Err(McpClientError::client(request_denied()));
+        }
+        Ok(())
     }
 
     async fn send_json_rpc(
@@ -522,7 +558,6 @@ where
         });
         Ok(PlannedMcpJsonRpc {
             id,
-            method,
             url: url.to_string(),
             policy_headers,
             body,
@@ -551,9 +586,11 @@ where
             planned.plan.response_body_limit,
             request.max_output_bytes,
         );
-        let credential_injections = planned
-            .method
-            .credential_injections(planned.plan.credential_injections)?;
+        self.reject_direct_lease_credential_injections(
+            request,
+            &planned.plan.credential_injections,
+        )?;
+        let credential_injections = planned.plan.credential_injections;
         let response = self
             .http
             .request(McpHostHttpRequest {
@@ -731,8 +768,10 @@ where
             McpJsonRpcMethod::ToolsCall,
             Some(tool_call_params),
         )?;
-        validate_tools_call_credential_injections(&tool_call_plan.plan.credential_injections)
-            .map_err(McpClientError::client)?;
+        self.reject_direct_lease_credential_injections(
+            &request,
+            &tool_call_plan.plan.credential_injections,
+        )?;
 
         let mut usage = self.initialize_session(&request, &session_key).await?;
 
@@ -783,8 +822,10 @@ where
             McpJsonRpcMethod::ToolsList,
             None,
         )?;
-        validate_staged_credential_injections(&tools_list_plan.plan.credential_injections)
-            .map_err(McpClientError::client)?;
+        self.reject_direct_lease_credential_injections(
+            &request,
+            &tools_list_plan.plan.credential_injections,
+        )?;
 
         let mut usage = self.initialize_session(&request, &session_key).await?;
         let tools = self
@@ -843,42 +884,14 @@ impl McpJsonRpcMethod {
             Self::ToolsCall => "tools/call",
         }
     }
-
-    fn credential_injections(
-        self,
-        credential_injections: Vec<RuntimeCredentialInjection>,
-    ) -> Result<Vec<RuntimeCredentialInjection>, String> {
-        if credential_injections
-            .iter()
-            .any(|injection| matches!(injection.source, RuntimeCredentialSource::SecretStoreLease))
-        {
-            return Err(request_denied());
-        }
-        Ok(credential_injections)
-    }
 }
 
-/// Validate credential injections planned for a `tools/call` request without
-/// consuming the list, so the caller can reuse it in the actual send.
-///
-/// Returns `Err(denied)` if any injection uses a [`RuntimeCredentialSource::SecretStoreLease`],
-/// which is not permitted over the MCP `tools/call` boundary.
-fn validate_tools_call_credential_injections(
+fn credential_injections_contain_secret_store_lease(
     credential_injections: &[RuntimeCredentialInjection],
-) -> Result<(), String> {
-    validate_staged_credential_injections(credential_injections)
-}
-
-fn validate_staged_credential_injections(
-    credential_injections: &[RuntimeCredentialInjection],
-) -> Result<(), String> {
-    if credential_injections
+) -> bool {
+    credential_injections
         .iter()
         .any(|injection| matches!(injection.source, RuntimeCredentialSource::SecretStoreLease))
-    {
-        return Err(request_denied());
-    }
-    Ok(())
 }
 
 fn mcp_client_http_error(error: McpHostHttpError) -> McpClientError {

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -444,7 +444,7 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
         McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
         planner.clone(),
     )
-    .with_security_audit_sink(security_sink_dyn);
+    .with_security_audit_sink(Some(security_sink_dyn));
 
     let error = client
         .call_tool(McpClientRequest {

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -1,6 +1,9 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use ironclaw_events::{
+    InMemorySecurityAuditSink, SecurityAuditSink, SecurityBoundary, SecurityDecision,
+};
 use ironclaw_extensions::*;
 use ironclaw_host_api::*;
 use ironclaw_mcp::*;
@@ -435,10 +438,13 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
     plan.credential_injections = vec![secret_store_lease];
     let egress = RecordingRuntimeEgress::json_rpc();
     let planner = RecordingEgressPlanner::new(plan.clone());
+    let security_sink = Arc::new(InMemorySecurityAuditSink::new());
+    let security_sink_dyn: Arc<dyn SecurityAuditSink> = security_sink.clone();
     let client = McpHostHttpClient::new(
         McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
         planner.clone(),
-    );
+    )
+    .with_security_audit_sink(security_sink_dyn);
 
     let error = client
         .call_tool(McpClientRequest {
@@ -456,6 +462,16 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
         .expect_err("direct secret-store leases must fail before MCP transport");
 
     assert_eq!(error.stable_reason(), "request_denied");
+    let events = security_sink.snapshot();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].boundary, SecurityBoundary::McpDirectLease);
+    assert_eq!(events[0].decision, SecurityDecision::Blocked);
+    assert_eq!(events[0].code, MCP_DIRECT_LEASE_DENY_CODE);
+    assert_eq!(
+        events[0].capability_id,
+        Some(CapabilityId::new("github-mcp.search").unwrap())
+    );
+    assert_eq!(events[0].scope, Some(scope.clone()));
     assert!(
         egress.requests().is_empty(),
         "direct leases must be rejected before initialize or tools/call transport"
@@ -493,6 +509,11 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
         "failed preflight must not leave a stale session id for the next initialize"
     );
     assert_eq!(planner.calls().len(), 4);
+    assert_eq!(
+        security_sink.snapshot().len(),
+        1,
+        "successful retry must not emit another direct-lease denial"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -304,10 +304,12 @@ where
     };
     let runtime_http_egress = runtime_ports.runtime_http_egress();
     let registry = services.shared_extension_registry();
+    let security_audit_sink = services.security_audit_sink();
 
     Ok(services.with_mcp_runtime(Arc::new(hosted_http_mcp_runtime(
         registry,
         runtime_http_egress,
+        security_audit_sink,
     ))))
 }
 

--- a/crates/ironclaw_reborn_composition/src/mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/mcp.rs
@@ -24,13 +24,11 @@ pub(crate) fn hosted_http_mcp_runtime(
 ) -> McpRuntime<
     McpHostHttpClient<McpRuntimeHttpAdapter<Arc<dyn RuntimeHttpEgress>>, RegistryMcpEgressPlanner>,
 > {
-    let mut client = McpHostHttpClient::new(
+    let client = McpHostHttpClient::new(
         McpRuntimeHttpAdapter::new(runtime_http_egress),
         RegistryMcpEgressPlanner::new(registry),
-    );
-    if let Some(sink) = security_audit_sink {
-        client = client.with_security_audit_sink(sink);
-    }
+    )
+    .with_security_audit_sink(security_audit_sink);
     McpRuntime::new(McpRuntimeConfig::default(), client)
 }
 

--- a/crates/ironclaw_reborn_composition/src/mcp.rs
+++ b/crates/ironclaw_reborn_composition/src/mcp.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use ironclaw_events::SecurityAuditSink;
 use ironclaw_extensions::{
     ExtensionPackage, ExtensionRuntime, ManifestSource, SharedExtensionRegistry,
 };
@@ -19,13 +20,17 @@ const MCP_TIMEOUT_MS: u32 = 60_000;
 pub(crate) fn hosted_http_mcp_runtime(
     registry: Arc<SharedExtensionRegistry>,
     runtime_http_egress: Arc<dyn RuntimeHttpEgress>,
+    security_audit_sink: Option<Arc<dyn SecurityAuditSink>>,
 ) -> McpRuntime<
     McpHostHttpClient<McpRuntimeHttpAdapter<Arc<dyn RuntimeHttpEgress>>, RegistryMcpEgressPlanner>,
 > {
-    let client = McpHostHttpClient::new(
+    let mut client = McpHostHttpClient::new(
         McpRuntimeHttpAdapter::new(runtime_http_egress),
         RegistryMcpEgressPlanner::new(registry),
     );
+    if let Some(sink) = security_audit_sink {
+        client = client.with_security_audit_sink(sink);
+    }
     McpRuntime::new(McpRuntimeConfig::default(), client)
 }
 


### PR DESCRIPTION
Fixes one boundary from #3959. Summary: records payload-free SecurityAuditEvent entries for MCP SecretStoreLease/direct-lease denials; threads the configured HostRuntimeServices security audit sink into the hosted MCP runtime; keeps the denial pre-transport and preserves successful retry behavior. Tests: cargo test -p ironclaw_mcp; cargo test -p ironclaw_reborn_composition mcp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP security audit event reporting for blocked direct secret-store lease credential injections (including a new deny code constant).
  * Wired an optional security audit sink into the hosted MCP runtime so audit events can be captured.

* **Security**
  * Centralized enforcement to reject direct secret-store lease credential injections consistently across tool request paths.

* **Tests**
  * Extended MCP adapter contract tests to verify a single expected blocked audit event and no duplicate emissions after retry.

* **Chores**
  * Added a new shared dependency needed for security audit types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->