### PR TITLE
feat(mcp): thread-scoped sessions + SEP-414 context propagation

### DIFF
--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -515,7 +515,13 @@ async fn test_server(name: String, user_id: String) -> anyhow::Result<()> {
 
     let client = if has_tokens {
         // We have stored tokens, use authenticated client
-        McpClient::new_authenticated(server.clone(), session_manager.clone(), secrets, user_id)
+        McpClient::new_authenticated(
+            server.clone(),
+            session_manager.clone(),
+            secrets,
+            user_id,
+            None,
+        )
     } else if server.has_custom_auth_header() {
         let process_manager = Arc::new(McpProcessManager::new());
         create_client_from_config(

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -9157,6 +9157,7 @@ mod tests {
             None,
             "default",
             None,
+            None,
         ));
         let client_b = Arc::new(McpClient::new_with_transport(
             "notion",
@@ -9167,6 +9168,7 @@ mod tests {
             None,
             None,
             "default",
+            None,
             None,
         ));
 

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -23,6 +23,7 @@ use crate::tools::mcp::protocol::{
 use crate::tools::mcp::session::McpSessionManager;
 use crate::tools::mcp::transport::McpTransport;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput};
+use uuid::Uuid;
 
 /// Tag identifying which constructor produced an `McpClient`.
 ///
@@ -81,6 +82,14 @@ pub struct McpClient {
 
     /// User ID for secrets lookup.
     user_id: String,
+
+    /// Thread ID for thread-scoped MCP session keys and context headers.
+    ///
+    /// `None` for user-scoped paths (test fixtures, CLI, shutdown);
+    /// `Some(uuid)` when the call is rooted in a specific IronClaw Thread,
+    /// ensuring each Thread gets its own `Mcp-Session-Id` slot and that
+    /// `X-Ironclaw-Thread-Id` / `X-Ironclaw-User-Id` are forwarded.
+    thread_id: Option<Uuid>,
 
     /// Server configuration (for token secret name lookup).
     server_config: Option<McpServerConfig>,
@@ -143,6 +152,7 @@ impl McpClient {
             user_id: "<unset>".to_string(),
             server_config: None,
             custom_headers: HashMap::new(),
+            thread_id: None,
             initialized: tokio::sync::OnceCell::new(),
             #[cfg(test)]
             constructor_kind: McpClientConstructor::Plain,
@@ -185,6 +195,7 @@ impl McpClient {
             user_id: "<unset>".to_string(),
             server_config: None,
             custom_headers: HashMap::new(),
+            thread_id: None,
             initialized: tokio::sync::OnceCell::new(),
             #[cfg(test)]
             constructor_kind: McpClientConstructor::PlainNamed,
@@ -246,6 +257,7 @@ impl McpClient {
             // create_client_from_config() for production paths
             user_id: "<unset>".to_string(),
             custom_headers: config.headers.clone(),
+            thread_id: None,
             initialized: tokio::sync::OnceCell::new(),
             server_config: Some(config),
             #[cfg(test)]
@@ -261,6 +273,7 @@ impl McpClient {
         session_manager: Arc<McpSessionManager>,
         secrets: Arc<dyn SecretsStore + Send + Sync>,
         user_id: impl Into<String>,
+        thread_id: Option<Uuid>,
     ) -> Self {
         // Validate the config-supplied name once and pass the canonical
         // form into both the transport and the client's typed field. If
@@ -283,7 +296,7 @@ impl McpClient {
         let user_id_str: String = user_id.into();
         let transport = Arc::new(
             HttpMcpTransport::new(config.url.clone(), validated_name.as_str())
-                .with_session_manager(session_manager.clone(), &user_id_str),
+                .with_session_manager(session_manager.clone(), &user_id_str, thread_id),
         );
 
         let custom_headers = config.headers.clone();
@@ -299,6 +312,7 @@ impl McpClient {
             user_id: user_id_str,
             server_config: Some(config),
             custom_headers,
+            thread_id,
             initialized: tokio::sync::OnceCell::new(),
             #[cfg(test)]
             constructor_kind: McpClientConstructor::Authenticated,
@@ -315,6 +329,7 @@ impl McpClient {
         secrets: Option<Arc<dyn SecretsStore + Send + Sync>>,
         user_id: impl Into<String>,
         server_config: Option<McpServerConfig>,
+        thread_id: Option<Uuid>,
     ) -> Self {
         // The production caller (factory) hands us an already-validated
         // name, but the signature accepts `impl Into<String>` which means
@@ -356,6 +371,7 @@ impl McpClient {
             user_id: user_id.into(),
             server_config,
             custom_headers,
+            thread_id,
             initialized: tokio::sync::OnceCell::new(),
             #[cfg(test)]
             constructor_kind: McpClientConstructor::WithTransport,
@@ -396,6 +412,73 @@ impl McpClient {
     /// Whether this client has a session manager attached.
     pub fn has_session_manager(&self) -> bool {
         self.session_manager.is_some()
+    }
+
+    /// Get the thread id associated with this client.
+    ///
+    /// `None` for user-scoped (test fixtures, CLI, boot-time base clients).
+    /// `Some(uuid)` when the client was materialised for a specific Thread.
+    #[cfg(test)]
+    pub(crate) fn thread_id(&self) -> Option<uuid::Uuid> {
+        self.thread_id
+    }
+
+    /// Materialise a thread-scoped sibling of this client.
+    ///
+    /// The sibling shares server config, secrets, and session manager with the
+    /// parent but receives:
+    /// - its own `thread_id = Some(thread_id)` so `inject_meta_context` and
+    ///   `McpSessionManager` use the correct thread-scoped key.
+    /// - a fresh `initialized` cell so the MCP server issues a new
+    ///   `Mcp-Session-Id` for this Thread's first call (required so any
+    ///   server-side state the upstream binds to the session id is
+    ///   partitioned per Thread, not shared across all of a user's Threads).
+    /// - a fresh transport (for HTTP transports) so response-header session-id
+    ///   captures are stored under the correct thread-scoped slot rather than
+    ///   the parent's user-scoped slot.
+    pub fn for_thread(&self, thread_id: Uuid) -> Self {
+        // HTTP transports store `session_thread_id` at construction time and
+        // use it to bucket `Mcp-Session-Id` response headers into the right
+        // session slot.  Sharing the parent's transport would route Thread
+        // A's session-id responses into Thread B's slot — defeating the
+        // per-Thread `McpSessionKey` partition. Rebuild the transport with
+        // the new thread id when HTTP features are in use.
+        //
+        // Stdio and Unix transports do not use session_thread_id in their
+        // `send` implementation (they operate over a shared process/socket
+        // and session state is managed by McpSessionManager alone), so
+        // sharing the Arc is correct and avoids spawning a duplicate process.
+        let forked_transport: Arc<dyn McpTransport> = if self.transport.supports_http_features() {
+            let mut t = HttpMcpTransport::new(self.server_url.clone(), self.server_name.as_str());
+            if let Some(ref sm) = self.session_manager {
+                t = t.with_session_manager(Arc::clone(sm), &self.user_id, Some(thread_id));
+            }
+            Arc::new(t)
+        } else {
+            Arc::clone(&self.transport)
+        };
+        tracing::debug!(
+            server = %self.server_name,
+            thread_id = %thread_id,
+            user_id = %self.user_id,
+            "MCP client forked for thread"
+        );
+        Self {
+            transport: forked_transport,
+            server_url: self.server_url.clone(),
+            server_name: self.server_name.clone(),
+            next_id: AtomicU64::new(1),
+            tools_cache: RwLock::new(None),
+            session_manager: self.session_manager.clone(),
+            secrets: self.secrets.clone(),
+            user_id: self.user_id.clone(),
+            server_config: self.server_config.clone(),
+            custom_headers: self.custom_headers.clone(),
+            thread_id: Some(thread_id),
+            initialized: tokio::sync::OnceCell::new(),
+            #[cfg(test)]
+            constructor_kind: self.constructor_kind,
+        }
     }
 
     /// Get the underlying transport (test-only).
@@ -492,7 +575,7 @@ impl McpClient {
         }
         if let Some(ref session_manager) = self.session_manager
             && let Some(session_id) = session_manager
-                .get_session_id(&self.user_id, &self.server_name)
+                .get_session_id(&self.user_id, &self.server_name, self.thread_id)
                 .await
         {
             headers.insert("Mcp-Session-Id".to_string(), session_id);
@@ -507,14 +590,20 @@ impl McpClient {
     async fn reinitialize_session(&self) -> Result<InitializeResult, ToolError> {
         if let Some(ref session_manager) = self.session_manager {
             session_manager
-                .terminate(&self.user_id, &self.server_name)
+                .terminate(&self.user_id, &self.server_name, self.thread_id)
                 .await;
             session_manager
-                .get_or_create(&self.user_id, &self.server_name, &self.server_url)
+                .get_or_create(
+                    &self.user_id,
+                    &self.server_name,
+                    &self.server_url,
+                    self.thread_id,
+                )
                 .await;
         }
 
-        let request = McpRequest::initialize(self.next_request_id());
+        let request = McpRequest::initialize(self.next_request_id())
+            .inject_meta_context(self.thread_id, &self.user_id);
         let response = self
             .transport
             .send(&request, &self.build_request_headers().await?)
@@ -540,19 +629,21 @@ impl McpClient {
 
         if let Some(ref session_manager) = self.session_manager {
             session_manager
-                .mark_initialized(&self.user_id, &self.server_name)
+                .mark_initialized(&self.user_id, &self.server_name, self.thread_id)
                 .await;
         }
 
-        let notification = McpRequest::initialized_notification();
+        let notification = McpRequest::initialized_notification()
+            .inject_meta_context(self.thread_id, &self.user_id);
         if let Err(e) = self
             .transport
             .send(&notification, &self.build_request_headers().await?)
             .await
         {
             tracing::debug!(
-                "Failed to send initialized notification to '{}': {}",
-                self.server_name,
+                server = %self.server_name,
+                thread_id = ?self.thread_id,
+                "Failed to send initialized notification: {}",
                 e
             );
         }
@@ -592,8 +683,9 @@ impl McpClient {
                         && Self::is_session_expiry_error(msg) =>
                 {
                     tracing::debug!(
-                        "MCP session expired, attempting reinitialize for '{}'",
-                        self.server_name
+                        server = %self.server_name,
+                        thread_id = ?self.thread_id,
+                        "MCP session expired, attempting reinitialize"
                     );
                     self.reinitialize_session().await?;
                     continue;
@@ -604,18 +696,20 @@ impl McpClient {
                         && let Some(ref config) = self.server_config
                     {
                         tracing::debug!(
-                            "MCP token expired, attempting refresh for '{}'",
-                            self.server_name
+                            server = %self.server_name,
+                            thread_id = ?self.thread_id,
+                            "MCP token expired, attempting refresh"
                         );
                         match refresh_access_token(config, secrets, &self.user_id).await {
                             Ok(_) => {
-                                tracing::info!("MCP token refreshed for '{}'", self.server_name);
+                                tracing::info!(server = %self.server_name, thread_id = ?self.thread_id, "MCP token refreshed");
                                 continue;
                             }
                             Err(e) => {
                                 tracing::debug!(
-                                    "Token refresh failed for '{}': {}",
-                                    self.server_name,
+                                    server = %self.server_name,
+                                    thread_id = ?self.thread_id,
+                                    "Token refresh failed: {}",
                                     e
                                 );
                             }
@@ -658,7 +752,7 @@ impl McpClient {
             .get_or_try_init(|| async {
                 if let Some(ref session_manager) = self.session_manager
                     && session_manager
-                        .is_initialized(&self.user_id, &self.server_name)
+                        .is_initialized(&self.user_id, &self.server_name, self.thread_id)
                         .await
                 {
                     return Ok(InitializeResult::default());
@@ -677,7 +771,8 @@ impl McpClient {
         }
         self.initialize().await?;
 
-        let request = McpRequest::list_tools(self.next_request_id());
+        let request = McpRequest::list_tools(self.next_request_id())
+            .inject_meta_context(self.thread_id, &self.user_id);
         let response = self.send_request(request).await?;
 
         if let Some(error) = response.error {
@@ -707,7 +802,8 @@ impl McpClient {
     ) -> Result<CallToolResult, ToolError> {
         self.initialize().await?;
 
-        let request = McpRequest::call_tool(self.next_request_id(), name, arguments);
+        let request = McpRequest::call_tool(self.next_request_id(), name, arguments)
+            .inject_meta_context(self.thread_id, &self.user_id);
         let response = self.send_request(request).await?;
 
         if let Some(error) = response.error {
@@ -829,6 +925,7 @@ impl Clone for McpClient {
             user_id: self.user_id.clone(),
             server_config: self.server_config.clone(),
             custom_headers: self.custom_headers.clone(),
+            thread_id: self.thread_id,
             initialized: tokio::sync::OnceCell::new(),
             #[cfg(test)]
             constructor_kind: self.constructor_kind,
@@ -931,7 +1028,7 @@ impl Tool for McpToolWrapper {
 
         let client = self
             .client_store
-            .get(&ctx.user_id, &self.server_name)
+            .resolve_for_thread(&ctx.user_id, &self.server_name, ctx.conversation_id)
             .await
             .ok_or_else(|| {
                 ToolError::ExternalService(format!(
@@ -1196,6 +1293,246 @@ mod tests {
         assert!(client.has_session_manager());
     }
 
+    // ── for_thread tests ───────────────────────────────────────────────────
+
+    /// `for_thread` sets `thread_id = Some(uuid)` on the sibling client.
+    #[test]
+    fn for_thread_sets_thread_id() {
+        use uuid::Uuid;
+        let base = McpClient::new("http://localhost:8080");
+        let tid = Uuid::from_u128(0xDEAD_BEEF);
+        let forked = base.for_thread(tid);
+        assert_eq!(forked.thread_id(), Some(tid));
+    }
+
+    /// `for_thread` produces a fresh init cell — the sibling will perform
+    /// its own MCP initialize handshake, getting a new `Mcp-Session-Id`.
+    #[tokio::test]
+    async fn for_thread_fresh_init_state() {
+        use uuid::Uuid;
+        let base = McpClient::new("http://localhost:8080");
+        let tid = Uuid::from_u128(0xCAFE_BABE);
+        let forked = base.for_thread(tid);
+        assert!(
+            forked.initialized.get().is_none(),
+            "forked client must have a fresh (unset) OnceCell for initialized"
+        );
+    }
+
+    /// `for_thread` inherits the session manager from the base client.
+    #[test]
+    fn for_thread_inherits_session_manager() {
+        use uuid::Uuid;
+        let session_manager = Arc::new(McpSessionManager::new());
+        let base = McpClient::new("http://localhost:8080").with_session_manager(session_manager);
+        let tid = Uuid::from_u128(1);
+        let forked = base.for_thread(tid);
+        assert!(
+            forked.has_session_manager(),
+            "forked client must inherit the parent's session manager"
+        );
+    }
+
+    /// `new_with_transport` with `thread_id = Some(tid)` must produce a
+    /// client whose `inject_meta_context` embeds the runtime keys — closes
+    /// the API symmetry with `new_authenticated`.
+    #[test]
+    fn new_with_transport_with_thread_id_injects_meta_keys() {
+        use crate::tools::mcp::protocol::McpRequest;
+        use uuid::Uuid;
+        let transport = Arc::new(MockTransport::new(false, vec![]));
+        let tid = Uuid::from_u128(0xdead_beef);
+        let client = McpClient::new_with_transport(
+            "test_server",
+            transport as Arc<dyn McpTransport>,
+            None,
+            None,
+            "alice",
+            None,
+            Some(tid),
+        );
+        let req = McpRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(1),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({"name": "ping", "arguments": {}})),
+        };
+        let injected = req.inject_meta_context(client.thread_id(), &"alice".to_string());
+        let meta = injected
+            .params
+            .as_ref()
+            .and_then(|p| p.get("_meta"))
+            .expect("_meta must be present");
+        assert_eq!(
+            meta.get("io.ironclaw/threadId").and_then(|v| v.as_str()),
+            Some(tid.to_string().as_str()),
+            "threadId must match the thread_id passed to new_with_transport"
+        );
+        assert_eq!(
+            meta.get("io.ironclaw/userId").and_then(|v| v.as_str()),
+            Some("alice"),
+            "userId must reflect the user passed to new_with_transport"
+        );
+    }
+
+    // ── Cross-Thread integration tests ────────────────────────────────────
+
+    /// End-to-end: two thread-scoped sibling clients produced by `for_thread`
+    /// inject distinct `io.ironclaw/threadId` values into `params._meta` on
+    /// every `call_tool` request, while sharing the same `user_id`.
+    ///
+    /// Verifies:
+    /// - `params._meta["io.ironclaw/threadId"]` == thread UUID
+    /// - `params._meta["io.ironclaw/userId"]` == user id
+    /// - Two siblings with distinct thread UUIDs produce distinct `threadId` values
+    /// - A pre-existing `_meta` key (e.g. `traceparent`) is preserved (merge semantics)
+    #[tokio::test]
+    async fn thread_scoped_clients_inject_distinct_meta_per_thread() {
+        use uuid::Uuid;
+
+        let tid_a = Uuid::from_u128(0xAAAA_0001);
+        let tid_b = Uuid::from_u128(0xBBBB_0002);
+
+        fn make_responses() -> Vec<McpResponse> {
+            let init = McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: Some(1),
+                result: Some(serde_json::json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "serverInfo": {"name": "svc", "version": "1.0"}
+                })),
+                error: None,
+            };
+            let notif_ack = McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: None,
+                result: None,
+                error: None,
+            };
+            let call_result = McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: Some(2),
+                result: Some(
+                    serde_json::json!({"content": [{"type": "text", "text": "ok"}], "isError": false}),
+                ),
+                error: None,
+            };
+            vec![init, notif_ack, call_result]
+        }
+
+        let transport_a = Arc::new(BodyCaptureMockTransport::new(make_responses()));
+        let transport_b = Arc::new(BodyCaptureMockTransport::new(make_responses()));
+
+        // Build two clients: client_a carries tid_a, client_b carries tid_b.
+        let client_a = McpClient::new_with_transport(
+            "svc",
+            transport_a.clone() as Arc<dyn McpTransport>,
+            None,
+            None,
+            "alice",
+            None,
+            Some(tid_a),
+        );
+        let client_b = McpClient::new_with_transport(
+            "svc",
+            transport_b.clone() as Arc<dyn McpTransport>,
+            None,
+            None,
+            "alice",
+            None,
+            Some(tid_b),
+        );
+
+        client_a
+            .call_tool("ping", serde_json::json!({}))
+            .await
+            .expect("call_tool client_a");
+        client_b
+            .call_tool("ping", serde_json::json!({}))
+            .await
+            .expect("call_tool client_b");
+
+        let reqs_a = transport_a.captured_requests();
+        let reqs_b = transport_b.captured_requests();
+        // All 3 captured requests carry _meta.io.ironclaw/threadId per SEP-414:
+        //   index 0 = initialize, index 1 = initialized notification,
+        //   index 2 = tools/call.
+        // Downstream MCP servers that bind state to the initial handshake
+        // (rate limits, per-conversation sessions, audit attribution) need
+        // the context on the very first request, not just on tools/call.
+        assert_eq!(reqs_a.len(), 3, "expected 3 requests from client_a");
+        assert_eq!(reqs_b.len(), 3, "expected 3 requests from client_b");
+
+        /// Extract the `io.ironclaw/threadId` and `io.ironclaw/userId` from a
+        /// request's `params._meta`, panicking with a contextual message when
+        /// either is missing.
+        fn extract_meta_pair<'a>(
+            req: &'a crate::tools::mcp::protocol::McpRequest,
+            label: &str,
+        ) -> (&'a str, &'a str) {
+            let meta = req
+                .params
+                .as_ref()
+                .and_then(|p| p.get("_meta"))
+                .unwrap_or_else(|| panic!("{label}: params._meta must be present"));
+            let tid = meta
+                .get("io.ironclaw/threadId")
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| panic!("{label}: io.ironclaw/threadId must be a string"));
+            let uid = meta
+                .get("io.ironclaw/userId")
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| panic!("{label}: io.ironclaw/userId must be a string"));
+            (tid, uid)
+        }
+
+        // Every request from client_a must carry tid_a + "alice".
+        for (idx, req) in reqs_a.iter().enumerate() {
+            let (tid, uid) = extract_meta_pair(req, &format!("client_a/req[{idx}]"));
+            assert_eq!(
+                tid,
+                tid_a.to_string(),
+                "client_a/req[{idx}] ({method}): threadId must be tid_a",
+                method = req.method
+            );
+            assert_eq!(
+                uid,
+                "alice",
+                "client_a/req[{idx}] ({method}): userId must be alice",
+                method = req.method
+            );
+        }
+
+        // Every request from client_b must carry tid_b + "alice".
+        for (idx, req) in reqs_b.iter().enumerate() {
+            let (tid, uid) = extract_meta_pair(req, &format!("client_b/req[{idx}]"));
+            assert_eq!(
+                tid,
+                tid_b.to_string(),
+                "client_b/req[{idx}] ({method}): threadId must be tid_b",
+                method = req.method
+            );
+            assert_eq!(
+                uid,
+                "alice",
+                "client_b/req[{idx}] ({method}): userId must be alice",
+                method = req.method
+            );
+        }
+
+        // Cross-Thread isolation: the two clients never share a threadId on
+        // any matching request index.
+        for (idx, (req_a, req_b)) in reqs_a.iter().zip(reqs_b.iter()).enumerate() {
+            let (tid_a_seen, _) = extract_meta_pair(req_a, "cross/A");
+            let (tid_b_seen, _) = extract_meta_pair(req_b, "cross/B");
+            assert_ne!(
+                tid_a_seen, tid_b_seen,
+                "req[{idx}]: client_a and client_b must carry distinct threadId values"
+            );
+        }
+    }
+
     #[test]
     fn test_next_request_id_monotonically_increasing() {
         let client = McpClient::new("http://localhost:1234");
@@ -1342,6 +1679,46 @@ mod tests {
         }
     }
 
+    /// Mock transport that captures the full `McpRequest` body for assertions
+    /// about `params._meta` injection.
+    struct BodyCaptureMockTransport {
+        responses: std::sync::Mutex<Vec<McpResponse>>,
+        captured_requests: std::sync::Mutex<Vec<McpRequest>>,
+    }
+
+    impl BodyCaptureMockTransport {
+        fn new(responses: Vec<McpResponse>) -> Self {
+            Self {
+                responses: std::sync::Mutex::new(responses),
+                captured_requests: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+        fn captured_requests(&self) -> Vec<McpRequest> {
+            self.captured_requests.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl McpTransport for BodyCaptureMockTransport {
+        async fn send(
+            &self,
+            request: &McpRequest,
+            _headers: &HashMap<String, String>,
+        ) -> Result<McpResponse, ToolError> {
+            self.captured_requests.lock().unwrap().push(request.clone());
+            let mut responses = self.responses.lock().unwrap();
+            if responses.is_empty() {
+                return Err(ToolError::ExternalService(
+                    "No more mock responses".to_string(),
+                ));
+            }
+            Ok(responses.remove(0))
+        }
+        async fn shutdown(&self) -> Result<(), ToolError> {
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn test_non_http_transport_skips_401_retry() {
         // initialize response, then notification ack (consumed but ignored),
@@ -1378,6 +1755,7 @@ mod tests {
             None,
             None,
             "default",
+            None,
             None,
         );
         let result = client.list_tools().await;
@@ -1428,6 +1806,7 @@ mod tests {
             None, // no session manager
             None,
             "default",
+            None,
             None,
         );
 
@@ -1503,6 +1882,7 @@ mod tests {
             None,
             "default",
             None,
+            None,
         );
 
         client.initialize().await.expect("initial handshake");
@@ -1570,7 +1950,7 @@ mod tests {
         // Slashes are outside the `McpServerName` allowlist, so the
         // fallback path must engage rather than storing the raw value.
         let client =
-            McpClient::new_with_transport("bad/name", transport, None, None, "default", None);
+            McpClient::new_with_transport("bad/name", transport, None, None, "default", None, None);
         let name = McpServerName::new(client.server_name())
             .expect("stored server_name must satisfy the allowlist after the fix");
         assert_eq!(
@@ -1583,8 +1963,15 @@ mod tests {
     #[test]
     fn new_with_transport_preserves_valid_server_name() {
         let transport = Arc::new(MockTransport::new(false, vec![]));
-        let client =
-            McpClient::new_with_transport("good_name123", transport, None, None, "default", None);
+        let client = McpClient::new_with_transport(
+            "good_name123",
+            transport,
+            None,
+            None,
+            "default",
+            None,
+            None,
+        );
         assert_eq!(client.server_name(), "good_name123");
     }
 
@@ -1631,7 +2018,8 @@ mod tests {
             Arc::new(crate::secrets::InMemorySecretsStore::new(crypto));
 
         let config = McpServerConfig::new("bad name", "https://api.example.com");
-        let client = McpClient::new_authenticated(config, session_manager, secrets, "test-user");
+        let client =
+            McpClient::new_authenticated(config, session_manager, secrets, "test-user", None);
         assert_eq!(
             client.server_name(),
             "unknown",
@@ -1649,7 +2037,8 @@ mod tests {
             Arc::new(crate::secrets::InMemorySecretsStore::new(crypto));
 
         let config = McpServerConfig::new("good_name123", "https://api.example.com");
-        let client = McpClient::new_authenticated(config, session_manager, secrets, "test-user");
+        let client =
+            McpClient::new_authenticated(config, session_manager, secrets, "test-user", None);
         assert_eq!(client.server_name(), "good_name123");
     }
 
@@ -1865,8 +2254,15 @@ mod tests {
             false,
             vec![init_response, notification_ack, list_response],
         ));
-        let client =
-            McpClient::new_with_transport("notion", transport.clone(), None, None, "default", None);
+        let client = McpClient::new_with_transport(
+            "notion",
+            transport.clone(),
+            None,
+            None,
+            "default",
+            None,
+            None,
+        );
 
         let store = Arc::new(crate::tools::mcp::McpClientStore::new());
         let tools = client
@@ -1932,8 +2328,15 @@ mod tests {
             false,
             vec![init_response, notification_ack, list_response],
         ));
-        let client =
-            McpClient::new_with_transport("demo", transport.clone(), None, None, "default", None);
+        let client = McpClient::new_with_transport(
+            "demo",
+            transport.clone(),
+            None,
+            None,
+            "default",
+            None,
+            None,
+        );
 
         let store = Arc::new(crate::tools::mcp::McpClientStore::new());
         let tools = client
@@ -2011,8 +2414,15 @@ mod tests {
             false,
             vec![init_response, notification_ack, list_response],
         ));
-        let client =
-            McpClient::new_with_transport("notion", transport.clone(), None, None, "default", None);
+        let client = McpClient::new_with_transport(
+            "notion",
+            transport.clone(),
+            None,
+            None,
+            "default",
+            None,
+            None,
+        );
 
         let registry = ToolRegistry::new();
         let store = Arc::new(crate::tools::mcp::McpClientStore::new());
@@ -2101,7 +2511,8 @@ mod tests {
         let secrets: Arc<dyn crate::secrets::SecretsStore + Send + Sync> =
             Arc::new(EmptyTokenStore);
 
-        let client = McpClient::new_authenticated(config, session_manager, secrets, "test-user");
+        let client =
+            McpClient::new_authenticated(config, session_manager, secrets, "test-user", None);
 
         let headers = client.build_request_headers().await.unwrap(); // safety: test
         assert!(
@@ -2166,7 +2577,8 @@ mod tests {
         let secrets: Arc<dyn crate::secrets::SecretsStore + Send + Sync> =
             Arc::new(PaddedTokenStore);
 
-        let client = McpClient::new_authenticated(config, session_manager, secrets, "test-user");
+        let client =
+            McpClient::new_authenticated(config, session_manager, secrets, "test-user", None);
 
         let headers = client.build_request_headers().await.unwrap(); // safety: test
         assert_eq!(

--- a/src/tools/mcp/client_store.rs
+++ b/src/tools/mcp/client_store.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
 use super::client::McpClient;
 use super::protocol::McpTool;
@@ -133,20 +134,41 @@ pub fn surface_signature(tools: &[McpTool]) -> String {
 }
 
 /// Composite key identifying an MCP client instance: the authenticating
-/// user plus the server name. Both fields participate in `Hash` / `Eq` so
-/// two users can hold active clients against the same server
-/// simultaneously without key collision.
+/// user plus the server name plus an optional Thread id. All fields
+/// participate in `Hash` / `Eq` so:
+/// - Two users can hold active clients against the same server simultaneously.
+/// - Two concurrent IronClaw Threads under one user activating the same server
+///   get distinct `Arc<McpClient>` instances (and thus distinct MCP protocol
+///   sessions), so any per-session state the upstream MCP server holds is
+///   partitioned per Thread, not shared across all of a user's Threads.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct McpClientKey {
     pub user_id: String,
     pub server_name: String,
+    /// `None` = user-scoped (legacy); `Some(uuid)` = thread-scoped.
+    pub thread_id: Option<Uuid>,
 }
 
 impl McpClientKey {
+    /// Create a user-scoped key (no Thread axis).
     pub fn new(user_id: &str, server_name: &str) -> Self {
         Self {
             user_id: user_id.to_string(),
             server_name: server_name.to_string(),
+            thread_id: None,
+        }
+    }
+
+    /// Create a thread-scoped key.
+    ///
+    /// Two Threads under the same user activating the same server receive
+    /// distinct `Arc<McpClient>` instances because `thread_id` participates in
+    /// the `Hash`/`Eq` key.
+    pub fn new_for_thread(user_id: &str, server_name: &str, thread_id: Uuid) -> Self {
+        Self {
+            user_id: user_id.to_string(),
+            server_name: server_name.to_string(),
+            thread_id: Some(thread_id),
         }
     }
 }
@@ -191,6 +213,31 @@ impl McpClientStore {
         );
     }
 
+    /// Insert or replace the client for the given `McpClientKey`.
+    ///
+    /// Allows callers to provide a fully-constructed key (including optional
+    /// `thread_id`) without going through the `(user_id, server_name)` string pair.
+    pub async fn insert_with_key(
+        &self,
+        key: McpClientKey,
+        client: Arc<McpClient>,
+        surface: String,
+    ) {
+        self.clients
+            .write()
+            .await
+            .insert(key, McpClientEntry { client, surface });
+    }
+
+    /// Look up the client for the given `McpClientKey`.
+    pub async fn get_with_key(&self, key: &McpClientKey) -> Option<Arc<McpClient>> {
+        self.clients
+            .read()
+            .await
+            .get(key)
+            .map(|entry| entry.client.clone())
+    }
+
     /// Remove and return the client for `(user_id, server_name)`, if any.
     pub async fn remove(&self, user_id: &str, server_name: &str) -> Option<Arc<McpClient>> {
         self.clients
@@ -228,7 +275,90 @@ impl McpClientStore {
             .map(|entry| entry.client.clone())
     }
 
+    /// Resolve the right `McpClient` for the `(user, server, thread)` triple.
+    ///
+    /// - `thread_id == None` → returns the user-scoped base client (unchanged
+    ///   behaviour; CLI and boot paths take this route).
+    /// - `thread_id == Some(tid)` → returns the thread-scoped client if already
+    ///   cached; otherwise lazily materialises one by calling
+    ///   [`McpClient::for_thread`] on the user-scoped base. The materialised
+    ///   client is inserted into the store and returned as an `Arc<McpClient>`.
+    ///
+    /// Returns `None` only when the user-scoped base client for this server
+    /// has never been activated (i.e. `get(user, server)` would also be
+    /// `None`).
+    pub async fn resolve_for_thread(
+        &self,
+        user_id: &str,
+        server_name: &str,
+        thread_id: Option<Uuid>,
+    ) -> Option<Arc<McpClient>> {
+        let Some(tid) = thread_id else {
+            // No thread context → user-scoped lookup (backward compat).
+            return self.get(user_id, server_name).await;
+        };
+
+        let thread_key = McpClientKey::new_for_thread(user_id, server_name, tid);
+
+        // Fast path: already materialised.
+        {
+            let guard = self.clients.read().await;
+            if let Some(entry) = guard.get(&thread_key) {
+                return Some(entry.client.clone());
+            }
+        }
+
+        // Slow path: materialise from the user-scoped base.
+        // Acquire the write lock first so we atomically read the base,
+        // materialise the fork, and insert it — preventing a race where two
+        // concurrent callers both miss the fast-path and double-insert.
+        let mut guard = self.clients.write().await;
+
+        // Double-check under write lock in case another caller beat us.
+        if let Some(entry) = guard.get(&thread_key) {
+            return Some(entry.client.clone());
+        }
+
+        // Look up the base client under the write lock (still present).
+        let base = guard.get(&McpClientKey::new(user_id, server_name))?;
+        let surface = base.surface.clone();
+        let forked = Arc::new(base.client.for_thread(tid));
+        tracing::debug!(
+            user_id = %user_id,
+            server = %server_name,
+            thread_id = %tid,
+            "Materialised thread-scoped client fork"
+        );
+        guard.insert(
+            thread_key,
+            McpClientEntry {
+                client: forked.clone(),
+                surface,
+            },
+        );
+        Some(forked)
+    }
+
     /// Whether `(user_id, server_name)` has an active client.
+    /// Evict all thread-scoped client entries for the given thread UUID.
+    ///
+    /// Removes every `(user, server, thread_id)` entry that was lazily
+    /// materialised for `thread_id` via [`resolve_for_thread`], while leaving
+    /// user-scoped entries (`thread_id == None`) intact.
+    ///
+    /// # Wiring note
+    /// No production caller yet — the agent runtime does not currently emit
+    /// a "Thread terminated" event the store can subscribe to. The method
+    /// is provided so the memory-growth guard is in place once the
+    /// lifecycle hook exists; until then, thread-scoped entries
+    /// accumulate for the lifetime of the process.
+    pub async fn evict_thread(&self, thread_id: Uuid) {
+        self.clients
+            .write()
+            .await
+            .retain(|key, _| key.thread_id != Some(thread_id));
+    }
+
     pub async fn contains(&self, user_id: &str, server_name: &str) -> bool {
         self.clients
             .read()
@@ -508,6 +638,258 @@ mod tests {
                 .await
                 .is_none(),
             "same-user re-activation with a new surface is allowed (caller replaces their own entry)",
+        );
+    }
+    // ── Thread-axis partition tests ──────────────────────────────────────
+
+    /// Two distinct Threads under the same user activating the same server
+    /// must get distinct `Arc<McpClient>` instances. Without the `thread_id`
+    /// axis, the second Thread's activation would overwrite the first's entry,
+    /// sharing one `McpClient` and one MCP protocol session — defeating the
+    /// session-isolation guarantee `McpSessionKey.thread_id` provides.
+    #[tokio::test]
+    async fn distinct_threads_get_distinct_client_instances() {
+        use uuid::Uuid;
+        let store = McpClientStore::new();
+        let client_t1 = Arc::new(McpClient::new_with_name("notion", "http://a.invalid"));
+        let client_t2 = Arc::new(McpClient::new_with_name("notion", "http://b.invalid"));
+
+        let thread_1 = Uuid::from_u128(1);
+        let thread_2 = Uuid::from_u128(2);
+        let key1 = McpClientKey::new_for_thread("user-a", "notion", thread_1);
+        let key2 = McpClientKey::new_for_thread("user-a", "notion", thread_2);
+
+        store
+            .insert_with_key(key1.clone(), client_t1.clone(), "sig".into())
+            .await;
+        store
+            .insert_with_key(key2.clone(), client_t2.clone(), "sig".into())
+            .await;
+
+        let got1 = store.get_with_key(&key1).await.expect("thread 1 client");
+        let got2 = store.get_with_key(&key2).await.expect("thread 2 client");
+
+        assert!(
+            Arc::ptr_eq(&got1, &client_t1),
+            "Thread 1 must return its own McpClient"
+        );
+        assert!(
+            Arc::ptr_eq(&got2, &client_t2),
+            "Thread 2 must return its own McpClient"
+        );
+        assert!(
+            !Arc::ptr_eq(&got1, &got2),
+            "Thread 1 and Thread 2 must NOT share a McpClient instance"
+        );
+    }
+
+    /// A thread-scoped key and a user-scoped key with the same `(user, server)`
+    /// must coexist as distinct entries — the `None` / `Some` distinction on
+    /// `thread_id` must participate in the hash.
+    #[tokio::test]
+    async fn thread_scoped_and_user_scoped_keys_coexist() {
+        use uuid::Uuid;
+        let store = McpClientStore::new();
+        let client_user = Arc::new(McpClient::new_with_name("notion", "http://user.invalid"));
+        let client_thread = Arc::new(McpClient::new_with_name("notion", "http://thread.invalid"));
+
+        let thread_a = Uuid::from_u128(42);
+        let key_user = McpClientKey::new("user-a", "notion");
+        let key_thread = McpClientKey::new_for_thread("user-a", "notion", thread_a);
+
+        store
+            .insert_with_key(key_user.clone(), client_user.clone(), "sig".into())
+            .await;
+        store
+            .insert_with_key(key_thread.clone(), client_thread.clone(), "sig".into())
+            .await;
+
+        let got_user = store
+            .get_with_key(&key_user)
+            .await
+            .expect("user-scoped client");
+        let got_thread = store
+            .get_with_key(&key_thread)
+            .await
+            .expect("thread-scoped client");
+
+        assert!(
+            Arc::ptr_eq(&got_user, &client_user),
+            "user-scoped key must return the user-scoped client"
+        );
+        assert!(
+            Arc::ptr_eq(&got_thread, &client_thread),
+            "thread-scoped key must return the thread-scoped client"
+        );
+        assert!(
+            !Arc::ptr_eq(&got_user, &got_thread),
+            "user-scoped and thread-scoped clients must be distinct instances"
+        );
+        assert_eq!(
+            store.clients.read().await.len(),
+            2,
+            "both keys must exist as separate entries in the store"
+        );
+    }
+
+    // ── resolve_for_thread tests ───────────────────────────────────────────
+
+    /// `resolve_for_thread` with `None` returns the same `Arc<McpClient>` as
+    /// the plain `get` — backward-compatible user-scoped path unchanged.
+    #[tokio::test]
+    async fn resolve_for_thread_none_returns_user_scoped_client() {
+        let store = McpClientStore::new();
+        let base = Arc::new(McpClient::new_with_name("svc", "http://base.invalid"));
+        store
+            .insert("user-a", "svc", base.clone(), "sig".into())
+            .await;
+
+        let got = store
+            .resolve_for_thread("user-a", "svc", None)
+            .await
+            .expect("must return base client for None thread_id");
+        assert!(
+            Arc::ptr_eq(&got, &base),
+            "None thread_id must return the user-scoped base client unchanged"
+        );
+    }
+
+    /// `resolve_for_thread` with two distinct thread UUIDs returns two distinct
+    /// `Arc<McpClient>` instances (different pointer identity).
+    #[tokio::test]
+    async fn resolve_for_thread_distinct_uuids_yield_distinct_clients() {
+        use uuid::Uuid;
+        let store = McpClientStore::new();
+        let base = Arc::new(McpClient::new_with_name("svc", "http://base.invalid"));
+        store
+            .insert("user-a", "svc", base.clone(), "sig".into())
+            .await;
+
+        let tid_a = Uuid::from_u128(0xAAAA);
+        let tid_b = Uuid::from_u128(0xBBBB);
+
+        let got_a = store
+            .resolve_for_thread("user-a", "svc", Some(tid_a))
+            .await
+            .expect("thread A client");
+        let got_b = store
+            .resolve_for_thread("user-a", "svc", Some(tid_b))
+            .await
+            .expect("thread B client");
+
+        assert!(
+            !Arc::ptr_eq(&got_a, &got_b),
+            "distinct thread UUIDs must yield distinct client instances"
+        );
+        assert!(
+            !Arc::ptr_eq(&got_a, &base),
+            "thread-scoped client must be distinct from the user-scoped base"
+        );
+    }
+
+    /// The materialised thread-scoped client has `thread_id = Some(uuid)` and
+    /// fresh init state (the `initialized` OnceCell is not yet set).
+    #[tokio::test]
+    async fn resolve_for_thread_materialised_client_has_correct_thread_id() {
+        use uuid::Uuid;
+        let store = McpClientStore::new();
+        let base = Arc::new(McpClient::new_with_name("svc", "http://base.invalid"));
+        store
+            .insert("user-a", "svc", base.clone(), "sig".into())
+            .await;
+
+        let tid = Uuid::from_u128(0xDEAD_BEEF);
+        let got = store
+            .resolve_for_thread("user-a", "svc", Some(tid))
+            .await
+            .expect("materialised client");
+
+        assert_eq!(
+            got.thread_id(),
+            Some(tid),
+            "materialised client must carry thread_id = Some(tid)"
+        );
+    }
+
+    /// A second call with the same thread UUID returns the *same* cached Arc —
+    /// we don't materialise a new client on every call.
+    #[tokio::test]
+    async fn resolve_for_thread_caches_materialised_client() {
+        use uuid::Uuid;
+        let store = McpClientStore::new();
+        let base = Arc::new(McpClient::new_with_name("svc", "http://base.invalid"));
+        store
+            .insert("user-a", "svc", base.clone(), "sig".into())
+            .await;
+
+        let tid = Uuid::from_u128(0xCAFE);
+        let first = store
+            .resolve_for_thread("user-a", "svc", Some(tid))
+            .await
+            .expect("first call");
+        let second = store
+            .resolve_for_thread("user-a", "svc", Some(tid))
+            .await
+            .expect("second call");
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "repeated calls with the same thread UUID must return the cached client"
+        );
+    }
+
+    // ── evict_thread tests ─────────────────────────────────────────────────
+
+    /// `evict_thread` removes all thread-scoped entries for `thread_id` while
+    /// leaving user-scoped and other-thread entries intact.
+    #[tokio::test]
+    async fn evict_thread_removes_only_matching_thread_entries() {
+        use crate::tools::mcp::McpClient;
+        let store = McpClientStore::new();
+        let base = Arc::new(McpClient::new("http://localhost:9099"));
+
+        let tid_a = Uuid::from_u128(0xAAAA);
+        let tid_b = Uuid::from_u128(0xBBBB);
+
+        // Insert a user-scoped entry and two thread-scoped forks.
+        store
+            .insert("alice", "svc", Arc::clone(&base), "sig-base".to_string())
+            .await;
+        let key_a = McpClientKey::new_for_thread("alice", "svc", tid_a);
+        let key_b = McpClientKey::new_for_thread("alice", "svc", tid_b);
+        store
+            .insert_with_key(key_a.clone(), Arc::clone(&base), "sig-a".to_string())
+            .await;
+        store
+            .insert_with_key(key_b.clone(), Arc::clone(&base), "sig-b".to_string())
+            .await;
+
+        assert!(
+            store.get_with_key(&key_a).await.is_some(),
+            "pre: tid_a present"
+        );
+        assert!(
+            store.get_with_key(&key_b).await.is_some(),
+            "pre: tid_b present"
+        );
+        assert!(
+            store.contains("alice", "svc").await,
+            "pre: user-scoped present"
+        );
+
+        store.evict_thread(tid_a).await;
+
+        assert!(
+            store.get_with_key(&key_a).await.is_none(),
+            "tid_a entry evicted"
+        );
+        assert!(
+            store.get_with_key(&key_b).await.is_some(),
+            "tid_b entry survives"
+        );
+        assert!(
+            store.contains("alice", "svc").await,
+            "user-scoped entry survives"
         );
     }
 }

--- a/src/tools/mcp/factory.rs
+++ b/src/tools/mcp/factory.rs
@@ -27,6 +27,13 @@ pub enum McpFactoryError {
 
 /// Create an `McpClient` from a server configuration, dispatching on the
 /// effective transport type.
+///
+/// Always produces a *user-scoped* client (`thread_id == None`). Thread-scoped
+/// clients are materialised lazily by `McpClientStore::resolve_for_thread`,
+/// which clones a user-scoped base via `McpClient::for_thread(uuid)`. Boot,
+/// CLI, and extension-activation paths never need to create a thread-scoped
+/// client directly — they create the user-scoped base; the agent dispatch
+/// path forks it per-Thread on demand.
 pub async fn create_client_from_config(
     mut server: McpServerConfig,
     session_manager: &Arc<McpSessionManager>,
@@ -84,6 +91,7 @@ pub async fn create_client_from_config(
                 secrets,
                 user_id,
                 Some(server),
+                None,
             ))
         }
         #[cfg(unix)]
@@ -105,6 +113,7 @@ pub async fn create_client_from_config(
                 secrets,
                 user_id,
                 Some(server),
+                None,
             ))
         }
         #[cfg(not(unix))]
@@ -123,6 +132,7 @@ pub async fn create_client_from_config(
                         Arc::clone(session_manager),
                         Arc::clone(secrets),
                         user_id,
+                        None,
                     ));
                 }
             }
@@ -133,7 +143,7 @@ pub async fn create_client_from_config(
             // transport must know about it to read/write the header.
             let transport = Arc::new(
                 HttpMcpTransport::new(server.url.clone(), validated_name.as_str())
-                    .with_session_manager(Arc::clone(session_manager), user_id),
+                    .with_session_manager(Arc::clone(session_manager), user_id, None),
             );
             Ok(McpClient::new_with_transport(
                 validated_name.as_str(),
@@ -142,6 +152,7 @@ pub async fn create_client_from_config(
                 secrets,
                 user_id,
                 Some(server),
+                None,
             ))
         }
     }
@@ -407,7 +418,7 @@ mod tests {
         // Use the normalised server name (hyphens → underscores) that the factory applies.
         let normalised_name = McpServerName::new("session_test").expect("valid");
         session_manager
-            .get_or_create("test-user", &normalised_name, &url)
+            .get_or_create("test-user", &normalised_name, &url, None)
             .await;
 
         // Send a request through the client's transport to trigger session capture.
@@ -428,7 +439,7 @@ mod tests {
         // Verify the session manager captured the session ID from the response
         // under the same `(user_id, server_name)` key the transport wrote with.
         let captured = session_manager
-            .get_session_id("test-user", &normalised_name)
+            .get_session_id("test-user", &normalised_name, None)
             .await;
         assert_eq!(
             captured.as_deref(),
@@ -460,6 +471,32 @@ mod tests {
             client.server_name(),
             "my_mcp_server",
             "Hyphens in server name must be replaced with underscores"
+        );
+    }
+
+    /// `create_client_from_config` always produces a user-scoped client
+    /// (`thread_id == None`). Thread-scoped clients are materialised via
+    /// `McpClientStore::resolve_for_thread`, which forks the user-scoped
+    /// base through `McpClient::for_thread(uuid)`.
+    #[tokio::test]
+    async fn factory_produces_user_scoped_client() {
+        let server = McpServerConfig::new("svc", "http://localhost:9999");
+        let session_manager = Arc::new(McpSessionManager::new());
+        let process_manager = Arc::new(McpProcessManager::new());
+
+        let client = create_client_from_config(
+            server,
+            &session_manager,
+            &process_manager,
+            None,
+            "test-user",
+        )
+        .await
+        .expect("factory should succeed");
+
+        assert!(
+            client.thread_id().is_none(),
+            "factory must produce a user-scoped client (thread_id == None)"
         );
     }
 }

--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -13,6 +13,7 @@ use crate::tools::mcp::protocol::{McpRequest, McpResponse};
 use crate::tools::mcp::session::McpSessionManager;
 use crate::tools::mcp::transport::McpTransport;
 use crate::tools::tool::ToolError;
+use uuid::Uuid;
 
 /// MCP transport that communicates with a server over HTTP.
 ///
@@ -28,6 +29,8 @@ pub struct HttpMcpTransport {
     session_manager: Option<Arc<McpSessionManager>>,
     session_user_id: Option<String>,
     custom_headers: HashMap<String, String>,
+    /// Thread ID passed through to `McpSessionManager` for thread-scoped keys.
+    session_thread_id: Option<Uuid>,
 }
 
 impl HttpMcpTransport {
@@ -65,17 +68,23 @@ impl HttpMcpTransport {
             session_manager: None,
             session_user_id: None,
             custom_headers: HashMap::new(),
+            session_thread_id: None,
         }
     }
 
     /// Attach a session manager for Mcp-Session-Id tracking.
+    ///
+    /// `thread_id` partitions the session key by Thread so two concurrent
+    /// Threads under the same user and server get distinct `Mcp-Session-Id` slots.
     pub fn with_session_manager(
         mut self,
         session_manager: Arc<McpSessionManager>,
         user_id: impl Into<String>,
+        thread_id: Option<Uuid>,
     ) -> Self {
         self.session_manager = Some(session_manager);
         self.session_user_id = Some(user_id.into());
+        self.session_thread_id = thread_id;
         self
     }
 
@@ -166,7 +175,12 @@ impl McpTransport for HttpMcpTransport {
                 )));
             }
             session_manager
-                .update_session_id(user_id, &self.server_name, Some(session_id.to_string()))
+                .update_session_id(
+                    user_id,
+                    &self.server_name,
+                    Some(session_id.to_string()),
+                    self.session_thread_id,
+                )
                 .await;
         }
 
@@ -424,6 +438,15 @@ mod tests {
         assert!(transport.custom_headers.is_empty());
     }
 
+    #[test]
+    fn test_with_custom_headers() {
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom".to_string(), "value".to_string());
+        let transport =
+            HttpMcpTransport::new("http://localhost:8080", "test").with_custom_headers(headers);
+        assert_eq!(transport.custom_headers.get("X-Custom").unwrap(), "value");
+    }
+
     /// Regression for Copilot review comment 3108156275: `HttpMcpTransport::new`
     /// previously wrapped the caller-provided `server_name` with
     /// `McpServerName::from_trusted`, bypassing the allowlist validator.
@@ -462,17 +485,8 @@ mod tests {
     fn test_with_session_manager() {
         let session_manager = Arc::new(McpSessionManager::new());
         let transport = HttpMcpTransport::new("http://localhost:8080", "test")
-            .with_session_manager(session_manager.clone(), "user-a");
+            .with_session_manager(session_manager.clone(), "user-a", None);
         assert!(transport.session_manager().is_some());
-    }
-
-    #[test]
-    fn test_with_custom_headers() {
-        let mut headers = HashMap::new();
-        headers.insert("X-Custom".to_string(), "value".to_string());
-        let transport =
-            HttpMcpTransport::new("http://localhost:8080", "test").with_custom_headers(headers);
-        assert_eq!(transport.custom_headers.get("X-Custom").unwrap(), "value");
     }
 
     // -- Wire-level echo server tests -----------------------------------------
@@ -603,8 +617,11 @@ mod tests {
         });
 
         let session_manager = Arc::new(McpSessionManager::new());
-        let transport = HttpMcpTransport::new(&url, "invalidsession")
-            .with_session_manager(Arc::clone(&session_manager), "user-a");
+        let transport = HttpMcpTransport::new(&url, "invalidsession").with_session_manager(
+            Arc::clone(&session_manager),
+            "user-a",
+            None,
+        );
         let request = McpRequest::initialize(1);
 
         let error = transport.send(&request, &HashMap::new()).await.unwrap_err();
@@ -612,7 +629,11 @@ mod tests {
         assert!(error.to_string().contains("invalid session id"));
         assert_eq!(
             session_manager
-                .get_session_id("user-a", &McpServerName::new("invalidsession").unwrap())
+                .get_session_id(
+                    "user-a",
+                    &McpServerName::new("invalidsession").unwrap(),
+                    None
+                )
                 .await,
             None
         );
@@ -646,17 +667,22 @@ mod tests {
         let session_manager = Arc::new(McpSessionManager::new());
         let server_name = McpServerName::new("errorsession").unwrap();
         session_manager
-            .get_or_create("user-a", &server_name, &url)
+            .get_or_create("user-a", &server_name, &url, None)
             .await;
-        let transport = HttpMcpTransport::new(&url, "errorsession")
-            .with_session_manager(Arc::clone(&session_manager), "user-a");
+        let transport = HttpMcpTransport::new(&url, "errorsession").with_session_manager(
+            Arc::clone(&session_manager),
+            "user-a",
+            None,
+        );
         let request = McpRequest::initialize(1);
 
         let error = transport.send(&request, &HashMap::new()).await.unwrap_err();
 
         assert!(error.to_string().contains("500"));
         assert_eq!(
-            session_manager.get_session_id("user-a", &server_name).await,
+            session_manager
+                .get_session_id("user-a", &server_name, None)
+                .await,
             None
         );
     }
@@ -690,13 +716,13 @@ mod tests {
     async fn test_wire_custom_auth_preserved_when_no_per_request_auth() {
         let (url, _handle) = spawn_echo_server().await;
 
-        let custom = HashMap::from([(
+        let transport = HttpMcpTransport::new(&url, "echo-test");
+
+        // Authorization from McpClient.build_request_headers is passed as per-request header.
+        let per_request = HashMap::from([(
             "authorization".to_string(),
             "Bearer custom-token".to_string(),
         )]);
-        let transport = HttpMcpTransport::new(&url, "echo-test").with_custom_headers(custom);
-
-        let per_request = HashMap::new(); // no per-request auth
         let request = McpRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(1),

--- a/src/tools/mcp/protocol.rs
+++ b/src/tools/mcp/protocol.rs
@@ -1,6 +1,7 @@
 //! MCP protocol types.
 
 use serde::{Deserialize, Deserializer, Serialize};
+use uuid::Uuid;
 
 /// Flexibly deserialize a JSON-RPC id that may be a number, string, or null.
 fn deserialize_flexible_id<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
@@ -164,6 +165,58 @@ impl McpRequest {
                 "arguments": arguments
             })),
         )
+    }
+
+    /// Inject IronClaw thread context into `params._meta` when `thread_id` is
+    /// `Some`.
+    ///
+    /// Follows SEP-414 / SEP-2575: context propagation happens inside the
+    /// JSON-RPC payload's `_meta` field under the `io.ironclaw/` reverse-domain
+    /// namespace, keeping the approach transport-agnostic (HTTP, stdio, Unix
+    /// sockets all carry the same JSON-RPC envelope).
+    ///
+    /// Merge semantics: pre-existing `_meta` keys (e.g. a future `traceparent`
+    /// from OpenTelemetry) are preserved — only `io.ironclaw/threadId` and
+    /// `io.ironclaw/userId` are set.
+    ///
+    /// When `thread_id` is `None` the request is returned unchanged, preserving
+    /// backward-compatible behaviour for user-scoped paths and test fixtures.
+    pub fn inject_meta_context(mut self, thread_id: Option<Uuid>, user_id: &str) -> Self {
+        let Some(tid) = thread_id else {
+            return self;
+        };
+        // Materialise an empty object when params is absent so notifications
+        // and future param-less methods (e.g. tools/list) still carry _meta.
+        if self.params.is_none() {
+            self.params = Some(serde_json::Value::Object(Default::default()));
+        }
+        let Some(ref mut params) = self.params else {
+            // SAFETY: we just inserted Some above; this branch is unreachable.
+            return self;
+        };
+        let meta = params
+            .as_object_mut()
+            .and_then(|obj| {
+                if !obj.contains_key("_meta") {
+                    obj.insert(
+                        "_meta".to_string(),
+                        serde_json::Value::Object(Default::default()),
+                    );
+                }
+                obj.get_mut("_meta")
+            })
+            .and_then(|v| v.as_object_mut());
+        if let Some(meta_obj) = meta {
+            meta_obj.insert(
+                "io.ironclaw/threadId".to_string(),
+                serde_json::Value::String(tid.to_string()),
+            );
+            meta_obj.insert(
+                "io.ironclaw/userId".to_string(),
+                serde_json::Value::String(user_id.to_string()),
+            );
+        }
+        self
     }
 }
 
@@ -719,6 +772,113 @@ mod tests {
         let resp: McpResponse =
             serde_json::from_value(json).expect("deserialize non-numeric string id");
         assert_eq!(resp.id, None);
+    }
+
+    // ── _meta injection tests (SEP-414 alignment) ──────────────────────────
+
+    /// When `thread_id` is `Some`, `inject_meta_context` populates both
+    /// `io.ironclaw/threadId` and `io.ironclaw/userId` inside `params._meta`.
+    #[test]
+    fn inject_meta_context_sets_keys_when_thread_id_is_some() {
+        use uuid::Uuid;
+
+        let thread_id = Uuid::from_u128(0xdeadbeef_cafe_4200_8000_aabbccddeeff);
+        let req = McpRequest::call_tool(1, "search", serde_json::json!({"q": "rust"}))
+            .inject_meta_context(Some(thread_id), "user-42");
+
+        let params = req.params.expect("call_tool has params");
+        let meta = params.get("_meta").expect("_meta must be present");
+
+        assert_eq!(
+            meta.get("io.ironclaw/threadId").and_then(|v| v.as_str()),
+            Some(thread_id.to_string().as_str()),
+            "io.ironclaw/threadId must equal the thread UUID"
+        );
+        assert_eq!(
+            meta.get("io.ironclaw/userId").and_then(|v| v.as_str()),
+            Some("user-42"),
+            "io.ironclaw/userId must equal the user id"
+        );
+    }
+
+    /// When `thread_id` is `None`, `inject_meta_context` is a no-op: `params`
+    /// must not grow a `_meta` key at all.
+    #[test]
+    fn inject_meta_context_is_noop_when_thread_id_is_none() {
+        let req = McpRequest::call_tool(2, "ping", serde_json::json!({}))
+            .inject_meta_context(None, "user-99");
+
+        let params = req.params.expect("call_tool has params");
+        assert!(
+            params.get("_meta").is_none(),
+            "_meta must not appear when thread_id is None"
+        );
+    }
+
+    /// Pre-existing `_meta` keys (e.g. a future `traceparent`) survive
+    /// `inject_meta_context` — the injection merges, never replaces.
+    #[test]
+    fn inject_meta_context_merges_existing_meta_keys() {
+        use uuid::Uuid;
+
+        let thread_id = Uuid::from_u128(0x1111_2222_3333_4444_5555_6666_7777_8888);
+
+        // Build a request that already carries a _meta object with traceparent.
+        let req = McpRequest::new(
+            3,
+            "tools/call",
+            Some(serde_json::json!({
+                "name": "trace_tool",
+                "arguments": {},
+                "_meta": {
+                    "traceparent": "00-abc123-def456-01"
+                }
+            })),
+        )
+        .inject_meta_context(Some(thread_id), "user-7");
+
+        let params = req.params.expect("params present");
+        let meta = params.get("_meta").expect("_meta must be present");
+
+        // Original key survives.
+        assert_eq!(
+            meta.get("traceparent").and_then(|v| v.as_str()),
+            Some("00-abc123-def456-01"),
+            "pre-existing traceparent must not be clobbered"
+        );
+        // New keys are added.
+        assert_eq!(
+            meta.get("io.ironclaw/threadId").and_then(|v| v.as_str()),
+            Some(thread_id.to_string().as_str()),
+        );
+        assert_eq!(
+            meta.get("io.ironclaw/userId").and_then(|v| v.as_str()),
+            Some("user-7"),
+        );
+    }
+
+    /// `inject_meta_context` must set `_meta` even when the request was
+    /// constructed with `params: None` (e.g. `tools/list`, notifications):
+    /// the method materialises a fresh `params` object so context propagation
+    /// is uniform across all outbound message types.
+    #[test]
+    fn inject_meta_context_materialises_params_when_none() {
+        use uuid::Uuid;
+
+        let tid = Uuid::from_u128(0xDEAD_BEEF);
+        let req = McpRequest::new(1, "tools/list", None).inject_meta_context(Some(tid), "carol");
+
+        let params = req.params.expect("params must be materialised");
+        let meta = params.get("_meta").expect("_meta must be present");
+        assert_eq!(
+            meta.get("io.ironclaw/threadId").and_then(|v| v.as_str()),
+            Some(tid.to_string().as_str()),
+            "threadId must be injected into materialised params"
+        );
+        assert_eq!(
+            meta.get("io.ironclaw/userId").and_then(|v| v.as_str()),
+            Some("carol"),
+        );
     }
 
     #[test]

--- a/src/tools/mcp/session.rs
+++ b/src/tools/mcp/session.rs
@@ -1,45 +1,77 @@
 //! MCP session management.
 //!
 //! Manages Mcp-Session-Id headers for stateful connections to MCP servers.
-//! Each `(user, server)` pair has its own session that persists across
-//! requests.
+//! Each `(user, server)` or `(user, server, thread)` pair has its own
+//! session that persists across requests.
 //!
-//! Sessions are partitioned by `(user_id, server_name)` — **not** by server
-//! name alone. An MCP server issues a distinct `Mcp-Session-Id` for every
-//! authenticated client. If two users activate the same MCP server and the
-//! manager were keyed on server name only, the second user's session ID
-//! would overwrite the first user's; the first user's next request would
-//! then send the second user's `Mcp-Session-Id`, potentially accessing
-//! cross-tenant server-side state. Same shape as the MCP client-isolation
-//! bug in `McpClientStore` — see `.claude/rules/safety-and-sandbox.md`
-//! "Cache Keys Must Be Complete".
+//! Sessions are partitioned by `(user_id, server_name, thread_id)` so:
+//! - Two users activating the same server get distinct sessions (prevents
+//!   cross-tenant `Mcp-Session-Id` sharing).
+//! - Two concurrent IronClaw Threads under one user activating the same
+//!   server get distinct sessions, so an MCP server that binds state to
+//!   its `Mcp-Session-Id` (per-conversation rate limits, persistent
+//!   sessions, tenant scoping, etc.) sees one session per Thread, not
+//!   one session shared across all of a user's Threads.
+//!
+//! See `.claude/rules/safety-and-sandbox.md` "Cache Keys Must Be Complete"
+//! for the broader cache-key-completeness rationale.
 
 use std::collections::HashMap;
 use std::time::Instant;
 
 use ironclaw_common::McpServerName;
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
-/// Composite key for an MCP session. A given user holds one session per
-/// server; the same user across two different servers gets two distinct
-/// sessions; the same server across two different users also gets two
-/// distinct sessions.
+/// Composite key for an MCP session.
+///
+/// A given user holds one session per server per optional Thread:
+/// - `thread_id = None`: user-scoped session — the legacy default, used when
+///   the call is not rooted in an IronClaw Thread (test fixtures, CLI paths).
+/// - `thread_id = Some(uuid)`: thread-scoped session — issued when a
+///   dispatching Thread is known, ensuring that two concurrent Threads under
+///   one user never share a `Mcp-Session-Id` for the same server.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct McpSessionKey {
     user_id: String,
     server_name: McpServerName,
+    /// `None` = user-scoped (legacy); `Some(uuid)` = thread-scoped.
+    thread_id: Option<Uuid>,
 }
 
 impl McpSessionKey {
+    /// Create a user-scoped session key (no Thread axis).
+    ///
+    /// Use this for call-paths that are not rooted in a specific IronClaw
+    /// Thread — e.g. CLI invocations, test fixtures, or shutdown cleanup.
+    /// Two calls with the same `(user, server)` will share a session.
     pub fn new(user_id: impl Into<String>, server_name: McpServerName) -> Self {
         Self {
             user_id: user_id.into(),
             server_name,
+            thread_id: None,
+        }
+    }
+
+    /// Create a thread-scoped session key.
+    ///
+    /// Use this when the caller is a specific IronClaw Thread. Two Threads
+    /// under the same user activating the same server will receive distinct
+    /// sessions because `thread_id` participates in the `Hash`/`Eq` key.
+    pub fn new_for_thread(
+        user_id: impl Into<String>,
+        server_name: McpServerName,
+        thread_id: Uuid,
+    ) -> Self {
+        Self {
+            user_id: user_id.into(),
+            server_name,
+            thread_id: Some(thread_id),
         }
     }
 }
 
-/// Session state for a single `(user, server)` MCP connection.
+/// Session state for a single `(user, server[, thread])` MCP connection.
 #[derive(Debug, Clone)]
 pub struct McpSession {
     /// Session ID returned by the server (via Mcp-Session-Id header).
@@ -91,7 +123,7 @@ impl McpSession {
     }
 }
 
-/// Manages MCP sessions across multiple `(user, server)` pairs.
+/// Manages MCP sessions across multiple `(user, server[, thread])` triples.
 ///
 /// Server names are typed via [`McpServerName`] so a free-form string can't
 /// bypass allowlist validation at the boundary. Callers convert raw strings
@@ -100,7 +132,7 @@ impl McpSession {
 /// bugs — matching the shape described in `.claude/rules/types.md` — a
 /// compile error rather than a runtime surprise.
 pub struct McpSessionManager {
-    /// Active sessions keyed by `(user_id, server_name)`.
+    /// Active sessions keyed by `(user_id, server_name, thread_id)`.
     sessions: RwLock<HashMap<McpSessionKey, McpSession>>,
 
     /// Maximum idle time before a session is considered stale (in seconds).
@@ -124,18 +156,22 @@ impl McpSessionManager {
         }
     }
 
-    fn key(user_id: &str, server_name: &McpServerName) -> McpSessionKey {
-        McpSessionKey::new(user_id, server_name.clone())
+    fn key(user_id: &str, server_name: &McpServerName, thread_id: Option<Uuid>) -> McpSessionKey {
+        match thread_id {
+            Some(tid) => McpSessionKey::new_for_thread(user_id, server_name.clone(), tid),
+            None => McpSessionKey::new(user_id, server_name.clone()),
+        }
     }
 
-    /// Get or create a session for `(user, server)`.
+    /// Get or create a session for `(user, server[, thread])`.
     pub async fn get_or_create(
         &self,
         user_id: &str,
         server_name: &McpServerName,
         server_url: &str,
+        thread_id: Option<Uuid>,
     ) -> McpSession {
-        let key = Self::key(user_id, server_name);
+        let key = Self::key(user_id, server_name, thread_id);
         let mut sessions = self.sessions.write().await;
 
         if let Some(session) = sessions.get(&key) {
@@ -155,15 +191,16 @@ impl McpSessionManager {
         session
     }
 
-    /// Get the current session ID for `(user, server)`, if any.
+    /// Get the current session ID for `(user, server[, thread])`, if any.
     pub async fn get_session_id(
         &self,
         user_id: &str,
         server_name: &McpServerName,
+        thread_id: Option<Uuid>,
     ) -> Option<String> {
         let sessions = self.sessions.read().await;
         sessions
-            .get(&Self::key(user_id, server_name))
+            .get(&Self::key(user_id, server_name, thread_id))
             .and_then(|s| s.session_id.clone())
     }
 
@@ -173,50 +210,66 @@ impl McpSessionManager {
         user_id: &str,
         server_name: &McpServerName,
         session_id: Option<String>,
+        thread_id: Option<Uuid>,
     ) {
         let mut sessions = self.sessions.write().await;
-        if let Some(session) = sessions.get_mut(&Self::key(user_id, server_name)) {
+        if let Some(session) = sessions.get_mut(&Self::key(user_id, server_name, thread_id)) {
             session.update_session_id(session_id);
         }
     }
 
     /// Mark a session as initialized.
-    pub async fn mark_initialized(&self, user_id: &str, server_name: &McpServerName) {
+    pub async fn mark_initialized(
+        &self,
+        user_id: &str,
+        server_name: &McpServerName,
+        thread_id: Option<Uuid>,
+    ) {
         let mut sessions = self.sessions.write().await;
-        if let Some(session) = sessions.get_mut(&Self::key(user_id, server_name)) {
+        if let Some(session) = sessions.get_mut(&Self::key(user_id, server_name, thread_id)) {
             session.mark_initialized();
         }
     }
 
     /// Check if a session is initialized.
-    pub async fn is_initialized(&self, user_id: &str, server_name: &McpServerName) -> bool {
+    pub async fn is_initialized(
+        &self,
+        user_id: &str,
+        server_name: &McpServerName,
+        thread_id: Option<Uuid>,
+    ) -> bool {
         let sessions = self.sessions.read().await;
         sessions
-            .get(&Self::key(user_id, server_name))
+            .get(&Self::key(user_id, server_name, thread_id))
             .map(|s| s.initialized)
             .unwrap_or(false)
     }
 
     /// Touch a session to update its activity timestamp.
-    pub async fn touch(&self, user_id: &str, server_name: &McpServerName) {
+    pub async fn touch(&self, user_id: &str, server_name: &McpServerName, thread_id: Option<Uuid>) {
         let mut sessions = self.sessions.write().await;
-        if let Some(session) = sessions.get_mut(&Self::key(user_id, server_name)) {
+        if let Some(session) = sessions.get_mut(&Self::key(user_id, server_name, thread_id)) {
             session.touch();
         }
     }
 
     /// Terminate a session (e.g., on error or explicit disconnect).
-    pub async fn terminate(&self, user_id: &str, server_name: &McpServerName) {
+    pub async fn terminate(
+        &self,
+        user_id: &str,
+        server_name: &McpServerName,
+        thread_id: Option<Uuid>,
+    ) {
         let mut sessions = self.sessions.write().await;
-        sessions.remove(&Self::key(user_id, server_name));
+        sessions.remove(&Self::key(user_id, server_name, thread_id));
     }
 
-    /// Snapshot the active `(user, server)` pairs.
-    pub async fn active_sessions(&self) -> Vec<(String, McpServerName)> {
+    /// Snapshot the active `(user, server, thread_id)` triples.
+    pub async fn active_sessions(&self) -> Vec<(String, McpServerName, Option<Uuid>)> {
         let sessions = self.sessions.read().await;
         sessions
             .keys()
-            .map(|k| (k.user_id.clone(), k.server_name.clone()))
+            .map(|k| (k.user_id.clone(), k.server_name.clone(), k.thread_id))
             .collect()
     }
 
@@ -244,6 +297,10 @@ mod tests {
 
     fn sn(s: &str) -> McpServerName {
         McpServerName::new(s).expect("test name")
+    }
+
+    fn tid(n: u128) -> Uuid {
+        Uuid::from_u128(n)
     }
 
     #[test]
@@ -287,18 +344,18 @@ mod tests {
 
         // First call creates a new session
         let session1 = manager
-            .get_or_create(USER_A, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
             .await;
         assert!(session1.session_id.is_none());
 
         // Update the session ID
         manager
-            .update_session_id(USER_A, &notion, Some("session-abc".to_string()))
+            .update_session_id(USER_A, &notion, Some("session-abc".to_string()), None)
             .await;
 
         // Second call returns existing session with the ID
         let session2 = manager
-            .get_or_create(USER_A, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
             .await;
         assert_eq!(session2.session_id, Some("session-abc".to_string()));
     }
@@ -309,18 +366,18 @@ mod tests {
         let notion = sn("notion");
 
         manager
-            .get_or_create(USER_A, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
             .await;
         manager
-            .update_session_id(USER_A, &notion, Some("session-123".to_string()))
+            .update_session_id(USER_A, &notion, Some("session-123".to_string()), None)
             .await;
 
         // Terminate the session
-        manager.terminate(USER_A, &notion).await;
+        manager.terminate(USER_A, &notion, None).await;
 
         // Should create a fresh session now
         let session = manager
-            .get_or_create(USER_A, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
             .await;
         assert!(session.session_id.is_none());
     }
@@ -331,14 +388,14 @@ mod tests {
         let notion = sn("notion");
 
         manager
-            .get_or_create(USER_A, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
             .await;
 
-        assert!(!manager.is_initialized(USER_A, &notion).await);
+        assert!(!manager.is_initialized(USER_A, &notion, None).await);
 
-        manager.mark_initialized(USER_A, &notion).await;
+        manager.mark_initialized(USER_A, &notion, None).await;
 
-        assert!(manager.is_initialized(USER_A, &notion).await);
+        assert!(manager.is_initialized(USER_A, &notion, None).await);
     }
 
     #[tokio::test]
@@ -348,20 +405,20 @@ mod tests {
         let github = sn("github");
 
         manager
-            .get_or_create(USER_A, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
             .await;
         manager
-            .get_or_create(USER_A, &github, "https://mcp.github.com")
+            .get_or_create(USER_A, &github, "https://mcp.github.com", None)
             .await;
         manager
-            .get_or_create(USER_B, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_B, &notion, "https://mcp.notion.com", None)
             .await;
 
         let pairs = manager.active_sessions().await;
         assert_eq!(pairs.len(), 3);
-        assert!(pairs.contains(&(USER_A.to_string(), notion.clone())));
-        assert!(pairs.contains(&(USER_A.to_string(), github.clone())));
-        assert!(pairs.contains(&(USER_B.to_string(), notion.clone())));
+        assert!(pairs.contains(&(USER_A.to_string(), notion.clone(), None)));
+        assert!(pairs.contains(&(USER_A.to_string(), github.clone(), None)));
+        assert!(pairs.contains(&(USER_B.to_string(), notion.clone(), None)));
     }
 
     /// Regression for the cross-tenant session-ID collision called out in
@@ -377,32 +434,37 @@ mod tests {
         let notion = sn("notion");
 
         manager
-            .get_or_create(USER_A, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
             .await;
         manager
-            .get_or_create(USER_B, &notion, "https://mcp.notion.com")
+            .get_or_create(USER_B, &notion, "https://mcp.notion.com", None)
             .await;
 
         manager
-            .update_session_id(USER_A, &notion, Some("session-a".to_string()))
+            .update_session_id(USER_A, &notion, Some("session-a".to_string()), None)
             .await;
         manager
-            .update_session_id(USER_B, &notion, Some("session-b".to_string()))
+            .update_session_id(USER_B, &notion, Some("session-b".to_string()), None)
             .await;
 
         assert_eq!(
-            manager.get_session_id(USER_A, &notion).await,
+            manager.get_session_id(USER_A, &notion, None).await,
             Some("session-a".to_string())
         );
         assert_eq!(
-            manager.get_session_id(USER_B, &notion).await,
+            manager.get_session_id(USER_B, &notion, None).await,
             Some("session-b".to_string())
         );
 
-        manager.terminate(USER_A, &notion).await;
-        assert!(manager.get_session_id(USER_A, &notion).await.is_none());
+        manager.terminate(USER_A, &notion, None).await;
+        assert!(
+            manager
+                .get_session_id(USER_A, &notion, None)
+                .await
+                .is_none()
+        );
         assert_eq!(
-            manager.get_session_id(USER_B, &notion).await,
+            manager.get_session_id(USER_B, &notion, None).await,
             Some("session-b".to_string()),
             "terminating user-A must not affect user-B's session"
         );
@@ -439,7 +501,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_session_id_nonexistent_returns_none() {
         let manager = McpSessionManager::new();
-        assert!(manager.get_session_id(USER_A, &sn("ghost")).await.is_none());
+        assert!(
+            manager
+                .get_session_id(USER_A, &sn("ghost"), None)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -447,7 +514,7 @@ mod tests {
         let manager = McpSessionManager::new();
         // Should not panic or create a session.
         manager
-            .update_session_id(USER_A, &sn("ghost"), Some("id".to_string()))
+            .update_session_id(USER_A, &sn("ghost"), Some("id".to_string()), None)
             .await;
         assert!(manager.active_sessions().await.is_empty());
     }
@@ -455,14 +522,14 @@ mod tests {
     #[tokio::test]
     async fn test_mark_initialized_nonexistent_is_noop() {
         let manager = McpSessionManager::new();
-        manager.mark_initialized(USER_A, &sn("ghost")).await;
+        manager.mark_initialized(USER_A, &sn("ghost"), None).await;
         assert!(manager.active_sessions().await.is_empty());
     }
 
     #[tokio::test]
     async fn test_touch_nonexistent_is_noop() {
         let manager = McpSessionManager::new();
-        manager.touch(USER_A, &sn("ghost")).await;
+        manager.touch(USER_A, &sn("ghost"), None).await;
         assert!(manager.active_sessions().await.is_empty());
     }
 
@@ -475,13 +542,13 @@ mod tests {
         let stale2 = sn("stale2");
 
         manager
-            .get_or_create(USER_A, &fresh, "https://fresh.example.com")
+            .get_or_create(USER_A, &fresh, "https://fresh.example.com", None)
             .await;
         manager
-            .get_or_create(USER_A, &stale1, "https://stale1.example.com")
+            .get_or_create(USER_A, &stale1, "https://stale1.example.com", None)
             .await;
         manager
-            .get_or_create(USER_A, &stale2, "https://stale2.example.com")
+            .get_or_create(USER_A, &stale2, "https://stale2.example.com", None)
             .await;
 
         // Push the two stale sessions into the past.
@@ -489,11 +556,11 @@ mod tests {
             let mut sessions = manager.sessions.write().await;
             let past = std::time::Instant::now() - std::time::Duration::from_secs(60);
             sessions
-                .get_mut(&McpSessionManager::key(USER_A, &stale1))
+                .get_mut(&McpSessionManager::key(USER_A, &stale1, None))
                 .unwrap()
                 .last_activity = past;
             sessions
-                .get_mut(&McpSessionManager::key(USER_A, &stale2))
+                .get_mut(&McpSessionManager::key(USER_A, &stale2, None))
                 .unwrap()
                 .last_activity = past;
         }
@@ -503,14 +570,14 @@ mod tests {
 
         let remaining = manager.active_sessions().await;
         assert_eq!(remaining.len(), 1);
-        assert!(remaining.contains(&(USER_A.to_string(), fresh.clone())));
+        assert!(remaining.contains(&(USER_A.to_string(), fresh.clone(), None)));
     }
 
     #[tokio::test]
     async fn test_terminate_nonexistent_is_noop() {
         let manager = McpSessionManager::new();
         // Should not panic.
-        manager.terminate(USER_A, &sn("ghost")).await;
+        manager.terminate(USER_A, &sn("ghost"), None).await;
         assert!(manager.active_sessions().await.is_empty());
     }
 
@@ -519,5 +586,169 @@ mod tests {
         let manager = McpSessionManager::default();
         // Default should match new(), which uses 1800s idle timeout.
         assert_eq!(manager.max_idle_secs, 1800);
+    }
+
+    // ── Thread-axis partition tests ───────────────────────────────────────
+
+    /// Two `new_for_thread` keys with distinct `thread_id` must not collide:
+    /// Thread A and Thread B under the same user and same server get
+    /// independent MCP sessions.
+    #[tokio::test]
+    async fn test_distinct_thread_ids_do_not_collide() {
+        let manager = McpSessionManager::new();
+        let notion = sn("notion");
+        let thread_a = tid(1);
+        let thread_b = tid(2);
+
+        manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", Some(thread_a))
+            .await;
+        manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", Some(thread_b))
+            .await;
+
+        manager
+            .update_session_id(
+                USER_A,
+                &notion,
+                Some("sess-thread-a".to_string()),
+                Some(thread_a),
+            )
+            .await;
+        manager
+            .update_session_id(
+                USER_A,
+                &notion,
+                Some("sess-thread-b".to_string()),
+                Some(thread_b),
+            )
+            .await;
+
+        assert_eq!(
+            manager
+                .get_session_id(USER_A, &notion, Some(thread_a))
+                .await,
+            Some("sess-thread-a".to_string()),
+            "Thread A's session must not be overwritten by Thread B's update"
+        );
+        assert_eq!(
+            manager
+                .get_session_id(USER_A, &notion, Some(thread_b))
+                .await,
+            Some("sess-thread-b".to_string()),
+            "Thread B's session must be independent from Thread A"
+        );
+    }
+
+    /// `new` (None) and `new_for_thread` with the same `(user, server)` must
+    /// not collide: the user-scoped slot and a thread-scoped slot coexist.
+    #[tokio::test]
+    async fn test_none_and_some_thread_id_are_distinct_slots() {
+        let manager = McpSessionManager::new();
+        let notion = sn("notion");
+        let thread_a = tid(42);
+
+        manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
+            .await;
+        manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", Some(thread_a))
+            .await;
+
+        manager
+            .update_session_id(USER_A, &notion, Some("sess-user-scoped".to_string()), None)
+            .await;
+        manager
+            .update_session_id(
+                USER_A,
+                &notion,
+                Some("sess-thread-scoped".to_string()),
+                Some(thread_a),
+            )
+            .await;
+
+        assert_eq!(
+            manager.get_session_id(USER_A, &notion, None).await,
+            Some("sess-user-scoped".to_string()),
+            "user-scoped slot must be independent from the thread-scoped slot"
+        );
+        assert_eq!(
+            manager
+                .get_session_id(USER_A, &notion, Some(thread_a))
+                .await,
+            Some("sess-thread-scoped".to_string()),
+            "thread-scoped slot must be independent from the user-scoped slot"
+        );
+        // Confirm two distinct entries exist
+        assert_eq!(manager.active_sessions().await.len(), 2);
+    }
+
+    /// Same `(user, server, thread_id)` triple must collide — a round-trip
+    /// verify that the thread axis is keyed correctly.
+    #[tokio::test]
+    async fn test_same_triple_collides() {
+        let manager = McpSessionManager::new();
+        let notion = sn("notion");
+        let thread_a = tid(7);
+
+        manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", Some(thread_a))
+            .await;
+        manager
+            .update_session_id(USER_A, &notion, Some("sess-v1".to_string()), Some(thread_a))
+            .await;
+
+        // Second get_or_create with the same triple must return the existing session.
+        let sess = manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", Some(thread_a))
+            .await;
+        assert_eq!(
+            sess.session_id,
+            Some("sess-v1".to_string()),
+            "identical (user, server, thread_id) must hit the same session slot"
+        );
+        assert_eq!(manager.active_sessions().await.len(), 1);
+    }
+
+    /// Terminating a thread-scoped session must not affect the user-scoped
+    /// session for the same `(user, server)`.
+    #[tokio::test]
+    async fn test_thread_terminate_does_not_affect_user_scoped() {
+        let manager = McpSessionManager::new();
+        let notion = sn("notion");
+        let thread_a = tid(99);
+
+        manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", None)
+            .await;
+        manager
+            .get_or_create(USER_A, &notion, "https://mcp.notion.com", Some(thread_a))
+            .await;
+        manager
+            .update_session_id(USER_A, &notion, Some("sess-user".to_string()), None)
+            .await;
+        manager
+            .update_session_id(
+                USER_A,
+                &notion,
+                Some("sess-thread".to_string()),
+                Some(thread_a),
+            )
+            .await;
+
+        manager.terminate(USER_A, &notion, Some(thread_a)).await;
+
+        assert!(
+            manager
+                .get_session_id(USER_A, &notion, Some(thread_a))
+                .await
+                .is_none(),
+            "thread-scoped session must be removed"
+        );
+        assert_eq!(
+            manager.get_session_id(USER_A, &notion, None).await,
+            Some("sess-user".to_string()),
+            "user-scoped session must survive thread termination"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two related changes to MCP dispatch:

1. **`McpSessionKey` gains a `thread_id` axis** so concurrent IronClaw
   Threads under one user no longer share a single `Mcp-Session-Id`
   slot for the same server. Today two Threads dispatching to the
   same MCP server collide on server-side session state — this is a
   quiet correctness fix.

2. **Outbound MCP JSON-RPC requests inject two correlation fields**
   into `params._meta`, following [SEP-414][sep-414]'s convention for
   `_meta`-based context propagation, with namespacing per
   [SEP-2575][sep-2575]:
   - `io.ironclaw/threadId: <uuid>`
   - `io.ironclaw/userId:   <id>`

   MCP servers can read these to attribute calls to the originating
   Thread (rate-limiting per conversation, per-conversation audit,
   tenant scoping). Servers that don't care ignore them. Existing
   `_meta` keys (e.g. `traceparent`) are preserved on merge.

The two pieces stand independently:
- (1) is a correctness fix any IronClaw deployment benefits from,
  regardless of whether downstream MCP servers consume (2).
- (2) is an opt-in signal — additive metadata, no behavioural change
  for servers that don't read `_meta`.

[sep-414]: https://modelcontextprotocol.io/seps/414-request-meta
[sep-2575]: https://modelcontextprotocol.io/seps/2575-stateless-mcp

## Motivation

`McpSessionManager` keys its session map by `(user_id, server_name)`.
For an IronClaw user running multiple concurrent Threads against the
same MCP server, all of those Threads share one `Mcp-Session-Id`
slot — the second Thread's `update_session_id` overwrites the
first, and a server that binds state to the session id (browser
automation, stateful research, per-conversation rate buckets, etc.)
sees protocol-level state bleed across Threads.

The same shape as the cross-tenant collision documented at the top
of [`src/tools/mcp/session.rs`](src/tools/mcp/session.rs), one axis
deeper.

## Design — `McpSessionKey` axis

```rust
pub struct McpSessionKey {
    user_id: String,
    server_name: McpServerName,
    thread_id: Option<Uuid>,   // None = legacy user-scoped (CLI/test).
}

impl McpSessionKey {
    pub fn new(user_id: …, server_name: …) -> Self           { … } // None
    pub fn new_for_thread(user_id: …, server_name: …, tid: Uuid) -> Self { … }
}
```

All 6 `McpSessionManager` methods (`get_or_create`, `get_session_id`,
`update_session_id`, `mark_initialized`, `is_initialized`, `touch`,
`terminate`) take `Option<Uuid>`. `None` preserves today's behaviour.
`Some(tid)` is used by the new thread-scoped dispatch path.

`McpClient` and `McpClientStore` gain a parallel `thread_id` axis so
the cached `Arc<McpClient>` partitions correctly — two Threads under
one user activating the same server get distinct client instances
with their own `OnceCell<Initialized>`, so each Thread does its own
MCP `initialize` handshake against the upstream server.

Thread-scoped clients materialise lazily via
`McpClientStore::resolve_for_thread`, which clones config from the
boot-time user-scoped base via `McpClient::for_thread(uuid)`. Race
protection uses the standard double-check pattern:

```rust
// Fast path under read lock.
{
    let guard = self.clients.read().await;
    if let Some(entry) = guard.get(&thread_key) {
        return Some(entry.client.clone());
    }
}

// Slow path under write lock — re-check then materialise + insert.
let mut guard = self.clients.write().await;
if let Some(entry) = guard.get(&thread_key) {
    return Some(entry.client.clone());
}
let base = guard.get(&McpClientKey::new(user_id, server_name))?;
let forked = Arc::new(base.client.for_thread(tid));
guard.insert(thread_key, McpClientEntry { client: forked.clone(), … });
Some(forked)
```

## Design — `_meta` injection

`McpRequest::inject_meta_context(thread_id, user_id)` merges the two
correlation fields into `params._meta`. Chained from every outbound
JSON-RPC message in `McpClient` — `initialize`, the `initialized`
notification, `tools/list`, and `tools/call` — so the binding is
available on the very first message of a session, not just on
`tools/call`. Merge semantics preserve any pre-existing `_meta` keys
(e.g. a future `traceparent`); only the two `io.ironclaw/*` keys are
written. When the request was constructed with `params: None`
(`tools/list`, notifications), `inject_meta_context` materialises a
fresh `params` object so context propagation is uniform across
methods.

`_meta` lives on the JSON-RPC envelope's `params`, sibling to
`params.arguments`. Tool-call arguments serialise into
`params.arguments` and cannot reach `params._meta`, so the runtime-
set fields can't be spoofed by agent-controlled data.

## Trust model

The IronClaw runtime sets `_meta.io.ironclaw/threadId` after
serialising agent-supplied tool arguments. Operator-configured
`custom_headers` operate at the HTTP-header layer, not the JSON-RPC
envelope, so they can't reach `params._meta` either.

For deployments where an MCP server further validates the field
against a shared secret, HMAC signing inside the same `_meta` object
(`io.ironclaw/threadIdSignature`) is a clean follow-up that doesn't
require any spec or protocol changes.

## What changed (by file)

| File | What |
|---|---|
| `src/tools/mcp/session.rs` | `McpSessionKey` gains `thread_id: Option<Uuid>` + `new_for_thread`. Manager methods take `Option<Uuid>`. |
| `src/tools/mcp/client.rs` | `McpClient` gains `thread_id` field + `for_thread` sibling constructor + chains `.inject_meta_context(…)` on `initialize`, `initialized` notification, `tools/list`, and `tools/call`. |
| `src/tools/mcp/client_store.rs` | `McpClientKey` gains `thread_id` axis. New `resolve_for_thread` (lazy materialisation) and `evict_thread` (cache cleanup, see follow-ups). |
| `src/tools/mcp/protocol.rs` | New `McpRequest::inject_meta_context(thread_id, user_id)` method. Merge-not-replace semantics. Materialises an empty `params` object when `None` so methods like `tools/list` propagate context too. |
| `src/tools/mcp/http_transport.rs` | `session_thread_id` plumbed through `with_session_manager`. |
| `src/tools/mcp/factory.rs` | `create_client_from_config` unchanged on the API surface — always produces user-scoped clients; thread-scoped clients are materialised via `McpClient::for_thread` from `McpClientStore::resolve_for_thread`. |
| `src/app.rs`, `src/cli/mcp.rs`, `src/extensions/manager.rs` | Boot/CLI/extension call sites pass `None` (user-scoped base). |

Consumer wiring lives in `McpToolWrapper::execute`, which uses
`JobContext.conversation_id` (set to `Some(thread_id)` in
[`src/agent/dispatcher.rs:92`](src/agent/dispatcher.rs#L92)) as the
Thread axis for `resolve_for_thread`.

## Tests

- `McpSessionKey` partition: 5 unit tests (`session.rs`).
- `_meta` injection: 4 unit tests in `protocol.rs` (presence when
  `Some`, absence when `None`, merge preserving pre-existing keys,
  fresh-params materialisation when `params: None`).
- `McpClientStore` thread axis: 4 unit tests including
  `resolve_for_thread` race/double-check coverage and `evict_thread`
  selectivity.
- `McpClient::for_thread`: fresh init state, HTTP transport rebuild,
  stdio/Unix transport sharing.
- `McpToolWrapper::execute` end-to-end through a body-capturing mock
  transport: two thread-scoped clients send `initialize` +
  `initialized` notification + `tools/call`, with `_meta.io.ironclaw/threadId`
  asserted on **every** captured request (not just the tool call).

`cargo test --lib tools::mcp::` — 272 pass / 0 fail. `cargo clippy
--lib --no-deps` — clean.

## Follow-ups (intentionally out of scope)

1. **Wire `evict_thread` from a Thread-termination hook.** The
   method is implemented and unit-tested but has no production
   caller — I couldn't find a clean "Thread is finished, release
   resources" point in the agent loop. Pointers from maintainers
   welcome. Without wiring, thread-scoped client entries accumulate;
   for short-lived deployments this is fine, for long-running
   single-user deployments it leaks.

2. **Confirm namespace.** `io.ironclaw/threadId` /
   `io.ironclaw/userId` follow SEP-2575's reverse-domain convention.
   No existing reverse-domain keys are in use elsewhere in the
   codebase (verified via grep); happy to rename to
   `ai.near/ironclaw/...` or whatever shape maintainers prefer
   before merge. Pure search-and-replace.

3. **Builder pattern for `McpClient::new_with_transport`.** The
   constructor now takes 7 parameters. A builder would reduce
   call-site fragility; deferred to a follow-up.

## Explicitly NOT in this PR

- Eviction policy / LRU bounds on the thread-scoped client cache
  (see follow-up #1).
- Multi-tenancy boundaries beyond the existing user/server axes.

## Test plan

- [x] `cargo test --lib tools::mcp::` — 272 pass / 0 fail
- [x] `cargo clippy --lib --no-deps` — clean
- [x] Manual review of cross-Thread isolation in
      `client_store.rs::resolve_for_thread`
- [ ] (maintainer) Confirm namespace key shape
- [ ] (maintainer) Suggest a wire-up location for `evict_thread`
