### PR TITLE
Add Slack personal DM outbound targets

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -823,7 +823,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 
 ### P1 - High Priority
 
-- 🚧 Slack channel (real implementation): Reborn host-beta route can be explicitly mounted by `ironclaw-reborn serve` with Slack Events API signing, DM/app-mention routing through Product Workflow/Reborn, final-reply delivery, host-state-backed personal binding pairing, WebUI v2 admin-managed allowed-channel picker, durable WebUI channel-route assignment APIs, and deterministic chat-side connect action metadata; DMs execute as the paired actor, while shared channel turns route to allowed dynamic or static channel subjects and fail closed for unrouted channels in admin-managed mode; production install/setup hardening and fuller E2E coverage remain follow-up.
+- 🚧 Slack channel (real implementation): Reborn host-beta route can be explicitly mounted by `ironclaw-reborn serve` with Slack Events API signing, DM/app-mention routing through Product Workflow/Reborn, final-reply delivery, host-state-backed personal binding pairing, WebUI v2 admin-managed allowed-channel picker, durable WebUI channel-route assignment APIs, provider-side default outbound target inventory for shared channels and explicitly provisioned personal DMs, and deterministic chat-side connect action metadata; DMs execute as the paired actor, while shared channel turns route to allowed dynamic or static channel subjects and fail closed for unrouted channels in admin-managed mode; production install/setup hardening and fuller E2E coverage remain follow-up.
 - ✅ Telegram channel (WASM, polling-first setup, DM pairing, caption, /start)
 - ❌ WhatsApp channel
 - ✅ Multi-provider failover (`FailoverProvider` with retryable error classification)

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -94,11 +94,15 @@ mod slack_connectable_channel;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_delivery;
 #[cfg(feature = "slack-v2-host-beta")]
+mod slack_dm_open;
+#[cfg(feature = "slack-v2-host-beta")]
 mod slack_egress;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_host_beta;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_host_state;
+#[cfg(feature = "slack-v2-host-beta")]
+mod slack_outbound_targets;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_pairing_notifier;
 #[cfg(feature = "slack-v2-host-beta")]

--- a/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
@@ -204,6 +204,49 @@ pub(crate) trait SlackChannelRouteStore: Send + Sync + std::fmt::Debug {
         &self,
         key: &SlackChannelRouteKey,
     ) -> Result<Option<UserId>, SlackChannelRouteError>;
+
+    /// List routes that belong to `subject_user_id`, paging through the store
+    /// `limit` entries at a time.  The default implementation re-uses
+    /// `list_routes` and filters each page in memory; it never materialises
+    /// more than `limit` entries at once and returns early once `cap` routes
+    /// have been accumulated.
+    ///
+    /// Implementors whose storage layout is subject-indexed may override this
+    /// with a cheaper query.  A true subject index remains a tracked follow-up
+    /// for stores where full-inventory scans become expensive at scale.
+    async fn list_routes_for_subject(
+        &self,
+        tenant_id: &TenantId,
+        installation_id: &AdapterInstallationId,
+        team_id: &str,
+        subject_user_id: &UserId,
+        page_size: usize,
+        cap: usize,
+    ) -> Result<Vec<SlackChannelRoute>, SlackChannelRouteError> {
+        let mut cursor = 0;
+        let mut result = Vec::new();
+        loop {
+            let page = self
+                .list_routes(tenant_id, installation_id, team_id, cursor, page_size)
+                .await?;
+            for route in page.routes {
+                if route.subject_user_id == subject_user_id.as_str() {
+                    if result.len() >= cap {
+                        return Err(SlackChannelRouteError::StoreUnavailable);
+                    }
+                    result.push(route);
+                }
+            }
+            let Some(next_cursor) = page.next_cursor else {
+                break;
+            };
+            if next_cursor <= cursor {
+                return Err(SlackChannelRouteError::StoreUnavailable);
+            }
+            cursor = next_cursor;
+        }
+        Ok(result)
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -175,6 +175,22 @@ mod tests {
         assert!(matches!(error, SlackDmOpenError::Backend(_)));
     }
 
+    #[tokio::test]
+    async fn open_slack_dm_channel_returns_channel_id_on_success() {
+        let channel_id = open_slack_dm_channel(
+            &ScriptedEgress::new(EgressResponse::new(
+                200,
+                br#"{"ok":true,"channel":{"id":"D123ABCD"}}"#.to_vec(),
+            )),
+            credential_handle(),
+            "U123",
+        )
+        .await
+        .expect("happy path succeeds");
+
+        assert_eq!(channel_id, "D123ABCD");
+    }
+
     #[test]
     fn validate_slack_dm_channel_id_rejects_invalid_shapes() {
         for value in ["", "C123", "G123", "D 123", "D/123", "D\x01123"] {

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -9,12 +9,14 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 
 const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
-const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
+pub(crate) const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub(crate) enum SlackDmOpenError {
     #[error("Slack DM open failed: {0}")]
     Backend(String),
+    #[error("Slack conversations.open response did not return a direct-message channel")]
+    InvalidChannel,
     #[error("Slack conversations.open response did not include a channel id")]
     MissingChannel,
 }
@@ -52,6 +54,21 @@ pub(crate) async fn open_slack_dm_channel(
         .map(|channel| channel.id)
         .filter(|id| !id.is_empty())
         .ok_or(SlackDmOpenError::MissingChannel)
+}
+
+pub(crate) fn validate_slack_dm_channel_id(value: &str) -> Result<(), SlackDmOpenError> {
+    if value.is_empty()
+        || value.len() > 128
+        || value.chars().any(|c| {
+            c == '\0' || c.is_control() || c.is_whitespace() || matches!(c, '/' | '\\' | ':' | ';')
+        })
+    {
+        return Err(SlackDmOpenError::InvalidChannel);
+    }
+    if !value.starts_with('D') {
+        return Err(SlackDmOpenError::InvalidChannel);
+    }
+    Ok(())
 }
 
 #[derive(Debug, Serialize)]
@@ -101,4 +118,106 @@ where
     serde_json::from_slice(body).map_err(|error| {
         SlackDmOpenError::Backend(format!("{label} response was invalid JSON: {error}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use ironclaw_product_adapters::{EgressResponse, ProtocolHttpEgressError};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn open_slack_dm_channel_returns_missing_channel_when_id_empty() {
+        for body in [
+            br#"{"ok":true}"#.to_vec(),
+            br#"{"ok":true,"channel":{"id":""}}"#.to_vec(),
+        ] {
+            let error = open_slack_dm_channel(
+                &ScriptedEgress::new(EgressResponse::new(200, body)),
+                credential_handle(),
+                "U123",
+            )
+            .await
+            .expect_err("missing channel fails");
+
+            assert!(matches!(error, SlackDmOpenError::MissingChannel));
+        }
+    }
+
+    #[tokio::test]
+    async fn open_slack_dm_channel_fails_on_non_2xx() {
+        let error = open_slack_dm_channel(
+            &ScriptedEgress::new(EgressResponse::new(503, b"unavailable".to_vec())),
+            credential_handle(),
+            "U123",
+        )
+        .await
+        .expect_err("non-2xx fails");
+
+        assert!(matches!(error, SlackDmOpenError::Backend(_)));
+    }
+
+    #[tokio::test]
+    async fn open_slack_dm_channel_fails_on_oversized_body() {
+        let error = open_slack_dm_channel(
+            &ScriptedEgress::new(EgressResponse::new(
+                200,
+                vec![b'{'; SLACK_API_RESPONSE_LIMIT + 1],
+            )),
+            credential_handle(),
+            "U123",
+        )
+        .await
+        .expect_err("oversized body fails");
+
+        assert!(matches!(error, SlackDmOpenError::Backend(_)));
+    }
+
+    #[test]
+    fn validate_slack_dm_channel_id_rejects_invalid_shapes() {
+        for value in ["", "C123", "G123", "D 123", "D/123", "D\x01123"] {
+            assert!(matches!(
+                validate_slack_dm_channel_id(value),
+                Err(SlackDmOpenError::InvalidChannel)
+            ));
+        }
+        assert!(matches!(
+            validate_slack_dm_channel_id(&format!("D{}", "1".repeat(128))),
+            Err(SlackDmOpenError::InvalidChannel)
+        ));
+        validate_slack_dm_channel_id("D123").expect("valid DM channel");
+    }
+
+    fn credential_handle() -> EgressCredentialHandle {
+        EgressCredentialHandle::new("slack_bot_token").expect("credential handle")
+    }
+
+    #[derive(Debug)]
+    struct ScriptedEgress {
+        response: Mutex<Option<EgressResponse>>,
+    }
+
+    impl ScriptedEgress {
+        fn new(response: EgressResponse) -> Self {
+            Self {
+                response: Mutex::new(Some(response)),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ProtocolHttpEgress for ScriptedEgress {
+        async fn send(
+            &self,
+            _request: EgressRequest,
+        ) -> Result<EgressResponse, ProtocolHttpEgressError> {
+            self.response
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .ok_or(ProtocolHttpEgressError::Timeout)
+        }
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -1,0 +1,104 @@
+//! Shared Slack conversations.open client for host-beta DM flows.
+
+use ironclaw_product_adapters::{
+    DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod, EgressPath,
+    EgressRequest, ProtocolHttpEgress,
+};
+use ironclaw_slack_v2_adapter::SLACK_API_HOST;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use thiserror::Error;
+
+const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
+const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum SlackDmOpenError {
+    #[error("Slack DM open failed: {0}")]
+    Backend(String),
+    #[error("Slack conversations.open response did not include a channel id")]
+    MissingChannel,
+}
+
+pub(crate) async fn open_slack_dm_channel(
+    egress: &dyn ProtocolHttpEgress,
+    credential_handle: EgressCredentialHandle,
+    slack_user_id: &str,
+) -> Result<String, SlackDmOpenError> {
+    let body = serde_json::to_vec(&SlackConversationsOpenRequest {
+        users: slack_user_id.to_string(),
+    })
+    .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    let request = slack_api_request(SLACK_CONVERSATIONS_OPEN_PATH, body, credential_handle)?;
+    let response = egress
+        .send(request)
+        .await
+        .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    if !(200..300).contains(&response.status()) {
+        return Err(SlackDmOpenError::Backend(format!(
+            "Slack API request {SLACK_CONVERSATIONS_OPEN_PATH} failed with HTTP {}",
+            response.status()
+        )));
+    }
+    let opened: SlackConversationsOpenResponse =
+        slack_json_response("Slack conversations.open", response.body())?;
+    if !opened.ok {
+        return Err(SlackDmOpenError::Backend(format!(
+            "Slack rejected conversations.open ({})",
+            opened.error.unwrap_or_else(|| "unknown_error".into())
+        )));
+    }
+    opened
+        .channel
+        .map(|channel| channel.id)
+        .filter(|id| !id.is_empty())
+        .ok_or(SlackDmOpenError::MissingChannel)
+}
+
+#[derive(Debug, Serialize)]
+struct SlackConversationsOpenRequest {
+    users: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenResponse {
+    ok: bool,
+    error: Option<String>,
+    channel: Option<SlackConversationsOpenChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenChannel {
+    id: String,
+}
+
+fn slack_api_request(
+    path: &'static str,
+    body: Vec<u8>,
+    credential_handle: EgressCredentialHandle,
+) -> Result<EgressRequest, SlackDmOpenError> {
+    let host = DeclaredEgressHost::new(SLACK_API_HOST)
+        .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    let method = EgressMethod::post();
+    let path =
+        EgressPath::new(path).map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    let content_type = EgressHeader::new("content-type", "application/json")
+        .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    Ok(EgressRequest::new(host, method, path)
+        .with_header(content_type)
+        .with_body(body)
+        .with_credential_handle(Some(credential_handle)))
+}
+
+fn slack_json_response<T>(label: &'static str, body: &[u8]) -> Result<T, SlackDmOpenError>
+where
+    T: DeserializeOwned,
+{
+    if body.len() > SLACK_API_RESPONSE_LIMIT {
+        return Err(SlackDmOpenError::Backend(format!(
+            "{label} response exceeded body limit"
+        )));
+    }
+    serde_json::from_slice(body).map_err(|error| {
+        SlackDmOpenError::Backend(format!("{label} response was invalid JSON: {error}"))
+    })
+}

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -206,6 +206,25 @@ mod tests {
         validate_slack_dm_channel_id("D123").expect("valid DM channel");
     }
 
+    #[test]
+    fn validate_slack_dm_channel_id_accepts_exactly_128_bytes_and_rejects_129() {
+        // Boundary: "D" + 127 ASCII chars = 128 bytes total — must be accepted.
+        let at_limit = format!("D{}", "X".repeat(127));
+        assert_eq!(at_limit.len(), 128, "fixture must be exactly 128 bytes");
+        validate_slack_dm_channel_id(&at_limit).expect("exactly 128-byte id must be valid");
+
+        // One byte over the limit — must be rejected.
+        let over_limit = format!("D{}", "X".repeat(128));
+        assert_eq!(over_limit.len(), 129, "fixture must be exactly 129 bytes");
+        assert!(
+            matches!(
+                validate_slack_dm_channel_id(&over_limit),
+                Err(SlackDmOpenError::InvalidChannel)
+            ),
+            "129-byte id must be rejected"
+        );
+    }
+
     fn credential_handle() -> EgressCredentialHandle {
         EgressCredentialHandle::new("slack_bot_token").expect("credential handle")
     }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -669,7 +669,8 @@ mod tests {
     };
     use crate::slack_outbound_targets::{
         InMemorySlackPersonalDmTargetStore, SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
-        SlackPersonalDmTargetError, SlackPersonalDmTargetProvisioner, SlackPersonalDmTargetStore,
+        SlackPersonalDmTarget, SlackPersonalDmTargetError, SlackPersonalDmTargetKey,
+        SlackPersonalDmTargetProvisioner, SlackPersonalDmTargetStore,
         slack_reply_target_binding_ref_from_raw, slack_shared_channel_reply_target_binding_ref,
     };
     use crate::slack_personal_binding_pairing_serve::{
@@ -1955,6 +1956,47 @@ mod tests {
             Some("slack:personal-dm:T0HOST:user:slack-host")
         );
         runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_reply_target_binding_ref_round_trips_authorized_dm() {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("personal target key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("personal DM target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("personal DM target stores");
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config_without_channel_routes()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store,
+        );
+        let listed = provider
+            .list_outbound_delivery_targets(&operator_caller())
+            .await
+            .expect("target list");
+        let binding_ref = listed[0].reply_target_binding_ref.clone();
+
+        let resolved = provider
+            .resolve_reply_target_binding(&operator_caller(), &binding_ref)
+            .await
+            .expect("binding resolves")
+            .expect("personal DM binding is authorized");
+
+        assert_eq!(
+            resolved.summary.target_id.as_str(),
+            "slack:personal-dm:T0HOST:user:slack-host"
+        );
+        assert_eq!(resolved.reply_target_binding_ref, binding_ref);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -14,23 +14,20 @@ use ironclaw_host_api::{AgentId, ProjectId, ResourceScope, TenantId, UserId};
 use ironclaw_outbound::{FilesystemOutboundStateStore, OutboundStateStore};
 use ironclaw_product_adapters::{
     AdapterInstallationId, DeclaredEgressHost, DeclaredEgressTarget, DeliveryStatus,
-    EgressCredentialHandle, ExternalActorRef, ExternalConversationRef, OutboundDeliverySink,
-    ProductAdapter, ProductAdapterId, ProtocolHttpEgress,
+    EgressCredentialHandle, ExternalActorRef, OutboundDeliverySink, ProductAdapter,
+    ProductAdapterId, ProtocolHttpEgress,
 };
 use ironclaw_product_workflow::{
     DefaultInboundTurnService, DefaultProductWorkflow, ProductActorUserResolutionRequest,
     ProductActorUserResolver, ProductConversationBindingService, ProductConversationRouteKey,
     ProductConversationSubjectRouteResolver, ProductInstallationKey, ProductInstallationScope,
-    ProductWorkflowError, RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
-    RebornOutboundDeliveryTargetSummary, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind, StaticProductInstallationResolver, WebUiAuthenticatedCaller,
+    ProductWorkflowError, StaticProductInstallationResolver,
 };
 use ironclaw_product_workflow_storage::RebornFilesystemIdempotencyLedger;
 use ironclaw_slack_v2_adapter::{
     SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID, SlackV2Adapter,
     SlackV2AdapterConfig, slack_request_signature_auth_requirement,
 };
-use ironclaw_turns::ReplyTargetBindingRef;
 use ironclaw_wasm_product_adapters::{
     EgressPolicy, HmacWebhookAuth, NativeProductAdapterRunner, NativeProductAdapterRunnerConfig,
     WebhookAuth,
@@ -39,11 +36,10 @@ use secrecy::{ExposeSecret, SecretString};
 use thiserror::Error;
 
 use crate::RebornRuntime;
-use crate::outbound_preferences::{OutboundDeliveryTargetEntry, OutboundDeliveryTargetProvider};
+use crate::outbound_preferences::OutboundDeliveryTargetProvider;
 use crate::slack_actor_identity::SlackUserIdentityActorResolver;
 use crate::slack_channel_routes::{
-    SlackChannelRouteAdminRouteConfig, SlackChannelRouteError, SlackChannelRouteKey,
-    SlackChannelRouteStore, SlackChannelRouteSubjectResolver,
+    SlackChannelRouteAdminRouteConfig, SlackChannelRouteStore, SlackChannelRouteSubjectResolver,
 };
 use crate::slack_delivery::{
     SlackFinalReplyDeliveryObserver, SlackFinalReplyDeliveryServices,
@@ -51,6 +47,10 @@ use crate::slack_delivery::{
 };
 use crate::slack_egress::{SlackProtocolHttpEgress, StaticSlackEgressCredentialProvider};
 use crate::slack_host_state::FilesystemSlackHostState;
+use crate::slack_outbound_targets::{
+    SlackConfiguredChannelRoute, SlackHostBetaOutboundTargetProvider,
+    SlackOutboundTargetProviderConfig, SlackPersonalDmTargetStore,
+};
 use crate::slack_pairing_notifier::SlackPairingChallengeHttpNotifier;
 use crate::slack_personal_binding::{
     RebornUserIdentityBindingStore, SlackPersonalBindingInstallation,
@@ -74,10 +74,6 @@ const SLACK_WEBHOOK_WORKFLOW_TIMEOUT: Duration = Duration::from_secs(2);
 const SLACK_MAX_IN_FLIGHT_WEBHOOKS: usize = 64;
 const SLACK_IDEMPOTENCY_LEDGER_SETTLED_LIMIT: usize = 10_000;
 const SLACK_IDEMPOTENCY_LEDGER_PRUNE_INTERVAL: usize = 1_000;
-// `ReplyTargetBindingRef` permits 256 bytes; this raw cap leaves room for the
-// `reply:` prefix that is added before constructing the typed ref.
-const SLACK_BINDING_REF_RAW_MAX_BYTES: usize = 240;
-const SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE: usize = 500;
 
 struct NoopSlackDeliverySink;
 
@@ -286,6 +282,7 @@ pub fn build_slack_host_beta_mounts(
         )),
     ));
     let channel_route_store: Arc<dyn SlackChannelRouteStore> = state.clone();
+    let personal_dm_target_store: Arc<dyn SlackPersonalDmTargetStore> = state.clone();
     let subject_route_resolver: Arc<dyn ProductConversationSubjectRouteResolver> =
         Arc::new(SlackChannelRouteSubjectResolver::new(
             config.tenant_id.clone(),
@@ -320,271 +317,27 @@ pub fn build_slack_host_beta_mounts(
         personal_binding_pairing: SlackPersonalBindingPairingRouteConfig::new(pairing),
         channel_routes,
         outbound_delivery_target_provider: Arc::new(SlackHostBetaOutboundTargetProvider::new(
-            config,
+            SlackOutboundTargetProviderConfig {
+                tenant_id: config.tenant_id.clone(),
+                agent_id: config.agent_id.clone(),
+                project_id: config.project_id.clone(),
+                installation_id: config.installation_id.clone(),
+                team_id: config.team_id.clone(),
+                configured_channel_routes: config
+                    .channel_routes
+                    .iter()
+                    .map(|route| {
+                        SlackConfiguredChannelRoute::new(
+                            route.channel_id.clone(),
+                            route.subject_user_id.clone(),
+                        )
+                    })
+                    .collect(),
+            },
             channel_route_store,
+            Arc::clone(&personal_dm_target_store),
         )),
     })
-}
-
-#[derive(Debug)]
-struct SlackHostBetaOutboundTargetProvider {
-    tenant_id: TenantId,
-    agent_id: AgentId,
-    project_id: Option<ProjectId>,
-    installation_id: AdapterInstallationId,
-    team_id: SlackTeamId,
-    target_id_prefix: String,
-    configured_channel_routes: Vec<SlackHostBetaChannelRoute>,
-    channel_route_store: Arc<dyn SlackChannelRouteStore>,
-}
-
-impl SlackHostBetaOutboundTargetProvider {
-    fn new(
-        config: SlackHostBetaConfig,
-        channel_route_store: Arc<dyn SlackChannelRouteStore>,
-    ) -> Self {
-        Self {
-            tenant_id: config.tenant_id,
-            agent_id: config.agent_id,
-            project_id: config.project_id,
-            installation_id: config.installation_id,
-            target_id_prefix: format!("slack:shared-channel:{}:", config.team_id.as_str()),
-            team_id: config.team_id,
-            configured_channel_routes: config.channel_routes,
-            channel_route_store,
-        }
-    }
-
-    fn target_id_for_shared_channel(
-        &self,
-        channel_id: &str,
-    ) -> Result<RebornOutboundDeliveryTargetId, RebornServicesError> {
-        RebornOutboundDeliveryTargetId::new(format!(
-            "slack:shared-channel:{}:{}",
-            self.team_id.as_str(),
-            channel_id
-        ))
-        .map_err(|_| slack_target_backend_error())
-    }
-
-    fn channel_id_for_target_id<'a>(
-        &self,
-        target_id: &'a RebornOutboundDeliveryTargetId,
-    ) -> Option<&'a str> {
-        target_id
-            .as_str()
-            .strip_prefix(&self.target_id_prefix)
-            .filter(|channel_id| !channel_id.is_empty())
-    }
-
-    fn channel_id_for_reply_target_binding_ref<'a>(
-        &self,
-        target: &'a ReplyTargetBindingRef,
-    ) -> Option<&'a str> {
-        let mut raw = target.as_str().strip_prefix("reply:")?;
-        let (adapter_id, rest) = take_product_binding_segment(raw, "adapter")?;
-        if adapter_id != SLACK_V2_ADAPTER_ID {
-            return None;
-        }
-        raw = rest;
-        let (installation_id, rest) = take_product_binding_segment(raw, "installation")?;
-        if installation_id != self.installation_id.as_str() {
-            return None;
-        }
-        raw = rest;
-        let (agent_id, rest) = take_product_binding_segment(raw, "agent")?;
-        if agent_id != self.agent_id.as_str() {
-            return None;
-        }
-        raw = rest;
-        let (project_id, rest) = take_product_binding_segment(raw, "project")?;
-        if project_id != self.project_id.as_ref().map_or("", |id| id.as_str()) {
-            return None;
-        }
-        raw = rest;
-        let (space_id, rest) = take_product_binding_segment(raw, "space")?;
-        if space_id != self.team_id.as_str() {
-            return None;
-        }
-        raw = rest;
-        let (channel_id, rest) = take_product_binding_segment(raw, "conversation")?;
-        let (topic_id, rest) = take_product_binding_segment(rest, "topic")?;
-        if channel_id.is_empty() || !topic_id.is_empty() || !rest.is_empty() {
-            return None;
-        }
-        Some(channel_id)
-    }
-
-    async fn shared_channel_route_for_channel(
-        &self,
-        channel_id: &str,
-    ) -> Result<Option<SlackHostBetaChannelRoute>, RebornServicesError> {
-        let key = match SlackChannelRouteKey::new(
-            self.tenant_id.clone(),
-            self.installation_id.clone(),
-            self.team_id.as_str().to_string(),
-            channel_id.to_string(),
-        ) {
-            Ok(key) => key,
-            Err(SlackChannelRouteError::InvalidRoute) => return Ok(None),
-            Err(error) => return Err(map_slack_target_route_error(error)),
-        };
-        if let Some(subject_user_id) = self
-            .channel_route_store
-            .resolve_subject_user_id(&key)
-            .await
-            .map_err(map_slack_target_route_error)?
-        {
-            return Ok(Some(SlackHostBetaChannelRoute::new(
-                channel_id.to_string(),
-                subject_user_id,
-            )));
-        }
-        Ok(self
-            .configured_channel_routes
-            .iter()
-            .find(|route| route.channel_id == channel_id)
-            .cloned())
-    }
-
-    async fn shared_channel_routes(
-        &self,
-    ) -> Result<Vec<SlackHostBetaChannelRoute>, RebornServicesError> {
-        let mut cursor = 0;
-        let mut stored_channel_ids = HashSet::new();
-        let mut routes = Vec::new();
-        loop {
-            let stored = self
-                .channel_route_store
-                .list_routes(
-                    &self.tenant_id,
-                    &self.installation_id,
-                    self.team_id.as_str(),
-                    cursor,
-                    SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
-                )
-                .await
-                .map_err(map_slack_target_route_error)?;
-            for route in stored.routes {
-                stored_channel_ids.insert(route.channel_id.clone());
-                routes.push(SlackHostBetaChannelRoute::new(
-                    route.channel_id,
-                    UserId::new(route.subject_user_id).map_err(|_| slack_target_backend_error())?,
-                ));
-            }
-            let Some(next_cursor) = stored.next_cursor else {
-                break;
-            };
-            if next_cursor <= cursor {
-                return Err(map_slack_target_route_error(
-                    SlackChannelRouteError::StoreUnavailable,
-                ));
-            }
-            cursor = next_cursor;
-        }
-        routes.extend(
-            self.configured_channel_routes
-                .iter()
-                .filter(|route| !stored_channel_ids.contains(&route.channel_id))
-                .cloned(),
-        );
-        Ok(routes)
-    }
-
-    fn entry_for_shared_channel_route(
-        &self,
-        route: &SlackHostBetaChannelRoute,
-    ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
-        let target_id = self.target_id_for_shared_channel(&route.channel_id)?;
-        let display_name = format!("Slack channel {}", route.channel_id);
-        Ok(OutboundDeliveryTargetEntry {
-            summary: RebornOutboundDeliveryTargetSummary::new(
-                target_id,
-                "slack",
-                display_name,
-                Some(format!(
-                    "Slack channel {} in team {}",
-                    route.channel_id,
-                    self.team_id.as_str()
-                )),
-            )
-            .map_err(|_| slack_target_backend_error())?,
-            capabilities: RebornOutboundDeliveryTargetCapabilities {
-                final_replies: true,
-                gate_prompts: true,
-                auth_prompts: true,
-            },
-            reply_target_binding_ref: slack_shared_channel_reply_target_binding_ref(
-                &self.installation_id,
-                &self.agent_id,
-                self.project_id.as_ref(),
-                &self.team_id,
-                &route.channel_id,
-            )?,
-        })
-    }
-
-    async fn resolve_for_channel_id(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-        channel_id: &str,
-    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        if caller.tenant_id != self.tenant_id {
-            return Ok(None);
-        }
-        let Some(route) = self.shared_channel_route_for_channel(channel_id).await? else {
-            return Ok(None);
-        };
-        if route.subject_user_id != caller.user_id {
-            return Ok(None);
-        }
-        self.entry_for_shared_channel_route(&route).map(Some)
-    }
-}
-
-#[async_trait::async_trait]
-impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
-    async fn list_outbound_delivery_targets(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        if caller.tenant_id != self.tenant_id {
-            return Ok(Vec::new());
-        }
-        let mut routes = self
-            .shared_channel_routes()
-            .await?
-            .into_iter()
-            .filter(|route| route.subject_user_id == caller.user_id)
-            .collect::<Vec<_>>();
-        routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
-        routes
-            .into_iter()
-            .map(|route| self.entry_for_shared_channel_route(&route))
-            .collect()
-    }
-
-    async fn resolve_outbound_delivery_target(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-        target_id: &RebornOutboundDeliveryTargetId,
-    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        let Some(channel_id) = self.channel_id_for_target_id(target_id) else {
-            return Ok(None);
-        };
-        self.resolve_for_channel_id(caller, channel_id).await
-    }
-
-    async fn resolve_reply_target_binding(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-        target: &ReplyTargetBindingRef,
-    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        let Some(channel_id) = self.channel_id_for_reply_target_binding_ref(target) else {
-            return Ok(None);
-        };
-        self.resolve_for_channel_id(caller, channel_id).await
-    }
 }
 
 pub fn build_slack_events_route_mount_with_actor_user_resolver(
@@ -743,81 +496,6 @@ fn slack_channel_route_key(
         .map_err(|reason| invalid_config("channel_routes", reason.to_string()))
 }
 
-fn slack_shared_channel_reply_target_binding_ref(
-    installation_id: &AdapterInstallationId,
-    agent_id: &AgentId,
-    project_id: Option<&ProjectId>,
-    team_id: &SlackTeamId,
-    channel_id: &str,
-) -> Result<ReplyTargetBindingRef, RebornServicesError> {
-    let conversation = ExternalConversationRef::new(Some(team_id.as_str()), channel_id, None, None)
-        .map_err(|_| slack_target_backend_error())?;
-    let raw = format!(
-        "{}{}{}{}{}",
-        product_binding_segment("adapter", SLACK_V2_ADAPTER_ID),
-        product_binding_segment("installation", installation_id.as_str()),
-        product_binding_segment("agent", agent_id.as_str()),
-        product_binding_segment("project", project_id.map_or("", |id| id.as_str())),
-        conversation.conversation_fingerprint()
-    );
-    slack_reply_target_binding_ref_from_raw(raw)
-}
-
-fn slack_reply_target_binding_ref_from_raw(
-    raw: String,
-) -> Result<ReplyTargetBindingRef, RebornServicesError> {
-    if raw.len() > SLACK_BINDING_REF_RAW_MAX_BYTES
-        || raw.chars().any(|c| c == '\0' || c.is_control())
-    {
-        return Err(slack_target_backend_error());
-    }
-    ReplyTargetBindingRef::new(format!("reply:{raw}")).map_err(|_| slack_target_backend_error())
-}
-
-// Keep this segment format in parity with
-// `ExternalConversationRef::conversation_fingerprint`.
-fn product_binding_segment(name: &str, value: &str) -> String {
-    format!("{name}:{}:{value};", value.len())
-}
-
-fn take_product_binding_segment<'a>(raw: &'a str, name: &str) -> Option<(&'a str, &'a str)> {
-    let raw = raw.strip_prefix(name)?.strip_prefix(':')?;
-    let (length, raw) = raw.split_once(':')?;
-    let length = length.parse::<usize>().ok()?;
-    let value = raw.get(..length)?;
-    let raw = raw.get(length..)?.strip_prefix(';')?;
-    Some((value, raw))
-}
-
-fn map_slack_target_route_error(error: SlackChannelRouteError) -> RebornServicesError {
-    match error {
-        SlackChannelRouteError::InvalidRoute => slack_target_not_found_error(),
-        SlackChannelRouteError::StoreUnavailable => slack_target_backend_error(),
-    }
-}
-
-fn slack_target_not_found_error() -> RebornServicesError {
-    RebornServicesError {
-        code: RebornServicesErrorCode::NotFound,
-        kind: RebornServicesErrorKind::NotFound,
-        status_code: 404,
-        retryable: false,
-        field: None,
-        validation_code: None,
-    }
-}
-
-fn slack_target_backend_error() -> RebornServicesError {
-    RebornServicesError {
-        code: RebornServicesErrorCode::Unavailable,
-        kind: RebornServicesErrorKind::ServiceUnavailable,
-        status_code: 503,
-        retryable: true,
-        field: None,
-        validation_code: None,
-    }
-}
-
 fn slack_bot_token_handle() -> Result<EgressCredentialHandle, SlackHostBetaBuildError> {
     EgressCredentialHandle::new(SLACK_BOT_TOKEN_HANDLE)
         .map_err(|reason| invalid_config("bot_token_handle", reason.to_string()))
@@ -965,7 +643,8 @@ mod tests {
     use ironclaw_processes::{InMemoryProcessResultStore, InMemoryProcessStore, ProcessServices};
     use ironclaw_product_workflow::{
         ProductActorUserResolutionRequest, ProductWorkflowError, RebornChannelConnectStrategy,
-        RebornOutboundDeliveryTargetStatus, RebornSetOutboundPreferencesRequest,
+        RebornOutboundDeliveryTargetId, RebornOutboundDeliveryTargetStatus,
+        RebornServicesErrorCode, RebornServicesErrorKind, RebornSetOutboundPreferencesRequest,
         WebUiAuthenticatedCaller,
     };
     use ironclaw_resources::InMemoryResourceGovernor;
@@ -981,15 +660,22 @@ mod tests {
     use super::*;
     use crate::slack_channel_routes::{
         InMemorySlackChannelRouteStore, SlackChannelRoute, SlackChannelRouteAdminRouteMount,
-        SlackChannelRouteListPage, WEBUI_V2_CHANNELS_SLACK_ALLOWED_PATH,
-        WEBUI_V2_CHANNELS_SLACK_ROUTES_PATH, slack_channel_route_admin_route_mount,
+        SlackChannelRouteError, SlackChannelRouteKey, SlackChannelRouteListPage,
+        WEBUI_V2_CHANNELS_SLACK_ALLOWED_PATH, WEBUI_V2_CHANNELS_SLACK_ROUTES_PATH,
+        slack_channel_route_admin_route_mount,
     };
     use crate::slack_connectable_channel::{
         SlackOperatorRouteVisibility, build_webui_services_with_slack_host_beta_mounts,
     };
+    use crate::slack_outbound_targets::{
+        InMemorySlackPersonalDmTargetStore, SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+        SlackPersonalDmTargetError, SlackPersonalDmTargetProvisioner, SlackPersonalDmTargetStore,
+        slack_reply_target_binding_ref_from_raw, slack_shared_channel_reply_target_binding_ref,
+    };
     use crate::slack_personal_binding_pairing_serve::{
         WEBUI_V2_EXTENSION_PAIRING_REDEEM_PATH, slack_personal_binding_pairing_route_mount,
     };
+    use crate::slack_serve::SlackUserId;
     use crate::{
         RebornBuildError, RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput,
         SLACK_EVENTS_PATH, WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime,
@@ -2093,8 +1779,7 @@ mod tests {
                 .await
                 .expect("route upserts");
         }
-        let provider =
-            SlackHostBetaOutboundTargetProvider::new(config_without_channel_routes(), store);
+        let provider = outbound_target_provider(config_without_channel_routes(), store);
 
         let targets = provider
             .list_outbound_delivery_targets(&shared_subject_caller())
@@ -2115,8 +1800,210 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slack_host_beta_targets_reject_non_advancing_route_cursor() {
+    async fn slack_shared_channel_targets_survive_personal_dm_store_failure() {
         let provider = SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            Arc::new(FailingSlackPersonalDmTargetStore),
+        );
+
+        let targets = provider
+            .list_outbound_delivery_targets(&shared_subject_caller())
+            .await
+            .expect("target list falls back to shared targets");
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(
+            targets[0].summary.target_id.as_str(),
+            "slack:shared-channel:T0HOST:C0HOST"
+        );
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_is_not_listed_without_provisioned_authority() {
+        let (runtime, _root) = runtime().await;
+        let mounts = build_slack_host_beta_mounts(&runtime, config_without_channel_routes())
+            .expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(operator_caller())
+            .await
+            .expect("target list");
+
+        assert!(
+            targets.targets.is_empty(),
+            "identity-only Slack state must not synthesize a personal DM target"
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_lists_after_explicit_provisioning() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
+        let config = config_without_channel_routes();
+        personal_dm_target_provisioner_for_test(&runtime, &config)
+            .provision_for_user(
+                UserId::new(USER).expect("user"),
+                SlackUserId::new(SLACK_USER),
+            )
+            .await
+            .expect("DM target provisions");
+        let mounts = build_slack_host_beta_mounts(&runtime, config).expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(operator_caller())
+            .await
+            .expect("target list");
+
+        assert_eq!(targets.targets.len(), 1);
+        assert_eq!(
+            targets.targets[0].target.target_id.as_str(),
+            "slack:personal-dm:T0HOST:user:slack-host"
+        );
+        assert!(targets.targets[0].capabilities.final_replies);
+        assert_eq!(
+            egress
+                .requests()
+                .iter()
+                .filter(|request| request.url.contains("/api/conversations.open"))
+                .count(),
+            1
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_round_trips_through_outbound_preferences() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
+        let config = config_without_channel_routes();
+        personal_dm_target_provisioner_for_test(&runtime, &config)
+            .provision_for_user(
+                UserId::new(USER).expect("user"),
+                SlackUserId::new(SLACK_USER),
+            )
+            .await
+            .expect("DM target provisions");
+        let mounts = build_slack_host_beta_mounts(&runtime, config).expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+        let caller = operator_caller();
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(caller.clone())
+            .await
+            .expect("target list");
+        let target = targets.targets.first().expect("personal DM target");
+
+        let selected = bundle
+            .api
+            .set_outbound_preferences(
+                caller.clone(),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target.target.target_id.clone()),
+                },
+            )
+            .await
+            .expect("set personal DM target");
+        assert_eq!(
+            selected.final_reply_target_status,
+            RebornOutboundDeliveryTargetStatus::Available
+        );
+
+        let preference = bundle
+            .api
+            .get_outbound_preferences(caller)
+            .await
+            .expect("get personal DM target preference");
+        assert_eq!(
+            preference.final_reply_target_status,
+            RebornOutboundDeliveryTargetStatus::Available
+        );
+        assert_eq!(
+            preference
+                .final_reply_target
+                .as_ref()
+                .map(|target| target.target_id.as_str()),
+            Some("slack:personal-dm:T0HOST:user:slack-host")
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_provisioning_fails_closed_on_slack_api_error() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::conversations_open_response(
+            200,
+            br#"{"ok":false,"error":"not_allowed"}"#,
+        ));
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
+        let config = config_without_channel_routes();
+        let error = personal_dm_target_provisioner_for_test(&runtime, &config)
+            .provision_for_user(
+                UserId::new(USER).expect("user"),
+                SlackUserId::new(SLACK_USER),
+            )
+            .await
+            .expect_err("Slack rejection must fail provisioning");
+        assert!(matches!(
+            error,
+            SlackPersonalDmTargetError::ProvisioningFailed(_)
+        ));
+        let mounts = build_slack_host_beta_mounts(&runtime, config).expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(operator_caller())
+            .await
+            .expect("target list");
+
+        assert!(
+            targets.targets.is_empty(),
+            "failed Slack DM provisioning must not persist a target authority"
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_host_beta_targets_reject_non_advancing_route_cursor() {
+        let provider = outbound_target_provider(
             config_without_channel_routes(),
             Arc::new(NonAdvancingCursorRouteStore),
         );
@@ -2187,12 +2074,12 @@ mod tests {
     #[test]
     fn slack_shared_channel_reply_target_binding_ref_rejects_oversized_raw() {
         let installation_id =
-            AdapterInstallationId::new("i".repeat(SLACK_BINDING_REF_RAW_MAX_BYTES))
-                .expect("long installation id still validates");
+            AdapterInstallationId::new("i".repeat(120)).expect("long installation id validates");
+        let agent_id = AgentId::new("a".repeat(120)).expect("long agent id validates");
 
         let error = slack_shared_channel_reply_target_binding_ref(
             &installation_id,
-            &AgentId::new(AGENT).expect("agent"),
+            &agent_id,
             Some(&ProjectId::new(PROJECT).expect("project")),
             &SlackTeamId::new(TEAM),
             "C0HOST",
@@ -2218,10 +2105,8 @@ mod tests {
 
     #[test]
     fn slack_shared_channel_reply_target_binding_ref_round_trips_channel_id() {
-        let provider = SlackHostBetaOutboundTargetProvider::new(
-            config(),
-            Arc::new(InMemorySlackChannelRouteStore::new()),
-        );
+        let provider =
+            outbound_target_provider(config(), Arc::new(InMemorySlackChannelRouteStore::new()));
         let binding_ref = slack_shared_channel_reply_target_binding_ref(
             &AdapterInstallationId::new(INSTALLATION).expect("installation"),
             &AgentId::new(AGENT).expect("agent"),
@@ -2233,16 +2118,14 @@ mod tests {
 
         assert_eq!(
             provider.channel_id_for_reply_target_binding_ref(&binding_ref),
-            Some("C0HOST")
+            Some("C0HOST".to_string())
         );
     }
 
     #[test]
     fn slack_host_beta_target_id_parser_rejects_empty_channel_suffix() {
-        let provider = SlackHostBetaOutboundTargetProvider::new(
-            config(),
-            Arc::new(InMemorySlackChannelRouteStore::new()),
-        );
+        let provider =
+            outbound_target_provider(config(), Arc::new(InMemorySlackChannelRouteStore::new()));
         let target_id =
             RebornOutboundDeliveryTargetId::new("slack:shared-channel:T0HOST:").expect("target id");
 
@@ -2699,6 +2582,36 @@ mod tests {
         .expect("valid config")
     }
 
+    fn outbound_target_provider_config(
+        config: SlackHostBetaConfig,
+    ) -> SlackOutboundTargetProviderConfig {
+        SlackOutboundTargetProviderConfig {
+            tenant_id: config.tenant_id,
+            agent_id: config.agent_id,
+            project_id: config.project_id,
+            installation_id: config.installation_id,
+            team_id: config.team_id,
+            configured_channel_routes: config
+                .channel_routes
+                .into_iter()
+                .map(|route| {
+                    SlackConfiguredChannelRoute::new(route.channel_id, route.subject_user_id)
+                })
+                .collect(),
+        }
+    }
+
+    fn outbound_target_provider(
+        config: SlackHostBetaConfig,
+        channel_route_store: Arc<dyn SlackChannelRouteStore>,
+    ) -> SlackHostBetaOutboundTargetProvider {
+        SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config),
+            channel_route_store,
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        )
+    }
+
     fn operator_caller() -> WebUiAuthenticatedCaller {
         WebUiAuthenticatedCaller::new(
             TenantId::new(TENANT).expect("tenant"),
@@ -2715,6 +2628,39 @@ mod tests {
             Some(AgentId::new(AGENT).expect("agent")),
             Some(ProjectId::new(PROJECT).expect("project")),
         )
+    }
+
+    fn personal_dm_target_provisioner_for_test(
+        runtime: &RebornRuntime,
+        config: &SlackHostBetaConfig,
+    ) -> SlackPersonalDmTargetProvisioner {
+        let token_handle = slack_bot_token_handle().expect("bot token handle");
+        SlackPersonalDmTargetProvisioner::new(
+            config.tenant_id.clone(),
+            config.installation_id.clone(),
+            config.team_id.clone(),
+            slack_protocol_egress(runtime, config, token_handle.clone()).expect("Slack egress"),
+            token_handle,
+            personal_dm_target_store_for_test(runtime, config),
+        )
+    }
+
+    fn personal_dm_target_store_for_test(
+        runtime: &RebornRuntime,
+        config: &SlackHostBetaConfig,
+    ) -> Arc<dyn SlackPersonalDmTargetStore> {
+        let local_runtime = runtime
+            .services()
+            .local_runtime
+            .as_ref()
+            .expect("local runtime");
+        Arc::new(FilesystemSlackHostState::new(
+            Arc::clone(&local_runtime.host_state_filesystem),
+            config.tenant_id.clone(),
+            config.user_id.clone(),
+            config.agent_id.clone(),
+            config.project_id.clone(),
+        ))
     }
 
     async fn upsert_slack_channel_route(
@@ -3166,6 +3112,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingRuntimeHttpEgress {
         requests: std::sync::Mutex<Vec<NetworkHttpRequest>>,
+        conversations_open_response: Option<(u16, Vec<u8>)>,
     }
 
     #[async_trait]
@@ -3174,17 +3121,19 @@ mod tests {
             &self,
             request: NetworkHttpRequest,
         ) -> Result<NetworkHttpResponse, NetworkHttpError> {
-            let response = if request.url.contains("/api/conversations.open") {
-                br#"{"ok":true,"channel":{"id":"D0HOST"}}"#.to_vec()
+            let (status, response) = if request.url.contains("/api/conversations.open") {
+                self.conversations_open_response
+                    .clone()
+                    .unwrap_or_else(|| (200, br#"{"ok":true,"channel":{"id":"D0HOST"}}"#.to_vec()))
             } else {
-                br#"{"ok":true}"#.to_vec()
+                (200, br#"{"ok":true}"#.to_vec())
             };
             self.requests
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(request);
             Ok(NetworkHttpResponse {
-                status: 200,
+                status,
                 headers: Vec::new(),
                 body: response,
                 usage: NetworkUsage {
@@ -3235,7 +3184,45 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct FailingSlackPersonalDmTargetStore;
+
+    #[async_trait]
+    impl SlackPersonalDmTargetStore for FailingSlackPersonalDmTargetStore {
+        async fn load_personal_dm_target(
+            &self,
+            _key: &crate::slack_outbound_targets::SlackPersonalDmTargetKey,
+        ) -> Result<
+            Option<crate::slack_outbound_targets::SlackPersonalDmTarget>,
+            SlackPersonalDmTargetError,
+        > {
+            Err(SlackPersonalDmTargetError::StoreUnavailable)
+        }
+
+        async fn upsert_personal_dm_target(
+            &self,
+            target: crate::slack_outbound_targets::SlackPersonalDmTarget,
+        ) -> Result<crate::slack_outbound_targets::SlackPersonalDmTarget, SlackPersonalDmTargetError>
+        {
+            Ok(target)
+        }
+    }
+
     impl RecordingRuntimeHttpEgress {
+        fn conversations_open_response(status: u16, body: &[u8]) -> Self {
+            Self {
+                requests: std::sync::Mutex::new(Vec::new()),
+                conversations_open_response: Some((status, body.to_vec())),
+            }
+        }
+
+        fn requests(&self) -> Vec<NetworkHttpRequest> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+
         fn request_bodies(&self) -> Vec<serde_json::Value> {
             self.requests
                 .lock()

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -651,8 +651,8 @@ mod tests {
     use ironclaw_secrets::InMemorySecretStore;
     use ironclaw_threads::{ListThreadsForScopeRequest, ThreadHistoryRequest, ThreadScope};
     use ironclaw_turns::{
-        GetRunStateRequest, TurnCoordinator, TurnRunId, TurnScope, TurnStatus,
-        run_profile::LoopCapabilityPort,
+        GetRunStateRequest, ReplyTargetBindingRef, TurnCoordinator, TurnRunId, TurnScope,
+        TurnStatus, run_profile::LoopCapabilityPort,
     };
     use secrecy::ExposeSecret;
     use tower::ServiceExt;
@@ -1997,6 +1997,49 @@ mod tests {
             "slack:personal-dm:T0HOST:user:slack-host"
         );
         assert_eq!(resolved.reply_target_binding_ref, binding_ref);
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_resolve_binding_rejects_mismatched_dm_channel_id() {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("personal target key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("personal DM target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("personal DM target stores");
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config_without_channel_routes()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store,
+        );
+        let listed = provider
+            .list_outbound_delivery_targets(&operator_caller())
+            .await
+            .expect("target list");
+        let mismatched_binding_ref = ReplyTargetBindingRef::new(
+            listed[0]
+                .reply_target_binding_ref
+                .as_str()
+                .replace("D0HOST", "D1HOST"),
+        )
+        .expect("mismatched binding ref still validates");
+
+        assert!(
+            provider
+                .resolve_reply_target_binding(&operator_caller(), &mismatched_binding_ref)
+                .await
+                .expect("binding lookup succeeds")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -1339,11 +1339,12 @@ fn stored_personal_dm_target(
     record: StoredSlackPersonalDmTarget,
 ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
     let key = SlackPersonalDmTargetKey::new(
-        TenantId::new(record.tenant_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        TenantId::new(record.tenant_id)
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
         AdapterInstallationId::new(record.installation_id)
-            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
         record.team_id,
-        UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
     )?;
     SlackPersonalDmTarget::new(
         key,
@@ -1737,6 +1738,40 @@ mod tests {
                 .expect("foreign tenant load fails closed"),
             None
         );
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_reports_corrupt_personal_dm_target_as_unavailable() {
+        let state = state();
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let path =
+            FilesystemSlackHostState::<InMemoryBackend>::personal_dm_target_path(&key).unwrap();
+        let record = StoredSlackPersonalDmTarget {
+            tenant_id: String::new(),
+            installation_id: installation().as_str().to_string(),
+            team_id: "T123".to_string(),
+            user_id: "user:alice".to_string(),
+            slack_user_id: "U123".to_string(),
+            dm_channel_id: "D123".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        state
+            .write_record(&path, &record, CasExpectation::Any)
+            .await
+            .expect("write corrupt personal DM record");
+
+        assert!(matches!(
+            state.load_personal_dm_target(&key).await,
+            Err(SlackPersonalDmTargetError::StoreUnavailable)
+        ));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -844,6 +844,14 @@ where
         match self.write_record(&path, &record, cas).await {
             Ok(_) => Ok(target),
             Err(FilesystemError::VersionMismatch { .. }) => {
+                // CAS lost to a concurrent writer. Read back and return the winning record.
+                // This is last-write-wins semantics: whichever writer committed first wins.
+                // This is safe today because provisioning the same (tenant, user) DM target is
+                // idempotent — both concurrent writers store the same DM channel ID for the same
+                // Slack user. If a future change makes the payload non-idempotent (e.g. storing a
+                // caller-chosen dm_channel_id that could differ between writers), this branch must
+                // be replaced with explicit conflict semantics (e.g. reject the loser with a
+                // retriable error rather than silently discarding the losing value).
                 let Some((record, _)) = self.read_personal_dm_target_record(&path).await? else {
                     return Err(SlackPersonalDmTargetError::StoreUnavailable);
                 };
@@ -1345,12 +1353,14 @@ fn stored_personal_dm_target(
             .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
         record.team_id,
         UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
-    )?;
+    )
+    .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?;
     SlackPersonalDmTarget::new(
         key,
         SlackUserId::new(record.slack_user_id),
         record.dm_channel_id,
     )
+    .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1615,7 +1625,7 @@ fn map_route_fs_error(error: FilesystemError) -> SlackChannelRouteError {
 }
 
 fn map_personal_dm_target_fs_error(error: FilesystemError) -> SlackPersonalDmTargetError {
-    tracing::error!(%error, "Slack personal DM target filesystem operation failed");
+    tracing::debug!(%error, "Slack personal DM target filesystem operation failed");
     SlackPersonalDmTargetError::StoreUnavailable
 }
 
@@ -1772,6 +1782,71 @@ mod tests {
             state.load_personal_dm_target(&key).await,
             Err(SlackPersonalDmTargetError::StoreUnavailable)
         ));
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_reports_corrupt_personal_dm_target_key_fields_as_unavailable()
+     {
+        // Regression guard: corrupt team_id (fails SlackPersonalDmTargetKey::new validation)
+        // and corrupt dm_channel_id (fails SlackPersonalDmTarget::new validation) must both map
+        // to StoreUnavailable (503), not InvalidTarget (404). A stored record that exists on disk
+        // with an invalid field is a data-integrity problem, not an absence.
+        let state = state();
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let path =
+            FilesystemSlackHostState::<InMemoryBackend>::personal_dm_target_path(&key).unwrap();
+
+        // Corrupt team_id — fails SlackPersonalDmTargetKey::new (validate_slack_id)
+        let record_bad_team = StoredSlackPersonalDmTarget {
+            tenant_id: "tenant-alpha".to_string(),
+            installation_id: installation().as_str().to_string(),
+            team_id: String::new(), // empty string fails Slack-ID validation
+            user_id: "user:alice".to_string(),
+            slack_user_id: "U123".to_string(),
+            dm_channel_id: "D123".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        state
+            .write_record(&path, &record_bad_team, CasExpectation::Any)
+            .await
+            .expect("write corrupt personal DM record with bad team_id");
+        assert!(
+            matches!(
+                state.load_personal_dm_target(&key).await,
+                Err(SlackPersonalDmTargetError::StoreUnavailable)
+            ),
+            "corrupt team_id must surface as StoreUnavailable, not InvalidTarget"
+        );
+
+        // Corrupt dm_channel_id — fails SlackPersonalDmTarget::new (validate_slack_dm_channel_id)
+        let record_bad_dm = StoredSlackPersonalDmTarget {
+            tenant_id: "tenant-alpha".to_string(),
+            installation_id: installation().as_str().to_string(),
+            team_id: "T123".to_string(),
+            user_id: "user:alice".to_string(),
+            slack_user_id: "U123".to_string(),
+            dm_channel_id: "NOTADM".to_string(), // must start with "D"
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        state
+            .write_record(&path, &record_bad_dm, CasExpectation::Any)
+            .await
+            .expect("write corrupt personal DM record with bad dm_channel_id");
+        assert!(
+            matches!(
+                state.load_personal_dm_target(&key).await,
+                Err(SlackPersonalDmTargetError::StoreUnavailable)
+            ),
+            "corrupt dm_channel_id must surface as StoreUnavailable, not InvalidTarget"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -30,6 +30,10 @@ use crate::slack_channel_routes::{
     SlackChannelRoute, SlackChannelRouteAssignment, SlackChannelRouteError, SlackChannelRouteKey,
     SlackChannelRouteListPage, SlackChannelRouteStore,
 };
+use crate::slack_outbound_targets::{
+    SlackPersonalDmTarget, SlackPersonalDmTargetError, SlackPersonalDmTargetKey,
+    SlackPersonalDmTargetStore,
+};
 use crate::slack_personal_binding::{
     RebornUserIdentityBinding, RebornUserIdentityBindingError, RebornUserIdentityBindingStore,
 };
@@ -45,6 +49,7 @@ const IDENTITY_ROOT: &str = "/tenant-shared/slack-personal-binding/identities";
 const PAIRING_CODE_ROOT: &str = "/tenant-shared/slack-personal-binding/pairing/codes";
 const PAIRING_ACTOR_ROOT: &str = "/tenant-shared/slack-personal-binding/pairing/actors";
 const CHANNEL_ROUTE_ROOT: &str = "/tenant-shared/slack-channel-routes";
+const PERSONAL_DM_TARGET_ROOT: &str = "/tenant-shared/slack-personal-binding/dm-targets";
 const PAIRING_CODE_LEN: usize = 8;
 const PAIRING_CODE_RETRIES: usize = 16;
 const DEFAULT_PAIRING_TTL: Duration = Duration::from_secs(10 * 60);
@@ -559,6 +564,18 @@ where
         ))
     }
 
+    fn personal_dm_target_path(
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<ScopedPath, FilesystemError> {
+        scoped_path(&format!(
+            "{}/{}/{}/{}.json",
+            PERSONAL_DM_TARGET_ROOT,
+            path_segment(key.installation_id.as_str()),
+            path_segment(&key.team_id),
+            path_segment(key.user_id.as_str())
+        ))
+    }
+
     fn listed_channel_route_path(
         installation_id: &AdapterInstallationId,
         team_id: &str,
@@ -760,6 +777,80 @@ where
         Err(RebornUserIdentityBindingError::Backend(
             "Slack actor is already bound to a different user".into(),
         ))
+    }
+}
+
+impl<F> FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn read_personal_dm_target_record(
+        &self,
+        path: &ScopedPath,
+    ) -> Result<Option<(StoredSlackPersonalDmTarget, RecordVersion)>, SlackPersonalDmTargetError>
+    {
+        match self.read_record::<StoredSlackPersonalDmTarget>(path).await {
+            Ok(record) => Ok(record),
+            Err(FilesystemError::NotFound { .. }) => Ok(None),
+            Err(error) => Err(map_personal_dm_target_fs_error(error)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<F> SlackPersonalDmTargetStore for FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn load_personal_dm_target(
+        &self,
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError> {
+        if key.tenant_id != self.scope.tenant_id {
+            return Ok(None);
+        }
+        let path = Self::personal_dm_target_path(key).map_err(map_personal_dm_target_fs_error)?;
+        let Some((record, _)) = self.read_personal_dm_target_record(&path).await? else {
+            return Ok(None);
+        };
+        stored_personal_dm_target(record).map(Some)
+    }
+
+    async fn upsert_personal_dm_target(
+        &self,
+        target: SlackPersonalDmTarget,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+        if target.key.tenant_id != self.scope.tenant_id {
+            return Err(SlackPersonalDmTargetError::InvalidTarget);
+        }
+        let path =
+            Self::personal_dm_target_path(&target.key).map_err(map_personal_dm_target_fs_error)?;
+        let lock = self.lock_for(format!(
+            "personal-dm:{}:{}:{}",
+            target.key.installation_id.as_str(),
+            target.key.team_id,
+            target.key.user_id.as_str()
+        ));
+        let _guard = lock.lock().await;
+        let existing = self.read_personal_dm_target_record(&path).await?;
+        let created_at = existing
+            .as_ref()
+            .map(|(record, _)| record.created_at)
+            .unwrap_or_else(Utc::now);
+        let record = StoredSlackPersonalDmTarget::from_target(&target, created_at);
+        let cas = existing
+            .map(|(_, version)| CasExpectation::Version(version))
+            .unwrap_or(CasExpectation::Absent);
+        match self.write_record(&path, &record, cas).await {
+            Ok(_) => Ok(target),
+            Err(FilesystemError::VersionMismatch { .. }) => {
+                let Some((record, _)) = self.read_personal_dm_target_record(&path).await? else {
+                    return Err(SlackPersonalDmTargetError::StoreUnavailable);
+                };
+                stored_personal_dm_target(record)
+            }
+            Err(error) => Err(map_personal_dm_target_fs_error(error)),
+        }
     }
 }
 
@@ -1217,6 +1308,50 @@ impl StoredSlackUserIdentity {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredSlackPersonalDmTarget {
+    tenant_id: String,
+    installation_id: String,
+    team_id: String,
+    user_id: String,
+    slack_user_id: String,
+    dm_channel_id: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl StoredSlackPersonalDmTarget {
+    fn from_target(target: &SlackPersonalDmTarget, created_at: DateTime<Utc>) -> Self {
+        Self {
+            tenant_id: target.key.tenant_id.as_str().to_string(),
+            installation_id: target.key.installation_id.as_str().to_string(),
+            team_id: target.key.team_id.clone(),
+            user_id: target.key.user_id.as_str().to_string(),
+            slack_user_id: target.slack_user_id.as_str().to_string(),
+            dm_channel_id: target.dm_channel_id.clone(),
+            created_at,
+            updated_at: Utc::now(),
+        }
+    }
+}
+
+fn stored_personal_dm_target(
+    record: StoredSlackPersonalDmTarget,
+) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+    let key = SlackPersonalDmTargetKey::new(
+        TenantId::new(record.tenant_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        AdapterInstallationId::new(record.installation_id)
+            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        record.team_id,
+        UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+    )?;
+    SlackPersonalDmTarget::new(
+        key,
+        SlackUserId::new(record.slack_user_id),
+        record.dm_channel_id,
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum StoredSlackPairingStatus {
@@ -1478,6 +1613,11 @@ fn map_route_fs_error(error: FilesystemError) -> SlackChannelRouteError {
     SlackChannelRouteError::StoreUnavailable
 }
 
+fn map_personal_dm_target_fs_error(error: FilesystemError) -> SlackPersonalDmTargetError {
+    tracing::error!(%error, "Slack personal DM target filesystem operation failed");
+    SlackPersonalDmTargetError::StoreUnavailable
+}
+
 fn is_unsupported_delete_error(error: &FilesystemError) -> bool {
     match error {
         FilesystemError::Unsupported {
@@ -1530,6 +1670,73 @@ mod tests {
         assert_eq!(resolved, Some(user("user:alice")));
         let stored = read_identity(&state, "slack", "install-alpha:U123").await;
         assert_eq!(stored.binding(), Some(binding));
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_persists_personal_dm_targets_across_state_recreation() {
+        let root = Arc::new(InMemoryBackend::default());
+        let writer = state_with_root(root.clone());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let target =
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D123".to_string())
+                .unwrap();
+
+        writer
+            .upsert_personal_dm_target(target.clone())
+            .await
+            .expect("upsert personal DM target succeeds");
+        assert_eq!(
+            writer
+                .load_personal_dm_target(&key)
+                .await
+                .expect("load personal DM target succeeds"),
+            Some(target.clone())
+        );
+
+        let reader = state_with_root(root);
+        assert_eq!(
+            reader
+                .load_personal_dm_target(&key)
+                .await
+                .expect("load persisted personal DM target succeeds"),
+            Some(target)
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_rejects_cross_tenant_personal_dm_target_operations() {
+        let state = state();
+        let foreign_key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-foreign").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let foreign_target = SlackPersonalDmTarget::new(
+            foreign_key.clone(),
+            SlackUserId::new("U123"),
+            "D123".to_string(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            state.upsert_personal_dm_target(foreign_target).await,
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+        assert_eq!(
+            state
+                .load_personal_dm_target(&foreign_key)
+                .await
+                .expect("foreign tenant load fails closed"),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -806,6 +806,11 @@ where
         &self,
         key: &SlackPersonalDmTargetKey,
     ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError> {
+        // Cross-tenant reads return Ok(None) (not an error) so a caller
+        // cannot distinguish "other tenant has this key" from "no target
+        // exists" — reads stay free of a tenant-existence oracle. Writes
+        // below differ deliberately: a cross-tenant upsert is a caller bug
+        // and fails loudly with InvalidTarget.
         if key.tenant_id != self.scope.tenant_id {
             return Ok(None);
         }
@@ -825,6 +830,11 @@ where
         }
         let path =
             Self::personal_dm_target_path(&target.key).map_err(map_personal_dm_target_fs_error)?;
+        // Lock key omits tenant_id: this store instance is pinned to one
+        // tenant (cross-tenant writes are rejected above before locking),
+        // so installation/team/user uniquely identify the record within
+        // the instance. Revisit if a multi-tenant store instance ever
+        // shares this lock map.
         let lock = self.lock_for(format!(
             "personal-dm:{}:{}:{}",
             target.key.installation_id.as_str(),

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -1775,6 +1775,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filesystem_slack_host_state_upsert_personal_dm_target_concurrent_write_returns_winner()
+    {
+        let root = Arc::new(RouteLockTestBackend::barrier_personal_dm_writes());
+        let writer_one = state_with_backend(root.clone());
+        let writer_two = state_with_backend(root.clone());
+        let reader = state_with_backend(root);
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let target_one =
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D123".to_string())
+                .unwrap();
+        let target_two =
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D456".to_string())
+                .unwrap();
+
+        let (stored_one, stored_two) = tokio::join!(
+            writer_one.upsert_personal_dm_target(target_one),
+            writer_two.upsert_personal_dm_target(target_two)
+        );
+        let stored_one = stored_one.expect("first upsert succeeds");
+        let stored_two = stored_two.expect("second upsert succeeds");
+        let persisted = reader
+            .load_personal_dm_target(&key)
+            .await
+            .expect("load personal DM target succeeds")
+            .expect("personal DM target persists");
+
+        assert_eq!(stored_one, stored_two);
+        assert_eq!(persisted, stored_one);
+        assert!(matches!(persisted.dm_channel_id.as_str(), "D123" | "D456"));
+    }
+
+    #[tokio::test]
     async fn filesystem_slack_host_state_rejects_rebinding_actor_to_different_user() {
         let state = state();
         state
@@ -2600,6 +2638,7 @@ mod tests {
         inner: InMemoryBackend,
         reject_lock_renewal: bool,
         route_write_delay: Option<Duration>,
+        personal_dm_write_barrier: Option<Arc<tokio::sync::Barrier>>,
         route_write_failures: AtomicUsize,
         lock_puts: AtomicUsize,
     }
@@ -2610,6 +2649,7 @@ mod tests {
                 inner: InMemoryBackend::default(),
                 reject_lock_renewal: false,
                 route_write_delay: None,
+                personal_dm_write_barrier: None,
                 route_write_failures: AtomicUsize::new(0),
                 lock_puts: AtomicUsize::new(0),
             }
@@ -2620,6 +2660,7 @@ mod tests {
                 inner: InMemoryBackend::default(),
                 reject_lock_renewal: false,
                 route_write_delay: Some(delay),
+                personal_dm_write_barrier: None,
                 route_write_failures: AtomicUsize::new(0),
                 lock_puts: AtomicUsize::new(0),
             }
@@ -2630,6 +2671,18 @@ mod tests {
                 inner: InMemoryBackend::default(),
                 reject_lock_renewal: true,
                 route_write_delay: Some(delay),
+                personal_dm_write_barrier: None,
+                route_write_failures: AtomicUsize::new(0),
+                lock_puts: AtomicUsize::new(0),
+            }
+        }
+
+        fn barrier_personal_dm_writes() -> Self {
+            Self {
+                inner: InMemoryBackend::default(),
+                reject_lock_renewal: false,
+                route_write_delay: None,
+                personal_dm_write_barrier: Some(Arc::new(tokio::sync::Barrier::new(2))),
                 route_write_failures: AtomicUsize::new(0),
                 lock_puts: AtomicUsize::new(0),
             }
@@ -2669,6 +2722,10 @@ mod tests {
                 && let Some(delay) = self.route_write_delay
             {
                 tokio::time::sleep(delay).await;
+            } else if is_personal_dm_target_record_path(path)
+                && let Some(barrier) = &self.personal_dm_write_barrier
+            {
+                barrier.wait().await;
             }
             if is_channel_route_record_path(path)
                 && self.route_write_failures.load(Ordering::SeqCst) > 0
@@ -2717,6 +2774,12 @@ mod tests {
         path.as_str().contains("/slack-channel-routes/")
             && path.as_str().ends_with(".json")
             && !is_replace_lock_path(path)
+    }
+
+    fn is_personal_dm_target_record_path(path: &VirtualPath) -> bool {
+        path.as_str()
+            .contains("/slack-personal-binding/dm-targets/")
+            && path.as_str().ends_with(".json")
     }
 
     fn binding(user_id: &str) -> RebornUserIdentityBinding {

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -674,7 +674,7 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
                 Ok(target) => targets.push(target),
                 Err(error) => {
                     tracing::warn!(
-                        ?error,
+                        %error,
                         "Slack personal DM target was skipped while listing outbound targets"
                     );
                 }
@@ -785,6 +785,10 @@ fn slack_personal_dm_reply_target_binding_ref(
 pub(crate) fn slack_reply_target_binding_ref_from_raw(
     raw: String,
 ) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    // Safety: all callers must pre-validate inputs via validate_slack_id /
+    // validate_slack_dm_channel_id which reject control characters (including NUL).
+    // ReplyTargetBindingRef::new enforces the 256-byte limit and rejects control chars
+    // as the primary defense — these caller-side validators are defense-in-depth.
     ReplyTargetBindingRef::new(format!("reply:{raw}")).map_err(|_| slack_target_backend_error())
 }
 
@@ -856,6 +860,83 @@ fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPerson
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::slack_channel_routes::{
+        InMemorySlackChannelRouteStore, SlackChannelRouteError, SlackChannelRouteKey,
+        SlackChannelRouteListPage,
+    };
+
+    // ── test constants ────────────────────────────────────────────────────────
+    const TENANT: &str = "tenant:alpha";
+    const INSTALLATION: &str = "install-alpha";
+    const TEAM: &str = "T123";
+    const USER: &str = "user:alice";
+    const OTHER_TENANT: &str = "tenant:other";
+    const OTHER_USER: &str = "user:bob";
+    const SLACK_USER: &str = "U123";
+    const AGENT: &str = "agent:alpha";
+    const PROJECT: &str = "project:alpha";
+
+    // ── test helpers ──────────────────────────────────────────────────────────
+
+    fn caller() -> WebUiAuthenticatedCaller {
+        WebUiAuthenticatedCaller::new(
+            TenantId::new(TENANT).expect("tenant"),
+            UserId::new(USER).expect("user"),
+            Some(AgentId::new(AGENT).expect("agent")),
+            Some(ProjectId::new(PROJECT).expect("project")),
+        )
+    }
+
+    fn provider_config(
+        channel_routes: Vec<SlackConfiguredChannelRoute>,
+    ) -> SlackOutboundTargetProviderConfig {
+        SlackOutboundTargetProviderConfig {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            agent_id: AgentId::new(AGENT).expect("agent"),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            installation_id: AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            team_id: SlackTeamId::new(TEAM),
+            configured_channel_routes: channel_routes,
+        }
+    }
+
+    fn empty_provider() -> SlackHostBetaOutboundTargetProvider {
+        SlackHostBetaOutboundTargetProvider::new(
+            provider_config(Vec::new()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        )
+    }
+
+    async fn provider_with_provisioned_dm() -> (
+        SlackHostBetaOutboundTargetProvider,
+        Arc<InMemorySlackPersonalDmTargetStore>,
+    ) {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("stores");
+        let store_dyn: Arc<dyn SlackPersonalDmTargetStore> = Arc::clone(&store) as _;
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(Vec::new()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store_dyn,
+        );
+        (provider, store)
+    }
+
+    // ── validate_slack_id ─────────────────────────────────────────────────────
 
     #[test]
     fn validate_slack_id_accepts_128_char_id_and_rejects_129_char_id() {
@@ -876,6 +957,8 @@ mod tests {
         }
     }
 
+    // ── validate_slack_dm_channel_id ──────────────────────────────────────────
+
     #[test]
     fn slack_personal_dm_target_rejects_non_d_prefixed_channel_id() {
         let key = SlackPersonalDmTargetKey::new(
@@ -890,7 +973,345 @@ mod tests {
             SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "C123".to_string()),
             Err(SlackPersonalDmTargetError::InvalidTarget)
         ));
-        SlackPersonalDmTarget::new(key, SlackUserId::new("U123"), "D123".to_string())
+        SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D123".to_string())
             .expect("DM-prefixed channel is valid");
+        // lowercase 'd' prefix is also invalid (must be uppercase 'D')
+        assert!(matches!(
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "d123".to_string()),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+        // empty is invalid
+        assert!(matches!(
+            SlackPersonalDmTarget::new(key, SlackUserId::new("U123"), String::new()),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+    }
+
+    // ── slack_personal_dm_reply_target_binding_ref round-trip ────────────────
+
+    #[test]
+    fn slack_personal_dm_reply_target_binding_ref_round_trips_dm_channel_and_slack_user() {
+        let provider = empty_provider();
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let agent_id = AgentId::new(AGENT).expect("agent");
+        let project_id = ProjectId::new(PROJECT).expect("project");
+        let team_id = SlackTeamId::new(TEAM);
+        let slack_user_id = SlackUserId::new(SLACK_USER);
+
+        let binding_ref = slack_personal_dm_reply_target_binding_ref(
+            &installation_id,
+            &agent_id,
+            Some(&project_id),
+            &team_id,
+            "D0HOST",
+            &slack_user_id,
+        )
+        .expect("binding ref builds");
+
+        // parse it back via route_for_reply_target_binding_ref
+        let parsed = provider
+            .route_for_reply_target_binding_ref(&binding_ref)
+            .expect("binding ref parses to a Slack reply target");
+
+        match parsed {
+            ParsedSlackReplyTarget::PersonalDm {
+                dm_channel_id,
+                slack_user_id: parsed_slack_user_id,
+            } => {
+                assert_eq!(dm_channel_id, "D0HOST", "dm_channel_id must round-trip");
+                assert_eq!(
+                    parsed_slack_user_id.as_str(),
+                    SLACK_USER,
+                    "slack_user_id must round-trip"
+                );
+            }
+            ParsedSlackReplyTarget::SharedChannel { .. } => {
+                panic!("personal DM binding ref must not parse as shared channel");
+            }
+        }
+    }
+
+    // ── resolve_reply_target_binding PersonalDm branch ────────────────────────
+
+    #[tokio::test]
+    async fn slack_personal_dm_reply_target_binding_resolves_to_stored_target() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        let listed = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect("target list");
+        assert_eq!(listed.len(), 1, "provisioned DM target must appear");
+        let binding_ref = listed[0].reply_target_binding_ref.clone();
+
+        let resolved = provider
+            .resolve_reply_target_binding(&caller(), &binding_ref)
+            .await
+            .expect("binding resolves without error")
+            .expect("stored DM target must resolve to Some");
+
+        assert_eq!(
+            resolved.summary.target_id.as_str(),
+            format!("slack:personal-dm:{}:{}", TEAM, USER)
+        );
+        assert_eq!(resolved.reply_target_binding_ref, binding_ref);
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_reply_target_binding_returns_none_when_no_target_stored() {
+        // Build binding ref for a user that has no provisioned DM target.
+        let provider = empty_provider();
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let agent_id = AgentId::new(AGENT).expect("agent");
+        let project_id = ProjectId::new(PROJECT).expect("project");
+        let team_id = SlackTeamId::new(TEAM);
+        let slack_user_id = SlackUserId::new(SLACK_USER);
+
+        let binding_ref = slack_personal_dm_reply_target_binding_ref(
+            &installation_id,
+            &agent_id,
+            Some(&project_id),
+            &team_id,
+            "D0HOST",
+            &slack_user_id,
+        )
+        .expect("binding ref builds");
+
+        // No target stored → should return Ok(None) (not an error).
+        let result = provider
+            .resolve_reply_target_binding(&caller(), &binding_ref)
+            .await
+            .expect("lookup succeeds");
+        assert!(result.is_none(), "ownerless binding ref must return None");
+    }
+
+    // ── mismatch-guard: stored slack_user_id differs from binding ref ─────────
+
+    #[tokio::test]
+    async fn slack_personal_dm_resolve_binding_rejects_mismatched_slack_user_id() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        // Listing gives us a real binding ref that encodes SLACK_USER + D0HOST.
+        let listed = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect("target list");
+        assert_eq!(listed.len(), 1);
+
+        // Replace the SLACK_USER segment in the raw binding ref string with a
+        // different Slack user id, keeping the dm_channel_id the same.
+        let original = listed[0].reply_target_binding_ref.as_str();
+        let tampered_raw = original.replace(SLACK_USER, "U_OTHER_USER");
+        let mismatched = ReplyTargetBindingRef::new(tampered_raw)
+            .expect("tampered ref is still syntactically valid");
+
+        let result = provider
+            .resolve_reply_target_binding(&caller(), &mismatched)
+            .await
+            .expect("lookup succeeds");
+        assert!(
+            result.is_none(),
+            "mismatched slack_user_id in binding ref must return None"
+        );
+    }
+
+    // ── cross-user: caller.user_id != requested user_id ──────────────────────
+
+    #[tokio::test]
+    async fn slack_personal_dm_resolve_personal_dm_for_user_returns_none_for_cross_user_caller() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        // Target was provisioned for USER ("user:alice").  A different user
+        // ("user:bob") tries to resolve the same target_id.
+        let target_id =
+            RebornOutboundDeliveryTargetId::new(format!("slack:personal-dm:{}:{}", TEAM, USER))
+                .expect("target id");
+
+        let cross_user_caller = WebUiAuthenticatedCaller::new(
+            TenantId::new(TENANT).expect("tenant"),
+            UserId::new(OTHER_USER).expect("other user"),
+            None,
+            None,
+        );
+
+        let result = provider
+            .resolve_outbound_delivery_target(&cross_user_caller, &target_id)
+            .await
+            .expect("lookup succeeds");
+        assert!(
+            result.is_none(),
+            "user B must not resolve user A's personal DM target"
+        );
+    }
+
+    // ── list: both shared-channel route AND personal DM appear together ───────
+
+    #[tokio::test]
+    async fn slack_list_outbound_delivery_targets_returns_shared_channels_and_personal_dm_together()
+    {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("stores");
+
+        // Add a static shared-channel route for the same caller.
+        let shared_route = SlackConfiguredChannelRoute::new(
+            "C0HOST".to_string(),
+            UserId::new(USER).expect("user"),
+        );
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(vec![shared_route]),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store,
+        );
+
+        let listed = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect("target list");
+
+        let target_ids: Vec<&str> = listed
+            .iter()
+            .map(|e| e.summary.target_id.as_str())
+            .collect();
+        assert!(
+            target_ids.iter().any(|id| id.contains("shared-channel")),
+            "shared-channel target must appear: {:?}",
+            target_ids
+        );
+        assert!(
+            target_ids.iter().any(|id| id.contains("personal-dm")),
+            "personal-DM target must appear: {:?}",
+            target_ids
+        );
+        assert_eq!(listed.len(), 2, "exactly one shared + one DM target");
+    }
+
+    // ── shared_channel_routes cap guard ──────────────────────────────────────
+
+    #[derive(Debug)]
+    struct OversizedPageRouteStore;
+
+    #[async_trait::async_trait]
+    impl SlackChannelRouteStore for OversizedPageRouteStore {
+        async fn list_routes(
+            &self,
+            _tenant_id: &TenantId,
+            _installation_id: &AdapterInstallationId,
+            _team_id: &str,
+            _cursor: usize,
+            _limit: usize,
+        ) -> Result<SlackChannelRouteListPage, SlackChannelRouteError> {
+            // Return more routes than the cap in a single page (no next cursor,
+            // so the loop will try the cap check on this batch).
+            let routes = (0..=SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES)
+                .map(|i| crate::slack_channel_routes::SlackChannelRoute {
+                    tenant_id: TENANT.to_string(),
+                    installation_id: INSTALLATION.to_string(),
+                    team_id: TEAM.to_string(),
+                    channel_id: format!("C{i:05}"),
+                    subject_user_id: USER.to_string(),
+                })
+                .collect();
+            Ok(SlackChannelRouteListPage {
+                routes,
+                next_cursor: None,
+            })
+        }
+
+        async fn upsert_route(
+            &self,
+            _key: SlackChannelRouteKey,
+            _subject_user_id: UserId,
+        ) -> Result<crate::slack_channel_routes::SlackChannelRoute, SlackChannelRouteError>
+        {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+
+        async fn delete_route(
+            &self,
+            _key: &SlackChannelRouteKey,
+        ) -> Result<bool, SlackChannelRouteError> {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+
+        async fn replace_managed_routes(
+            &self,
+            _tenant_id: &TenantId,
+            _installation_id: &AdapterInstallationId,
+            _team_id: &str,
+            _assignments: Vec<crate::slack_channel_routes::SlackChannelRouteAssignment>,
+        ) -> Result<Vec<crate::slack_channel_routes::SlackChannelRoute>, SlackChannelRouteError>
+        {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+
+        async fn resolve_subject_user_id(
+            &self,
+            _key: &SlackChannelRouteKey,
+        ) -> Result<Option<UserId>, SlackChannelRouteError> {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+    }
+
+    #[tokio::test]
+    async fn slack_shared_channel_routes_fails_when_stored_batch_exceeds_max_total() {
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(Vec::new()),
+            Arc::new(OversizedPageRouteStore),
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        );
+
+        let error = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect_err("oversized batch must fail closed");
+
+        assert_eq!(error.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(error.kind, RebornServicesErrorKind::ServiceUnavailable);
+        assert_eq!(error.status_code, 503);
+        assert!(error.retryable);
+    }
+
+    // ── cross-tenant personal-DM resolve ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn slack_host_beta_targets_ignore_cross_tenant_personal_dm_resolve() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        // Build a personal-DM target_id that matches the provisioned target.
+        let target_id =
+            RebornOutboundDeliveryTargetId::new(format!("slack:personal-dm:{}:{}", TEAM, USER))
+                .expect("target id");
+
+        // A caller from a different tenant with the same user_id.
+        let foreign_tenant_caller = WebUiAuthenticatedCaller::new(
+            TenantId::new(OTHER_TENANT).expect("other tenant"),
+            UserId::new(USER).expect("user"),
+            None,
+            None,
+        );
+
+        let result = provider
+            .resolve_outbound_delivery_target(&foreign_tenant_caller, &target_id)
+            .await
+            .expect("lookup succeeds without error");
+
+        assert!(
+            result.is_none(),
+            "cross-tenant caller must not resolve personal DM target; got: {:?}",
+            result.map(|e| e.summary.target_id.as_str().to_string())
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -27,6 +27,7 @@ use crate::outbound_preferences::{OutboundDeliveryTargetEntry, OutboundDeliveryT
 use crate::slack_channel_routes::{
     SlackChannelRouteError, SlackChannelRouteKey, SlackChannelRouteStore,
 };
+use crate::slack_dm_open::validate_slack_dm_channel_id;
 #[cfg(test)]
 use crate::slack_dm_open::{SlackDmOpenError, open_slack_dm_channel};
 use crate::slack_serve::{SlackTeamId, SlackUserId};
@@ -97,7 +98,8 @@ impl SlackPersonalDmTarget {
         dm_channel_id: String,
     ) -> Result<Self, SlackPersonalDmTargetError> {
         validate_slack_id("slack user", slack_user_id.as_str())?;
-        validate_slack_dm_channel_id(&dm_channel_id)?;
+        validate_slack_dm_channel_id(&dm_channel_id)
+            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?;
         Ok(Self {
             key,
             slack_user_id,
@@ -113,6 +115,7 @@ pub(crate) enum SlackPersonalDmTargetError {
     #[error("Slack personal DM target store unavailable")]
     StoreUnavailable,
     #[error("Slack personal DM provisioning failed: {0}")]
+    // arch-exempt: dead_code, reserved for explicit Slack DM provisioning product route, plan #4600
     #[allow(dead_code)]
     ProvisioningFailed(String),
 }
@@ -124,6 +127,7 @@ pub(crate) trait SlackPersonalDmTargetStore: Send + Sync + std::fmt::Debug {
         key: &SlackPersonalDmTargetKey,
     ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError>;
 
+    // arch-exempt: dead_code, reserved for explicit Slack DM provisioning product route, plan #4600
     #[allow(dead_code)]
     async fn upsert_personal_dm_target(
         &self,
@@ -216,7 +220,6 @@ impl SlackPersonalDmTargetProvisioner {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn provision_for_user(
         &self,
         user_id: UserId,
@@ -233,7 +236,6 @@ impl SlackPersonalDmTargetProvisioner {
         self.store.upsert_personal_dm_target(target).await
     }
 
-    #[allow(dead_code)]
     async fn open_dm_channel(
         &self,
         slack_user_id: &str,
@@ -245,12 +247,15 @@ impl SlackPersonalDmTargetProvisioner {
         )
         .await
         .map_err(|error| match error {
-            SlackDmOpenError::MissingChannel => SlackPersonalDmTargetError::InvalidTarget,
+            SlackDmOpenError::InvalidChannel | SlackDmOpenError::MissingChannel => {
+                SlackPersonalDmTargetError::InvalidTarget
+            }
             SlackDmOpenError::Backend(reason) => {
                 SlackPersonalDmTargetError::ProvisioningFailed(reason)
             }
         })?;
-        validate_slack_dm_channel_id(&channel_id)?;
+        validate_slack_dm_channel_id(&channel_id)
+            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?;
         Ok(channel_id)
     }
 }
@@ -386,7 +391,7 @@ impl SlackHostBetaOutboundTargetProvider {
         })
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn channel_id_for_reply_target_binding_ref(
         &self,
         target: &ReplyTargetBindingRef,
@@ -629,13 +634,21 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
             .into_iter()
             .map(|route| self.entry_for_shared_channel_route(&route))
             .collect::<Result<Vec<_>, _>>()?;
-        let key = SlackPersonalDmTargetKey::new(
+        let key = match SlackPersonalDmTargetKey::new(
             self.tenant_id.clone(),
             self.installation_id.clone(),
             self.team_id.as_str().to_string(),
             caller.user_id.clone(),
-        )
-        .map_err(map_slack_personal_dm_target_error)?;
+        ) {
+            Ok(key) => key,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "Slack personal DM target key could not be built while listing outbound targets"
+                );
+                return Ok(targets);
+            }
+        };
         match self
             .personal_dm_target_store
             .load_personal_dm_target(&key)
@@ -818,14 +831,6 @@ fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPerson
         })
     {
         tracing::debug!(field, "invalid Slack id for personal DM target");
-        return Err(SlackPersonalDmTargetError::InvalidTarget);
-    }
-    Ok(())
-}
-
-fn validate_slack_dm_channel_id(value: &str) -> Result<(), SlackPersonalDmTargetError> {
-    validate_slack_id("slack dm channel", value)?;
-    if !value.starts_with('D') {
         return Err(SlackPersonalDmTargetError::InvalidTarget);
     }
     Ok(())

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -1,0 +1,832 @@
+//! Slack outbound target authority for default delivery.
+//!
+//! Core outbound preferences only see opaque target ids and validated reply
+//! target bindings. Slack-specific channel and DM authority stays here.
+
+#[cfg(test)]
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::RwLock;
+
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+use ironclaw_product_adapters::{AdapterInstallationId, ExternalActorRef, ExternalConversationRef};
+#[cfg(test)]
+use ironclaw_product_adapters::{EgressCredentialHandle, ProtocolHttpEgress};
+use ironclaw_product_workflow::{
+    RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
+    RebornOutboundDeliveryTargetSummary, RebornServicesError, RebornServicesErrorCode,
+    RebornServicesErrorKind, WebUiAuthenticatedCaller,
+};
+use ironclaw_slack_v2_adapter::{SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID};
+use ironclaw_turns::ReplyTargetBindingRef;
+use thiserror::Error;
+
+use crate::outbound_preferences::{OutboundDeliveryTargetEntry, OutboundDeliveryTargetProvider};
+use crate::slack_channel_routes::{
+    SlackChannelRouteError, SlackChannelRouteKey, SlackChannelRouteStore,
+};
+#[cfg(test)]
+use crate::slack_dm_open::{SlackDmOpenError, open_slack_dm_channel};
+use crate::slack_serve::{SlackTeamId, SlackUserId};
+
+pub(crate) const SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE: usize = 500;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SlackConfiguredChannelRoute {
+    pub(crate) channel_id: String,
+    pub(crate) subject_user_id: UserId,
+}
+
+impl SlackConfiguredChannelRoute {
+    pub(crate) fn new(channel_id: String, subject_user_id: UserId) -> Self {
+        Self {
+            channel_id,
+            subject_user_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SlackOutboundTargetProviderConfig {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) agent_id: AgentId,
+    pub(crate) project_id: Option<ProjectId>,
+    pub(crate) installation_id: AdapterInstallationId,
+    pub(crate) team_id: SlackTeamId,
+    pub(crate) configured_channel_routes: Vec<SlackConfiguredChannelRoute>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SlackPersonalDmTargetKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) installation_id: AdapterInstallationId,
+    pub(crate) team_id: String,
+    pub(crate) user_id: UserId,
+}
+
+impl SlackPersonalDmTargetKey {
+    pub(crate) fn new(
+        tenant_id: TenantId,
+        installation_id: AdapterInstallationId,
+        team_id: String,
+        user_id: UserId,
+    ) -> Result<Self, SlackPersonalDmTargetError> {
+        validate_slack_id("slack team", &team_id)?;
+        Ok(Self {
+            tenant_id,
+            installation_id,
+            team_id,
+            user_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SlackPersonalDmTarget {
+    pub(crate) key: SlackPersonalDmTargetKey,
+    pub(crate) slack_user_id: SlackUserId,
+    pub(crate) dm_channel_id: String,
+}
+
+impl SlackPersonalDmTarget {
+    pub(crate) fn new(
+        key: SlackPersonalDmTargetKey,
+        slack_user_id: SlackUserId,
+        dm_channel_id: String,
+    ) -> Result<Self, SlackPersonalDmTargetError> {
+        validate_slack_id("slack user", slack_user_id.as_str())?;
+        validate_slack_dm_channel_id(&dm_channel_id)?;
+        Ok(Self {
+            key,
+            slack_user_id,
+            dm_channel_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum SlackPersonalDmTargetError {
+    #[error("invalid Slack personal DM target")]
+    InvalidTarget,
+    #[error("Slack personal DM target store unavailable")]
+    StoreUnavailable,
+    #[error("Slack personal DM provisioning failed: {0}")]
+    #[allow(dead_code)]
+    ProvisioningFailed(String),
+}
+
+#[async_trait::async_trait]
+pub(crate) trait SlackPersonalDmTargetStore: Send + Sync + std::fmt::Debug {
+    async fn load_personal_dm_target(
+        &self,
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError>;
+
+    #[allow(dead_code)]
+    async fn upsert_personal_dm_target(
+        &self,
+        target: SlackPersonalDmTarget,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError>;
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub(crate) struct InMemorySlackPersonalDmTargetStore {
+    targets: RwLock<HashMap<SlackPersonalDmTargetKey, SlackPersonalDmTarget>>,
+}
+
+#[cfg(test)]
+impl InMemorySlackPersonalDmTargetStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl SlackPersonalDmTargetStore for InMemorySlackPersonalDmTargetStore {
+    async fn load_personal_dm_target(
+        &self,
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError> {
+        Ok(self
+            .targets
+            .read()
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?
+            .get(key)
+            .cloned())
+    }
+
+    async fn upsert_personal_dm_target(
+        &self,
+        target: SlackPersonalDmTarget,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+        self.targets
+            .write()
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?
+            .insert(target.key.clone(), target.clone());
+        Ok(target)
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct SlackPersonalDmTargetProvisioner {
+    tenant_id: TenantId,
+    installation_id: AdapterInstallationId,
+    team_id: SlackTeamId,
+    egress: Arc<dyn ProtocolHttpEgress>,
+    credential_handle: EgressCredentialHandle,
+    store: Arc<dyn SlackPersonalDmTargetStore>,
+}
+
+#[cfg(test)]
+impl std::fmt::Debug for SlackPersonalDmTargetProvisioner {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SlackPersonalDmTargetProvisioner")
+            .field("tenant_id", &self.tenant_id)
+            .field("installation_id", &self.installation_id)
+            .field("team_id", &self.team_id)
+            .field("egress", &"Arc<dyn ProtocolHttpEgress>")
+            .field("credential_handle", &self.credential_handle)
+            .field("store", &self.store)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+impl SlackPersonalDmTargetProvisioner {
+    pub(crate) fn new(
+        tenant_id: TenantId,
+        installation_id: AdapterInstallationId,
+        team_id: SlackTeamId,
+        egress: Arc<dyn ProtocolHttpEgress>,
+        credential_handle: EgressCredentialHandle,
+        store: Arc<dyn SlackPersonalDmTargetStore>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            installation_id,
+            team_id,
+            egress,
+            credential_handle,
+            store,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn provision_for_user(
+        &self,
+        user_id: UserId,
+        slack_user_id: SlackUserId,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            user_id,
+        )?;
+        let dm_channel_id = self.open_dm_channel(slack_user_id.as_str()).await?;
+        let target = SlackPersonalDmTarget::new(key, slack_user_id, dm_channel_id)?;
+        self.store.upsert_personal_dm_target(target).await
+    }
+
+    #[allow(dead_code)]
+    async fn open_dm_channel(
+        &self,
+        slack_user_id: &str,
+    ) -> Result<String, SlackPersonalDmTargetError> {
+        let channel_id = open_slack_dm_channel(
+            self.egress.as_ref(),
+            self.credential_handle.clone(),
+            slack_user_id,
+        )
+        .await
+        .map_err(|error| match error {
+            SlackDmOpenError::MissingChannel => SlackPersonalDmTargetError::InvalidTarget,
+            SlackDmOpenError::Backend(reason) => {
+                SlackPersonalDmTargetError::ProvisioningFailed(reason)
+            }
+        })?;
+        validate_slack_dm_channel_id(&channel_id)?;
+        Ok(channel_id)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SlackHostBetaOutboundTargetProvider {
+    tenant_id: TenantId,
+    agent_id: AgentId,
+    project_id: Option<ProjectId>,
+    installation_id: AdapterInstallationId,
+    team_id: SlackTeamId,
+    shared_target_id_prefix: String,
+    personal_target_id_prefix: String,
+    configured_channel_routes: Vec<SlackConfiguredChannelRoute>,
+    channel_route_store: Arc<dyn SlackChannelRouteStore>,
+    personal_dm_target_store: Arc<dyn SlackPersonalDmTargetStore>,
+}
+
+impl SlackHostBetaOutboundTargetProvider {
+    pub(crate) fn new(
+        config: SlackOutboundTargetProviderConfig,
+        channel_route_store: Arc<dyn SlackChannelRouteStore>,
+        personal_dm_target_store: Arc<dyn SlackPersonalDmTargetStore>,
+    ) -> Self {
+        Self {
+            tenant_id: config.tenant_id,
+            agent_id: config.agent_id,
+            project_id: config.project_id,
+            installation_id: config.installation_id,
+            shared_target_id_prefix: format!("slack:shared-channel:{}:", config.team_id.as_str()),
+            personal_target_id_prefix: format!("slack:personal-dm:{}:", config.team_id.as_str()),
+            team_id: config.team_id,
+            configured_channel_routes: config.configured_channel_routes,
+            channel_route_store,
+            personal_dm_target_store,
+        }
+    }
+
+    fn target_id_for_shared_channel(
+        &self,
+        channel_id: &str,
+    ) -> Result<RebornOutboundDeliveryTargetId, RebornServicesError> {
+        RebornOutboundDeliveryTargetId::new(format!(
+            "slack:shared-channel:{}:{}",
+            self.team_id.as_str(),
+            channel_id
+        ))
+        .map_err(|_| slack_target_backend_error())
+    }
+
+    fn target_id_for_personal_dm(
+        &self,
+        user_id: &UserId,
+    ) -> Result<RebornOutboundDeliveryTargetId, RebornServicesError> {
+        RebornOutboundDeliveryTargetId::new(format!(
+            "slack:personal-dm:{}:{}",
+            self.team_id.as_str(),
+            user_id.as_str()
+        ))
+        .map_err(|_| slack_target_backend_error())
+    }
+
+    pub(crate) fn channel_id_for_target_id<'a>(
+        &self,
+        target_id: &'a RebornOutboundDeliveryTargetId,
+    ) -> Option<&'a str> {
+        target_id
+            .as_str()
+            .strip_prefix(&self.shared_target_id_prefix)
+            .filter(|channel_id| !channel_id.is_empty())
+    }
+
+    fn user_id_for_personal_target_id(
+        &self,
+        target_id: &RebornOutboundDeliveryTargetId,
+    ) -> Option<UserId> {
+        UserId::new(
+            target_id
+                .as_str()
+                .strip_prefix(&self.personal_target_id_prefix)?,
+        )
+        .ok()
+    }
+
+    fn route_for_reply_target_binding_ref(
+        &self,
+        target: &ReplyTargetBindingRef,
+    ) -> Option<ParsedSlackReplyTarget> {
+        let mut raw = target.as_str().strip_prefix("reply:")?;
+        let (adapter_id, rest) = take_product_binding_segment(raw, "adapter")?;
+        if adapter_id != SLACK_V2_ADAPTER_ID {
+            return None;
+        }
+        raw = rest;
+        let (installation_id, rest) = take_product_binding_segment(raw, "installation")?;
+        if installation_id != self.installation_id.as_str() {
+            return None;
+        }
+        raw = rest;
+        let (agent_id, rest) = take_product_binding_segment(raw, "agent")?;
+        if agent_id != self.agent_id.as_str() {
+            return None;
+        }
+        raw = rest;
+        let (project_id, rest) = take_product_binding_segment(raw, "project")?;
+        if project_id != self.project_id.as_ref().map_or("", |id| id.as_str()) {
+            return None;
+        }
+        raw = rest;
+        let (space_id, rest) = take_product_binding_segment(raw, "space")?;
+        if space_id != self.team_id.as_str() {
+            return None;
+        }
+        raw = rest;
+        let (conversation_id, rest) = take_product_binding_segment(raw, "conversation")?;
+        let (topic_id, rest) = take_product_binding_segment(rest, "topic")?;
+        if conversation_id.is_empty() || !topic_id.is_empty() {
+            return None;
+        }
+        if rest.is_empty() {
+            return Some(ParsedSlackReplyTarget::SharedChannel {
+                channel_id: conversation_id.to_string(),
+            });
+        }
+        let (actor_kind, rest) = take_product_binding_segment(rest, "actor_kind")?;
+        let (actor_id, rest) = take_product_binding_segment(rest, "actor")?;
+        if actor_kind != SLACK_USER_ACTOR_KIND || actor_id.is_empty() || !rest.is_empty() {
+            return None;
+        }
+        Some(ParsedSlackReplyTarget::PersonalDm {
+            dm_channel_id: conversation_id.to_string(),
+            slack_user_id: SlackUserId::new(actor_id),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn channel_id_for_reply_target_binding_ref(
+        &self,
+        target: &ReplyTargetBindingRef,
+    ) -> Option<String> {
+        match self.route_for_reply_target_binding_ref(target)? {
+            ParsedSlackReplyTarget::SharedChannel { channel_id } => Some(channel_id),
+            ParsedSlackReplyTarget::PersonalDm { .. } => None,
+        }
+    }
+
+    async fn shared_channel_route_for_channel(
+        &self,
+        channel_id: &str,
+    ) -> Result<Option<SlackConfiguredChannelRoute>, RebornServicesError> {
+        let key = match SlackChannelRouteKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            channel_id.to_string(),
+        ) {
+            Ok(key) => key,
+            Err(SlackChannelRouteError::InvalidRoute) => return Ok(None),
+            Err(error) => return Err(map_slack_target_route_error(error)),
+        };
+        if let Some(subject_user_id) = self
+            .channel_route_store
+            .resolve_subject_user_id(&key)
+            .await
+            .map_err(map_slack_target_route_error)?
+        {
+            return Ok(Some(SlackConfiguredChannelRoute::new(
+                channel_id.to_string(),
+                subject_user_id,
+            )));
+        }
+        Ok(self
+            .configured_channel_routes
+            .iter()
+            .find(|route| route.channel_id == channel_id)
+            .cloned())
+    }
+
+    async fn shared_channel_routes(
+        &self,
+    ) -> Result<Vec<SlackConfiguredChannelRoute>, RebornServicesError> {
+        let mut cursor = 0;
+        let mut stored_channel_ids = HashSet::new();
+        let mut routes = Vec::new();
+        loop {
+            let stored = self
+                .channel_route_store
+                .list_routes(
+                    &self.tenant_id,
+                    &self.installation_id,
+                    self.team_id.as_str(),
+                    cursor,
+                    SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+                )
+                .await
+                .map_err(map_slack_target_route_error)?;
+            for route in stored.routes {
+                stored_channel_ids.insert(route.channel_id.clone());
+                routes.push(SlackConfiguredChannelRoute::new(
+                    route.channel_id,
+                    UserId::new(route.subject_user_id).map_err(|_| slack_target_backend_error())?,
+                ));
+            }
+            let Some(next_cursor) = stored.next_cursor else {
+                break;
+            };
+            if next_cursor <= cursor {
+                return Err(map_slack_target_route_error(
+                    SlackChannelRouteError::StoreUnavailable,
+                ));
+            }
+            cursor = next_cursor;
+        }
+        routes.extend(
+            self.configured_channel_routes
+                .iter()
+                .filter(|route| !stored_channel_ids.contains(&route.channel_id))
+                .cloned(),
+        );
+        Ok(routes)
+    }
+
+    fn entry_for_shared_channel_route(
+        &self,
+        route: &SlackConfiguredChannelRoute,
+    ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
+        let target_id = self.target_id_for_shared_channel(&route.channel_id)?;
+        let display_name = format!("Slack channel {}", route.channel_id);
+        Ok(OutboundDeliveryTargetEntry {
+            summary: RebornOutboundDeliveryTargetSummary::new(
+                target_id,
+                "slack",
+                display_name,
+                Some(format!(
+                    "Slack channel {} in team {}",
+                    route.channel_id,
+                    self.team_id.as_str()
+                )),
+            )
+            .map_err(|_| slack_target_backend_error())?,
+            capabilities: RebornOutboundDeliveryTargetCapabilities {
+                final_replies: true,
+                gate_prompts: true,
+                auth_prompts: true,
+            },
+            reply_target_binding_ref: slack_shared_channel_reply_target_binding_ref(
+                &self.installation_id,
+                &self.agent_id,
+                self.project_id.as_ref(),
+                &self.team_id,
+                &route.channel_id,
+            )?,
+        })
+    }
+
+    fn entry_for_personal_dm_target(
+        &self,
+        target: &SlackPersonalDmTarget,
+    ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
+        let target_id = self.target_id_for_personal_dm(&target.key.user_id)?;
+        Ok(OutboundDeliveryTargetEntry {
+            summary: RebornOutboundDeliveryTargetSummary::new(
+                target_id,
+                "slack",
+                "Slack DM".to_string(),
+                Some(format!("Slack DM in team {}", self.team_id.as_str())),
+            )
+            .map_err(|_| slack_target_backend_error())?,
+            capabilities: RebornOutboundDeliveryTargetCapabilities {
+                final_replies: true,
+                gate_prompts: true,
+                auth_prompts: true,
+            },
+            reply_target_binding_ref: slack_personal_dm_reply_target_binding_ref(
+                &self.installation_id,
+                &self.agent_id,
+                self.project_id.as_ref(),
+                &self.team_id,
+                &target.dm_channel_id,
+                &target.slack_user_id,
+            )?,
+        })
+    }
+
+    async fn resolve_for_channel_id(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        channel_id: &str,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id {
+            return Ok(None);
+        }
+        let Some(route) = self.shared_channel_route_for_channel(channel_id).await? else {
+            return Ok(None);
+        };
+        if route.subject_user_id != caller.user_id {
+            return Ok(None);
+        }
+        self.entry_for_shared_channel_route(&route).map(Some)
+    }
+
+    async fn resolve_personal_dm_for_user(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        user_id: &UserId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id || &caller.user_id != user_id {
+            return Ok(None);
+        }
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        )
+        .map_err(map_slack_personal_dm_target_error)?;
+        let Some(target) = self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+            .map_err(map_slack_personal_dm_target_error)?
+        else {
+            return Ok(None);
+        };
+        self.entry_for_personal_dm_target(&target).map(Some)
+    }
+
+    async fn resolve_personal_dm_for_binding(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        dm_channel_id: &str,
+        slack_user_id: &SlackUserId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id {
+            return Ok(None);
+        }
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        )
+        .map_err(map_slack_personal_dm_target_error)?;
+        let Some(target) = self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+            .map_err(map_slack_personal_dm_target_error)?
+        else {
+            return Ok(None);
+        };
+        if target.dm_channel_id != dm_channel_id || target.slack_user_id != *slack_user_id {
+            return Ok(None);
+        }
+        self.entry_for_personal_dm_target(&target).map(Some)
+    }
+}
+
+#[async_trait::async_trait]
+impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
+    async fn list_outbound_delivery_targets(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id {
+            return Ok(Vec::new());
+        }
+        let mut routes = self
+            .shared_channel_routes()
+            .await?
+            .into_iter()
+            .filter(|route| route.subject_user_id == caller.user_id)
+            .collect::<Vec<_>>();
+        routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
+        let mut targets = routes
+            .into_iter()
+            .map(|route| self.entry_for_shared_channel_route(&route))
+            .collect::<Result<Vec<_>, _>>()?;
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        )
+        .map_err(map_slack_personal_dm_target_error)?;
+        match self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+        {
+            Ok(Some(target)) => match self.entry_for_personal_dm_target(&target) {
+                Ok(target) => targets.push(target),
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        "Slack personal DM target was skipped while listing outbound targets"
+                    );
+                }
+            },
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "Slack personal DM target lookup failed while listing outbound targets"
+                );
+            }
+        }
+        Ok(targets)
+    }
+
+    async fn resolve_outbound_delivery_target(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target_id: &RebornOutboundDeliveryTargetId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if let Some(channel_id) = self.channel_id_for_target_id(target_id) {
+            return self.resolve_for_channel_id(caller, channel_id).await;
+        }
+        let Some(user_id) = self.user_id_for_personal_target_id(target_id) else {
+            return Ok(None);
+        };
+        self.resolve_personal_dm_for_user(caller, &user_id).await
+    }
+
+    async fn resolve_reply_target_binding(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target: &ReplyTargetBindingRef,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        match self.route_for_reply_target_binding_ref(target) {
+            Some(ParsedSlackReplyTarget::SharedChannel { channel_id }) => {
+                self.resolve_for_channel_id(caller, &channel_id).await
+            }
+            Some(ParsedSlackReplyTarget::PersonalDm {
+                dm_channel_id,
+                slack_user_id,
+            }) => {
+                self.resolve_personal_dm_for_binding(caller, &dm_channel_id, &slack_user_id)
+                    .await
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+enum ParsedSlackReplyTarget {
+    SharedChannel {
+        channel_id: String,
+    },
+    PersonalDm {
+        dm_channel_id: String,
+        slack_user_id: SlackUserId,
+    },
+}
+
+pub(crate) fn slack_shared_channel_reply_target_binding_ref(
+    installation_id: &AdapterInstallationId,
+    agent_id: &AgentId,
+    project_id: Option<&ProjectId>,
+    team_id: &SlackTeamId,
+    channel_id: &str,
+) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    let conversation = ExternalConversationRef::new(Some(team_id.as_str()), channel_id, None, None)
+        .map_err(|_| slack_target_backend_error())?;
+    let raw = format!(
+        "{}{}{}{}{}",
+        product_binding_segment("adapter", SLACK_V2_ADAPTER_ID),
+        product_binding_segment("installation", installation_id.as_str()),
+        product_binding_segment("agent", agent_id.as_str()),
+        product_binding_segment("project", project_id.map_or("", |id| id.as_str())),
+        conversation.conversation_fingerprint()
+    );
+    slack_reply_target_binding_ref_from_raw(raw)
+}
+
+fn slack_personal_dm_reply_target_binding_ref(
+    installation_id: &AdapterInstallationId,
+    agent_id: &AgentId,
+    project_id: Option<&ProjectId>,
+    team_id: &SlackTeamId,
+    dm_channel_id: &str,
+    slack_user_id: &SlackUserId,
+) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    let conversation =
+        ExternalConversationRef::new(Some(team_id.as_str()), dm_channel_id, None, None)
+            .map_err(|_| slack_target_backend_error())?;
+    let actor = ExternalActorRef::new(SLACK_USER_ACTOR_KIND, slack_user_id.as_str(), None::<&str>)
+        .map_err(|_| slack_target_backend_error())?;
+    let raw = format!(
+        "{}{}{}{}{}{}{}",
+        product_binding_segment("adapter", SLACK_V2_ADAPTER_ID),
+        product_binding_segment("installation", installation_id.as_str()),
+        product_binding_segment("agent", agent_id.as_str()),
+        product_binding_segment("project", project_id.map_or("", |id| id.as_str())),
+        conversation.conversation_fingerprint(),
+        product_binding_segment("actor_kind", actor.kind()),
+        product_binding_segment("actor", actor.id())
+    );
+    slack_reply_target_binding_ref_from_raw(raw)
+}
+
+pub(crate) fn slack_reply_target_binding_ref_from_raw(
+    raw: String,
+) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    ReplyTargetBindingRef::new(format!("reply:{raw}")).map_err(|_| slack_target_backend_error())
+}
+
+// Keep this segment format in parity with
+// `ExternalConversationRef::conversation_fingerprint`.
+fn product_binding_segment(name: &str, value: &str) -> String {
+    format!("{name}:{}:{value};", value.len())
+}
+
+fn take_product_binding_segment<'a>(raw: &'a str, name: &str) -> Option<(&'a str, &'a str)> {
+    let raw = raw.strip_prefix(name)?.strip_prefix(':')?;
+    let (length, raw) = raw.split_once(':')?;
+    let length = length.parse::<usize>().ok()?;
+    let value = raw.get(..length)?;
+    let raw = raw.get(length..)?.strip_prefix(';')?;
+    Some((value, raw))
+}
+
+fn map_slack_target_route_error(error: SlackChannelRouteError) -> RebornServicesError {
+    match error {
+        SlackChannelRouteError::InvalidRoute => slack_target_not_found_error(),
+        SlackChannelRouteError::StoreUnavailable => slack_target_backend_error(),
+    }
+}
+
+fn map_slack_personal_dm_target_error(error: SlackPersonalDmTargetError) -> RebornServicesError {
+    match error {
+        SlackPersonalDmTargetError::InvalidTarget => slack_target_not_found_error(),
+        SlackPersonalDmTargetError::StoreUnavailable
+        | SlackPersonalDmTargetError::ProvisioningFailed(_) => slack_target_backend_error(),
+    }
+}
+
+fn slack_target_not_found_error() -> RebornServicesError {
+    RebornServicesError {
+        code: RebornServicesErrorCode::NotFound,
+        kind: RebornServicesErrorKind::NotFound,
+        status_code: 404,
+        retryable: false,
+        field: None,
+        validation_code: None,
+    }
+}
+
+fn slack_target_backend_error() -> RebornServicesError {
+    RebornServicesError {
+        code: RebornServicesErrorCode::Unavailable,
+        kind: RebornServicesErrorKind::ServiceUnavailable,
+        status_code: 503,
+        retryable: true,
+        field: None,
+        validation_code: None,
+    }
+}
+
+fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPersonalDmTargetError> {
+    if value.is_empty()
+        || value.len() > 128
+        || value.chars().any(|c| {
+            c == '\0' || c.is_control() || c.is_whitespace() || matches!(c, '/' | '\\' | ':' | ';')
+        })
+    {
+        tracing::debug!(field, "invalid Slack id for personal DM target");
+        return Err(SlackPersonalDmTargetError::InvalidTarget);
+    }
+    Ok(())
+}
+
+fn validate_slack_dm_channel_id(value: &str) -> Result<(), SlackPersonalDmTargetError> {
+    validate_slack_id("slack dm channel", value)?;
+    if !value.starts_with('D') {
+        return Err(SlackPersonalDmTargetError::InvalidTarget);
+    }
+    Ok(())
+}

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -435,62 +435,6 @@ impl SlackHostBetaOutboundTargetProvider {
             .cloned())
     }
 
-    async fn shared_channel_routes(
-        &self,
-    ) -> Result<Vec<SlackConfiguredChannelRoute>, RebornServicesError> {
-        let mut cursor = 0;
-        let mut stored_channel_ids = HashSet::new();
-        let mut routes = Vec::new();
-        loop {
-            let stored = self
-                .channel_route_store
-                .list_routes(
-                    &self.tenant_id,
-                    &self.installation_id,
-                    self.team_id.as_str(),
-                    cursor,
-                    SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
-                )
-                .await
-                .map_err(map_slack_target_route_error)?;
-            if routes.len() + stored.routes.len() > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES {
-                return Err(map_slack_target_route_error(
-                    SlackChannelRouteError::StoreUnavailable,
-                ));
-            }
-            for route in stored.routes {
-                stored_channel_ids.insert(route.channel_id.clone());
-                routes.push(SlackConfiguredChannelRoute::new(
-                    route.channel_id,
-                    UserId::new(route.subject_user_id).map_err(|_| slack_target_backend_error())?,
-                ));
-            }
-            let Some(next_cursor) = stored.next_cursor else {
-                break;
-            };
-            if next_cursor <= cursor {
-                return Err(map_slack_target_route_error(
-                    SlackChannelRouteError::StoreUnavailable,
-                ));
-            }
-            cursor = next_cursor;
-        }
-        if routes.len() + self.configured_channel_routes.len()
-            > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES
-        {
-            return Err(map_slack_target_route_error(
-                SlackChannelRouteError::StoreUnavailable,
-            ));
-        }
-        routes.extend(
-            self.configured_channel_routes
-                .iter()
-                .filter(|route| !stored_channel_ids.contains(&route.channel_id))
-                .cloned(),
-        );
-        Ok(routes)
-    }
-
     fn entry_for_shared_channel_route(
         &self,
         route: &SlackConfiguredChannelRoute,
@@ -658,12 +602,67 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
                 }
             }
         };
-        let (routes, personal_dm_target) =
-            tokio::join!(self.shared_channel_routes(), personal_dm_target);
-        let mut routes = routes?
+        let subject_routes = self.channel_route_store.list_routes_for_subject(
+            &self.tenant_id,
+            &self.installation_id,
+            self.team_id.as_str(),
+            &caller.user_id,
+            SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+            SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+        );
+        let (stored_routes, personal_dm_target) = tokio::join!(subject_routes, personal_dm_target);
+        let stored_routes = stored_routes.map_err(map_slack_target_route_error)?;
+        // Collect the channel ids returned for this subject so we can skip
+        // static configured routes that the store has already overridden with
+        // any subject (including a different one).  Collect as owned Strings so
+        // `stored_routes` can be moved into the route vec below.
+        let stored_channel_ids: HashSet<String> =
+            stored_routes.iter().map(|r| r.channel_id.clone()).collect();
+        let mut routes: Vec<SlackConfiguredChannelRoute> = stored_routes
             .into_iter()
-            .filter(|route| route.subject_user_id == caller.user_id)
-            .collect::<Vec<_>>();
+            .map(|r| {
+                UserId::new(r.subject_user_id)
+                    .map_err(|_| slack_target_backend_error())
+                    .map(|uid| SlackConfiguredChannelRoute::new(r.channel_id, uid))
+            })
+            .collect::<Result<_, _>>()?;
+        // For each static configured route belonging to this caller that is not
+        // already in the subject-scoped store results, check whether the store
+        // has ANY entry for that channel (even under a different subject).  If
+        // the store has overridden the channel, omit the stale static entry so
+        // the admin-assigned subject wins.  A true subject index remains a
+        // tracked follow-up; for now the N point-lookups over the (typically
+        // small) static route list are cheaper than a full-inventory scan.
+        for static_route in self
+            .configured_channel_routes
+            .iter()
+            .filter(|r| r.subject_user_id == caller.user_id)
+        {
+            if stored_channel_ids.contains(&static_route.channel_id) {
+                // Already present from the subject-scoped store results.
+                continue;
+            }
+            let key = match SlackChannelRouteKey::new(
+                self.tenant_id.clone(),
+                self.installation_id.clone(),
+                self.team_id.as_str().to_string(),
+                static_route.channel_id.clone(),
+            ) {
+                Ok(key) => key,
+                Err(_) => continue,
+            };
+            let store_override = self
+                .channel_route_store
+                .resolve_subject_user_id(&key)
+                .await
+                .map_err(map_slack_target_route_error)?;
+            if store_override.is_none() {
+                // No store entry for this channel — static route is active.
+                routes.push(static_route.clone());
+            }
+            // If the store has an entry for another subject, the static route
+            // is suppressed (admin override takes precedence).
+        }
         routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
         let mut targets = routes
             .into_iter()
@@ -1282,6 +1281,101 @@ mod tests {
         assert_eq!(error.kind, RebornServicesErrorKind::ServiceUnavailable);
         assert_eq!(error.status_code, 503);
         assert!(error.retryable);
+    }
+
+    // ── list_routes_for_subject ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_routes_for_subject_returns_only_callers_routes_across_multiple_subjects() {
+        let store = Arc::new(InMemorySlackChannelRouteStore::new());
+        let tenant_id = TenantId::new(TENANT).expect("tenant");
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let alice = UserId::new(USER).expect("alice");
+        let bob = UserId::new(OTHER_USER).expect("bob");
+
+        // Seed: two channels for alice, one for bob.
+        for (channel_id, subject) in [
+            ("C0ALICE1", alice.clone()),
+            ("C0ALICE2", alice.clone()),
+            ("C0BOB1", bob.clone()),
+        ] {
+            let key = SlackChannelRouteKey::new(
+                tenant_id.clone(),
+                installation_id.clone(),
+                TEAM.to_string(),
+                channel_id.to_string(),
+            )
+            .expect("key");
+            store.upsert_route(key, subject).await.expect("upsert");
+        }
+
+        // Alice's scoped listing must return exactly her two routes.
+        let alice_routes = store
+            .list_routes_for_subject(
+                &tenant_id,
+                &installation_id,
+                TEAM,
+                &alice,
+                100,
+                SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+            )
+            .await
+            .expect("listing succeeds");
+        assert_eq!(alice_routes.len(), 2, "alice must see exactly 2 routes");
+        assert!(
+            alice_routes
+                .iter()
+                .all(|r| r.subject_user_id == alice.as_str()),
+            "all returned routes must belong to alice"
+        );
+        assert!(
+            alice_routes.iter().any(|r| r.channel_id == "C0ALICE1"),
+            "C0ALICE1 must be present"
+        );
+        assert!(
+            alice_routes.iter().any(|r| r.channel_id == "C0ALICE2"),
+            "C0ALICE2 must be present"
+        );
+
+        // Bob's listing must return only his route — not alice's.
+        let bob_routes = store
+            .list_routes_for_subject(
+                &tenant_id,
+                &installation_id,
+                TEAM,
+                &bob,
+                100,
+                SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+            )
+            .await
+            .expect("listing succeeds");
+        assert_eq!(bob_routes.len(), 1, "bob must see exactly 1 route");
+        assert_eq!(bob_routes[0].channel_id, "C0BOB1");
+    }
+
+    #[tokio::test]
+    async fn list_routes_for_subject_enforces_cap_on_subject_matching_routes() {
+        // Reuse OversizedPageRouteStore: every route belongs to USER, so the
+        // subject filter won't reduce the count and the cap must still fire.
+        let store = Arc::new(OversizedPageRouteStore);
+        let tenant_id = TenantId::new(TENANT).expect("tenant");
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let alice = UserId::new(USER).expect("alice");
+
+        let result = store
+            .list_routes_for_subject(
+                &tenant_id,
+                &installation_id,
+                TEAM,
+                &alice,
+                SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+                SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(SlackChannelRouteError::StoreUnavailable)),
+            "cap guard must fire when subject routes exceed the maximum: {result:?}"
+        );
     }
 
     // ── cross-tenant personal-DM resolve ─────────────────────────────────────

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -33,6 +33,7 @@ use crate::slack_dm_open::{SlackDmOpenError, open_slack_dm_channel};
 use crate::slack_serve::{SlackTeamId, SlackUserId};
 
 pub(crate) const SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE: usize = 500;
+const SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES: usize = 10_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SlackConfiguredChannelRoute {
@@ -452,6 +453,11 @@ impl SlackHostBetaOutboundTargetProvider {
                 )
                 .await
                 .map_err(map_slack_target_route_error)?;
+            if routes.len() + stored.routes.len() > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES {
+                return Err(map_slack_target_route_error(
+                    SlackChannelRouteError::StoreUnavailable,
+                ));
+            }
             for route in stored.routes {
                 stored_channel_ids.insert(route.channel_id.clone());
                 routes.push(SlackConfiguredChannelRoute::new(
@@ -468,6 +474,13 @@ impl SlackHostBetaOutboundTargetProvider {
                 ));
             }
             cursor = next_cursor;
+        }
+        if routes.len() + self.configured_channel_routes.len()
+            > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES
+        {
+            return Err(map_slack_target_route_error(
+                SlackChannelRouteError::StoreUnavailable,
+            ));
         }
         routes.extend(
             self.configured_channel_routes
@@ -623,9 +636,31 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
         if caller.tenant_id != self.tenant_id {
             return Ok(Vec::new());
         }
-        let mut routes = self
-            .shared_channel_routes()
-            .await?
+        let personal_dm_key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        );
+        let personal_dm_target = async {
+            match personal_dm_key {
+                Ok(key) => Some(
+                    self.personal_dm_target_store
+                        .load_personal_dm_target(&key)
+                        .await,
+                ),
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "Slack personal DM target key could not be built while listing outbound targets"
+                    );
+                    None
+                }
+            }
+        };
+        let (routes, personal_dm_target) =
+            tokio::join!(self.shared_channel_routes(), personal_dm_target);
+        let mut routes = routes?
             .into_iter()
             .filter(|route| route.subject_user_id == caller.user_id)
             .collect::<Vec<_>>();
@@ -634,27 +669,8 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
             .into_iter()
             .map(|route| self.entry_for_shared_channel_route(&route))
             .collect::<Result<Vec<_>, _>>()?;
-        let key = match SlackPersonalDmTargetKey::new(
-            self.tenant_id.clone(),
-            self.installation_id.clone(),
-            self.team_id.as_str().to_string(),
-            caller.user_id.clone(),
-        ) {
-            Ok(key) => key,
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    "Slack personal DM target key could not be built while listing outbound targets"
-                );
-                return Ok(targets);
-            }
-        };
-        match self
-            .personal_dm_target_store
-            .load_personal_dm_target(&key)
-            .await
-        {
-            Ok(Some(target)) => match self.entry_for_personal_dm_target(&target) {
+        match personal_dm_target {
+            Some(Ok(Some(target))) => match self.entry_for_personal_dm_target(&target) {
                 Ok(target) => targets.push(target),
                 Err(error) => {
                     tracing::warn!(
@@ -663,13 +679,14 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
                     );
                 }
             },
-            Ok(None) => {}
-            Err(error) => {
+            Some(Ok(None)) => {}
+            Some(Err(error)) => {
                 tracing::warn!(
                     %error,
                     "Slack personal DM target lookup failed while listing outbound targets"
                 );
             }
+            None => {}
         }
         Ok(targets)
     }
@@ -834,4 +851,46 @@ fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPerson
         return Err(SlackPersonalDmTargetError::InvalidTarget);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_slack_id_accepts_128_char_id_and_rejects_129_char_id() {
+        validate_slack_id("slack id", &"A".repeat(128)).expect("128 chars is valid");
+        assert!(matches!(
+            validate_slack_id("slack id", &"A".repeat(129)),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+    }
+
+    #[test]
+    fn validate_slack_id_rejects_whitespace_and_special_chars() {
+        for value in ["", "A B", "A\0B", "A/B", "A\\B", "A:B", "A;B", "A\nB"] {
+            assert!(matches!(
+                validate_slack_id("slack id", value),
+                Err(SlackPersonalDmTargetError::InvalidTarget)
+            ));
+        }
+    }
+
+    #[test]
+    fn slack_personal_dm_target_rejects_non_d_prefixed_channel_id() {
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").expect("tenant"),
+            AdapterInstallationId::new("install-alpha").expect("installation"),
+            "T123".to_string(),
+            UserId::new("user:alice").expect("user"),
+        )
+        .expect("personal target key");
+
+        assert!(matches!(
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "C123".to_string()),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+        SlackPersonalDmTarget::new(key, SlackUserId::new("U123"), "D123".to_string())
+            .expect("DM-prefixed channel is valid");
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -113,6 +113,7 @@ struct SlackApiResponse {
     error: Option<String>,
 }
 
+// TODO: consolidate slack_api_request/slack_json_response with slack_dm_open once error types are unified
 fn slack_api_request(
     path: &'static str,
     body: Vec<u8>,

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -9,14 +9,15 @@ use ironclaw_product_adapters::{
 use ironclaw_slack_v2_adapter::SLACK_API_HOST;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::slack_dm_open::open_slack_dm_channel;
+use crate::slack_dm_open::{
+    SLACK_API_RESPONSE_LIMIT, open_slack_dm_channel, validate_slack_dm_channel_id,
+};
 use crate::slack_personal_binding_pairing::{
     SlackPersonalBindingPairingError, SlackPersonalBindingPairingNotification,
     SlackPersonalBindingPairingNotifier,
 };
 
 const SLACK_POST_MESSAGE_PATH: &str = "/api/chat.postMessage";
-const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
 
 pub(crate) struct SlackPairingChallengeHttpNotifier {
     egress: Arc<dyn ProtocolHttpEgress>,
@@ -66,13 +67,16 @@ impl SlackPairingChallengeHttpNotifier {
         &self,
         slack_user_id: &str,
     ) -> Result<String, SlackPersonalBindingPairingError> {
-        open_slack_dm_channel(
+        let channel_id = open_slack_dm_channel(
             self.egress.as_ref(),
             self.credential_handle.clone(),
             slack_user_id,
         )
         .await
-        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        validate_slack_dm_channel_id(&channel_id)
+            .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        Ok(channel_id)
     }
 
     async fn send_slack_request(
@@ -241,6 +245,22 @@ mod tests {
                 Err(SlackPersonalBindingPairingError::Backend(_))
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn slack_pairing_notifier_rejects_non_dm_channel_from_open_response() {
+        let notifier = SlackPairingChallengeHttpNotifier::new(
+            Arc::new(ScriptedEgress::new([EgressResponse::new(
+                200,
+                br#"{"ok":true,"channel":{"id":"G123"}}"#.to_vec(),
+            )])),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+
+        assert!(matches!(
+            notifier.send_pairing_challenge(notification()).await,
+            Err(SlackPersonalBindingPairingError::Backend(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -9,12 +9,12 @@ use ironclaw_product_adapters::{
 use ironclaw_slack_v2_adapter::SLACK_API_HOST;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+use crate::slack_dm_open::open_slack_dm_channel;
 use crate::slack_personal_binding_pairing::{
     SlackPersonalBindingPairingError, SlackPersonalBindingPairingNotification,
     SlackPersonalBindingPairingNotifier,
 };
 
-const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
 const SLACK_POST_MESSAGE_PATH: &str = "/api/chat.postMessage";
 const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
 
@@ -66,30 +66,13 @@ impl SlackPairingChallengeHttpNotifier {
         &self,
         slack_user_id: &str,
     ) -> Result<String, SlackPersonalBindingPairingError> {
-        let body = serde_json::to_vec(&SlackConversationsOpenRequest {
-            users: slack_user_id.to_string(),
-        })
-        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
-        let response = self
-            .send_slack_request(SLACK_CONVERSATIONS_OPEN_PATH, body)
-            .await?;
-        let opened: SlackConversationsOpenResponse =
-            slack_json_response("Slack conversations.open", response.body())?;
-        if !opened.ok {
-            return Err(SlackPersonalBindingPairingError::Backend(format!(
-                "Slack rejected conversations.open ({})",
-                opened.error.unwrap_or_else(|| "unknown_error".into())
-            )));
-        }
-        opened
-            .channel
-            .map(|channel| channel.id)
-            .filter(|id| !id.is_empty())
-            .ok_or_else(|| {
-                SlackPersonalBindingPairingError::Backend(
-                    "Slack conversations.open response did not include a channel id".into(),
-                )
-            })
+        open_slack_dm_channel(
+            self.egress.as_ref(),
+            self.credential_handle.clone(),
+            slack_user_id,
+        )
+        .await
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))
     }
 
     async fn send_slack_request(
@@ -111,23 +94,6 @@ impl SlackPairingChallengeHttpNotifier {
         }
         Ok(response)
     }
-}
-
-#[derive(Debug, Serialize)]
-struct SlackConversationsOpenRequest {
-    users: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct SlackConversationsOpenResponse {
-    ok: bool,
-    error: Option<String>,
-    channel: Option<SlackConversationsOpenChannel>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SlackConversationsOpenChannel {
-    id: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -223,7 +189,7 @@ mod tests {
 
         let calls = egress.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].path().as_str(), SLACK_CONVERSATIONS_OPEN_PATH);
+        assert_eq!(calls[0].path().as_str(), "/api/conversations.open");
         let open_body: serde_json::Value = serde_json::from_slice(calls[0].body()).unwrap();
         assert_eq!(open_body["users"], "U123");
         assert_eq!(calls[1].path().as_str(), SLACK_POST_MESSAGE_PATH);
@@ -337,7 +303,7 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(request);
             let response = match self.calls().last().map(|request| request.path().as_str()) {
-                Some(SLACK_CONVERSATIONS_OPEN_PATH) => {
+                Some("/api/conversations.open") => {
                     br#"{"ok":true,"channel":{"id":"D123"}}"#.to_vec()
                 }
                 _ => br#"{"ok":true}"#.to_vec(),

--- a/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
+++ b/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
@@ -501,28 +501,29 @@ provider and authority resolver.
 
 Current implementation status:
 
-- PR C1 is the active Phase 4 slice: shared-agent Slack channel targets backed
-  by admin-managed Slack channel routes.
+- PR C1 is merged: shared-agent Slack channel targets are backed by
+  admin-managed Slack channel routes.
 - PR C1 treats persisted admin routes as authoritative over static seeded
   Slack channel fallback when the same channel has a stored owner.
-- PR C2 remains the next Slack slice: personal Slack DM targets need durable
-  provider authority for the concrete Slack DM conversation id returned by
-  `conversations.open`.
+- PR C2 implements provider-side personal Slack DM target authority:
+  `conversations.open` provisions the concrete `D...` conversation id, the
+  Slack host-state store persists it under the Slack personal-binding mount,
+  and the outbound target provider lists a personal DM target only after that
+  durable authority exists.
 - Static seeded Slack channel deletion needs explicit tombstone/disabled-route
   state before delete can override startup fallback. PR C1 does not invent that
   persistence contract; keep it as a follow-up if static seeded routes must be
   revocable from the admin UI.
-- PR C1 keeps shared-channel target authority in the Slack host-beta composition
-  module to avoid refactor churn. Follow up by moving the provider into
-  `slack_channel_routes` or a dedicated Slack route-authority module if the
-  target-provider implementation grows beyond this first shared-channel slice.
+- PR C2 moves Slack outbound target authority into
+  `slack_outbound_targets.rs`, keeping shared-channel and personal-DM Slack
+  details out of core outbound preference logic.
 - PR C1 pages through the existing route-store API for shared-channel target
   inventory so stored routes past the first page still override static fallback.
   Follow up with a subject-scoped route-store query if route inventory scans
   become too expensive for tenants with many Slack channel routes.
-- PR C1 keeps the Slack reply-target binding formatter local. Follow up with a
-  shared bounded binding-ref helper only if another provider needs the same
-  formatter shape; do not move crate APIs just for this first Slack target.
+- PR C2 keeps the Slack reply-target binding formatter inside the Slack
+  outbound-target module. Follow up with a shared bounded binding-ref helper
+  only if another provider needs the same formatter shape.
 - Slack pairing-code redemption remains identity-only. It must not synthesize a
   personal default, write preferences, or treat a paired Slack user id as a
   deliverable DM target.
@@ -532,15 +533,18 @@ Deliverables:
 - Shared-agent Slack channel target backed by admin-managed Slack channel
   routes. Implemented in PR C1.
 - Personal Slack DM target backed by durable Slack identity/DM target authority.
-  Deferred to PR C2 until Slack-owned durable DM target state exists.
+  Implemented in PR C2 at provider/storage level; user-facing provisioning and
+  default-selection routes remain Phase 5.
 - Slack route deletion/owner-change tests. Covered in PR C1 for admin-managed
   shared-channel targets, plus persisted-owner override for static seeded
   channels. Static seeded delete-over-fallback needs tombstone state.
-- Shared-channel target provider placement, subject-scoped listing, and shared
-  binding-ref helper extraction are documented follow-ups, not PR C1 blockers.
+- Subject-scoped shared-route listing and shared binding-ref helper extraction
+  remain follow-ups, not Phase 4 blockers.
 - Pairing-code redemption tests proving it remains identity-only.
 - First-inbound/DM target tests proving only a concrete target can become a
-  personal default. Deferred to PR C2 with durable DM target state.
+  personal default. PR C2 covers explicit DM provisioning plus "no provisioned
+  authority means no personal target"; first-inbound prompt routing remains
+  Phase 5.
 
 Exit criteria:
 
@@ -548,7 +552,8 @@ Exit criteria:
   covers listing, preference selection, deletion revocation, and owner-change
   authority movement.
 - Personal agents can target the owner's Slack DM after DM authority exists.
-  Deferred to PR C2.
+  PR C2 implements provider-side target inventory after authority exists;
+  selecting it as a default through user-facing routes remains Phase 5.
 - No target is synthesized from arbitrary client input.
 - Slack final reply delivery still uses `chat.postMessage`.
 


### PR DESCRIPTION
## Summary

Implements Phase 4 C2 of the trigger delivery default outbound plan by adding provider-side Slack personal DM target authority alongside the existing shared Slack channel target inventory.

This keeps the backend contract channel-neutral: clients still see and select stable outbound target IDs, while Slack-specific target validation and reply-target minting stay inside Reborn composition / Slack host-beta provider code.

## What Changed

- Added `SlackHostBetaOutboundTargetProvider` support for personal DM targets backed by durable provider authority.
- Added filesystem-backed Slack personal DM target persistence under the existing Slack host-state root.
- Added a shared `slack_dm_open` helper so Slack pairing and DM target provisioning use one `conversations.open` client path.
- Kept the personal DM provisioner out of the production `SlackHostBetaMounts` facade; the provisioner is currently test-only until a product/API route owns the explicit provisioning flow.
- Made shared Slack channel target listing degrade gracefully when optional personal-DM lookup fails, while explicit target resolution remains fail-closed.
- Removed the extra Slack-local raw binding-ref byte cap and relies on the canonical `ReplyTargetBindingRef` 256-byte validation.
- Updated the delivery plan and `FEATURE_PARITY.md` to reflect provider-side shared-channel and explicitly provisioned personal-DM outbound target inventory.

## Code Review Follow-Up

Ran the requested multi-agent code review with 5.4-mini subagents and fixed the straightforward findings:

- Production mount facade no longer exposes the DM provisioner.
- Duplicated Slack `conversations.open` plumbing was extracted into a shared helper.
- Added caller-level personal-DM preference set/get coverage.
- Added provisioning failure-path coverage.
- Added cross-tenant durable store guard coverage.
- Added shared-channel fallback coverage when the personal-DM store is unavailable.
- Fixed binding-ref length handling to rely on the canonical turns contract.

No remaining review item needs design discussion from that pass.

## Verification

- `cargo fmt -p ironclaw_reborn_composition`
- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_personal_dm_target -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_shared_channel_targets_survive_personal_dm_store_failure -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_pairing_notifier -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta filesystem_slack_host_state_rejects_cross_tenant_personal_dm_target_operations -- --nocapture`
- `cargo test -p ironclaw_reborn_composition --features slack-v2-host-beta slack_shared_channel_reply_target_binding_ref -- --nocapture`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries -- --nocapture`
- `cargo clippy -p ironclaw_reborn_composition --features slack-v2-host-beta --tests -- -D warnings`
- `git diff --check`

