### PR TITLE
feat(llm): NormalizingProvider Layer-3 decorator (RC3/M9 Phase C)

### DIFF
--- a/crates/ironclaw_llm/CLAUDE.md
+++ b/crates/ironclaw_llm/CLAUDE.md
@@ -36,6 +36,7 @@ Multi-provider LLM integration with circuit breaker, retry, failover, and respon
 | `runtime.rs` | `SwappableLlmProvider` + `LlmReloadHandle` for hot-reloading the provider chain on settings change |
 | `registry.rs` | Provider registry (`ProviderDefinition`, `ProviderProtocol`); resolves backend strings to clients |
 | `resolution.rs` | Full `LlmConfig` resolution for composition roots that select from `providers.json` and need dedicated providers plus the shared provider chain |
+| `normalizing.rs` | `NormalizingProvider` — Layer-3 shape-invariant decorator (RC1/M1); enforces non-empty `tool_calls` → `FinishReason::ToolUse`, closing Bedrock `Unknown` quirk |
 | `tool_args.rs` | Shared sub-step primitives for provider tool-call parsing: fail-loud and silent-fallback JSON arg parsing, ordered reasoning-field probe (Layer 2 of RC3/M9 framework) |
 | `tool_schema.rs` | Tool schema normalization policies (`FlattenOnly` for NearAI, strict OpenAI for `RigAdapter` / Codex) |
 | `transcription/{mod,openai,chat_completions}.rs` | Audio transcription pipeline (Whisper / chat-completions back-ends) |
@@ -232,6 +233,7 @@ Uses the Responses API at `chatgpt.com/backend-api/codex/responses` with ChatGPT
 
 ```
 Raw provider
+  → NormalizingProvider     (RC1/M1: non-empty tool_calls → ToolUse; always applied)
   → RetryProvider           (per-provider backoff; wraps both primary and fallback)
   → SmartRoutingProvider    (cheap/primary split when NEARAI_CHEAP_MODEL is set)
   → FailoverProvider        (fallback model; only when NEARAI_FALLBACK_MODEL is set)

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -840,6 +840,14 @@ fn create_cheap_provider_for_backend(
     Ok(Some(provider))
 }
 
+/// Wrap a raw provider in `NormalizingProvider`. Single source of truth
+/// for the Layer-3 wrap — every raw provider entering the decorator
+/// stack MUST pass through this helper. Adding new raw-provider paths?
+/// Call this helper, not `NormalizingProvider::new` directly.
+fn normalized(p: Arc<dyn LlmProvider>) -> Arc<dyn LlmProvider> {
+    Arc::new(NormalizingProvider::new(p))
+}
+
 /// Build the full LLM provider chain with all configured wrappers.
 ///
 /// Applies decorators in this order:
@@ -886,13 +894,8 @@ async fn build_provider_chain_components_with_options(
     };
     tracing::debug!("LLM provider initialized: {}", raw.model_name());
 
-    // 0. Normalize — Layer 3 shape-invariant decorator. Sits at the innermost
-    // position so every downstream decorator (retry, smart routing, failover,
-    // circuit breaker, cache, recording) observes a canonical
-    // `ToolCompletionResponse` regardless of which provider produced it.
-    // Closes RC1/M1 (Bedrock dropping tool calls on `FinishReason::Unknown`)
-    // universally rather than per-provider.
-    let llm: Arc<dyn LlmProvider> = Arc::new(NormalizingProvider::new(raw));
+    // 0. Normalize — Layer-3 shape-invariant decorator (see `normalized()`).
+    let llm: Arc<dyn LlmProvider> = normalized(raw);
 
     // 1. Retry — uses top-level LlmConfig fields (resolved from LLM_* env vars
     // with fallback to NEARAI_* for backward compatibility).
@@ -919,9 +922,7 @@ async fn build_provider_chain_components_with_options(
                     config.backend
                 ),
             })?;
-        // Normalize the cheap provider at the innermost position too, mirroring
-        // the primary chain — every cheap-path decorator must see canonical shape.
-        let cheap: Arc<dyn LlmProvider> = Arc::new(NormalizingProvider::new(cheap));
+        let cheap: Arc<dyn LlmProvider> = normalized(cheap);
         let cheap: Arc<dyn LlmProvider> = if retry_config.max_retries > 0 {
             Arc::new(RetryProvider::new(cheap, retry_config.clone()))
         } else {
@@ -963,8 +964,7 @@ async fn build_provider_chain_components_with_options(
             fallback = %fallback.model_name(),
             "LLM failover enabled"
         );
-        // Normalize the fallback raw provider at the innermost position too.
-        let fallback: Arc<dyn LlmProvider> = Arc::new(NormalizingProvider::new(fallback));
+        let fallback: Arc<dyn LlmProvider> = normalized(fallback);
         let fallback: Arc<dyn LlmProvider> = if retry_config.max_retries > 0 {
             Arc::new(RetryProvider::new(fallback, retry_config.clone()))
         } else {
@@ -1016,11 +1016,8 @@ async fn build_provider_chain_components_with_options(
     };
 
     // Standalone cheap LLM for heartbeat/evaluation (not part of the chain).
-    // Normalize at innermost position too — callers that bypass the main chain
-    // (heartbeat, evaluation) still benefit from shape-invariant tool_calls.
     let cheap_llm = if include_standalone_cheap {
-        create_cheap_llm_provider(config, session)?
-            .map(|p| Arc::new(NormalizingProvider::new(p)) as Arc<dyn LlmProvider>)
+        create_cheap_llm_provider(config, session)?.map(normalized)
     } else {
         None
     };

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -26,6 +26,7 @@ mod github_copilot;
 pub(crate) mod github_copilot_auth;
 pub mod host;
 pub mod nearai_chat;
+pub mod normalizing;
 pub mod openai_codex_provider;
 pub(crate) mod openai_codex_session;
 mod provider;
@@ -74,6 +75,7 @@ pub use host::{
     SharedSessionSecrets,
 };
 pub use nearai_chat::{DEFAULT_MODEL, ModelInfo, NearAiChatProvider, default_models};
+pub use normalizing::NormalizingProvider;
 pub use openai_codex_provider::OpenAiCodexProvider;
 pub use openai_codex_session::{DeviceCodeStart, OpenAiCodexSessionManager};
 pub use provider::sanitize_tool_messages;
@@ -877,12 +879,20 @@ async fn build_provider_chain_components_with_options(
     session: Arc<SessionManager>,
     include_standalone_cheap: bool,
 ) -> Result<ProviderChainComponents, LlmError> {
-    let llm: Arc<dyn LlmProvider> = if config.backend == "openai_codex" {
+    let raw: Arc<dyn LlmProvider> = if config.backend == "openai_codex" {
         create_openai_codex_provider(config).await?
     } else {
         create_llm_provider(config, session.clone()).await?
     };
-    tracing::debug!("LLM provider initialized: {}", llm.model_name());
+    tracing::debug!("LLM provider initialized: {}", raw.model_name());
+
+    // 0. Normalize — Layer 3 shape-invariant decorator. Sits at the innermost
+    // position so every downstream decorator (retry, smart routing, failover,
+    // circuit breaker, cache, recording) observes a canonical
+    // `ToolCompletionResponse` regardless of which provider produced it.
+    // Closes RC1/M1 (Bedrock dropping tool calls on `FinishReason::Unknown`)
+    // universally rather than per-provider.
+    let llm: Arc<dyn LlmProvider> = Arc::new(NormalizingProvider::new(raw));
 
     // 1. Retry — uses top-level LlmConfig fields (resolved from LLM_* env vars
     // with fallback to NEARAI_* for backward compatibility).
@@ -909,6 +919,9 @@ async fn build_provider_chain_components_with_options(
                     config.backend
                 ),
             })?;
+        // Normalize the cheap provider at the innermost position too, mirroring
+        // the primary chain — every cheap-path decorator must see canonical shape.
+        let cheap: Arc<dyn LlmProvider> = Arc::new(NormalizingProvider::new(cheap));
         let cheap: Arc<dyn LlmProvider> = if retry_config.max_retries > 0 {
             Arc::new(RetryProvider::new(cheap, retry_config.clone()))
         } else {
@@ -950,6 +963,8 @@ async fn build_provider_chain_components_with_options(
             fallback = %fallback.model_name(),
             "LLM failover enabled"
         );
+        // Normalize the fallback raw provider at the innermost position too.
+        let fallback: Arc<dyn LlmProvider> = Arc::new(NormalizingProvider::new(fallback));
         let fallback: Arc<dyn LlmProvider> = if retry_config.max_retries > 0 {
             Arc::new(RetryProvider::new(fallback, retry_config.clone()))
         } else {
@@ -1000,9 +1015,12 @@ async fn build_provider_chain_components_with_options(
         llm
     };
 
-    // Standalone cheap LLM for heartbeat/evaluation (not part of the chain)
+    // Standalone cheap LLM for heartbeat/evaluation (not part of the chain).
+    // Normalize at innermost position too — callers that bypass the main chain
+    // (heartbeat, evaluation) still benefit from shape-invariant tool_calls.
     let cheap_llm = if include_standalone_cheap {
         create_cheap_llm_provider(config, session)?
+            .map(|p| Arc::new(NormalizingProvider::new(p)) as Arc<dyn LlmProvider>)
     } else {
         None
     };

--- a/crates/ironclaw_llm/src/normalizing.rs
+++ b/crates/ironclaw_llm/src/normalizing.rs
@@ -7,8 +7,11 @@
 //! reasoning-field names, arg-parse policy) stay in each provider file.
 //!
 //! Current invariants:
-//! - If response.tool_calls is non-empty and finish_reason is not ToolUse,
-//!   set finish_reason = ToolUse. Closes audit RC1/M1 universally.
+//! - If response.tool_calls is non-empty and finish_reason is one of the
+//!   ambiguous-but-tool-using variants (`Unknown` or `Stop`), upgrade
+//!   finish_reason to `ToolUse`. `Length` (truncation) and `ContentFilter`
+//!   (policy stop) are deliberately preserved — they carry meaningful error
+//!   classification that downstream callers rely on. Closes audit RC1/M1.
 
 use std::sync::Arc;
 
@@ -40,12 +43,25 @@ impl NormalizingProvider {
 
 /// Enforce Class A shape invariants on a decoded `ToolCompletionResponse`.
 ///
-/// Invariant RC1/M1: if tool_calls is non-empty and finish_reason is not
-/// `ToolUse`, force it to `ToolUse`. Some providers (notably Bedrock) drop
-/// the tool-use stop reason on certain response shapes; this closes the gap
-/// universally once rather than in each individual provider.
+/// Invariant RC1/M1: if `tool_calls` is non-empty AND `finish_reason` is one
+/// of the ambiguous-but-tool-using variants (`Unknown` or `Stop`), upgrade
+/// `finish_reason` to `ToolUse`. `Length` (truncation) and `ContentFilter`
+/// (policy stop) are deliberately preserved — they carry meaningful error
+/// classification that downstream callers (e.g. `agentic_loop`,
+/// `model_gateway`) rely on to discard malformed truncated tool args or
+/// surface policy-denied calls.
 fn normalize_shape(resp: &mut ToolCompletionResponse) {
-    if !resp.tool_calls.is_empty() && resp.finish_reason != FinishReason::ToolUse {
+    if !resp.tool_calls.is_empty()
+        && matches!(
+            resp.finish_reason,
+            FinishReason::Unknown | FinishReason::Stop
+        )
+    {
+        tracing::debug!(
+            tool_call_count = resp.tool_calls.len(),
+            "NormalizingProvider rewrote finish_reason to ToolUse (was {:?})",
+            resp.finish_reason,
+        );
         resp.finish_reason = FinishReason::ToolUse;
     }
 }
@@ -298,5 +314,89 @@ mod tests {
             "complete_with_tools must not be called"
         );
         assert_eq!(resp.content, "delegated");
+    }
+
+    /// FinishReason::Length carries token-cap-truncation semantics. The
+    /// normalizer must preserve it even with non-empty tool_calls, because
+    /// truncated args are likely incomplete and downstream callers
+    /// (agentic_loop.rs:317, model_gateway.rs:1033) need the original finish
+    /// to discard the call or surface BudgetExceeded.
+    #[tokio::test]
+    async fn does_not_rewrite_length_finish_with_calls() {
+        let stub = Arc::new(StubProvider::new(
+            FinishReason::Length,
+            vec![make_tool_call()],
+        ));
+        let provider = NormalizingProvider::new(stub);
+
+        let resp = provider
+            .complete_with_tools(make_tool_request())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.finish_reason, FinishReason::Length);
+        assert_eq!(resp.tool_calls.len(), 1);
+    }
+
+    /// FinishReason::ContentFilter means a safety stop. The normalizer must
+    /// preserve it so policy-denied tool calls surface through the right
+    /// downstream branch instead of being executed.
+    #[tokio::test]
+    async fn does_not_rewrite_content_filter_finish_with_calls() {
+        let stub = Arc::new(StubProvider::new(
+            FinishReason::ContentFilter,
+            vec![make_tool_call()],
+        ));
+        let provider = NormalizingProvider::new(stub);
+
+        let resp = provider
+            .complete_with_tools(make_tool_request())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.finish_reason, FinishReason::ContentFilter);
+        assert_eq!(resp.tool_calls.len(), 1);
+    }
+
+    /// `?` on inner.complete_with_tools must forward Err unchanged — the
+    /// normalizer is a shape-fixup, not an error interceptor.
+    #[tokio::test]
+    async fn propagates_inner_error_on_complete_with_tools() {
+        struct ErrorStub;
+
+        #[async_trait]
+        impl LlmProvider for ErrorStub {
+            fn model_name(&self) -> &str {
+                "error-stub"
+            }
+
+            fn cost_per_token(&self) -> (Decimal, Decimal) {
+                (Decimal::ZERO, Decimal::ZERO)
+            }
+
+            async fn complete(&self, _: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+                unimplemented!()
+            }
+
+            async fn complete_with_tools(
+                &self,
+                _: ToolCompletionRequest,
+            ) -> Result<ToolCompletionResponse, LlmError> {
+                Err(LlmError::RequestFailed {
+                    provider: "error-stub".to_string(),
+                    reason: "synthetic test failure".to_string(),
+                })
+            }
+        }
+
+        let provider = NormalizingProvider::new(Arc::new(ErrorStub));
+        let err = provider
+            .complete_with_tools(make_tool_request())
+            .await
+            .expect_err("expected synthetic RequestFailed");
+        assert!(
+            matches!(err, LlmError::RequestFailed { .. }),
+            "expected RequestFailed, got {err:?}"
+        );
     }
 }

--- a/crates/ironclaw_llm/src/normalizing.rs
+++ b/crates/ironclaw_llm/src/normalizing.rs
@@ -1,0 +1,302 @@
+//! NormalizingProvider — Layer 3 shape-invariant decorator.
+//!
+//! Sits between any LlmProvider and downstream consumers (RetryProvider,
+//! SmartRoutingProvider, etc.). Enforces Class A invariants on the decoded
+//! ToolCompletionResponse — invariants that hold for every provider
+//! regardless of wire format. Class B quirks (wire-decode dialects,
+//! reasoning-field names, arg-parse policy) stay in each provider file.
+//!
+//! Current invariants:
+//! - If response.tool_calls is non-empty and finish_reason is not ToolUse,
+//!   set finish_reason = ToolUse. Closes audit RC1/M1 universally.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+
+use crate::error::LlmError;
+use crate::provider::{
+    CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ModelMetadata,
+    ToolCompletionRequest, ToolCompletionResponse,
+};
+
+/// Decorator that enforces Class A shape invariants on every
+/// `ToolCompletionResponse` returned by the wrapped provider.
+///
+/// Construct via `NormalizingProvider::new(inner)` where `inner` is any
+/// `Arc<dyn LlmProvider>`. All methods delegate to the inner provider;
+/// only `complete_with_tools` applies normalization before returning.
+pub struct NormalizingProvider {
+    inner: Arc<dyn LlmProvider>,
+}
+
+impl NormalizingProvider {
+    /// Wrap an existing provider with shape-invariant normalization.
+    pub fn new(inner: Arc<dyn LlmProvider>) -> Self {
+        Self { inner }
+    }
+}
+
+/// Enforce Class A shape invariants on a decoded `ToolCompletionResponse`.
+///
+/// Invariant RC1/M1: if tool_calls is non-empty and finish_reason is not
+/// `ToolUse`, force it to `ToolUse`. Some providers (notably Bedrock) drop
+/// the tool-use stop reason on certain response shapes; this closes the gap
+/// universally once rather than in each individual provider.
+fn normalize_shape(resp: &mut ToolCompletionResponse) {
+    if !resp.tool_calls.is_empty() && resp.finish_reason != FinishReason::ToolUse {
+        resp.finish_reason = FinishReason::ToolUse;
+    }
+}
+
+#[async_trait]
+impl LlmProvider for NormalizingProvider {
+    fn model_name(&self) -> &str {
+        self.inner.model_name()
+    }
+
+    fn cost_per_token(&self) -> (Decimal, Decimal) {
+        self.inner.cost_per_token()
+    }
+
+    fn cache_write_multiplier(&self) -> Decimal {
+        self.inner.cache_write_multiplier()
+    }
+
+    fn cache_read_discount(&self) -> Decimal {
+        self.inner.cache_read_discount()
+    }
+
+    async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        self.inner.complete(request).await
+    }
+
+    async fn complete_with_tools(
+        &self,
+        request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        let mut resp = self.inner.complete_with_tools(request).await?;
+        normalize_shape(&mut resp);
+        Ok(resp)
+    }
+
+    async fn list_models(&self) -> Result<Vec<String>, LlmError> {
+        self.inner.list_models().await
+    }
+
+    async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
+        self.inner.model_metadata().await
+    }
+
+    fn effective_model_name(&self, requested_model: Option<&str>) -> String {
+        self.inner.effective_model_name(requested_model)
+    }
+
+    fn active_model_name(&self) -> String {
+        self.inner.active_model_name()
+    }
+
+    fn set_model(&self, model: &str) -> Result<(), LlmError> {
+        self.inner.set_model(model)
+    }
+
+    fn calculate_cost(&self, input_tokens: u32, output_tokens: u32) -> Decimal {
+        self.inner.calculate_cost(input_tokens, output_tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+    use async_trait::async_trait;
+    use rust_decimal::Decimal;
+
+    use super::NormalizingProvider;
+    use crate::error::LlmError;
+    use crate::provider::{
+        CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCall,
+        ToolCompletionRequest, ToolCompletionResponse,
+    };
+
+    /// Minimal stub that returns a pre-baked `ToolCompletionResponse`.
+    struct StubProvider {
+        tool_response: ToolCompletionResponse,
+        complete_called: AtomicBool,
+        tool_call_count: AtomicU32,
+    }
+
+    impl StubProvider {
+        fn new(finish_reason: FinishReason, tool_calls: Vec<ToolCall>) -> Self {
+            Self {
+                tool_response: ToolCompletionResponse {
+                    content: None,
+                    tool_calls,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    finish_reason,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                    reasoning: None,
+                },
+                complete_called: AtomicBool::new(false),
+                tool_call_count: AtomicU32::new(0),
+            }
+        }
+
+        fn complete_was_called(&self) -> bool {
+            self.complete_called.load(Ordering::Relaxed)
+        }
+
+        fn tool_calls_made(&self) -> u32 {
+            self.tool_call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for StubProvider {
+        fn model_name(&self) -> &str {
+            "stub"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            self.complete_called.store(true, Ordering::Relaxed);
+            Ok(CompletionResponse {
+                content: "delegated".to_string(),
+                input_tokens: 0,
+                output_tokens: 0,
+                finish_reason: FinishReason::Stop,
+                reasoning: None,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _request: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            self.tool_call_count.fetch_add(1, Ordering::Relaxed);
+            Ok(self.tool_response.clone())
+        }
+    }
+
+    fn make_tool_call() -> ToolCall {
+        ToolCall {
+            name: "x".into(),
+            id: "1".into(),
+            ..Default::default()
+        }
+    }
+
+    fn make_tool_request() -> ToolCompletionRequest {
+        ToolCompletionRequest::new(vec![crate::ChatMessage::user("hi")], vec![])
+    }
+
+    fn make_completion_request() -> CompletionRequest {
+        CompletionRequest::new(vec![crate::ChatMessage::user("hi")])
+    }
+
+    /// RC1/M1: Bedrock (and similar providers) can return FinishReason::Unknown
+    /// even when tool_calls are present. The normalizer must upgrade it to ToolUse.
+    #[tokio::test]
+    async fn normalizes_unknown_finish_with_calls_to_tool_use() {
+        let stub = Arc::new(StubProvider::new(
+            FinishReason::Unknown,
+            vec![make_tool_call()],
+        ));
+        let provider = NormalizingProvider::new(stub);
+
+        let resp = provider
+            .complete_with_tools(make_tool_request())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.finish_reason, FinishReason::ToolUse);
+        assert_eq!(resp.tool_calls.len(), 1);
+    }
+
+    /// Stop finish with non-empty calls must also be upgraded to ToolUse.
+    #[tokio::test]
+    async fn normalizes_stop_finish_with_calls_to_tool_use() {
+        let stub = Arc::new(StubProvider::new(
+            FinishReason::Stop,
+            vec![make_tool_call()],
+        ));
+        let provider = NormalizingProvider::new(stub);
+
+        let resp = provider
+            .complete_with_tools(make_tool_request())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.finish_reason, FinishReason::ToolUse);
+    }
+
+    /// When finish_reason is already ToolUse and calls are present,
+    /// the normalizer must not change it (idempotent).
+    #[tokio::test]
+    async fn does_not_touch_tool_use_already_set() {
+        let stub = Arc::new(StubProvider::new(
+            FinishReason::ToolUse,
+            vec![make_tool_call()],
+        ));
+        let provider = NormalizingProvider::new(stub);
+
+        let resp = provider
+            .complete_with_tools(make_tool_request())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.finish_reason, FinishReason::ToolUse);
+    }
+
+    /// When tool_calls is empty, the normalizer must leave finish_reason alone
+    /// even if it is Unknown (only non-empty calls trigger the upgrade).
+    #[tokio::test]
+    async fn does_not_touch_when_no_calls() {
+        let stub = Arc::new(StubProvider::new(FinishReason::Unknown, vec![]));
+        let provider = NormalizingProvider::new(stub);
+
+        let resp = provider
+            .complete_with_tools(make_tool_request())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.finish_reason, FinishReason::Unknown);
+        assert!(resp.tool_calls.is_empty());
+    }
+
+    /// complete() (not complete_with_tools) must delegate unchanged —
+    /// the normalizer only operates on the tool path.
+    #[tokio::test]
+    async fn passes_through_complete_unchanged() {
+        let stub = Arc::new(StubProvider::new(FinishReason::Unknown, vec![]));
+        let provider = NormalizingProvider::new(stub.clone());
+
+        assert!(!stub.complete_was_called());
+        assert_eq!(stub.tool_calls_made(), 0);
+
+        let resp = provider.complete(make_completion_request()).await.unwrap();
+
+        assert!(
+            stub.complete_was_called(),
+            "complete() must delegate to inner"
+        );
+        assert_eq!(
+            stub.tool_calls_made(),
+            0,
+            "complete_with_tools must not be called"
+        );
+        assert_eq!(resp.content, "delegated");
+    }
+}

--- a/crates/ironclaw_llm/tests/normalizing_integration.rs
+++ b/crates/ironclaw_llm/tests/normalizing_integration.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use rust_decimal::Decimal;
 
+use ironclaw_llm::NormalizingProvider;
 use ironclaw_llm::error::LlmError;
-use ironclaw_llm::normalizing::NormalizingProvider;
 use ironclaw_llm::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCall,
     ToolCompletionRequest, ToolCompletionResponse,

--- a/crates/ironclaw_llm/tests/normalizing_integration.rs
+++ b/crates/ironclaw_llm/tests/normalizing_integration.rs
@@ -1,0 +1,96 @@
+//! Integration test for `NormalizingProvider` — RC1/M1 closure.
+//!
+//! Verifies that when an inner provider returns a `ToolCompletionResponse`
+//! with `finish_reason = FinishReason::Unknown` and a non-empty `tool_calls`
+//! list, the `NormalizingProvider` decorator forces `finish_reason` to
+//! `FinishReason::ToolUse`.
+//!
+//! This closes audit RC1/M1 (Bedrock returning `Unknown` with tool calls).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+
+use ironclaw_llm::error::LlmError;
+use ironclaw_llm::normalizing::NormalizingProvider;
+use ironclaw_llm::{
+    ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCall,
+    ToolCompletionRequest, ToolCompletionResponse,
+};
+
+// ── Stub ────────────────────────────────────────────────────────────────────
+//
+// `StubLlm` in `ironclaw_llm::testing` always returns `FinishReason::Stop`
+// with an empty `tool_calls` vec and cannot be reconfigured for the specific
+// (Unknown + non-empty tool_calls) scenario that RC1 exercises. A minimal
+// one-shot inline stub is therefore used here.
+
+/// Returns a fixed `ToolCompletionResponse` with `finish_reason = Unknown`
+/// and one tool call — simulating Bedrock's misbehaving wire response.
+struct BedrockUnknownStub;
+
+#[async_trait]
+impl LlmProvider for BedrockUnknownStub {
+    fn model_name(&self) -> &str {
+        "bedrock-unknown-stub"
+    }
+
+    fn cost_per_token(&self) -> (Decimal, Decimal) {
+        (Decimal::ZERO, Decimal::ZERO)
+    }
+
+    async fn complete(&self, _request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        unimplemented!("only complete_with_tools is exercised by this test")
+    }
+
+    async fn complete_with_tools(
+        &self,
+        _request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        Ok(ToolCompletionResponse {
+            content: None,
+            tool_calls: vec![ToolCall {
+                id: "1".to_string(),
+                name: "echo".to_string(),
+                arguments: serde_json::json!({}),
+                reasoning: None,
+                signature: None,
+                arguments_parse_error: None,
+            }],
+            input_tokens: 10,
+            output_tokens: 5,
+            // Bedrock (and similar providers) sometimes emit Unknown here even
+            // when tool_calls is non-empty — that is the bug RC1/M1 fixes.
+            finish_reason: FinishReason::Unknown,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning: None,
+        })
+    }
+}
+
+// ── Test ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn bedrock_unknown_finish_with_calls_routes_through_normalizing() {
+    let stub: Arc<dyn LlmProvider> = Arc::new(BedrockUnknownStub);
+    let wrapped = NormalizingProvider::new(stub);
+
+    let request = ToolCompletionRequest::new(vec![ChatMessage::user("ping")], vec![]);
+
+    let resp = wrapped
+        .complete_with_tools(request)
+        .await
+        .expect("complete_with_tools should succeed");
+
+    // RC1/M1 invariant: non-empty tool_calls must always produce ToolUse.
+    assert!(
+        matches!(resp.finish_reason, FinishReason::ToolUse),
+        "expected FinishReason::ToolUse, got {:?}",
+        resp.finish_reason,
+    );
+    assert_eq!(resp.tool_calls.len(), 1, "tool call must be preserved");
+    assert_eq!(resp.tool_calls[0].name, "echo");
+    assert_eq!(resp.tool_calls[0].id, "1");
+}


### PR DESCRIPTION
## Summary

- Adds `NormalizingProvider<P>` decorator at the innermost position of `build_provider_chain` — wraps primary, cheap, fallback, and standalone cheap providers.
- Closes audit RC1/M1 universally: non-empty `tool_calls` + non-`ToolUse` finish_reason → forced to `FinishReason::ToolUse`. Bedrock's `Unknown`-on-tool-use response shape no longer drops tool calls in the gateway dispatch gate.
- Single Class A shape invariant today; additional invariants land per concrete bug.

Decorator placement: for the codex path, `TokenRefreshingProvider` remains innermost and `NormalizingProvider` wraps it from outside. Functionally equivalent — `TokenRefreshingProvider` only handles 401-retry and never transforms the `ToolCompletionResponse` shape — but mildly diverges from the plan's suggested `raw → Normalizing → TokenRefreshing` order in favor of one universal wrap point.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo build --workspace --all-features` — exit 0
- [x] `cargo test -p ironclaw_llm --lib --tests --all-features` — 875 lib + 1 integration pass
- [x] `cargo test -p ironclaw_llm --lib normalizing::` — 5/5 pass (each `normalize_shape` branch + `complete()` delegation)
- [x] `cargo test -p ironclaw_llm --test normalizing_integration` — `bedrock_unknown_finish_with_calls_routes_through_normalizing` pass (RC1 closure proof)
- [x] `cargo test -p ironclaw_reborn --test llm_gateway --features root-llm-provider` — 59/59 pass (decorator wrap invisible to gateway consumers)
- [x] `cargo test -p ironclaw_architecture` — 30/30 pass (no new boundary crossings)
- [ ] Pre-existing `ironclaw_llm` doctest failure for `testing/fault_injection.rs` (uses stale `use ironclaw::testing::...` path from pre-extraction era) — not introduced by this PR; confirmed on `origin/main`.

## Audit / plan refs

- Audit: `docs/reborn/2026-06-05-loop-ux-gap-audit.md` RC3/M9
- Phase A (`tool_args.rs`): #4522 (merged)
- Phase B (`ToolCall.arguments_parse_error`): #4576 (merged)
- This PR: Phase C (`NormalizingProvider<P>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)