### PR TITLE
Reborn: wire production Postgres storage config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -341,6 +341,8 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # IRONCLAW_REBORN_HOME=/data/ironclaw-reborn
 # IRONCLAW_REBORN_PROFILE=local-dev
 # IRONCLAW_REBORN_LOG=info
+# IRONCLAW_REBORN_POSTGRES_URL=postgres://user:password@db.example.com/ironclaw?sslmode=require
+# IRONCLAW_REBORN_SECRET_MASTER_KEY=replace-with-independent-secret-key-material
 # IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 # IRONCLAW_REBORN_SERVE_PORT=3000
 # IRONCLAW_REBORN_CONFIRM_HOST_ACCESS=false

--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ Important: `api_key_env` is the name of an environment variable, not the secret
 itself. Reborn rejects inline secret-shaped values in `config.toml` and
 `providers.json`.
 
+Production storage uses the same env-only pattern. A production Reborn config
+may name the PostgreSQL URL variable, but must not contain the raw URL:
+
+```toml
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+```
+
+Set `IRONCLAW_REBORN_POSTGRES_URL` in the process environment. Managed remote
+PostgreSQL providers must use TLS, for example by appending `sslmode=require`.
+
 Once `[llm.default]` exists, that config selects the provider. `LLM_BACKEND` is
 only an env fallback when no default LLM slot is configured. To switch providers
 after writing config, use `models set-provider <provider>` or edit
@@ -180,6 +192,7 @@ the current branch.
 | --- | --- |
 | `IRONCLAW_REBORN_HOME` | Absolute Reborn state root. Defaults to `$HOME/.ironclaw/reborn`. The resolver rejects unsafe paths and v1 state-root aliases such as `$HOME/.ironclaw`. |
 | `IRONCLAW_REBORN_PROFILE` | Boot profile selector. Supported values: `local-dev`, `local-dev-yolo`, `production`, `migration-dry-run`. |
+| `IRONCLAW_REBORN_POSTGRES_URL` | Production PostgreSQL storage URL when `[storage].backend = "postgres"` and `[storage].url_env` names this variable. Keep it out of `config.toml`; remote providers must use TLS. |
 | `IRONCLAW_REBORN_LOG` | Tracing filter for the Reborn binary, for example `debug,ironclaw_reborn=trace`. |
 
 `run` and `repl` currently support `local-dev` and `local-dev-yolo` runtime

--- a/README.md
+++ b/README.md
@@ -148,10 +148,13 @@ may name the PostgreSQL URL variable, but must not contain the raw URL:
 [storage]
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 ```
 
-Set `IRONCLAW_REBORN_POSTGRES_URL` in the process environment. Managed remote
-PostgreSQL providers must use TLS, for example by appending `sslmode=require`.
+Set `IRONCLAW_REBORN_POSTGRES_URL` in the process environment, and set
+`IRONCLAW_REBORN_SECRET_MASTER_KEY` to independent cryptographic key material.
+Managed remote PostgreSQL providers must use TLS, for example by appending
+`sslmode=require`.
 
 Once `[llm.default]` exists, that config selects the provider. `LLM_BACKEND` is
 only an env fallback when no default LLM slot is configured. To switch providers
@@ -193,6 +196,7 @@ the current branch.
 | `IRONCLAW_REBORN_HOME` | Absolute Reborn state root. Defaults to `$HOME/.ironclaw/reborn`. The resolver rejects unsafe paths and v1 state-root aliases such as `$HOME/.ironclaw`. |
 | `IRONCLAW_REBORN_PROFILE` | Boot profile selector. Supported values: `local-dev`, `local-dev-yolo`, `production`, `migration-dry-run`. |
 | `IRONCLAW_REBORN_POSTGRES_URL` | Production PostgreSQL storage URL when `[storage].backend = "postgres"` and `[storage].url_env` names this variable. Keep it out of `config.toml`; remote providers must use TLS. |
+| `IRONCLAW_REBORN_SECRET_MASTER_KEY` | Production Reborn secret master key when `[storage].secret_master_key_env` names this variable. Keep it independent from the database URL and out of `config.toml`. |
 | `IRONCLAW_REBORN_LOG` | Tracing filter for the Reborn binary, for example `debug,ironclaw_reborn=trace`. |
 
 `run` and `repl` currently support `local-dev` and `local-dev-yolo` runtime

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -52,6 +52,10 @@ openai-compat-beta = [
     "webui-v2-beta",
     "ironclaw_reborn_composition/openai-compat-beta",
 ]
+# Enable production PostgreSQL storage composition for `ironclaw-reborn`.
+postgres = [
+    "ironclaw_reborn_composition/postgres",
+]
 [dependencies]
 anyhow = "1"
 async-trait = { version = "0.1", optional = true }

--- a/crates/ironclaw_reborn_cli/src/commands/config/init.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/init.rs
@@ -196,6 +196,7 @@ regex_activation_enabled = true
 # # `sslmode=require` to IRONCLAW_REBORN_POSTGRES_URL.
 # backend = "postgres"
 # url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+# secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 
 [llm.default]
 # LLM slot selection. `provider_id` references an entry in

--- a/crates/ironclaw_reborn_cli/src/commands/config/init.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config/init.rs
@@ -189,6 +189,14 @@ poll_interval_ms        = 200
 # `$code-review` still activate skills.
 regex_activation_enabled = true
 
+# [storage]
+# # Production storage selection. The database URL value is env-only; this
+# # file may name the variable but must never contain the raw URL.
+# # Managed remote Postgres providers must use TLS, e.g. append
+# # `sslmode=require` to IRONCLAW_REBORN_POSTGRES_URL.
+# backend = "postgres"
+# url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+
 [llm.default]
 # LLM slot selection. `provider_id` references an entry in
 # providers.json (built-in or user-overlay). `model` / `base_url` /

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -30,6 +30,8 @@ mod trigger_poller;
 
 use trigger_poller::trigger_poller_settings;
 
+const DEFAULT_REBORN_POSTGRES_URL_ENV: &str = "IRONCLAW_REBORN_POSTGRES_URL";
+
 pub(crate) fn init_tracing() {
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::fmt;
@@ -398,31 +400,39 @@ pub(crate) fn build_services_input_with_options(
 
     let owner_id = default_owner_id(config_file.as_ref());
 
-    let local_dev_root: PathBuf = config.home().path().join("local-dev");
-
-    let workspace_root = std::env::current_dir()
-        .context("failed to resolve current directory for local-dev workspace")?;
     let profile = effective_profile(config, config_file.as_ref())?;
-    let mut services_input = local_runtime_build_input_with_options(
-        composition_profile(profile),
-        owner_id,
-        local_dev_root,
-        RebornLocalRuntimeProfileOptions {
-            confirm_host_access: options.confirm_host_access,
-        },
-    )
-    .with_context(|| {
-        format!(
-            "ironclaw-reborn run currently supports profile=local-dev or profile=local-dev-yolo; \
-                     got profile={profile}. Production wiring lands in a follow-up slice."
-        )
-    })?
-    .with_local_dev_workspace_root(workspace_root);
-    if services_input.requires_local_dev_confirmed_host_home_root() {
-        let host_home_root =
-            confirmed_host_home_root(options).context("local-dev-yolo host access")?;
-        services_input = services_input.with_local_dev_confirmed_host_home_root(host_home_root);
-    }
+    let mut services_input = match profile {
+        RebornProfile::LocalDev | RebornProfile::LocalDevYolo => {
+            let local_dev_root: PathBuf = config.home().path().join("local-dev");
+            let workspace_root = std::env::current_dir()
+                .context("failed to resolve current directory for local-dev workspace")?;
+            let mut services_input = local_runtime_build_input_with_options(
+                composition_profile(profile),
+                owner_id,
+                local_dev_root,
+                RebornLocalRuntimeProfileOptions {
+                    confirm_host_access: options.confirm_host_access,
+                },
+            )
+            .with_context(|| {
+                format!(
+                    "ironclaw-reborn run currently supports profile=local-dev or profile=local-dev-yolo; \
+                     got profile={profile}."
+                )
+            })?
+            .with_local_dev_workspace_root(workspace_root);
+            if services_input.requires_local_dev_confirmed_host_home_root() {
+                let host_home_root =
+                    confirmed_host_home_root(options).context("local-dev-yolo host access")?;
+                services_input =
+                    services_input.with_local_dev_confirmed_host_home_root(host_home_root);
+            }
+            services_input
+        }
+        RebornProfile::Production | RebornProfile::MigrationDryRun => {
+            build_production_services_input(profile, owner_id, config_file.as_ref())?
+        }
+    };
     if let Some(ResolvedGoogleOAuthConfig {
         client,
         hosted_domain_hint: _hosted_domain_hint,
@@ -435,6 +445,65 @@ pub(crate) fn build_services_input_with_options(
         services_input,
         config_file,
     })
+}
+
+#[cfg(feature = "postgres")]
+fn build_production_services_input(
+    profile: RebornProfile,
+    owner_id: &str,
+    config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
+) -> anyhow::Result<RebornBuildInput> {
+    let storage = config_file
+        .and_then(|file| file.storage.as_ref())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "profile={profile} requires [storage] backend = \"postgres\" with url_env naming \
+                 an environment variable such as {DEFAULT_REBORN_POSTGRES_URL_ENV}"
+            )
+        })?;
+    let backend = storage.backend.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("profile={profile} requires [storage].backend = \"postgres\"")
+    })?;
+    if backend != "postgres" {
+        anyhow::bail!(
+            "profile={profile} supports only [storage].backend = \"postgres\" in this slice; got `{backend}`"
+        );
+    }
+    let url_env = storage
+        .url_env
+        .as_deref()
+        .unwrap_or(DEFAULT_REBORN_POSTGRES_URL_ENV);
+    let database_url = std::env::var(url_env).map_err(|_| {
+        anyhow::anyhow!(
+            "{url_env} must be set to the Reborn production PostgreSQL URL; \
+             config.toml may only name this env var via [storage].url_env, never contain the URL"
+        )
+    })?;
+    if database_url.trim().is_empty() {
+        anyhow::bail!("{url_env} must not be empty");
+    }
+    let pool = ironclaw_reborn_composition::open_reborn_postgres_pool(SecretString::from(
+        database_url.clone(),
+    ))
+    .context("failed to configure Reborn production PostgreSQL storage")?;
+    Ok(RebornBuildInput::postgres_with_resolved_secret_master_key(
+        composition_profile(profile),
+        owner_id,
+        pool,
+        SecretString::from(database_url),
+    ))
+}
+
+#[cfg(not(feature = "postgres"))]
+fn build_production_services_input(
+    profile: RebornProfile,
+    _owner_id: &str,
+    _config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
+) -> anyhow::Result<RebornBuildInput> {
+    anyhow::bail!(
+        "profile={profile} requires a binary built with the `postgres` feature for production \
+         storage; the default PostgreSQL URL env var is {DEFAULT_REBORN_POSTGRES_URL_ENV}"
+    )
 }
 
 pub(crate) fn resolve_google_oauth_config_from_env()
@@ -832,6 +901,170 @@ regex_activation_enabled = false
             "host_workspace_and_home"
         );
         assert_eq!(policy.secret_mode.as_str(), "inherited_env");
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_requires_storage_section() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::clear("IRONCLAW_REBORN_POSTGRES_URL");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.into_os_string()),
+            None,
+            None,
+            Some("production".into()),
+        )
+        .expect("boot config");
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("production requires explicit storage config");
+
+        assert!(
+            err.to_string().contains("[storage]"),
+            "error must mention storage config, got: {err:#}"
+        );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_requires_postgres_url_env_value() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::clear("IRONCLAW_REBORN_POSTGRES_URL");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        std::fs::write(
+            reborn_home.join("config.toml"),
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+"#,
+        )
+        .expect("write config");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.into_os_string()),
+            None,
+            None,
+            Some("production".into()),
+        )
+        .expect("boot config");
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("missing Postgres URL env must fail closed");
+
+        assert!(
+            err.to_string().contains("IRONCLAW_REBORN_POSTGRES_URL"),
+            "error must mention missing env var name, got: {err:#}"
+        );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_rejects_remote_postgres_sslmode_disable_redacted() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=disable",
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        std::fs::write(
+            reborn_home.join("config.toml"),
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+"#,
+        )
+        .expect("write config");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.into_os_string()),
+            None,
+            None,
+            Some("production".into()),
+        )
+        .expect("boot config");
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("sslmode=disable must fail closed before connecting");
+        let rendered = format!("{err:#}");
+
+        assert!(
+            rendered.contains("sslmode=require") && rendered.contains("sslmode=disable"),
+            "error should explain TLS requirement, got: {rendered}"
+        );
+        assert!(!rendered.contains("RAW_PASSWORD_SENTINEL_3162"));
+        assert!(!rendered.contains("postgres://"));
+        assert!(!rendered.contains("db.example.com"));
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_constructs_postgres_services_input() {
+        let lock = lock_trigger_env();
+        let (enabled, interval) = clear_trigger_poller_env();
+        let postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        std::fs::write(
+            reborn_home.join("config.toml"),
+            r#"
+[identity]
+default_owner = "prod-owner"
+
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+"#,
+        )
+        .expect("write config");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.into_os_string()),
+            None,
+            None,
+            Some("production".into()),
+        )
+        .expect("boot config");
+
+        let runtime_input =
+            build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+        let services = runtime_input.services.expect("services input");
+
+        assert_eq!(services.profile(), RebornCompositionProfile::Production);
+        assert_eq!(services.owner_id(), "prod-owner");
+
+        drop(postgres_url);
+        drop(interval);
+        drop(enabled);
+        drop(lock);
+
+        let err = block_on_cli(async move {
+            ironclaw_reborn_composition::build_reborn_services(services).await
+        })
+        .expect_err("production composition should now fail on missing production wiring");
+        assert!(
+            format!("{err:#}").contains("production trust policy"),
+            "production storage handoff should reach production composition wiring, got: {err:#}"
+        );
     }
 
     // Regression for the review point that `serve` rejected legitimate

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -31,6 +31,28 @@ mod trigger_poller;
 use trigger_poller::trigger_poller_settings;
 
 const DEFAULT_REBORN_POSTGRES_URL_ENV: &str = "IRONCLAW_REBORN_POSTGRES_URL";
+#[cfg(feature = "postgres")]
+const DEFAULT_REBORN_SECRET_MASTER_KEY_ENV: &str = "IRONCLAW_REBORN_SECRET_MASTER_KEY";
+
+#[cfg(feature = "postgres")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProductionStorageBackend {
+    Postgres,
+}
+
+#[cfg(feature = "postgres")]
+impl TryFrom<&str> for ProductionStorageBackend {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "postgres" => Ok(Self::Postgres),
+            other => anyhow::bail!(
+                "production storage supports only [storage].backend = \"postgres\" in this slice; got `{other}`"
+            ),
+        }
+    }
+}
 
 pub(crate) fn init_tracing() {
     use tracing_subscriber::EnvFilter;
@@ -430,6 +452,9 @@ pub(crate) fn build_services_input_with_options(
             services_input
         }
         RebornProfile::Production | RebornProfile::MigrationDryRun => {
+            // MigrationDryRun needs production storage handles so follow-up migration
+            // code can inspect durable schema state; this branch only constructs
+            // those handles and does not execute migration writes.
             build_production_services_input(profile, owner_id, config_file.as_ref())?
         }
     };
@@ -453,47 +478,70 @@ fn build_production_services_input(
     owner_id: &str,
     config_file: Option<&ironclaw_reborn_config::RebornConfigFile>,
 ) -> anyhow::Result<RebornBuildInput> {
-    let storage = config_file
-        .and_then(|file| file.storage.as_ref())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "profile={profile} requires [storage] backend = \"postgres\" with url_env naming \
-                 an environment variable such as {DEFAULT_REBORN_POSTGRES_URL_ENV}"
-            )
-        })?;
+    let config_file = config_file.ok_or_else(|| {
+        anyhow::anyhow!(
+            "profile={profile} requires a config.toml file with a [storage] section; \
+             run `ironclaw-reborn config init` to create one"
+        )
+    })?;
+    let storage = config_file.storage.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "profile={profile} requires [storage] backend = \"postgres\" with url_env naming \
+             an environment variable such as {DEFAULT_REBORN_POSTGRES_URL_ENV}"
+        )
+    })?;
     let backend = storage.backend.as_deref().ok_or_else(|| {
         anyhow::anyhow!("profile={profile} requires [storage].backend = \"postgres\"")
     })?;
-    if backend != "postgres" {
-        anyhow::bail!(
-            "profile={profile} supports only [storage].backend = \"postgres\" in this slice; got `{backend}`"
-        );
-    }
+    let _backend = ProductionStorageBackend::try_from(backend)?;
+
     let url_env = storage
         .url_env
         .as_deref()
         .unwrap_or(DEFAULT_REBORN_POSTGRES_URL_ENV);
-    let database_url = std::env::var(url_env).map_err(|_| {
-        anyhow::anyhow!(
-            "{url_env} must be set to the Reborn production PostgreSQL URL; \
-             config.toml may only name this env var via [storage].url_env, never contain the URL"
-        )
-    })?;
-    if database_url.trim().is_empty() {
-        anyhow::bail!("{url_env} must not be empty");
-    }
-    let pool = ironclaw_reborn_composition::open_reborn_postgres_pool(SecretString::from(
-        database_url.clone(),
-    ))
-    .context("failed to configure Reborn production PostgreSQL storage")?;
-    Ok(RebornBuildInput::postgres_with_resolved_secret_master_key(
+    let secret_master_key_env = storage
+        .secret_master_key_env
+        .as_deref()
+        .unwrap_or(DEFAULT_REBORN_SECRET_MASTER_KEY_ENV);
+    let database_url = required_production_secret_env(
+        url_env,
+        "Reborn production PostgreSQL URL",
+        "storage.url_env",
+    )?;
+    let secret_master_key = required_production_secret_env(
+        secret_master_key_env,
+        "Reborn production secret master key",
+        "storage.secret_master_key_env",
+    )?;
+
+    let pool = ironclaw_reborn_composition::open_reborn_postgres_pool(database_url.clone())
+        .context("failed to configure Reborn production PostgreSQL storage")?;
+    Ok(RebornBuildInput::postgres(
         composition_profile(profile),
         owner_id,
         pool,
-        SecretString::from(database_url),
+        database_url,
+        secret_master_key,
     ))
 }
 
+#[cfg(feature = "postgres")]
+fn required_production_secret_env(
+    env_name: &str,
+    description: &str,
+    config_field: &str,
+) -> anyhow::Result<SecretString> {
+    let value = std::env::var(env_name).map_err(|_| {
+        anyhow::anyhow!(
+            "{env_name} must be set to the {description}; config.toml may only name this env var via [{config_field}], never contain the secret value"
+        )
+    })?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("{env_name} must not be empty");
+    }
+    Ok(SecretString::from(trimmed.to_string()))
+}
 #[cfg(not(feature = "postgres"))]
 fn build_production_services_input(
     profile: RebornProfile,
@@ -904,11 +952,31 @@ regex_activation_enabled = false
     }
 
     #[cfg(feature = "postgres")]
+    fn boot_config_with_config_toml(
+        profile: &str,
+        config_toml: &str,
+    ) -> (tempfile::TempDir, RebornBootConfig) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        std::fs::write(reborn_home.join("config.toml"), config_toml).expect("write config");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.into_os_string()),
+            None,
+            None,
+            Some(profile.into()),
+        )
+        .expect("boot config");
+        (temp, config)
+    }
+
+    #[cfg(feature = "postgres")]
     #[test]
     fn build_runtime_input_production_requires_storage_section() {
         let _lock = lock_trigger_env();
         let (_enabled, _interval) = clear_trigger_poller_env();
         let _postgres_url = EnvGuard::clear("IRONCLAW_REBORN_POSTGRES_URL");
+        let _secret_master_key = EnvGuard::clear("IRONCLAW_REBORN_SECRET_MASTER_KEY");
 
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
@@ -937,6 +1005,7 @@ regex_activation_enabled = false
         let _lock = lock_trigger_env();
         let (_enabled, _interval) = clear_trigger_poller_env();
         let _postgres_url = EnvGuard::clear("IRONCLAW_REBORN_POSTGRES_URL");
+        let _secret_master_key = EnvGuard::clear("IRONCLAW_REBORN_SECRET_MASTER_KEY");
 
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
@@ -947,6 +1016,7 @@ regex_activation_enabled = false
 [storage]
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 "#,
         )
         .expect("write config");
@@ -970,13 +1040,148 @@ url_env = "IRONCLAW_REBORN_POSTGRES_URL"
 
     #[cfg(feature = "postgres")]
     #[test]
-    fn build_runtime_input_production_rejects_remote_postgres_sslmode_disable_redacted() {
+    fn build_runtime_input_production_storage_section_missing_backend_field() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::clear("IRONCLAW_REBORN_POSTGRES_URL");
+        let _secret_master_key = EnvGuard::clear("IRONCLAW_REBORN_SECRET_MASTER_KEY");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        );
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("missing backend must fail closed");
+        assert!(
+            err.to_string().contains("backend"),
+            "error must mention missing backend field, got: {err:#}"
+        );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_rejects_unsupported_backend() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "libsql"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        );
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("unsupported backend must fail closed");
+        assert!(
+            err.to_string().contains("postgres") && err.to_string().contains("libsql"),
+            "error must mention supported and bad backend values, got: {err:#}"
+        );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_rejects_whitespace_only_postgres_url() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::set("IRONCLAW_REBORN_POSTGRES_URL", "   ");
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        );
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("whitespace-only URL env must fail closed");
+        assert!(
+            err.to_string().contains("empty"),
+            "error must mention empty URL env var, got: {err:#}"
+        );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_uses_custom_url_env_name() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _default_postgres_url = EnvGuard::clear("IRONCLAW_REBORN_POSTGRES_URL");
+        let _custom_postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_CUSTOM_POSTGRES_URL",
+            "postgres://localhost/ironclaw_reborn_cli_test",
+        );
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_CUSTOM_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        );
+
+        let runtime_input =
+            build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+        let services = runtime_input.services.expect("services input");
+        assert_eq!(services.profile(), RebornCompositionProfile::Production);
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_constructs_migration_dry_run_services_input() {
         let _lock = lock_trigger_env();
         let (_enabled, _interval) = clear_trigger_poller_env();
         let _postgres_url = EnvGuard::set(
             "IRONCLAW_REBORN_POSTGRES_URL",
-            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=disable",
+            "postgres://localhost/ironclaw_reborn_cli_test",
         );
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+        let (_temp, config) = boot_config_with_config_toml(
+            "migration-dry-run",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        );
+
+        let runtime_input =
+            build_runtime_input(&config, RuntimeInputCaller::Run).expect("runtime input");
+        let services = runtime_input.services.expect("services input");
+        assert_eq!(
+            services.profile(),
+            RebornCompositionProfile::MigrationDryRun
+        );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_requires_secret_master_key_env_value() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
+        );
+        let _secret_master_key = EnvGuard::clear("IRONCLAW_REBORN_SECRET_MASTER_KEY");
 
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
@@ -987,6 +1192,53 @@ url_env = "IRONCLAW_REBORN_POSTGRES_URL"
 [storage]
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        )
+        .expect("write config");
+        let config = RebornBootConfig::resolve_from_env_parts(
+            Some(reborn_home.into_os_string()),
+            None,
+            None,
+            Some("production".into()),
+        )
+        .expect("boot config");
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("missing secret master key env must fail closed");
+        let rendered = format!("{err:#}");
+
+        assert!(
+            rendered.contains("IRONCLAW_REBORN_SECRET_MASTER_KEY"),
+            "error must mention missing secret master key env var, got: {rendered}"
+        );
+        assert!(!rendered.contains("RAW_PASSWORD_SENTINEL_3162"));
+        assert!(!rendered.contains("postgres://"));
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_rejects_remote_postgres_sslmode_disable_redacted() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=disable",
+        );
+        let _secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let reborn_home = temp.path().join("reborn-home");
+        std::fs::create_dir_all(&reborn_home).expect("mkdir");
+        std::fs::write(
+            reborn_home.join("config.toml"),
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 "#,
         )
         .expect("write config");
@@ -1021,6 +1273,8 @@ url_env = "IRONCLAW_REBORN_POSTGRES_URL"
             "IRONCLAW_REBORN_POSTGRES_URL",
             "postgres://event_user:RAW_PASSWORD_SENTINEL_3162@db.example.com/events?sslmode=require",
         );
+        let secret_master_key =
+            EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "test-master-key");
 
         let temp = tempfile::tempdir().expect("tempdir");
         let reborn_home = temp.path().join("reborn-home");
@@ -1034,6 +1288,7 @@ default_owner = "prod-owner"
 [storage]
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 "#,
         )
         .expect("write config");
@@ -1053,6 +1308,7 @@ url_env = "IRONCLAW_REBORN_POSTGRES_URL"
         assert_eq!(services.owner_id(), "prod-owner");
 
         drop(postgres_url);
+        drop(secret_master_key);
         drop(interval);
         drop(enabled);
         drop(lock);

--- a/crates/ironclaw_reborn_cli/src/runtime/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime/mod.rs
@@ -16,6 +16,8 @@ use ironclaw_reborn_composition::{
     RebornLocalRuntimeProfileOptions, RebornRuntimeIdentity, RebornRuntimeInput,
     TurnRunnerSettings, build_reborn_runtime, local_runtime_build_input_with_options,
 };
+#[cfg(feature = "postgres")]
+use ironclaw_reborn_config::StorageBackend;
 use ironclaw_reborn_config::{
     REBORN_PROFILE_ENV, RebornBootConfig, RebornProfile, seed_default_config_file_if_missing,
 };
@@ -33,26 +35,6 @@ use trigger_poller::trigger_poller_settings;
 const DEFAULT_REBORN_POSTGRES_URL_ENV: &str = "IRONCLAW_REBORN_POSTGRES_URL";
 #[cfg(feature = "postgres")]
 const DEFAULT_REBORN_SECRET_MASTER_KEY_ENV: &str = "IRONCLAW_REBORN_SECRET_MASTER_KEY";
-
-#[cfg(feature = "postgres")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProductionStorageBackend {
-    Postgres,
-}
-
-#[cfg(feature = "postgres")]
-impl TryFrom<&str> for ProductionStorageBackend {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &str) -> anyhow::Result<Self> {
-        match value {
-            "postgres" => Ok(Self::Postgres),
-            other => anyhow::bail!(
-                "production storage supports only [storage].backend = \"postgres\" in this slice; got `{other}`"
-            ),
-        }
-    }
-}
 
 pub(crate) fn init_tracing() {
     use tracing_subscriber::EnvFilter;
@@ -490,10 +472,13 @@ fn build_production_services_input(
              an environment variable such as {DEFAULT_REBORN_POSTGRES_URL_ENV}"
         )
     })?;
-    let backend = storage.backend.as_deref().ok_or_else(|| {
-        anyhow::anyhow!("profile={profile} requires [storage].backend = \"postgres\"")
-    })?;
-    let _backend = ProductionStorageBackend::try_from(backend)?;
+    match storage.backend {
+        Some(StorageBackend::Postgres) => {}
+        Some(StorageBackend::Unknown(_)) => anyhow::bail!(
+            "profile={profile} supports only [storage].backend = \"postgres\" in this slice"
+        ),
+        None => anyhow::bail!("profile={profile} requires [storage].backend = \"postgres\""),
+    }
 
     let url_env = storage
         .url_env
@@ -1111,6 +1096,35 @@ secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
         assert!(
             err.to_string().contains("empty"),
             "error must mention empty URL env var, got: {err:#}"
+        );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn build_runtime_input_production_rejects_whitespace_only_secret_master_key() {
+        let _lock = lock_trigger_env();
+        let (_enabled, _interval) = clear_trigger_poller_env();
+        let _postgres_url = EnvGuard::set(
+            "IRONCLAW_REBORN_POSTGRES_URL",
+            "postgres://localhost/ironclaw_reborn_cli_test",
+        );
+        let _secret_master_key = EnvGuard::set("IRONCLAW_REBORN_SECRET_MASTER_KEY", "   ");
+        let (_temp, config) = boot_config_with_config_toml(
+            "production",
+            r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+"#,
+        );
+
+        let err = build_runtime_input(&config, RuntimeInputCaller::Run)
+            .err()
+            .expect("whitespace-only secret master key env must fail closed");
+        assert!(
+            err.to_string().contains("empty"),
+            "error must mention empty secret master key env var, got: {err:#}"
         );
     }
 

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -870,6 +870,10 @@ where
 
 /// Open a PostgreSQL pool for Reborn production storage using the same
 /// TLS/cleartext policy enforced by the production event-store backend.
+///
+/// Callers are responsible for validating that production boot selected the
+/// PostgreSQL storage backend and that the URL came from an env-only config
+/// reference before passing it here.
 #[cfg(feature = "postgres")]
 pub fn open_reborn_postgres_pool(
     url: secrecy::SecretString,

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -868,6 +868,15 @@ where
     factory::build_postgres_production_host_runtime_services(config).await
 }
 
+/// Open a PostgreSQL pool for Reborn production storage using the same
+/// TLS/cleartext policy enforced by the production event-store backend.
+#[cfg(feature = "postgres")]
+pub fn open_reborn_postgres_pool(
+    url: secrecy::SecretString,
+) -> Result<deadpool_postgres::Pool, RebornCompositionError> {
+    Ok(ironclaw_reborn_event_store::open_postgres_pool(url)?)
+}
+
 #[cfg(all(test, any(feature = "libsql", feature = "postgres")))]
 mod mount_view_tests {
     use super::*;

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -165,9 +165,9 @@ pub struct SkillsSection {
 
 /// Durable storage selection for production Reborn boot.
 ///
-/// `url_env` is an environment variable NAME, not a database URL. The parser
-/// rejects raw URL-shaped values so credentials cannot be pasted into
-/// `config.toml`.
+/// `url_env` and `secret_master_key_env` are environment variable NAMES, not
+/// credential-bearing values. The parser rejects raw URL-shaped values so
+/// credentials cannot be pasted into `config.toml`.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StorageSection {
@@ -175,6 +175,8 @@ pub struct StorageSection {
     pub backend: Option<String>,
     /// Environment variable name containing the PostgreSQL connection URL.
     pub url_env: Option<String>,
+    /// Environment variable name containing the Reborn secret master key.
+    pub secret_master_key_env: Option<String>,
 }
 
 /// WebChat v2 HTTP gateway configuration.
@@ -664,10 +666,29 @@ impl RebornConfigFile {
         if let Some(storage) = &self.storage {
             if let Some(backend) = &storage.backend {
                 check_non_empty_trimmed(Cow::Borrowed("storage.backend"), backend)?;
+                if backend.contains("://") {
+                    return Err(RebornConfigFileError::InvalidField {
+                        path: attributed_path.display().to_string(),
+                        field: "storage.backend".to_string(),
+                        reason: "must be a backend name, not a URL or inline secret value"
+                            .to_string(),
+                    });
+                }
             }
             if let Some(url_env) = &storage.url_env {
                 check_non_empty_trimmed(Cow::Borrowed("storage.url_env"), url_env)?;
                 validate_env_var_reference("storage.url_env", url_env, attributed_path)?;
+            }
+            if let Some(secret_master_key_env) = &storage.secret_master_key_env {
+                check_non_empty_trimmed(
+                    Cow::Borrowed("storage.secret_master_key_env"),
+                    secret_master_key_env,
+                )?;
+                validate_env_var_reference(
+                    "storage.secret_master_key_env",
+                    secret_master_key_env,
+                    attributed_path,
+                )?;
             }
         }
         if let Some(webui) = &self.webui {
@@ -1094,6 +1115,7 @@ regex_activation_enabled = false
 [storage]
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 
 [llm.default]
 provider_id = "openai"
@@ -1143,6 +1165,10 @@ subject_user_id = "eng-team-agent"
         assert_eq!(
             storage.url_env.as_deref(),
             Some("IRONCLAW_REBORN_POSTGRES_URL")
+        );
+        assert_eq!(
+            storage.secret_master_key_env.as_deref(),
+            Some("IRONCLAW_REBORN_SECRET_MASTER_KEY")
         );
         let default_slot = cfg.default_llm_slot().expect("default slot present");
         assert_eq!(default_slot.provider_id.as_deref(), Some("openai"));
@@ -1324,6 +1350,7 @@ signing_secret_env = "sk-proj-1234567890abcdef1234567890"
 [storage]
 backend = "postgres"
 url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
 "#;
         let cfg = RebornConfigFile::parse_text(toml, &attributed())
             .expect("storage env reference must parse");
@@ -1332,6 +1359,59 @@ url_env = "IRONCLAW_REBORN_POSTGRES_URL"
         assert_eq!(
             storage.url_env.as_deref(),
             Some("IRONCLAW_REBORN_POSTGRES_URL")
+        );
+        assert_eq!(
+            storage.secret_master_key_env.as_deref(),
+            Some("IRONCLAW_REBORN_SECRET_MASTER_KEY")
+        );
+    }
+
+    #[test]
+    fn rejects_whitespace_only_storage_backend() {
+        let toml = r#"
+[storage]
+backend = "   "
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("whitespace-only backend must be rejected");
+        assert!(matches!(err, RebornConfigFileError::InvalidField { .. }));
+        assert!(
+            err.to_string().contains("storage.backend"),
+            "error should identify storage.backend: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_url_shaped_storage_backend_without_echoing_credentials() {
+        let toml = r#"
+[storage]
+backend = "postgres://user:password@db.example.com/ironclaw"
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("backend must not accept raw URLs");
+        assert!(matches!(err, RebornConfigFileError::InvalidField { .. }));
+        assert!(
+            err.to_string().contains("storage.backend"),
+            "error should identify storage.backend: {err}"
+        );
+        assert!(
+            !err.to_string().contains("password"),
+            "error must not echo credential-bearing backend value: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_whitespace_only_storage_url_env() {
+        let toml = r#"
+[storage]
+url_env = "   "
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("whitespace-only url_env must be rejected");
+        assert!(matches!(err, RebornConfigFileError::InvalidField { .. }));
+        assert!(
+            err.to_string().contains("storage.url_env"),
+            "error should identify storage.url_env: {err}"
         );
     }
 
@@ -1352,6 +1432,27 @@ url_env = "postgres://user:password@db.example.com/ironclaw?sslmode=require"
         assert!(
             !err.to_string().contains("password"),
             "error must not echo credential-bearing URL: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_inline_secret_in_storage_secret_master_key_env() {
+        let toml = r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "postgres://user:password.example.com/ironclaw"
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("storage secret_master_key_env must not accept raw secrets");
+        assert!(matches!(err, RebornConfigFileError::InvalidField { .. }));
+        assert!(
+            err.to_string().contains("storage.secret_master_key_env"),
+            "error should identify storage.secret_master_key_env: {err}"
+        );
+        assert!(
+            !err.to_string().contains("password"),
+            "error must not echo credential-bearing value: {err}"
         );
     }
 

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -67,6 +67,11 @@ pub struct RebornConfigFile {
     pub runner: Option<RunnerSection>,
     /// Skill activation selection settings for local-dev runtime skill context.
     pub skills: Option<SkillsSection>,
+    /// Durable storage selection for production Reborn boot.
+    ///
+    /// Credential-bearing database URLs must stay env-only. This section names
+    /// the backend and the environment variable that contains the URL.
+    pub storage: Option<StorageSection>,
     /// Per-slot LLM selection. Keyed by Reborn model slot name. Today
     /// composition wires only the `default` slot; the `mission` slot
     /// becomes live when the planned driver lands. Operators are free
@@ -156,6 +161,20 @@ pub struct SkillsSection {
     /// When false, regex activation criteria no longer auto-load full skill context.
     /// Keyword/tag activation and explicit skill mentions still work.
     pub regex_activation_enabled: Option<bool>,
+}
+
+/// Durable storage selection for production Reborn boot.
+///
+/// `url_env` is an environment variable NAME, not a database URL. The parser
+/// rejects raw URL-shaped values so credentials cannot be pasted into
+/// `config.toml`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StorageSection {
+    /// Storage backend name. First production slice supports `"postgres"`.
+    pub backend: Option<String>,
+    /// Environment variable name containing the PostgreSQL connection URL.
+    pub url_env: Option<String>,
 }
 
 /// WebChat v2 HTTP gateway configuration.
@@ -642,6 +661,15 @@ impl RebornConfigFile {
                 }
             }
         }
+        if let Some(storage) = &self.storage {
+            if let Some(backend) = &storage.backend {
+                check_non_empty_trimmed(Cow::Borrowed("storage.backend"), backend)?;
+            }
+            if let Some(url_env) = &storage.url_env {
+                check_non_empty_trimmed(Cow::Borrowed("storage.url_env"), url_env)?;
+                validate_env_var_reference("storage.url_env", url_env, attributed_path)?;
+            }
+        }
         if let Some(webui) = &self.webui {
             if let Some(host) = &webui.listen_host {
                 check(Cow::Borrowed("webui.listen_host"), host)?;
@@ -979,6 +1007,26 @@ fn validate_api_version(found: &str, path: &Path) -> Result<(), RebornConfigFile
     Ok(())
 }
 
+fn validate_env_var_reference(
+    field: &str,
+    value: &str,
+    path: &Path,
+) -> Result<(), RebornConfigFileError> {
+    let mut chars = value.chars();
+    let valid = chars
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+        && chars.all(|character| character.is_ascii_alphanumeric() || character == '_');
+    if valid {
+        return Ok(());
+    }
+    Err(RebornConfigFileError::InvalidField {
+        path: path.display().to_string(),
+        field: field.to_string(),
+        reason: "must be an environment variable name, not an inline secret or URL".to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1006,6 +1054,7 @@ mod tests {
         assert!(cfg.harness.is_none());
         assert!(cfg.runner.is_none());
         assert!(cfg.skills.is_none());
+        assert!(cfg.storage.is_none());
         assert!(cfg.llm.is_none());
         assert!(cfg.slack.is_none());
     }
@@ -1041,6 +1090,10 @@ poll_interval_ms = 200
 
 [skills]
 regex_activation_enabled = false
+
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
 
 [llm.default]
 provider_id = "openai"
@@ -1084,6 +1137,12 @@ subject_user_id = "eng-team-agent"
         assert_eq!(
             cfg.skills.as_ref().unwrap().regex_activation_enabled,
             Some(false)
+        );
+        let storage = cfg.storage.as_ref().expect("storage section present");
+        assert_eq!(storage.backend.as_deref(), Some("postgres"));
+        assert_eq!(
+            storage.url_env.as_deref(),
+            Some("IRONCLAW_REBORN_POSTGRES_URL")
         );
         let default_slot = cfg.default_llm_slot().expect("default slot present");
         assert_eq!(default_slot.provider_id.as_deref(), Some("openai"));
@@ -1256,6 +1315,43 @@ signing_secret_env = "sk-proj-1234567890abcdef1234567890"
         assert!(
             err.to_string().contains("slack.signing_secret_env"),
             "error should identify Slack field: {err}"
+        );
+    }
+
+    #[test]
+    fn parses_storage_postgres_env_reference() {
+        let toml = r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+"#;
+        let cfg = RebornConfigFile::parse_text(toml, &attributed())
+            .expect("storage env reference must parse");
+        let storage = cfg.storage.expect("storage section");
+        assert_eq!(storage.backend.as_deref(), Some("postgres"));
+        assert_eq!(
+            storage.url_env.as_deref(),
+            Some("IRONCLAW_REBORN_POSTGRES_URL")
+        );
+    }
+
+    #[test]
+    fn rejects_inline_postgres_url_in_storage_url_env() {
+        let toml = r#"
+[storage]
+backend = "postgres"
+url_env = "postgres://user:password@db.example.com/ironclaw?sslmode=require"
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("storage url_env must not accept raw URLs");
+        assert!(matches!(err, RebornConfigFileError::InvalidField { .. }));
+        assert!(
+            err.to_string().contains("storage.url_env"),
+            "error should identify storage.url_env: {err}"
+        );
+        assert!(
+            !err.to_string().contains("password"),
+            "error must not echo credential-bearing URL: {err}"
         );
     }
 

--- a/crates/ironclaw_reborn_config/src/config_file.rs
+++ b/crates/ironclaw_reborn_config/src/config_file.rs
@@ -37,7 +37,8 @@ use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer};
 use thiserror::Error;
 
 use crate::secrets_guard::{InlineSecretError, reject_inline_secret};
@@ -163,6 +164,43 @@ pub struct SkillsSection {
     pub regex_activation_enabled: Option<bool>,
 }
 
+/// Durable storage backend names accepted by the Reborn production boot config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageBackend {
+    Postgres,
+    #[doc(hidden)]
+    Unknown(String),
+}
+
+impl<'de> Deserialize<'de> for StorageBackend {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StorageBackendVisitor;
+
+        impl Visitor<'_> for StorageBackendVisitor {
+            type Value = StorageBackend;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a storage backend name such as `postgres`")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    "postgres" => Ok(StorageBackend::Postgres),
+                    candidate => Ok(StorageBackend::Unknown(candidate.to_string())),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(StorageBackendVisitor)
+    }
+}
+
 /// Durable storage selection for production Reborn boot.
 ///
 /// `url_env` and `secret_master_key_env` are environment variable NAMES, not
@@ -172,7 +210,7 @@ pub struct SkillsSection {
 #[serde(deny_unknown_fields)]
 pub struct StorageSection {
     /// Storage backend name. First production slice supports `"postgres"`.
-    pub backend: Option<String>,
+    pub backend: Option<StorageBackend>,
     /// Environment variable name containing the PostgreSQL connection URL.
     pub url_env: Option<String>,
     /// Environment variable name containing the Reborn secret master key.
@@ -664,16 +702,18 @@ impl RebornConfigFile {
             }
         }
         if let Some(storage) = &self.storage {
-            if let Some(backend) = &storage.backend {
+            if let Some(StorageBackend::Unknown(backend)) = &storage.backend {
                 check_non_empty_trimmed(Cow::Borrowed("storage.backend"), backend)?;
-                if backend.contains("://") {
-                    return Err(RebornConfigFileError::InvalidField {
-                        path: attributed_path.display().to_string(),
-                        field: "storage.backend".to_string(),
-                        reason: "must be a backend name, not a URL or inline secret value"
-                            .to_string(),
-                    });
-                }
+                let reason = if backend.contains("://") {
+                    "must be a backend name, not a URL or inline secret value".to_string()
+                } else {
+                    format!("supports only \"postgres\" in this slice; got `{backend}`")
+                };
+                return Err(RebornConfigFileError::InvalidField {
+                    path: attributed_path.display().to_string(),
+                    field: "storage.backend".to_string(),
+                    reason,
+                });
             }
             if let Some(url_env) = &storage.url_env {
                 check_non_empty_trimmed(Cow::Borrowed("storage.url_env"), url_env)?;
@@ -1161,7 +1201,7 @@ subject_user_id = "eng-team-agent"
             Some(false)
         );
         let storage = cfg.storage.as_ref().expect("storage section present");
-        assert_eq!(storage.backend.as_deref(), Some("postgres"));
+        assert_eq!(storage.backend, Some(StorageBackend::Postgres));
         assert_eq!(
             storage.url_env.as_deref(),
             Some("IRONCLAW_REBORN_POSTGRES_URL")
@@ -1355,7 +1395,7 @@ secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
         let cfg = RebornConfigFile::parse_text(toml, &attributed())
             .expect("storage env reference must parse");
         let storage = cfg.storage.expect("storage section");
-        assert_eq!(storage.backend.as_deref(), Some("postgres"));
+        assert_eq!(storage.backend, Some(StorageBackend::Postgres));
         assert_eq!(
             storage.url_env.as_deref(),
             Some("IRONCLAW_REBORN_POSTGRES_URL")
@@ -1397,6 +1437,23 @@ backend = "postgres://user:password@db.example.com/ironclaw"
         assert!(
             !err.to_string().contains("password"),
             "error must not echo credential-bearing backend value: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_whitespace_only_storage_secret_master_key_env() {
+        let toml = r#"
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "   "
+"#;
+        let err = RebornConfigFile::parse_text(toml, &attributed())
+            .expect_err("whitespace-only secret_master_key_env must be rejected");
+        assert!(matches!(err, RebornConfigFileError::InvalidField { .. }));
+        assert!(
+            err.to_string().contains("storage.secret_master_key_env"),
+            "error should identify storage.secret_master_key_env: {err}"
         );
     }
 

--- a/crates/ironclaw_reborn_config/src/lib.rs
+++ b/crates/ironclaw_reborn_config/src/lib.rs
@@ -42,7 +42,8 @@ pub use config_file::{
     HarnessSection, IdentitySection, LlmSlotFieldUpdate, LlmSlotSelection, PolicySection,
     REBORN_CONFIG_API_VERSION, RebornConfigFile, RebornConfigFileError,
     RebornConfigFileUpdateError, RunnerSection, SlackChannelRouteSection, SlackSection,
-    TriggerPollerConfigSection, begin_default_llm_slot_update, update_default_llm_slot,
+    StorageBackend, StorageSection, TriggerPollerConfigSection, begin_default_llm_slot_update,
+    update_default_llm_slot,
 };
 pub use config_seed::{
     RebornConfigSeedError, RebornConfigSeedOutcome, seed_default_config_file_if_missing,

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -523,6 +523,7 @@ mod postgres_backed {
             Manager::from_config(pg_config, tls, manager_config)
         };
         Pool::builder(manager)
+            .max_size(16)
             .runtime(Runtime::Tokio1)
             .build()
             .map_err(|source| RebornEventStoreError::backend("postgres", "build pool", source))

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -51,6 +51,15 @@ mod filesystem_store;
 
 pub use filesystem_store::{FilesystemDurableAuditLog, FilesystemDurableEventLog};
 
+/// Open a PostgreSQL pool using the same TLS policy as the production event
+/// store backend.
+#[cfg(feature = "postgres")]
+pub fn open_postgres_pool(
+    url: SecretString,
+) -> Result<deadpool_postgres::Pool, RebornEventStoreError> {
+    postgres_backed::build_pool(url)
+}
+
 /// Backend configuration for Reborn durable event/audit stores.
 ///
 /// The `Libsql` / `Postgres` variants open a backend-specific
@@ -478,7 +487,7 @@ mod postgres_backed {
     pub(super) async fn build(
         url: SecretString,
     ) -> Result<RebornEventStores, RebornEventStoreError> {
-        let pool = build_pool(url).await?;
+        let pool = build_pool(url)?;
         let filesystem = Arc::new(PostgresRootFilesystem::new(pool));
         filesystem.run_migrations().await.map_err(|source| {
             RebornEventStoreError::backend("postgres", "run migrations", source)
@@ -486,7 +495,7 @@ mod postgres_backed {
         wrap_root_filesystem_as_event_stores(filesystem)
     }
 
-    async fn build_pool(url: SecretString) -> Result<Pool, RebornEventStoreError> {
+    pub(super) fn build_pool(url: SecretString) -> Result<Pool, RebornEventStoreError> {
         let raw_url = url.expose_secret();
         let mut pg_config: Config = raw_url.parse().map_err(|source| {
             RebornEventStoreError::backend("postgres", "parse connection string", source)


### PR DESCRIPTION
## Summary

- Add `[storage] backend = "postgres"` plus env-only `url_env` parsing/validation for Reborn config.
- Add the `ironclaw_reborn_cli/postgres` feature and production profile storage resolver that reads `IRONCLAW_REBORN_POSTGRES_URL` from env.
- Reuse the existing TLS-safe Postgres pool construction through composition/event-store facades.
- Document the storage config stub and README startup variable.

## Notes

This wires the #4551 CLI/config/Postgres storage slice. Full production runtime launch remains the companion follow-up in #4615; backend-parity production readiness coverage remains separate in #4620. The new caller-level test verifies the handoff reaches production composition wiring and then fails on the current missing production trust-policy wiring.

Addresses #4551.

## Tests

- `cargo fmt -- crates/ironclaw_reborn_config/src/config_file.rs crates/ironclaw_reborn_event_store/src/lib.rs crates/ironclaw_reborn_composition/src/lib.rs crates/ironclaw_reborn_cli/src/runtime/mod.rs crates/ironclaw_reborn_cli/src/commands/config/init.rs`
- `cargo test -p ironclaw_reborn_config`
- `cargo test -p ironclaw_reborn_cli --features postgres`
- `cargo test -p ironclaw_reborn_cli`
- `cargo clippy -p ironclaw_reborn_cli --features postgres --all-targets -- -D warnings`