### PR TITLE
[hooks] Record auth continuation dispatch failures

### DIFF
--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -368,6 +368,10 @@ where
         }
     }
 
+    pub fn security_audit_sink(&self) -> Option<Arc<dyn SecurityAuditSink>> {
+        self.security_audit_sink.clone()
+    }
+
     /// Builds a runtime dispatcher with every configured runtime adapter.
     fn runtime_dispatcher(&self) -> RuntimeDispatcher<'static, F, G> {
         let mut dispatcher = RuntimeDispatcher::from_shared_registry(

--- a/crates/ironclaw_reborn_composition/src/auth.rs
+++ b/crates/ironclaw_reborn_composition/src/auth.rs
@@ -19,6 +19,7 @@ use ironclaw_auth::{
     SecretCleanupReport, SecretCleanupRequest, SecretCleanupService, SecretSubmitRequest,
     SecretSubmitResult, Timestamp, TurnGateAuthFlowQuery, TurnRunRef, scope_matches,
 };
+use ironclaw_events::{SecurityAuditEvent, SecurityAuditSink, SecurityBoundary, SecurityDecision};
 use ironclaw_product_adapters::AuthPromptChallengeKind;
 use ironclaw_product_workflow::ProductAuthTurnGateResumeDispatcher;
 use secrecy::SecretString;
@@ -34,6 +35,8 @@ use crate::product_auth_runtime_credentials::{
     ProductAuthRuntimeCredentialAccountSelector, RuntimeCredentialAccountSelectionService,
 };
 use crate::{AuthChallengeProvider, AuthChallengeView};
+
+pub(crate) const AUTH_CONTINUATION_DISPATCH_FAILED_CODE: &str = "auth_continuation_dispatch_failed";
 
 /// Dispatches a typed continuation event once an OAuth callback flow has
 /// completed.
@@ -451,6 +454,7 @@ pub struct RebornProductAuthServices {
     provider_client: Arc<dyn AuthProviderClient>,
     cleanup_service: Arc<dyn SecretCleanupService>,
     continuation_dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
+    security_audit_sink: Option<Arc<dyn SecurityAuditSink>>,
     dcr_oauth_registry: Option<Arc<OAuthDcrProviderRegistry>>,
     oauth_gate_registry: Option<Arc<GoogleOAuthGateProviderRegistry>>,
     /// Optional read projection for WebUI/local-dev auth interactions.
@@ -495,6 +499,7 @@ impl std::fmt::Debug for RebornProductAuthServices {
                 "continuation_dispatcher",
                 &"Arc<dyn RebornAuthContinuationDispatcher>",
             )
+            .field("security_audit_sink", &self.security_audit_sink.is_some())
             .field("flow_record_source", &self.flow_record_source.is_some())
             .field("dcr_oauth_registry", &self.dcr_oauth_registry.is_some())
             .field("oauth_gate_registry", &self.oauth_gate_registry.is_some())
@@ -527,6 +532,7 @@ impl RebornProductAuthServices {
             provider_client,
             cleanup_service,
             continuation_dispatcher,
+            security_audit_sink: None,
             dcr_oauth_registry: None,
             oauth_gate_registry: None,
             flow_record_source: None,
@@ -687,6 +693,11 @@ impl RebornProductAuthServices {
         dispatcher: Arc<dyn RebornAuthContinuationDispatcher>,
     ) -> Self {
         self.continuation_dispatcher = dispatcher;
+        self
+    }
+
+    pub fn with_security_audit_sink(mut self, sink: Arc<dyn SecurityAuditSink>) -> Self {
+        self.security_audit_sink = Some(sink);
         self
     }
 
@@ -1180,6 +1191,7 @@ impl RebornProductAuthServices {
             .dispatch_auth_continuation(event)
             .await
         {
+            self.record_auth_continuation_dispatch_failure(&completed);
             tracing::debug!(
                 flow_id = %completed.id,
                 error_code = ?error.code(),
@@ -1196,6 +1208,19 @@ impl RebornProductAuthServices {
         self.flow_manager
             .mark_continuation_dispatched(&completed.scope, completed.id, emitted_at)
             .await
+    }
+
+    fn record_auth_continuation_dispatch_failure(&self, completed: &AuthFlowRecord) {
+        if let Some(sink) = &self.security_audit_sink {
+            sink.record(
+                SecurityAuditEvent::new(
+                    SecurityBoundary::AuthContinuation,
+                    SecurityDecision::Blocked,
+                    AUTH_CONTINUATION_DISPATCH_FAILED_CODE,
+                )
+                .with_scope(completed.scope.resource.clone()),
+            );
+        }
     }
 
     #[allow(

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -538,12 +538,16 @@ fn compose_product_auth_services(
     ports: RebornProductAuthServicePorts,
     turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator>,
     provider_composition: OAuthProviderComposition,
+    security_audit_sink: Option<Arc<dyn ironclaw_events::SecurityAuditSink>>,
 ) -> Arc<RebornProductAuthServices> {
     let ports = match provider_composition.client {
         Some(provider_client) => ports.with_provider_client(provider_client),
         None => ports,
     };
     let mut services = ports.into_services(auth_continuation_dispatcher(turn_coordinator));
+    if let Some(sink) = security_audit_sink {
+        services = services.with_security_audit_sink(sink);
+    }
     if let Some(registry) = provider_composition.dcr_registry {
         services = services.with_dcr_oauth_registry(registry);
     }
@@ -742,10 +746,14 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         Arc::clone(&secret_store),
         product_auth_runtime_ports.clone(),
     )?;
+    let security_audit_sink = services.security_audit_sink();
     let product_auth = match product_auth_ports {
-        Some(ports) => {
-            compose_product_auth_services(ports, turn_coordinator.clone(), provider_composition)
-        }
+        Some(ports) => compose_product_auth_services(
+            ports,
+            turn_coordinator.clone(),
+            provider_composition,
+            security_audit_sink.clone(),
+        ),
         None => {
             #[cfg(any(feature = "libsql", feature = "postgres"))]
             {
@@ -771,6 +779,10 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
                     Some(registry) => services.with_oauth_gate_registry(registry),
                     None => services,
                 };
+                let services = match security_audit_sink.clone() {
+                    Some(sink) => services.with_security_audit_sink(sink),
+                    None => services,
+                };
                 Arc::new(services)
             }
             #[cfg(not(any(feature = "libsql", feature = "postgres")))]
@@ -784,6 +796,10 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
                 };
                 let services = match provider_composition.dcr_registry.clone() {
                     Some(registry) => services.with_dcr_oauth_registry(registry),
+                    None => services,
+                };
+                let services = match security_audit_sink.clone() {
+                    Some(sink) => services.with_security_audit_sink(sink),
                     None => services,
                 };
                 Arc::new(match provider_composition.gate_registry.clone() {
@@ -2696,6 +2712,7 @@ where
         production_wiring.runtime_process_binding,
     );
     let services = attach_wasm_runtime(services)?;
+    let security_audit_sink = services.security_audit_sink();
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);
@@ -2716,6 +2733,7 @@ where
         product_auth_ports,
         turn_coordinator.clone(),
         provider_composition,
+        security_audit_sink,
     );
     let product_auth_ready = true;
     // Wire ProductAuthAccount runtime credential resolver before

--- a/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
+++ b/crates/ironclaw_reborn_composition/src/factory/auth_tests.rs
@@ -9,6 +9,7 @@ use ironclaw_auth::{
     TurnRunRef,
 };
 use ironclaw_capabilities::{CapabilityObligationHandler, CapabilityObligationRequest};
+use ironclaw_events::{InMemorySecurityAuditSink, SecurityBoundary, SecurityDecision};
 use ironclaw_host_api::{
     AgentId, InvocationId, ProjectId, ResourceScope, RuntimeHttpEgress, RuntimeHttpEgressError,
     RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, TenantId, ThreadId, UserId,
@@ -25,6 +26,8 @@ use ironclaw_turns::{
 };
 use secrecy::SecretString;
 use std::sync::Mutex;
+
+use crate::auth::AUTH_CONTINUATION_DISPATCH_FAILED_CODE;
 
 use super::*;
 use crate::notion_oauth::{NOTION_PROVIDER_ID, notion_provider_spec};
@@ -528,9 +531,12 @@ async fn oauth_callback_continuation_dispatch_maps_turn_error_categories() {
             Arc::new(InMemoryAuthProductServices::new()),
             Arc::new(ProductAuthTurnGateResumeDispatcher::new(coordinator)),
         );
+        let security_audit_sink = Arc::new(InMemorySecurityAuditSink::new());
+        let services = services.with_security_audit_sink(security_audit_sink.clone());
         let scope = turn_scope();
         let actor = TurnActor::new(UserId::new("alice").unwrap());
         let auth_scope = auth_scope_for_turn(&scope, &actor);
+        let expected_scope = auth_scope.resource.clone();
         let flow_id = create_flow(
             &services,
             auth_scope.clone(),
@@ -548,6 +554,13 @@ async fn oauth_callback_continuation_dispatch_maps_turn_error_categories() {
 
         assert_eq!(error.code, expected_code);
         assert_eq!(error.retryable, expected_retryable);
+
+        let events = security_audit_sink.snapshot();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].boundary, SecurityBoundary::AuthContinuation);
+        assert_eq!(events[0].decision, SecurityDecision::Blocked);
+        assert_eq!(events[0].code, AUTH_CONTINUATION_DISPATCH_FAILED_CODE);
+        assert_eq!(events[0].scope.as_ref(), Some(&expected_scope));
     }
 }
 


### PR DESCRIPTION
## Summary
- add a payload-free SecurityAuditSink path for auth-continuation dispatch failures
- thread the existing host-runtime security audit sink into product-auth composition
- assert callback-driven continuation failures emit exactly one AuthContinuation blocked audit event

## Tests
- cargo test -p ironclaw_reborn_composition oauth_callback_continuation_dispatch_maps_turn_error_categories
- cargo test -p ironclaw_host_runtime host_runtime_services_with_security_audit_sink_records_leak_block

Part of #3959.