### PR TITLE
[codex] Add Reborn Railway config

### DIFF
--- a/railway.reborn.toml
+++ b/railway.reborn.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile.reborn"
+
+[deploy]
+startCommand = "/usr/local/bin/ironclaw-reborn-entrypoint"
+healthcheckPath = "/api/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/railway.reborn.toml
+++ b/railway.reborn.toml
@@ -3,7 +3,6 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile.reborn"
 
 [deploy]
-startCommand = "/usr/local/bin/ironclaw-reborn-entrypoint"
 healthcheckPath = "/api/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary

- Add a separate `railway.reborn.toml` for the Reborn Railway service.
- Point that opt-in config at `Dockerfile.reborn` while letting the Dockerfile entrypoint own startup.
- Leave the existing root `railway.toml` untouched so old deployments keep using the current root Dockerfile configuration.

## Validation

- Verified `railway.toml` has no local diff.
- Ran a targeted sanity check that `railway.reborn.toml` selects `Dockerfile.reborn` and does not set `startCommand`.
- Confirmed `Dockerfile.reborn` defines the Reborn entrypoint and `docker/reborn/entrypoint.sh` handles Railway's `$PORT` when invoked with no arguments.