### PR TITLE
test(reborn): verify OpenAI timeout turn admission

### DIFF
--- a/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
@@ -278,10 +278,9 @@ mod openai_compat_mount_tests {
         assert_eq!(denied_body["error"]["code"], "rate_limited");
         assert_eq!(turn_state.active_admission_reservations().len(), 1);
 
-        let run_id = turn_state.active_admission_reservations()[0].run_id;
         let runner_id = TurnRunnerId::new();
         let lease_token = TurnLeaseToken::new();
-        turn_state
+        let claimed = turn_state
             .claim_next_run(ClaimRunRequest {
                 runner_id,
                 lease_token,
@@ -292,7 +291,7 @@ mod openai_compat_mount_tests {
             .expect("active run should be claimable");
         turn_state
             .complete_run(CompleteRunRequest {
-                run_id,
+                run_id: claimed.state.run_id,
                 runner_id,
                 lease_token,
             })

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
@@ -130,6 +130,10 @@ mod openai_compat_mount_tests {
         ProductAdapterError, ProductInboundAck, ProductInboundEnvelope, ProductProjectionReadInput,
         ProductProjectionSubject, ProductWorkflow, ProjectionReadRequest, RedactedString,
     };
+    use ironclaw_product_workflow::{
+        ConversationBindingService, DefaultInboundTurnService, DefaultProductWorkflow,
+        FakeIdempotencyLedger, ProductWorkflowError, ResolveBindingRequest, ResolvedBinding,
+    };
     use ironclaw_reborn_composition::ProtectedRouteMount;
     use ironclaw_reborn_openai_compat::{
         InMemoryOpenAiCompatRefStore, OpenAiChatCompletionProjection,
@@ -140,7 +144,13 @@ mod openai_compat_mount_tests {
         OpenAiResponseWaitRequest, OpenAiResponsesMessageRole, OpenAiResponsesProjectionReader,
         OpenAiResponsesWorkflow, openai_compat_router_with_state, openai_compat_routes,
     };
-    use ironclaw_turns::{AcceptedMessageRef, TurnActor, TurnRunId, TurnScope};
+    use ironclaw_threads::InMemorySessionThreadService;
+    use ironclaw_turns::runner::{ClaimRunRequest, CompleteRunRequest, TurnRunTransitionPort};
+    use ironclaw_turns::{
+        AcceptedMessageRef, DefaultTurnCoordinator, InMemoryTurnStateStore,
+        StaticTurnAdmissionLimitProvider, TurnActor, TurnAdmissionAxisKind, TurnLeaseToken,
+        TurnRunId, TurnRunnerId, TurnScope,
+    };
 
     const AGENT: &str = "agent-alpha";
     const PROJECT: &str = "project-alpha";
@@ -200,6 +210,109 @@ mod openai_compat_mount_tests {
     }
 
     #[tokio::test]
+    async fn openai_chat_timeout_keeps_shared_turn_admission_until_terminal_release() {
+        let limits = StaticTurnAdmissionLimitProvider::default()
+            .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+        let turn_state = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+            Arc::new(limits),
+        ));
+        let turn_coordinator = Arc::new(DefaultTurnCoordinator::new(turn_state.clone()));
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let binding = AdmissionTestBindingService;
+        let inbound = Arc::new(DefaultInboundTurnService::new(
+            binding.clone(),
+            thread_service,
+            turn_coordinator,
+        ));
+        let workflow: Arc<dyn ProductWorkflow> = Arc::new(DefaultProductWorkflow::new(
+            inbound,
+            Arc::new(FakeIdempotencyLedger::new()),
+            Arc::new(binding),
+        ));
+        let chat = Arc::new(
+            OpenAiChatCompletionsWorkflow::new(
+                workflow,
+                Arc::new(InMemoryOpenAiCompatRefStore::new()),
+                Arc::new(NeverCompletingChatProjectionReader),
+            )
+            .with_wait_timeout(Duration::from_millis(1)),
+        );
+        let mount = ProtectedRouteMount::new(
+            openai_compat_router_with_state(OpenAiCompatRouterState::with_chat_completions(chat)),
+            openai_compat_routes(),
+        );
+        let bundle = RebornWebuiBundle {
+            api: Arc::new(StubServices::default()),
+            product_auth: None,
+            readiness: RebornReadiness::disabled(),
+        };
+        let config = WebuiServeConfig::new(
+            TenantId::new(TENANT).expect("tenant"),
+            Arc::new(OnlyValidToken),
+            vec![HeaderValue::from_static("http://localhost:3000")],
+        )
+        .with_default_agent_id(AgentId::new(AGENT).expect("agent"))
+        .with_default_project_id(ProjectId::new(PROJECT).expect("project"))
+        .with_protected_route_mount(mount);
+        let app = webui_v2_app(bundle, config).expect("webui v2 app");
+
+        let timed_out = app
+            .clone()
+            .oneshot(chat_request(Some(VALID_TOKEN)))
+            .await
+            .expect("timed-out chat response");
+        assert_eq!(timed_out.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(turn_state.active_admission_reservations().len(), 1);
+
+        let denied = app
+            .clone()
+            .oneshot(chat_request(Some(VALID_TOKEN)))
+            .await
+            .expect("admission-denied chat response");
+        assert_eq!(denied.status(), StatusCode::TOO_MANY_REQUESTS);
+        let denied_body = to_bytes(denied.into_body(), 4096)
+            .await
+            .expect("denied body");
+        let denied_body: serde_json::Value =
+            serde_json::from_slice(&denied_body).expect("denied json");
+        assert_eq!(denied_body["error"]["code"], "rate_limited");
+        assert_eq!(turn_state.active_admission_reservations().len(), 1);
+
+        let run_id = turn_state.active_admission_reservations()[0].run_id;
+        let runner_id = TurnRunnerId::new();
+        let lease_token = TurnLeaseToken::new();
+        turn_state
+            .claim_next_run(ClaimRunRequest {
+                runner_id,
+                lease_token,
+                scope_filter: None,
+            })
+            .await
+            .expect("claim active run")
+            .expect("active run should be claimable");
+        turn_state
+            .complete_run(CompleteRunRequest {
+                run_id,
+                runner_id,
+                lease_token,
+            })
+            .await
+            .expect("complete active run");
+        assert!(turn_state.active_admission_reservations().is_empty());
+
+        let accepted_after_release = app
+            .oneshot(chat_request(Some(VALID_TOKEN)))
+            .await
+            .expect("chat response after release");
+        assert_eq!(
+            accepted_after_release.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "the route still times out waiting for projection, but admission accepted a new turn"
+        );
+        assert_eq!(turn_state.active_admission_reservations().len(), 1);
+    }
+
+    #[tokio::test]
     async fn openai_responses_mount_uses_webui_auth_and_product_workflow() {
         let workflow = Arc::new(GatewayOpenAiWorkflow::default());
         let responses = Arc::new(OpenAiResponsesWorkflow::new(
@@ -251,6 +364,57 @@ mod openai_compat_mount_tests {
         );
         assert_eq!(workflow.submit_count(), 1);
         assert_eq!(workflow.read_count(), 1);
+    }
+
+    #[derive(Clone)]
+    struct AdmissionTestBindingService;
+
+    #[async_trait]
+    impl ConversationBindingService for AdmissionTestBindingService {
+        async fn resolve_binding(
+            &self,
+            request: ResolveBindingRequest,
+        ) -> Result<ResolvedBinding, ProductWorkflowError> {
+            self.resolve(request)
+        }
+
+        async fn lookup_binding(
+            &self,
+            request: ResolveBindingRequest,
+        ) -> Result<ResolvedBinding, ProductWorkflowError> {
+            self.resolve(request)
+        }
+    }
+
+    impl AdmissionTestBindingService {
+        fn resolve(
+            &self,
+            request: ResolveBindingRequest,
+        ) -> Result<ResolvedBinding, ProductWorkflowError> {
+            Ok(ResolvedBinding {
+                tenant_id: TenantId::new(TENANT).map_err(binding_error("test OpenAI tenant id"))?,
+                actor_user_id: UserId::new(request.external_actor_ref.id())
+                    .map_err(binding_error("test OpenAI actor user id"))?,
+                subject_user_id: Some(
+                    UserId::new(request.external_actor_ref.id())
+                        .map_err(binding_error("test OpenAI subject user id"))?,
+                ),
+                thread_id: ThreadId::new(format!("thread-{}", request.external_event_id.as_str()))
+                    .map_err(binding_error("test OpenAI thread id"))?,
+                agent_id: Some(AgentId::new(AGENT).map_err(binding_error("test OpenAI agent id"))?),
+                project_id: Some(
+                    ProjectId::new(PROJECT).map_err(binding_error("test OpenAI project id"))?,
+                ),
+            })
+        }
+    }
+
+    fn binding_error(
+        field: &'static str,
+    ) -> impl FnOnce(ironclaw_host_api::HostApiError) -> ProductWorkflowError + 'static {
+        move |reason| ProductWorkflowError::BindingResolutionFailed {
+            reason: format!("{field}: {reason}"),
+        }
     }
 
     fn chat_request(token: Option<&str>) -> Request<Body> {
@@ -386,6 +550,22 @@ mod openai_compat_mount_tests {
             ironclaw_reborn_openai_compat::OpenAiCompatHttpError,
         > {
             Ok(self.projection.clone())
+        }
+    }
+
+    struct NeverCompletingChatProjectionReader;
+
+    #[async_trait]
+    impl OpenAiChatCompletionProjectionReader for NeverCompletingChatProjectionReader {
+        async fn read_chat_completion_projection(
+            &self,
+            _request: OpenAiChatCompletionProjectionRequest,
+        ) -> Result<
+            OpenAiChatCompletionProjection,
+            ironclaw_reborn_openai_compat::OpenAiCompatHttpError,
+        > {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(OpenAiChatCompletionProjection::text("late"))
         }
     }
 

--- a/crates/ironclaw_reborn_openai_compat/CLAUDE.md
+++ b/crates/ironclaw_reborn_openai_compat/CLAUDE.md
@@ -53,6 +53,10 @@ handles Chat Completions create and optional projection-backed SSE streaming:
   composition-supplied `OpenAiChatCompletionProjectionReader`. Timeout returns
   a retryable sanitized API error and does not cancel or detach the underlying
   product turn.
+- Detached waits must remain bounded by the shared Reborn turn-admission
+  reservation held by `ProductWorkflow` / `TurnCoordinator`. Do not add a
+  route-local OpenAI-compatible quota, and do not release admission capacity
+  until the underlying turn reaches a terminal state.
 - The canonical projection read actor/scope must match the authenticated caller
   before the projection reader is invoked.
 - The requested public model string is carried as a composition/policy hint for

--- a/docs/reborn/contracts/openai-compatible-api.md
+++ b/docs/reborn/contracts/openai-compatible-api.md
@@ -81,6 +81,10 @@ bind sockets or call `axum::serve`.
 - Non-streaming Chat Completions wait timeout detaches from the wait, not from
   the underlying turn. The API response is a retryable sanitized service
   unavailable error.
+- Timed-out create requests remain bounded by the shared Reborn turn-admission
+  reservation held by ProductWorkflow / TurnCoordinator. OpenAI-compatible
+  wrappers must not add route-local quota, route-local cancellation, or any
+  admission release separate from the underlying turn's terminal transition.
 - SSE translation consumes a composition-supplied projection stream port and
   emits OpenAI-compatible events from `ProductProjectionItem` state. Reborn
   keepalive/control frames, projection cursors, internal refs, provider
@@ -111,6 +115,10 @@ The route:
   reader polls `SessionThreadService::finalized_assistant_message_by_run` for
   the accepted run's finalized assistant message and returns a sanitized Chat
   Completions response.
+- Inherits the shared turn-admission policy from the configured
+  `TurnCoordinator` / turn-state store. A wait timeout must not release
+  admission capacity while the underlying run remains queued, running, blocked,
+  cancel-requested, or otherwise non-terminal.
 - Carries the requested public model string as a composition/policy hint for
   the projection reader; the route must not inject the model name into user
   transcript text.


### PR DESCRIPTION
## Summary

- Added caller-level composition coverage for OpenAI-compatible Chat Completions wait timeouts against the shared Reborn turn admission boundary.
- Verified a timed-out non-streaming wait keeps the underlying turn admission reservation until the run reaches a terminal state.
- Verified a second mutating request is rejected as stable OpenAI-compatible `rate_limited` backpressure while the first timed-out turn is still active.
- Documented that OpenAI-compatible wrappers must not add route-local quota, route-local cancellation, or admission release separate from ProductWorkflow / TurnCoordinator terminal state.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Closes #4586

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_reborn_composition --features "webui-v2-beta openai-compat-beta" openai_compat_mount_tests --test webui_v2_serve`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; regression is covered by caller-level route/composition tests.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo clippy -p ironclaw_reborn_composition --features "webui-v2-beta openai-compat-beta" --all-targets -- -D warnings`
- `git diff --check`

## Security Impact

Yes. This PR verifies the OpenAI-compatible non-streaming wait timeout path remains bounded by shared Reborn turn admission/resource policy. It does not add new permissions, listeners, network calls, secrets access, file access, tool execution, sandbox policy, or route-local quota/cancellation behavior.

## Database Impact

None.

## Blast Radius

Limited to Reborn OpenAI-compatible composition contract coverage and documentation. Production code paths are unchanged.

## Rollback Plan

Revert this PR to remove the regression test and documentation updates. No migrations or runtime state changes are involved.

## Review Follow-Through

Reviewer judgment requested on whether this caller-level composition coverage is sufficient for #4586, or whether a later production-config PR should add an explicit default admission policy for the Reborn binary once that policy surface is finalized.

---

**Review track**: B
