### PR TITLE
feat(reborn): map production wiring into readiness diagnostics

### DIFF
--- a/crates/ironclaw_host_runtime/src/services/production_wiring.rs
+++ b/crates/ironclaw_host_runtime/src/services/production_wiring.rs
@@ -148,6 +148,15 @@ pub struct ProductionWiringIssue {
 }
 
 impl ProductionWiringIssue {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn for_test(component: ProductionWiringComponent, kind: ProductionWiringIssueKind) -> Self {
+        Self {
+            component,
+            kind,
+            implementation: None,
+        }
+    }
+
     pub fn component(&self) -> ProductionWiringComponent {
         self.component
     }
@@ -168,6 +177,11 @@ pub struct ProductionWiringReport {
 }
 
 impl ProductionWiringReport {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn for_test(issues: Vec<ProductionWiringIssue>) -> Self {
+        Self { issues }
+    }
+
     pub fn issues(&self) -> &[ProductionWiringIssue] {
         &self.issues
     }

--- a/crates/ironclaw_reborn_composition/src/readiness.rs
+++ b/crates/ironclaw_reborn_composition/src/readiness.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::RebornCompositionProfile;
+use ironclaw_host_runtime::{
+    ProductionWiringComponent, ProductionWiringIssue, ProductionWiringIssueKind,
+    ProductionWiringReport,
+};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -295,6 +299,71 @@ impl RebornReadinessDiagnostic {
             status: RebornReadinessDiagnosticStatus::Blocking,
             blocks_production: true,
         })
+    }
+
+    pub fn from_production_wiring_report(
+        profile: RebornCompositionProfile,
+        report: &ProductionWiringReport,
+    ) -> Vec<Self> {
+        if !profile.requires_production_shape() {
+            return Vec::new();
+        }
+
+        report
+            .issues()
+            .iter()
+            .map(|issue| Self::from_production_wiring_issue(profile, issue))
+            .collect()
+    }
+
+    pub fn from_production_wiring_issue(
+        profile: RebornCompositionProfile,
+        issue: &ProductionWiringIssue,
+    ) -> Self {
+        Self::production_blocker(profile, issue.component().into(), issue.kind().into())
+    }
+}
+
+impl From<ProductionWiringComponent> for RebornReadinessDiagnosticComponent {
+    fn from(component: ProductionWiringComponent) -> Self {
+        match component {
+            ProductionWiringComponent::RuntimeBackend => Self::RuntimeBackend,
+            ProductionWiringComponent::RuntimePolicy => Self::RuntimePolicy,
+            ProductionWiringComponent::TrustPolicy => Self::TrustPolicy,
+            ProductionWiringComponent::Filesystem => Self::Filesystem,
+            ProductionWiringComponent::ResourceGovernor => Self::ResourceGovernor,
+            ProductionWiringComponent::ProcessStore => Self::ProcessStore,
+            ProductionWiringComponent::ProcessResultStore => Self::ProcessResultStore,
+            ProductionWiringComponent::RunState => Self::RunState,
+            ProductionWiringComponent::ApprovalRequests => Self::ApprovalRequests,
+            ProductionWiringComponent::CapabilityLeases => Self::CapabilityLeases,
+            ProductionWiringComponent::EventSink => Self::EventSink,
+            ProductionWiringComponent::AuditSink => Self::AuditSink,
+            ProductionWiringComponent::SecretStore => Self::SecretStore,
+            ProductionWiringComponent::CredentialAccountStore => Self::CredentialAccountStore,
+            ProductionWiringComponent::CredentialSessionStore => Self::CredentialSessionStore,
+            ProductionWiringComponent::RuntimeHttpEgress => Self::RuntimeHttpEgress,
+            ProductionWiringComponent::RuntimeProcessPort => Self::RuntimeProcessPort,
+            ProductionWiringComponent::WasmCredentialProvider => Self::WasmCredentialProvider,
+            ProductionWiringComponent::ScriptRuntime => Self::ScriptRuntime,
+            ProductionWiringComponent::McpRuntime => Self::McpRuntime,
+            ProductionWiringComponent::WasmRuntime => Self::WasmRuntime,
+            ProductionWiringComponent::FirstPartyRuntime => Self::FirstPartyRuntime,
+            ProductionWiringComponent::TurnState => Self::TurnState,
+            ProductionWiringComponent::RunProfileResolver => Self::RunProfileResolver,
+            ProductionWiringComponent::TurnRunWakeNotifier => Self::TurnRunWakeNotifier,
+        }
+    }
+}
+
+impl From<ProductionWiringIssueKind> for RebornReadinessDiagnosticReason {
+    fn from(kind: ProductionWiringIssueKind) -> Self {
+        match kind {
+            ProductionWiringIssueKind::Missing => Self::Missing,
+            ProductionWiringIssueKind::UnsupportedRequirement => Self::Unsupported,
+            ProductionWiringIssueKind::LocalOnlyImplementation => Self::LocalOnly,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation => Self::Unverified,
+        }
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/readiness.rs
+++ b/crates/ironclaw_reborn_composition/src/readiness.rs
@@ -312,14 +312,14 @@ impl RebornReadinessDiagnostic {
         report
             .issues()
             .iter()
-            .map(|issue| Self::from_production_wiring_issue(profile, issue))
+            .filter_map(|issue| Self::from_production_wiring_issue(profile, issue))
             .collect()
     }
 
     pub fn from_production_wiring_issue(
         profile: RebornCompositionProfile,
         issue: &ProductionWiringIssue,
-    ) -> Self {
+    ) -> Option<Self> {
         Self::production_blocker(profile, issue.component().into(), issue.kind().into())
     }
 }

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -38,6 +38,11 @@ use ironclaw_reborn_composition::{
     RebornBuildInput, RebornManualTokenSetupRequest, RebornManualTokenSubmitRequest,
     RebornReadinessDiagnostic, RebornReadinessState, build_reborn_services,
 };
+#[cfg(feature = "libsql")]
+use ironclaw_reborn_composition::{
+    RebornReadinessDiagnosticComponent, RebornReadinessDiagnosticReason,
+    RebornReadinessDiagnosticStatus,
+};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_secrets::SecretMaterial;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -903,6 +908,45 @@ async fn production_rejects_local_only_runtime_policy() {
         ),
         "local-only runtime policy should fail production wiring: {report:?}"
     );
+    let diagnostics = RebornReadinessDiagnostic::from_production_wiring_report(
+        RebornCompositionProfile::Production,
+        &report,
+    );
+    assert!(
+        RebornReadinessDiagnostic::from_production_wiring_report(
+            RebornCompositionProfile::LocalDev,
+            &report,
+        )
+        .is_empty(),
+        "production wiring reports should not produce production diagnostics for local-dev profiles"
+    );
+    assert!(
+        diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
+            RebornCompositionProfile::Production,
+            RebornReadinessDiagnosticComponent::RuntimePolicy,
+            RebornReadinessDiagnosticReason::LocalOnly,
+        )),
+        "runtime policy local-only issue should map to readiness diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
+            RebornCompositionProfile::Production,
+            RebornReadinessDiagnosticComponent::RuntimeProcessPort,
+            RebornReadinessDiagnosticReason::LocalOnly,
+        )),
+        "runtime process port local-only issue should map to readiness diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.status == RebornReadinessDiagnosticStatus::Blocking)
+    );
+    let serialized = serde_json::to_string(&diagnostics).unwrap();
+    assert!(!serialized.contains("LocalOnlyImplementation"));
+    assert!(!serialized.contains("EffectiveRuntimePolicy"));
+    assert!(!serialized.contains("ironclaw_"));
+    assert!(!serialized.contains("/root/"));
+    assert!(!serialized.contains("postgres://"));
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -921,19 +921,25 @@ async fn production_rejects_local_only_runtime_policy() {
         "production wiring reports should not produce production diagnostics for local-dev profiles"
     );
     assert!(
-        diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
-            RebornCompositionProfile::Production,
-            RebornReadinessDiagnosticComponent::RuntimePolicy,
-            RebornReadinessDiagnosticReason::LocalOnly,
-        )),
+        diagnostics.contains(
+            &RebornReadinessDiagnostic::production_blocker(
+                RebornCompositionProfile::Production,
+                RebornReadinessDiagnosticComponent::RuntimePolicy,
+                RebornReadinessDiagnosticReason::LocalOnly,
+            )
+            .expect("production profile should create a blocker")
+        ),
         "runtime policy local-only issue should map to readiness diagnostics: {diagnostics:?}"
     );
     assert!(
-        diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
-            RebornCompositionProfile::Production,
-            RebornReadinessDiagnosticComponent::RuntimeProcessPort,
-            RebornReadinessDiagnosticReason::LocalOnly,
-        )),
+        diagnostics.contains(
+            &RebornReadinessDiagnostic::production_blocker(
+                RebornCompositionProfile::Production,
+                RebornReadinessDiagnosticComponent::RuntimeProcessPort,
+                RebornReadinessDiagnosticReason::LocalOnly,
+            )
+            .expect("production profile should create a blocker")
+        ),
         "runtime process port local-only issue should map to readiness diagnostics: {diagnostics:?}"
     );
     assert!(

--- a/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
+++ b/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
@@ -503,27 +503,21 @@ fn production_wiring_report_maps_through_public_readiness_entrypoint() {
             diagnostic.status == RebornReadinessDiagnosticStatus::Blocking
                 && diagnostic.blocks_production
         }));
-        assert!(
-            diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
-                profile,
-                RebornReadinessDiagnosticComponent::SecretStore,
-                RebornReadinessDiagnosticReason::Missing,
-            ))
-        );
-        assert!(
-            diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
-                profile,
-                RebornReadinessDiagnosticComponent::AuditSink,
-                RebornReadinessDiagnosticReason::Unverified,
-            ))
-        );
-        assert!(
-            diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
-                profile,
-                RebornReadinessDiagnosticComponent::RuntimeBackend,
-                RebornReadinessDiagnosticReason::Unsupported,
-            ))
-        );
+        assert!(diagnostics.contains(&production_blocker(
+            profile,
+            RebornReadinessDiagnosticComponent::SecretStore,
+            RebornReadinessDiagnosticReason::Missing,
+        )));
+        assert!(diagnostics.contains(&production_blocker(
+            profile,
+            RebornReadinessDiagnosticComponent::AuditSink,
+            RebornReadinessDiagnosticReason::Unverified,
+        )));
+        assert!(diagnostics.contains(&production_blocker(
+            profile,
+            RebornReadinessDiagnosticComponent::RuntimeBackend,
+            RebornReadinessDiagnosticReason::Unsupported,
+        )));
     }
 
     assert!(

--- a/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
+++ b/crates/ironclaw_reborn_composition/tests/profile_acceptance.rs
@@ -7,6 +7,10 @@ use ironclaw_reborn_composition::{
 };
 
 use ironclaw_host_api::runtime_policy::{FilesystemBackendKind, RuntimeProfile, SecretMode};
+use ironclaw_host_runtime::{
+    ProductionWiringComponent, ProductionWiringIssue, ProductionWiringIssueKind,
+    ProductionWiringReport,
+};
 use ironclaw_runtime_policy::ResolveError;
 use serde_json::json;
 
@@ -377,6 +381,158 @@ fn readiness_diagnostics_do_not_carry_sensitive_detail_fields() {
     assert!(!json.contains("ironclaw_host_runtime::"));
     assert!(!json.contains("approval_id"));
     assert!(!json.contains("lease_id"));
+}
+
+#[test]
+fn production_wiring_issue_kinds_map_to_stable_readiness_reasons() {
+    assert_eq!(
+        RebornReadinessDiagnosticReason::from(ProductionWiringIssueKind::Missing),
+        RebornReadinessDiagnosticReason::Missing
+    );
+    assert_eq!(
+        RebornReadinessDiagnosticReason::from(ProductionWiringIssueKind::LocalOnlyImplementation),
+        RebornReadinessDiagnosticReason::LocalOnly
+    );
+    assert_eq!(
+        RebornReadinessDiagnosticReason::from(
+            ProductionWiringIssueKind::UnverifiedProductionImplementation,
+        ),
+        RebornReadinessDiagnosticReason::Unverified
+    );
+    assert_eq!(
+        RebornReadinessDiagnosticReason::from(ProductionWiringIssueKind::UnsupportedRequirement),
+        RebornReadinessDiagnosticReason::Unsupported
+    );
+}
+
+#[test]
+fn production_wiring_components_keep_host_runtime_stable_names() {
+    for component in [
+        ProductionWiringComponent::RuntimeBackend,
+        ProductionWiringComponent::RuntimePolicy,
+        ProductionWiringComponent::TrustPolicy,
+        ProductionWiringComponent::Filesystem,
+        ProductionWiringComponent::ResourceGovernor,
+        ProductionWiringComponent::ProcessStore,
+        ProductionWiringComponent::ProcessResultStore,
+        ProductionWiringComponent::RunState,
+        ProductionWiringComponent::ApprovalRequests,
+        ProductionWiringComponent::CapabilityLeases,
+        ProductionWiringComponent::EventSink,
+        ProductionWiringComponent::AuditSink,
+        ProductionWiringComponent::SecretStore,
+        ProductionWiringComponent::CredentialAccountStore,
+        ProductionWiringComponent::CredentialSessionStore,
+        ProductionWiringComponent::RuntimeHttpEgress,
+        ProductionWiringComponent::RuntimeProcessPort,
+        ProductionWiringComponent::WasmCredentialProvider,
+        ProductionWiringComponent::ScriptRuntime,
+        ProductionWiringComponent::McpRuntime,
+        ProductionWiringComponent::WasmRuntime,
+        ProductionWiringComponent::FirstPartyRuntime,
+        ProductionWiringComponent::TurnState,
+        ProductionWiringComponent::RunProfileResolver,
+        ProductionWiringComponent::TurnRunWakeNotifier,
+    ] {
+        let expected = component.as_str();
+        let readiness_component = RebornReadinessDiagnosticComponent::from(component);
+        let serialized = serde_json::to_value(readiness_component).unwrap();
+
+        assert_eq!(serialized, json!(expected));
+    }
+}
+
+#[test]
+fn production_wiring_report_with_no_issues_returns_empty_diagnostics() {
+    let report = ProductionWiringReport::for_test(Vec::new());
+
+    for profile in [
+        RebornCompositionProfile::Production,
+        RebornCompositionProfile::MigrationDryRun,
+    ] {
+        assert!(
+            RebornReadinessDiagnostic::from_production_wiring_report(profile, &report).is_empty()
+        );
+    }
+}
+
+#[test]
+fn production_wiring_report_skipped_for_non_production_profiles() {
+    let report = ProductionWiringReport::for_test(vec![ProductionWiringIssue::for_test(
+        ProductionWiringComponent::SecretStore,
+        ProductionWiringIssueKind::Missing,
+    )]);
+
+    for profile in [
+        RebornCompositionProfile::Disabled,
+        RebornCompositionProfile::LocalDev,
+        RebornCompositionProfile::LocalDevYolo,
+    ] {
+        assert!(
+            RebornReadinessDiagnostic::from_production_wiring_report(profile, &report).is_empty()
+        );
+    }
+}
+
+#[test]
+fn production_wiring_report_maps_through_public_readiness_entrypoint() {
+    let report = ProductionWiringReport::for_test(vec![
+        ProductionWiringIssue::for_test(
+            ProductionWiringComponent::SecretStore,
+            ProductionWiringIssueKind::Missing,
+        ),
+        ProductionWiringIssue::for_test(
+            ProductionWiringComponent::AuditSink,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation,
+        ),
+        ProductionWiringIssue::for_test(
+            ProductionWiringComponent::RuntimeBackend,
+            ProductionWiringIssueKind::UnsupportedRequirement,
+        ),
+    ]);
+
+    for profile in [
+        RebornCompositionProfile::Production,
+        RebornCompositionProfile::MigrationDryRun,
+    ] {
+        let diagnostics =
+            RebornReadinessDiagnostic::from_production_wiring_report(profile, &report);
+
+        assert_eq!(diagnostics.len(), 3);
+        assert!(diagnostics.iter().all(|diagnostic| {
+            diagnostic.status == RebornReadinessDiagnosticStatus::Blocking
+                && diagnostic.blocks_production
+        }));
+        assert!(
+            diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
+                profile,
+                RebornReadinessDiagnosticComponent::SecretStore,
+                RebornReadinessDiagnosticReason::Missing,
+            ))
+        );
+        assert!(
+            diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
+                profile,
+                RebornReadinessDiagnosticComponent::AuditSink,
+                RebornReadinessDiagnosticReason::Unverified,
+            ))
+        );
+        assert!(
+            diagnostics.contains(&RebornReadinessDiagnostic::production_blocker(
+                profile,
+                RebornReadinessDiagnosticComponent::RuntimeBackend,
+                RebornReadinessDiagnosticReason::Unsupported,
+            ))
+        );
+    }
+
+    assert!(
+        RebornReadinessDiagnostic::from_production_wiring_report(
+            RebornCompositionProfile::LocalDev,
+            &report,
+        )
+        .is_empty()
+    );
 }
 
 fn readiness_for_contract(


### PR DESCRIPTION
## Summary
- map host-runtime `ProductionWiringReport` issues into Reborn readiness diagnostics
- preserve host-runtime stable component names through the readiness component enum
- map missing/local-only/unverified/unsupported issue kinds to readiness reason codes
- add caller-level coverage from a production composition wiring rejection

## Tests
- cargo fmt -p ironclaw_reborn_composition
- cargo test -p ironclaw_reborn_composition --test profile_acceptance
- cargo test -p ironclaw_reborn_composition --features libsql --test facade_factory production_rejects_local_only_runtime_policy
- cargo test -p ironclaw_reborn_composition readiness

Depends on #4626.
Closes #4618