### PR TITLE
[codex] Soften activity summary failures

### DIFF
--- a/crates/ironclaw_gateway/static/js/core/tool-activity.js
+++ b/crates/ironclaw_gateway/static/js/core/tool-activity.js
@@ -48,6 +48,11 @@ function getToolActivityGroupStatus(entries) {
   return lastEntry && lastEntry.status === 'fail' ? 'fail' : 'success';
 }
 
+function isSubtleToolFailure(entries, index) {
+  const entry = entries[index];
+  return !!(entry && entry.status === 'fail' && index !== entries.length - 1);
+}
+
 function createToolActivitySummary(toolCount, totalDurationMs, includeDuration, status) {
   const toolWord = toolCount === 1 ? 'tool' : 'tools';
   const summary = document.createElement('button');
@@ -203,7 +208,6 @@ function createActivityGroupFromEntries(entries, options) {
   const hasTerminalError = groupStatus === 'fail';
   const group = document.createElement('div');
   group.className = 'activity-group' + (hasTerminalError ? '' : ' collapsed');
-  group.setAttribute('data-status', groupStatus);
 
   let totalDurationMs = 0;
   let hasDuration = false;
@@ -233,7 +237,7 @@ function createActivityGroupFromEntries(entries, options) {
     const rendered = createToolActivityCard(entry, {
       showDuration: !!options.showCardDurations,
       expandErrors: options.expandErrors !== false,
-      subtleFailure: entry.status === 'fail' && index !== entries.length - 1,
+      subtleFailure: isSubtleToolFailure(entries, index),
     });
     cardsContainer.appendChild(rendered.card);
   });
@@ -435,33 +439,30 @@ function createToolActivityController(options) {
     removeThinking();
     if (!activeGroup) return;
 
-    for (const rendered of activeEntries) {
-      clearTimer(rendered);
-      if (rendered.entry.duration_ms === null) {
-        rendered.entry.duration_ms = Date.now() - rendered.entry.started_at_ms;
-      }
-      applyToolActivityCardState(rendered, {
-        showDuration: true,
-        expandErrors: true,
-      });
-    }
-
     if (activeEntries.length === 0) {
       activeGroup.remove();
       reset(false);
       return;
     }
 
+    for (const rendered of activeEntries) {
+      clearTimer(rendered);
+      if (rendered.entry.duration_ms === null) {
+        rendered.entry.duration_ms = Date.now() - rendered.entry.started_at_ms;
+      }
+    }
+
     const totalDurationMs = activeEntries.reduce((sum, rendered) => {
       return sum + (typeof rendered.entry.duration_ms === 'number' ? rendered.entry.duration_ms : 0);
     }, 0);
 
-    const groupStatus = getToolActivityGroupStatus(activeEntries.map((rendered) => rendered.entry));
+    const finalizedEntries = activeEntries.map((rendered) => rendered.entry);
+    const groupStatus = getToolActivityGroupStatus(finalizedEntries);
     activeEntries.forEach((rendered, index) => {
       applyToolActivityCardState(rendered, {
         showDuration: true,
         expandErrors: true,
-        subtleFailure: rendered.entry.status === 'fail' && index !== activeEntries.length - 1,
+        subtleFailure: isSubtleToolFailure(finalizedEntries, index),
       });
     });
 
@@ -482,7 +483,6 @@ function createToolActivityController(options) {
 
     activeGroup.innerHTML = '';
     activeGroup.classList.add('collapsed');
-    activeGroup.setAttribute('data-status', groupStatus);
     activeGroup.appendChild(summary);
     activeGroup.appendChild(cardsContainer);
 

--- a/crates/ironclaw_gateway/static/js/core/tool-activity.js
+++ b/crates/ironclaw_gateway/static/js/core/tool-activity.js
@@ -42,11 +42,18 @@ function normalizeHistoryToolCall(toolCall) {
   };
 }
 
-function createToolActivitySummary(toolCount, totalDurationMs, includeDuration) {
+function getToolActivityGroupStatus(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return 'success';
+  const lastEntry = entries[entries.length - 1];
+  return lastEntry && lastEntry.status === 'fail' ? 'fail' : 'success';
+}
+
+function createToolActivitySummary(toolCount, totalDurationMs, includeDuration, status) {
   const toolWord = toolCount === 1 ? 'tool' : 'tools';
   const summary = document.createElement('button');
   summary.type = 'button';
   summary.className = 'activity-summary';
+  summary.setAttribute('data-status', status === 'fail' ? 'fail' : 'success');
   summary.setAttribute('aria-expanded', 'false');
   summary.innerHTML = '<span class="activity-summary-chevron"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 4 10 8 6 12"/></svg></span>'
     + '<span class="activity-summary-text">Used ' + toolCount + ' ' + toolWord + '</span>';
@@ -78,6 +85,7 @@ function applyToolActivityCardState(rendered, options) {
     rendered.card.removeAttribute('data-call-id');
   }
   rendered.card.setAttribute('data-status', status);
+  rendered.card.setAttribute('data-emphasis', options.subtleFailure && status === 'fail' ? 'subtle' : 'normal');
   rendered.toolName.textContent = entry.name;
 
   if (options.showDuration && entry.duration_ms !== null) {
@@ -95,7 +103,12 @@ function applyToolActivityCardState(rendered, options) {
   }
 
   rendered.output.textContent = getToolActivityBodyText(entry);
-  const shouldAutoExpand = !!(options.expandErrors && status === 'fail' && rendered.output.textContent);
+  const shouldAutoExpand = !!(
+    options.expandErrors
+    && !options.subtleFailure
+    && status === 'fail'
+    && rendered.output.textContent
+  );
   setToolActivityCardExpanded(rendered, shouldAutoExpand);
 }
 
@@ -186,9 +199,11 @@ function createToolActivityCard(entry, options) {
 }
 
 function createActivityGroupFromEntries(entries, options) {
-  const hasError = entries.some(entry => entry.status === 'fail');
+  const groupStatus = getToolActivityGroupStatus(entries);
+  const hasTerminalError = groupStatus === 'fail';
   const group = document.createElement('div');
-  group.className = 'activity-group' + (hasError ? '' : ' collapsed');
+  group.className = 'activity-group' + (hasTerminalError ? '' : ' collapsed');
+  group.setAttribute('data-status', groupStatus);
 
   let totalDurationMs = 0;
   let hasDuration = false;
@@ -199,23 +214,29 @@ function createActivityGroupFromEntries(entries, options) {
     }
   }
 
-  const summary = createToolActivitySummary(entries.length, totalDurationMs, options.includeSummaryDuration && hasDuration);
-  if (hasError) {
+  const summary = createToolActivitySummary(
+    entries.length,
+    totalDurationMs,
+    options.includeSummaryDuration && hasDuration,
+    groupStatus
+  );
+  if (hasTerminalError) {
     summary.querySelector('.activity-summary-chevron').classList.add('expanded');
     summary.setAttribute('aria-expanded', 'true');
   }
 
   const cardsContainer = document.createElement('div');
   cardsContainer.className = 'activity-cards-container';
-  cardsContainer.style.display = hasError ? 'flex' : 'none';
+  cardsContainer.style.display = hasTerminalError ? 'flex' : 'none';
 
-  for (const entry of entries) {
+  entries.forEach((entry, index) => {
     const rendered = createToolActivityCard(entry, {
       showDuration: !!options.showCardDurations,
       expandErrors: options.expandErrors !== false,
+      subtleFailure: entry.status === 'fail' && index !== entries.length - 1,
     });
     cardsContainer.appendChild(rendered.card);
-  }
+  });
 
   summary.addEventListener('click', () => {
     const isOpen = cardsContainer.style.display !== 'none';
@@ -435,6 +456,15 @@ function createToolActivityController(options) {
       return sum + (typeof rendered.entry.duration_ms === 'number' ? rendered.entry.duration_ms : 0);
     }, 0);
 
+    const groupStatus = getToolActivityGroupStatus(activeEntries.map((rendered) => rendered.entry));
+    activeEntries.forEach((rendered, index) => {
+      applyToolActivityCardState(rendered, {
+        showDuration: true,
+        expandErrors: true,
+        subtleFailure: rendered.entry.status === 'fail' && index !== activeEntries.length - 1,
+      });
+    });
+
     const cardsContainer = document.createElement('div');
     cardsContainer.className = 'activity-cards-container';
     cardsContainer.style.display = 'none';
@@ -442,7 +472,7 @@ function createToolActivityController(options) {
       cardsContainer.appendChild(rendered.card);
     }
 
-    const summary = createToolActivitySummary(activeEntries.length, totalDurationMs, true);
+    const summary = createToolActivitySummary(activeEntries.length, totalDurationMs, true, groupStatus);
     summary.addEventListener('click', () => {
       const isOpen = cardsContainer.style.display !== 'none';
       cardsContainer.style.display = isOpen ? 'none' : 'flex';
@@ -452,6 +482,7 @@ function createToolActivityController(options) {
 
     activeGroup.innerHTML = '';
     activeGroup.classList.add('collapsed');
+    activeGroup.setAttribute('data-status', groupStatus);
     activeGroup.appendChild(summary);
     activeGroup.appendChild(cardsContainer);
 
@@ -514,4 +545,3 @@ function humanizeToolName(rawName) {
 function shouldShowChannelConnectedMessage(extensionName, success) {
   return false;
 }
-

--- a/crates/ironclaw_gateway/static/styles/surfaces/chat.css
+++ b/crates/ironclaw_gateway/static/styles/surfaces/chat.css
@@ -384,6 +384,15 @@
   color: var(--danger);
 }
 
+.activity-tool-card[data-status="fail"][data-emphasis="subtle"] {
+  border-color: var(--border);
+}
+
+.activity-tool-card[data-status="fail"][data-emphasis="subtle"] .activity-tool-name,
+.activity-tool-card[data-status="fail"][data-emphasis="subtle"] .activity-icon-fail {
+  color: var(--text-secondary);
+}
+
 .activity-tool-header {
   display: flex;
   align-items: center;
@@ -528,6 +537,10 @@
 
 .activity-summary:hover {
   background: var(--bg-tertiary);
+}
+
+.activity-summary[data-status="fail"] {
+  color: var(--danger);
 }
 
 .activity-summary:focus-visible {
@@ -1563,4 +1576,3 @@
   font-size: 13px;
   line-height: 1.4;
 }
-


### PR DESCRIPTION
## Summary

- Base the collapsed Activity tool summary state on the last tool entry instead of any failed tool in the run.
- Keep intermediate failed tool cards muted and collapsed when a later tool succeeds.
- Preserve red summary styling for terminal tool failures only.

## Root Cause

The history-rendered Activity group treated `entries.some(status === 'fail')` as the whole group state, so a recovered intermediate tool failure made passing runs look broken at a glance.

## Validation

- Node renderer check for failed-then-success and success-then-failed tool groups.
- `node --check crates/ironclaw_gateway/static/js/core/tool-activity.js`
- `cargo test -p ironclaw_gateway`