### PR TITLE
fix(embeddings): honor config precedence, validate provider, enforce batch limits

### DIFF
--- a/crates/ironclaw_embeddings/src/bedrock.rs
+++ b/crates/ironclaw_embeddings/src/bedrock.rs
@@ -113,6 +113,10 @@ mod imp {
             &self.model
         }
 
+        fn provider_name(&self) -> &str {
+            "bedrock"
+        }
+
         fn max_input_length(&self) -> usize {
             32_000
         }

--- a/crates/ironclaw_embeddings/src/bedrock.rs
+++ b/crates/ironclaw_embeddings/src/bedrock.rs
@@ -113,8 +113,8 @@ mod imp {
             &self.model
         }
 
-        fn provider_name(&self) -> &str {
-            "bedrock"
+        fn provider_kind(&self) -> crate::provider::EmbeddingProviderKind {
+            crate::provider::EmbeddingProviderKind::Bedrock
         }
 
         fn max_input_length(&self) -> usize {

--- a/crates/ironclaw_embeddings/src/cache.rs
+++ b/crates/ironclaw_embeddings/src/cache.rs
@@ -104,6 +104,10 @@ impl EmbeddingProvider for CachedEmbeddingProvider {
         self.inner.model_name()
     }
 
+    fn provider_name(&self) -> &str {
+        self.inner.provider_name()
+    }
+
     fn max_input_length(&self) -> usize {
         self.inner.max_input_length()
     }

--- a/crates/ironclaw_embeddings/src/cache.rs
+++ b/crates/ironclaw_embeddings/src/cache.rs
@@ -104,8 +104,8 @@ impl EmbeddingProvider for CachedEmbeddingProvider {
         self.inner.model_name()
     }
 
-    fn provider_name(&self) -> &str {
-        self.inner.provider_name()
+    fn provider_kind(&self) -> crate::provider::EmbeddingProviderKind {
+        self.inner.provider_kind()
     }
 
     fn max_input_length(&self) -> usize {
@@ -274,6 +274,9 @@ mod tests {
         fn max_input_length(&self) -> usize {
             10_000
         }
+        fn provider_kind(&self) -> crate::provider::EmbeddingProviderKind {
+            crate::provider::EmbeddingProviderKind::NearAi
+        }
         async fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
             self.embed_calls.fetch_add(1, Ordering::SeqCst);
             // Simple deterministic embedding: val = text.len() / 100.0
@@ -290,6 +293,20 @@ mod tests {
                 })
                 .collect()
         }
+    }
+
+    #[test]
+    fn provider_kind_delegates_to_inner() {
+        // The cache wrapper is the typical production wrapper; the auth-failure
+        // hint depends on it surfacing the inner provider's kind, not the default.
+        let cached = CachedEmbeddingProvider::new(
+            Arc::new(CountingMock::new(4, "m")),
+            EmbeddingCacheConfig { max_entries: 1 },
+        );
+        assert_eq!(
+            cached.provider_kind(),
+            crate::provider::EmbeddingProviderKind::NearAi
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_embeddings/src/factory.rs
+++ b/crates/ironclaw_embeddings/src/factory.rs
@@ -107,7 +107,7 @@ pub async fn create_provider(
                     .with_model(&config.model, config.dimension),
             ) as Arc<dyn EmbeddingProvider>)
         }
-        _ => {
+        "openai" => {
             if let Some(api_key) = config.openai_api_key() {
                 let mut provider =
                     OpenAiEmbeddings::with_model(api_key, &config.model, config.dimension);
@@ -135,6 +135,15 @@ pub async fn create_provider(
                 tracing::warn!("Embeddings configured but OPENAI_API_KEY not set");
                 None
             }
+        }
+        other => {
+            // The binary's config resolver (`resolve_embeddings_config`) rejects
+            // unknown providers before they ever reach the factory. This arm is
+            // a defensive backstop for any other caller that builds an
+            // `EmbeddingsConfig` directly: fail loudly instead of silently
+            // falling back to OpenAI (#3751).
+            tracing::error!("Unknown embedding provider '{other}'; refusing to build");
+            None
         }
     }
 }

--- a/crates/ironclaw_embeddings/src/factory.rs
+++ b/crates/ironclaw_embeddings/src/factory.rs
@@ -224,6 +224,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unknown_provider_returns_none() {
+        // The defensive `other =>` arm: a caller that builds EmbeddingsConfig
+        // directly with a misspelled provider gets a loud None, not a silent
+        // OpenAI fallback (#3751).
+        let cfg = config_with_provider("totally-unknown");
+        assert!(create_provider(&cfg, stub_deps()).await.is_none());
+    }
+
+    #[tokio::test]
     async fn accepts_localhost_ollama() {
         let cfg = EmbeddingsConfig {
             ollama_base_url: "http://localhost:11434".to_string(),

--- a/crates/ironclaw_embeddings/src/lib.rs
+++ b/crates/ironclaw_embeddings/src/lib.rs
@@ -27,4 +27,4 @@ pub use config::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig, default_dimensi
 pub use factory::{ProviderDeps, create_provider};
 #[cfg(any(test, feature = "testing"))]
 pub use mock::MockEmbeddings;
-pub use provider::{EmbeddingError, EmbeddingProvider};
+pub use provider::{EmbeddingError, EmbeddingProvider, EmbeddingProviderKind};

--- a/crates/ironclaw_embeddings/src/nearai.rs
+++ b/crates/ironclaw_embeddings/src/nearai.rs
@@ -67,6 +67,10 @@ impl EmbeddingProvider for NearAiEmbeddings {
         &self.model
     }
 
+    fn provider_name(&self) -> &str {
+        "nearai"
+    }
+
     fn max_input_length(&self) -> usize {
         32_000
     }
@@ -92,6 +96,8 @@ impl EmbeddingProvider for NearAiEmbeddings {
         if texts.is_empty() {
             return Ok(Vec::new());
         }
+
+        crate::provider::ensure_batch_within_limit(texts, self.max_input_length())?;
 
         let request = NearAiEmbeddingRequest {
             model: &self.model,
@@ -140,5 +146,27 @@ impl EmbeddingProvider for NearAiEmbeddings {
         })?;
 
         Ok(result.data.into_iter().map(|d| d.embedding).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_llm::{SessionConfig, SessionManager};
+
+    #[tokio::test]
+    async fn embed_batch_rejects_over_limit_item() {
+        // The batched override enforces the per-item byte cap before the token
+        // fetch or any network call (#3752).
+        let provider = NearAiEmbeddings::new(
+            "https://api.near.ai",
+            std::sync::Arc::new(SessionManager::new(SessionConfig::default())),
+        );
+        let oversized = "a".repeat(provider.max_input_length() + 1);
+        let err = provider
+            .embed_batch(&[oversized])
+            .await
+            .expect_err("over-limit item must be rejected");
+        assert!(matches!(err, EmbeddingError::TextTooLong { .. }));
     }
 }

--- a/crates/ironclaw_embeddings/src/nearai.rs
+++ b/crates/ironclaw_embeddings/src/nearai.rs
@@ -67,8 +67,8 @@ impl EmbeddingProvider for NearAiEmbeddings {
         &self.model
     }
 
-    fn provider_name(&self) -> &str {
-        "nearai"
+    fn provider_kind(&self) -> crate::provider::EmbeddingProviderKind {
+        crate::provider::EmbeddingProviderKind::NearAi
     }
 
     fn max_input_length(&self) -> usize {

--- a/crates/ironclaw_embeddings/src/ollama.rs
+++ b/crates/ironclaw_embeddings/src/ollama.rs
@@ -58,6 +58,10 @@ impl EmbeddingProvider for OllamaEmbeddings {
         &self.model
     }
 
+    fn provider_name(&self) -> &str {
+        "ollama"
+    }
+
     fn max_input_length(&self) -> usize {
         // Most Ollama embedding models support ~8192 tokens, budgeted
         // here as ~32_000 UTF-8 bytes (matches `str::len()` semantics —
@@ -84,6 +88,8 @@ impl EmbeddingProvider for OllamaEmbeddings {
         if texts.is_empty() {
             return Ok(Vec::new());
         }
+
+        crate::provider::ensure_batch_within_limit(texts, self.max_input_length())?;
 
         let request = OllamaEmbedRequest {
             model: &self.model,
@@ -121,5 +127,23 @@ impl EmbeddingProvider for OllamaEmbeddings {
         }
 
         Ok(result.embeddings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn embed_batch_rejects_over_limit_item() {
+        // The batched override enforces the per-item byte cap before any
+        // network call (#3752).
+        let provider = OllamaEmbeddings::new("http://localhost:11434");
+        let oversized = "a".repeat(provider.max_input_length() + 1);
+        let err = provider
+            .embed_batch(&[oversized])
+            .await
+            .expect_err("over-limit item must be rejected");
+        assert!(matches!(err, EmbeddingError::TextTooLong { .. }));
     }
 }

--- a/crates/ironclaw_embeddings/src/ollama.rs
+++ b/crates/ironclaw_embeddings/src/ollama.rs
@@ -58,8 +58,8 @@ impl EmbeddingProvider for OllamaEmbeddings {
         &self.model
     }
 
-    fn provider_name(&self) -> &str {
-        "ollama"
+    fn provider_kind(&self) -> crate::provider::EmbeddingProviderKind {
+        crate::provider::EmbeddingProviderKind::Ollama
     }
 
     fn max_input_length(&self) -> usize {

--- a/crates/ironclaw_embeddings/src/openai.rs
+++ b/crates/ironclaw_embeddings/src/openai.rs
@@ -81,7 +81,7 @@ impl OpenAiEmbeddings {
         let url = base_url.trim();
 
         // Auto-prepend https:// if no scheme is present.
-        let mut url = if !url.starts_with("http://") && !url.starts_with("https://") {
+        let url = if !url.starts_with("http://") && !url.starts_with("https://") {
             tracing::debug!(
                 "No scheme in embedding base URL '{}', prepending https://",
                 url
@@ -91,11 +91,13 @@ impl OpenAiEmbeddings {
             url.to_string()
         };
 
-        while url.ends_with('/') {
-            url.pop();
-        }
-
-        self.base_url = url;
+        // Normalize so the request path (`/v1/embeddings`) isn't doubled when an
+        // operator points EMBEDDING_BASE_URL at an OpenAI-compatible root that
+        // already ends in `/v1` (Together, Groq, OpenRouter, vLLM, llama.cpp) —
+        // otherwise we'd build `/v1/v1/embeddings` and 404 (#3754).
+        let normalized = url.trim_end_matches('/');
+        let normalized = normalized.strip_suffix("/v1").unwrap_or(normalized);
+        self.base_url = normalized.to_string();
         self
     }
 }
@@ -126,6 +128,10 @@ impl EmbeddingProvider for OpenAiEmbeddings {
         &self.model
     }
 
+    fn provider_name(&self) -> &str {
+        "openai"
+    }
+
     fn max_input_length(&self) -> usize {
         // text-embedding-3-small/large + ada-002: ~8191 tokens, budgeted
         // here as ~32_000 UTF-8 bytes (matches `str::len()` semantics —
@@ -152,6 +158,8 @@ impl EmbeddingProvider for OpenAiEmbeddings {
         if texts.is_empty() {
             return Ok(Vec::new());
         }
+
+        crate::provider::ensure_batch_within_limit(texts, self.max_input_length())?;
 
         let request = OpenAiEmbeddingRequest {
             model: &self.model,
@@ -236,7 +244,43 @@ mod tests {
 
     #[test]
     fn test_openai_with_base_url_schemeless_prepends_https() {
-        let provider = OpenAiEmbeddings::new("test-key").with_base_url("custom.example.com/v1");
-        assert_eq!(provider.base_url, "https://custom.example.com/v1");
+        let provider = OpenAiEmbeddings::new("test-key").with_base_url("custom.example.com");
+        assert_eq!(provider.base_url, "https://custom.example.com");
+    }
+
+    #[test]
+    fn test_openai_with_base_url_strips_trailing_v1() {
+        // OpenAI-compatible roots are commonly documented with a `/v1` suffix
+        // (Together, Groq, OpenRouter, vLLM, llama.cpp). The request path
+        // appends `/v1/embeddings`, so the suffix must be stripped to avoid
+        // `/v1/v1/embeddings` (#3754).
+        for input in [
+            "https://host.example.com/v1",
+            "https://host.example.com/v1/",
+            "host.example.com/v1",
+        ] {
+            let provider = OpenAiEmbeddings::new("test-key").with_base_url(input);
+            assert_eq!(
+                provider.base_url, "https://host.example.com",
+                "base_url for input {input:?}"
+            );
+        }
+
+        // http scheme is preserved while the trailing /v1 is still stripped.
+        let provider = OpenAiEmbeddings::new("test-key").with_base_url("http://localhost:8080/v1");
+        assert_eq!(provider.base_url, "http://localhost:8080");
+    }
+
+    #[tokio::test]
+    async fn test_openai_embed_batch_rejects_over_limit_item() {
+        // The batched override must enforce the per-item byte cap the same way
+        // `embed` does, before any network call (#3752).
+        let provider = OpenAiEmbeddings::new("test-key");
+        let oversized = "a".repeat(provider.max_input_length() + 1);
+        let err = provider
+            .embed_batch(&[oversized])
+            .await
+            .expect_err("over-limit item must be rejected");
+        assert!(matches!(err, EmbeddingError::TextTooLong { .. }));
     }
 }

--- a/crates/ironclaw_embeddings/src/openai.rs
+++ b/crates/ironclaw_embeddings/src/openai.rs
@@ -128,8 +128,8 @@ impl EmbeddingProvider for OpenAiEmbeddings {
         &self.model
     }
 
-    fn provider_name(&self) -> &str {
-        "openai"
+    fn provider_kind(&self) -> crate::provider::EmbeddingProviderKind {
+        crate::provider::EmbeddingProviderKind::OpenAi
     }
 
     fn max_input_length(&self) -> usize {

--- a/crates/ironclaw_embeddings/src/provider.rs
+++ b/crates/ironclaw_embeddings/src/provider.rs
@@ -41,6 +41,15 @@ pub trait EmbeddingProvider: Send + Sync {
     /// Get the model name.
     fn model_name(&self) -> &str;
 
+    /// Provider family identifier — `"openai"`, `"nearai"`, `"ollama"`, or
+    /// `"bedrock"`. Used to tailor operator-facing hints (e.g. which credential
+    /// to check on an auth failure). All four production providers override
+    /// this; the `"unknown"` default is only reached by test doubles and maps
+    /// to the generic OpenAI-flavored hint.
+    fn provider_name(&self) -> &str {
+        "unknown"
+    }
+
     /// Maximum input length in **bytes** (matches `str::len()` semantics).
     ///
     /// Provider implementations enforce this against `text.len()`, which
@@ -63,4 +72,25 @@ pub trait EmbeddingProvider: Send + Sync {
         }
         Ok(embeddings)
     }
+}
+
+/// Enforce `max` (bytes) for every item in a batch.
+///
+/// The `embed_batch` overrides (OpenAI, NEAR AI, Ollama) issue a single
+/// batched request, so — unlike the per-item `embed` path — they must validate
+/// each input themselves before hitting the provider. Shared here so the three
+/// overrides stay in lockstep (#3752).
+pub(crate) fn ensure_batch_within_limit(
+    texts: &[String],
+    max: usize,
+) -> Result<(), EmbeddingError> {
+    for text in texts {
+        if text.len() > max {
+            return Err(EmbeddingError::TextTooLong {
+                length: text.len(),
+                max,
+            });
+        }
+    }
+    Ok(())
 }

--- a/crates/ironclaw_embeddings/src/provider.rs
+++ b/crates/ironclaw_embeddings/src/provider.rs
@@ -32,6 +32,45 @@ impl From<reqwest::Error> for EmbeddingError {
     }
 }
 
+/// The provider family backing an [`EmbeddingProvider`].
+///
+/// A closed set rather than a free string, so credential-hint dispatch is
+/// exhaustive: adding a provider forces every `match` to handle it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingProviderKind {
+    OpenAi,
+    NearAi,
+    Ollama,
+    Bedrock,
+}
+
+impl EmbeddingProviderKind {
+    /// Operator-facing hint appended to an embedding `AuthFailed` warning,
+    /// tailored to where this provider keeps its credential. `AuthFailed`
+    /// surfaces from OpenAI (401), NEAR AI (401 or session-token fetch failure),
+    /// and Bedrock (AccessDenied), so a single OpenAI-flavored hint misleads the
+    /// others (#3755).
+    pub fn auth_failed_hint(self) -> &'static str {
+        match self {
+            EmbeddingProviderKind::NearAi => {
+                ". Run `ironclaw onboard` to refresh your NEAR AI session, or set \
+                 EMBEDDING_PROVIDER=ollama for local embeddings"
+            }
+            EmbeddingProviderKind::Bedrock => {
+                ". Check your AWS credentials (AWS_PROFILE or AWS_ACCESS_KEY_ID + \
+                 AWS_SECRET_ACCESS_KEY), or set EMBEDDING_PROVIDER=ollama for local \
+                 embeddings"
+            }
+            // Ollama is local and not auth-bearing, so it shares the generic
+            // OpenAI hint rather than getting a bespoke one.
+            EmbeddingProviderKind::OpenAi | EmbeddingProviderKind::Ollama => {
+                ". Check OPENAI_API_KEY or set EMBEDDING_PROVIDER=ollama for local \
+                 embeddings"
+            }
+        }
+    }
+}
+
 /// Trait for embedding providers.
 #[async_trait]
 pub trait EmbeddingProvider: Send + Sync {
@@ -41,13 +80,12 @@ pub trait EmbeddingProvider: Send + Sync {
     /// Get the model name.
     fn model_name(&self) -> &str;
 
-    /// Provider family identifier — `"openai"`, `"nearai"`, `"ollama"`, or
-    /// `"bedrock"`. Used to tailor operator-facing hints (e.g. which credential
-    /// to check on an auth failure). All four production providers override
-    /// this; the `"unknown"` default is only reached by test doubles and maps
-    /// to the generic OpenAI-flavored hint.
-    fn provider_name(&self) -> &str {
-        "unknown"
+    /// The provider family backing this provider, used to tailor operator-facing
+    /// hints (e.g. which credential to check on an auth failure). The four
+    /// production providers override this; the default is only reached by test
+    /// doubles.
+    fn provider_kind(&self) -> EmbeddingProviderKind {
+        EmbeddingProviderKind::OpenAi
     }
 
     /// Maximum input length in **bytes** (matches `str::len()` semantics).
@@ -93,4 +131,53 @@ pub(crate) fn ensure_batch_within_limit(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_batch_is_ok() {
+        assert!(ensure_batch_within_limit(&[], 10).is_ok());
+    }
+
+    #[test]
+    fn item_exactly_at_limit_is_ok() {
+        assert!(ensure_batch_within_limit(&["aaaaa".to_string()], 5).is_ok());
+    }
+
+    #[test]
+    fn second_item_over_limit_fails() {
+        let texts = vec!["ok".to_string(), "way too long".to_string()];
+        let err = ensure_batch_within_limit(&texts, 5).expect_err("second item exceeds the limit");
+        assert!(matches!(
+            err,
+            EmbeddingError::TextTooLong { length: 12, max: 5 }
+        ));
+    }
+
+    #[test]
+    fn auth_failed_hint_is_provider_specific() {
+        assert!(
+            EmbeddingProviderKind::NearAi
+                .auth_failed_hint()
+                .contains("onboard")
+        );
+        assert!(
+            EmbeddingProviderKind::Bedrock
+                .auth_failed_hint()
+                .contains("AWS_PROFILE")
+        );
+        assert!(
+            EmbeddingProviderKind::OpenAi
+                .auth_failed_hint()
+                .contains("OPENAI_API_KEY")
+        );
+        assert!(
+            EmbeddingProviderKind::Ollama
+                .auth_failed_hint()
+                .contains("OPENAI_API_KEY")
+        );
+    }
 }

--- a/src/config/embeddings.rs
+++ b/src/config/embeddings.rs
@@ -39,9 +39,38 @@ pub(crate) fn resolve_embeddings_config(
         "EMBEDDING_PROVIDER",
     )?;
 
-    let model = if provider == "bedrock" {
-        optional_env("EMBEDDING_MODEL")?
-            .unwrap_or_else(|| "amazon.titan-embed-text-v2:0".to_string())
+    // Reject unknown provider strings up front rather than silently routing
+    // them to the OpenAI-compatible path in the embeddings factory (#3751).
+    const KNOWN_PROVIDERS: [&str; 4] = ["openai", "nearai", "ollama", "bedrock"];
+    if !KNOWN_PROVIDERS.contains(&provider.as_str()) {
+        // Bound the echoed value — it comes from operator config (env/DB) and
+        // flows into startup logs.
+        let shown: String = provider.chars().take(64).collect();
+        return Err(ConfigError::InvalidValue {
+            key: "EMBEDDING_PROVIDER".to_string(),
+            message: format!(
+                "unknown embedding provider '{shown}' \
+                 (expected one of: openai, nearai, ollama, bedrock)"
+            ),
+        });
+    }
+
+    // Resolve the model with DB/TOML > env > default precedence for every
+    // provider. Bedrock's default differs from the shared `defaults.model` (an
+    // OpenAI model name), so when no explicit model is configured — detected the
+    // same way `db_first_or_default` itself does, i.e. the setting still equals
+    // its default — we resolve env > Titan v2 here instead of letting the OpenAI
+    // default leak into the Bedrock path (#3750).
+    //
+    // silent-ok: a Bedrock deployment that *explicitly* sets its model to the
+    // OpenAI default string is indistinguishable from "unset" here and falls
+    // back to env/Titan. That configuration is nonsensical, so we accept it
+    // rather than widen `EmbeddingsSettings::model` to `Option<String>`.
+    let model = if provider == "bedrock" && settings.embeddings.model == defaults.model {
+        parse_optional_env(
+            "EMBEDDING_MODEL",
+            "amazon.titan-embed-text-v2:0".to_string(),
+        )?
     } else {
         db_first_or_default(
             &settings.embeddings.model,
@@ -257,6 +286,101 @@ mod tests {
             std::env::remove_var("EMBEDDING_ENABLED");
             std::env::remove_var("EMBEDDING_PROVIDER");
             std::env::remove_var("EMBEDDING_MODEL");
+        }
+    }
+
+    #[test]
+    fn bedrock_model_from_db_settings_is_respected() {
+        // Regression for #3750: a configured DB/TOML model must win for the
+        // Bedrock provider instead of being dropped in favor of the Titan
+        // default. EMBEDDING_DIMENSION is set to a Bedrock-valid value so the
+        // separate dimension validation doesn't reject a non-Titan model name.
+        let _guard = lock_env();
+        clear_embedding_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("EMBEDDING_DIMENSION", "1024");
+        }
+
+        let settings = Settings {
+            embeddings: EmbeddingsSettings {
+                enabled: true,
+                provider: "bedrock".to_string(),
+                model: "my-titan-variant".to_string(),
+            },
+            ..Default::default()
+        };
+
+        let config = resolve_embeddings_config(&settings, "https://api.near.ai")
+            .expect("resolve should succeed");
+        assert_eq!(
+            config.model, "my-titan-variant",
+            "DB/TOML model must win for Bedrock, not be dropped for the Titan default (#3750)"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("EMBEDDING_DIMENSION");
+        }
+    }
+
+    #[test]
+    fn bedrock_model_env_wins_when_db_is_default() {
+        // Regression for #3750: when no DB/TOML model is set (it still equals
+        // the shared default), the Bedrock path resolves EMBEDDING_MODEL env >
+        // Titan default rather than ignoring the env entirely.
+        let _guard = lock_env();
+        clear_embedding_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("EMBEDDING_PROVIDER", "bedrock");
+            std::env::set_var("EMBEDDING_MODEL", "amazon.titan-embed-text-v1:0");
+            std::env::set_var("EMBEDDING_DIMENSION", "1024");
+        }
+
+        // Settings left at defaults — embeddings.model stays at the shared default.
+        let settings = Settings::default();
+        let config = resolve_embeddings_config(&settings, "https://api.near.ai")
+            .expect("resolve should succeed");
+        assert_eq!(
+            config.model, "amazon.titan-embed-text-v1:0",
+            "env EMBEDDING_MODEL must win for Bedrock when no DB model is set (#3750)"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("EMBEDDING_PROVIDER");
+            std::env::remove_var("EMBEDDING_MODEL");
+            std::env::remove_var("EMBEDDING_DIMENSION");
+        }
+    }
+
+    #[test]
+    fn unknown_provider_is_rejected() {
+        // Regression for #3751: a typo'd provider must fail with a clear error
+        // instead of silently routing to the OpenAI-compatible path.
+        let _guard = lock_env();
+        clear_embedding_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("EMBEDDING_PROVIDER", "near-ai");
+        }
+
+        let settings = Settings::default();
+        let result = resolve_embeddings_config(&settings, "https://api.near.ai");
+        assert!(
+            result.is_err(),
+            "unknown provider must be rejected, not routed to OpenAI"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unknown embedding provider"),
+            "error should name the unknown provider clearly: {err}"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("EMBEDDING_PROVIDER");
         }
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2481,21 +2481,54 @@ impl Workspace {
                     count += 1;
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Failed to embed chunk {}: {}{}",
-                        chunk.id,
-                        e,
-                        if matches!(e, EmbeddingError::AuthFailed) {
-                            ". Check OPENAI_API_KEY or set EMBEDDING_PROVIDER=ollama for local embeddings"
-                        } else {
-                            ""
-                        }
-                    );
+                    let hint = if matches!(e, EmbeddingError::AuthFailed) {
+                        auth_failed_hint(provider.provider_name())
+                    } else {
+                        ""
+                    };
+                    tracing::warn!("Failed to embed chunk {}: {}{}", chunk.id, e, hint);
                 }
             }
         }
 
         Ok(count)
+    }
+}
+
+/// Operator-facing hint appended to an embedding `AuthFailed` warning, tailored
+/// to where the active provider keeps its credential. `AuthFailed` surfaces from
+/// OpenAI (401), NEAR AI (401 or session-token fetch failure), and Bedrock
+/// (AccessDenied) alike, so a single OpenAI-flavored hint misleads the other two
+/// (#3755).
+fn auth_failed_hint(provider_name: &str) -> &'static str {
+    match provider_name {
+        "nearai" => {
+            ". Run `ironclaw onboard` to refresh your NEAR AI session, or set \
+             EMBEDDING_PROVIDER=ollama for local embeddings"
+        }
+        "bedrock" => {
+            ". Check your AWS credentials (AWS_PROFILE or AWS_ACCESS_KEY_ID + \
+             AWS_SECRET_ACCESS_KEY), or set EMBEDDING_PROVIDER=ollama for local \
+             embeddings"
+        }
+        _ => {
+            ". Check OPENAI_API_KEY or set EMBEDDING_PROVIDER=ollama for local \
+             embeddings"
+        }
+    }
+}
+
+#[cfg(test)]
+mod auth_hint_tests {
+    use super::auth_failed_hint;
+
+    #[test]
+    fn hint_is_provider_aware() {
+        assert!(auth_failed_hint("nearai").contains("onboard"));
+        assert!(auth_failed_hint("bedrock").contains("AWS_PROFILE"));
+        assert!(auth_failed_hint("openai").contains("OPENAI_API_KEY"));
+        // Unknown / default falls back to the OpenAI-flavored hint.
+        assert!(auth_failed_hint("unknown").contains("OPENAI_API_KEY"));
     }
 }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2482,7 +2482,7 @@ impl Workspace {
                 }
                 Err(e) => {
                     let hint = if matches!(e, EmbeddingError::AuthFailed) {
-                        auth_failed_hint(provider.provider_name())
+                        provider.provider_kind().auth_failed_hint()
                     } else {
                         ""
                     };
@@ -2492,43 +2492,6 @@ impl Workspace {
         }
 
         Ok(count)
-    }
-}
-
-/// Operator-facing hint appended to an embedding `AuthFailed` warning, tailored
-/// to where the active provider keeps its credential. `AuthFailed` surfaces from
-/// OpenAI (401), NEAR AI (401 or session-token fetch failure), and Bedrock
-/// (AccessDenied) alike, so a single OpenAI-flavored hint misleads the other two
-/// (#3755).
-fn auth_failed_hint(provider_name: &str) -> &'static str {
-    match provider_name {
-        "nearai" => {
-            ". Run `ironclaw onboard` to refresh your NEAR AI session, or set \
-             EMBEDDING_PROVIDER=ollama for local embeddings"
-        }
-        "bedrock" => {
-            ". Check your AWS credentials (AWS_PROFILE or AWS_ACCESS_KEY_ID + \
-             AWS_SECRET_ACCESS_KEY), or set EMBEDDING_PROVIDER=ollama for local \
-             embeddings"
-        }
-        _ => {
-            ". Check OPENAI_API_KEY or set EMBEDDING_PROVIDER=ollama for local \
-             embeddings"
-        }
-    }
-}
-
-#[cfg(test)]
-mod auth_hint_tests {
-    use super::auth_failed_hint;
-
-    #[test]
-    fn hint_is_provider_aware() {
-        assert!(auth_failed_hint("nearai").contains("onboard"));
-        assert!(auth_failed_hint("bedrock").contains("AWS_PROFILE"));
-        assert!(auth_failed_hint("openai").contains("OPENAI_API_KEY"));
-        // Unknown / default falls back to the OpenAI-flavored hint.
-        assert!(auth_failed_hint("unknown").contains("OPENAI_API_KEY"));
     }
 }
 


### PR DESCRIPTION
## Summary
Five embeddings bugs in the config-resolution and provider layers:

- **#3750** Bedrock dropped a configured DB/TOML model and always used the Titan default. The model now resolves DB/TOML > env > default for every provider; the Titan default applies only when no model is set.
- **#3751** Unknown `EMBEDDING_PROVIDER` values silently routed to OpenAI. The resolver rejects them with a clear error, and the factory has an explicit `openai` arm plus a loud fallback for any other caller.
- **#3752** The `embed_batch` overrides (OpenAI, NEAR AI, Ollama) skipped the per-item `max_input_length` check that `embed` enforces. A shared guard now runs in all three.
- **#3754** A base URL already ending in `/v1` produced `/v1/v1/embeddings`. `with_base_url` now strips a trailing `/v1` alongside the existing slash trim.
- **#3755** The workspace `AuthFailed` embed hint was OpenAI-specific; it is now provider-aware (NEAR AI session / AWS credentials / OpenAI key) via a `provider_name()` accessor.

#3753 is already fixed on `main`.

## Validation
- `cargo test -p ironclaw_embeddings` incl. `--features bedrock`
- `cargo test -p ironclaw --lib config::embeddings`
- `cargo clippy --tests -- -D warnings` (and `--all-features` on the embeddings crate)
- Regression tests added for each fix.

## Risk
Low. Confined to embeddings config resolution and provider request/validation; no schema or wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
