### PR TITLE
fix(llm): strip strict-mode unset-optional placeholders at the provider boundary

### DIFF
--- a/crates/ironclaw_llm/src/codex_chatgpt.rs
+++ b/crates/ironclaw_llm/src/codex_chatgpt.rs
@@ -910,26 +910,6 @@ impl CodexChatGptProvider {
             }
         }
     }
-
-    /// Remove keys with empty-string values from a JSON object.
-    ///
-    /// gpt-5.2-codex fills optional tool parameters with `""` (e.g.
-    /// `"timestamp": ""`). IronClaw's tool validation treats these as
-    /// invalid "non-empty input expected". Stripping them makes the
-    /// tool see only the actually-provided values.
-    fn strip_empty_string_values(value: Value) -> Value {
-        match value {
-            Value::Object(map) => {
-                let cleaned: serde_json::Map<String, Value> = map
-                    .into_iter()
-                    .filter(|(_, v)| !matches!(v, Value::String(s) if s.is_empty()))
-                    .map(|(k, v)| (k, Self::strip_empty_string_values(v)))
-                    .collect();
-                Value::Object(cleaned)
-            }
-            other => other,
-        }
-    }
 }
 
 #[derive(Debug, Default)]
@@ -999,7 +979,7 @@ impl LlmProvider for CodexChatGptProvider {
         );
         let result = self.send_request(body).await?;
 
-        let tool_calls: Vec<ToolCall> = result
+        let mut tool_calls: Vec<ToolCall> = result
             .pending_tool_calls
             .into_values()
             .map(|tc| {
@@ -1010,10 +990,6 @@ impl LlmProvider for CodexChatGptProvider {
                     .unwrap_or(returned_name);
                 let args: Value =
                     serde_json::from_str(&tc.arguments).unwrap_or_else(|_| json!(tc.arguments));
-                // gpt-5.2-codex fills optional parameters with empty strings (e.g.
-                // `"timestamp": ""`), which IronClaw's tool validation rejects.
-                // Strip them so only actually-provided values reach the tool.
-                let args = Self::strip_empty_string_values(args);
                 ToolCall {
                     id: tc.call_id,
                     name,
@@ -1024,6 +1000,12 @@ impl LlmProvider for CodexChatGptProvider {
                 }
             })
             .collect();
+        // Strict-mode tool schemas advertise every optional as required+nullable,
+        // so the model fills unset optionals with `null` (or `""` for some codex
+        // models). Strip those placeholders against each tool's original schema
+        // so only genuinely-provided values reach the tool. `true`: the codex
+        // family fills with `""` as well as `null`.
+        crate::tool_schema::strip_unset_optional_fields(&mut tool_calls, &request.tools, true);
 
         let finish_reason = if tool_calls.is_empty() {
             FinishReason::Stop
@@ -1654,16 +1636,49 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":3,"output
         );
     }
 
-    #[test]
-    fn test_strip_empty_string_values() {
-        let input = json!({
-            "format": "%Y-%m-%d",
-            "operation": "now",
-            "timestamp": "",
-            "timestamp2": "",
-        });
-        let cleaned = CodexChatGptProvider::strip_empty_string_values(input);
-        assert_eq!(cleaned, json!({"format": "%Y-%m-%d", "operation": "now"}));
+    #[tokio::test]
+    async fn complete_with_tools_strips_unset_optional_placeholders_through_the_caller() {
+        // Test-through-the-caller (.claude/rules/testing.md): drive the whole
+        // complete_with_tools path, not just the helper. The model fills two
+        // optional fields with strict-mode placeholders (`null` and `""`); the
+        // provider must strip them so only the provided value reaches the caller.
+        let sse = r#"event: response.output_item.added
+data: {"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"demo"}}
+
+event: response.function_call_arguments.done
+data: {"item_id":"fc_1","arguments":"{\"required_arg\":\"x\",\"optional_arg\":null,\"optional_str\":\"\"}"}
+
+event: response.completed
+data: {"response":{"usage":{"input_tokens":5,"output_tokens":5}}}
+
+"#;
+        let base_url = responses_api_test_server::spawn(sse).await;
+        let provider = CodexChatGptProvider::new(&base_url, "test-key", "gpt-4o");
+        let tools = vec![ToolDefinition {
+            name: "demo".to_string(),
+            description: "demo".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "required_arg": { "type": "string" },
+                    "optional_arg": { "type": "string" },
+                    "optional_str": { "type": "string" }
+                },
+                "required": ["required_arg"]
+            }),
+        }];
+        let request = ToolCompletionRequest::new(vec![ChatMessage::user("call demo")], tools);
+        let response = provider
+            .complete_with_tools(request)
+            .await
+            .expect("complete_with_tools");
+        assert_eq!(response.tool_calls.len(), 1);
+        // `optional_arg: null` and `optional_str: ""` are dropped at the provider
+        // boundary; only the genuinely-provided required arg survives.
+        assert_eq!(
+            response.tool_calls[0].arguments,
+            json!({ "required_arg": "x" })
+        );
     }
 
     mod responses_api_test_server {

--- a/crates/ironclaw_llm/src/openai_codex_provider.rs
+++ b/crates/ironclaw_llm/src/openai_codex_provider.rs
@@ -313,6 +313,16 @@ impl LlmProvider for OpenAiCodexProvider {
             }
         }
 
+        // Strict-mode tool schemas advertise every optional as required+nullable,
+        // so the model fills unset optionals with `null` (or `""` for some codex
+        // models). Strip those placeholders against each tool's original schema so
+        // only provided values reach the tool. `true`: this is a codex model.
+        crate::tool_schema::strip_unset_optional_fields(
+            &mut parsed.tool_calls,
+            &request.tools,
+            true,
+        );
+
         let finish_reason = if !parsed.tool_calls.is_empty() {
             FinishReason::ToolUse
         } else {

--- a/crates/ironclaw_llm/src/rig_adapter.rs
+++ b/crates/ironclaw_llm/src/rig_adapter.rs
@@ -747,6 +747,13 @@ where
             }
         }
 
+        // Strict-mode tool schemas advertise every optional as required+nullable,
+        // so the model fills unset optionals with `null`. Strip those placeholders
+        // against each tool's original schema so only provided values reach the
+        // tool. `false`: rig providers send `null`, not `""`, so a deliberately
+        // empty string from the model is preserved.
+        crate::tool_schema::strip_unset_optional_fields(&mut tool_calls, &request.tools, false);
+
         let resp = ToolCompletionResponse {
             content: text,
             tool_calls,

--- a/crates/ironclaw_llm/src/tool_schema.rs
+++ b/crates/ironclaw_llm/src/tool_schema.rs
@@ -1,5 +1,7 @@
 use serde_json::Value as JsonValue;
 
+use crate::provider::{ToolCall, ToolDefinition};
+
 /// Policy for shaping tool schemas at the provider boundary.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ToolSchemaPolicy {
@@ -398,9 +400,234 @@ fn make_nullable(schema: &mut JsonValue) {
     }
 }
 
+/// Strip "unset optional" placeholder values that the strict-mode tool-schema
+/// transform induces, from each tool call's arguments.
+///
+/// `shape_tool_schema(StrictOpenAi, ..)` forces every property to be `required`
+/// and makes the originally-optional ones nullable, because OpenAI strict
+/// function-calling has no notion of an absent property. Models therefore fill
+/// the optionals they aren't using with a placeholder — `null` for most, `""`
+/// for some (e.g. gpt-5.2-codex). Validating those against the tool's *original*
+/// schema (where the fields are optional and non-nullable) would reject them, so
+/// this removes them: the inverse of that transform, keyed on the effective
+/// `required` set (the original schema's, unioned across `oneOf`/`anyOf`/`allOf`
+/// variants — so tagged-enum tools keep their variant-required fields), leaving
+/// required fields and genuinely provided values intact.
+///
+/// `strip_empty_strings` should be `true` only for the codex family, which fills
+/// unset optionals with `""`; other strict providers send `null`, so passing
+/// `false` preserves a deliberately-empty string they may have sent.
+///
+/// Only the strict providers (Codex / OpenAI / `RigAdapter`) call this; NEAR
+/// AI's `FlattenOnly` path never induces the placeholders and must not be
+/// touched. (When the RC3/M9 `NormalizingProvider` decorator lands it should
+/// adopt this as a Class-A shape invariant.)
+pub(crate) fn strip_unset_optional_fields(
+    tool_calls: &mut [ToolCall],
+    tools: &[ToolDefinition],
+    strip_empty_strings: bool,
+) {
+    for call in tool_calls.iter_mut() {
+        if let Some(tool) = tools.iter().find(|tool| tool.name == call.name) {
+            strip_unset_optionals_in_value(
+                &mut call.arguments,
+                &tool.parameters,
+                strip_empty_strings,
+            );
+        }
+    }
+}
+
+/// Recursive worker for [`strip_unset_optional_fields`]: walks `value` alongside
+/// its original `schema`, dropping unset-placeholder values on the fields the
+/// schema's *top-level* `required` marks optional, and recursing into nested
+/// objects and array items.
+///
+/// Top-level on purpose: a tagged-enum tool is a top-level `oneOf`/`anyOf`, which
+/// the forward transform (`flatten_top_level`) rewrites to `required: []` +
+/// `additionalProperties: true`, so dropping every placeholder is exactly what
+/// collapses the model's reply to the single variant it populated. Unioning the
+/// variants' `required` sets would keep a non-selected variant's placeholder and
+/// make the args match more than one `oneOf` branch (regressing e.g.
+/// `skill_install`/`routine`), so keep it top-level.
+fn strip_unset_optionals_in_value(
+    value: &mut JsonValue,
+    schema: &JsonValue,
+    strip_empty_strings: bool,
+) {
+    match value {
+        JsonValue::Object(map) => {
+            let required: Vec<&str> = schema
+                .get("required")
+                .and_then(JsonValue::as_array)
+                .map(|names| names.iter().filter_map(JsonValue::as_str).collect())
+                .unwrap_or_default();
+            let properties = schema.get("properties").and_then(JsonValue::as_object);
+            let to_remove: Vec<String> = map
+                .iter()
+                .filter(|(key, val)| {
+                    !required.contains(&key.as_str())
+                        && is_unset_placeholder(val, strip_empty_strings)
+                })
+                .map(|(key, _)| key.clone())
+                .collect();
+            for key in &to_remove {
+                map.remove(key);
+            }
+            for (key, val) in map.iter_mut() {
+                if let Some(prop_schema) = properties.and_then(|props| props.get(key.as_str())) {
+                    strip_unset_optionals_in_value(val, prop_schema, strip_empty_strings);
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            if let Some(item_schema) = schema.get("items") {
+                for item in items.iter_mut() {
+                    strip_unset_optionals_in_value(item, item_schema, strip_empty_strings);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A value the model emitted only as a strict-mode placeholder for an unset
+/// field: `null` always, or an empty string when `strip_empty_strings` is set.
+/// The codex family fills unset optionals with `""`; other strict providers send
+/// `null`, so their callers pass `false` to preserve a deliberately-empty string.
+fn is_unset_placeholder(value: &JsonValue, strip_empty_strings: bool) -> bool {
+    match value {
+        JsonValue::Null => true,
+        JsonValue::String(string) => strip_empty_strings && string.is_empty(),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_strip_unset_optional_fields_drops_optional_null_and_empty() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "operation": { "type": "string" },
+                "format": { "type": "string" },
+                "timezone": { "type": "string" }
+            }
+        });
+        let mut value = serde_json::json!({ "operation": "now", "format": null, "timezone": "" });
+        strip_unset_optionals_in_value(&mut value, &schema, true);
+        assert_eq!(value, serde_json::json!({ "operation": "now" }));
+    }
+
+    #[test]
+    fn test_strip_unset_optional_fields_keeps_required_placeholders() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "id": { "type": "string" }, "note": { "type": "string" } },
+            "required": ["id"]
+        });
+        let mut value = serde_json::json!({ "id": null, "note": null });
+        strip_unset_optionals_in_value(&mut value, &schema, true);
+        // The required `id` is kept (it surfaces as a validation error
+        // downstream); only the optional `note` placeholder is dropped.
+        assert_eq!(value, serde_json::json!({ "id": null }));
+    }
+
+    #[test]
+    fn test_strip_unset_optional_fields_collapses_top_level_oneof_to_one_variant() {
+        // A tagged-enum tool (top-level `oneOf`, mirroring `skill_install`) has no
+        // top-level `required`, and the forward transform flattens it to a
+        // permissive object. The model populates the variant it chose (`url`) and
+        // leaves the other variant's field as a placeholder; stripping every
+        // placeholder collapses the args to the single matching variant. Verified
+        // end-to-end on a live build by driving `skill_install` through the agent
+        // (the call passed validation and reached the approval gate). Unioning the
+        // variants' `required` would instead keep `content` and match both.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "content": { "type": "string" },
+                "url": { "type": "string" }
+            },
+            "oneOf": [ { "required": ["content"] }, { "required": ["url"] } ],
+            "additionalProperties": false
+        });
+        let mut value = serde_json::json!({ "url": "https://example.com/SKILL.md", "content": "" });
+        strip_unset_optionals_in_value(&mut value, &schema, true);
+        assert_eq!(
+            value,
+            serde_json::json!({ "url": "https://example.com/SKILL.md" })
+        );
+    }
+
+    #[test]
+    fn test_strip_unset_optional_fields_recurses_objects_and_arrays() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+                        "required": ["a"]
+                    }
+                }
+            }
+        });
+        let mut value =
+            serde_json::json!({ "items": [ { "a": "x", "b": null }, { "a": "y", "b": "" } ] });
+        strip_unset_optionals_in_value(&mut value, &schema, true);
+        assert_eq!(
+            value,
+            serde_json::json!({ "items": [ { "a": "x" }, { "a": "y" } ] })
+        );
+    }
+
+    #[test]
+    fn test_strip_unset_optional_fields_preserves_empty_string_when_disabled() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "prefix": { "type": "string" } }
+        });
+        // With empty-string stripping off (non-codex providers), a deliberately
+        // empty optional string is preserved...
+        let mut keep = serde_json::json!({ "prefix": "" });
+        strip_unset_optionals_in_value(&mut keep, &schema, false);
+        assert_eq!(keep, serde_json::json!({ "prefix": "" }));
+        // ...but `null` is always a placeholder and is still dropped.
+        let mut drop_null = serde_json::json!({ "prefix": null });
+        strip_unset_optionals_in_value(&mut drop_null, &schema, false);
+        assert_eq!(drop_null, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_strip_unset_optional_fields_matches_calls_to_their_tool_schema() {
+        let tools = vec![ToolDefinition {
+            name: "time".to_string(),
+            description: String::new(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "operation": { "type": "string" }, "format": { "type": "string" } }
+            }),
+        }];
+        let mut calls = vec![ToolCall {
+            id: "1".to_string(),
+            name: "time".to_string(),
+            arguments: serde_json::json!({ "operation": "now", "format": null }),
+            reasoning: None,
+            signature: None,
+            arguments_parse_error: None,
+        }];
+        strip_unset_optional_fields(&mut calls, &tools, true);
+        assert_eq!(
+            calls[0].arguments,
+            serde_json::json!({ "operation": "now" })
+        );
+    }
 
     #[test]
     fn test_flatten_only_preserves_optional_object_fields() {


### PR DESCRIPTION
## What

Strict-mode LLM providers had their tool calls rejected as `invalid_input`, breaking most first-party tools.

When tools are advertised to OpenAI/Codex (and Anthropic/Ollama/Tinfoil via `RigAdapter`), `shape_tool_schema(StrictOpenAi)` forces every property `required` and makes optionals nullable — strict function-calling has no notion of an absent property. So the model fills the optionals it isn't using with `null` (or `""` for some codex models). The capability port then validated that reply against the tool's *original* (non-nullable) schema → `null` is a type mismatch → `invalid_input`, and the tool never ran. `builtin.time` literally couldn't return the current time (`format: null` rejected), which cascaded into the calendar returning junk.

This affects ~16 of 23 first-party tools (any with an optional param), on every strict provider. **NEAR AI** (the default backend) uses `FlattenOnly` and never sends the placeholders, which is why it stayed latent until we ran on Codex.

## Fix

`strip_unset_optional_fields` in `crates/ironclaw_llm/src/tool_schema.rs` is the **inverse of the strict transform**: it drops a `null`/`""` value on a field that was **optional** in the tool's original schema — keyed on the same `required` set the forward transform keyed on, so it needs **no nullability heuristic** (no `oneOf`/`anyOf`/`const`/`$ref` null-detection) — recursing into nested objects and array items. The three strict providers (`codex_chatgpt`, `openai_codex_provider`, `rig_adapter`) call it when decoding tool calls.

- **Generalizes + replaces** the codex-only `strip_empty_string_values` (which stripped even a *required* `""`); now schema-guided and extended to the other two providers.
- **Co-located with the forward transform** in `ironclaw_llm`, so the provider-agnostic capability port is unchanged, and the args are canonical everywhere — validation, dispatch, **and replay/audit** (persisted tool-call args no longer carry `null` placeholders).
- Fixes both Reborn and the legacy `Reasoning` path in one place.

## Validation

- New `tool_schema.rs` tests: drops optional `null`/`""`; keeps a *required* placeholder; recurses objects + arrays; matches calls to their tool schema. All **832 `ironclaw_llm` tests** pass; `fmt`/`clippy` clean.
- Verified **live** against `ironclaw-reborn serve` (gpt-5.5 via Codex): `builtin.time` now completes with canonical args `{"operation":"now"}` (previously `invalid_input` on `format: null`), and "what are my upcoming meetings?" returns a correct, ordered list.

Closes #4642
