### PR TITLE
fix(llm): drop temperature for models that reject it (Opus 4.7/4.8, gpt-5.x)

### DIFF
--- a/crates/ironclaw_llm/src/anthropic_oauth.rs
+++ b/crates/ironclaw_llm/src/anthropic_oauth.rs
@@ -290,6 +290,10 @@ impl LlmProvider for AnthropicOAuthProvider {
             .take_model_override()
             .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_completion_params(&mut req);
+        // Opus 4.7/4.8 reject an explicit temperature, and Anthropic also serves
+        // models that accept it, so drop it per resolved model rather than via a
+        // provider-wide flag (#4334).
+        req.temperature = crate::reasoning_models::effective_temperature(&model, req.temperature);
         let (system, messages) = convert_messages(req.messages);
         let max_tokens = req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
 
@@ -333,6 +337,8 @@ impl LlmProvider for AnthropicOAuthProvider {
             .take_model_override()
             .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_tool_params(&mut req);
+        // See `complete`: drop temperature for Opus 4.7/4.8 per resolved model (#4334).
+        req.temperature = crate::reasoning_models::effective_temperature(&model, req.temperature);
         let (system, messages) = convert_messages(req.messages);
 
         let tools: Vec<AnthropicTool> = req

--- a/crates/ironclaw_llm/src/anthropic_oauth.rs
+++ b/crates/ironclaw_llm/src/anthropic_oauth.rs
@@ -891,4 +891,71 @@ mod tests {
         // Subsequent reads see the updated token
         assert_eq!(token.read().unwrap().expose_secret(), "new_token");
     }
+
+    #[tokio::test]
+    async fn complete_omits_temperature_and_keeps_thinking_off_for_opus_47() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0_u8; 8192];
+            let n = socket.read(&mut buf).await.unwrap();
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+            let _ = tx.send(raw.split("\r\n\r\n").nth(1).unwrap_or("").to_string());
+            let resp = serde_json::json!({
+                "content": [{ "type": "text", "text": "ok" }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0
+                }
+            })
+            .to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                resp.len(),
+                resp
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        });
+
+        let mut cfg = crate::config::RegistryProviderConfig::generic(
+            crate::registry::ProviderProtocol::Anthropic,
+            "anthropic_oauth",
+            None,
+            base_url,
+            "claude-opus-4-7",
+        );
+        cfg.oauth_token = Some(SecretString::from("test-token".to_string()));
+        let provider = AnthropicOAuthProvider::new(&cfg).expect("provider");
+
+        // Opus 4.7 rejects an explicit temperature, so the wire body must omit it.
+        // Dropping it must NOT enable adaptive thinking: the caller supplied a
+        // temperature (which disables thinking), and the thinking gate must still
+        // honor that intent (#4334). Opus 4.7 is in the adaptive-thinking set, so a
+        // regression here would surface as a `thinking` block in the body.
+        let req = CompletionRequest::new(vec![ChatMessage::user("hi")])
+            .with_model("claude-opus-4-7")
+            .with_temperature(0.5);
+        let _ = provider.complete(req).await;
+
+        let body = rx.await.expect("captured request body");
+        let json: serde_json::Value =
+            serde_json::from_str(&body).expect("request body should be JSON");
+        assert!(
+            json.get("temperature").is_none(),
+            "Opus 4.7 must omit temperature on the wire; body={body}"
+        );
+        assert!(
+            json.get("thinking").is_none(),
+            "dropping temperature must not enable thinking; body={body}"
+        );
+        let _ = server.await;
+    }
 }

--- a/crates/ironclaw_llm/src/anthropic_oauth.rs
+++ b/crates/ironclaw_llm/src/anthropic_oauth.rs
@@ -290,15 +290,17 @@ impl LlmProvider for AnthropicOAuthProvider {
             .take_model_override()
             .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_completion_params(&mut req);
-        // Opus 4.7/4.8 reject an explicit temperature, and Anthropic also serves
-        // models that accept it, so drop it per resolved model rather than via a
-        // provider-wide flag (#4334).
+        // Opus 4.7/4.8 reject an explicit temperature on the wire (#4334), so drop
+        // it per resolved model. Keep the caller's original value for the thinking
+        // gate: `thinking_for_request` disables thinking when a temperature is set,
+        // and dropping it here must not silently flip thinking back on.
+        let requested_temperature = req.temperature;
         req.temperature = crate::reasoning_models::effective_temperature(&model, req.temperature);
         let (system, messages) = convert_messages(req.messages);
         let max_tokens = req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
 
         let request = AnthropicRequest {
-            thinking: thinking_for_request(&model, max_tokens, req.temperature, false),
+            thinking: thinking_for_request(&model, max_tokens, requested_temperature, false),
             model,
             messages,
             system,
@@ -337,7 +339,9 @@ impl LlmProvider for AnthropicOAuthProvider {
             .take_model_override()
             .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_tool_params(&mut req);
-        // See `complete`: drop temperature for Opus 4.7/4.8 per resolved model (#4334).
+        // See `complete`: drop the wire temperature for Opus 4.7/4.8 but keep the
+        // caller's original value for the thinking gate (#4334).
+        let requested_temperature = req.temperature;
         req.temperature = crate::reasoning_models::effective_temperature(&model, req.temperature);
         let (system, messages) = convert_messages(req.messages);
 
@@ -383,7 +387,7 @@ impl LlmProvider for AnthropicOAuthProvider {
             thinking: if has_tools {
                 None
             } else {
-                thinking_for_request(&model, max_tokens, req.temperature, false)
+                thinking_for_request(&model, max_tokens, requested_temperature, false)
             },
             model,
             messages,

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -519,10 +519,14 @@ impl LlmProvider for NearAiChatProvider {
             raw
         };
 
+        // NEAR AI routes to a mix of models, so temperature support is decided
+        // per-model rather than provider-wide (#4535).
+        let temperature = crate::reasoning_models::effective_temperature(&model, req.temperature);
+
         let request = ChatCompletionRequest {
             model,
             messages,
-            temperature: req.temperature,
+            temperature,
             max_tokens: req.max_tokens,
             stop: req.stop_sequences,
             tools: None,
@@ -595,11 +599,15 @@ impl LlmProvider for NearAiChatProvider {
             messages
         };
 
+        // Model-aware temperature: NEAR AI routes to many models, some of which
+        // reject an explicit temperature (#4535).
+        let temperature = crate::reasoning_models::effective_temperature(&model, req.temperature);
+
         let request = build_chat_completion_request(
             model,
             messages,
             req.tools,
-            req.temperature,
+            temperature,
             req.max_tokens,
             req.stop_sequences,
             req.tool_choice,

--- a/crates/ironclaw_llm/src/nearai_chat.rs
+++ b/crates/ironclaw_llm/src/nearai_chat.rs
@@ -1287,6 +1287,97 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn complete_omits_temperature_for_reasoning_model() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0_u8; 8192];
+            let n = socket.read(&mut buf).await.unwrap();
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+            let _ = tx.send(raw.split("\r\n\r\n").nth(1).unwrap_or("").to_string());
+            let resp = serde_json::json!({
+                "choices": [{ "message": { "content": "ok" }, "finish_reason": "stop" }],
+                "usage": { "prompt_tokens": 0, "completion_tokens": 0 }
+            })
+            .to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                resp.len(),
+                resp
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        });
+
+        let provider = NearAiChatProvider::new(test_nearai_config(&base_url), test_session())
+            .expect("provider");
+        // o3-mini rejects an explicit temperature; the outbound body must omit it
+        // even though the caller supplied one — exercised through the model
+        // resolution path in `complete()`, not just the helper (#4535).
+        let req = CompletionRequest::new(vec![ChatMessage::user("hi")])
+            .with_model("o3-mini")
+            .with_temperature(0.7);
+        let _ = provider.complete(req).await;
+
+        let body = rx.await.expect("captured request body");
+        let json: serde_json::Value =
+            serde_json::from_str(&body).expect("request body should be JSON");
+        assert!(
+            json.get("temperature").is_none(),
+            "reasoning model must omit temperature on the wire; body={body}"
+        );
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_omits_temperature_for_reasoning_model() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0_u8; 8192];
+            let n = socket.read(&mut buf).await.unwrap();
+            let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+            let _ = tx.send(raw.split("\r\n\r\n").nth(1).unwrap_or("").to_string());
+            let resp = serde_json::json!({
+                "choices": [{ "message": { "content": "ok" }, "finish_reason": "stop" }],
+                "usage": { "prompt_tokens": 0, "completion_tokens": 0 }
+            })
+            .to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                resp.len(),
+                resp
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        });
+
+        let provider = NearAiChatProvider::new(test_nearai_config(&base_url), test_session())
+            .expect("provider");
+        let req = ToolCompletionRequest::new(vec![ChatMessage::user("hi")], vec![])
+            .with_model("o3-mini")
+            .with_temperature(0.5);
+        let _ = provider.complete_with_tools(req).await;
+
+        let body = rx.await.expect("captured request body");
+        let json: serde_json::Value =
+            serde_json::from_str(&body).expect("request body should be JSON");
+        assert!(
+            json.get("temperature").is_none(),
+            "reasoning model must omit temperature on the wire; body={body}"
+        );
+        let _ = server.await;
+    }
+
     #[test]
     fn test_api_url_with_base_already_v1() {
         let cfg = test_nearai_config("http://127.0.0.1:8318/v1");

--- a/crates/ironclaw_llm/src/reasoning_models.rs
+++ b/crates/ironclaw_llm/src/reasoning_models.rs
@@ -80,6 +80,50 @@ pub fn supports_openai_reasoning(model: &str) -> bool {
     OPENAI_REASONING_PATTERNS.iter().any(|p| lower.contains(p))
 }
 
+/// Returns `true` when *model* rejects an explicit `temperature` (the caller
+/// must omit it, not just clamp it).
+///
+/// Two families 400 on a non-default temperature: OpenAI's reasoning models
+/// (`o1`/`o3`/`o4`, `gpt-5`) and Anthropic's Claude Opus 4.7/4.8 (temperature is
+/// deprecated there). `gpt-4.1` is deliberately excluded — it accepts temperature
+/// even though it supports the reasoning field.
+///
+/// This is model-aware rather than a provider-level `unsupported_params` flag
+/// because multi-model gateways (NEAR AI, OpenRouter, Bedrock) route to a mix of
+/// models where most still honor temperature (#4334, #4535).
+///
+/// The short o-series names are anchored at the start of the final path segment,
+/// so a gateway prefix like `openai/o3-mini` still matches but an unrelated
+/// `vendor/sora4` does not; the longer names are specific enough to match
+/// anywhere in the segment.
+pub fn model_rejects_temperature(model: &str) -> bool {
+    let name = model
+        .rsplit('/')
+        .next()
+        .unwrap_or(model)
+        .to_ascii_lowercase();
+    const O_SERIES: &[&str] = &["o1", "o3", "o4"];
+    if O_SERIES.iter().any(|p| {
+        name.strip_prefix(p)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('-'))
+    }) {
+        return true;
+    }
+    const SPECIFIC: &[&str] = &["gpt-5", "claude-opus-4-7", "claude-opus-4-8"];
+    SPECIFIC.iter().any(|p| name.contains(p))
+}
+
+/// The temperature to actually send for `model`: the requested value, or `None`
+/// when the model rejects an explicit temperature (#4334, #4535). Convenience
+/// over [`model_rejects_temperature`] for callers that build a request directly.
+pub fn effective_temperature(model: &str, requested: Option<f32>) -> Option<f32> {
+    if model_rejects_temperature(model) {
+        None
+    } else {
+        requested
+    }
+}
+
 /// Anthropic models that use the `adaptive` thinking mode (4.6+/4.7+).
 ///
 /// These models accept `{type: "adaptive"}` and do not require a
@@ -226,5 +270,63 @@ mod tests {
         assert!(!has_native_thinking("glm-4-air"));
         assert!(!has_native_thinking("glm-4v"));
         assert!(!has_native_thinking("step-3-mini"));
+    }
+
+    // ── model_rejects_temperature tests ──
+
+    #[test]
+    fn temperature_rejected_for_reasoning_and_opus_47_48() {
+        for m in [
+            "o1",
+            "o1-mini",
+            "o3",
+            "o3-mini",
+            "o4-mini",
+            "gpt-5",
+            "gpt-5.5",
+            "openai/gpt-5.5",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "anthropic.claude-opus-4-8-v1:0",
+        ] {
+            assert!(
+                model_rejects_temperature(m),
+                "{m} should reject an explicit temperature"
+            );
+        }
+    }
+
+    #[test]
+    fn temperature_allowed_for_other_models() {
+        for m in [
+            "gpt-4o",
+            "gpt-4.1",
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
+            "deepseek-ai/DeepSeek-V4-Flash",
+            "llama-3.3-70b",
+            "qwen3-30b",
+            "",
+            // Anti-false-positive: "o3"/"o4" appear mid-segment but must not
+            // match the anchored o-series patterns.
+            "vendor/sora4",
+            "audio3-preview",
+        ] {
+            assert!(
+                !model_rejects_temperature(m),
+                "{m} should keep an explicit temperature"
+            );
+        }
+    }
+
+    #[test]
+    fn effective_temperature_drops_only_for_rejecting_models() {
+        assert_eq!(effective_temperature("openai/gpt-5.5", Some(0.7)), None);
+        assert_eq!(effective_temperature("claude-opus-4-8", Some(0.2)), None);
+        assert_eq!(
+            effective_temperature("claude-sonnet-4-6", Some(0.2)),
+            Some(0.2)
+        );
+        assert_eq!(effective_temperature("gpt-4o", None), None);
     }
 }

--- a/crates/ironclaw_llm/src/reasoning_models.rs
+++ b/crates/ironclaw_llm/src/reasoning_models.rs
@@ -97,9 +97,12 @@ pub fn supports_openai_reasoning(model: &str) -> bool {
 /// `vendor/sora4` does not; the longer names are specific enough to match
 /// anywhere in the segment.
 pub fn model_rejects_temperature(model: &str) -> bool {
+    // Take the last *non-empty* path segment so a gateway prefix
+    // (`openai/o3-mini`) matches and a trailing slash (`openai/o1/`) doesn't
+    // collapse to an empty name that slips past the classifier.
     let name = model
-        .rsplit('/')
-        .next()
+        .split('/')
+        .rfind(|s| !s.is_empty())
         .unwrap_or(model)
         .to_ascii_lowercase();
     const O_SERIES: &[&str] = &["o1", "o3", "o4"];
@@ -288,6 +291,9 @@ mod tests {
             "claude-opus-4-7",
             "claude-opus-4-8",
             "anthropic.claude-opus-4-8-v1:0",
+            // A trailing slash must not collapse the final segment to empty.
+            "openai/o1/",
+            "claude-opus-4-8/",
         ] {
             assert!(
                 model_rejects_temperature(m),

--- a/crates/ironclaw_llm/src/reasoning_models.rs
+++ b/crates/ironclaw_llm/src/reasoning_models.rs
@@ -68,43 +68,27 @@ pub fn has_native_thinking(model: &str) -> bool {
     NATIVE_THINKING_PATTERNS.iter().any(|p| lower.contains(p))
 }
 
-/// Models that are known to support OpenAI's Responses API `reasoning` field.
+/// The final non-empty path segment of *model*, lowercased.
 ///
-/// Sending the `reasoning` object to unsupported models (e.g. `gpt-4o`) causes
-/// the API to reject the request instead of ignoring the parameter.
-const OPENAI_REASONING_PATTERNS: &[&str] = &["o1", "o3", "o4", "/reasoning/", "gpt-5", "gpt-4.1"];
-
-/// Returns `true` when *model* is known to support the Responses API `reasoning` field.
-pub fn supports_openai_reasoning(model: &str) -> bool {
-    let lower = model.to_ascii_lowercase();
-    OPENAI_REASONING_PATTERNS.iter().any(|p| lower.contains(p))
-}
-
-/// Returns `true` when *model* rejects an explicit `temperature` (the caller
-/// must omit it, not just clamp it).
-///
-/// Two families 400 on a non-default temperature: OpenAI's reasoning models
-/// (`o1`/`o3`/`o4`, `gpt-5`) and Anthropic's Claude Opus 4.7/4.8 (temperature is
-/// deprecated there). `gpt-4.1` is deliberately excluded — it accepts temperature
-/// even though it supports the reasoning field.
-///
-/// This is model-aware rather than a provider-level `unsupported_params` flag
-/// because multi-model gateways (NEAR AI, OpenRouter, Bedrock) route to a mix of
-/// models where most still honor temperature (#4334, #4535).
-///
-/// The short o-series names are anchored at the start of the final path segment,
-/// so a gateway prefix like `openai/o3-mini` still matches but an unrelated
-/// `vendor/sora4` does not; the longer names are specific enough to match
-/// anywhere in the segment.
-pub fn model_rejects_temperature(model: &str) -> bool {
-    // Take the last *non-empty* path segment so a gateway prefix
-    // (`openai/o3-mini`) matches and a trailing slash (`openai/o1/`) doesn't
-    // collapse to an empty name that slips past the classifier.
-    let name = model
+/// Gateways prefix the provider (`openai/o3-mini`); the trailing-slash guard
+/// keeps `openai/o1/` from collapsing to an empty string.
+fn model_leaf(model: &str) -> String {
+    model
         .split('/')
         .rfind(|s| !s.is_empty())
         .unwrap_or(model)
-        .to_ascii_lowercase();
+        .to_ascii_lowercase()
+}
+
+/// OpenAI models that both support the Responses `reasoning` field and reject an
+/// explicit `temperature`: the o-series (`o1`/`o3`/`o4`) and the `gpt-5` family.
+///
+/// The short o-series names are anchored at the start of the leaf segment, so a
+/// gateway prefix like `openai/o3-mini` matches but an unrelated `vendor/sora4`
+/// does not. Shared by [`supports_openai_reasoning`] and
+/// [`model_rejects_temperature`] so the two classifiers can't drift apart.
+pub fn is_openai_o_series_or_gpt5(model: &str) -> bool {
+    let name = model_leaf(model);
     const O_SERIES: &[&str] = &["o1", "o3", "o4"];
     if O_SERIES.iter().any(|p| {
         name.strip_prefix(p)
@@ -112,8 +96,35 @@ pub fn model_rejects_temperature(model: &str) -> bool {
     }) {
         return true;
     }
-    const SPECIFIC: &[&str] = &["gpt-5", "claude-opus-4-7", "claude-opus-4-8"];
-    SPECIFIC.iter().any(|p| name.contains(p))
+    name.contains("gpt-5")
+}
+
+/// Returns `true` when *model* is known to support the Responses API `reasoning`
+/// field.
+///
+/// Sending the `reasoning` object to unsupported models (e.g. `gpt-4o`) causes
+/// the API to reject the request instead of ignoring the parameter. `gpt-4.1`
+/// supports the field but — unlike the o-series/`gpt-5` — accepts temperature, so
+/// it lives here and not in [`model_rejects_temperature`].
+pub fn supports_openai_reasoning(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    is_openai_o_series_or_gpt5(model) || lower.contains("gpt-4.1") || lower.contains("/reasoning/")
+}
+
+/// Returns `true` when *model* rejects an explicit `temperature` (the caller must
+/// omit it, not just clamp it).
+///
+/// Two families 400 on a non-default temperature: OpenAI's reasoning models
+/// (o-series, `gpt-5`) and Anthropic's Claude Opus 4.7/4.8 (temperature is
+/// deprecated there). Model-aware rather than a provider-level `unsupported_params`
+/// flag because multi-model gateways (NEAR AI, OpenRouter, Bedrock) route to a mix
+/// where most models still honor temperature (#4334, #4535).
+pub fn model_rejects_temperature(model: &str) -> bool {
+    if is_openai_o_series_or_gpt5(model) {
+        return true;
+    }
+    let name = model_leaf(model);
+    name.contains("claude-opus-4-7") || name.contains("claude-opus-4-8")
 }
 
 /// The temperature to actually send for `model`: the requested value, or `None`
@@ -334,5 +345,25 @@ mod tests {
             Some(0.2)
         );
         assert_eq!(effective_temperature("gpt-4o", None), None);
+    }
+
+    #[test]
+    fn supports_openai_reasoning_covers_o_series_gpt5_and_gpt41() {
+        for m in [
+            "o1",
+            "o3-mini",
+            "openai/o4-mini",
+            "gpt-5",
+            "openai/gpt-5.5",
+            "gpt-4.1",
+        ] {
+            assert!(
+                supports_openai_reasoning(m),
+                "{m} should support the reasoning field"
+            );
+        }
+        for m in ["gpt-4o", "claude-opus-4-8", "vendor/sora4", "llama-3.3-70b"] {
+            assert!(!supports_openai_reasoning(m), "{m} should not");
+        }
     }
 }


### PR DESCRIPTION
## Summary
OpenAI's reasoning models (o1/o3/o4, gpt-5.x) and Claude Opus 4.7/4.8 reject an explicit `temperature` and return 400. `providers.json` only carries provider-level `unsupported_params`, which can't express this on providers that serve a mix of models where most still honor temperature (Anthropic, NEAR AI).

Adds a model-aware `model_rejects_temperature` classifier — anchored on the final path segment so gateway-prefixed names like `openai/gpt-5.5` match while unrelated substrings (e.g. `vendor/sora4`) don't — and an `effective_temperature` helper. Temperature is dropped for the resolved model where the two affected providers build their requests: the Anthropic provider (#4334) and the NEAR AI chat provider (#4535). The effective model (per-request override or configured default) is only known inside each provider, so the drop lives at the build site rather than the shared param-strip helpers.

## Validation
- `cargo test -p ironclaw_llm` (reasoning_models, provider, anthropic, nearai — no regressions)
- `cargo clippy -p ironclaw_llm --tests -- -D warnings`
- Classifier tests incl. gateway-prefix and false-positive guards.

## Risk
Low–medium (`scope: llm`). Request-construction change that drops a parameter the listed models already reject. Other providers can adopt `effective_temperature` as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
