### PR TITLE
[hooks] Enforce aggregate tenant predicate key caps

### DIFF
--- a/crates/ironclaw_hooks/docs/operator-runbook.md
+++ b/crates/ironclaw_hooks/docs/operator-runbook.md
@@ -92,6 +92,12 @@ capability × hook × field)` key arrives at the cap, the LRU entry
 The cap defends against unbounded growth across permutations
 (threat-model D5).
 
+A single tenant is additionally capped at
+`MAX_KEYS_PER_TENANT = MAX_HISTORY_KEYS / 4` across BOTH predicate
+history maps. Invocation-count keys and numeric-sum keys share that
+tenant budget; when the tenant is at the cap, the oldest-front key
+for that tenant is evicted regardless of which map owns it.
+
 ### What an eviction *means*
 
 The evicted key's rolling window is lost. The next invocation

--- a/crates/ironclaw_hooks/src/predicate_state.rs
+++ b/crates/ironclaw_hooks/src/predicate_state.rs
@@ -501,7 +501,7 @@ pub struct InMemoryPredicateStateBackend {
 /// in-memory backend's memory footprint against threat-model finding **D5**.
 pub const MAX_HISTORY_KEYS: usize = 8_192;
 
-/// Per-tenant ceiling on distinct keys held in either history map.
+/// Per-tenant ceiling on distinct keys held across both history maps.
 /// Defends against the cross-tenant LRU-reset attack (henrypark133 MED
 /// on PR #3635 5-19 review): without a per-tenant quota, a noisy tenant
 /// can grow its key footprint to evict a quiet tenant's bucket, which
@@ -596,26 +596,33 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
         // (henrypark133 must-fix #2 on PR #3635). A poisoning thread has
         // already aborted; refusing service indefinitely is worse than
         // proceeding with possibly-incomplete state.
-        let mut history = match self.invocation_history.lock() {
+        let mut invocation_history = match self.invocation_history.lock() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
-        if !history.contains_key(key) {
+        let mut value_history = match self.value_history.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if !invocation_history.contains_key(key) {
             // Per-tenant quota: if this tenant already holds the cap,
-            // evict their oldest-front bucket FIRST (not a global LRU
-            // pass) so noisy tenants can't push quiet tenants out.
-            // henrypark133 MED on PR #3635 5-19 review.
-            let tenant_count = history
-                .keys()
-                .filter(|k| k.tenant_id == key.tenant_id)
-                .count();
+            // counting BOTH history maps, evict their oldest-front bucket
+            // FIRST (not a global LRU pass) so noisy tenants can't push quiet
+            // tenants out.
+            let tenant_count = tenant_invocation_key_count(&invocation_history, &key.tenant_id)
+                + tenant_value_key_count(&value_history, &key.tenant_id);
             if tenant_count >= MAX_KEYS_PER_TENANT {
-                evict_lru_invocation_for_tenant(&mut history, &key.tenant_id, &self.evictions);
-            } else if history.len() >= MAX_HISTORY_KEYS {
-                evict_lru_invocation(&mut history, &self.evictions);
+                evict_lru_for_tenant(
+                    &mut invocation_history,
+                    &mut value_history,
+                    &key.tenant_id,
+                    &self.evictions,
+                );
+            } else if invocation_history.len() >= MAX_HISTORY_KEYS {
+                evict_lru_invocation(&mut invocation_history, &self.evictions);
             }
         }
-        let bucket = history.entry(key.clone()).or_default();
+        let bucket = invocation_history.entry(key.clone()).or_default();
         // Trim entries outside the window using a wall-clock cutoff. With
         // the `DateTime<Utc>` clock, `window_cutoff` computes `now - window`
         // via saturating `chrono` arithmetic, so the `Instant::checked_sub`
@@ -651,7 +658,7 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
                 // Drop the bucket if the trim above emptied it, so an
                 // overflow-on-a-stale-key doesn't leave a zombie bucket.
                 if bucket.entries.is_empty() {
-                    history.remove(key);
+                    invocation_history.remove(key);
                 }
                 return Err(PredicateBackendError::WindowOverflow {
                     key: format!("{}/{}", key.tenant_id.as_str(), key.capability),
@@ -666,7 +673,7 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
         // removed every entry AND `duplicate` was true (so we didn't add
         // a new one).
         if bucket.entries.is_empty() {
-            history.remove(key);
+            invocation_history.remove(key);
         }
         Ok(count)
     }
@@ -679,22 +686,29 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
         value: Decimal,
         window: Duration,
     ) -> Result<Decimal, PredicateBackendError> {
-        let mut history = match self.value_history.lock() {
+        let mut invocation_history = match self.invocation_history.lock() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
-        if !history.contains_key(key) {
-            let tenant_count = history
-                .keys()
-                .filter(|k| k.tenant_id == key.tenant_id)
-                .count();
+        let mut value_history = match self.value_history.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if !value_history.contains_key(key) {
+            let tenant_count = tenant_invocation_key_count(&invocation_history, &key.tenant_id)
+                + tenant_value_key_count(&value_history, &key.tenant_id);
             if tenant_count >= MAX_KEYS_PER_TENANT {
-                evict_lru_value_for_tenant(&mut history, &key.tenant_id, &self.evictions);
-            } else if history.len() >= MAX_HISTORY_KEYS {
-                evict_lru_value(&mut history, &self.evictions);
+                evict_lru_for_tenant(
+                    &mut invocation_history,
+                    &mut value_history,
+                    &key.tenant_id,
+                    &self.evictions,
+                );
+            } else if value_history.len() >= MAX_HISTORY_KEYS {
+                evict_lru_value(&mut value_history, &self.evictions);
             }
         }
-        let bucket = history.entry(key.clone()).or_default();
+        let bucket = value_history.entry(key.clone()).or_default();
         // Wall-clock cutoff trim — see `record_invocation` for why the
         // `DateTime<Utc>` clock removes the Bug 2 underflow hazard.
         let cutoff = window_cutoff(now, window);
@@ -716,7 +730,7 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
             // reject so the evaluator can deny.
             if bucket.entries.len() >= MAX_SAMPLES_PER_KEY {
                 if bucket.entries.is_empty() {
-                    history.remove(key);
+                    value_history.remove(key);
                 }
                 return Err(PredicateBackendError::WindowOverflow {
                     key: format!(
@@ -736,7 +750,7 @@ impl PredicateStateBackend for InMemoryPredicateStateBackend {
         // the potential empty-bucket removal below.
         let sum = bucket.running_sum;
         if bucket.entries.is_empty() {
-            history.remove(key);
+            value_history.remove(key);
         }
         Ok(sum)
     }
@@ -828,31 +842,76 @@ fn evict_lru_invocation(
     }
 }
 
-/// Tenant-scoped variant: evict the oldest-front bucket BELONGING TO
-/// `tenant_id`. Used when a single tenant hits [`MAX_KEYS_PER_TENANT`]
-/// so the eviction stays within that tenant's footprint and cannot
-/// reach into another tenant's buckets (henrypark133 MED on PR #3635
-/// 5-19 review).
-fn evict_lru_invocation_for_tenant(
+fn tenant_invocation_key_count(
+    history: &HashMap<InvocationKey, InvocationBucket>,
+    tenant_id: &TenantId,
+) -> usize {
+    history
+        .keys()
+        .filter(|key| key.tenant_id == *tenant_id)
+        .count()
+}
+
+fn tenant_value_key_count(history: &HashMap<ValueKey, ValueBucket>, tenant_id: &TenantId) -> usize {
+    history
+        .keys()
+        .filter(|key| key.tenant_id == *tenant_id)
+        .count()
+}
+
+fn lru_invocation_candidate_for_tenant(
+    history: &HashMap<InvocationKey, InvocationBucket>,
+    tenant_id: &TenantId,
+) -> Option<(InvocationKey, Option<DateTime<Utc>>)> {
+    history
+        .iter()
+        .filter(|(key, _)| key.tenant_id == *tenant_id)
+        .map(|(key, bucket)| (key.clone(), bucket.entries.front().map(|(ts, _)| *ts)))
+        .min_by_key(|(_, oldest)| *oldest)
+}
+
+fn lru_value_candidate_for_tenant(
+    history: &HashMap<ValueKey, ValueBucket>,
+    tenant_id: &TenantId,
+) -> Option<(ValueKey, Option<DateTime<Utc>>)> {
+    history
+        .iter()
+        .filter(|(key, _)| key.tenant_id == *tenant_id)
+        .map(|(key, bucket)| (key.clone(), bucket.entries.front().map(|(ts, _, _)| *ts)))
+        .min_by_key(|(_, oldest)| *oldest)
+}
+
+/// Tenant-scoped aggregate variant: evict the oldest-front bucket BELONGING TO
+/// `tenant_id` across BOTH history maps. Used when a single tenant hits
+/// [`MAX_KEYS_PER_TENANT`] so the eviction stays within that tenant's combined
+/// footprint and cannot reach into another tenant's buckets.
+fn evict_lru_for_tenant(
     history: &mut HashMap<InvocationKey, InvocationBucket>,
+    value_history: &mut HashMap<ValueKey, ValueBucket>,
     tenant_id: &TenantId,
     evictions: &AtomicU64,
 ) {
-    let empty_victim = history
-        .iter()
-        .find(|(k, v)| k.tenant_id == *tenant_id && v.entries.is_empty())
-        .map(|(k, _)| k.clone());
-    let victim = empty_victim.or_else(|| {
-        history
-            .iter()
-            .filter(|(k, _)| k.tenant_id == *tenant_id)
-            .filter_map(|(k, v)| v.entries.front().map(|(ts, _)| (k.clone(), *ts)))
-            .min_by_key(|(_, ts)| *ts)
-            .map(|(k, _)| k)
-    });
-    if let Some(k) = victim {
-        history.remove(&k);
-        evictions.fetch_add(1, AtomicOrdering::Relaxed);
+    let invocation_victim = lru_invocation_candidate_for_tenant(history, tenant_id);
+    let value_victim = lru_value_candidate_for_tenant(value_history, tenant_id);
+
+    match (invocation_victim, value_victim) {
+        (Some((invocation_key, invocation_ts)), Some((value_key, value_ts))) => {
+            if invocation_ts <= value_ts {
+                history.remove(&invocation_key);
+            } else {
+                value_history.remove(&value_key);
+            }
+            evictions.fetch_add(1, AtomicOrdering::Relaxed);
+        }
+        (Some((invocation_key, _)), None) => {
+            history.remove(&invocation_key);
+            evictions.fetch_add(1, AtomicOrdering::Relaxed);
+        }
+        (None, Some((value_key, _))) => {
+            value_history.remove(&value_key);
+            evictions.fetch_add(1, AtomicOrdering::Relaxed);
+        }
+        (None, None) => {}
     }
 }
 
@@ -864,31 +923,6 @@ fn evict_lru_value(history: &mut HashMap<ValueKey, ValueBucket>, evictions: &Ato
     let victim = empty_victim.or_else(|| {
         history
             .iter()
-            .filter_map(|(k, v)| v.entries.front().map(|(ts, _, _)| (k.clone(), *ts)))
-            .min_by_key(|(_, ts)| *ts)
-            .map(|(k, _)| k)
-    });
-    if let Some(k) = victim {
-        history.remove(&k);
-        evictions.fetch_add(1, AtomicOrdering::Relaxed);
-    }
-}
-
-/// Tenant-scoped variant for the value-sum map. Same rationale as
-/// [`evict_lru_invocation_for_tenant`].
-fn evict_lru_value_for_tenant(
-    history: &mut HashMap<ValueKey, ValueBucket>,
-    tenant_id: &TenantId,
-    evictions: &AtomicU64,
-) {
-    let empty_victim = history
-        .iter()
-        .find(|(k, v)| k.tenant_id == *tenant_id && v.entries.is_empty())
-        .map(|(k, _)| k.clone());
-    let victim = empty_victim.or_else(|| {
-        history
-            .iter()
-            .filter(|(k, _)| k.tenant_id == *tenant_id)
             .filter_map(|(k, v)| v.entries.front().map(|(ts, _, _)| (k.clone(), *ts)))
             .min_by_key(|(_, ts)| *ts)
             .map(|(k, _)| k)
@@ -1197,6 +1231,48 @@ pub mod contract {
         );
     }
 
+    /// Contract: [`MAX_KEYS_PER_TENANT`] is a tenant-wide aggregate quota
+    /// across invocation and value histories, not one independent quota per
+    /// map. Filling a tenant to the cap with invocation keys, then adding a
+    /// value key for the same tenant, must evict one of that tenant's existing
+    /// keys and advance the eviction counter.
+    pub async fn tenant_key_quota_spans_invocation_and_value_maps<B, F>(factory: F)
+    where
+        B: PredicateStateBackend,
+        F: Fn() -> B,
+    {
+        let backend = factory();
+        let tenant = "alpha";
+        let window = Duration::from_secs(86_400);
+        for i in 0..MAX_KEYS_PER_TENANT {
+            let key = inv_key(tenant, &format!("cap.inv.{i}"));
+            backend
+                .record_invocation(&key, &ev(&format!("inv-{i}")), at(i as i64), window)
+                .await
+                .expect("invocation insert under tenant cap succeeds");
+        }
+        let before_evictions = backend.evictions_observed();
+
+        let value_key = val_key(tenant, "cap.value", "amount");
+        let sum = backend
+            .record_value(
+                &value_key,
+                &ev("value-over-cap"),
+                at(MAX_KEYS_PER_TENANT as i64 + 1),
+                Decimal::from(1),
+                window,
+            )
+            .await
+            .expect("value insert should evict within the same tenant, not fail");
+
+        assert_eq!(sum, Decimal::from(1));
+        assert!(
+            backend.evictions_observed() > before_evictions,
+            "adding a value key when invocation keys already fill the tenant \
+             quota must trigger aggregate per-tenant eviction"
+        );
+    }
+
     /// Contract: the per-key sample cap is FAIL CLOSED. Filling a single
     /// key past [`MAX_SAMPLES_PER_KEY`] with distinct in-window event ids
     /// must return [`PredicateBackendError::WindowOverflow`] rather than
@@ -1413,6 +1489,7 @@ pub mod contract {
             $emit!([$($ctx)*] duplicate_event_id_is_noop_for_values);
             $emit!([$($ctx)*] invocation_retains_entry_at_exact_window_cutoff);
             $emit!([$($ctx)*] event_id_dedup_isolated_across_maps);
+            $emit!([$($ctx)*] tenant_key_quota_spans_invocation_and_value_maps);
             $emit!([$($ctx)*] record_invocation_overflow_is_fail_closed);
             $emit!([$($ctx)*] evict_older_than_reaps_strictly_older_rows);
             $emit!([$($ctx)*] evict_older_than_retains_entry_at_exact_cutoff);

--- a/crates/ironclaw_hooks_libsql/src/backend.rs
+++ b/crates/ironclaw_hooks_libsql/src/backend.rs
@@ -278,12 +278,13 @@ impl LibSqlPredicateStateBackend {
                     });
                 }
 
-                // 4. Per-tenant LRU quota: only relevant when inserting a NEW
-                //    key (a fresh PRIMARY KEY). Mirror the in-memory backend's
-                //    "evict before insert when at quota" semantics, ranking the
-                //    tenant's keys by oldest-front (MIN(occurred_at)).
+                // 4. Per-tenant aggregate LRU quota: only relevant when
+                //    inserting a NEW key (a fresh PRIMARY KEY). Mirror the
+                //    in-memory backend's "evict before insert when at quota"
+                //    semantics, ranking the tenant's keys across both typed
+                //    tables by oldest-front (MIN(occurred_at)).
                 if !key_exists(&conn, table, &key_hash).await? {
-                    evicted += enforce_caps(&conn, table, &scope).await?;
+                    evicted += enforce_caps(&conn, &scope).await?;
                 }
 
                 // 5. Insert (table-specific shape via the spec). The dedup
@@ -587,12 +588,12 @@ async fn key_exists(
 
 /// Enforce the per-tenant [`MAX_KEYS_PER_TENANT`] distinct-key quota before
 /// inserting a NEW key. A tenant is a distinct `scope_hash`; its keys are the
-/// distinct `key_hash` values under that scope, each key's "front timestamp"
-/// being its `min(occurred_at)`. The victim is the tenant's key with the
-/// smallest front timestamp — the durable equivalent of the in-memory
-/// `min_by_key(front ts)` LRU. Returns the number of keys evicted (one
-/// increment per evicted bucket, matching the in-memory backend's `evictions`
-/// semantics).
+/// distinct `key_hash` values under that scope across BOTH typed tables, each
+/// key's "front timestamp" being its `min(occurred_at)`. The victim is the
+/// tenant's key with the smallest front timestamp — the durable equivalent of
+/// the in-memory `min_by_key(front ts)` LRU. Returns the number of keys evicted
+/// (one increment per evicted bucket, matching the in-memory backend's
+/// `evictions` semantics).
 ///
 /// # No global cap (parity with the Postgres backend)
 ///
@@ -608,15 +609,15 @@ async fn key_exists(
 ///
 /// # Reaper requirement — quota counts un-reaped expired rows
 ///
-/// The `COUNT(DISTINCT key_hash) WHERE scope_hash = ?1` below counts EVERY
-/// stored row for the tenant, including expired rows from OTHER keys: the
-/// per-key window trim in `record_*` only deletes `WHERE key_hash = ?1`, never
-/// sibling keys. So a tenant with many idle short-window keys can read at
-/// `MAX_KEYS_PER_TENANT` and trip LRU eviction (advancing `evictions_observed`)
-/// even though its *active* key count is lower. The evicted keys are already
-/// expired, so gate correctness is unaffected, but operators MUST schedule a
-/// periodic [`PredicateStateBackend::evict_older_than`] reaper to keep the
-/// quota aligned with the active key count. See
+/// The unioned distinct-key count below counts EVERY stored row for the tenant
+/// across both tables, including expired rows from OTHER keys: the per-key
+/// window trim in `record_*` only deletes `WHERE key_hash = ?1`, never sibling
+/// keys. So a tenant with many idle short-window keys can read at
+/// `MAX_KEYS_PER_TENANT` and trip LRU eviction (advancing
+/// `evictions_observed`) even though its *active* key count is lower. The
+/// evicted keys are already expired, so gate correctness is unaffected, but
+/// operators MUST schedule a periodic [`PredicateStateBackend::evict_older_than`]
+/// reaper to keep the quota aligned with the active key count. See
 /// `ironclaw_hooks/docs/successors/03-persistent-counter.md` (Reaper
 /// requirement). This is NOT fixed by a behavior change here: counting only
 /// in-window rows would require a window per key, which the quota does not have.
@@ -624,25 +625,27 @@ async fn key_exists(
 /// [`MAX_HISTORY_KEYS`]: ironclaw_hooks::predicate_state::MAX_HISTORY_KEYS
 /// [`MAX_KEYS_PER_TENANT`]: ironclaw_hooks::predicate_state::MAX_KEYS_PER_TENANT
 /// [`PredicateStateBackend::evict_older_than`]: ironclaw_hooks::predicate_state::PredicateStateBackend::evict_older_than
-async fn enforce_caps(
-    conn: &Connection,
-    table: &str,
-    scope: &[u8],
-) -> Result<u64, PredicateBackendError> {
+async fn enforce_caps(conn: &Connection, scope: &[u8]) -> Result<u64, PredicateBackendError> {
     let mut evicted = 0u64;
 
     // Per-tenant quota (matches in-memory: a tenant at its cap evicts ITS OWN
     // oldest key so it can't push out other tenants). No global cap — see
     // the fn-level doc; durable backends reap by time, not a global key count.
     // The tenant grain is `scope_hash`; its keys are the distinct `key_hash`
-    // values under it.
+    // values under it across both typed tables.
     let tenant_keys = scalar_u32(
         conn,
-        &format!("SELECT count(DISTINCT key_hash) FROM {table} WHERE scope_hash = ?1"),
+        &format!(
+            "SELECT count(*) FROM (
+                 SELECT key_hash FROM {INVOCATIONS_TABLE} WHERE scope_hash = ?1
+                 UNION
+                 SELECT key_hash FROM {VALUES_TABLE} WHERE scope_hash = ?1
+             ) tenant_keys"
+        ),
         params![scope.to_vec()],
     )
     .await?;
-    if tenant_keys as usize >= MAX_KEYS_PER_TENANT && evict_oldest_key(conn, table, scope).await? {
+    if tenant_keys as usize >= MAX_KEYS_PER_TENANT && evict_oldest_key(conn, scope).await? {
         evicted += 1;
     }
     Ok(evicted)
@@ -652,14 +655,21 @@ async fn enforce_caps(
 /// (oldest-front victim selection). Returns true if a key was evicted. Always
 /// tenant-scoped: durable backends only enforce the per-tenant quota (no global
 /// cap — see [`enforce_caps`]).
-async fn evict_oldest_key(
-    conn: &Connection,
-    table: &str,
-    scope: &[u8],
-) -> Result<bool, PredicateBackendError> {
+async fn evict_oldest_key(conn: &Connection, scope: &[u8]) -> Result<bool, PredicateBackendError> {
     let select_victim = format!(
-        "SELECT key_hash FROM {table} WHERE scope_hash = ?1 \
-         GROUP BY key_hash ORDER BY min(occurred_at) ASC, key_hash ASC LIMIT 1"
+        "SELECT table_name, key_hash FROM (
+             SELECT 'invocation' AS table_name, key_hash, min(occurred_at) AS oldest_ts
+               FROM {INVOCATIONS_TABLE}
+              WHERE scope_hash = ?1
+              GROUP BY key_hash
+             UNION ALL
+             SELECT 'value' AS table_name, key_hash, min(occurred_at) AS oldest_ts
+               FROM {VALUES_TABLE}
+              WHERE scope_hash = ?1
+              GROUP BY key_hash
+         ) victims
+         ORDER BY oldest_ts ASC, table_name ASC, key_hash ASC
+         LIMIT 1"
     );
     let mut rows = conn
         .query(&select_victim, params![scope.to_vec()])
@@ -668,11 +678,21 @@ async fn evict_oldest_key(
     let Some(row) = rows.next().await.map_err(map_err)? else {
         return Ok(false);
     };
-    let victim: Vec<u8> = row.get_value(0).map_err(map_err).and_then(blob_value)?;
+    let victim_table_name: String = row.get(0).map_err(map_err)?;
+    let victim_table = match victim_table_name.as_str() {
+        "invocation" => INVOCATIONS_TABLE,
+        "value" => VALUES_TABLE,
+        other => {
+            return Err(PredicateBackendError::Unavailable(format!(
+                "unexpected predicate victim table tag: {other}"
+            )));
+        }
+    };
+    let victim: Vec<u8> = row.get_value(1).map_err(map_err).and_then(blob_value)?;
     drop(rows);
     conn.execute(
-        &format!("DELETE FROM {table} WHERE key_hash = ?1"),
-        params![victim],
+        &format!("DELETE FROM {victim_table} WHERE scope_hash = ?1 AND key_hash = ?2"),
+        params![scope.to_vec(), victim],
     )
     .await
     .map_err(map_err)?;

--- a/crates/ironclaw_hooks_postgres/src/backend.rs
+++ b/crates/ironclaw_hooks_postgres/src/backend.rs
@@ -34,11 +34,12 @@
 //!    into the kind-specific table (`hooks_predicate_invocations` for
 //!    counts, `hooks_predicate_values` for numeric sums — explicit typed
 //!    tables, not a generic `kind` discriminator column).
-//! 5. **Evicts** the scope's oldest-front key — the key whose oldest
-//!    retained sample (`MIN(occurred_at)`) is oldest — when the scope's
-//!    distinct-key count exceeds [`MAX_KEYS_PER_TENANT`] (the durable
-//!    analogue of the in-memory per-tenant LRU quota, which ranks buckets by
-//!    their oldest entry). Each victim's rows
+//! 5. **Evicts** the scope's oldest-front key across both typed tables — the
+//!    key whose oldest retained sample (`MIN(occurred_at)`) is oldest — when
+//!    the scope's aggregate distinct-key count exceeds
+//!    [`MAX_KEYS_PER_TENANT`] (the durable analogue of the in-memory
+//!    per-tenant LRU quota, which ranks buckets by their oldest entry). Each
+//!    victim's rows
 //!    are deleted only after acquiring that victim key's per-key advisory
 //!    lock with the NON-blocking `pg_try_advisory_xact_lock`, so eviction
 //!    obeys the same per-bucket serialization as a recorder and can never
@@ -99,16 +100,6 @@ impl RecordKind {
         match self {
             RecordKind::Invocation => INVOCATIONS_TABLE,
             RecordKind::Value => VALUES_TABLE,
-        }
-    }
-
-    /// One-byte discriminant folded into the per-scope advisory-lock key so
-    /// the invocation and value scope-quota passes lock independently (they
-    /// touch disjoint tables, so they must not serialize against each other).
-    fn lock_tag(self) -> &'static [u8] {
-        match self {
-            RecordKind::Invocation => b"i",
-            RecordKind::Value => b"v",
         }
     }
 }
@@ -344,9 +335,10 @@ impl PostgresPredicateStateBackend {
         // make the count always pre-insert. Sequential statements inside
         // the transaction DO see prior statements' writes.
         //
-        // The distinct-key count is needed independently of the returned
-        // aggregate (the value table's aggregate is a SUM, not a count), so
-        // read it explicitly to gate the quota pass.
+        // The current key's in-window count is needed independently of the
+        // returned aggregate (the value table's aggregate is a SUM, not a
+        // count), so read it explicitly to detect when this record created a
+        // brand-new bucket and should run the aggregate tenant quota pass.
         let in_window_count: i64 = tx
             .query_one(
                 &format!(
@@ -359,17 +351,15 @@ impl PostgresPredicateStateBackend {
             .map_err(map_pg)?
             .get(0);
 
-        // (5) Per-scope distinct-key LRU quota. Only scan when this key is
-        // newly material (count == 1 after insert means we may have just
-        // created the scope's Nth key). Distinct keys are counted by
-        // key_hash within the scope (one typed table per kind, so no kind
-        // filter is needed); if over quota, evict the least-recently-active
-        // key's rows entirely. Scope-LRU eviction only ever touches OTHER
-        // keys, so it cannot change this key's aggregate and does not require
-        // a re-read.
+        // (5) Per-scope aggregate distinct-key LRU quota. Only scan when this
+        // key is newly material (count == 1 after insert means we may have
+        // just created the scope's Nth key). Distinct keys are counted by
+        // key_hash within the scope across both typed tables; if over quota,
+        // evict the least-recently-active key's rows entirely. Scope-LRU
+        // eviction only ever touches OTHER keys, so it cannot change this
+        // key's aggregate and does not require a re-read.
         let evicted = if in_window_count == 1 {
-            self.enforce_scope_quota(&tx, kind, scope_ref, key_ref)
-                .await?
+            self.enforce_scope_quota(&tx, scope_ref, key_ref).await?
         } else {
             0
         };
@@ -432,7 +422,8 @@ impl PostgresPredicateStateBackend {
         }
     }
 
-    /// Enforce [`MAX_KEYS_PER_TENANT`] distinct keys per scope+kind.
+    /// Enforce [`MAX_KEYS_PER_TENANT`] distinct keys per scope across both
+    /// typed predicate tables.
     /// Returns the number of keys evicted (0 or more). Eviction drops the
     /// key whose OLDEST retained sample is oldest (`MIN(ts)` per key) —
     /// the "oldest-front" victim selection, matching the in-memory backend
@@ -441,14 +432,14 @@ impl PostgresPredicateStateBackend {
     ///
     /// # Reaper requirement — quota counts un-reaped expired rows
     ///
-    /// The `COUNT(DISTINCT key_hash) WHERE scope_hash = $1` below counts EVERY
-    /// stored row for the scope, including expired rows from OTHER keys: the
+    /// The unioned distinct-key count below counts EVERY stored row for the
+    /// scope across both tables, including expired rows from OTHER keys: the
     /// per-key window trim in `record_*` only deletes the current key's
     /// out-of-window rows, never sibling keys. So a tenant with many idle
-    /// short-window keys can read at `MAX_KEYS_PER_TENANT` and trip LRU eviction
-    /// (advancing `evictions_observed`) even though its *active* key count is
-    /// lower. The evicted keys are already expired, so gate correctness is
-    /// unaffected, but operators MUST schedule a periodic
+    /// short-window keys can read at `MAX_KEYS_PER_TENANT` and trip LRU
+    /// eviction (advancing `evictions_observed`) even though its *active* key
+    /// count is lower. The evicted keys are already expired, so gate
+    /// correctness is unaffected, but operators MUST schedule a periodic
     /// [`PredicateStateBackend::evict_older_than`] reaper to keep the quota
     /// aligned with the active key count. See
     /// `ironclaw_hooks/docs/successors/03-persistent-counter.md` (Reaper
@@ -484,11 +475,9 @@ impl PostgresPredicateStateBackend {
     async fn enforce_scope_quota(
         &self,
         tx: &deadpool_postgres::Transaction<'_>,
-        kind: RecordKind,
         scope_ref: &[u8],
         current_key: &[u8],
     ) -> Result<u64, PredicateBackendError> {
-        let table = kind.table();
         // Serialize quota enforcement within the scope. Concurrent inserts
         // of DISTINCT new keys in the same scope each reach this path with
         // `count == 1`, but under READ COMMITTED neither sees the other's
@@ -499,7 +488,7 @@ impl PostgresPredicateStateBackend {
         // space, disjoint from the per-key `(int4,int4)` lock space. Hot-path
         // same-key writes never reach here (only newly-material keys do), so
         // this does not serialize steady-state traffic.
-        let scope_lock = scope_advisory_lock_key(scope_ref, kind.lock_tag());
+        let scope_lock = scope_advisory_lock_key(scope_ref);
         tx.execute("SELECT pg_advisory_xact_lock($1)", &[&scope_lock])
             .await
             .map_err(map_pg)?;
@@ -507,9 +496,11 @@ impl PostgresPredicateStateBackend {
         let distinct: i64 = tx
             .query_one(
                 &format!(
-                    "SELECT COUNT(DISTINCT key_hash)::BIGINT
-                       FROM {table}
-                      WHERE scope_hash = $1"
+                    "SELECT COUNT(*)::BIGINT FROM (
+                         SELECT key_hash FROM {INVOCATIONS_TABLE} WHERE scope_hash = $1
+                         UNION
+                         SELECT key_hash FROM {VALUES_TABLE} WHERE scope_hash = $1
+                     ) tenant_keys"
                 ),
                 &[&scope_ref],
             )
@@ -545,15 +536,25 @@ impl PostgresPredicateStateBackend {
         let candidate_rows = tx
             .query(
                 &format!(
-                    "SELECT key_hash FROM (
-                         SELECT key_hash, MIN(occurred_at) AS oldest_ts
-                           FROM {table}
+                    "SELECT table_name, key_hash FROM (
+                         SELECT 'invocation'::TEXT AS table_name,
+                                key_hash,
+                                MIN(occurred_at) AS oldest_ts
+                           FROM {INVOCATIONS_TABLE}
                           WHERE scope_hash = $1
                             AND key_hash <> $2
                           GROUP BY key_hash
-                          ORDER BY oldest_ts ASC
-                          LIMIT $3
-                     ) victims"
+                         UNION ALL
+                         SELECT 'value'::TEXT AS table_name,
+                                key_hash,
+                                MIN(occurred_at) AS oldest_ts
+                           FROM {VALUES_TABLE}
+                          WHERE scope_hash = $1
+                            AND key_hash <> $2
+                          GROUP BY key_hash
+                     ) victims
+                     ORDER BY oldest_ts ASC, table_name ASC, key_hash ASC
+                     LIMIT $3"
                 ),
                 &[&scope_ref, &current_key, &candidate_limit],
             )
@@ -573,7 +574,13 @@ impl PostgresPredicateStateBackend {
             if evicted as usize >= to_evict {
                 break;
             }
-            let victim_key: Vec<u8> = row.get(0);
+            let victim_table_name: String = row.get(0);
+            let victim_key: Vec<u8> = row.get(1);
+            let victim_table = match victim_table_name.as_str() {
+                "invocation" => INVOCATIONS_TABLE,
+                "value" => VALUES_TABLE,
+                _ => continue,
+            };
             let lock_key = advisory_lock_key_from_bytes(&victim_key);
             let got_lock: bool = tx
                 .query_one(
@@ -589,7 +596,7 @@ impl PostgresPredicateStateBackend {
                 continue;
             }
             tx.execute(
-                &format!("DELETE FROM {table} WHERE scope_hash = $1 AND key_hash = $2"),
+                &format!("DELETE FROM {victim_table} WHERE scope_hash = $1 AND key_hash = $2"),
                 &[&scope_ref, &victim_key],
             )
             .await
@@ -703,12 +710,12 @@ fn advisory_lock_key_from_bytes(key: &[u8]) -> (i32, i32) {
 /// Derive the single-`i64` scope advisory-lock key. Uses the `(int8)`
 /// advisory space, which Postgres keeps disjoint from the `(int4,int4)`
 /// space used for per-key locks, so a key lock and a scope lock can never
-/// alias each other. Folds in the `kind` byte so the invocation and value
-/// maps lock independently.
-fn scope_advisory_lock_key(scope: &[u8], kind: &[u8]) -> i64 {
+/// alias each other. The lock is scope-wide across both predicate tables
+/// because [`MAX_KEYS_PER_TENANT`] is an aggregate per-tenant quota.
+fn scope_advisory_lock_key(scope: &[u8]) -> i64 {
     let mut hasher = blake3::Hasher::new();
     hasher.update(scope);
-    hasher.update(kind);
+    hasher.update(b"predicate-scope");
     let d = hasher.finalize();
     let bytes = d.as_bytes();
     i64::from_le_bytes([

--- a/crates/ironclaw_hooks_postgres/tests/predicate_state_postgres_contract.rs
+++ b/crates/ironclaw_hooks_postgres/tests/predicate_state_postgres_contract.rs
@@ -1,7 +1,7 @@
 //! `PostgresPredicateStateBackend` run against the shared trait-level
 //! contract harness from `ironclaw_hooks::predicate_state::contract`.
 //!
-//! All nine contract functions are exercised. The harness is the same
+//! Every contract function is exercised. The harness is the same
 //! one the in-memory backend is wired through (PR 1/4), so this proves
 //! the durable backend honors the identical isolation / dedup / window /
 //! atomicity invariants by construction.
@@ -176,6 +176,7 @@ pg_contract!(duplicate_event_id_is_noop_for_invocations);
 pg_contract!(duplicate_event_id_is_noop_for_values);
 pg_contract!(invocation_retains_entry_at_exact_window_cutoff);
 pg_contract!(event_id_dedup_isolated_across_maps);
+pg_contract!(tenant_key_quota_spans_invocation_and_value_maps);
 pg_contract!(record_invocation_overflow_is_fail_closed);
 pg_contract!(evict_older_than_reaps_strictly_older_rows);
 pg_contract!(evict_older_than_retains_entry_at_exact_cutoff);


### PR DESCRIPTION
## Summary
- enforce MAX_KEYS_PER_TENANT across invocation and value predicate histories together
- update in-memory, libSQL, and Postgres predicate backends to evict oldest-front keys across both typed maps/tables
- add a shared PredicateStateBackend contract case for cross-map tenant quota enforcement
- document the aggregate tenant budget in the hooks operator runbook

Closes part of #3957: aggregate per-tenant predicate-state cap.

## Tests
- cargo test -p ironclaw_hooks tenant_key_quota_spans_invocation_and_value_maps
- cargo test -p ironclaw_hooks per_tenant_quota
- cargo test -p ironclaw_hooks predicate_state::
- cargo test -p ironclaw_hooks_libsql tenant_key_quota_spans_invocation_and_value_maps
- cargo test -p ironclaw_hooks_postgres tenant_key_quota_spans_invocation_and_value_maps (compiled; Postgres test binary is feature/env gated and did not run without DB URL)
- cargo test -p ironclaw_hooks_postgres --no-run
- cargo test -p ironclaw_hooks_libsql --no-run