### PR TITLE
Fix staged credentials for MCP sessions

### DIFF
--- a/crates/ironclaw_host_runtime/src/egress/credential.rs
+++ b/crates/ironclaw_host_runtime/src/egress/credential.rs
@@ -1,6 +1,6 @@
 use ironclaw_host_api::{
     CapabilityId, RuntimeCredentialInjection, RuntimeCredentialSource, RuntimeCredentialTarget,
-    RuntimeHttpEgressError, RuntimeHttpEgressRequest, SecretHandle,
+    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeKind, SecretHandle,
 };
 use ironclaw_network::is_rfc3986_unreserved_segment;
 use ironclaw_safety::redaction_values_for_secret;
@@ -169,6 +169,9 @@ fn restore_staged_secrets(
     request: &RuntimeHttpEgressRequest,
     cache: &mut Vec<CredentialCacheEntry>,
 ) {
+    if runtime_reuses_staged_credentials(request.runtime) {
+        return;
+    }
     let Some(secret_injections) = secret_injections else {
         return;
     };
@@ -234,13 +237,22 @@ fn staged_secret_for_injection(
     let Some(secret_injections) = secret_injections else {
         return missing_runtime_credential(injection.required);
     };
-    match secret_injections.take(&request.scope, capability_id, &injection.handle) {
+    let material = if runtime_reuses_staged_credentials(request.runtime) {
+        secret_injections.clone_material(&request.scope, capability_id, &injection.handle)
+    } else {
+        secret_injections.take(&request.scope, capability_id, &injection.handle)
+    };
+    match material {
         Ok(Some(material)) => Ok(Some(material)),
         Ok(None) => missing_runtime_credential(injection.required),
         Err(_) => Err(RuntimeHttpEgressError::Credential {
             reason: "runtime credential injection store unavailable".to_string(),
         }),
     }
+}
+
+fn runtime_reuses_staged_credentials(runtime: RuntimeKind) -> bool {
+    runtime == RuntimeKind::Mcp
 }
 
 fn missing_runtime_credential(

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -31,6 +31,7 @@ use ironclaw_safety::LeakDetector;
 use ironclaw_secrets::{
     SecretLease, SecretLeaseId, SecretMaterial, SecretMetadata, SecretStore, SecretStoreError,
 };
+use secrecy::ExposeSecret;
 
 use crate::{
     ToolCallHttpEgress,
@@ -143,6 +144,24 @@ impl RuntimeSecretInjectionStore {
                 handle,
             ))
             .map(|entry| entry.material))
+    }
+
+    pub(crate) fn clone_material(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        handle: &SecretHandle,
+    ) -> Result<Option<SecretMaterial>, RuntimeSecretInjectionStoreError> {
+        let now = Instant::now();
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, now);
+        Ok(secrets
+            .get(&RuntimeSecretInjectionKey::new(
+                scope,
+                capability_id,
+                handle,
+            ))
+            .map(|entry| SecretMaterial::from(entry.material.expose_secret().to_string())))
     }
 
     /// Discard all staged secrets for a scoped capability before process ownership exists.

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -161,7 +161,7 @@ impl RuntimeSecretInjectionStore {
                 capability_id,
                 handle,
             ))
-            .map(|entry| SecretMaterial::from(entry.material.expose_secret().to_string())))
+            .map(|entry| SecretMaterial::from(entry.material.expose_secret())))
     }
 
     /// Discard all staged secrets for a scoped capability before process ownership exists.

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -2295,7 +2295,7 @@ async fn mcp_http_client_reuses_real_host_staged_network_policy_for_json_rpc_ses
 }
 
 #[tokio::test]
-async fn mcp_http_client_consumes_staged_credential_on_first_session_request() {
+async fn mcp_http_client_reuses_staged_credential_for_json_rpc_session() {
     let network = JsonRpcMcpNetwork::new();
     let network_recorder = network.requests.clone();
     let services = test_obligation_services();
@@ -2332,7 +2332,7 @@ async fn mcp_http_client_consumes_staged_credential_on_first_session_request() {
         }),
     );
 
-    let error = client
+    let output = client
         .call_tool(McpClientRequest {
             provider: ExtensionId::new("mcp").unwrap(),
             capability_id: capability_id.clone(),
@@ -2345,30 +2345,31 @@ async fn mcp_http_client_consumes_staged_credential_on_first_session_request() {
             max_output_bytes: 4096,
         })
         .await
-        .expect_err("one-shot staged credential must not cover the whole MCP session");
-    assert_eq!(error.stable_reason(), "credential_unavailable");
+        .expect("staged MCP credential should cover the whole JSON-RPC session");
+
+    assert_eq!(
+        output.output,
+        json!({"content":[{"type":"text","text":"ok"}],"isError":false})
+    );
     let requests = network_recorder.lock().unwrap();
     assert_eq!(
         requests.len(),
-        1,
-        "initialize should consume the staged credential before initialized/tools-call retry"
+        3,
+        "initialize, initialized notification, and tools/call should all reach transport"
     );
-    assert_eq!(
-        requests[0]
-            .headers
-            .iter()
-            .find(|(name, _)| name == "authorization"),
-        Some(&(
-            "authorization".to_string(),
-            "Bearer sk-staged-mcp-secret".to_string(),
-        )),
-        "initialize must receive the staged MCP credential"
+    assert!(
+        requests.iter().all(|request| {
+            request.headers.iter().any(|(name, value)| {
+                name == "authorization" && value == "Bearer sk-staged-mcp-secret"
+            })
+        }),
+        "every MCP session request must receive the staged credential"
     );
     drop(requests);
 }
 
 #[tokio::test]
-async fn mcp_http_client_consumes_product_auth_staged_credential_on_first_session_request() {
+async fn mcp_http_client_reuses_product_auth_staged_credential_for_json_rpc_session() {
     let network = JsonRpcMcpNetwork::new();
     let network_recorder = network.requests.clone();
     let source_scope = sample_scope();
@@ -2436,7 +2437,7 @@ async fn mcp_http_client_consumes_product_auth_staged_credential_on_first_sessio
         }),
     );
 
-    let error = client
+    let output = client
         .call_tool(McpClientRequest {
             provider: ExtensionId::new("mcp").unwrap(),
             capability_id: capability_id.clone(),
@@ -2449,24 +2450,25 @@ async fn mcp_http_client_consumes_product_auth_staged_credential_on_first_sessio
             max_output_bytes: 4096,
         })
         .await
-        .expect_err("one-shot product-auth credential must not cover the whole MCP session");
-    assert_eq!(error.stable_reason(), "credential_unavailable");
+        .expect("product-auth staged credential should cover the whole MCP JSON-RPC session");
+
+    assert_eq!(
+        output.output,
+        json!({"content":[{"type":"text","text":"ok"}],"isError":false})
+    );
     let requests = network_recorder.lock().unwrap();
     assert_eq!(
         requests.len(),
-        1,
-        "initialize should consume the staged product-auth credential before initialized/tools-call retry"
+        3,
+        "initialize, initialized notification, and tools/call should all reach transport"
     );
-    assert_eq!(
-        requests[0]
+    assert!(
+        requests.iter().all(|request| request
             .headers
             .iter()
-            .find(|(name, _)| name == "authorization"),
-        Some(&(
-            "authorization".to_string(),
-            "Bearer sk-account-scope-mcp-secret".to_string(),
-        )),
-        "initialize must receive the staged product-auth credential"
+            .any(|(name, value)| name == "authorization"
+                && value == "Bearer sk-account-scope-mcp-secret")),
+        "every MCP session request must receive the staged product-auth credential"
     );
     drop(requests);
 }

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -343,7 +343,9 @@ pub struct McpHostHttpEgressPlanRequest<'a> {
 /// its credential sources, then threads that plan into the later `tools/call`
 /// transport send. Planner-visible headers are stable policy headers only; the
 /// dynamic MCP session header is added by the protocol client after planning.
-/// Handshake requests are planned independently and remain credential-free.
+/// Hosted MCP providers may require authentication for the entire JSON-RPC
+/// session, including initialization, so staged credentials must remain scoped
+/// to the invocation until the capability dispatch completes.
 pub trait McpHostHttpEgressPlanner: Send + Sync {
     fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan;
 }

--- a/docs/reborn/contracts/mcp.md
+++ b/docs/reborn/contracts/mcp.md
@@ -158,9 +158,11 @@ Transport-specific policy is a host adapter responsibility:
 - Planner-visible headers exclude the dynamic MCP session header. The protocol
   client appends `Mcp-Session-Id` after planning when the server establishes a
   session.
-- `initialize` and `notifications/initialized` remain credential-free even
-  when the host-planned `tools/call` or `tools/list` carries staged
-  credentials.
+- Hosted providers may require authentication on the whole JSON-RPC session,
+  including `initialize`, `notifications/initialized`, `tools/list`, and
+  `tools/call`. Staged credentials for MCP runtime egress therefore remain
+  reusable for the scoped capability invocation and are discarded by the normal
+  capability completion/abort cleanup.
 - MCP protocol code consumes `RuntimeCredentialInjection` plans only; product
   auth account selection belongs to composition, not to the MCP crate.
 


### PR DESCRIPTION
## Summary
- allow MCP runtime egress to reuse scoped staged credentials across a full JSON-RPC session
- keep non-MCP staged credential behavior one-shot
- update MCP contract docs and regression tests for hosted providers that require auth on initialize/tools calls

## Validation
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract mcp_http_client_reuses -- --nocapture`
- `cargo test -p ironclaw_host_runtime host_http_egress_helper_consumes_staged_credentials_after_first_egress -- --nocapture`
- `cargo clippy -p ironclaw_host_runtime --tests -- -D warnings`

## Thermo Loop
- Loops run: 2/5
- Fixed: 1 maintainability finding in the MCP staged-secret restore path
- Stop condition: no remaining actionable thermo-level issues found