### PR TITLE
[codex] Handle Reborn Railway start command placeholders

### DIFF
--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -34,29 +34,33 @@ if [ ! -f "$config_path" ]; then
   trap - EXIT HUP INT TERM
 fi
 
+host="${IRONCLAW_REBORN_SERVE_HOST:-127.0.0.1}"
+port="${PORT:-${IRONCLAW_REBORN_SERVE_PORT:-3000}}"
+
+resolve_env_placeholder_arg() {
+  case "$1" in
+    '$IRONCLAW_REBORN_SERVE_HOST'|'${IRONCLAW_REBORN_SERVE_HOST}')
+      printf '%s\n' "$host"
+      ;;
+    '$PORT'|'${PORT}'|'$IRONCLAW_REBORN_SERVE_PORT'|'${IRONCLAW_REBORN_SERVE_PORT}')
+      printf '%s\n' "$port"
+      ;;
+    *)
+      printf '%s\n' "$1"
+      ;;
+  esac
+}
+
 if [ "$#" -gt 0 ]; then
-  host="${IRONCLAW_REBORN_SERVE_HOST:-127.0.0.1}"
-  port="${PORT:-${IRONCLAW_REBORN_SERVE_PORT:-3000}}"
   original_arg_count="$#"
   while [ "$original_arg_count" -gt 0 ]; do
-    arg="$1"
+    arg="$(resolve_env_placeholder_arg "$1")"
     shift
     original_arg_count=$((original_arg_count - 1))
-    case "$arg" in
-      '$IRONCLAW_REBORN_SERVE_HOST'|'${IRONCLAW_REBORN_SERVE_HOST}')
-        arg="$host"
-        ;;
-      '$PORT'|'${PORT}'|'$IRONCLAW_REBORN_SERVE_PORT'|'${IRONCLAW_REBORN_SERVE_PORT}')
-        arg="$port"
-        ;;
-    esac
     set -- "$@" "$arg"
   done
   exec ironclaw-reborn "$@"
 fi
-
-host="${IRONCLAW_REBORN_SERVE_HOST:-127.0.0.1}"
-port="${PORT:-${IRONCLAW_REBORN_SERVE_PORT:-3000}}"
 
 set -- serve --host "$host" --port "$port"
 

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -35,6 +35,23 @@ if [ ! -f "$config_path" ]; then
 fi
 
 if [ "$#" -gt 0 ]; then
+  host="${IRONCLAW_REBORN_SERVE_HOST:-127.0.0.1}"
+  port="${PORT:-${IRONCLAW_REBORN_SERVE_PORT:-3000}}"
+  original_arg_count="$#"
+  while [ "$original_arg_count" -gt 0 ]; do
+    arg="$1"
+    shift
+    original_arg_count=$((original_arg_count - 1))
+    case "$arg" in
+      '$IRONCLAW_REBORN_SERVE_HOST'|'${IRONCLAW_REBORN_SERVE_HOST}')
+        arg="$host"
+        ;;
+      '$PORT'|'${PORT}'|'$IRONCLAW_REBORN_SERVE_PORT'|'${IRONCLAW_REBORN_SERVE_PORT}')
+        arg="$port"
+        ;;
+    esac
+    set -- "$@" "$arg"
+  done
   exec ironclaw-reborn "$@"
 fi
 

--- a/docs/reborn/deploy-reborn-cli-docker.md
+++ b/docs/reborn/deploy-reborn-cli-docker.md
@@ -78,6 +78,11 @@ Set the service Dockerfile path to `Dockerfile.reborn`. Railway sets `PORT`;
 keep `IRONCLAW_REBORN_SERVE_HOST=0.0.0.0`. The Reborn WebUI service serves
 `/api/health` for Railway's healthcheck.
 
+Leave Railway's Start Command empty for the Docker image. The image entrypoint
+builds the `ironclaw-reborn serve` arguments from `PORT` and
+`IRONCLAW_REBORN_SERVE_HOST`; Railway does not shell-expand `$VAR` placeholders
+in Docker command arguments before they reach the entrypoint.
+
 Minimum Railway variables:
 
 ```bash

--- a/tests/dockerfile_runtime_home.rs
+++ b/tests/dockerfile_runtime_home.rs
@@ -218,6 +218,40 @@ fn reborn_entrypoint_passes_explicit_args_through() {
 
 #[test]
 #[cfg(unix)]
+fn reborn_entrypoint_resolves_known_env_placeholders_in_explicit_args() {
+    let fake = setup_fake_entrypoint();
+    let output = Command::new("sh")
+        .arg(repo_file("docker/reborn/entrypoint.sh"))
+        .args([
+            "serve",
+            "--host",
+            "$IRONCLAW_REBORN_SERVE_HOST",
+            "--port",
+            "$PORT",
+        ])
+        .env_clear()
+        .env("PATH", fake.path_env())
+        .env("IRONCLAW_REBORN_HOME", &fake.home_dir)
+        .env("IRONCLAW_REBORN_DEFAULT_CONFIG", &fake.default_config)
+        .env("IRONCLAW_REBORN_SERVE_HOST", "0.0.0.0")
+        .env("PORT", "4321")
+        .env("IRONCLAW_REBORN_TEST_ARGS_FILE", &fake.args_file)
+        .output()
+        .expect("entrypoint should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&fake.args_file).expect("captured args"),
+        "serve\n--host\n0.0.0.0\n--port\n4321\n"
+    );
+}
+
+#[test]
+#[cfg(unix)]
 fn reborn_entrypoint_preserves_existing_config() {
     let fake = setup_fake_entrypoint();
     std::fs::create_dir_all(&fake.home_dir).expect("home dir");


### PR DESCRIPTION
## Summary

Fixes the Railway runtime startup failure:

```text
error: invalid value '$IRONCLAW_REBORN_SERVE_HOST' for '--host <HOST>': invalid IP address syntax
```

This happens when Railway supplies a Docker start command containing literal `$VAR` placeholders. Docker passes those command arguments to the image entrypoint without shell expansion, and the entrypoint's explicit-args path previously forwarded them directly to `ironclaw-reborn`.

## Changes

- Resolve known serve host/port placeholders in `docker/reborn/entrypoint.sh` when explicit Docker command args contain:
  - `$IRONCLAW_REBORN_SERVE_HOST`
  - `${IRONCLAW_REBORN_SERVE_HOST}`
  - `$PORT`
  - `${PORT}`
  - `$IRONCLAW_REBORN_SERVE_PORT`
  - `${IRONCLAW_REBORN_SERVE_PORT}`
- Keep host/port resolution single-sourced inside the entrypoint and isolate placeholder mapping in a small helper.
- Add a regression test that reproduces explicit args containing `$IRONCLAW_REBORN_SERVE_HOST` and `$PORT`.
- Document that Railway's Start Command should be left empty for this Docker image because the entrypoint builds serve args from env.

## Validation

- `cargo test --test dockerfile_runtime_home`
- `cargo test --test dockerfile_runtime_home reborn_entrypoint_resolves_known_env_placeholders_in_explicit_args`
- `sh -n docker/reborn/entrypoint.sh`
- `git diff --check`
- `git diff --check origin/main...HEAD`

Full local Docker build was not run because the Docker daemon is unavailable in this environment.

## Thermo Loop

- Ran max-5 thermo loop against this PR branch.
- Fixed one maintainability issue: removed duplicated host/port computation from the entrypoint explicit/default paths and isolated placeholder mapping.
- Second review pass found no further actionable thermo-level issues.