### PR TITLE
feat(outbound): add scoped delivery defaults

### DIFF
--- a/crates/ironclaw_outbound/Cargo.toml
+++ b/crates/ironclaw_outbound/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
+tokio = { version = "1", features = ["sync"] }
 tokio-postgres = { version = "0.7", optional = true }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -1,56 +1,313 @@
 use async_trait::async_trait;
-use ironclaw_host_api::{TenantId, Timestamp, UserId};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_turns::ReplyTargetBindingRef;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{CommunicationModality, OutboundError};
 
-/// Tenant/user lookup key for outbound-owned communication preferences.
+/// Owner scope for default outbound delivery preferences.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum DeliveryDefaultScope {
+    Personal {
+        tenant_id: TenantId,
+        user_id: UserId,
+    },
+    SharedAgent {
+        tenant_id: TenantId,
+        agent_id: AgentId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project_id: Option<ProjectId>,
+    },
+}
+
+impl DeliveryDefaultScope {
+    pub fn personal(tenant_id: TenantId, user_id: UserId) -> Self {
+        Self::Personal { tenant_id, user_id }
+    }
+
+    pub fn shared_agent(
+        tenant_id: TenantId,
+        agent_id: AgentId,
+        project_id: Option<ProjectId>,
+    ) -> Self {
+        Self::SharedAgent {
+            tenant_id,
+            agent_id,
+            project_id,
+        }
+    }
+
+    pub fn tenant_id(&self) -> &TenantId {
+        match self {
+            Self::Personal { tenant_id, .. } | Self::SharedAgent { tenant_id, .. } => tenant_id,
+        }
+    }
+}
+
+/// Scoped lookup key for outbound-owned communication preferences.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CommunicationPreferenceKey {
-    pub tenant_id: TenantId,
-    pub user_id: UserId,
+    pub scope: DeliveryDefaultScope,
 }
 
 impl CommunicationPreferenceKey {
     pub fn new(tenant_id: TenantId, user_id: UserId) -> Self {
-        Self { tenant_id, user_id }
+        Self {
+            scope: DeliveryDefaultScope::personal(tenant_id, user_id),
+        }
+    }
+
+    pub fn for_scope(scope: DeliveryDefaultScope) -> Self {
+        Self { scope }
     }
 }
 
-/// Durable tenant/user communication defaults owned by outbound policy.
+/// Opaque version for compare-and-swap writes to communication preferences.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CommunicationPreferenceVersion(pub(crate) u64);
+
+impl CommunicationPreferenceVersion {
+    pub fn from_backend(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+/// Compare-and-swap expectation for scoped communication preference writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "version")]
+pub enum CommunicationPreferenceWriteExpectation {
+    Any,
+    Absent,
+    Version(CommunicationPreferenceVersion),
+}
+
+/// Versioned communication preference returned by repositories that support
+/// caller-visible stale-write detection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionedCommunicationPreferenceRecord {
+    pub record: CommunicationPreferenceRecord,
+    pub version: CommunicationPreferenceVersion,
+}
+
+/// Named preference target slot updated by product configuration callers.
+///
+/// Each variant maps to one optional target in
+/// [`CommunicationPreferenceTargets`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommunicationPreferenceSlot {
+    FinalReply,
+    Progress,
+    ApprovalPrompt,
+    AuthPrompt,
+}
+
+/// Candidate reply targets for each outbound communication purpose.
+///
+/// Targets are durable defaults only. Callers must revalidate the selected
+/// target through outbound policy before sending externally.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunicationPreferenceTargets {
+    pub final_reply: Option<ReplyTargetBindingRef>,
+    pub progress: Option<ReplyTargetBindingRef>,
+    pub approval_prompt: Option<ReplyTargetBindingRef>,
+    pub auth_prompt: Option<ReplyTargetBindingRef>,
+}
+
+impl CommunicationPreferenceTargets {
+    pub fn target(&self, slot: CommunicationPreferenceSlot) -> Option<&ReplyTargetBindingRef> {
+        match slot {
+            CommunicationPreferenceSlot::FinalReply => self.final_reply.as_ref(),
+            CommunicationPreferenceSlot::Progress => self.progress.as_ref(),
+            CommunicationPreferenceSlot::ApprovalPrompt => self.approval_prompt.as_ref(),
+            CommunicationPreferenceSlot::AuthPrompt => self.auth_prompt.as_ref(),
+        }
+    }
+
+    pub fn target_mut(
+        &mut self,
+        slot: CommunicationPreferenceSlot,
+    ) -> &mut Option<ReplyTargetBindingRef> {
+        match slot {
+            CommunicationPreferenceSlot::FinalReply => &mut self.final_reply,
+            CommunicationPreferenceSlot::Progress => &mut self.progress,
+            CommunicationPreferenceSlot::ApprovalPrompt => &mut self.approval_prompt,
+            CommunicationPreferenceSlot::AuthPrompt => &mut self.auth_prompt,
+        }
+    }
+}
+
+/// Compare-and-swap request for updating one communication preference slot.
+///
+/// `expected_version` is the version observed by the caller. If the record has
+/// advanced but the selected slot still equals `expected_current_target`, the
+/// repository may merge the disjoint slot update and preserve the newer values
+/// in other slots. If the selected slot changed, the write fails with
+/// [`OutboundError::CasConflict`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateCommunicationPreferenceSlotRequest {
+    pub key: CommunicationPreferenceKey,
+    pub expected_version: CommunicationPreferenceVersion,
+    pub slot: CommunicationPreferenceSlot,
+    pub expected_current_target: Option<ReplyTargetBindingRef>,
+    pub target: Option<ReplyTargetBindingRef>,
+    pub updated_at: Timestamp,
+    pub updated_by: UserId,
+}
+
+/// Durable scoped communication defaults owned by outbound policy.
 ///
 /// Stored reply targets are candidates only. Callers must revalidate every
 /// target through the outbound validation path before sending externally.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommunicationPreferenceRecord {
-    pub tenant_id: TenantId,
-    pub user_id: UserId,
-    pub final_reply_target: Option<ReplyTargetBindingRef>,
-    pub progress_target: Option<ReplyTargetBindingRef>,
-    pub approval_prompt_target: Option<ReplyTargetBindingRef>,
-    pub auth_prompt_target: Option<ReplyTargetBindingRef>,
+    pub scope: DeliveryDefaultScope,
+    pub targets: CommunicationPreferenceTargets,
     pub default_modality: Option<CommunicationModality>,
     pub updated_at: Timestamp,
     pub updated_by: UserId,
 }
 
-impl CommunicationPreferenceRecord {
-    pub fn key(&self) -> CommunicationPreferenceKey {
-        CommunicationPreferenceKey::new(self.tenant_id.clone(), self.user_id.clone())
+impl<'de> Deserialize<'de> for CommunicationPreferenceRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireRecord {
+            scope: Option<DeliveryDefaultScope>,
+            tenant_id: Option<TenantId>,
+            user_id: Option<UserId>,
+            targets: Option<CommunicationPreferenceTargets>,
+            final_reply_target: Option<ReplyTargetBindingRef>,
+            progress_target: Option<ReplyTargetBindingRef>,
+            approval_prompt_target: Option<ReplyTargetBindingRef>,
+            auth_prompt_target: Option<ReplyTargetBindingRef>,
+            default_modality: Option<CommunicationModality>,
+            updated_at: Timestamp,
+            updated_by: UserId,
+        }
+
+        let wire = WireRecord::deserialize(deserializer)?;
+        let scope = match wire.scope {
+            Some(scope) => scope,
+            None => DeliveryDefaultScope::personal(
+                wire.tenant_id
+                    .ok_or_else(|| serde::de::Error::missing_field("scope or legacy tenant_id"))?,
+                wire.user_id
+                    .ok_or_else(|| serde::de::Error::missing_field("scope or legacy user_id"))?,
+            ),
+        };
+        let targets = wire.targets.unwrap_or(CommunicationPreferenceTargets {
+            final_reply: wire.final_reply_target,
+            progress: wire.progress_target,
+            approval_prompt: wire.approval_prompt_target,
+            auth_prompt: wire.auth_prompt_target,
+        });
+        Ok(Self {
+            scope,
+            targets,
+            default_modality: wire.default_modality,
+            updated_at: wire.updated_at,
+            updated_by: wire.updated_by,
+        })
     }
 }
 
-/// Store for durable tenant/user communication delivery preferences.
+impl CommunicationPreferenceRecord {
+    pub fn key(&self) -> CommunicationPreferenceKey {
+        CommunicationPreferenceKey::for_scope(self.scope.clone())
+    }
+}
+
+/// Store for durable scoped communication delivery preferences.
 #[async_trait]
 pub trait CommunicationPreferenceRepository: Send + Sync {
     async fn put_communication_preference(
         &self,
         record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError>;
+    ) -> Result<(), OutboundError> {
+        self.write_communication_preference(record, CommunicationPreferenceWriteExpectation::Any)
+            .await
+            .map(|_| ())
+    }
 
     async fn load_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError>;
+    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        Ok(self
+            .load_versioned_communication_preference(key)
+            .await?
+            .map(|versioned| versioned.record))
+    }
+
+    async fn write_communication_preference(
+        &self,
+        record: CommunicationPreferenceRecord,
+        expectation: CommunicationPreferenceWriteExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError>;
+
+    async fn load_versioned_communication_preference(
+        &self,
+        key: CommunicationPreferenceKey,
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError>;
+
+    async fn update_communication_preference_slot(
+        &self,
+        request: UpdateCommunicationPreferenceSlotRequest,
+    ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
+        if request.updated_by.as_str().is_empty() {
+            return Err(OutboundError::InvalidRequest {
+                reason: "communication preference updater is required",
+            });
+        }
+        for _ in 0..5 {
+            let Some(mut versioned) = self
+                .load_versioned_communication_preference(request.key.clone())
+                .await?
+            else {
+                return Err(OutboundError::CasConflict);
+            };
+            if versioned.record.key() != request.key {
+                return Err(OutboundError::Backend);
+            }
+            if versioned.version != request.expected_version
+                && versioned.record.targets.target(request.slot)
+                    != request.expected_current_target.as_ref()
+            {
+                return Err(OutboundError::CasConflict);
+            }
+            *versioned.record.targets.target_mut(request.slot) = request.target.clone();
+            versioned.record.updated_at = request.updated_at;
+            versioned.record.updated_by = request.updated_by.clone();
+            match self
+                .write_communication_preference(
+                    versioned.record.clone(),
+                    CommunicationPreferenceWriteExpectation::Version(versioned.version),
+                )
+                .await
+            {
+                Ok(version) => {
+                    return Ok(VersionedCommunicationPreferenceRecord {
+                        record: versioned.record,
+                        version,
+                    });
+                }
+                Err(OutboundError::CasConflict) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(OutboundError::Backend)
+    }
 }

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -26,19 +26,24 @@
 //!   `delivery_id`. An indexed `scope` projection allows
 //!   `list_delivery_attempts(scope)` to filter within the tenant-scoped
 //!   subtree without materializing every row.
-//! - `/outbound/communication-preferences/<sha256(v1-length-prefixed-key)>.json` — tenant/user
-//!   communication preference row keyed by a hashed `CommunicationPreferenceKey`.
-//!   Reply-target refs remain candidates and do not grant send authority.
+//! - `/outbound/communication-preferences/<scope-hash>.json` — scoped
+//!   communication preference row keyed by a hashed
+//!   `CommunicationPreferenceKey`. Personal defaults keep the legacy v1
+//!   tenant/user hash; shared-agent defaults use a v2 tenant/agent/project
+//!   hash. Reply-target refs remain candidates and do not grant send authority.
 
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, MutexGuard, OnceLock, Weak},
+};
 
 use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
 use ironclaw_filesystem::{
     CasExpectation, ContentType, Entry, FilesystemError, Filter, IndexKey, IndexKind, IndexName,
-    IndexSpec, IndexValue, Page, RootFilesystem, ScopedFilesystem, VersionedEntry,
+    IndexSpec, IndexValue, Page, RecordVersion, RootFilesystem, ScopedFilesystem, VersionedEntry,
 };
-use ironclaw_host_api::{ResourceScope, ScopedPath, TenantId, ThreadId, UserId};
+use ironclaw_host_api::{ResourceScope, ScopedPath, TenantId, ThreadId};
 use ironclaw_turns::{TurnActor, TurnScope};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -50,9 +55,11 @@ use crate::validation::{
 };
 use crate::{
     AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
-    OutboundDeliveryId, OutboundError, OutboundStateStore, ProjectionSubscriptionId,
-    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    CommunicationPreferenceRepository, CommunicationPreferenceVersion,
+    CommunicationPreferenceWriteExpectation, DeliveryDefaultScope, LoadSubscriptionCursorRequest,
+    OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError, OutboundStateStore,
+    ProjectionSubscriptionId, ProjectionSubscriptionRecord, ThreadNotificationPolicy,
+    UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
 };
 
 /// Maximum number of compare-and-swap retries on a read-then-write path
@@ -114,6 +121,19 @@ where
         tenant: &TenantId,
         cas: CasExpectation,
     ) -> Result<(), OutboundError> {
+        self.put_json_versioned(scope, path, value, tenant, cas)
+            .await
+            .map(|_| ())
+    }
+
+    async fn put_json_versioned<T: Serialize>(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+        value: &T,
+        tenant: &TenantId,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, OutboundError> {
         let body = serde_json::to_vec(value).map_err(|_| OutboundError::Serialization)?;
         let entry = Entry::bytes(body)
             .with_content_type(ContentType::json())
@@ -145,34 +165,93 @@ where
                 tenant_id_index_key(),
                 tenant_id_index_value(&attempt.scope.tenant_id),
             );
-        self.put_with_byte_fallback(scope, path, entry, cas).await
+        self.put_with_byte_fallback(scope, path, entry, cas)
+            .await
+            .map(|_| ())
     }
 
     /// Write `entry` with the given CAS expectation, falling back to a
-    /// metadata-stripped opaque write + `CasExpectation::Any` for backends
-    /// that reject record-shape entries or non-`Any` CAS (e.g.
-    /// `LocalFilesystem`). Mirrors
-    /// [`ironclaw_processes::filesystem_store::put_with_byte_fallback`] so
-    /// every byte-only mount in the workspace stays writeable through the
-    /// new filesystem stores.
+    /// metadata-stripped opaque write for backends that reject record-shape
+    /// entries. The original CAS expectation is preserved on fallback so
+    /// byte-only backends cannot silently downgrade stale-write protection to
+    /// an unconditional overwrite. Byte-only backends do not expose durable
+    /// record versions, so the fallback keeps process-local versions under a
+    /// path lock to preserve stale-write detection within this process.
     async fn put_with_byte_fallback(
         &self,
         scope: &ResourceScope,
         path: &ScopedPath,
         entry: Entry,
         cas: CasExpectation,
-    ) -> Result<(), OutboundError> {
+    ) -> Result<RecordVersion, OutboundError> {
         match self.filesystem.put(scope, path, entry.clone(), cas).await {
-            Ok(_) => Ok(()),
+            Ok(version) => Ok(version),
             Err(FilesystemError::Unsupported { .. }) => {
-                let opaque = Entry::bytes(entry.body).with_content_type(entry.content_type);
+                self.put_opaque_with_fallback_cas(scope, path, entry, cas)
+                    .await
+            }
+            Err(error) => Err(map_fs_error(error)),
+        }
+    }
+
+    async fn put_opaque_with_fallback_cas(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, OutboundError> {
+        let key = filesystem_record_key(self.filesystem.as_ref(), scope, path);
+        let record_lock = filesystem_record_lock_for_key(&key);
+        let _guard = record_lock.lock().await;
+        let opaque = Entry::bytes(entry.body).with_content_type(entry.content_type);
+        match cas {
+            CasExpectation::Any => {
                 self.filesystem
                     .put(scope, path, opaque, CasExpectation::Any)
                     .await
-                    .map(|_| ())
-                    .map_err(map_fs_error)
+                    .map_err(map_fs_error)?;
+                Ok(set_fallback_version(&key, |current| {
+                    current.saturating_add(1)
+                }))
             }
-            Err(error) => Err(map_fs_error(error)),
+            CasExpectation::Absent => {
+                if self
+                    .filesystem
+                    .get(scope, path)
+                    .await
+                    .map_err(map_fs_error)?
+                    .is_some()
+                {
+                    return Err(OutboundError::CasConflict);
+                }
+                self.filesystem
+                    .put(scope, path, opaque, CasExpectation::Any)
+                    .await
+                    .map_err(map_fs_error)?;
+                Ok(set_fallback_version(&key, |_| 1))
+            }
+            CasExpectation::Version(expected) => {
+                let Some(versioned) = self
+                    .filesystem
+                    .get(scope, path)
+                    .await
+                    .map_err(map_fs_error)?
+                else {
+                    return Err(OutboundError::CasConflict);
+                };
+                let current = fallback_version(&key).unwrap_or(versioned.version);
+                if current != expected {
+                    return Err(OutboundError::CasConflict);
+                }
+                self.filesystem
+                    .put(scope, path, opaque, CasExpectation::Any)
+                    .await
+                    .map_err(map_fs_error)?;
+                Ok(set_fallback_version(&key, |current| {
+                    current.max(expected.get()).saturating_add(1)
+                }))
+            }
         }
     }
 
@@ -219,6 +298,12 @@ where
         };
         let parsed = serde_json::from_slice(&versioned.entry.body)
             .map_err(|_| OutboundError::Serialization)?;
+        let key = filesystem_record_key(self.filesystem.as_ref(), scope, path);
+        let version = fallback_version(&key).unwrap_or(versioned.version);
+        let versioned = VersionedEntry {
+            version,
+            ..versioned
+        };
         Ok(Some((parsed, versioned)))
     }
 
@@ -231,6 +316,27 @@ where
             .get_versioned_json::<T>(scope, path)
             .await?
             .map(|(value, _)| value))
+    }
+
+    async fn write_communication_preference_at(
+        &self,
+        path: &ScopedPath,
+        resource_scope: &ResourceScope,
+        record: &CommunicationPreferenceRecord,
+        expectation: CommunicationPreferenceWriteExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError> {
+        self.ensure_tenant_id_index(resource_scope, &communication_preferences_root()?)
+            .await?;
+        let version = self
+            .put_json_versioned(
+                resource_scope,
+                path,
+                record,
+                record.scope.tenant_id(),
+                communication_preference_cas(expectation),
+            )
+            .await?;
+        Ok(CommunicationPreferenceVersion::from_backend(version.get()))
     }
 }
 
@@ -246,29 +352,27 @@ where
         validate_communication_preference(&record)?;
         let key = record.key();
         let path = communication_preference_path(&key)?;
-        let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
+        let resource_scope = communication_preference_resource_scope(&key);
         for _ in 0..MAX_CAS_RETRIES {
-            let (cas, existing) = match self
+            let expectation = match self
                 .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
                 .await?
             {
                 Some((existing, versioned)) => {
-                    (CasExpectation::Version(versioned.version), Some(existing))
+                    if existing.key() != key {
+                        return Err(OutboundError::Backend);
+                    }
+                    CommunicationPreferenceWriteExpectation::Version(
+                        CommunicationPreferenceVersion::from_backend(versioned.version.get()),
+                    )
                 }
-                None => (CasExpectation::Absent, None),
+                None => CommunicationPreferenceWriteExpectation::Absent,
             };
-            if let Some(existing) = existing.as_ref()
-                && existing.key() != key
-            {
-                return Err(OutboundError::Backend);
-            }
-            self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
-                .await?;
             match self
-                .put_json(&resource_scope, &path, &record, &record.tenant_id, cas)
+                .write_communication_preference_at(&path, &resource_scope, &record, expectation)
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(_) => return Ok(()),
                 Err(OutboundError::CasConflict) => continue,
                 Err(error) => return Err(error),
             }
@@ -276,22 +380,45 @@ where
         Err(OutboundError::Backend)
     }
 
-    async fn load_communication_preference(
+    async fn write_communication_preference(
+        &self,
+        record: CommunicationPreferenceRecord,
+        expectation: CommunicationPreferenceWriteExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError> {
+        validate_communication_preference(&record)?;
+        let key = record.key();
+        let path = communication_preference_path(&key)?;
+        let resource_scope = communication_preference_resource_scope(&key);
+        if let Some(existing) = self
+            .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
+            .await?
+            && existing.0.key() != key
+        {
+            return Err(OutboundError::Backend);
+        }
+        self.write_communication_preference_at(&path, &resource_scope, &record, expectation)
+            .await
+    }
+
+    async fn load_versioned_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         let path = communication_preference_path(&key)?;
-        let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
-        let Some(record) = self
-            .get_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
+        let resource_scope = communication_preference_resource_scope(&key);
+        let Some((record, versioned)) = self
+            .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
             .await?
         else {
             return Ok(None);
         };
-        if record.tenant_id != key.tenant_id || record.user_id != key.user_id {
+        if record.key() != key {
             return Err(OutboundError::Backend);
         }
-        Ok(Some(record))
+        Ok(Some(VersionedCommunicationPreferenceRecord {
+            record,
+            version: CommunicationPreferenceVersion(versioned.version.get()),
+        }))
     }
 }
 
@@ -603,29 +730,78 @@ fn communication_preference_path(
     key: &CommunicationPreferenceKey,
 ) -> Result<ScopedPath, OutboundError> {
     let mut hasher = Sha256::new();
-    let tenant = key.tenant_id.as_str();
-    let user = key.user_id.as_str();
-    hasher.update(b"v1:");
-    hasher.update(tenant.len().to_string().as_bytes());
-    hasher.update(b":");
-    hasher.update(tenant.as_bytes());
-    hasher.update(b":");
-    hasher.update(user.len().to_string().as_bytes());
-    hasher.update(b":");
-    hasher.update(user.as_bytes());
+    match &key.scope {
+        DeliveryDefaultScope::Personal { tenant_id, user_id } => {
+            let tenant = tenant_id.as_str();
+            let user = user_id.as_str();
+            hasher.update(b"v1:");
+            hasher.update(tenant.len().to_string().as_bytes());
+            hasher.update(b":");
+            hasher.update(tenant.as_bytes());
+            hasher.update(b":");
+            hasher.update(user.len().to_string().as_bytes());
+            hasher.update(b":");
+            hasher.update(user.as_bytes());
+        }
+        DeliveryDefaultScope::SharedAgent {
+            tenant_id,
+            agent_id,
+            project_id,
+        } => {
+            hash_len_prefixed(&mut hasher, b"v2:shared-agent", tenant_id.as_str());
+            hash_len_prefixed(&mut hasher, b"agent", agent_id.as_str());
+            match project_id {
+                Some(project_id) => {
+                    hash_len_prefixed(&mut hasher, b"project:some", project_id.as_str())
+                }
+                None => hash_len_prefixed(&mut hasher, b"project:none", ""),
+            }
+        }
+    }
     let digest = hex::encode(hasher.finalize());
     ScopedPath::new(format!("{COMMUNICATION_PREFERENCES_ROOT}/{digest}.json"))
         .map_err(|_| OutboundError::Backend)
 }
 
-fn communication_preference_resource_scope(
-    tenant_id: &TenantId,
-    user_id: &UserId,
-) -> ResourceScope {
+fn communication_preference_resource_scope(key: &CommunicationPreferenceKey) -> ResourceScope {
     let mut scope = ResourceScope::system();
-    scope.tenant_id = tenant_id.clone();
-    scope.user_id = user_id.clone();
+    match &key.scope {
+        DeliveryDefaultScope::Personal { tenant_id, user_id } => {
+            scope.tenant_id = tenant_id.clone();
+            scope.user_id = user_id.clone();
+        }
+        DeliveryDefaultScope::SharedAgent {
+            tenant_id,
+            agent_id,
+            project_id,
+        } => {
+            scope.tenant_id = tenant_id.clone();
+            scope.agent_id = Some(agent_id.clone());
+            scope.project_id = project_id.clone();
+        }
+    }
     scope
+}
+
+fn communication_preference_cas(
+    expectation: CommunicationPreferenceWriteExpectation,
+) -> CasExpectation {
+    match expectation {
+        CommunicationPreferenceWriteExpectation::Any => CasExpectation::Any,
+        CommunicationPreferenceWriteExpectation::Absent => CasExpectation::Absent,
+        CommunicationPreferenceWriteExpectation::Version(version) => {
+            CasExpectation::Version(RecordVersion::from_backend(version.get()))
+        }
+    }
+}
+
+fn hash_len_prefixed(hasher: &mut Sha256, label: &[u8], value: &str) {
+    hasher.update(label);
+    hasher.update(b":");
+    hasher.update(value.len().to_string().as_bytes());
+    hasher.update(b":");
+    hasher.update(value.as_bytes());
+    hasher.update(b":");
 }
 
 fn deliveries_root() -> Result<ScopedPath, OutboundError> {
@@ -722,6 +898,60 @@ fn scope_matches(left: &TurnScope, right: &TurnScope) -> bool {
         && left.agent_id == right.agent_id
         && left.project_id == right.project_id
         && left.thread_id == right.thread_id
+}
+
+type FilesystemRecordLock = Arc<tokio::sync::Mutex<()>>;
+
+static FILESYSTEM_RECORD_LOCKS: OnceLock<Mutex<HashMap<String, Weak<tokio::sync::Mutex<()>>>>> =
+    OnceLock::new();
+static FALLBACK_RECORD_VERSIONS: OnceLock<Mutex<HashMap<String, RecordVersion>>> = OnceLock::new();
+
+fn filesystem_record_key<F>(
+    filesystem: &ScopedFilesystem<F>,
+    scope: &ResourceScope,
+    path: &ScopedPath,
+) -> String
+where
+    F: RootFilesystem,
+{
+    filesystem
+        .resolve(scope, path)
+        .map(|virtual_path| virtual_path.as_str().to_string())
+        .unwrap_or_else(|_| path.as_str().to_string())
+}
+
+fn filesystem_record_lock_for_key(key: &str) -> FilesystemRecordLock {
+    let locks = FILESYSTEM_RECORD_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard: MutexGuard<'_, HashMap<String, Weak<tokio::sync::Mutex<()>>>> = locks
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.retain(|_, weak| weak.strong_count() > 0);
+    if let Some(existing) = guard.get(key).and_then(Weak::upgrade) {
+        return existing;
+    }
+    let fresh: FilesystemRecordLock = Arc::new(tokio::sync::Mutex::new(()));
+    guard.insert(key.to_string(), Arc::downgrade(&fresh));
+    fresh
+}
+
+fn fallback_version(key: &str) -> Option<RecordVersion> {
+    FALLBACK_RECORD_VERSIONS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(key)
+        .copied()
+}
+
+fn set_fallback_version(key: &str, update: impl FnOnce(u64) -> u64) -> RecordVersion {
+    let versions = FALLBACK_RECORD_VERSIONS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = versions
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let current = guard.get(key).map_or(0, |version| version.get());
+    let next = RecordVersion::from_backend(update(current));
+    guard.insert(key.to_string(), next);
+    next
 }
 
 fn map_fs_error(error: FilesystemError) -> OutboundError {

--- a/crates/ironclaw_outbound/src/lib.rs
+++ b/crates/ironclaw_outbound/src/lib.rs
@@ -19,6 +19,9 @@ mod validation;
 
 pub use communication_preferences::{
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
+    CommunicationPreferenceSlot, CommunicationPreferenceTargets, CommunicationPreferenceVersion,
+    CommunicationPreferenceWriteExpectation, DeliveryDefaultScope,
+    UpdateCommunicationPreferenceSlotRequest, VersionedCommunicationPreferenceRecord,
 };
 pub use delivery_resolution::{
     CommunicationDeliveryCandidate, CommunicationDeliveryIntent, CommunicationDeliveryKind,

--- a/crates/ironclaw_outbound/src/memory.rs
+++ b/crates/ironclaw_outbound/src/memory.rs
@@ -14,9 +14,11 @@ use crate::validation::{
 };
 use crate::{
     AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
-    OutboundDeliveryId, OutboundError, OutboundStateStore, ProjectionSubscriptionId,
-    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    CommunicationPreferenceRepository, CommunicationPreferenceVersion,
+    CommunicationPreferenceWriteExpectation, LoadSubscriptionCursorRequest,
+    OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError, OutboundStateStore,
+    ProjectionSubscriptionId, ProjectionSubscriptionRecord, ThreadNotificationPolicy,
+    UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
 };
 
 #[derive(Default)]
@@ -26,7 +28,8 @@ pub struct InMemoryOutboundStateStore {
 
 #[derive(Default)]
 struct InMemoryOutboundState {
-    communication_preferences: HashMap<CommunicationPreferenceKey, CommunicationPreferenceRecord>,
+    communication_preferences:
+        HashMap<CommunicationPreferenceKey, VersionedCommunicationPreferenceRecord>,
     policies: HashMap<ThreadScopeKey, ThreadNotificationPolicy>,
     subscriptions: HashMap<ProjectionSubscriptionKey, ProjectionSubscriptionRecord>,
     deliveries: HashMap<OutboundDeliveryId, OutboundDeliveryAttempt>,
@@ -91,20 +94,36 @@ impl ProjectionSubscriptionKey {
 
 #[async_trait]
 impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
-    async fn put_communication_preference(
+    async fn write_communication_preference(
         &self,
         record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
+        expectation: CommunicationPreferenceWriteExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError> {
         validate_communication_preference(&record)?;
         let mut state = self.lock_state()?;
-        state.communication_preferences.insert(record.key(), record);
-        Ok(())
+        let key = record.key();
+        let existing = state.communication_preferences.get(&key);
+        match (expectation, existing) {
+            (CommunicationPreferenceWriteExpectation::Any, _) => {}
+            (CommunicationPreferenceWriteExpectation::Absent, None) => {}
+            (CommunicationPreferenceWriteExpectation::Version(expected), Some(existing))
+                if existing.version == expected => {}
+            _ => return Err(OutboundError::CasConflict),
+        }
+        let version = existing
+            .map(|existing| existing.version.next())
+            .unwrap_or(CommunicationPreferenceVersion(1));
+        state.communication_preferences.insert(
+            key,
+            VersionedCommunicationPreferenceRecord { record, version },
+        );
+        Ok(version)
     }
 
-    async fn load_communication_preference(
+    async fn load_versioned_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         let state = self.lock_state()?;
         Ok(state.communication_preferences.get(&key).cloned())
     }

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -3,8 +3,9 @@ use ironclaw_turns::ReplyTargetBindingRef;
 use crate::{
     CommunicationDeliveryCandidate, CommunicationDeliveryIntent, CommunicationDeliveryKind,
     CommunicationDeliveryResolution, CommunicationDeliveryResolutionRequest,
-    CommunicationPreferenceKey, CommunicationPreferenceRepository, OutboundError,
-    RequestedOutboundContext, RunNotificationContext, RunNotificationOrigin,
+    CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
+    DeliveryDefaultScope, OutboundError, RequestedOutboundContext, RunNotificationContext,
+    RunNotificationOrigin,
 };
 
 /// Deterministic host-owned outbound target selection.
@@ -150,22 +151,32 @@ impl<'a> OutboundResolutionEngine<'a> {
         kind: PreferenceTargetKind,
     ) -> Result<ReplyTargetBindingRef, OutboundError> {
         let key = CommunicationPreferenceKey::new(scope.tenant_id.clone(), actor.user_id.clone());
-        let Some(record) = self
+        if let Some(target) = self
             .communication_preferences
             .load_communication_preference(key)
             .await?
-        else {
-            return Err(missing_preference_error(kind));
-        };
+            .and_then(|record| target_for_kind(record, kind))
+        {
+            return Ok(target);
+        }
 
-        let target = match kind {
-            PreferenceTargetKind::FinalReply => record.final_reply_target,
-            PreferenceTargetKind::Progress => record.progress_target,
-            PreferenceTargetKind::ApprovalPrompt => record.approval_prompt_target,
-            PreferenceTargetKind::AuthPrompt => record.auth_prompt_target,
-        };
+        if let Some(agent_id) = &scope.agent_id {
+            let key = CommunicationPreferenceKey::for_scope(DeliveryDefaultScope::shared_agent(
+                scope.tenant_id.clone(),
+                agent_id.clone(),
+                scope.project_id.clone(),
+            ));
+            if let Some(target) = self
+                .communication_preferences
+                .load_communication_preference(key)
+                .await?
+                .and_then(|record| target_for_kind(record, kind))
+            {
+                return Ok(target);
+            }
+        }
 
-        target.ok_or_else(|| missing_preference_error(kind))
+        Err(missing_preference_error(kind))
     }
 }
 
@@ -176,6 +187,19 @@ enum PreferenceTargetKind {
     Progress,
     ApprovalPrompt,
     AuthPrompt,
+}
+
+#[allow(dead_code, reason = "wired into OutboundPolicyService in PR6")]
+fn target_for_kind(
+    record: CommunicationPreferenceRecord,
+    kind: PreferenceTargetKind,
+) -> Option<ReplyTargetBindingRef> {
+    match kind {
+        PreferenceTargetKind::FinalReply => record.targets.final_reply,
+        PreferenceTargetKind::Progress => record.targets.progress,
+        PreferenceTargetKind::ApprovalPrompt => record.targets.approval_prompt,
+        PreferenceTargetKind::AuthPrompt => record.targets.auth_prompt,
+    }
 }
 
 #[allow(dead_code, reason = "wired into OutboundPolicyService in PR6")]
@@ -203,26 +227,30 @@ mod tests {
 
     use super::*;
     use crate::{
-        CommunicationModality, CommunicationPreferenceRecord, InMemoryOutboundStateStore,
-        RequestedOutboundKind, RunNotificationEventKind, SourceRouteContext, SystemEventReasonCode,
+        CommunicationModality, CommunicationPreferenceRecord, CommunicationPreferenceTargets,
+        CommunicationPreferenceVersion, CommunicationPreferenceWriteExpectation,
+        DeliveryDefaultScope, InMemoryOutboundStateStore, RequestedOutboundKind,
+        RunNotificationEventKind, SourceRouteContext, SystemEventReasonCode,
         TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
+        VersionedCommunicationPreferenceRecord,
     };
 
     struct BackendErrorPreferenceRepository;
 
     #[async_trait]
     impl CommunicationPreferenceRepository for BackendErrorPreferenceRepository {
-        async fn put_communication_preference(
+        async fn write_communication_preference(
             &self,
             _record: CommunicationPreferenceRecord,
-        ) -> Result<(), OutboundError> {
-            Ok(())
+            _expectation: CommunicationPreferenceWriteExpectation,
+        ) -> Result<CommunicationPreferenceVersion, OutboundError> {
+            Err(OutboundError::Backend)
         }
 
-        async fn load_communication_preference(
+        async fn load_versioned_communication_preference(
             &self,
             _key: CommunicationPreferenceKey,
-        ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
             Err(OutboundError::Backend)
         }
     }
@@ -416,6 +444,36 @@ mod tests {
         let candidate = expect_candidate(candidate);
 
         assert_eq!(candidate.target, reply_ref("reply:triggered-default"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_final_reply_falls_back_to_shared_agent_preference() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(shared_preference_record(
+                Some("reply:shared-agent-default"),
+                None,
+                None,
+                None,
+            ))
+            .await
+            .expect("seed shared preference");
+
+        let candidate = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::FinalReplyReady,
+                RunNotificationOrigin::Triggered {
+                    trigger: trigger_context(),
+                },
+            ))
+            .await
+            .expect("triggered final reply resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:shared-agent-default"));
         assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
     }
 
@@ -665,12 +723,40 @@ mod tests {
         auth_prompt_target: Option<&str>,
     ) -> CommunicationPreferenceRecord {
         CommunicationPreferenceRecord {
-            tenant_id: TenantId::new("tenant-a").expect("valid tenant"),
-            user_id: UserId::new("user-a").expect("valid user"),
-            final_reply_target: final_reply_target.map(reply_ref),
-            progress_target: progress_target.map(reply_ref),
-            approval_prompt_target: approval_prompt_target.map(reply_ref),
-            auth_prompt_target: auth_prompt_target.map(reply_ref),
+            scope: DeliveryDefaultScope::personal(
+                TenantId::new("tenant-a").expect("valid tenant"),
+                UserId::new("user-a").expect("valid user"),
+            ),
+            targets: CommunicationPreferenceTargets {
+                final_reply: final_reply_target.map(reply_ref),
+                progress: progress_target.map(reply_ref),
+                approval_prompt: approval_prompt_target.map(reply_ref),
+                auth_prompt: auth_prompt_target.map(reply_ref),
+            },
+            default_modality: Some(CommunicationModality::Text),
+            updated_at: now(),
+            updated_by: UserId::new("user-a").expect("valid user"),
+        }
+    }
+
+    fn shared_preference_record(
+        final_reply_target: Option<&str>,
+        progress_target: Option<&str>,
+        approval_prompt_target: Option<&str>,
+        auth_prompt_target: Option<&str>,
+    ) -> CommunicationPreferenceRecord {
+        CommunicationPreferenceRecord {
+            scope: DeliveryDefaultScope::shared_agent(
+                TenantId::new("tenant-a").expect("valid tenant"),
+                AgentId::new("agent-a").expect("valid agent"),
+                Some(ProjectId::new("project-a").expect("valid project")),
+            ),
+            targets: CommunicationPreferenceTargets {
+                final_reply: final_reply_target.map(reply_ref),
+                progress: progress_target.map(reply_ref),
+                approval_prompt: approval_prompt_target.map(reply_ref),
+                auth_prompt: auth_prompt_target.map(reply_ref),
+            },
             default_modality: Some(CommunicationModality::Text),
             updated_at: now(),
             updated_by: UserId::new("user-a").expect("valid user"),

--- a/crates/ironclaw_outbound/src/service.rs
+++ b/crates/ironclaw_outbound/src/service.rs
@@ -268,9 +268,10 @@ mod tests {
     use super::*;
     use crate::{
         CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
-        CommunicationPreferenceRecord, InMemoryOutboundStateStore, OutboundPushKind,
-        RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin,
-        SourceRouteContext, SystemEventReasonCode,
+        CommunicationPreferenceRecord, CommunicationPreferenceTargets, DeliveryDefaultScope,
+        InMemoryOutboundStateStore, OutboundPushKind, RunNotificationContext,
+        RunNotificationEventKind, RunNotificationOrigin, SourceRouteContext, SystemEventReasonCode,
+        TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
     };
 
     #[tokio::test]
@@ -340,7 +341,8 @@ mod tests {
                 modality: CommunicationModality::Text,
                 intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
                     event_kind: RunNotificationEventKind::ApprovalNeeded,
-                    origin: RunNotificationOrigin::LiveSourceRoute {
+                    origin: RunNotificationOrigin::TriggeredFromSourceRoute {
+                        trigger: trigger_context(),
                         source_route: SourceRouteContext {
                             reply_target_binding_ref: reply_ref("reply:source"),
                         },
@@ -433,12 +435,13 @@ mod tests {
         auth_prompt_target: Option<&str>,
     ) -> CommunicationPreferenceRecord {
         CommunicationPreferenceRecord {
-            tenant_id: scope.tenant_id.clone(),
-            user_id: user_id("alice"),
-            final_reply_target: final_reply_target.map(reply_ref),
-            progress_target: progress_target.map(reply_ref),
-            approval_prompt_target: approval_prompt_target.map(reply_ref),
-            auth_prompt_target: auth_prompt_target.map(reply_ref),
+            scope: DeliveryDefaultScope::personal(scope.tenant_id.clone(), user_id("alice")),
+            targets: CommunicationPreferenceTargets {
+                final_reply: final_reply_target.map(reply_ref),
+                progress: progress_target.map(reply_ref),
+                approval_prompt: approval_prompt_target.map(reply_ref),
+                auth_prompt: auth_prompt_target.map(reply_ref),
+            },
             default_modality: Some(CommunicationModality::Text),
             updated_at: now(),
             updated_by: user_id("alice"),
@@ -452,6 +455,16 @@ mod tests {
             Some(ProjectId::new("project-a").expect("valid project")),
             ThreadId::new(thread_id).expect("valid thread"),
         )
+    }
+
+    fn trigger_context() -> TriggerCommunicationContext {
+        TriggerCommunicationContext {
+            trigger_origin_ref: TriggerOriginRef::new("trigger:service-test")
+                .expect("valid trigger origin ref"),
+            trigger_source_kind: TriggerSourceKind::Schedule,
+            fire_slot: TriggerFireSlot::new("2026-06-08T09:00:00Z")
+                .expect("valid trigger fire slot"),
+        }
     }
 
     fn actor(user_id_value: &str) -> TurnActor {

--- a/crates/ironclaw_outbound/src/validation.rs
+++ b/crates/ironclaw_outbound/src/validation.rs
@@ -3,9 +3,10 @@ use std::collections::HashSet;
 use ironclaw_turns::ReplyTargetBindingRef;
 
 use crate::{
-    AdvanceSubscriptionCursorRequest, CommunicationPreferenceRecord, DeliveryFailureKind,
-    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryStatus, OutboundError,
-    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    AdvanceSubscriptionCursorRequest, CommunicationPreferenceRecord, DeliveryDefaultScope,
+    DeliveryFailureKind, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
+    OutboundDeliveryStatus, OutboundError, ProjectionSubscriptionRecord, ThreadNotificationPolicy,
+    UpdateDeliveryStatusRequest,
 };
 
 const MAX_NOTIFICATION_TARGETS: usize = 32;
@@ -175,15 +176,43 @@ pub(crate) fn validate_delivery_identity(
 pub(crate) fn validate_communication_preference(
     record: &CommunicationPreferenceRecord,
 ) -> Result<(), OutboundError> {
-    if record.tenant_id.as_str().is_empty() {
-        return Err(OutboundError::InvalidRequest {
-            reason: "communication preference tenant is required",
-        });
-    }
-    if record.user_id.as_str().is_empty() {
-        return Err(OutboundError::InvalidRequest {
-            reason: "communication preference user is required",
-        });
+    match &record.scope {
+        DeliveryDefaultScope::Personal { tenant_id, user_id } => {
+            if tenant_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference tenant is required",
+                });
+            }
+            if user_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference user is required",
+                });
+            }
+        }
+        DeliveryDefaultScope::SharedAgent {
+            tenant_id,
+            agent_id,
+            project_id,
+        } => {
+            if tenant_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference tenant is required",
+                });
+            }
+            if agent_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference agent is required",
+                });
+            }
+            if project_id
+                .as_ref()
+                .is_some_and(|project_id| project_id.as_str().is_empty())
+            {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference project is required when present",
+                });
+            }
+        }
     }
     if record.updated_by.as_str().is_empty() {
         return Err(OutboundError::InvalidRequest {

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -870,17 +870,18 @@ struct BackendErrorPreferenceRepository;
 
 #[async_trait]
 impl CommunicationPreferenceRepository for BackendErrorPreferenceRepository {
-    async fn put_communication_preference(
+    async fn write_communication_preference(
         &self,
         _record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
-        Ok(())
+        _expectation: CommunicationPreferenceWriteExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError> {
+        Err(OutboundError::Backend)
     }
 
-    async fn load_communication_preference(
+    async fn load_versioned_communication_preference(
         &self,
         _key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         Err(OutboundError::Backend)
     }
 }
@@ -1136,12 +1137,16 @@ fn preference_record(
     auth_prompt_target: Option<&str>,
 ) -> CommunicationPreferenceRecord {
     CommunicationPreferenceRecord {
-        tenant_id: TenantId::new("tenant-a").expect("valid tenant"),
-        user_id: UserId::new("user-a").expect("valid user"),
-        final_reply_target: final_reply_target.map(reply_ref),
-        progress_target: progress_target.map(reply_ref),
-        approval_prompt_target: approval_prompt_target.map(reply_ref),
-        auth_prompt_target: auth_prompt_target.map(reply_ref),
+        scope: DeliveryDefaultScope::personal(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            UserId::new("user-a").expect("valid user"),
+        ),
+        targets: CommunicationPreferenceTargets {
+            final_reply: final_reply_target.map(reply_ref),
+            progress: progress_target.map(reply_ref),
+            approval_prompt: approval_prompt_target.map(reply_ref),
+            auth_prompt: auth_prompt_target.map(reply_ref),
+        },
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
         updated_by: UserId::new("user-a").expect("valid user"),

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -5,12 +5,12 @@ use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
 use ironclaw_events::{EventCursor, EventStreamKey, ReadScope};
 use ironclaw_filesystem::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FilesystemError,
-    Filter, InMemoryBackend, IndexSpec, Page, RecordVersion, RootFilesystem, ScopedFilesystem,
-    VersionedEntry,
+    Filter, InMemoryBackend, IndexSpec, LocalFilesystem, Page, RecordVersion, RootFilesystem,
+    ScopedFilesystem, VersionedEntry,
 };
 use ironclaw_host_api::{
-    AgentId, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, TenantId, ThreadId,
-    UserId, VirtualPath,
+    AgentId, HostPath, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, TenantId,
+    ThreadId, UserId, VirtualPath,
 };
 use ironclaw_outbound::*;
 use ironclaw_turns::{ReplyTargetBindingRef, TurnActor, TurnRunId, TurnScope};
@@ -42,11 +42,29 @@ fn build_outbound_store_for_backend(
     FilesystemOutboundStateStore::new(build_scoped_fs(backend, TEST_OUTBOUND_ROOT))
 }
 
+fn build_local_outbound_store(
+    root: &std::path::Path,
+) -> FilesystemOutboundStateStore<LocalFilesystem> {
+    let mut backend = LocalFilesystem::new();
+    backend
+        .mount_local(
+            VirtualPath::new("/engine").expect("virtual root"),
+            HostPath::from_path_buf(root.to_path_buf()),
+        )
+        .expect("mount local root");
+    FilesystemOutboundStateStore::new(build_scoped_fs(Arc::new(backend), TEST_OUTBOUND_ROOT))
+}
+
 #[tokio::test]
 async fn in_memory_defaults_policy_progress_opt_in_and_subscription_scope() {
     let store = InMemoryOutboundStateStore::default();
     communication_preferences_are_tenant_user_scoped(&store).await;
+    communication_preferences_support_scoped_defaults_and_cas(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
+    communication_preferences_reject_empty_shared_agent_scope_fields(&store).await;
+    communication_preference_slot_update_rejects_missing_updater_and_absent_key(&store).await;
+    communication_preference_slot_update_covers_prompt_slots(&store).await;
+    communication_preference_slot_update_retries_transient_cas_conflict().await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
     subscription_ids_are_scoped_not_global(&store).await;
@@ -66,8 +84,13 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     let backend = std::sync::Arc::new(ironclaw_filesystem::InMemoryBackend::new());
     let store = build_outbound_store_for_backend(Arc::clone(&backend));
     communication_preferences_are_tenant_user_scoped(&store).await;
+    communication_preferences_support_scoped_defaults_and_cas(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
+    communication_preferences_reject_empty_shared_agent_scope_fields(&store).await;
+    communication_preference_slot_update_rejects_missing_updater_and_absent_key(&store).await;
+    communication_preference_slot_update_covers_prompt_slots(&store).await;
     filesystem_store_retries_communication_preference_put_through_cas_conflict(&backend).await;
+    filesystem_store_loads_legacy_personal_communication_preference(&backend, &store).await;
     filesystem_store_rejects_mismatched_communication_preference_identity(&backend, &store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
@@ -75,6 +98,55 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     subscription_cursor_rejects_backward_advancement(&store).await;
     delivery_status_rejects_inconsistent_failure_kind(&store).await;
     notification_policy_rejects_excessive_targets(&store).await;
+}
+
+#[tokio::test]
+async fn filesystem_store_updates_preferences_on_byte_only_local_backend() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let store = build_local_outbound_store(tempdir.path());
+
+    let key = CommunicationPreferenceKey::new(
+        TenantId::new("tenant-outbound-local").unwrap(),
+        UserId::new("user-outbound-local").unwrap(),
+    );
+    let record = CommunicationPreferenceRecord {
+        scope: key.scope.clone(),
+        targets: preference_targets(Some(reply_ref("reply-local-initial")), None, None, None),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-local-updater").unwrap(),
+    };
+    let version = store
+        .write_communication_preference(record, CommunicationPreferenceWriteExpectation::Absent)
+        .await
+        .unwrap();
+
+    let updated = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key: key.clone(),
+            expected_version: version,
+            slot: CommunicationPreferenceSlot::FinalReply,
+            expected_current_target: Some(reply_ref("reply-local-initial")),
+            target: Some(reply_ref("reply-local-updated")),
+            updated_at: now(),
+            updated_by: UserId::new("user-outbound-local-updater").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated.record.targets.final_reply,
+        Some(reply_ref("reply-local-updated"))
+    );
+    assert_ne!(updated.version, version);
+    assert_eq!(
+        store
+            .load_versioned_communication_preference(key)
+            .await
+            .unwrap()
+            .map(|versioned| (versioned.record.targets.final_reply, versioned.version)),
+        Some((Some(reply_ref("reply-local-updated")), updated.version))
+    );
 }
 
 // Legacy LibSqlOutboundStateStore / PostgresOutboundStateStore have been
@@ -93,12 +165,13 @@ where
     let updated_by = UserId::new("tenant-admin-outbound").unwrap();
     let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
     let record = CommunicationPreferenceRecord {
-        tenant_id: tenant_id.clone(),
-        user_id: user_id.clone(),
-        final_reply_target: Some(reply_ref("reply-pref-final")),
-        progress_target: Some(reply_ref("reply-pref-progress")),
-        approval_prompt_target: Some(reply_ref("reply-pref-approval")),
-        auth_prompt_target: Some(reply_ref("reply-pref-auth")),
+        scope: DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone()),
+        targets: preference_targets(
+            Some(reply_ref("reply-pref-final")),
+            Some(reply_ref("reply-pref-progress")),
+            Some(reply_ref("reply-pref-approval")),
+            Some(reply_ref("reply-pref-auth")),
+        ),
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
         updated_by: updated_by.clone(),
@@ -140,10 +213,12 @@ where
     );
 
     let updated = CommunicationPreferenceRecord {
-        final_reply_target: Some(reply_ref("reply-pref-final-updated")),
-        progress_target: None,
-        approval_prompt_target: Some(reply_ref("reply-pref-approval")),
-        auth_prompt_target: None,
+        targets: preference_targets(
+            Some(reply_ref("reply-pref-final-updated")),
+            None,
+            Some(reply_ref("reply-pref-approval")),
+            None,
+        ),
         default_modality: Some(CommunicationModality::Voice),
         updated_at: now(),
         updated_by,
@@ -168,17 +243,178 @@ where
     );
 }
 
+async fn communication_preferences_support_scoped_defaults_and_cas<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound-scoped").unwrap();
+    let user_id = UserId::new("user-outbound-scoped").unwrap();
+    let agent_id = AgentId::new("agent-outbound-scoped").unwrap();
+    let project_id = ProjectId::new("project-outbound-scoped").unwrap();
+    let personal_scope = DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone());
+    let shared_scope = DeliveryDefaultScope::shared_agent(tenant_id, agent_id, Some(project_id));
+    let personal_key = CommunicationPreferenceKey::for_scope(personal_scope.clone());
+    let shared_key = CommunicationPreferenceKey::for_scope(shared_scope.clone());
+
+    let personal = CommunicationPreferenceRecord {
+        scope: personal_scope,
+        targets: preference_targets(Some(reply_ref("reply-scoped-personal")), None, None, None),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-scoped").unwrap(),
+    };
+    let version = store
+        .write_communication_preference(
+            personal.clone(),
+            CommunicationPreferenceWriteExpectation::Absent,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .load_versioned_communication_preference(personal_key.clone())
+            .await
+            .unwrap()
+            .map(|versioned| (versioned.record, versioned.version)),
+        Some((personal.clone(), version))
+    );
+    assert!(
+        store
+            .load_communication_preference(shared_key.clone())
+            .await
+            .unwrap()
+            .is_none(),
+        "shared-agent defaults must not be faked through the personal user key"
+    );
+
+    let shared = CommunicationPreferenceRecord {
+        scope: shared_scope,
+        targets: preference_targets(Some(reply_ref("reply-scoped-shared")), None, None, None),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-scoped").unwrap(),
+    };
+    store
+        .write_communication_preference(
+            shared.clone(),
+            CommunicationPreferenceWriteExpectation::Absent,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .load_communication_preference(shared_key)
+            .await
+            .unwrap(),
+        Some(shared)
+    );
+
+    let absent_result = store
+        .write_communication_preference(
+            personal.clone(),
+            CommunicationPreferenceWriteExpectation::Absent,
+        )
+        .await;
+    assert!(matches!(absent_result, Err(OutboundError::CasConflict)));
+
+    let mut racing_targets = personal.targets.clone();
+    racing_targets.final_reply = Some(reply_ref("reply-scoped-personal-racing"));
+    let racing_update = CommunicationPreferenceRecord {
+        targets: racing_targets,
+        updated_at: now(),
+        ..personal.clone()
+    };
+    let newer_version = store
+        .write_communication_preference(
+            racing_update.clone(),
+            CommunicationPreferenceWriteExpectation::Version(version),
+        )
+        .await
+        .unwrap();
+    let mut stale_targets = racing_update.targets.clone();
+    stale_targets.final_reply = Some(reply_ref("reply-scoped-personal-stale"));
+    let stale_update = CommunicationPreferenceRecord {
+        targets: stale_targets,
+        updated_at: now(),
+        ..racing_update
+    };
+    let stale_result = store
+        .write_communication_preference(
+            stale_update,
+            CommunicationPreferenceWriteExpectation::Version(version),
+        )
+        .await;
+    assert!(matches!(stale_result, Err(OutboundError::CasConflict)));
+    assert_eq!(
+        store
+            .load_versioned_communication_preference(personal_key)
+            .await
+            .unwrap()
+            .map(|versioned| versioned.version),
+        Some(newer_version)
+    );
+
+    let personal_key = CommunicationPreferenceKey::new(
+        TenantId::new("tenant-outbound-scoped").unwrap(),
+        UserId::new("user-outbound-scoped").unwrap(),
+    );
+    let merged = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key: personal_key.clone(),
+            expected_version: version,
+            slot: CommunicationPreferenceSlot::Progress,
+            expected_current_target: None,
+            target: Some(reply_ref("reply-scoped-progress-merged")),
+            updated_at: now(),
+            updated_by: UserId::new("tenant-admin-outbound-scoped").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        merged.record.targets.final_reply,
+        Some(reply_ref("reply-scoped-personal-racing")),
+        "stale disjoint slot merge must preserve the newer final-reply target"
+    );
+    assert_eq!(
+        merged.record.targets.progress,
+        Some(reply_ref("reply-scoped-progress-merged"))
+    );
+
+    let same_slot_result = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key: personal_key.clone(),
+            expected_version: version,
+            slot: CommunicationPreferenceSlot::FinalReply,
+            expected_current_target: Some(reply_ref("reply-scoped-personal")),
+            target: Some(reply_ref("reply-scoped-personal-overwrite")),
+            updated_at: now(),
+            updated_by: UserId::new("tenant-admin-outbound-scoped").unwrap(),
+        })
+        .await;
+    assert!(matches!(same_slot_result, Err(OutboundError::CasConflict)));
+    assert_eq!(
+        store
+            .load_communication_preference(personal_key)
+            .await
+            .unwrap()
+            .map(|record| (record.targets.final_reply, record.targets.progress)),
+        Some((
+            Some(reply_ref("reply-scoped-personal-racing")),
+            Some(reply_ref("reply-scoped-progress-merged"))
+        ))
+    );
+}
+
 async fn communication_preferences_reject_empty_updated_by<S>(store: &S)
 where
     S: CommunicationPreferenceRepository + OutboundStateStore,
 {
     let valid_record = CommunicationPreferenceRecord {
-        tenant_id: TenantId::new("tenant-outbound-validation").unwrap(),
-        user_id: UserId::new("user-outbound-validation").unwrap(),
-        final_reply_target: Some(reply_ref("reply-pref-validation")),
-        progress_target: None,
-        approval_prompt_target: None,
-        auth_prompt_target: None,
+        scope: DeliveryDefaultScope::personal(
+            TenantId::new("tenant-outbound-validation").unwrap(),
+            UserId::new("user-outbound-validation").unwrap(),
+        ),
+        targets: preference_targets(Some(reply_ref("reply-pref-validation")), None, None, None),
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
         updated_by: UserId::new("user-outbound-validation-updater").unwrap(),
@@ -190,14 +426,258 @@ where
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 
     let mut missing_tenant = valid_record.clone();
-    missing_tenant.tenant_id = TenantId::from_trusted(String::new());
+    missing_tenant.scope = DeliveryDefaultScope::personal(
+        TenantId::from_trusted(String::new()),
+        UserId::new("user-outbound-validation").unwrap(),
+    );
     let result = store.put_communication_preference(missing_tenant).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 
     let mut missing_user = valid_record;
-    missing_user.user_id = UserId::from_trusted(String::new());
+    missing_user.scope = DeliveryDefaultScope::personal(
+        TenantId::new("tenant-outbound-validation").unwrap(),
+        UserId::from_trusted(String::new()),
+    );
     let result = store.put_communication_preference(missing_user).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+}
+
+async fn communication_preferences_reject_empty_shared_agent_scope_fields<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let valid_record = CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::shared_agent(
+            TenantId::new("tenant-outbound-shared-validation").unwrap(),
+            AgentId::new("agent-outbound-shared-validation").unwrap(),
+            Some(ProjectId::new("project-outbound-shared-validation").unwrap()),
+        ),
+        targets: preference_targets(
+            Some(reply_ref("reply-pref-shared-validation")),
+            None,
+            None,
+            None,
+        ),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-shared-validation-updater").unwrap(),
+    };
+
+    let mut missing_tenant = valid_record.clone();
+    missing_tenant.scope = DeliveryDefaultScope::shared_agent(
+        TenantId::from_trusted(String::new()),
+        AgentId::new("agent-outbound-shared-validation").unwrap(),
+        Some(ProjectId::new("project-outbound-shared-validation").unwrap()),
+    );
+    let result = store.put_communication_preference(missing_tenant).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+
+    let mut missing_agent = valid_record.clone();
+    missing_agent.scope = DeliveryDefaultScope::shared_agent(
+        TenantId::new("tenant-outbound-shared-validation").unwrap(),
+        AgentId::from_trusted(String::new()),
+        Some(ProjectId::new("project-outbound-shared-validation").unwrap()),
+    );
+    let result = store.put_communication_preference(missing_agent).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+
+    let mut missing_project = valid_record.clone();
+    missing_project.scope = DeliveryDefaultScope::shared_agent(
+        TenantId::new("tenant-outbound-shared-validation").unwrap(),
+        AgentId::new("agent-outbound-shared-validation").unwrap(),
+        Some(ProjectId::from_trusted(String::new())),
+    );
+    let result = store.put_communication_preference(missing_project).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+}
+
+async fn communication_preference_slot_update_rejects_missing_updater_and_absent_key<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let key = CommunicationPreferenceKey::new(
+        TenantId::new("tenant-outbound-slot-validation").unwrap(),
+        UserId::new("user-outbound-slot-validation").unwrap(),
+    );
+    let record = CommunicationPreferenceRecord {
+        scope: key.scope.clone(),
+        targets: preference_targets(Some(reply_ref("reply-slot-validation")), None, None, None),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-slot-validation-updater").unwrap(),
+    };
+    let version = store
+        .write_communication_preference(record, CommunicationPreferenceWriteExpectation::Absent)
+        .await
+        .unwrap();
+
+    let missing_updater = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key: key.clone(),
+            expected_version: version,
+            slot: CommunicationPreferenceSlot::Progress,
+            expected_current_target: None,
+            target: Some(reply_ref("reply-slot-validation-progress")),
+            updated_at: now(),
+            updated_by: UserId::from_trusted(String::new()),
+        })
+        .await;
+    assert!(matches!(
+        missing_updater,
+        Err(OutboundError::InvalidRequest { .. })
+    ));
+
+    let absent_key = CommunicationPreferenceKey::new(
+        TenantId::new("tenant-outbound-slot-absent").unwrap(),
+        UserId::new("user-outbound-slot-absent").unwrap(),
+    );
+    let absent_result = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key: absent_key,
+            expected_version: version,
+            slot: CommunicationPreferenceSlot::Progress,
+            expected_current_target: None,
+            target: Some(reply_ref("reply-slot-absent-progress")),
+            updated_at: now(),
+            updated_by: UserId::new("user-outbound-slot-validation-updater").unwrap(),
+        })
+        .await;
+    assert!(matches!(absent_result, Err(OutboundError::CasConflict)));
+}
+
+async fn communication_preference_slot_update_covers_prompt_slots<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let key = CommunicationPreferenceKey::new(
+        TenantId::new("tenant-outbound-prompt-slots").unwrap(),
+        UserId::new("user-outbound-prompt-slots").unwrap(),
+    );
+    let record = CommunicationPreferenceRecord {
+        scope: key.scope.clone(),
+        targets: preference_targets(
+            Some(reply_ref("reply-prompt-slots-final")),
+            None,
+            None,
+            None,
+        ),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-prompt-slots-updater").unwrap(),
+    };
+    let version = store
+        .write_communication_preference(record, CommunicationPreferenceWriteExpectation::Absent)
+        .await
+        .unwrap();
+    let approval = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key: key.clone(),
+            expected_version: version,
+            slot: CommunicationPreferenceSlot::ApprovalPrompt,
+            expected_current_target: None,
+            target: Some(reply_ref("reply-prompt-slots-approval")),
+            updated_at: now(),
+            updated_by: UserId::new("user-outbound-prompt-slots-updater").unwrap(),
+        })
+        .await
+        .unwrap();
+    let auth = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key: key.clone(),
+            expected_version: approval.version,
+            slot: CommunicationPreferenceSlot::AuthPrompt,
+            expected_current_target: None,
+            target: Some(reply_ref("reply-prompt-slots-auth")),
+            updated_at: now(),
+            updated_by: UserId::new("user-outbound-prompt-slots-updater").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        (
+            auth.record.targets.approval_prompt,
+            auth.record.targets.auth_prompt
+        ),
+        (
+            Some(reply_ref("reply-prompt-slots-approval")),
+            Some(reply_ref("reply-prompt-slots-auth"))
+        )
+    );
+}
+
+async fn communication_preference_slot_update_retries_transient_cas_conflict() {
+    struct TransientCasPreferenceRepository {
+        inner: InMemoryOutboundStateStore,
+        fail_next_version_write: Mutex<bool>,
+    }
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for TransientCasPreferenceRepository {
+        async fn write_communication_preference(
+            &self,
+            record: CommunicationPreferenceRecord,
+            expectation: CommunicationPreferenceWriteExpectation,
+        ) -> Result<CommunicationPreferenceVersion, OutboundError> {
+            if matches!(
+                expectation,
+                CommunicationPreferenceWriteExpectation::Version(_)
+            ) {
+                let mut fail_next = self.fail_next_version_write.lock().await;
+                if *fail_next {
+                    *fail_next = false;
+                    return Err(OutboundError::CasConflict);
+                }
+            }
+            self.inner
+                .write_communication_preference(record, expectation)
+                .await
+        }
+
+        async fn load_versioned_communication_preference(
+            &self,
+            key: CommunicationPreferenceKey,
+        ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
+            self.inner
+                .load_versioned_communication_preference(key)
+                .await
+        }
+    }
+
+    let store = TransientCasPreferenceRepository {
+        inner: InMemoryOutboundStateStore::default(),
+        fail_next_version_write: Mutex::new(true),
+    };
+    let key = CommunicationPreferenceKey::new(
+        TenantId::new("tenant-outbound-slot-retry").unwrap(),
+        UserId::new("user-outbound-slot-retry").unwrap(),
+    );
+    let record = CommunicationPreferenceRecord {
+        scope: key.scope.clone(),
+        targets: preference_targets(Some(reply_ref("reply-slot-retry-final")), None, None, None),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-slot-retry-updater").unwrap(),
+    };
+    let version = store
+        .write_communication_preference(record, CommunicationPreferenceWriteExpectation::Absent)
+        .await
+        .unwrap();
+    let updated = store
+        .update_communication_preference_slot(UpdateCommunicationPreferenceSlotRequest {
+            key,
+            expected_version: version,
+            slot: CommunicationPreferenceSlot::Progress,
+            expected_current_target: None,
+            target: Some(reply_ref("reply-slot-retry-progress")),
+            updated_at: now(),
+            updated_by: UserId::new("user-outbound-slot-retry-updater").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        updated.record.targets.progress,
+        Some(reply_ref("reply-slot-retry-progress"))
+    );
 }
 
 async fn filesystem_store_rejects_mismatched_communication_preference_identity(
@@ -207,12 +687,8 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let tenant_id = TenantId::new("tenant-outbound-corrupt").unwrap();
     let user_id = UserId::new("user-outbound-corrupt").unwrap();
     let record = CommunicationPreferenceRecord {
-        tenant_id: tenant_id.clone(),
-        user_id: user_id.clone(),
-        final_reply_target: Some(reply_ref("reply-pref-corrupt")),
-        progress_target: None,
-        approval_prompt_target: None,
-        auth_prompt_target: None,
+        scope: DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone()),
+        targets: preference_targets(Some(reply_ref("reply-pref-corrupt")), None, None, None),
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-corrupt").unwrap(),
@@ -220,7 +696,10 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let (key, path) = put_preference_and_find_virtual_path(backend, store, record.clone()).await;
 
     let mut user_mismatch_record = record;
-    user_mismatch_record.user_id = UserId::new("user-outbound-corrupt-other").unwrap();
+    user_mismatch_record.scope = DeliveryDefaultScope::personal(
+        tenant_id,
+        UserId::new("user-outbound-corrupt-other").unwrap(),
+    );
     let entry = Entry::bytes(serde_json::to_vec(&user_mismatch_record).unwrap())
         .with_content_type(ContentType::json());
     backend
@@ -234,12 +713,16 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let tenant_mismatch_tenant_id = TenantId::new("tenant-outbound-corrupt-tenant").unwrap();
     let tenant_mismatch_user_id = UserId::new("user-outbound-corrupt-tenant").unwrap();
     let tenant_mismatch_seed = CommunicationPreferenceRecord {
-        tenant_id: tenant_mismatch_tenant_id,
-        user_id: tenant_mismatch_user_id.clone(),
-        final_reply_target: Some(reply_ref("reply-pref-corrupt-tenant-seed")),
-        progress_target: None,
-        approval_prompt_target: None,
-        auth_prompt_target: None,
+        scope: DeliveryDefaultScope::personal(
+            tenant_mismatch_tenant_id,
+            tenant_mismatch_user_id.clone(),
+        ),
+        targets: preference_targets(
+            Some(reply_ref("reply-pref-corrupt-tenant-seed")),
+            None,
+            None,
+            None,
+        ),
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-corrupt-tenant-seed").unwrap(),
@@ -247,12 +730,16 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let (tenant_mismatch_key, tenant_mismatch_path) =
         put_preference_and_find_virtual_path(backend, store, tenant_mismatch_seed).await;
     let tenant_mismatch_record = CommunicationPreferenceRecord {
-        tenant_id: TenantId::new("tenant-outbound-corrupt-other").unwrap(),
-        user_id: tenant_mismatch_user_id,
-        final_reply_target: Some(reply_ref("reply-pref-corrupt-tenant")),
-        progress_target: None,
-        approval_prompt_target: None,
-        auth_prompt_target: None,
+        scope: DeliveryDefaultScope::personal(
+            TenantId::new("tenant-outbound-corrupt-other").unwrap(),
+            tenant_mismatch_user_id,
+        ),
+        targets: preference_targets(
+            Some(reply_ref("reply-pref-corrupt-tenant")),
+            None,
+            None,
+            None,
+        ),
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-corrupt-tenant").unwrap(),
@@ -274,6 +761,73 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     assert!(matches!(result, Err(OutboundError::Backend)));
 }
 
+async fn filesystem_store_loads_legacy_personal_communication_preference(
+    backend: &Arc<InMemoryBackend>,
+    store: &FilesystemOutboundStateStore<InMemoryBackend>,
+) {
+    #[derive(serde::Serialize)]
+    struct LegacyCommunicationPreferenceRecord {
+        tenant_id: TenantId,
+        user_id: UserId,
+        final_reply_target: Option<ReplyTargetBindingRef>,
+        progress_target: Option<ReplyTargetBindingRef>,
+        approval_prompt_target: Option<ReplyTargetBindingRef>,
+        auth_prompt_target: Option<ReplyTargetBindingRef>,
+        default_modality: Option<CommunicationModality>,
+        updated_at: ironclaw_host_api::Timestamp,
+        updated_by: UserId,
+    }
+
+    let tenant_id = TenantId::new("tenant-outbound-legacy-pref").unwrap();
+    let user_id = UserId::new("user-outbound-legacy-pref").unwrap();
+    let modern_seed = CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone()),
+        targets: preference_targets(
+            Some(reply_ref("reply-legacy-modern-seed")),
+            None,
+            None,
+            None,
+        ),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-legacy-updater").unwrap(),
+    };
+    let (key, path) = put_preference_and_find_virtual_path(backend, store, modern_seed).await;
+    let legacy = LegacyCommunicationPreferenceRecord {
+        tenant_id,
+        user_id,
+        final_reply_target: Some(reply_ref("reply-legacy-final")),
+        progress_target: Some(reply_ref("reply-legacy-progress")),
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-legacy-updater").unwrap(),
+    };
+    backend
+        .put(
+            &path,
+            Entry::bytes(serde_json::to_vec(&legacy).unwrap())
+                .with_content_type(ContentType::json()),
+            CasExpectation::Any,
+        )
+        .await
+        .unwrap();
+
+    let loaded = store
+        .load_communication_preference(key)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        (loaded.targets.final_reply, loaded.targets.progress),
+        (
+            Some(reply_ref("reply-legacy-final")),
+            Some(reply_ref("reply-legacy-progress"))
+        )
+    );
+}
+
 async fn filesystem_store_retries_communication_preference_put_through_cas_conflict(
     backend: &Arc<InMemoryBackend>,
 ) {
@@ -290,12 +844,13 @@ async fn filesystem_store_retries_communication_preference_put_through_cas_confl
         .await;
 
     let record = CommunicationPreferenceRecord {
-        tenant_id: tenant_id.clone(),
-        user_id: user_id.clone(),
-        final_reply_target: Some(reply_ref("reply-pref-cas")),
-        progress_target: Some(reply_ref("reply-pref-cas-progress")),
-        approval_prompt_target: None,
-        auth_prompt_target: None,
+        scope: DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone()),
+        targets: preference_targets(
+            Some(reply_ref("reply-pref-cas")),
+            Some(reply_ref("reply-pref-cas-progress")),
+            None,
+            None,
+        ),
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-cas").unwrap(),
@@ -923,6 +1478,20 @@ fn thread_id() -> ThreadId {
 
 fn reply_ref(value: &str) -> ReplyTargetBindingRef {
     ReplyTargetBindingRef::new(value).unwrap()
+}
+
+fn preference_targets(
+    final_reply: Option<ReplyTargetBindingRef>,
+    progress: Option<ReplyTargetBindingRef>,
+    approval_prompt: Option<ReplyTargetBindingRef>,
+    auth_prompt: Option<ReplyTargetBindingRef>,
+) -> CommunicationPreferenceTargets {
+    CommunicationPreferenceTargets {
+        final_reply,
+        progress,
+        approval_prompt,
+        auth_prompt,
+    }
 }
 
 fn now() -> ironclaw_host_api::Timestamp {

--- a/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
@@ -8,13 +8,15 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_outbound::{
     CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
-    InMemoryOutboundStateStore, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
-    OutboundError, OutboundPolicyService, OutboundStateStore, ProjectionSubscriptionRecord,
-    ReplyTargetBindingClaim, ReplyTargetBindingValidator, RequestedOutboundContext,
-    RequestedOutboundKind, RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin,
-    SystemEventReasonCode, ThreadNotificationPolicy, ThreadProjectionAccessClaim,
-    ThreadProjectionAccessPolicy, ThreadProjectionAccessRequest, TriggerFireSlot, TriggerOriginRef,
-    TriggerSourceKind, UpdateDeliveryStatusRequest,
+    CommunicationPreferenceTargets, CommunicationPreferenceVersion,
+    CommunicationPreferenceWriteExpectation, DeliveryDefaultScope, InMemoryOutboundStateStore,
+    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundError, OutboundPolicyService,
+    OutboundStateStore, ProjectionSubscriptionRecord, ReplyTargetBindingClaim,
+    ReplyTargetBindingValidator, RequestedOutboundContext, RequestedOutboundKind,
+    RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin, SystemEventReasonCode,
+    ThreadNotificationPolicy, ThreadProjectionAccessClaim, ThreadProjectionAccessPolicy,
+    ThreadProjectionAccessRequest, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
+    UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
 };
 use ironclaw_product_adapters::{
     AdapterInstallationId, AuthRequirement, DeliveryStatus, EgressCredentialHandle, EgressResponse,
@@ -143,25 +145,30 @@ impl FakePreferenceRepository {
 
 #[async_trait]
 impl CommunicationPreferenceRepository for FakePreferenceRepository {
-    async fn put_communication_preference(
+    async fn write_communication_preference(
         &self,
         record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
+        _expectation: CommunicationPreferenceWriteExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError> {
         self.put_record(record);
-        Ok(())
+        Ok(CommunicationPreferenceVersion::from_backend(1))
     }
 
-    async fn load_communication_preference(
+    async fn load_versioned_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         *self.load_calls.lock().expect("preference lock") += 1;
         Ok(self
             .records
             .lock()
             .expect("preference lock")
             .get(&key)
-            .cloned())
+            .cloned()
+            .map(|record| VersionedCommunicationPreferenceRecord {
+                record,
+                version: CommunicationPreferenceVersion::from_backend(1),
+            }))
     }
 }
 
@@ -237,18 +244,23 @@ impl StatusFailingOutboundStore {
 
 #[async_trait]
 impl CommunicationPreferenceRepository for StatusFailingOutboundStore {
-    async fn put_communication_preference(
+    async fn write_communication_preference(
         &self,
         record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
-        self.inner.put_communication_preference(record).await
+        expectation: CommunicationPreferenceWriteExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError> {
+        self.inner
+            .write_communication_preference(record, expectation)
+            .await
     }
 
-    async fn load_communication_preference(
+    async fn load_versioned_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
-        self.inner.load_communication_preference(key).await
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
+        self.inner
+            .load_versioned_communication_preference(key)
+            .await
     }
 }
 
@@ -631,12 +643,32 @@ fn seed_preference(repo: &FakePreferenceRepository, scope: &TurnScope) {
 
 fn preference_record(scope: &TurnScope) -> CommunicationPreferenceRecord {
     CommunicationPreferenceRecord {
-        tenant_id: scope.tenant_id.clone(),
-        user_id: actor().user_id.clone(),
-        final_reply_target: Some(validated_reply_target()),
-        progress_target: None,
-        approval_prompt_target: None,
-        auth_prompt_target: None,
+        scope: DeliveryDefaultScope::personal(scope.tenant_id.clone(), actor().user_id.clone()),
+        targets: CommunicationPreferenceTargets {
+            final_reply: Some(validated_reply_target()),
+            progress: None,
+            approval_prompt: None,
+            auth_prompt: None,
+        },
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: Utc::now(),
+        updated_by: UserId::new("pref-updater").expect("valid updater"),
+    }
+}
+
+fn shared_preference_record(scope: &TurnScope) -> CommunicationPreferenceRecord {
+    CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::shared_agent(
+            scope.tenant_id.clone(),
+            scope.agent_id.clone().expect("agent-scoped test scope"),
+            scope.project_id.clone(),
+        ),
+        targets: CommunicationPreferenceTargets {
+            final_reply: Some(validated_reply_target()),
+            progress: None,
+            approval_prompt: None,
+            auth_prompt: None,
+        },
         default_modality: Some(CommunicationModality::Text),
         updated_at: Utc::now(),
         updated_by: UserId::new("pref-updater").expect("valid updater"),
@@ -712,6 +744,48 @@ async fn authorized_final_reply_renders_through_telegram_egress_after_validation
         attempts[0].status,
         ironclaw_outbound::OutboundDeliveryStatus::Delivered
     );
+}
+
+#[tokio::test]
+async fn shared_agent_default_renders_through_product_workflow_after_validation() {
+    let scope = scope();
+    let store = InMemoryOutboundStateStore::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    validator.allow(validated_reply_target());
+    let preferences = FakePreferenceRepository::default();
+    preferences.put_record(shared_preference_record(&scope));
+    let resolver = FakeProductOutboundTargetResolver::default();
+    let policy = configured_policy(&store, &validator);
+    let adapter = telegram_adapter();
+    let egress = FakeProtocolHttpEgress::new(["api.telegram.org".to_string()]);
+    egress.allow_credential_handle("telegram_bot_token");
+    let sink = FakeOutboundDeliverySink::new();
+
+    let outcome = prepare_and_render_product_outbound(
+        &policy,
+        &preferences,
+        &resolver,
+        ProductOutboundDeliveryRequest {
+            delivery: delivery_request(scope),
+            payload: final_reply_payload(),
+            projection_cursor: ProjectionCursor::new("cursor:outbound:shared")
+                .expect("valid cursor"),
+            adapter: &adapter,
+            egress: &egress,
+            delivery_sink: &sink,
+        },
+    )
+    .await
+    .expect("delivery succeeds");
+
+    assert!(matches!(
+        outcome,
+        ProductOutboundDeliveryOutcome::Rendered { .. }
+    ));
+    assert_eq!(validator.calls(), 1);
+    assert_eq!(preferences.load_calls(), 2);
+    assert_eq!(resolver.called_targets(), vec![validated_reply_target()]);
+    assert_eq!(egress.calls().len(), 1);
 }
 
 #[tokio::test]

--- a/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
+++ b/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
@@ -1,0 +1,752 @@
+# Trigger Delivery Scoped Default Outbound E2E Plan
+
+Date: 2026-06-05
+
+Status: planning artifact, revised 2026-06-08
+
+Context: `$gsd-discuss-phase` was requested for this work, but this checkout has
+no `.planning/ROADMAP.md` phase entry to attach to. This repo-native plan
+captures the phase context and implementation decisions for downstream agents.
+
+## Summary
+
+This plan turns trigger result delivery from an internal fast-follow into a
+user-visible end-to-end flow with scoped delivery defaults:
+
+1. A triggered event resolves the delivery default for the run's owner scope.
+2. Shared tenant agents send to an admin-configured shared delivery channel.
+3. Personal agents send to the owning user's personal delivery target, such as
+   a paired Slack DM.
+4. Trigger completion sends final replies through the existing outbound policy
+   and product-adapter path.
+
+Slack is the first external delivery channel because the current Slack adapter
+already supports outbound `FinalReply`, `GatePrompt`, and `AuthPrompt` via
+Slack `chat.postMessage`. The first E2E remains text final replies only; Slack
+progress/projection payloads and non-text modality defaults remain deferred.
+
+## Current Status
+
+Completed or merged before this revision:
+
+- Product-workflow outbound preference facade exists:
+  `get_outbound_preferences`, `set_outbound_preferences`, and
+  `list_outbound_delivery_targets`.
+- Client-safe target DTOs exist for target IDs, labels, channel metadata, and
+  capability flags.
+- Composition has a product-surface-neutral outbound preferences facade backed
+  by `RebornLocalRuntimeServices::outbound_preferences`.
+- Current default preference storage is still user-scoped through
+  `CommunicationPreferenceRecord { tenant_id, user_id, ... }`.
+
+Implementation note for branch `trigger-delivery-scoped-defaults`:
+
+- Phase 2 has been implemented in `ironclaw_outbound` on top of the current
+  `origin/reborn-integration` base, which did not contain the product-workflow
+  outbound preference facade described above.
+- `CommunicationPreferenceRecord` now carries `DeliveryDefaultScope` directly,
+  with `Personal { tenant_id, user_id }` and
+  `SharedAgent { tenant_id, agent_id, project_id? }`.
+- `CommunicationPreferenceRepository` now exposes versioned read/write
+  operations and a slot-update helper that fails stale same-slot writes while
+  allowing disjoint-slot merges to preserve both updates.
+- Filesystem-backed communication preference writes preserve `Absent` and
+  `Version` CAS expectations through byte-only fallback instead of downgrading
+  to unconditional writes.
+- Existing personal lookup behavior remains available through
+  `CommunicationPreferenceKey::new(tenant_id, user_id)` for current delivery
+  callers; shared-agent trigger ownership resolution remains Phase 3+.
+
+Staged or in-progress in the phase-4 prereq worktree:
+
+- Slack host-beta can expose configured/persisted Slack channel routes through
+  a generic `OutboundDeliveryTargetProvider` staged on `SlackHostBetaMounts`.
+- Slack final-reply delivery reads the shared
+  `local_runtime.outbound_preferences` repository instead of a private
+  in-memory preference repository.
+- The staged Slack provider is not yet wired into the WebUI/API bundle and
+  should not become user-selectable until the scoped authority model below is
+  implemented.
+
+Known gaps after this revision:
+
+- Shared-agent default delivery scope exists in the outbound repository
+  contract, but run ownership resolution is not yet wired to select it during
+  trigger delivery.
+- There is no durable target-authority resolver for validating a saved Slack
+  channel or DM target at trigger-fire time.
+- WebUI v2 still has no outbound preference/target HTTP routes.
+- Automations has no Delivery panel.
+- Trigger terminal completion is not yet wired to external outbound delivery.
+
+## Carry-Forward Deferred Work
+
+These items came from the earlier default-outbound and trigger-delivery review
+loops. They are not optional polish; each one must either be completed before
+the affected phase ships or explicitly deferred again in that PR body with a
+tracked follow-up.
+
+### Repository And CAS Hardening
+
+- Harden communication-preference read-modify-write semantics before depending
+  on concurrent preference updates for production delivery behavior.
+- Byte-only filesystem roots must not downgrade `Absent` or `Version` compare
+  and swap expectations to unconditional `Any` writes. Safe outcomes are:
+  - preserve `Absent` write-once semantics
+  - fail closed for unsupported versioned CAS
+  - use a real scoped backend lock/transaction where available
+- Do not treat a process-local mutex as the production CAS guarantee. A
+  byte-only `LocalFilesystem` fallback may use a path lock plus process-local
+  version overlay so local/dev preference updates do not silently overwrite
+  stale writes, but restart-safe or multi-process scoped defaults require a
+  real versioned backend lock/transaction.
+- Add caller-level tests through the preference repository or product facade,
+  not only helper-level tests.
+
+### Product API Follow-Ups
+
+- Expand public modality support in a dedicated API phase before surfacing
+  non-text defaults. The outbound repository can store more modalities than
+  the current product response DTO intentionally exposes.
+- Add a product-safe stale-target representation before UI treats unavailable
+  targets as first-class state. Preferred low-churn shape: keep the current
+  selected-target summary field and add a sibling status such as
+  `none_configured`, `available`, or `unavailable`.
+- Keep route/UI state out of backend DTOs. Backend status may describe target
+  availability and validation errors; it must not encode Automations panel
+  layout, button labels, saved/loading state, or WebUI copy.
+
+### Persistence And Local-Dev Store Graph
+
+- Local-dev builds with the `postgres` feature do not change store topology in
+  this E2E. Broad filesystem persistence for outbound preferences or the wider
+  non-libSQL local-dev store graph is a follow-up after scoped delivery lands.
+- Do not switch only one preference store casually while run, thread,
+  checkpoint, event, conversation-binding, idempotency, or delivery-attempt
+  state remains in-memory. A persisted default target with non-persisted
+  authority state can create false confidence after restart.
+- Slack host-beta currently still uses in-memory conversation bindings,
+  idempotency, and delivery-attempt state. Shared default delivery must not
+  claim restart-safe Slack E2E until the target authority state needed for
+  validation is durable.
+
+### Trigger And Poller Follow-Ups
+
+- Trigger terminal delivery must not use WebUI projections as a substitute for
+  product-adapter outbound delivery.
+- Preserve the trigger-poller security fast-follows from the PR 19 plan:
+  trusted trigger ingress must stay sealed, and fire-time creator authorization
+  must use the real agent/project access source of truth before a shipped
+  runtime enables arbitrary user-created trigger firing.
+- One-time immediate trigger creation remains out of scope for this E2E unless
+  explicitly pulled into a later phase.
+
+## Locked Decisions
+
+- Trigger delivery defaults are scoped by run ownership:
+  - personal agent/run -> personal delivery default
+  - shared tenant agent/run -> shared-agent delivery default
+- Scope resolution, preference storage, target inventory, stale-target handling,
+  and send-time authority validation must be channel-neutral. Slack is the
+  first provider implementation, not a special backend rule.
+- Keep per-automation delivery overrides out of the first E2E.
+- Store only the final-reply target in the first UI slice. Preserve the
+  non-final slots inside `CommunicationPreferenceTargets` and preserve
+  `default_modality` unless a later phase explicitly expands those contracts.
+- Do not let any client write arbitrary `ReplyTargetBindingRef` values. Clients
+  submit stable `target_id` values; backend composition resolves and validates
+  those targets.
+- Treat outbound preferences as a reusable product configuration API, not a
+  WebUI rendering API. Backend responses may expose stable ids, labels, channel
+  metadata, capability flags, current selection, status, and errors; they must
+  not encode Automations panel layout, button/copy state, saved/loading UI
+  state, or WebUI-only presentation decisions.
+- Do not set a channel default during identity-only pairing flows. For Slack,
+  pairing-code redemption binds identity only and does not have a concrete
+  reply target.
+- After successful pairing, the UI may offer an explicit follow-up action to
+  use the user's Slack DM as the personal default for triggered automation
+  delivery. Accepting that prompt provisions or validates a concrete DM target,
+  then saves its provider-issued `target_id`; pairing success alone never
+  mutates defaults.
+- Personal channel defaults require a concrete personal target backed by
+  durable provider authority. For Slack this is a DM-capable target, typically
+  after a real inbound Slack DM or an explicit DM target provisioning flow.
+  Pairing identity alone is not sufficient authority for a saved personal
+  delivery default.
+- Shared-agent channel defaults use admin-managed shared destinations. For
+  Slack this is an admin-managed channel route.
+- Missing, stale, deleted, revoked, or ownership-mismatched targets fail closed
+  and send nothing externally.
+- Trigger delivery derives `DeliveryDefaultScope` from the persisted run/agent
+  ownership record, not from the trigger creator, last editor, last inbound
+  sender, or a synthetic user id. Missing or ambiguous ownership fails closed.
+- Preserve outbound ownership: target choice and validation stay under
+  `ironclaw_outbound` / `OutboundPolicyService`; product adapters render only
+  after policy approval.
+- Implement in a separate worktree off the active integration branch; leave the
+  dirty main checkout alone.
+
+## Core Model
+
+Introduce a delivery default scope before wiring any provider deeper:
+
+```text
+DeliveryDefaultScope
+  Personal {
+    tenant_id,
+    user_id
+  }
+
+  SharedAgent {
+    tenant_id,
+    agent_id,
+    project_id?
+  }
+```
+
+Triggered delivery with no live source route resolves defaults in this order:
+
+```text
+Trigger completes
+    |
+    v
+Does the run have a live source route?
+    |
+    +-- yes --> TriggeredFromSourceRoute
+    |           validate observed source route
+    |           send to that source route
+    |
+    +-- no ---> Determine run ownership scope
+                    |
+                    +-- Personal     -> personal default, e.g. Slack DM
+                    |
+                    +-- SharedAgent  -> shared default, e.g. Slack #alerts
+                    |
+                    v
+              resolve saved target authority
+                    |
+                    +-- valid --> OutboundPolicyService -> adapter render/send
+                    |
+                    +-- missing/stale/invalid --> fail closed
+```
+
+Definitions:
+
+- Live source route: a run was directly caused by an inbound product event and
+  still carries that event's concrete reply target. For Slack this means an
+  observed Slack envelope or accepted inbound message produced the
+  `reply_target_binding_ref`; future providers should expose equivalent
+  observed source authority without changing outbound resolution rules.
+- Default outbound route: where trigger results go when no inbound conversation
+  caused the run.
+
+## Provider-Neutral Contract
+
+Every outbound channel provider must plug into the same three concepts:
+
+1. Target inventory
+   - lists client-safe targets for a delivery scope
+   - returns stable `target_id`, display metadata, channel/provider id, and
+     capability flags
+   - does not expose raw provider credentials or raw `ReplyTargetBindingRef`
+     values to clients
+
+2. Target authority resolution
+   - resolves a selected `target_id` before writing a default
+   - revalidates a saved default before sending
+   - returns stale/unavailable when the provider-side route, pairing,
+     permission, or destination no longer exists
+   - validates already-durable concrete targets; identity-only bindings and
+     generic provider names are not writable defaults
+
+3. Product-adapter delivery
+   - receives only validated target metadata
+   - renders provider-specific payloads after `OutboundPolicyService` approval
+   - never loads preferences or invents default targets itself
+
+Slack-specific details such as team id, channel id, DM target, and
+`chat.postMessage` belong inside the Slack provider/adapter implementation.
+They must not leak into the core default-resolution rules.
+
+## Slack Mapping
+
+Slack has two defaultable target families:
+
+1. Shared agent channel target
+   - Source: admin-managed Slack channel route.
+   - Scope: `SharedAgent { tenant_id, agent_id, project_id? }`.
+   - Example: shared tenant agent sends trigger results to `#alerts`.
+   - Required authority: route still exists, belongs to the tenant/agent scope,
+     and the Slack installation/team/channel remain postable.
+
+2. Personal DM target
+   - Source: durable Slack identity binding plus a DM-capable target.
+   - Scope: `Personal { tenant_id, user_id }`.
+   - Example: personal agent sends trigger results to the owner's Slack DM.
+   - Required authority: user remains paired and the DM target can be resolved
+     without trusting raw client input.
+   - Provisioning flow: call Slack `conversations.open` with the paired Slack
+     user id, store the returned DM conversation id as durable provider
+     authority, and send later with `chat.postMessage` using that DM
+     conversation id.
+   - Required Slack scopes: `im:write` to open or resume the 1:1 DM and
+     `chat:write` to post. `im:read` is needed only if validation uses
+     `conversations.info`; `users:read` is needed only if the provider must
+     discover Slack user ids itself.
+
+Not defaultable in the first E2E:
+
+- pairing-code redemption by itself
+- arbitrary Slack channel ID supplied by the client
+- a generic "Slack" channel with no concrete conversation
+- implicit "last Slack conversation" defaults
+- Slack progress/projection delivery
+- non-text modality defaults
+
+## Canonical Refs
+
+- `docs/plans/2026-05-29-trigger-loop-delivery-resolution-implementation.md`
+  - PR 19 fast-follow scope and trigger delivery readiness notes.
+- `docs/reborn/contracts/communication-delivery-resolution.md`
+  - preference fields, rule order, and trigger delivery boundary.
+- `docs/reborn/contracts/product-adapters.md`
+  - adapter outbound rendering boundary and Slack-like external channel
+    capability model.
+- `crates/ironclaw_outbound/src/communication_preferences.rs`
+  - scoped `CommunicationPreferenceRecord`, `CommunicationPreferenceTargets`,
+    `DeliveryDefaultScope`, and versioned repository contract.
+- `crates/ironclaw_outbound/src/resolution_engine.rs`
+  - triggered notification preference lookup and fail-closed behavior.
+- `crates/ironclaw_product_workflow/src/outbound_delivery.rs`
+  - `prepare_and_render_product_outbound` validation-before-render path.
+- `crates/ironclaw_reborn_composition/src/slack_delivery.rs`
+  - Slack final-reply observer and observed reply-target authority.
+- `crates/ironclaw_reborn_composition/src/slack_personal_binding_pairing_serve.rs`
+  - pairing-code redeem route; identity-only today.
+- `crates/ironclaw_webui_v2/src/handlers.rs`
+  - WebUI handlers must delegate through `RebornServicesApi`.
+- `crates/ironclaw_webui_v2_static/static/js/pages/automations/automations-page.js`
+  - Automations page composition point.
+
+## Phase Breakdown
+
+Break the work into small PR-sized phases. Each phase should land with focused
+caller-level tests and should not require later phases to make its local
+contracts correct.
+
+### Phase 1 — Existing Product Facade Baseline
+
+Status: completed before this revision.
+
+Goal: create the client-safe product workflow contract for reading/writing a
+final delivery target and listing eligible targets.
+
+Exit criteria now carried forward:
+
+- Future WebUI handlers, CLI commands, Slack prompts, and product surfaces can
+  call a stable facade without knowing outbound storage.
+- Client input uses `target_id`, not raw `ReplyTargetBindingRef`.
+- The facade remains product-surface neutral.
+
+### Phase 2 — Scoped Default Model And Repository Contract
+
+Goal: add scoped delivery defaults so background trigger delivery can choose
+between personal DM defaults and shared-agent channel defaults.
+
+Deliverables:
+
+- `DeliveryDefaultScope` or equivalent model:
+  - `Personal { tenant_id, user_id }`
+  - `SharedAgent { tenant_id, agent_id, project_id? }`
+- Repository contract/storage for shared-agent defaults.
+- CAS-safe read-modify-write behavior for every scoped default store path.
+- Scoped preference reads return a version or ETag, and set/clear operations
+  require the caller's expected version. Stale same-slot writes return a
+  conflict instead of silently overwriting a newer default.
+- Migration or adapter plan for existing user-scoped
+  `CommunicationPreferenceRecord`.
+- Resolution tests proving:
+  - personal runs use personal defaults
+  - shared tenant-agent runs use shared-agent defaults
+  - missing defaults fail closed
+  - stale or mismatched scopes fail closed
+  - concurrent updates do not drop existing slots or overwrite a racing writer
+  - stale same-slot updates conflict, while intentional disjoint-slot merges
+    preserve both updates
+
+Exit criteria:
+
+- Trigger delivery no longer assumes every default is tenant/user scoped.
+- Shared-agent defaults are not faked through a synthetic user id.
+- Personal preference behavior remains backward compatible.
+- CAS fallback behavior is either supported or fails closed; it never silently
+  degrades to an unconditional write.
+
+### Phase 3 — Channel-Neutral Target Authority Resolver
+
+Goal: validate saved target IDs at write time and trigger-fire time without
+adding Slack-specific backend bridge logic.
+
+Deliverables:
+
+- Generic target inventory/provider contract for listing client-safe targets.
+- Generic target authority resolver:
+  - `target_id` -> validated reply target candidate
+  - saved/default target -> revalidated authority at send time
+- Stale-target outcome that callers can surface safely without making missing
+  inventory look valid.
+- Tests for valid target, invalid target, deleted target, ownership change,
+  tenant isolation, and user isolation.
+
+Exit criteria:
+
+- Clients never submit arbitrary raw `ReplyTargetBindingRef` values that are
+  accepted without backend validation.
+- The same resolver path is used for preference writes and trigger delivery
+  revalidation.
+- The contract can support Slack now and future outbound channels later.
+- No core resolver branch matches on Slack-specific team/channel/DM concepts.
+
+### Phase 4 — Slack Target Implementations
+
+Goal: implement Slack as the first channel using the channel-neutral target
+provider and authority resolver.
+
+Deliverables:
+
+- Shared-agent Slack channel target backed by admin-managed Slack channel
+  routes.
+- Personal Slack DM target backed by durable Slack identity/DM target
+  authority.
+- Slack route deletion/owner-change tests.
+- Pairing-code redemption tests proving it remains identity-only.
+- First-inbound/DM target tests proving only a concrete target can become a
+  personal default.
+
+Exit criteria:
+
+- Shared tenant agents can target an admin-configured Slack channel.
+- Personal agents can target the owner's Slack DM after DM authority exists.
+- No target is synthesized from arbitrary client input.
+- Slack final reply delivery still uses `chat.postMessage`.
+
+### Phase 5 — WebUI v2 Outbound Preference Routes
+
+Goal: expose scoped defaults and target inventory through WebUI v2 routes while
+preserving the existing route/facade boundary.
+
+Deliverables:
+
+- Route descriptors, handlers, and router mounts for:
+  - `GET /api/webchat/v2/outbound/preferences`
+  - `PUT /api/webchat/v2/outbound/preferences`
+  - `GET /api/webchat/v2/outbound/targets`
+- Request shape that includes or derives delivery scope safely.
+- Admin/operator authorization for shared-agent default updates.
+- Handler tests proving every route delegates through `RebornServicesApi`.
+- Descriptor tests for route IDs, methods, paths, and product workflow effect
+  ownership.
+
+Exit criteria:
+
+- HTTP clients can read options and update final targets through product
+  workflow only.
+- Personal users cannot mutate shared-agent defaults unless authorized.
+- Malformed requests fail before preference mutation.
+
+### Phase 6 — Automations Delivery Panel
+
+Goal: make the default delivery target visible and editable from Automations.
+
+Deliverables:
+
+- Shared WebUI API helpers for outbound preferences and targets.
+- `useDeliveryDefaults` React Query hook.
+- Standalone Delivery panel above the automations list.
+- Personal-agent state: default DM/personal target or none.
+- Shared-agent/admin state: default shared channel or none.
+- Empty, loading, error, selected, saved, clearing, and stale-target states.
+- Static API tests and asset embedding coverage.
+
+Exit criteria:
+
+- Users can see the default that a background trigger will actually use.
+- Authorized users can change or clear the applicable default.
+- The automations table remains structurally unchanged.
+
+### Phase 7 — Trigger Completion Delivery E2E
+
+Goal: connect trigger terminal completion to external final-reply delivery.
+
+Deliverables:
+
+- Trigger terminal delivery caller that constructs `RunNotificationOrigin`.
+- `Triggered` final-reply path through scoped default resolution.
+- `TriggeredFromSourceRoute` source-route precedence coverage.
+- Authoritative `DeliveryDefaultScope` lookup from the persisted run/agent
+  ownership record, with fail-closed behavior when ownership is missing,
+  ambiguous, or inconsistent with the trigger context.
+- Validation through `OutboundPolicyService` before adapter render.
+- Slack E2E or integration coverage proving:
+  - shared-agent trigger result reaches configured Slack channel
+  - personal-agent trigger result reaches paired Slack DM
+  - missing/stale targets fail closed
+
+Exit criteria:
+
+- Missing defaults fail closed and send nothing.
+- Invalid/revoked targets fail validation and send nothing.
+- Valid Slack defaults render through the Slack product adapter, not WebUI
+  projections.
+
+## Suggested PR Stack
+
+1. PR A: scoped default model and repository contract.
+2. PR B: channel-neutral target authority resolver.
+3. PR C: Slack shared-channel and personal-DM target implementations.
+4. PR D: WebUI v2 routes.
+5. PR E: Automations Delivery panel.
+6. PR F: trigger terminal delivery E2E.
+
+If Slack authority exposes unexpected storage gaps, split PR C into:
+
+- PR C1: Slack shared-channel target authority
+- PR C2: Slack personal DM target authority
+
+## Implementation Plan
+
+### 1. Scoped Default Model
+
+Add a default delivery scope contract before adding more Slack UI wiring.
+
+The repository/API should support:
+
+- read scoped default
+- update scoped final target
+- clear scoped final target
+- preserve non-final slots for the same scope
+- reject cross-scope writes
+- return a scoped version or ETag on reads
+- require that expected version or ETag on set/clear writes
+- return a conflict for stale same-slot writes
+
+The old user-scoped `CommunicationPreferenceRecord` can remain the personal
+scope implementation initially, but shared-agent defaults need their own real
+storage shape.
+
+### 2. Target Inventory And Authority
+
+Add a composition-owned provider/resolver that:
+
+- lists client-safe eligible targets for a requested delivery scope
+- resolves a client-selected `target_id` before writing preferences
+- revalidates a saved target before trigger delivery sends
+- returns a stale/unavailable result when the target disappeared
+
+Target inventory must be backed by known conversation/reply-target authority,
+not raw client input.
+
+This layer must be written in provider-neutral terms such as target id, delivery
+scope, capabilities, validation status, and verified outbound metadata. Provider
+implementations may use Slack channel routes, DMs, or future channel-specific
+state internally, but core outbound code must not encode those channel details.
+
+### 3. Slack Authority
+
+Implement Slack target authority in two paths:
+
+- Shared channel route:
+  - route exists
+  - route belongs to the tenant/agent/project scope
+  - Slack installation/team/channel metadata matches
+  - route is still postable
+- Personal DM:
+  - user is paired
+  - DM target authority already exists as a durable concrete target before it
+    is listed or saved as a default
+  - explicit post-pairing opt-in can provision the DM target by calling Slack
+    `conversations.open(users = slack_user_id)` and storing the returned
+    `D...` conversation id as provider authority
+  - any DM target provisioning flow is explicit, idempotent across processes,
+    keyed by tenant/user/provider identity, and backed by a durable unique
+    constraint or equivalent insert-if-absent operation
+  - target belongs to the same tenant/user
+
+Do not write defaults at pairing-code redemption time. Do not run provider
+network calls while holding preference CAS locks; resolve or provision durable
+target authority first, then write the preference with the scoped compare
+token.
+
+Slack DM send-time validation should treat `missing_scope`, `user_not_found`,
+`user_disabled`, `user_not_visible`, Slack Connect `invalid_user_combination`,
+and `channel_not_found` as unavailable/stale target outcomes. These outcomes
+fail closed and do not retry indefinitely.
+
+### 4. WebUI v2 Routes
+
+Add route descriptors, handlers, and router mounts:
+
+- `GET /api/webchat/v2/outbound/preferences`
+- `PUT /api/webchat/v2/outbound/preferences`
+- `GET /api/webchat/v2/outbound/targets`
+
+Handlers must depend only on `RebornServicesApi`, matching existing WebUI v2
+boundaries. Invalid target IDs and malformed bodies should fail before any
+preference write.
+
+### 5. Automations Delivery Panel
+
+Add a standalone Delivery panel under Automations:
+
+- load scoped preferences and targets with React Query
+- show the current default target for the active agent/run ownership scope
+- allow authorized selection or clearing
+- after Slack pairing succeeds, offer a one-click choice to make the paired
+  Slack DM the personal default for triggered automation delivery
+- show the paired Slack DM as a selectable personal target once durable DM
+  authority exists
+- show admin-managed Slack channel routes as selectable shared-agent targets
+  for authorized operators
+- show empty state when no eligible delivery targets exist
+- show stale target state when the saved default can no longer be resolved
+- keep the existing automations list/table unchanged
+- do not read, write, or imply per-automation delivery overrides in this phase
+
+Expected WebUI starting points:
+
+- `crates/ironclaw_webui_v2_static/static/js/lib/api.js`
+- `crates/ironclaw_webui_v2_static/static/js/lib/api.test.mjs`
+- `crates/ironclaw_webui_v2_static/static/js/pages/automations/automations-page.js`
+- new `pages/automations/hooks/useDeliveryDefaults.js`
+- new `pages/automations/components/delivery-defaults-panel.js`
+- `crates/ironclaw_webui_v2_static/static/js/i18n/en.js`
+- `crates/ironclaw_webui_v2_static/src/assets.rs`
+
+### 6. Trigger Completion Delivery
+
+Wire trigger terminal completion to the product outbound path:
+
+- construct `RunNotificationOrigin::Triggered` for trigger-origin final replies
+- construct `TriggeredFromSourceRoute` when a trigger run has a live source
+  route and verify source-route precedence
+- resolve scoped defaults with `OutboundResolutionEngine`
+- validate with `OutboundPolicyService`
+- render only through ready Reborn product-adapter outbound paths
+
+Do not use WebUI projections as a delivery substitute. Do not let adapter code
+load preferences or construct validated targets.
+
+## Tests And Acceptance Criteria
+
+### Scoped Defaults
+
+- personal scope reads/writes/clears final target
+- shared-agent scope reads/writes/clears final target
+- personal users cannot mutate shared-agent defaults without authorization
+- missing default fails closed
+- clearing target preserves non-final slots
+- tenant/user/agent/project scoping does not leak
+- scope lookup uses persisted run/agent ownership rather than trigger creator,
+  last editor, last inbound sender, or synthetic user id
+- CAS conflict/retry coverage proves scoped preference updates preserve
+  concurrent writes and reject unsupported CAS safely
+- stale same-slot writes return conflict through the product facade and HTTP
+  route; disjoint-slot merges preserve both updates
+
+### Target Authority
+
+- valid target writes default
+- invalid target rejects mutation
+- stale target surfaces unavailable state
+- deleted route fails closed
+- owner change fails closed
+- same resolver path supports write-time and send-time validation
+- product facade/preference-write tests drive a fake provider/resolver and prove
+  invalid, stale, cross-scope, and capability-mismatched targets are rejected
+- trigger completion tests drive send-time revalidation and prove failure happens
+  before adapter render
+
+### WebUI v2
+
+- route descriptors include the three outbound routes
+- handlers dispatch only through `RebornServicesApi`
+- malformed body returns 400 before facade mutation
+- facade errors map to HTTP status consistently
+- shared-agent mutations require admin/operator authorization
+- GET preferences, PUT preferences, and GET targets derive or authorize scope
+  from the authenticated caller before facade calls
+- spoofed `tenant_id`, `user_id`, `agent_id`, or `project_id` inputs cannot
+  enumerate, read, or mutate another personal or shared-agent scope
+
+### Static WebUI
+
+- API tests cover GET/PUT paths and JSON body
+- Delivery panel renders loading, empty, error, selected, saved, clearing, and
+  stale-target states
+- personal and shared-agent copy/states are distinct
+- asset embedding test covers the new Automations Delivery panel
+
+### Slack
+
+- shared Slack channel routes list as shared-agent targets only for authorized
+  scopes
+- personal Slack DM target lists only after user pairing/DM authority exists
+- successful Slack pairing can offer, but does not automatically apply, a
+  follow-up action to make Slack DM the personal default for triggered
+  automation delivery
+- accepting the post-pairing default prompt provisions or validates the DM
+  target and saves only the provider-issued `target_id`
+- personal Slack DM target provisioning is explicit, idempotent, durable, and
+  does not run inside preference CAS locks
+- Slack DM provisioning calls `conversations.open` for the paired Slack user
+  and persists the returned `D...` conversation id before default selection
+- Slack DM sends use `chat.postMessage` with the validated `D...` conversation
+  id, not a raw client-submitted Slack user id
+- raw client-supplied Slack team/channel/DM ids cannot become saved defaults
+- generic Slack selections and implicit last-conversation defaults cannot become
+  saved defaults
+- pairing-code redemption never writes default targets
+- Slack final reply delivery still sends `chat.postMessage`
+- progress/projection payloads remain deferred
+
+### Trigger Delivery
+
+- personal trigger final reply loads personal default
+- shared-agent trigger final reply loads shared-agent default
+- missing default target fails closed and sends nothing
+- revoked/invalid target fails validation and sends nothing
+- valid Slack shared-channel target reaches adapter render and records Slack
+  egress
+- valid Slack personal DM target reaches adapter render and records Slack egress
+- `TriggeredFromSourceRoute` preserves live source route precedence
+- `OutboundPolicyService` is invoked before adapter render for personal,
+  shared-agent, and source-route delivery
+- outbound policy denial prevents Slack render and external egress
+
+## Out-Of-Scope Follow-Ups
+
+- Per-automation delivery overrides: future Automations delivery override phase.
+- UI for progress, approval, and auth prompt targets: future modality expansion
+  phase after final-reply E2E ships.
+- Slack progress/projection delivery: future Slack delivery modality phase.
+- Non-text modality defaults: future product API modality expansion phase.
+- One-time immediate trigger creation: future trigger-create UX/API phase;
+  current `trigger_create` remains
+  recurring-cron focused.
+- Accurate automation totals beyond the current capped list contract: future
+  Automations list pagination/totals phase.
+
+## Suggested Worktree
+
+Use a clean worktree:
+
+```bash
+git fetch origin reborn-integration
+git worktree add -b trigger-delivery-scoped-defaults \
+  ../worktrees/ironclaw/trigger-delivery-scoped-defaults \
+  origin/reborn-integration
+```
+
+Run implementation and verification from that worktree. Do not reuse the dirty
+main checkout for code changes.


### PR DESCRIPTION
## Summary

Adds the scoped outbound default model needed for triggered delivery to choose between personal delivery defaults and shared-agent delivery defaults.

This is the next implementation slice from `docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md`.

## What Changed

### Scoped Communication Preferences

- Adds `DeliveryDefaultScope`:
  - `Personal { tenant_id, user_id }`
  - `SharedAgent { tenant_id, agent_id, project_id? }`
- Changes `CommunicationPreferenceRecord` to carry a scope directly.
- Replaces parallel top-level target fields with `CommunicationPreferenceTargets`, a target collection for:
  - final reply
  - progress
  - approval prompt
  - auth prompt
- Keeps backward-compatible deserialization for legacy personal preference rows that still have top-level `tenant_id`, `user_id`, and target fields.

### Versioned Preference Writes

- Adds `CommunicationPreferenceVersion` and `CommunicationPreferenceWriteExpectation`.
- Adds versioned repository reads/writes for stale-write detection.
- Adds single-slot update support with CAS semantics:
  - stale same-slot writes conflict
  - disjoint slot updates can merge safely
  - existing non-final slots are preserved when final reply defaults change

### Filesystem Store Support

- Stores personal preferences with the legacy v1 tenant/user path hash.
- Stores shared-agent preferences with a v2 tenant/agent/project path hash.
- Validates shared-agent tenant, agent, and present project IDs.
- Preserves CAS behavior for versioned filesystems.
- Adds a byte-only `LocalFilesystem` fallback using a path lock plus process-local version overlay so local/dev updates do not silently degrade into unconditional overwrites.

### Triggered Delivery Resolution

- Triggered delivery first checks the actor's personal preference.
- If no applicable personal target exists and the `TurnScope` has an agent, delivery falls back to the shared-agent preference for `(tenant, agent, project?)`.
- The resolver remains product-surface-neutral: no Slack/WebUI-specific routing logic is added to `ironclaw_outbound`.
- Product workflow caller-level tests prove a shared-agent default still goes through outbound validation before adapter render.

### Plan Doc

- Adds/updates the E2E plan for default outbound delivery, Slack personal DM/shared-channel follow-ups, target authority, WebUI route boundaries, and trigger delivery acceptance criteria.

## Boundaries

- `ironclaw_outbound` owns preference scope, CAS, default resolution, and validation-before-delivery contracts.
- `ironclaw_product_workflow` continues to render only after outbound validates a candidate target.
- No Slack-specific bridge logic is introduced in backend default resolution.
- No WebUI rendering/state concepts are added to backend DTOs.

## Verification

- `cargo test -p ironclaw_outbound`
- `cargo test -p ironclaw_product_workflow --test outbound_delivery_contract`
- `cargo clippy -p ironclaw_outbound --all-targets -- -D warnings`
- `git diff --check`

## Follow-Ups

- Channel-neutral target inventory and authority resolver.
- Slack shared-channel and personal-DM target implementations.
- WebUI v2 routes and Automations delivery panel.
- Trigger terminal completion delivery E2E.
