### PR TITLE
Add scoped outbound delivery defaults

### DIFF
--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -1,31 +1,104 @@
 use async_trait::async_trait;
-use ironclaw_host_api::{TenantId, Timestamp, UserId};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_turns::ReplyTargetBindingRef;
 use serde::{Deserialize, Serialize};
 
 use crate::{CommunicationModality, OutboundError};
 
-/// Tenant/user lookup key for outbound-owned communication preferences.
+/// Owner scope for default outbound delivery preferences.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DeliveryDefaultScope {
+    Personal {
+        tenant_id: TenantId,
+        user_id: UserId,
+    },
+    SharedAgent {
+        tenant_id: TenantId,
+        agent_id: AgentId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project_id: Option<ProjectId>,
+    },
+}
+
+impl DeliveryDefaultScope {
+    pub fn personal(tenant_id: TenantId, user_id: UserId) -> Self {
+        Self::Personal { tenant_id, user_id }
+    }
+
+    pub fn shared_agent(
+        tenant_id: TenantId,
+        agent_id: AgentId,
+        project_id: Option<ProjectId>,
+    ) -> Self {
+        Self::SharedAgent {
+            tenant_id,
+            agent_id,
+            project_id,
+        }
+    }
+
+    pub fn tenant_id(&self) -> &TenantId {
+        match self {
+            Self::Personal { tenant_id, .. } | Self::SharedAgent { tenant_id, .. } => tenant_id,
+        }
+    }
+}
+
+/// Scoped lookup key for outbound-owned communication preferences.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CommunicationPreferenceKey {
-    pub tenant_id: TenantId,
-    pub user_id: UserId,
+    pub scope: DeliveryDefaultScope,
 }
 
 impl CommunicationPreferenceKey {
     pub fn new(tenant_id: TenantId, user_id: UserId) -> Self {
-        Self { tenant_id, user_id }
+        Self::personal(tenant_id, user_id)
+    }
+
+    pub fn personal(tenant_id: TenantId, user_id: UserId) -> Self {
+        Self {
+            scope: DeliveryDefaultScope::personal(tenant_id, user_id),
+        }
+    }
+
+    pub fn shared_agent(
+        tenant_id: TenantId,
+        agent_id: AgentId,
+        project_id: Option<ProjectId>,
+    ) -> Self {
+        Self {
+            scope: DeliveryDefaultScope::shared_agent(tenant_id, agent_id, project_id),
+        }
     }
 }
 
-/// Durable tenant/user communication defaults owned by outbound policy.
+/// Opaque compare token returned with a preference read and required on writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CommunicationPreferenceVersion(u64);
+
+impl CommunicationPreferenceVersion {
+    pub fn from_raw(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+/// Durable scoped communication defaults owned by outbound policy.
 ///
 /// Stored reply targets are candidates only. Callers must revalidate every
 /// target through the outbound validation path before sending externally.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommunicationPreferenceRecord {
-    pub tenant_id: TenantId,
-    pub user_id: UserId,
+    pub scope: DeliveryDefaultScope,
     pub final_reply_target: Option<ReplyTargetBindingRef>,
     pub progress_target: Option<ReplyTargetBindingRef>,
     pub approval_prompt_target: Option<ReplyTargetBindingRef>,
@@ -37,38 +110,167 @@ pub struct CommunicationPreferenceRecord {
 
 impl CommunicationPreferenceRecord {
     pub fn key(&self) -> CommunicationPreferenceKey {
-        CommunicationPreferenceKey::new(self.tenant_id.clone(), self.user_id.clone())
+        CommunicationPreferenceKey {
+            scope: self.scope.clone(),
+        }
     }
 }
 
-/// Transform the currently stored communication preference record.
-///
-/// Repository implementations may invoke this callback more than once when
-/// retrying compare-and-swap conflicts. Callers must keep the callback
-/// deterministic and free of external side effects.
-pub type CommunicationPreferenceUpdate = Box<
-    dyn FnMut(
-            Option<CommunicationPreferenceRecord>,
-        ) -> Result<CommunicationPreferenceRecord, OutboundError>
-        + Send,
->;
+impl<'de> Deserialize<'de> for CommunicationPreferenceRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            #[serde(default)]
+            scope: Option<DeliveryDefaultScope>,
+            #[serde(default)]
+            tenant_id: Option<TenantId>,
+            #[serde(default)]
+            user_id: Option<UserId>,
+            final_reply_target: Option<ReplyTargetBindingRef>,
+            progress_target: Option<ReplyTargetBindingRef>,
+            approval_prompt_target: Option<ReplyTargetBindingRef>,
+            auth_prompt_target: Option<ReplyTargetBindingRef>,
+            default_modality: Option<CommunicationModality>,
+            updated_at: Timestamp,
+            updated_by: UserId,
+        }
 
-/// Store for durable tenant/user communication delivery preferences.
+        let wire = Wire::deserialize(deserializer)?;
+        let scope = match (wire.scope, wire.tenant_id, wire.user_id) {
+            (Some(scope), _, _) => scope,
+            (None, Some(tenant_id), Some(user_id)) => {
+                DeliveryDefaultScope::personal(tenant_id, user_id)
+            }
+            _ => {
+                return Err(serde::de::Error::custom(
+                    "communication preference scope is required",
+                ));
+            }
+        };
+        Ok(Self {
+            scope,
+            final_reply_target: wire.final_reply_target,
+            progress_target: wire.progress_target,
+            approval_prompt_target: wire.approval_prompt_target,
+            auth_prompt_target: wire.auth_prompt_target,
+            default_modality: wire.default_modality,
+            updated_at: wire.updated_at,
+            updated_by: wire.updated_by,
+        })
+    }
+}
+
+/// Communication preference row plus the optimistic-lock token returned by a read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionedCommunicationPreferenceRecord {
+    pub record: CommunicationPreferenceRecord,
+    pub version: CommunicationPreferenceVersion,
+}
+
+/// Versioned preference write request.
+///
+/// `expected_version: None` creates a row only when no scoped preference
+/// exists. Updates must pass the version returned by
+/// [`CommunicationPreferenceRepository::load_communication_preference`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WriteCommunicationPreferenceRequest {
+    pub record: CommunicationPreferenceRecord,
+    pub expected_version: Option<CommunicationPreferenceVersion>,
+}
+
+/// Store for durable scoped communication delivery preferences.
 #[async_trait]
 pub trait CommunicationPreferenceRepository: Send + Sync {
+    /// Create a scoped preference row when it does not already exist.
+    ///
+    /// This convenience path is intentionally insert-only. Callers updating an
+    /// existing preference must read the current version and use
+    /// [`Self::write_communication_preference`] with `expected_version`.
     async fn put_communication_preference(
         &self,
         record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError>;
+    ) -> Result<(), OutboundError> {
+        self.write_communication_preference(WriteCommunicationPreferenceRequest {
+            record,
+            expected_version: None,
+        })
+        .await
+        .map(|_| ())
+    }
 
     async fn load_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError>;
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError>;
 
-    async fn update_communication_preference(
+    async fn write_communication_preference(
         &self,
-        key: CommunicationPreferenceKey,
-        update: CommunicationPreferenceUpdate,
-    ) -> Result<CommunicationPreferenceRecord, OutboundError>;
+        request: WriteCommunicationPreferenceRequest,
+    ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+
+    use super::*;
+
+    #[test]
+    fn communication_preference_record_deserializes_scoped_and_legacy_payloads() {
+        let updated_at = Utc::now();
+        let scoped = CommunicationPreferenceRecord {
+            scope: DeliveryDefaultScope::shared_agent(
+                TenantId::new("tenant-pref-json").unwrap(),
+                AgentId::new("agent-pref-json").unwrap(),
+                Some(ProjectId::new("project-pref-json").unwrap()),
+            ),
+            final_reply_target: None,
+            progress_target: None,
+            approval_prompt_target: None,
+            auth_prompt_target: None,
+            default_modality: Some(CommunicationModality::Text),
+            updated_at,
+            updated_by: UserId::new("user-pref-json-updater").unwrap(),
+        };
+        let serialized = serde_json::to_string(&scoped).expect("serialize scoped preference");
+        let decoded: CommunicationPreferenceRecord =
+            serde_json::from_str(&serialized).expect("deserialize scoped preference");
+        assert_eq!(decoded, scoped);
+
+        let legacy = serde_json::json!({
+            "tenant_id": "tenant-pref-legacy",
+            "user_id": "user-pref-legacy",
+            "final_reply_target": null,
+            "progress_target": null,
+            "approval_prompt_target": null,
+            "auth_prompt_target": null,
+            "default_modality": "text",
+            "updated_at": updated_at,
+            "updated_by": "user-pref-legacy-updater"
+        });
+        let decoded: CommunicationPreferenceRecord =
+            serde_json::from_value(legacy).expect("deserialize legacy preference");
+        assert_eq!(
+            decoded.scope,
+            DeliveryDefaultScope::personal(
+                TenantId::new("tenant-pref-legacy").unwrap(),
+                UserId::new("user-pref-legacy").unwrap()
+            )
+        );
+
+        let missing_scope = serde_json::json!({
+            "final_reply_target": null,
+            "progress_target": null,
+            "approval_prompt_target": null,
+            "auth_prompt_target": null,
+            "default_modality": null,
+            "updated_at": updated_at,
+            "updated_by": "user-pref-missing-updater"
+        });
+        assert!(serde_json::from_value::<CommunicationPreferenceRecord>(missing_scope).is_err());
+    }
 }

--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -189,6 +189,12 @@ pub trait CommunicationPreferenceRepository: Send + Sync {
     /// This convenience path is intentionally insert-only. Callers updating an
     /// existing preference must read the current version and use
     /// [`Self::write_communication_preference`] with `expected_version`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutboundError::CasConflict`] when the scoped preference row
+    /// already exists. Callers that need upsert or update behavior should use
+    /// [`Self::write_communication_preference`] with an observed version.
     async fn put_communication_preference(
         &self,
         record: CommunicationPreferenceRecord,
@@ -218,6 +224,14 @@ mod tests {
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
 
     use super::*;
+
+    #[test]
+    fn version_next_saturates_at_u64_max() {
+        assert_eq!(
+            CommunicationPreferenceVersion::from_raw(u64::MAX).next(),
+            CommunicationPreferenceVersion::from_raw(u64::MAX)
+        );
+    }
 
     #[test]
     fn communication_preference_record_deserializes_scoped_and_legacy_payloads() {

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -26,9 +26,10 @@
 //!   `delivery_id`. An indexed `scope` projection allows
 //!   `list_delivery_attempts(scope)` to filter within the tenant-scoped
 //!   subtree without materializing every row.
-//! - `/outbound/communication-preferences/<sha256(v1-length-prefixed-key)>.json` — tenant/user
-//!   communication preference row keyed by a hashed `CommunicationPreferenceKey`.
-//!   Reply-target refs remain candidates and do not grant send authority.
+//! - `/outbound/communication-preferences/<sha256(v2-scoped-key)>.json` —
+//!   scoped communication preference row keyed by a hashed
+//!   `CommunicationPreferenceKey`. Reply-target refs remain candidates and do
+//!   not grant send authority.
 
 use std::sync::Arc;
 
@@ -38,7 +39,7 @@ use ironclaw_filesystem::{
     CasExpectation, ContentType, Entry, FilesystemError, Filter, IndexKey, IndexKind, IndexName,
     IndexSpec, IndexValue, Page, RootFilesystem, ScopedFilesystem, VersionedEntry,
 };
-use ironclaw_host_api::{ResourceScope, ScopedPath, TenantId, ThreadId, UserId};
+use ironclaw_host_api::{ResourceScope, ScopedPath, TenantId, ThreadId};
 use ironclaw_turns::{TurnActor, TurnScope};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -50,10 +51,11 @@ use crate::validation::{
 };
 use crate::{
     AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, CommunicationPreferenceUpdate,
+    CommunicationPreferenceRepository, CommunicationPreferenceVersion, DeliveryDefaultScope,
     LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError,
     OutboundStateStore, ProjectionSubscriptionId, ProjectionSubscriptionRecord,
-    ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    ThreadNotificationPolicy, UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
+    WriteCommunicationPreferenceRequest,
 };
 
 /// Maximum number of compare-and-swap retries on a read-then-write path
@@ -234,47 +236,23 @@ where
             .map(|(value, _)| value))
     }
 
-    async fn write_communication_preference_with_cas(
+    async fn put_json_strict_cas<T: Serialize>(
         &self,
-        key: CommunicationPreferenceKey,
-        mut update: CommunicationPreferenceUpdate,
-    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
-        let path = communication_preference_path(&key)?;
-        let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
-        self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
-            .await?;
-        for _ in 0..MAX_CAS_RETRIES {
-            let (cas, existing) = match self
-                .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
-                .await?
-            {
-                Some((existing, versioned)) => {
-                    (CasExpectation::Version(versioned.version), Some(existing))
-                }
-                None => (CasExpectation::Absent, None),
-            };
-            if let Some(existing) = existing.as_ref()
-                && existing.key() != key
-            {
-                return Err(OutboundError::Backend);
-            }
-            let record = update(existing)?;
-            validate_communication_preference(&record)?;
-            if record.key() != key {
-                return Err(OutboundError::InvalidRequest {
-                    reason: "communication preference update key mismatch",
-                });
-            }
-            match self
-                .put_json(&resource_scope, &path, &record, &record.tenant_id, cas)
-                .await
-            {
-                Ok(()) => return Ok(record),
-                Err(OutboundError::CasConflict) => continue,
-                Err(error) => return Err(error),
-            }
-        }
-        Err(OutboundError::Backend)
+        scope: &ResourceScope,
+        path: &ScopedPath,
+        value: &T,
+        tenant: &TenantId,
+        cas: CasExpectation,
+    ) -> Result<CommunicationPreferenceVersion, OutboundError> {
+        let body = serde_json::to_vec(value).map_err(|_| OutboundError::Serialization)?;
+        let entry = Entry::bytes(body)
+            .with_content_type(ContentType::json())
+            .with_indexed(tenant_id_index_key(), tenant_id_index_value(tenant));
+        self.filesystem
+            .put(scope, path, entry, cas)
+            .await
+            .map(|version| CommunicationPreferenceVersion::from_raw(version.get()))
+            .map_err(map_fs_error)
     }
 }
 
@@ -283,41 +261,56 @@ impl<F> CommunicationPreferenceRepository for FilesystemOutboundStateStore<F>
 where
     F: RootFilesystem,
 {
-    async fn put_communication_preference(
-        &self,
-        record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
-        let key = record.key();
-        self.write_communication_preference_with_cas(key, Box::new(move |_| Ok(record.clone())))
-            .await?;
-        Ok(())
-    }
-
     async fn load_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         let path = communication_preference_path(&key)?;
-        let resource_scope = communication_preference_resource_scope(&key.tenant_id, &key.user_id);
-        let Some(record) = self
-            .get_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
+        let resource_scope = communication_preference_resource_scope(&key.scope);
+        let Some((record, versioned)) = self
+            .get_versioned_json::<CommunicationPreferenceRecord>(&resource_scope, &path)
             .await?
         else {
             return Ok(None);
         };
-        if record.tenant_id != key.tenant_id || record.user_id != key.user_id {
+        if record.key() != key {
             return Err(OutboundError::Backend);
         }
-        Ok(Some(record))
+        Ok(Some(VersionedCommunicationPreferenceRecord {
+            record,
+            version: CommunicationPreferenceVersion::from_raw(versioned.version.get()),
+        }))
     }
 
-    async fn update_communication_preference(
+    async fn write_communication_preference(
         &self,
-        key: CommunicationPreferenceKey,
-        update: CommunicationPreferenceUpdate,
-    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
-        self.write_communication_preference_with_cas(key, update)
-            .await
+        request: WriteCommunicationPreferenceRequest,
+    ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
+        validate_communication_preference(&request.record)?;
+        let key = request.record.key();
+        let path = communication_preference_path(&key)?;
+        let resource_scope = communication_preference_resource_scope(&key.scope);
+        self.ensure_tenant_id_index(&resource_scope, &communication_preferences_root()?)
+            .await?;
+        let cas = match request.expected_version {
+            Some(version) => CasExpectation::Version(
+                ironclaw_filesystem::RecordVersion::from_backend(version.raw()),
+            ),
+            None => CasExpectation::Absent,
+        };
+        let version = self
+            .put_json_strict_cas(
+                &resource_scope,
+                &path,
+                &request.record,
+                request.record.scope.tenant_id(),
+                cas,
+            )
+            .await?;
+        Ok(VersionedCommunicationPreferenceRecord {
+            record: request.record,
+            version,
+        })
     }
 }
 
@@ -629,29 +622,62 @@ fn communication_preference_path(
     key: &CommunicationPreferenceKey,
 ) -> Result<ScopedPath, OutboundError> {
     let mut hasher = Sha256::new();
-    let tenant = key.tenant_id.as_str();
-    let user = key.user_id.as_str();
-    hasher.update(b"v1:");
-    hasher.update(tenant.len().to_string().as_bytes());
-    hasher.update(b":");
-    hasher.update(tenant.as_bytes());
-    hasher.update(b":");
-    hasher.update(user.len().to_string().as_bytes());
-    hasher.update(b":");
-    hasher.update(user.as_bytes());
+    hasher.update(b"v2:");
+    hash_delivery_default_scope(&mut hasher, &key.scope);
     let digest = hex::encode(hasher.finalize());
     ScopedPath::new(format!("{COMMUNICATION_PREFERENCES_ROOT}/{digest}.json"))
         .map_err(|_| OutboundError::Backend)
 }
 
-fn communication_preference_resource_scope(
-    tenant_id: &TenantId,
-    user_id: &UserId,
-) -> ResourceScope {
-    let mut scope = ResourceScope::system();
-    scope.tenant_id = tenant_id.clone();
-    scope.user_id = user_id.clone();
-    scope
+fn hash_delivery_default_scope(hasher: &mut Sha256, scope: &DeliveryDefaultScope) {
+    match scope {
+        DeliveryDefaultScope::Personal { tenant_id, user_id } => {
+            update_hash_part(hasher, "personal");
+            update_hash_part(hasher, tenant_id.as_str());
+            update_hash_part(hasher, user_id.as_str());
+        }
+        DeliveryDefaultScope::SharedAgent {
+            tenant_id,
+            agent_id,
+            project_id,
+        } => {
+            update_hash_part(hasher, "shared_agent");
+            update_hash_part(hasher, tenant_id.as_str());
+            update_hash_part(hasher, agent_id.as_str());
+            match project_id {
+                Some(project_id) => {
+                    update_hash_part(hasher, "project");
+                    update_hash_part(hasher, project_id.as_str());
+                }
+                None => update_hash_part(hasher, "no_project"),
+            }
+        }
+    }
+}
+
+fn update_hash_part(hasher: &mut Sha256, value: &str) {
+    hasher.update(value.len().to_be_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn communication_preference_resource_scope(scope: &DeliveryDefaultScope) -> ResourceScope {
+    let mut resource_scope = ResourceScope::system();
+    match scope {
+        DeliveryDefaultScope::Personal { tenant_id, user_id } => {
+            resource_scope.tenant_id = tenant_id.clone();
+            resource_scope.user_id = user_id.clone();
+        }
+        DeliveryDefaultScope::SharedAgent {
+            tenant_id,
+            agent_id,
+            project_id,
+        } => {
+            resource_scope.tenant_id = tenant_id.clone();
+            resource_scope.agent_id = Some(agent_id.clone());
+            resource_scope.project_id = project_id.clone();
+        }
+    }
+    resource_scope
 }
 
 fn deliveries_root() -> Result<ScopedPath, OutboundError> {

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -236,6 +236,11 @@ where
             .map(|(value, _)| value))
     }
 
+    /// Writes preference records with versioned CAS only.
+    ///
+    /// This intentionally bypasses the byte-only fallback used by non-CAS
+    /// helpers: preference updates must fail closed when the mount cannot
+    /// preserve the expected version.
     async fn put_json_strict_cas<T: Serialize>(
         &self,
         scope: &ResourceScope,
@@ -656,7 +661,7 @@ fn hash_delivery_default_scope(hasher: &mut Sha256, scope: &DeliveryDefaultScope
 }
 
 fn update_hash_part(hasher: &mut Sha256, value: &str) {
-    hasher.update(value.len().to_be_bytes());
+    hasher.update((value.len() as u64).to_be_bytes());
     hasher.update(value.as_bytes());
 }
 

--- a/crates/ironclaw_outbound/src/lib.rs
+++ b/crates/ironclaw_outbound/src/lib.rs
@@ -19,7 +19,8 @@ mod validation;
 
 pub use communication_preferences::{
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
-    CommunicationPreferenceUpdate,
+    CommunicationPreferenceVersion, DeliveryDefaultScope, VersionedCommunicationPreferenceRecord,
+    WriteCommunicationPreferenceRequest,
 };
 pub use delivery_resolution::{
     CommunicationDeliveryCandidate, CommunicationDeliveryIntent, CommunicationDeliveryKind,

--- a/crates/ironclaw_outbound/src/memory.rs
+++ b/crates/ironclaw_outbound/src/memory.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Mutex;
-use std::task::{Context, Poll};
 
 use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
@@ -16,30 +13,13 @@ use crate::validation::{
     validate_subscription_identity, validate_subscription_record, validate_subscription_request,
 };
 use crate::{
-    AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey, CommunicationPreferenceRecord,
-    CommunicationPreferenceRepository, CommunicationPreferenceUpdate,
+    AdvanceSubscriptionCursorRequest, CommunicationPreferenceKey,
+    CommunicationPreferenceRepository, CommunicationPreferenceVersion,
     LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryId, OutboundError,
     OutboundStateStore, ProjectionSubscriptionId, ProjectionSubscriptionRecord,
-    ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    ThreadNotificationPolicy, UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
+    WriteCommunicationPreferenceRequest,
 };
-
-const MAX_CAS_RETRIES: usize = 5;
-
-struct YieldOnce(bool);
-
-impl Future for YieldOnce {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.0 {
-            Poll::Ready(())
-        } else {
-            self.0 = true;
-            cx.waker().wake_by_ref();
-            Poll::Pending
-        }
-    }
-}
 
 #[derive(Default)]
 pub struct InMemoryOutboundStateStore {
@@ -48,7 +28,8 @@ pub struct InMemoryOutboundStateStore {
 
 #[derive(Default)]
 struct InMemoryOutboundState {
-    communication_preferences: HashMap<CommunicationPreferenceKey, CommunicationPreferenceRecord>,
+    communication_preferences:
+        HashMap<CommunicationPreferenceKey, VersionedCommunicationPreferenceRecord>,
     policies: HashMap<ThreadScopeKey, ThreadNotificationPolicy>,
     subscriptions: HashMap<ProjectionSubscriptionKey, ProjectionSubscriptionRecord>,
     deliveries: HashMap<OutboundDeliveryId, OutboundDeliveryAttempt>,
@@ -113,58 +94,38 @@ impl ProjectionSubscriptionKey {
 
 #[async_trait]
 impl CommunicationPreferenceRepository for InMemoryOutboundStateStore {
-    async fn put_communication_preference(
-        &self,
-        record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
-        validate_communication_preference(&record)?;
-        let mut state = self.lock_state()?;
-        state.communication_preferences.insert(record.key(), record);
-        Ok(())
-    }
-
     async fn load_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         let state = self.lock_state()?;
         Ok(state.communication_preferences.get(&key).cloned())
     }
 
-    async fn update_communication_preference(
+    async fn write_communication_preference(
         &self,
-        key: CommunicationPreferenceKey,
-        mut update: CommunicationPreferenceUpdate,
-    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
-        for _ in 0..MAX_CAS_RETRIES {
-            let existing = {
-                let state = self.lock_state()?;
-                state.communication_preferences.get(&key).cloned()
-            };
-            let record = update(existing.clone())?;
-            validate_communication_preference(&record)?;
-            if record.key() != key {
-                return Err(OutboundError::InvalidRequest {
-                    reason: "communication preference update key mismatch",
-                });
+        request: WriteCommunicationPreferenceRequest,
+    ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
+        validate_communication_preference(&request.record)?;
+        let key = request.record.key();
+        let mut state = self.lock_state()?;
+        let existing = state.communication_preferences.get(&key);
+        let version = match (request.expected_version, existing) {
+            (None, None) => CommunicationPreferenceVersion::from_raw(1),
+            (None, Some(_)) => return Err(OutboundError::CasConflict),
+            (Some(expected), Some(existing)) if existing.version == expected => {
+                existing.version.next()
             }
-            let updated = {
-                let mut state = self.lock_state()?;
-                if state.communication_preferences.get(&key).cloned() == existing {
-                    state
-                        .communication_preferences
-                        .insert(record.key(), record.clone());
-                    true
-                } else {
-                    false
-                }
-            };
-            if updated {
-                return Ok(record);
-            }
-            YieldOnce(false).await;
-        }
-        Err(OutboundError::Backend)
+            (Some(_), Some(_)) | (Some(_), None) => return Err(OutboundError::CasConflict),
+        };
+        let versioned = VersionedCommunicationPreferenceRecord {
+            record: request.record,
+            version,
+        };
+        state
+            .communication_preferences
+            .insert(key, versioned.clone());
+        Ok(versioned)
     }
 }
 

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -181,6 +181,13 @@ fn default_preference_key(
         );
     }
 
+    if !scope.has_explicit_thread_owner() {
+        return CommunicationPreferenceKey::personal(
+            scope.tenant_id.clone(),
+            actor.user_id.clone(),
+        );
+    }
+
     if let Some(agent_id) = scope.agent_id.clone() {
         return CommunicationPreferenceKey::shared_agent(
             scope.tenant_id.clone(),
@@ -445,7 +452,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn triggered_final_reply_uses_shared_agent_default_without_explicit_owner() {
+    async fn triggered_final_reply_actor_fallback_uses_actor_personal_default_even_with_agent() {
         let store = InMemoryOutboundStateStore::default();
         let engine = OutboundResolutionEngine::new(&store);
 
@@ -478,7 +485,94 @@ mod tests {
 
         let candidate = engine
             .resolve(&CommunicationDeliveryResolutionRequest {
-                scope: shared_scope(),
+                scope: actor_fallback_agent_scope(),
+                actor: actor("user-a"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::Triggered {
+                        trigger: trigger_context(),
+                    },
+                }),
+            })
+            .await
+            .expect("actor-fallback triggered final reply resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:personal-default"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_final_reply_actor_fallback_without_agent_uses_actor_personal_default() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:personal-default"),
+                Some("reply:personal-progress"),
+                Some("reply:personal-approval"),
+                Some("reply:personal-auth"),
+            ))
+            .await
+            .expect("seed personal preference");
+
+        let candidate = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: actor_fallback_agentless_scope(),
+                actor: actor("user-a"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::Triggered {
+                        trigger: trigger_context(),
+                    },
+                }),
+            })
+            .await
+            .expect("actor-fallback triggered final reply resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:personal-default"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_final_reply_ownerless_agent_scope_uses_shared_agent_default() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(CommunicationPreferenceRecord {
+                scope: DeliveryDefaultScope::shared_agent(
+                    TenantId::new("tenant-a").expect("valid tenant"),
+                    AgentId::new("agent-a").expect("valid agent"),
+                    Some(ProjectId::new("project-a").expect("valid project")),
+                ),
+                final_reply_target: Some(reply_ref("reply:shared-default")),
+                progress_target: Some(reply_ref("reply:shared-progress")),
+                approval_prompt_target: Some(reply_ref("reply:shared-approval")),
+                auth_prompt_target: Some(reply_ref("reply:shared-auth")),
+                default_modality: Some(CommunicationModality::Text),
+                updated_at: now(),
+                updated_by: UserId::new("tenant-admin").expect("valid updater"),
+            })
+            .await
+            .expect("seed shared-agent preference");
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:personal-default"),
+                Some("reply:personal-progress"),
+                Some("reply:personal-approval"),
+                Some("reply:personal-auth"),
+            ))
+            .await
+            .expect("seed personal preference");
+
+        let candidate = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: ownerless_agent_scope(),
                 actor: actor("user-a"),
                 modality: CommunicationModality::Text,
                 intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
@@ -835,12 +929,31 @@ mod tests {
         )
     }
 
-    fn shared_scope() -> TurnScope {
+    fn actor_fallback_agent_scope() -> TurnScope {
         TurnScope::new(
             TenantId::new("tenant-a").expect("valid tenant"),
             Some(AgentId::new("agent-a").expect("valid agent")),
             Some(ProjectId::new("project-a").expect("valid project")),
             thread_id("thread-a"),
+        )
+    }
+
+    fn actor_fallback_agentless_scope() -> TurnScope {
+        TurnScope::new(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            None,
+            Some(ProjectId::new("project-a").expect("valid project")),
+            thread_id("thread-a"),
+        )
+    }
+
+    fn ownerless_agent_scope() -> TurnScope {
+        TurnScope::new_with_owner(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            Some(AgentId::new("agent-a").expect("valid agent")),
+            Some(ProjectId::new("project-a").expect("valid project")),
+            thread_id("thread-a"),
+            None,
         )
     }
 

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -174,29 +174,21 @@ fn default_preference_key(
     scope: &ironclaw_turns::TurnScope,
     actor: &ironclaw_turns::TurnActor,
 ) -> CommunicationPreferenceKey {
-    if let Some(owner_user_id) = scope.explicit_owner_user_id() {
-        return CommunicationPreferenceKey::personal(
-            scope.tenant_id.clone(),
-            owner_user_id.clone(),
-        );
-    }
-
-    if !scope.has_explicit_thread_owner() {
-        return CommunicationPreferenceKey::personal(
-            scope.tenant_id.clone(),
-            actor.user_id.clone(),
-        );
-    }
-
-    if let Some(agent_id) = scope.agent_id.clone() {
-        return CommunicationPreferenceKey::shared_agent(
+    match (
+        scope.explicit_owner_user_id(),
+        scope.has_explicit_thread_owner(),
+        scope.agent_id.clone(),
+    ) {
+        (Some(owner_user_id), _, _) => {
+            CommunicationPreferenceKey::personal(scope.tenant_id.clone(), owner_user_id.clone())
+        }
+        (None, true, Some(agent_id)) => CommunicationPreferenceKey::shared_agent(
             scope.tenant_id.clone(),
             agent_id,
             scope.project_id.clone(),
-        );
+        ),
+        _ => CommunicationPreferenceKey::personal(scope.tenant_id.clone(), actor.user_id.clone()),
     }
-
-    CommunicationPreferenceKey::personal(scope.tenant_id.clone(), actor.user_id.clone())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -591,6 +583,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn triggered_final_reply_ownerless_without_agent_uses_actor_personal_default() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:personal-default"),
+                Some("reply:personal-progress"),
+                Some("reply:personal-approval"),
+                Some("reply:personal-auth"),
+            ))
+            .await
+            .expect("seed personal preference");
+
+        let candidate = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: ownerless_agentless_scope(),
+                actor: actor("user-a"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::Triggered {
+                        trigger: trigger_context(),
+                    },
+                }),
+            })
+            .await
+            .expect("ownerless agentless triggered final reply resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:personal-default"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
     async fn triggered_default_target_uses_explicit_owner_preferences_when_actor_differs() {
         let store = InMemoryOutboundStateStore::default();
         let engine = OutboundResolutionEngine::new(&store);
@@ -951,6 +978,16 @@ mod tests {
         TurnScope::new_with_owner(
             TenantId::new("tenant-a").expect("valid tenant"),
             Some(AgentId::new("agent-a").expect("valid agent")),
+            Some(ProjectId::new("project-a").expect("valid project")),
+            thread_id("thread-a"),
+            None,
+        )
+    }
+
+    fn ownerless_agentless_scope() -> TurnScope {
+        TurnScope::new_with_owner(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            None,
             Some(ProjectId::new("project-a").expect("valid project")),
             thread_id("thread-a"),
             None,

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -149,7 +149,7 @@ impl<'a> OutboundResolutionEngine<'a> {
         actor: &ironclaw_turns::TurnActor,
         kind: PreferenceTargetKind,
     ) -> Result<ReplyTargetBindingRef, OutboundError> {
-        let key = CommunicationPreferenceKey::new(scope.tenant_id.clone(), actor.user_id.clone());
+        let key = default_preference_key(scope, actor);
         let Some(record) = self
             .communication_preferences
             .load_communication_preference(key)
@@ -157,6 +157,7 @@ impl<'a> OutboundResolutionEngine<'a> {
         else {
             return Err(missing_preference_error(kind));
         };
+        let record = record.record;
 
         let target = match kind {
             PreferenceTargetKind::FinalReply => record.final_reply_target,
@@ -167,6 +168,28 @@ impl<'a> OutboundResolutionEngine<'a> {
 
         target.ok_or_else(|| missing_preference_error(kind))
     }
+}
+
+fn default_preference_key(
+    scope: &ironclaw_turns::TurnScope,
+    actor: &ironclaw_turns::TurnActor,
+) -> CommunicationPreferenceKey {
+    if let Some(owner_user_id) = scope.explicit_owner_user_id() {
+        return CommunicationPreferenceKey::personal(
+            scope.tenant_id.clone(),
+            owner_user_id.clone(),
+        );
+    }
+
+    if let Some(agent_id) = scope.agent_id.clone() {
+        return CommunicationPreferenceKey::shared_agent(
+            scope.tenant_id.clone(),
+            agent_id,
+            scope.project_id.clone(),
+        );
+    }
+
+    CommunicationPreferenceKey::personal(scope.tenant_id.clone(), actor.user_id.clone())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -203,34 +226,28 @@ mod tests {
 
     use super::*;
     use crate::{
-        CommunicationModality, CommunicationPreferenceRecord, InMemoryOutboundStateStore,
-        RequestedOutboundKind, RunNotificationEventKind, SourceRouteContext, SystemEventReasonCode,
-        TriggerCommunicationContext, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
+        CommunicationModality, CommunicationPreferenceRecord, DeliveryDefaultScope,
+        InMemoryOutboundStateStore, RequestedOutboundKind, RunNotificationEventKind,
+        SourceRouteContext, SystemEventReasonCode, TriggerCommunicationContext, TriggerFireSlot,
+        TriggerOriginRef, TriggerSourceKind, VersionedCommunicationPreferenceRecord,
+        WriteCommunicationPreferenceRequest,
     };
 
     struct BackendErrorPreferenceRepository;
 
     #[async_trait]
     impl CommunicationPreferenceRepository for BackendErrorPreferenceRepository {
-        async fn put_communication_preference(
-            &self,
-            _record: CommunicationPreferenceRecord,
-        ) -> Result<(), OutboundError> {
-            Ok(())
-        }
-
         async fn load_communication_preference(
             &self,
             _key: CommunicationPreferenceKey,
-        ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
             Err(OutboundError::Backend)
         }
 
-        async fn update_communication_preference(
+        async fn write_communication_preference(
             &self,
-            _key: CommunicationPreferenceKey,
-            _update: crate::CommunicationPreferenceUpdate,
-        ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+            _request: WriteCommunicationPreferenceRequest,
+        ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
             Err(OutboundError::Backend)
         }
     }
@@ -424,6 +441,123 @@ mod tests {
         let candidate = expect_candidate(candidate);
 
         assert_eq!(candidate.target, reply_ref("reply:triggered-default"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_final_reply_uses_shared_agent_default_without_explicit_owner() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(CommunicationPreferenceRecord {
+                scope: DeliveryDefaultScope::shared_agent(
+                    TenantId::new("tenant-a").expect("valid tenant"),
+                    AgentId::new("agent-a").expect("valid agent"),
+                    Some(ProjectId::new("project-a").expect("valid project")),
+                ),
+                final_reply_target: Some(reply_ref("reply:shared-default")),
+                progress_target: Some(reply_ref("reply:shared-progress")),
+                approval_prompt_target: Some(reply_ref("reply:shared-approval")),
+                auth_prompt_target: Some(reply_ref("reply:shared-auth")),
+                default_modality: Some(CommunicationModality::Text),
+                updated_at: now(),
+                updated_by: UserId::new("tenant-admin").expect("valid updater"),
+            })
+            .await
+            .expect("seed shared-agent preference");
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:personal-default"),
+                Some("reply:personal-progress"),
+                Some("reply:personal-approval"),
+                Some("reply:personal-auth"),
+            ))
+            .await
+            .expect("seed personal preference");
+
+        let candidate = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: shared_scope(),
+                actor: actor("user-a"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::Triggered {
+                        trigger: trigger_context(),
+                    },
+                }),
+            })
+            .await
+            .expect("shared-agent triggered final reply resolves");
+        let candidate = expect_candidate(candidate);
+
+        assert_eq!(candidate.target, reply_ref("reply:shared-default"));
+        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+    }
+
+    #[tokio::test]
+    async fn triggered_default_target_uses_explicit_owner_preferences_when_actor_differs() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+        let owner = UserId::new("user-owner").expect("valid owner");
+
+        store
+            .put_communication_preference(CommunicationPreferenceRecord {
+                scope: DeliveryDefaultScope::personal(
+                    TenantId::new("tenant-a").expect("valid tenant"),
+                    owner.clone(),
+                ),
+                final_reply_target: Some(reply_ref("reply:owner-default")),
+                progress_target: None,
+                approval_prompt_target: None,
+                auth_prompt_target: None,
+                default_modality: Some(CommunicationModality::Text),
+                updated_at: now(),
+                updated_by: owner.clone(),
+            })
+            .await
+            .expect("seed owner preference");
+        store
+            .put_communication_preference(CommunicationPreferenceRecord {
+                scope: DeliveryDefaultScope::personal(
+                    TenantId::new("tenant-a").expect("valid tenant"),
+                    UserId::new("user-actor").expect("valid actor"),
+                ),
+                final_reply_target: Some(reply_ref("reply:actor-default")),
+                progress_target: None,
+                approval_prompt_target: None,
+                auth_prompt_target: None,
+                default_modality: Some(CommunicationModality::Text),
+                updated_at: now(),
+                updated_by: owner,
+            })
+            .await
+            .expect("seed actor preference");
+
+        let resolution = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: TurnScope::new_with_owner(
+                    TenantId::new("tenant-a").expect("valid tenant"),
+                    Some(AgentId::new("agent-a").expect("valid agent")),
+                    Some(ProjectId::new("project-a").expect("valid project")),
+                    thread_id("thread-owner"),
+                    Some(UserId::new("user-owner").expect("valid owner")),
+                ),
+                actor: actor("user-actor"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::Triggered {
+                        trigger: trigger_context(),
+                    },
+                }),
+            })
+            .await
+            .expect("triggered final reply resolves");
+        let candidate = expect_candidate(resolution);
+
+        assert_eq!(candidate.target, reply_ref("reply:owner-default"));
         assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
     }
 
@@ -673,8 +807,10 @@ mod tests {
         auth_prompt_target: Option<&str>,
     ) -> CommunicationPreferenceRecord {
         CommunicationPreferenceRecord {
-            tenant_id: TenantId::new("tenant-a").expect("valid tenant"),
-            user_id: UserId::new("user-a").expect("valid user"),
+            scope: DeliveryDefaultScope::personal(
+                TenantId::new("tenant-a").expect("valid tenant"),
+                UserId::new("user-a").expect("valid user"),
+            ),
             final_reply_target: final_reply_target.map(reply_ref),
             progress_target: progress_target.map(reply_ref),
             approval_prompt_target: approval_prompt_target.map(reply_ref),
@@ -686,6 +822,20 @@ mod tests {
     }
 
     fn scope() -> TurnScope {
+        personal_scope()
+    }
+
+    fn personal_scope() -> TurnScope {
+        TurnScope::new_with_owner(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            Some(AgentId::new("agent-a").expect("valid agent")),
+            Some(ProjectId::new("project-a").expect("valid project")),
+            thread_id("thread-a"),
+            Some(UserId::new("user-a").expect("valid user")),
+        )
+    }
+
+    fn shared_scope() -> TurnScope {
         TurnScope::new(
             TenantId::new("tenant-a").expect("valid tenant"),
             Some(AgentId::new("agent-a").expect("valid agent")),

--- a/crates/ironclaw_outbound/src/service.rs
+++ b/crates/ironclaw_outbound/src/service.rs
@@ -340,7 +340,14 @@ mod tests {
                 modality: CommunicationModality::Text,
                 intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
                     event_kind: RunNotificationEventKind::ApprovalNeeded,
-                    origin: RunNotificationOrigin::LiveSourceRoute {
+                    origin: RunNotificationOrigin::TriggeredFromSourceRoute {
+                        trigger: crate::TriggerCommunicationContext {
+                            trigger_origin_ref: crate::TriggerOriginRef::new("trigger:approval")
+                                .expect("valid trigger id"),
+                            trigger_source_kind: crate::TriggerSourceKind::Schedule,
+                            fire_slot: crate::TriggerFireSlot::new("2026-06-08T09:00:00Z")
+                                .expect("valid fire slot"),
+                        },
                         source_route: SourceRouteContext {
                             reply_target_binding_ref: reply_ref("reply:source"),
                         },
@@ -433,8 +440,7 @@ mod tests {
         auth_prompt_target: Option<&str>,
     ) -> CommunicationPreferenceRecord {
         CommunicationPreferenceRecord {
-            tenant_id: scope.tenant_id.clone(),
-            user_id: user_id("alice"),
+            scope: crate::DeliveryDefaultScope::personal(scope.tenant_id.clone(), user_id("alice")),
             final_reply_target: final_reply_target.map(reply_ref),
             progress_target: progress_target.map(reply_ref),
             approval_prompt_target: approval_prompt_target.map(reply_ref),
@@ -446,11 +452,12 @@ mod tests {
     }
 
     fn turn_scope(thread_id: &str) -> TurnScope {
-        TurnScope::new(
+        TurnScope::new_with_owner(
             TenantId::new("tenant-a").expect("valid tenant"),
             Some(AgentId::new("agent-a").expect("valid agent")),
             Some(ProjectId::new("project-a").expect("valid project")),
             ThreadId::new(thread_id).expect("valid thread"),
+            Some(user_id("alice")),
         )
     }
 

--- a/crates/ironclaw_outbound/src/validation.rs
+++ b/crates/ironclaw_outbound/src/validation.rs
@@ -3,9 +3,10 @@ use std::collections::HashSet;
 use ironclaw_turns::ReplyTargetBindingRef;
 
 use crate::{
-    AdvanceSubscriptionCursorRequest, CommunicationPreferenceRecord, DeliveryFailureKind,
-    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundDeliveryStatus, OutboundError,
-    ProjectionSubscriptionRecord, ThreadNotificationPolicy, UpdateDeliveryStatusRequest,
+    AdvanceSubscriptionCursorRequest, CommunicationPreferenceRecord, DeliveryDefaultScope,
+    DeliveryFailureKind, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
+    OutboundDeliveryStatus, OutboundError, ProjectionSubscriptionRecord, ThreadNotificationPolicy,
+    UpdateDeliveryStatusRequest,
 };
 
 const MAX_NOTIFICATION_TARGETS: usize = 32;
@@ -175,15 +176,35 @@ pub(crate) fn validate_delivery_identity(
 pub(crate) fn validate_communication_preference(
     record: &CommunicationPreferenceRecord,
 ) -> Result<(), OutboundError> {
-    if record.tenant_id.as_str().is_empty() {
-        return Err(OutboundError::InvalidRequest {
-            reason: "communication preference tenant is required",
-        });
-    }
-    if record.user_id.as_str().is_empty() {
-        return Err(OutboundError::InvalidRequest {
-            reason: "communication preference user is required",
-        });
+    match &record.scope {
+        DeliveryDefaultScope::Personal { tenant_id, user_id } => {
+            if tenant_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference tenant is required",
+                });
+            }
+            if user_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference user is required",
+                });
+            }
+        }
+        DeliveryDefaultScope::SharedAgent {
+            tenant_id,
+            agent_id,
+            ..
+        } => {
+            if tenant_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference tenant is required",
+                });
+            }
+            if agent_id.as_str().is_empty() {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference shared agent is required",
+                });
+            }
+        }
     }
     if record.updated_by.as_str().is_empty() {
         return Err(OutboundError::InvalidRequest {

--- a/crates/ironclaw_outbound/src/validation.rs
+++ b/crates/ironclaw_outbound/src/validation.rs
@@ -192,7 +192,7 @@ pub(crate) fn validate_communication_preference(
         DeliveryDefaultScope::SharedAgent {
             tenant_id,
             agent_id,
-            ..
+            project_id,
         } => {
             if tenant_id.as_str().is_empty() {
                 return Err(OutboundError::InvalidRequest {
@@ -202,6 +202,14 @@ pub(crate) fn validate_communication_preference(
             if agent_id.as_str().is_empty() {
                 return Err(OutboundError::InvalidRequest {
                     reason: "communication preference shared agent is required",
+                });
+            }
+            if project_id
+                .as_ref()
+                .is_some_and(|project_id| project_id.as_str().is_empty())
+            {
+                return Err(OutboundError::InvalidRequest {
+                    reason: "communication preference project is required when present",
                 });
             }
         }

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -397,6 +397,63 @@ async fn communication_delivery_triggered_default_target_validates_preference_ta
 }
 
 #[tokio::test]
+async fn communication_delivery_triggered_shared_agent_scope_validates_shared_preference_target() {
+    let store = InMemoryOutboundStateStore::default();
+    let access_policy = FakeThreadProjectionAccessPolicy::default();
+    let validator = FakeReplyTargetBindingValidator::default();
+    let service = OutboundPolicyService::new(&store, &access_policy, &validator);
+    let scope = ownerless_agent_scope("thread-1");
+    let request = run_notification_request_with_scope(
+        scope.clone(),
+        RunNotificationEventKind::FinalReplyReady,
+        RunNotificationOrigin::Triggered {
+            trigger: trigger_context(),
+        },
+    );
+    validator.allow(reply_ref("reply:shared-default"));
+    store
+        .put_communication_preference(preference_record(
+            Some("reply:personal-default"),
+            Some("reply:personal-progress"),
+            None,
+            None,
+        ))
+        .await
+        .expect("seed personal preference");
+    store
+        .put_communication_preference(shared_agent_preference_record(
+            Some("reply:shared-default"),
+            Some("reply:shared-progress"),
+            None,
+            None,
+        ))
+        .await
+        .expect("seed shared-agent preference");
+
+    let decision = service
+        .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
+        .await
+        .expect("shared-agent triggered default resolves and prepares")
+        .expect("shared-agent triggered default has a delivery target");
+
+    let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
+        panic!("expected authorized delivery");
+    };
+    assert_eq!(target.target(), &reply_ref("reply:shared-default"));
+    assert_eq!(attempt.candidate.target, reply_ref("reply:shared-default"));
+    assert_eq!(attempt.candidate.kind, OutboundPushKind::FinalReply);
+    assert_eq!(validator.calls(), 1);
+    assert_eq!(
+        store
+            .list_delivery_attempts(scope)
+            .await
+            .expect("list delivery attempts")
+            .as_slice(),
+        std::slice::from_ref(&attempt)
+    );
+}
+
+#[tokio::test]
 async fn communication_delivery_lowers_progress_update_to_progress_push_kind() {
     let store = InMemoryOutboundStateStore::default();
     let access_policy = FakeThreadProjectionAccessPolicy::default();
@@ -1150,6 +1207,28 @@ fn preference_record(
     }
 }
 
+fn shared_agent_preference_record(
+    final_reply_target: Option<&str>,
+    progress_target: Option<&str>,
+    approval_prompt_target: Option<&str>,
+    auth_prompt_target: Option<&str>,
+) -> CommunicationPreferenceRecord {
+    CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::shared_agent(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            AgentId::new("agent-a").expect("valid agent"),
+            Some(ProjectId::new("project-a").expect("valid project")),
+        ),
+        final_reply_target: final_reply_target.map(reply_ref),
+        progress_target: progress_target.map(reply_ref),
+        approval_prompt_target: approval_prompt_target.map(reply_ref),
+        auth_prompt_target: auth_prompt_target.map(reply_ref),
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin").expect("valid updater"),
+    }
+}
+
 fn trigger_context() -> TriggerCommunicationContext {
     TriggerCommunicationContext {
         trigger_origin_ref: TriggerOriginRef::new("trigger:daily")
@@ -1170,6 +1249,16 @@ fn turn_scope(thread: &str) -> TurnScope {
         Some(ProjectId::new("project-a").expect("valid project")),
         thread_id(thread),
         Some(UserId::new("user-a").expect("valid user")),
+    )
+}
+
+fn ownerless_agent_scope(thread: &str) -> TurnScope {
+    TurnScope::new_with_owner(
+        TenantId::new("tenant-a").expect("valid tenant"),
+        Some(AgentId::new("agent-a").expect("valid agent")),
+        Some(ProjectId::new("project-a").expect("valid project")),
+        thread_id(thread),
+        None,
     )
 }
 

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -870,25 +870,17 @@ struct BackendErrorPreferenceRepository;
 
 #[async_trait]
 impl CommunicationPreferenceRepository for BackendErrorPreferenceRepository {
-    async fn put_communication_preference(
-        &self,
-        _record: CommunicationPreferenceRecord,
-    ) -> Result<(), OutboundError> {
-        Ok(())
-    }
-
     async fn load_communication_preference(
         &self,
         _key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         Err(OutboundError::Backend)
     }
 
-    async fn update_communication_preference(
+    async fn write_communication_preference(
         &self,
-        _key: CommunicationPreferenceKey,
-        _update: CommunicationPreferenceUpdate,
-    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+        _request: WriteCommunicationPreferenceRequest,
+    ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
         Err(OutboundError::Backend)
     }
 }
@@ -1144,8 +1136,10 @@ fn preference_record(
     auth_prompt_target: Option<&str>,
 ) -> CommunicationPreferenceRecord {
     CommunicationPreferenceRecord {
-        tenant_id: TenantId::new("tenant-a").expect("valid tenant"),
-        user_id: UserId::new("user-a").expect("valid user"),
+        scope: DeliveryDefaultScope::personal(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            UserId::new("user-a").expect("valid user"),
+        ),
         final_reply_target: final_reply_target.map(reply_ref),
         progress_target: progress_target.map(reply_ref),
         approval_prompt_target: approval_prompt_target.map(reply_ref),
@@ -1170,11 +1164,12 @@ fn subscription_id(value: &str) -> ProjectionSubscriptionId {
 }
 
 fn turn_scope(thread: &str) -> TurnScope {
-    TurnScope::new(
+    TurnScope::new_with_owner(
         TenantId::new("tenant-a").expect("valid tenant"),
         Some(AgentId::new("agent-a").expect("valid agent")),
         Some(ProjectId::new("project-a").expect("valid project")),
         thread_id(thread),
+        Some(UserId::new("user-a").expect("valid user")),
     )
 }
 

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -359,13 +359,22 @@ where
     let result = store.put_communication_preference(missing_tenant).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 
-    let mut missing_agent = valid_record;
+    let mut missing_agent = valid_record.clone();
     missing_agent.scope = DeliveryDefaultScope::shared_agent(
         TenantId::new("tenant-outbound-shared-validation").unwrap(),
         AgentId::from_trusted(String::new()),
         None,
     );
     let result = store.put_communication_preference(missing_agent).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+
+    let mut missing_project = valid_record;
+    missing_project.scope = DeliveryDefaultScope::shared_agent(
+        TenantId::new("tenant-outbound-shared-validation").unwrap(),
+        AgentId::new("agent-outbound-shared-validation").unwrap(),
+        Some(ProjectId::from_trusted(String::new())),
+    );
+    let result = store.put_communication_preference(missing_project).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 }
 
@@ -664,6 +673,60 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
         .load_communication_preference(tenant_mismatch_key)
         .await;
     assert!(matches!(result, Err(OutboundError::Backend)));
+}
+
+#[tokio::test]
+async fn filesystem_store_personal_and_shared_agent_hashes_are_always_distinct() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let store = build_outbound_store_for_backend(Arc::clone(&backend));
+    let tenant_id = TenantId::new("tenant-outbound-hash-distinct").unwrap();
+    let shared_id = "same-principal-id";
+    let personal_key =
+        CommunicationPreferenceKey::personal(tenant_id.clone(), UserId::new(shared_id).unwrap());
+    let personal_record = CommunicationPreferenceRecord {
+        scope: personal_key.scope.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-hash-personal")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-hash-personal").unwrap(),
+    };
+    let (_, personal_path) =
+        put_preference_and_find_virtual_path(&backend, &store, personal_record.clone()).await;
+
+    let shared_key =
+        CommunicationPreferenceKey::shared_agent(tenant_id, AgentId::new(shared_id).unwrap(), None);
+    let shared_record = CommunicationPreferenceRecord {
+        scope: shared_key.scope.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-hash-shared")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Voice),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-hash-shared").unwrap(),
+    };
+    let (_, shared_path) =
+        put_preference_and_find_virtual_path(&backend, &store, shared_record.clone()).await;
+
+    assert_ne!(
+        personal_path, shared_path,
+        "personal and shared-agent preference scopes with the same id text must not share a v2 hash path",
+    );
+    assert_eq!(
+        communication_preference_virtual_paths(&backend).await.len(),
+        2
+    );
+    assert_eq!(
+        load_preference_record(&store, personal_key).await,
+        Some(personal_record)
+    );
+    assert_eq!(
+        load_preference_record(&store, shared_key).await,
+        Some(shared_record)
+    );
 }
 
 async fn filesystem_store_rejects_communication_preference_put_cas_conflict(

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -5,8 +5,8 @@ use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
 use ironclaw_events::{EventCursor, EventStreamKey, ReadScope};
 use ironclaw_filesystem::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FilesystemError,
-    Filter, InMemoryBackend, IndexSpec, Page, RecordVersion, RootFilesystem, ScopedFilesystem,
-    VersionedEntry,
+    FilesystemOperation, Filter, InMemoryBackend, IndexSpec, Page, RecordVersion, RootFilesystem,
+    ScopedFilesystem, VersionedEntry,
 };
 use ironclaw_host_api::{
     AgentId, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, TenantId, ThreadId,
@@ -816,6 +816,40 @@ async fn filesystem_store_rejects_communication_preference_update_cas_conflict(
     assert_eq!(load_preference_record(&store, key).await, Some(record));
 }
 
+#[tokio::test]
+async fn filesystem_store_rejects_communication_preference_write_on_unsupported_cas_mount() {
+    let inner = Arc::new(InMemoryBackend::new());
+    let backend = Arc::new(UnsupportedPreferenceCasBackend::new(Arc::clone(&inner)));
+    let store = FilesystemOutboundStateStore::new(build_scoped_fs(
+        Arc::clone(&backend),
+        TEST_OUTBOUND_ROOT,
+    ));
+    let tenant_id = TenantId::new("tenant-outbound-unsupported-cas").unwrap();
+    let user_id = UserId::new("user-outbound-unsupported-cas").unwrap();
+    let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::personal(tenant_id, user_id),
+        final_reply_target: Some(reply_ref("reply-pref-unsupported-cas")),
+        progress_target: Some(reply_ref("reply-pref-unsupported-cas-progress")),
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-unsupported-cas").unwrap(),
+    };
+
+    let result = store
+        .write_communication_preference(WriteCommunicationPreferenceRequest {
+            record,
+            expected_version: None,
+        })
+        .await;
+
+    assert!(matches!(result, Err(OutboundError::Backend)));
+    assert_eq!(backend.unsupported_count().await, 1);
+    assert_eq!(load_preference_record(&store, key).await, None);
+}
+
 async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateStore) {
     let scope = turn_scope();
     let default_reply = reply_ref("reply-default");
@@ -1543,6 +1577,88 @@ impl RootFilesystem for VersionRacingBackend {
                     found: None,
                 });
             }
+        }
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.inner.get(path).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        self.inner.query(path, filter, page).await
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        self.inner.ensure_index(path, spec).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+}
+
+/// Test backend that mimics a mount that cannot honor CAS writes for
+/// communication-preference records. An accidental byte fallback would retry
+/// as `CasExpectation::Any` and succeed through the inner backend, so the
+/// test above proves preference writes fail closed instead.
+struct UnsupportedPreferenceCasBackend {
+    inner: Arc<InMemoryBackend>,
+    unsupported: Mutex<u32>,
+}
+
+impl UnsupportedPreferenceCasBackend {
+    fn new(inner: Arc<InMemoryBackend>) -> Self {
+        Self {
+            inner,
+            unsupported: Mutex::new(0),
+        }
+    }
+
+    async fn unsupported_count(&self) -> u32 {
+        *self.unsupported.lock().await
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for UnsupportedPreferenceCasBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        if path
+            .as_str()
+            .starts_with(&format!("{TEST_OUTBOUND_ROOT}/communication-preferences/"))
+            && !matches!(cas, CasExpectation::Any)
+        {
+            *self.unsupported.lock().await += 1;
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::WriteFile,
+            });
         }
         self.inner.put(path, entry, cas).await
     }

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use ironclaw_event_projections::{ProjectionCursor, ProjectionScope};
@@ -47,10 +46,13 @@ fn build_outbound_store_for_backend(
 async fn in_memory_defaults_policy_progress_opt_in_and_subscription_scope() {
     let store = InMemoryOutboundStateStore::default();
     communication_preferences_are_tenant_user_scoped(&store).await;
+    communication_preferences_are_shared_agent_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
+    communication_preferences_reject_empty_shared_agent_scope(&store).await;
+    communication_preference_put_existing_conflicts_without_writing(&store).await;
     communication_preference_atomic_update_preserves_existing_slots(&store).await;
     communication_preference_update_inserts_absent_record(&store).await;
-    communication_preference_update_propagates_update_error_without_writing(&store).await;
+    communication_preference_stale_version_conflicts_without_writing(&store).await;
     communication_preference_update_rejects_invalid_or_mismatched_record(&store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
@@ -71,13 +73,16 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     let backend = std::sync::Arc::new(ironclaw_filesystem::InMemoryBackend::new());
     let store = build_outbound_store_for_backend(Arc::clone(&backend));
     communication_preferences_are_tenant_user_scoped(&store).await;
+    communication_preferences_are_shared_agent_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
+    communication_preferences_reject_empty_shared_agent_scope(&store).await;
+    communication_preference_put_existing_conflicts_without_writing(&store).await;
     communication_preference_atomic_update_preserves_existing_slots(&store).await;
     communication_preference_update_inserts_absent_record(&store).await;
-    communication_preference_update_propagates_update_error_without_writing(&store).await;
+    communication_preference_stale_version_conflicts_without_writing(&store).await;
     communication_preference_update_rejects_invalid_or_mismatched_record(&store).await;
-    filesystem_store_retries_communication_preference_put_through_cas_conflict(&backend).await;
-    filesystem_store_retries_communication_preference_update_through_cas_conflict(&backend).await;
+    filesystem_store_rejects_communication_preference_put_cas_conflict(&backend).await;
+    filesystem_store_rejects_communication_preference_update_cas_conflict(&backend).await;
     filesystem_store_rejects_mismatched_communication_preference_identity(&backend, &store).await;
     durable_policy_subscription_delivery_flow(&store).await;
     subscription_cursor_rejects_mismatched_scope(&store).await;
@@ -94,6 +99,37 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
 // `RootFilesystem` backend, not of an outbound-specific persistence
 // implementation.
 
+async fn load_preference_record<S>(
+    store: &S,
+    key: CommunicationPreferenceKey,
+) -> Option<CommunicationPreferenceRecord>
+where
+    S: CommunicationPreferenceRepository,
+{
+    store
+        .load_communication_preference(key)
+        .await
+        .unwrap()
+        .map(|versioned| versioned.record)
+}
+
+async fn write_preference_record<S>(
+    store: &S,
+    record: CommunicationPreferenceRecord,
+    expected_version: Option<CommunicationPreferenceVersion>,
+) -> VersionedCommunicationPreferenceRecord
+where
+    S: CommunicationPreferenceRepository,
+{
+    store
+        .write_communication_preference(WriteCommunicationPreferenceRequest {
+            record,
+            expected_version,
+        })
+        .await
+        .unwrap()
+}
+
 async fn communication_preferences_are_tenant_user_scoped<S>(store: &S)
 where
     S: CommunicationPreferenceRepository + OutboundStateStore,
@@ -103,8 +139,7 @@ where
     let updated_by = UserId::new("tenant-admin-outbound").unwrap();
     let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
     let record = CommunicationPreferenceRecord {
-        tenant_id: tenant_id.clone(),
-        user_id: user_id.clone(),
+        scope: DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone()),
         final_reply_target: Some(reply_ref("reply-pref-final")),
         progress_target: Some(reply_ref("reply-pref-progress")),
         approval_prompt_target: Some(reply_ref("reply-pref-approval")),
@@ -119,11 +154,13 @@ where
         .put_communication_preference(record.clone())
         .await
         .unwrap();
+    let inserted = store
+        .load_communication_preference(key.clone())
+        .await
+        .unwrap()
+        .expect("inserted preference record");
     assert_eq!(
-        store
-            .load_communication_preference(key.clone())
-            .await
-            .unwrap(),
+        load_preference_record(store, key.clone()).await,
         Some(record.clone())
     );
 
@@ -159,14 +196,8 @@ where
         updated_by,
         ..record
     };
-    store
-        .put_communication_preference(updated.clone())
-        .await
-        .unwrap();
-    assert_eq!(
-        store.load_communication_preference(key).await.unwrap(),
-        Some(updated)
-    );
+    write_preference_record(store, updated.clone(), Some(inserted.version)).await;
+    assert_eq!(load_preference_record(store, key).await, Some(updated));
 
     let thread_policy = store
         .load_thread_notification_policy(turn_scope())
@@ -178,13 +209,97 @@ where
     );
 }
 
+async fn communication_preferences_are_shared_agent_scoped<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound-shared").unwrap();
+    let agent_id = AgentId::new("agent-outbound-shared").unwrap();
+    let project_id = ProjectId::new("project-outbound-shared").unwrap();
+    let updated_by = UserId::new("tenant-admin-outbound-shared").unwrap();
+    let project_key = CommunicationPreferenceKey::shared_agent(
+        tenant_id.clone(),
+        agent_id.clone(),
+        Some(project_id.clone()),
+    );
+    let project_record = CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::shared_agent(
+            tenant_id.clone(),
+            agent_id.clone(),
+            Some(project_id.clone()),
+        ),
+        final_reply_target: Some(reply_ref("reply-pref-shared-project")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: updated_by.clone(),
+    };
+    store
+        .put_communication_preference(project_record.clone())
+        .await
+        .unwrap();
+    assert_eq!(project_record.key(), project_key);
+    assert_eq!(
+        load_preference_record(store, project_key.clone()).await,
+        Some(project_record)
+    );
+
+    let projectless_key =
+        CommunicationPreferenceKey::shared_agent(tenant_id.clone(), agent_id.clone(), None);
+    let projectless_record = CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::shared_agent(tenant_id.clone(), agent_id.clone(), None),
+        final_reply_target: Some(reply_ref("reply-pref-shared-projectless")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Voice),
+        updated_at: now(),
+        updated_by,
+    };
+    store
+        .put_communication_preference(projectless_record.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        load_preference_record(store, projectless_key).await,
+        Some(projectless_record)
+    );
+
+    let personal_key = CommunicationPreferenceKey::personal(
+        tenant_id,
+        UserId::new("user-outbound-shared").unwrap(),
+    );
+    assert!(
+        store
+            .load_communication_preference(personal_key)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        store
+            .load_communication_preference(CommunicationPreferenceKey::shared_agent(
+                TenantId::new("tenant-outbound-shared-other").unwrap(),
+                agent_id,
+                Some(project_id),
+            ))
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
 async fn communication_preferences_reject_empty_updated_by<S>(store: &S)
 where
     S: CommunicationPreferenceRepository + OutboundStateStore,
 {
     let valid_record = CommunicationPreferenceRecord {
-        tenant_id: TenantId::new("tenant-outbound-validation").unwrap(),
-        user_id: UserId::new("user-outbound-validation").unwrap(),
+        scope: DeliveryDefaultScope::personal(
+            TenantId::new("tenant-outbound-validation").unwrap(),
+            UserId::new("user-outbound-validation").unwrap(),
+        ),
         final_reply_target: Some(reply_ref("reply-pref-validation")),
         progress_target: None,
         approval_prompt_target: None,
@@ -200,14 +315,91 @@ where
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 
     let mut missing_tenant = valid_record.clone();
-    missing_tenant.tenant_id = TenantId::from_trusted(String::new());
+    missing_tenant.scope = DeliveryDefaultScope::personal(
+        TenantId::from_trusted(String::new()),
+        UserId::new("user-outbound-validation").unwrap(),
+    );
     let result = store.put_communication_preference(missing_tenant).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 
     let mut missing_user = valid_record;
-    missing_user.user_id = UserId::from_trusted(String::new());
+    missing_user.scope = DeliveryDefaultScope::personal(
+        TenantId::new("tenant-outbound-validation").unwrap(),
+        UserId::from_trusted(String::new()),
+    );
     let result = store.put_communication_preference(missing_user).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+}
+
+async fn communication_preferences_reject_empty_shared_agent_scope<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let valid_record = CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::shared_agent(
+            TenantId::new("tenant-outbound-shared-validation").unwrap(),
+            AgentId::new("agent-outbound-shared-validation").unwrap(),
+            None,
+        ),
+        final_reply_target: Some(reply_ref("reply-pref-shared-validation")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-shared-validation").unwrap(),
+    };
+
+    let mut missing_tenant = valid_record.clone();
+    missing_tenant.scope = DeliveryDefaultScope::shared_agent(
+        TenantId::from_trusted(String::new()),
+        AgentId::new("agent-outbound-shared-validation").unwrap(),
+        None,
+    );
+    let result = store.put_communication_preference(missing_tenant).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+
+    let mut missing_agent = valid_record;
+    missing_agent.scope = DeliveryDefaultScope::shared_agent(
+        TenantId::new("tenant-outbound-shared-validation").unwrap(),
+        AgentId::from_trusted(String::new()),
+        None,
+    );
+    let result = store.put_communication_preference(missing_agent).await;
+    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
+}
+
+async fn communication_preference_put_existing_conflicts_without_writing<S>(store: &S)
+where
+    S: CommunicationPreferenceRepository + OutboundStateStore,
+{
+    let tenant_id = TenantId::new("tenant-outbound-duplicate").unwrap();
+    let user_id = UserId::new("user-outbound-duplicate").unwrap();
+    let key = CommunicationPreferenceKey::personal(tenant_id.clone(), user_id.clone());
+    let record = CommunicationPreferenceRecord {
+        scope: DeliveryDefaultScope::personal(tenant_id, user_id),
+        final_reply_target: Some(reply_ref("reply-pref-duplicate")),
+        progress_target: None,
+        approval_prompt_target: None,
+        auth_prompt_target: None,
+        default_modality: Some(CommunicationModality::Text),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-duplicate").unwrap(),
+    };
+    store
+        .put_communication_preference(record.clone())
+        .await
+        .unwrap();
+
+    let duplicate = CommunicationPreferenceRecord {
+        final_reply_target: Some(reply_ref("reply-pref-duplicate-replacement")),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-duplicate-2").unwrap(),
+        ..record.clone()
+    };
+    let result = store.put_communication_preference(duplicate).await;
+    assert!(matches!(result, Err(OutboundError::CasConflict)));
+    assert_eq!(load_preference_record(store, key).await, Some(record));
 }
 
 async fn communication_preference_atomic_update_preserves_existing_slots<S>(store: &S)
@@ -218,8 +410,7 @@ where
     let user_id = UserId::new("user-outbound-atomic").unwrap();
     let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
     let record = CommunicationPreferenceRecord {
-        tenant_id,
-        user_id,
+        scope: DeliveryDefaultScope::personal(tenant_id, user_id),
         final_reply_target: Some(reply_ref("reply-pref-atomic-final")),
         progress_target: Some(reply_ref("reply-pref-atomic-progress")),
         approval_prompt_target: Some(reply_ref("reply-pref-atomic-approval")),
@@ -233,21 +424,23 @@ where
         .await
         .unwrap();
 
-    let updated = store
-        .update_communication_preference(
-            key.clone(),
-            Box::new(move |existing| {
-                let existing = existing.expect("existing communication preference");
-                Ok(CommunicationPreferenceRecord {
-                    final_reply_target: Some(reply_ref("reply-pref-atomic-final-updated")),
-                    updated_at: now(),
-                    updated_by: UserId::new("user-outbound-atomic-updater-2").unwrap(),
-                    ..existing
-                })
-            }),
-        )
+    let existing = store
+        .load_communication_preference(key.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .expect("existing communication preference");
+    let updated = write_preference_record(
+        store,
+        CommunicationPreferenceRecord {
+            final_reply_target: Some(reply_ref("reply-pref-atomic-final-updated")),
+            updated_at: now(),
+            updated_by: UserId::new("user-outbound-atomic-updater-2").unwrap(),
+            ..existing.record
+        },
+        Some(existing.version),
+    )
+    .await
+    .record;
 
     assert_eq!(
         updated.final_reply_target,
@@ -260,10 +453,7 @@ where
     );
     assert_eq!(updated.auth_prompt_target, record.auth_prompt_target);
     assert_eq!(updated.default_modality, record.default_modality);
-    assert_eq!(
-        store.load_communication_preference(key).await.unwrap(),
-        Some(updated)
-    );
+    assert_eq!(load_preference_record(store, key).await, Some(updated));
 }
 
 async fn communication_preference_update_inserts_absent_record<S>(store: &S)
@@ -274,8 +464,7 @@ where
     let user_id = UserId::new("user-outbound-update-absent").unwrap();
     let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
     let record = CommunicationPreferenceRecord {
-        tenant_id,
-        user_id,
+        scope: DeliveryDefaultScope::personal(tenant_id, user_id),
         final_reply_target: Some(reply_ref("reply-pref-update-absent-final")),
         progress_target: Some(reply_ref("reply-pref-update-absent-progress")),
         approval_prompt_target: None,
@@ -284,31 +473,15 @@ where
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-update-absent").unwrap(),
     };
-    let update_calls = Arc::new(AtomicUsize::new(0));
-    let calls = Arc::clone(&update_calls);
-    let callback_record = record.clone();
-
-    let updated = store
-        .update_communication_preference(
-            key.clone(),
-            Box::new(move |existing| {
-                calls.fetch_add(1, Ordering::SeqCst);
-                assert!(existing.is_none());
-                Ok(callback_record.clone())
-            }),
-        )
+    let updated = write_preference_record(store, record.clone(), None)
         .await
-        .unwrap();
+        .record;
 
     assert_eq!(updated, record);
-    assert_eq!(update_calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        store.load_communication_preference(key).await.unwrap(),
-        Some(record)
-    );
+    assert_eq!(load_preference_record(store, key).await, Some(record));
 }
 
-async fn communication_preference_update_propagates_update_error_without_writing<S>(store: &S)
+async fn communication_preference_stale_version_conflicts_without_writing<S>(store: &S)
 where
     S: CommunicationPreferenceRepository + OutboundStateStore,
 {
@@ -316,8 +489,7 @@ where
     let user_id = UserId::new("user-outbound-update-error").unwrap();
     let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
     let record = CommunicationPreferenceRecord {
-        tenant_id,
-        user_id,
+        scope: DeliveryDefaultScope::personal(tenant_id, user_id),
         final_reply_target: Some(reply_ref("reply-pref-update-error-final")),
         progress_target: Some(reply_ref("reply-pref-update-error-progress")),
         approval_prompt_target: None,
@@ -331,18 +503,32 @@ where
         .await
         .unwrap();
 
+    let existing = store
+        .load_communication_preference(key.clone())
+        .await
+        .unwrap()
+        .expect("existing communication preference");
+    let first_update = CommunicationPreferenceRecord {
+        final_reply_target: Some(reply_ref("reply-pref-update-error-race")),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-update-error-racer").unwrap(),
+        ..existing.record.clone()
+    };
+    write_preference_record(store, first_update, Some(existing.version)).await;
+    let stale_update = CommunicationPreferenceRecord {
+        final_reply_target: Some(reply_ref("reply-pref-update-error-stale")),
+        updated_at: now(),
+        updated_by: UserId::new("user-outbound-update-error-stale").unwrap(),
+        ..existing.record
+    };
     let result = store
-        .update_communication_preference(
-            key.clone(),
-            Box::new(|_| Err(OutboundError::AccessDenied)),
-        )
+        .write_communication_preference(WriteCommunicationPreferenceRequest {
+            record: stale_update,
+            expected_version: Some(existing.version),
+        })
         .await;
 
-    assert!(matches!(result, Err(OutboundError::AccessDenied)));
-    assert_eq!(
-        store.load_communication_preference(key).await.unwrap(),
-        Some(record)
-    );
+    assert!(matches!(result, Err(OutboundError::CasConflict)));
 }
 
 async fn communication_preference_update_rejects_invalid_or_mismatched_record<S>(store: &S)
@@ -353,8 +539,7 @@ where
     let user_id = UserId::new("user-outbound-update-invalid").unwrap();
     let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
     let record = CommunicationPreferenceRecord {
-        tenant_id,
-        user_id,
+        scope: DeliveryDefaultScope::personal(tenant_id, user_id),
         final_reply_target: Some(reply_ref("reply-pref-update-invalid-final")),
         progress_target: None,
         approval_prompt_target: None,
@@ -368,39 +553,37 @@ where
         .await
         .unwrap();
 
+    let existing = store
+        .load_communication_preference(key.clone())
+        .await
+        .unwrap()
+        .expect("existing communication preference");
+    let mut invalid_record = existing.record.clone();
+    invalid_record.updated_by = UserId::from_trusted(String::new());
     let invalid_result = store
-        .update_communication_preference(
-            key.clone(),
-            Box::new(|existing| {
-                let mut record = existing.expect("existing communication preference");
-                record.updated_by = UserId::from_trusted(String::new());
-                Ok(record)
-            }),
-        )
+        .write_communication_preference(WriteCommunicationPreferenceRequest {
+            record: invalid_record,
+            expected_version: Some(existing.version),
+        })
         .await;
     assert!(matches!(
         invalid_result,
         Err(OutboundError::InvalidRequest { .. })
     ));
 
-    let mismatch_result = store
-        .update_communication_preference(
-            key.clone(),
-            Box::new(|existing| {
-                let mut record = existing.expect("existing communication preference");
-                record.user_id = UserId::new("user-outbound-update-invalid-other").unwrap();
-                Ok(record)
-            }),
-        )
-        .await;
-    assert!(matches!(
-        mismatch_result,
-        Err(OutboundError::InvalidRequest { .. })
-    ));
-    assert_eq!(
-        store.load_communication_preference(key).await.unwrap(),
-        Some(record)
+    let mut mismatched_record = existing.record;
+    mismatched_record.scope = DeliveryDefaultScope::personal(
+        TenantId::new("tenant-outbound-update-invalid").unwrap(),
+        UserId::new("user-outbound-update-invalid-other").unwrap(),
     );
+    let mismatch_result = store
+        .write_communication_preference(WriteCommunicationPreferenceRequest {
+            record: mismatched_record,
+            expected_version: Some(existing.version),
+        })
+        .await;
+    assert!(matches!(mismatch_result, Err(OutboundError::CasConflict)));
+    assert_eq!(load_preference_record(store, key).await, Some(record));
 }
 
 async fn filesystem_store_rejects_mismatched_communication_preference_identity(
@@ -410,8 +593,7 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let tenant_id = TenantId::new("tenant-outbound-corrupt").unwrap();
     let user_id = UserId::new("user-outbound-corrupt").unwrap();
     let record = CommunicationPreferenceRecord {
-        tenant_id: tenant_id.clone(),
-        user_id: user_id.clone(),
+        scope: DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone()),
         final_reply_target: Some(reply_ref("reply-pref-corrupt")),
         progress_target: None,
         approval_prompt_target: None,
@@ -423,7 +605,10 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let (key, path) = put_preference_and_find_virtual_path(backend, store, record.clone()).await;
 
     let mut user_mismatch_record = record;
-    user_mismatch_record.user_id = UserId::new("user-outbound-corrupt-other").unwrap();
+    user_mismatch_record.scope = DeliveryDefaultScope::personal(
+        tenant_id.clone(),
+        UserId::new("user-outbound-corrupt-other").unwrap(),
+    );
     let entry = Entry::bytes(serde_json::to_vec(&user_mismatch_record).unwrap())
         .with_content_type(ContentType::json());
     backend
@@ -437,8 +622,10 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let tenant_mismatch_tenant_id = TenantId::new("tenant-outbound-corrupt-tenant").unwrap();
     let tenant_mismatch_user_id = UserId::new("user-outbound-corrupt-tenant").unwrap();
     let tenant_mismatch_seed = CommunicationPreferenceRecord {
-        tenant_id: tenant_mismatch_tenant_id,
-        user_id: tenant_mismatch_user_id.clone(),
+        scope: DeliveryDefaultScope::personal(
+            tenant_mismatch_tenant_id,
+            tenant_mismatch_user_id.clone(),
+        ),
         final_reply_target: Some(reply_ref("reply-pref-corrupt-tenant-seed")),
         progress_target: None,
         approval_prompt_target: None,
@@ -450,8 +637,10 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     let (tenant_mismatch_key, tenant_mismatch_path) =
         put_preference_and_find_virtual_path(backend, store, tenant_mismatch_seed).await;
     let tenant_mismatch_record = CommunicationPreferenceRecord {
-        tenant_id: TenantId::new("tenant-outbound-corrupt-other").unwrap(),
-        user_id: tenant_mismatch_user_id,
+        scope: DeliveryDefaultScope::personal(
+            TenantId::new("tenant-outbound-corrupt-other").unwrap(),
+            tenant_mismatch_user_id,
+        ),
         final_reply_target: Some(reply_ref("reply-pref-corrupt-tenant")),
         progress_target: None,
         approval_prompt_target: None,
@@ -477,7 +666,7 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
     assert!(matches!(result, Err(OutboundError::Backend)));
 }
 
-async fn filesystem_store_retries_communication_preference_put_through_cas_conflict(
+async fn filesystem_store_rejects_communication_preference_put_cas_conflict(
     backend: &Arc<InMemoryBackend>,
 ) {
     let racing = Arc::new(VersionRacingBackend::new(Arc::clone(backend)));
@@ -493,8 +682,7 @@ async fn filesystem_store_retries_communication_preference_put_through_cas_confl
         .await;
 
     let record = CommunicationPreferenceRecord {
-        tenant_id: tenant_id.clone(),
-        user_id: user_id.clone(),
+        scope: DeliveryDefaultScope::personal(tenant_id.clone(), user_id.clone()),
         final_reply_target: Some(reply_ref("reply-pref-cas")),
         progress_target: Some(reply_ref("reply-pref-cas-progress")),
         approval_prompt_target: None,
@@ -503,21 +691,16 @@ async fn filesystem_store_retries_communication_preference_put_through_cas_confl
         updated_at: now(),
         updated_by: UserId::new("tenant-admin-outbound-cas").unwrap(),
     };
-    store
-        .put_communication_preference(record.clone())
-        .await
-        .unwrap();
+    let result = store.put_communication_preference(record).await;
+    assert!(matches!(result, Err(OutboundError::CasConflict)));
     assert_eq!(
-        store
-            .load_communication_preference(CommunicationPreferenceKey::new(tenant_id, user_id))
-            .await
-            .unwrap(),
-        Some(record)
+        load_preference_record(&store, CommunicationPreferenceKey::new(tenant_id, user_id),).await,
+        None
     );
     assert_eq!(racing.injected_count().await, 1);
 }
 
-async fn filesystem_store_retries_communication_preference_update_through_cas_conflict(
+async fn filesystem_store_rejects_communication_preference_update_cas_conflict(
     backend: &Arc<InMemoryBackend>,
 ) {
     let racing = Arc::new(VersionRacingBackend::new(Arc::clone(backend)));
@@ -527,8 +710,7 @@ async fn filesystem_store_retries_communication_preference_update_through_cas_co
     let user_id = UserId::new("user-outbound-update-cas").unwrap();
     let key = CommunicationPreferenceKey::new(tenant_id.clone(), user_id.clone());
     let record = CommunicationPreferenceRecord {
-        tenant_id,
-        user_id,
+        scope: DeliveryDefaultScope::personal(tenant_id, user_id),
         final_reply_target: Some(reply_ref("reply-pref-update-cas")),
         progress_target: Some(reply_ref("reply-pref-update-cas-progress")),
         approval_prompt_target: Some(reply_ref("reply-pref-update-cas-approval")),
@@ -548,41 +730,27 @@ async fn filesystem_store_retries_communication_preference_update_through_cas_co
         )
         .await;
 
-    let update_calls = Arc::new(AtomicUsize::new(0));
-    let calls = Arc::clone(&update_calls);
-    let updated = store
-        .update_communication_preference(
-            key.clone(),
-            Box::new(move |existing| {
-                calls.fetch_add(1, Ordering::SeqCst);
-                let existing = existing.expect("existing communication preference");
-                Ok(CommunicationPreferenceRecord {
-                    final_reply_target: Some(reply_ref("reply-pref-update-cas-final-updated")),
-                    updated_at: now(),
-                    updated_by: UserId::new("tenant-admin-outbound-update-cas-2").unwrap(),
-                    ..existing
-                })
-            }),
-        )
+    let existing = store
+        .load_communication_preference(key.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .expect("existing communication preference");
+    let updated = CommunicationPreferenceRecord {
+        final_reply_target: Some(reply_ref("reply-pref-update-cas-final-updated")),
+        updated_at: now(),
+        updated_by: UserId::new("tenant-admin-outbound-update-cas-2").unwrap(),
+        ..existing.record
+    };
+    let result = store
+        .write_communication_preference(WriteCommunicationPreferenceRequest {
+            record: updated,
+            expected_version: Some(existing.version),
+        })
+        .await;
 
-    assert_eq!(
-        updated.final_reply_target,
-        Some(reply_ref("reply-pref-update-cas-final-updated"))
-    );
-    assert_eq!(updated.progress_target, record.progress_target);
-    assert_eq!(
-        updated.approval_prompt_target,
-        record.approval_prompt_target
-    );
-    assert_eq!(updated.default_modality, record.default_modality);
+    assert!(matches!(result, Err(OutboundError::CasConflict)));
     assert_eq!(racing.injected_count().await, 1);
-    assert_eq!(update_calls.load(Ordering::SeqCst), 2);
-    assert_eq!(
-        store.load_communication_preference(key).await.unwrap(),
-        Some(updated)
-    );
+    assert_eq!(load_preference_record(&store, key).await, Some(record));
 }
 
 async fn durable_policy_subscription_delivery_flow(store: &impl OutboundStateStore) {

--- a/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/outbound_delivery_contract.rs
@@ -8,13 +8,15 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_outbound::{
     CommunicationDeliveryIntent, CommunicationDeliveryResolutionRequest, CommunicationModality,
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
-    InMemoryOutboundStateStore, LoadSubscriptionCursorRequest, OutboundDeliveryAttempt,
-    OutboundError, OutboundPolicyService, OutboundStateStore, ProjectionSubscriptionRecord,
-    ReplyTargetBindingClaim, ReplyTargetBindingValidator, RequestedOutboundContext,
-    RequestedOutboundKind, RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin,
-    SystemEventReasonCode, ThreadNotificationPolicy, ThreadProjectionAccessClaim,
-    ThreadProjectionAccessPolicy, ThreadProjectionAccessRequest, TriggerFireSlot, TriggerOriginRef,
-    TriggerSourceKind, UpdateDeliveryStatusRequest,
+    CommunicationPreferenceVersion, DeliveryDefaultScope, InMemoryOutboundStateStore,
+    LoadSubscriptionCursorRequest, OutboundDeliveryAttempt, OutboundError, OutboundPolicyService,
+    OutboundStateStore, ProjectionSubscriptionRecord, ReplyTargetBindingClaim,
+    ReplyTargetBindingValidator, RequestedOutboundContext, RequestedOutboundKind,
+    RunNotificationContext, RunNotificationEventKind, RunNotificationOrigin, SystemEventReasonCode,
+    ThreadNotificationPolicy, ThreadProjectionAccessClaim, ThreadProjectionAccessPolicy,
+    ThreadProjectionAccessRequest, TriggerFireSlot, TriggerOriginRef, TriggerSourceKind,
+    UpdateDeliveryStatusRequest, VersionedCommunicationPreferenceRecord,
+    WriteCommunicationPreferenceRequest,
 };
 use ironclaw_product_adapters::{
     AdapterInstallationId, AuthRequirement, DeliveryStatus, EgressCredentialHandle, EgressResponse,
@@ -124,16 +126,19 @@ impl ReplyTargetBindingValidator for FakeReplyTargetBindingValidator {
 
 #[derive(Default)]
 struct FakePreferenceRepository {
-    records: Mutex<HashMap<CommunicationPreferenceKey, CommunicationPreferenceRecord>>,
+    records: Mutex<HashMap<CommunicationPreferenceKey, VersionedCommunicationPreferenceRecord>>,
     load_calls: Mutex<usize>,
 }
 
 impl FakePreferenceRepository {
     fn put_record(&self, record: CommunicationPreferenceRecord) {
-        self.records
-            .lock()
-            .expect("preference lock")
-            .insert(record.key(), record);
+        self.records.lock().expect("preference lock").insert(
+            record.key(),
+            VersionedCommunicationPreferenceRecord {
+                record,
+                version: CommunicationPreferenceVersion::from_raw(1),
+            },
+        );
     }
 
     fn load_calls(&self) -> usize {
@@ -154,7 +159,7 @@ impl CommunicationPreferenceRepository for FakePreferenceRepository {
     async fn load_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         *self.load_calls.lock().expect("preference lock") += 1;
         Ok(self
             .records
@@ -164,19 +169,22 @@ impl CommunicationPreferenceRepository for FakePreferenceRepository {
             .cloned())
     }
 
-    async fn update_communication_preference(
+    async fn write_communication_preference(
         &self,
-        key: CommunicationPreferenceKey,
-        mut update: ironclaw_outbound::CommunicationPreferenceUpdate,
-    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
-        let existing = self.load_communication_preference(key.clone()).await?;
-        let record = update(existing)?;
-        if record.key() != key {
-            return Err(OutboundError::InvalidRequest {
-                reason: "communication preference update key mismatch",
-            });
-        }
-        self.put_communication_preference(record.clone()).await?;
+        request: WriteCommunicationPreferenceRequest,
+    ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
+        let mut records = self.records.lock().expect("preference lock");
+        let key = request.record.key();
+        let next_version = match (records.get(&key), request.expected_version) {
+            (None, None) => CommunicationPreferenceVersion::from_raw(1),
+            (Some(existing), Some(expected)) if existing.version == expected => expected.next(),
+            _ => return Err(OutboundError::CasConflict),
+        };
+        let record = VersionedCommunicationPreferenceRecord {
+            record: request.record,
+            version: next_version,
+        };
+        records.insert(key, record.clone());
         Ok(record)
     }
 }
@@ -263,18 +271,15 @@ impl CommunicationPreferenceRepository for StatusFailingOutboundStore {
     async fn load_communication_preference(
         &self,
         key: CommunicationPreferenceKey,
-    ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+    ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
         self.inner.load_communication_preference(key).await
     }
 
-    async fn update_communication_preference(
+    async fn write_communication_preference(
         &self,
-        key: CommunicationPreferenceKey,
-        update: ironclaw_outbound::CommunicationPreferenceUpdate,
-    ) -> Result<CommunicationPreferenceRecord, OutboundError> {
-        self.inner
-            .update_communication_preference(key, update)
-            .await
+        request: WriteCommunicationPreferenceRequest,
+    ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
+        self.inner.write_communication_preference(request).await
     }
 }
 
@@ -520,11 +525,12 @@ impl ProductAdapter for FailingAdapter {
 }
 
 fn scope() -> TurnScope {
-    TurnScope::new(
+    TurnScope::new_with_owner(
         TenantId::new("tenant-product-outbound").expect("valid tenant"),
         Some(AgentId::new("agent-product-outbound").expect("valid agent")),
         Some(ProjectId::new("project-product-outbound").expect("valid project")),
         ThreadId::new("thread-product-outbound").expect("valid thread"),
+        Some(UserId::new("user-product-outbound").expect("valid user")),
     )
 }
 
@@ -657,8 +663,7 @@ fn seed_preference(repo: &FakePreferenceRepository, scope: &TurnScope) {
 
 fn preference_record(scope: &TurnScope) -> CommunicationPreferenceRecord {
     CommunicationPreferenceRecord {
-        tenant_id: scope.tenant_id.clone(),
-        user_id: actor().user_id.clone(),
+        scope: DeliveryDefaultScope::personal(scope.tenant_id.clone(), actor().user_id.clone()),
         final_reply_target: Some(validated_reply_target()),
         progress_target: None,
         approval_prompt_target: None,

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use futures::future::try_join_all;
 use ironclaw_outbound::{
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
-    DeliveryDefaultScope, OutboundError, WriteCommunicationPreferenceRequest,
+    OutboundError, WriteCommunicationPreferenceRequest,
 };
 use ironclaw_product_workflow::{
     OutboundPreferencesProductFacade, RebornOutboundDeliveryModality,
@@ -175,6 +175,7 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
         request: RebornSetOutboundPreferencesRequest,
     ) -> Result<RebornOutboundPreferencesResponse, RebornServicesError> {
         let key = Self::key(&caller);
+        let scope = key.scope.clone();
         let resolved_final_reply_target = match request.final_reply_target_id.as_ref() {
             Some(target_id) => Some(self.resolve_final_reply_target(&caller, target_id).await?),
             None => None,
@@ -187,8 +188,6 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             .load_communication_preference(key)
             .await
             .map_err(map_outbound_repository_error)?;
-        let scope =
-            DeliveryDefaultScope::personal(caller.tenant_id.clone(), caller.user_id.clone());
         let user_id = caller.user_id.clone();
         let updated_at = Utc::now();
         let updated = self

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use futures::future::try_join_all;
 use ironclaw_outbound::{
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
-    OutboundError,
+    OutboundError, WriteCommunicationPreferenceRequest,
 };
 use ironclaw_product_workflow::{
     OutboundPreferencesProductFacade, RebornOutboundDeliveryModality,
@@ -165,7 +165,8 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             .load_communication_preference(Self::key(&caller))
             .await
             .map_err(map_outbound_repository_error)?;
-        self.response_for_record(&caller, record.as_ref()).await
+        self.response_for_record(&caller, record.as_ref().map(|record| &record.record))
+            .await
     }
 
     async fn set_outbound_preferences(
@@ -181,38 +182,43 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
         let final_reply_target = resolved_final_reply_target
             .as_ref()
             .map(|entry| entry.reply_target_binding_ref.clone());
-        let tenant_id = caller.tenant_id.clone();
+        let existing = self
+            .preferences
+            .load_communication_preference(key)
+            .await
+            .map_err(map_outbound_repository_error)?;
+        let scope =
+            CommunicationPreferenceKey::personal(caller.tenant_id.clone(), caller.user_id.clone())
+                .scope;
         let user_id = caller.user_id.clone();
         let updated_at = Utc::now();
         let updated = self
             .preferences
-            .update_communication_preference(
-                key,
-                Box::new(move |existing| {
-                    Ok(CommunicationPreferenceRecord {
-                        tenant_id: tenant_id.clone(),
-                        user_id: user_id.clone(),
-                        final_reply_target: final_reply_target.clone(),
-                        progress_target: existing
-                            .as_ref()
-                            .and_then(|record| record.progress_target.clone()),
-                        approval_prompt_target: existing
-                            .as_ref()
-                            .and_then(|record| record.approval_prompt_target.clone()),
-                        auth_prompt_target: existing
-                            .as_ref()
-                            .and_then(|record| record.auth_prompt_target.clone()),
-                        default_modality: existing
-                            .as_ref()
-                            .and_then(|record| record.default_modality),
-                        updated_at,
-                        updated_by: user_id.clone(),
-                    })
-                }),
-            )
+            .write_communication_preference(WriteCommunicationPreferenceRequest {
+                expected_version: existing.as_ref().map(|existing| existing.version),
+                record: CommunicationPreferenceRecord {
+                    scope,
+                    final_reply_target,
+                    progress_target: existing
+                        .as_ref()
+                        .and_then(|record| record.record.progress_target.clone()),
+                    approval_prompt_target: existing
+                        .as_ref()
+                        .and_then(|record| record.record.approval_prompt_target.clone()),
+                    auth_prompt_target: existing
+                        .as_ref()
+                        .and_then(|record| record.record.auth_prompt_target.clone()),
+                    default_modality: existing
+                        .as_ref()
+                        .and_then(|record| record.record.default_modality),
+                    updated_at,
+                    updated_by: user_id.clone(),
+                },
+            })
             .await
             .map_err(map_outbound_repository_error)?;
-        self.response_for_record(&caller, Some(&updated)).await
+        self.response_for_record(&caller, Some(&updated.record))
+            .await
     }
 
     async fn list_outbound_delivery_targets(
@@ -293,7 +299,8 @@ mod tests {
 
     use ironclaw_host_api::{TenantId, UserId};
     use ironclaw_outbound::{
-        CommunicationModality, CommunicationPreferenceRepository, InMemoryOutboundStateStore,
+        CommunicationModality, CommunicationPreferenceRepository, CommunicationPreferenceVersion,
+        DeliveryDefaultScope, InMemoryOutboundStateStore, VersionedCommunicationPreferenceRecord,
     };
 
     use super::*;
@@ -363,15 +370,14 @@ mod tests {
         async fn load_communication_preference(
             &self,
             _key: CommunicationPreferenceKey,
-        ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
             Err(OutboundError::Backend)
         }
 
-        async fn update_communication_preference(
+        async fn write_communication_preference(
             &self,
-            _key: CommunicationPreferenceKey,
-            _update: ironclaw_outbound::CommunicationPreferenceUpdate,
-        ) -> Result<CommunicationPreferenceRecord, OutboundError> {
+            _request: WriteCommunicationPreferenceRequest,
+        ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
             Err(OutboundError::Backend)
         }
     }
@@ -390,22 +396,56 @@ mod tests {
         async fn load_communication_preference(
             &self,
             _key: CommunicationPreferenceKey,
-        ) -> Result<Option<CommunicationPreferenceRecord>, OutboundError> {
+        ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
             Ok(None)
         }
 
-        async fn update_communication_preference(
+        async fn write_communication_preference(
             &self,
-            key: CommunicationPreferenceKey,
-            mut update: ironclaw_outbound::CommunicationPreferenceUpdate,
-        ) -> Result<CommunicationPreferenceRecord, OutboundError> {
-            let record = update(None)?;
-            if record.key() != key {
-                return Err(OutboundError::InvalidRequest {
-                    reason: "communication preference update key mismatch",
-                });
-            }
+            _request: WriteCommunicationPreferenceRequest,
+        ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
             Err(OutboundError::Backend)
+        }
+    }
+
+    struct CasConflictingPreferenceRepository;
+
+    #[async_trait]
+    impl CommunicationPreferenceRepository for CasConflictingPreferenceRepository {
+        async fn put_communication_preference(
+            &self,
+            _record: CommunicationPreferenceRecord,
+        ) -> Result<(), OutboundError> {
+            Err(OutboundError::CasConflict)
+        }
+
+        async fn load_communication_preference(
+            &self,
+            _key: CommunicationPreferenceKey,
+        ) -> Result<Option<VersionedCommunicationPreferenceRecord>, OutboundError> {
+            Ok(Some(VersionedCommunicationPreferenceRecord {
+                record: CommunicationPreferenceRecord {
+                    scope: DeliveryDefaultScope::personal(
+                        tenant("tenant-alpha"),
+                        user("user-alpha"),
+                    ),
+                    final_reply_target: None,
+                    progress_target: None,
+                    approval_prompt_target: None,
+                    auth_prompt_target: None,
+                    default_modality: None,
+                    updated_at: Utc::now(),
+                    updated_by: user("user-alpha"),
+                },
+                version: CommunicationPreferenceVersion::from_raw(1),
+            }))
+        }
+
+        async fn write_communication_preference(
+            &self,
+            _request: WriteCommunicationPreferenceRequest,
+        ) -> Result<VersionedCommunicationPreferenceRecord, OutboundError> {
+            Err(OutboundError::CasConflict)
         }
     }
 
@@ -519,12 +559,13 @@ mod tests {
             .expect("stored record");
         assert_eq!(
             stored
+                .record
                 .final_reply_target
                 .as_ref()
                 .map(|target| target.as_str()),
             Some("reply:slack-alpha")
         );
-        assert!(stored.default_modality.is_none());
+        assert!(stored.record.default_modality.is_none());
 
         let error = facade
             .set_outbound_preferences(
@@ -590,6 +631,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_preferences_maps_write_cas_conflict_to_conflict() {
+        let provider = Arc::new(FakeTargetProvider::default());
+        provider.insert(
+            "user-alpha",
+            target_entry("slack-alpha", "reply:slack-alpha", true),
+        );
+        let facade = RebornOutboundPreferencesFacade::new(
+            Arc::new(CasConflictingPreferenceRepository),
+            provider,
+        );
+
+        let error = facade
+            .set_outbound_preferences(
+                caller("tenant-alpha", "user-alpha"),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target_id("slack-alpha")),
+                },
+            )
+            .await
+            .expect_err("conflicting preference write");
+
+        assert_eq!(error.code, RebornServicesErrorCode::Conflict);
+        assert_eq!(error.kind, RebornServicesErrorKind::Conflict);
+        assert_eq!(error.status_code, 409);
+        assert!(!error.retryable);
+    }
+
+    #[tokio::test]
     async fn set_preferences_with_none_target_on_new_user_creates_empty_record() {
         let store = Arc::new(InMemoryOutboundStateStore::default());
         let provider = Arc::new(FakeTargetProvider::default());
@@ -614,11 +683,11 @@ mod tests {
             .await
             .expect("load stored record")
             .expect("stored record");
-        assert!(stored.final_reply_target.is_none());
-        assert!(stored.progress_target.is_none());
-        assert!(stored.approval_prompt_target.is_none());
-        assert!(stored.auth_prompt_target.is_none());
-        assert!(stored.default_modality.is_none());
+        assert!(stored.record.final_reply_target.is_none());
+        assert!(stored.record.progress_target.is_none());
+        assert!(stored.record.approval_prompt_target.is_none());
+        assert!(stored.record.auth_prompt_target.is_none());
+        assert!(stored.record.default_modality.is_none());
     }
 
     #[tokio::test]
@@ -689,9 +758,10 @@ mod tests {
             .await
             .expect("load stored record")
             .expect("stored record");
-        assert!(stored.final_reply_target.is_none());
+        assert!(stored.record.final_reply_target.is_none());
         assert_eq!(
             stored
+                .record
                 .progress_target
                 .as_ref()
                 .map(|target| target.as_str()),
@@ -699,6 +769,7 @@ mod tests {
         );
         assert_eq!(
             stored
+                .record
                 .approval_prompt_target
                 .as_ref()
                 .map(|target| target.as_str()),
@@ -706,12 +777,16 @@ mod tests {
         );
         assert_eq!(
             stored
+                .record
                 .auth_prompt_target
                 .as_ref()
                 .map(|target| target.as_str()),
             Some("reply:auth")
         );
-        assert_eq!(stored.default_modality, Some(CommunicationModality::Voice));
+        assert_eq!(
+            stored.record.default_modality,
+            Some(CommunicationModality::Voice)
+        );
     }
 
     #[tokio::test]
@@ -805,6 +880,7 @@ mod tests {
             .expect("stored record");
         assert_eq!(
             stored
+                .record
                 .final_reply_target
                 .as_ref()
                 .map(|target| target.as_str()),
@@ -910,8 +986,7 @@ mod tests {
     ) {
         store
             .put_communication_preference(CommunicationPreferenceRecord {
-                tenant_id: tenant(tenant_id),
-                user_id: user(user_id),
+                scope: DeliveryDefaultScope::personal(tenant(tenant_id), user(user_id)),
                 final_reply_target,
                 progress_target: Some(reply_ref("reply:progress")),
                 approval_prompt_target: Some(reply_ref("reply:approval")),

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use futures::future::try_join_all;
 use ironclaw_outbound::{
     CommunicationPreferenceKey, CommunicationPreferenceRecord, CommunicationPreferenceRepository,
-    OutboundError, WriteCommunicationPreferenceRequest,
+    DeliveryDefaultScope, OutboundError, WriteCommunicationPreferenceRequest,
 };
 use ironclaw_product_workflow::{
     OutboundPreferencesProductFacade, RebornOutboundDeliveryModality,
@@ -150,7 +150,7 @@ impl RebornOutboundPreferencesFacade {
     /// This key and target-provider scope intentionally share the same
     /// verified caller identity.
     fn key(caller: &WebUiAuthenticatedCaller) -> CommunicationPreferenceKey {
-        CommunicationPreferenceKey::new(caller.tenant_id.clone(), caller.user_id.clone())
+        CommunicationPreferenceKey::personal(caller.tenant_id.clone(), caller.user_id.clone())
     }
 }
 
@@ -188,8 +188,7 @@ impl OutboundPreferencesProductFacade for RebornOutboundPreferencesFacade {
             .await
             .map_err(map_outbound_repository_error)?;
         let scope =
-            CommunicationPreferenceKey::personal(caller.tenant_id.clone(), caller.user_id.clone())
-                .scope;
+            DeliveryDefaultScope::personal(caller.tenant_id.clone(), caller.user_id.clone());
         let user_id = caller.user_id.clone();
         let updated_at = Utc::now();
         let updated = self

--- a/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
+++ b/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
@@ -107,6 +107,10 @@ tracked follow-up.
   retry loops that blindly rewrite a complete preference record after a
   conflict; storage does not know whether the caller intended to merge or
   replace each slot.
+- Follow-up: extend `WriteCommunicationPreferenceRequest` with an explicit
+  expected key or expected scope before tightening mismatch classification.
+  Then `expected_key != record.key()` can fail as `InvalidRequest`, while true
+  stale-version or missing-row races continue to surface as `CasConflict`.
 - Add caller-level tests through the preference repository or product facade,
   not only helper-level tests.
 

--- a/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
+++ b/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
@@ -40,8 +40,8 @@ progress/projection payloads and non-text modality defaults remain deferred.
   capability flags.
 - Composition has a product-surface-neutral outbound preferences facade backed
   by `RebornLocalRuntimeServices::outbound_preferences`.
-- Current default preference storage is still user-scoped through
-  `CommunicationPreferenceRecord { tenant_id, user_id, ... }`.
+- Phase 2 introduces scoped preference storage through `DeliveryDefaultScope`
+  so defaults can be personal or shared-agent scoped.
 
 ## Implementation Snapshot
 
@@ -66,7 +66,7 @@ progress/projection payloads and non-text modality defaults remain deferred.
 
 ## Known Gaps Before Phase 2
 
-- There is no shared-agent default delivery scope yet on `main`.
+- Shared-agent default delivery scope is implemented in Phase 2.
 - There is no durable target-authority resolver for validating a saved Slack
   channel or DM target at trigger-fire time.
 - WebUI v2 still has no outbound preference/target HTTP routes.
@@ -98,6 +98,10 @@ tracked follow-up.
   version overlay so local/dev preference updates do not silently overwrite
   stale writes, but restart-safe or multi-process scoped defaults require a
   real versioned backend lock/transaction.
+- Phase 2 chooses the fail-closed outcome for communication preferences when a
+  filesystem backend cannot preserve versioned CAS. Any byte-only local/dev
+  overlay is a follow-up and must not silently fall back to unconditional
+  writes.
 - Add caller-level tests through the preference repository or product facade,
   not only helper-level tests.
 
@@ -200,6 +204,10 @@ tracked follow-up.
 - Trigger delivery derives `DeliveryDefaultScope` from the persisted run/agent
   ownership record, not from the trigger creator, last editor, last inbound
   sender, or a synthetic user id. Missing or ambiguous ownership fails closed.
+- Communication-preference writes must use versioned compare-and-swap. Byte-only
+  filesystem fallback must fail closed when it cannot preserve `Absent` or
+  `Version` expectations; unconditional `Any` writes are not acceptable for
+  preferences.
 - Preserve outbound ownership: target choice and validation stay under
   `ironclaw_outbound` / `OutboundPolicyService`; product adapters render only
   after policy approval.
@@ -373,8 +381,8 @@ Exit criteria now carried forward:
 
 ### Phase 2 — Scoped Default Model And Repository Contract
 
-Goal: add scoped delivery defaults so background trigger delivery can choose
-between personal DM defaults and shared-agent channel defaults.
+Goal: add scoped delivery defaults and make outbound resolution choose between
+personal DM defaults and shared-agent channel defaults.
 
 Current implementation approach:
 
@@ -383,15 +391,24 @@ Current implementation approach:
   branch as a semantic change, not a direct conflict-marker resolution.
 - Make the versioned scoped repository contract the only supported mutation
   path for this phase.
+- Treat `put_communication_preference` as an insert-only seed/create helper.
+  Existing preference mutation must read the scoped version or ETag and write
+  through the versioned repository contract.
 - Do not preserve `update_communication_preference` as a compatibility adapter.
   The old preference callback API has not launched, so current internal callers
   should migrate directly to read scoped preference, apply the update with the
   observed version or ETag, and write with CAS.
+- Do not add v1 filesystem path dual-read migration in this phase because the
+  outbound preference surface has not launched with durable production rows.
+  The record decoder still accepts legacy `{ tenant_id, user_id }` payloads
+  when such a row is loaded through the current storage path; live migration of
+  old path hashes is unnecessary unless a future rollout identifies launched
+  persisted rows.
 - Any temporary helper used during the phase must be private, must require the
   observed scoped version or ETag, and must be removed before Phase 2 exits.
 - Keep the PR scoped to outbound model, repository/storage behavior,
-  resolution behavior, and caller-level tests. WebUI routes, Slack target
-  authority, and trigger terminal E2E remain later phases.
+  default-resolution behavior, and caller-level tests. WebUI routes, Slack
+  target authority, and trigger terminal E2E remain later phases.
 
 Deliverables:
 
@@ -406,8 +423,8 @@ Deliverables:
 - Scoped preference reads return a version or ETag, and set/clear operations
   require the caller's expected version. Stale same-slot writes return a
   conflict instead of silently overwriting a newer default.
-- Migration or adapter plan for existing user-scoped
-  `CommunicationPreferenceRecord`.
+- Compatibility note for existing user-scoped `CommunicationPreferenceRecord`
+  payloads and whether a path-level migration is required.
 - Resolution tests proving:
   - personal runs use personal defaults
   - shared tenant-agent runs use shared-agent defaults
@@ -421,6 +438,8 @@ Exit criteria:
 
 - Trigger delivery no longer assumes every default is tenant/user scoped.
 - Shared-agent defaults are not faked through a synthetic user id.
+- Outbound resolution consults shared-agent defaults for ownerless shared-agent
+  scopes and personal defaults for explicitly owned scopes.
 - Personal preference behavior remains backward compatible.
 - CAS fallback behavior fails closed when versioned CAS is unsupported;
   unconditional `Any` writes are not an acceptable fallback.

--- a/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
+++ b/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
@@ -102,11 +102,22 @@ tracked follow-up.
   filesystem backend cannot preserve versioned CAS. Any byte-only local/dev
   overlay is a follow-up and must not silently fall back to unconditional
   writes.
+- Phase 2 intentionally preserves explicit `CasConflict` results for valid
+  versioned preference write races. Do not reintroduce hidden storage-level
+  retry loops that blindly rewrite a complete preference record after a
+  conflict; storage does not know whether the caller intended to merge or
+  replace each slot.
 - Add caller-level tests through the preference repository or product facade,
   not only helper-level tests.
 
 ### Product API Follow-Ups
 
+- Add conflict handling for outbound preference updates in the product API/UI
+  phase. Recommended first behavior: surface a stable conflict response that
+  tells the client to reload the latest preference before retrying. If the UI
+  needs lower-friction saves later, add a bounded product-facade retry that
+  reloads the latest record and reapplies only the requested field, with tests
+  for same-field conflicts and disjoint-field preservation.
 - Expand public modality support in a dedicated API phase before surfacing
   non-text defaults. The outbound repository can store more modalities than
   the current product response DTO intentionally exposes.


### PR DESCRIPTION
## Summary

Implements Phase 2 of the trigger delivery default outbound plan: scoped delivery defaults with versioned preference writes and default-resolution behavior for personal versus shared-agent runs.

This changes outbound preferences from a tenant/user-only record into a scoped model:

- `DeliveryDefaultScope::Personal { tenant_id, user_id }`
- `DeliveryDefaultScope::SharedAgent { tenant_id, agent_id, project_id }`

Triggered outbound resolution now chooses:

- explicit owner scope -> personal default
- ownerless agent scope -> shared-agent default
- ownerless/agentless legacy scope -> actor personal fallback

The PR keeps WebUI routes, Slack target authority, and trigger terminal E2E wiring out of scope; those remain later phases in the delivery plan.

## What changed

### Scoped preference model

- Adds `DeliveryDefaultScope`, scoped `CommunicationPreferenceKey`, `CommunicationPreferenceVersion`, `VersionedCommunicationPreferenceRecord`, and `WriteCommunicationPreferenceRequest`.
- Replaces the old callback update API with explicit read-version/write-version repository semantics.
- Keeps `put_communication_preference` as an insert-only create helper; existing mutations must call `write_communication_preference` with the observed version.
- Allows legacy `{ tenant_id, user_id }` payloads to decode as personal scoped defaults when loaded through the current storage path.

### Store behavior

- Updates in-memory and filesystem preference repositories to return versioned records.
- Enforces CAS behavior for preference writes:
  - `expected_version: None` creates only when absent.
  - matching expected version updates and increments the version.
  - missing, duplicate, stale, or mismatched versions return `CasConflict`.
- Keeps communication-preference filesystem writes strict CAS. Byte-only backends that cannot preserve `Absent` or `Version` expectations fail closed rather than falling back to unconditional `Any` writes.
- Uses a v2 scoped hashed preference path instead of synthetic user ids for shared-agent defaults.

### Resolution behavior

- Triggered final replies and non-final run notifications now resolve defaults from the scoped preference key.
- Personal runs use explicit owner defaults.
- Shared-agent ownerless runs use shared-agent defaults.
- Live source route behavior is unchanged: source-route final/progress/status delivery keeps the observed source target, while prompted trigger-from-source-route events still use the configured prompt defaults.

### Product facade and tests

- Migrates `RebornOutboundPreferencesFacade` to load the current version, preserve non-final slots, and write through the versioned repository contract.
- Updates product-workflow and composition test repositories to the new versioned contract.
- Updates the delivery plan doc to reflect current Phase 2 behavior and explicit deferrals.

## Intentional deferrals

These are intentionally not implemented in this PR:

- WebUI v2 outbound preference routes.
- Automations Delivery panel.
- Slack target authority resolver and target inventory.
- Slack DM/channel target provisioning and validation.
- Trigger terminal completion E2E wiring.
- v1 filesystem path dual-read migration. The outbound preference surface has not launched with durable production rows; legacy row payload shape is still accepted if loaded through the current path.
- Byte-only local/dev CAS overlay. Preference writes currently require a backend that can preserve versioned CAS or fail closed.

## Verification

Ran after rebasing onto latest `origin/main`:

- `cargo test -p ironclaw_outbound`
- `cargo test -p ironclaw_product_workflow --test outbound_delivery_contract`
- `cargo test -p ironclaw_reborn_composition outbound_preferences`
- `git diff --check HEAD~1..HEAD`

Note: `ironclaw_reborn_composition` still emits the existing `clear_local_runtime_for_test` dead-code warning during test builds.
