### PR TITLE
feat(threads): carry attachment refs through the Reborn transcript contract (#4644)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5360,6 +5360,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "ironclaw_common",
  "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_safety",

--- a/crates/ironclaw_common/src/attachment.rs
+++ b/crates/ironclaw_common/src/attachment.rs
@@ -24,7 +24,12 @@ pub fn normalize_mime_type(mime: &str) -> String {
 }
 
 /// Kind of attachment carried on an incoming message.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serializes as a wire-stable snake_case string (`"audio"`, `"image"`,
+/// `"document"`) so it can be persisted in transcript attachment references
+/// and other durable contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AttachmentKind {
     /// Audio content (voice notes, audio files).
     Audio,

--- a/crates/ironclaw_common/src/attachment_format.rs
+++ b/crates/ironclaw_common/src/attachment_format.rs
@@ -459,7 +459,7 @@ pub fn canonical_extension(mime: &str) -> Option<&'static str> {
 /// [`AttachmentKind::Image`]).
 pub fn kind_for_mime(mime: &str) -> AttachmentKind {
     lookup(mime)
-        .map(|format| format.kind.clone())
+        .map(|format| format.kind)
         .unwrap_or_else(|| AttachmentKind::from_mime_type(mime))
 }
 

--- a/crates/ironclaw_loop_support/src/compaction_task.rs
+++ b/crates/ironclaw_loop_support/src/compaction_task.rs
@@ -751,6 +751,7 @@ mod tests {
             tool_result_ref: None,
             tool_result_provider_call: None,
             content: content.map(ToString::to_string),
+            attachments: Vec::new(),
             redaction_ref: None,
         }
     }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -3669,6 +3669,12 @@ fn map_thread_error(error: SessionThreadError) -> RebornServicesError {
         | SessionThreadError::OverlappingSummaryRange { .. } => {
             RebornServicesError::from_status(RebornServicesErrorCode::Conflict, 409, false)
         }
+        SessionThreadError::InvalidAttachment(_) => RebornServicesError::from_status_kind(
+            RebornServicesErrorCode::InvalidRequest,
+            RebornServicesErrorKind::Validation,
+            400,
+            false,
+        ),
         SessionThreadError::GeneratedThreadId(_)
         | SessionThreadError::Serialization(_)
         | SessionThreadError::Deserialization(_)

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -159,6 +159,7 @@ fn fake_thread_history(owner: &WebUiAuthenticatedCaller, thread_id: &str) -> Thr
             tool_result_ref: None,
             tool_result_provider_call: None,
             content: Some("timeline from fake M2 port".to_string()),
+            attachments: Vec::new(),
             redaction_ref: None,
         }],
         summary_artifacts: vec![],

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -835,6 +835,7 @@ async fn thread_checkpoint_evidence_rejects_wrong_run_and_malformed_result_ref_r
             tool_result_ref: Some(malformed_result.as_str().to_string()),
             tool_result_provider_call: None,
             content: Some("not-json".to_string()),
+            attachments: Vec::new(),
             redaction_ref: None,
         });
         history.messages.push(ThreadMessageRecord {
@@ -854,6 +855,7 @@ async fn thread_checkpoint_evidence_rejects_wrong_run_and_malformed_result_ref_r
                 r#"{{"version":1,"result_ref":"{}","safe_summary":"raw tool input includes secret"}}"#,
                 unsafe_summary_result.as_str()
             )),
+            attachments: Vec::new(),
             redaction_ref: None,
         });
         history

--- a/crates/ironclaw_threads/Cargo.toml
+++ b/crates/ironclaw_threads/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
+ironclaw_common = { path = "../ironclaw_common", version = "0.4.2" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_safety = { path = "../ironclaw_safety", version = "0.2.2" }

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -1,3 +1,4 @@
+use ironclaw_common::AttachmentKind;
 use ironclaw_host_api::{AgentId, MissionId, ProjectId, TenantId, ThreadId, UserId};
 use serde::{Deserialize, Serialize};
 
@@ -42,27 +43,86 @@ impl ThreadScope {
     }
 }
 
-/// Safe transcript text accepted by this boundary.
+/// A reference to a single attachment carried alongside a transcript message.
+///
+/// This is a *reference*, never the bytes. Per the crate guardrails the
+/// transcript must not hold raw runtime payloads, host paths, or secrets, so an
+/// `AttachmentRef` carries only metadata plus an opaque `storage_key` (a
+/// rendered scoped path into host-side storage, not a raw host path) and the
+/// extracted/transcribed text once an extractor has run. The bytes live behind
+/// the filesystem authority that owns `storage_key`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttachmentRef {
+    /// Stable identifier for this attachment within its message.
+    pub id: String,
+    /// Image / Audio / Document.
+    pub kind: AttachmentKind,
+    /// MIME type as received at the ingress boundary. Validated upstream
+    /// against the attachment format registry; stored verbatim here.
+    pub mime_type: String,
+    /// Original filename, when the source provided one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// File size in bytes, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    /// Opaque storage reference for the bytes (a rendered scoped path into
+    /// host-side storage, never a raw host path). `None` until the attachment
+    /// has been landed in storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_key: Option<String>,
+    /// Extracted document text or audio transcript, once an extractor has run.
+    /// Sanitized external data; never raw bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extracted_text: Option<String>,
+}
+
+/// Safe transcript content accepted by this boundary.
 ///
 /// Model visibility is determined by message kind/status at context-read time;
 /// durable UI-only records such as capability previews also store their
-/// sanitized payloads here.
+/// sanitized payloads here. Attachments are carried as references only (see
+/// [`AttachmentRef`]) — never raw bytes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MessageContent {
     text: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<AttachmentRef>,
 }
 
 impl MessageContent {
     pub fn text(value: impl Into<String>) -> Self {
-        Self { text: value.into() }
+        Self {
+            text: value.into(),
+            attachments: Vec::new(),
+        }
+    }
+
+    /// Build content carrying both text and attachment references.
+    pub fn with_attachments(value: impl Into<String>, attachments: Vec<AttachmentRef>) -> Self {
+        Self {
+            text: value.into(),
+            attachments,
+        }
     }
 
     pub fn as_text(&self) -> &str {
         &self.text
     }
 
+    pub fn attachments(&self) -> &[AttachmentRef] {
+        &self.attachments
+    }
+
     pub fn into_text(self) -> String {
         self.text
+    }
+
+    /// Consume the content into its text body and attachment references. Use
+    /// this when persisting both parts so neither is dropped (`into_text`
+    /// alone discards attachments).
+    pub fn into_parts(self) -> (String, Vec<AttachmentRef>) {
+        (self.text, self.attachments)
     }
 }
 
@@ -126,6 +186,10 @@ pub struct ThreadMessageRecord {
     #[serde(default, skip_serializing)]
     pub tool_result_provider_call: Option<ProviderToolCallReferenceEnvelope>,
     pub content: Option<String>,
+    /// Attachment references for this message. Empty for messages that carry
+    /// no attachments. Cleared on redaction in parity with `content`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<AttachmentRef>,
     pub redaction_ref: Option<String>,
 }
 
@@ -418,4 +482,113 @@ pub struct CreateSummaryArtifactRequest {
 pub struct UpdateThreadGoalRequest {
     pub thread_id: ThreadId,
     pub goal: ThreadGoal,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_ref() -> AttachmentRef {
+        AttachmentRef {
+            id: "att-1".to_string(),
+            kind: AttachmentKind::Document,
+            mime_type: "application/pdf".to_string(),
+            filename: Some("report.pdf".to_string()),
+            size_bytes: Some(2048),
+            storage_key: Some("attachments/2026-06-09/m1-report.pdf".to_string()),
+            extracted_text: Some("quarterly numbers".to_string()),
+        }
+    }
+
+    #[test]
+    fn text_constructor_carries_no_attachments() {
+        let content = MessageContent::text("hello");
+        assert_eq!(content.as_text(), "hello");
+        assert!(content.attachments().is_empty());
+    }
+
+    #[test]
+    fn into_parts_preserves_text_and_attachments() {
+        let content = MessageContent::with_attachments("see attached", vec![sample_ref()]);
+        assert_eq!(content.attachments().len(), 1);
+        let (text, attachments) = content.into_parts();
+        assert_eq!(text, "see attached");
+        assert_eq!(attachments, vec![sample_ref()]);
+    }
+
+    #[test]
+    fn into_text_discards_attachments() {
+        // `into_text` is the text-only accessor; callers that must keep
+        // attachments use `into_parts`. This documents the lossy path.
+        let content = MessageContent::with_attachments("body", vec![sample_ref()]);
+        assert_eq!(content.into_text(), "body");
+    }
+
+    #[test]
+    fn message_content_skips_empty_attachments_on_the_wire() {
+        let json = serde_json::to_string(&MessageContent::text("hi")).unwrap();
+        assert_eq!(json, r#"{"text":"hi"}"#);
+    }
+
+    #[test]
+    fn attachment_kind_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&AttachmentKind::Image).unwrap(),
+            r#""image""#
+        );
+        assert_eq!(
+            serde_json::from_str::<AttachmentKind>(r#""document""#).unwrap(),
+            AttachmentKind::Document
+        );
+    }
+
+    #[test]
+    fn attachment_ref_round_trips_and_omits_empty_optionals() {
+        let minimal = AttachmentRef {
+            id: "att-2".to_string(),
+            kind: AttachmentKind::Image,
+            mime_type: "image/png".to_string(),
+            filename: None,
+            size_bytes: None,
+            storage_key: None,
+            extracted_text: None,
+        };
+        let json = serde_json::to_string(&minimal).unwrap();
+        assert_eq!(
+            json,
+            r#"{"id":"att-2","kind":"image","mime_type":"image/png"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<AttachmentRef>(&json).unwrap(),
+            minimal
+        );
+
+        let full = sample_ref();
+        let round =
+            serde_json::from_str::<AttachmentRef>(&serde_json::to_string(&full).unwrap()).unwrap();
+        assert_eq!(round, full);
+    }
+
+    #[test]
+    fn thread_message_record_attachments_default_when_absent() {
+        // Old persisted rows have no `attachments` field; it must default to
+        // empty rather than failing deserialization.
+        let json = r#"{
+            "message_id": "00000000-0000-0000-0000-000000000001",
+            "thread_id": "thread-x",
+            "sequence": 1,
+            "kind": "user",
+            "status": "accepted",
+            "actor_id": null,
+            "source_binding_id": null,
+            "reply_target_binding_id": null,
+            "turn_id": null,
+            "turn_run_id": null,
+            "content": "legacy row",
+            "redaction_ref": null
+        }"#;
+        let record: ThreadMessageRecord = serde_json::from_str(json).unwrap();
+        assert!(record.attachments.is_empty());
+        assert_eq!(record.content.as_deref(), Some("legacy row"));
+    }
 }

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -114,7 +114,17 @@ impl MessageContent {
         &self.attachments
     }
 
+    /// Consume the content into its text body, **discarding any attachment
+    /// references**. Only correct for content known to be attachment-free
+    /// (assistant drafts, tool results); use [`Self::into_parts`] whenever
+    /// attachments must survive. The debug assertion turns a silent drop into a
+    /// loud failure in debug/test builds.
     pub fn into_text(self) -> String {
+        debug_assert!(
+            self.attachments.is_empty(),
+            "into_text() dropped {} attachment ref(s); use into_parts() to keep them",
+            self.attachments.len()
+        );
         self.text
     }
 
@@ -517,11 +527,20 @@ mod tests {
     }
 
     #[test]
-    fn into_text_discards_attachments() {
-        // `into_text` is the text-only accessor; callers that must keep
-        // attachments use `into_parts`. This documents the lossy path.
-        let content = MessageContent::with_attachments("body", vec![sample_ref()]);
+    fn into_text_keeps_text_when_attachment_free() {
+        // The non-lossy use: `into_text` is the text-only accessor for content
+        // known to carry no attachments (assistant drafts, tool results).
+        let content = MessageContent::text("body");
         assert_eq!(content.into_text(), "body");
+    }
+
+    #[test]
+    #[should_panic(expected = "dropped 1 attachment ref")]
+    fn into_text_debug_asserts_when_it_would_drop_attachments() {
+        // Callers that must keep attachments use `into_parts`; `into_text` on
+        // attachment-bearing content is a bug and fails loudly in debug/tests.
+        let content = MessageContent::with_attachments("body", vec![sample_ref()]);
+        let _ = content.into_text();
     }
 
     #[test]

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -136,6 +136,44 @@ impl MessageContent {
     }
 }
 
+/// Upper bound on a single attachment's `extracted_text` accepted at the
+/// transcript boundary.
+///
+/// Extraction caps text upstream (~100K chars); this is a generous defensive
+/// ceiling so a misbehaving producer cannot persist an unbounded blob that is
+/// then pulled inline on every message load. The contract rejects loudly at
+/// this layer rather than silently truncating.
+pub(crate) const MAX_EXTRACTED_TEXT_CHARS: usize = 200_000;
+
+/// Validate the attachment references on an inbound message before they are
+/// persisted. Enforces the invariants the doc comments promise but the plain
+/// `String`/`Vec` shapes cannot: ids are unique within the message (so
+/// per-attachment lookup/update/delete is unambiguous) and `extracted_text` is
+/// bounded ([`MAX_EXTRACTED_TEXT_CHARS`]).
+pub(crate) fn validate_attachment_refs(
+    attachments: &[AttachmentRef],
+) -> Result<(), crate::error::SessionThreadError> {
+    let mut seen = std::collections::HashSet::with_capacity(attachments.len());
+    for attachment in attachments {
+        if !seen.insert(attachment.id.as_str()) {
+            return Err(crate::error::SessionThreadError::InvalidAttachment(
+                format!("duplicate attachment id {:?} in one message", attachment.id),
+            ));
+        }
+        if let Some(text) = &attachment.extracted_text
+            && text.chars().count() > MAX_EXTRACTED_TEXT_CHARS
+        {
+            return Err(crate::error::SessionThreadError::InvalidAttachment(
+                format!(
+                    "attachment {:?} extracted_text exceeds {MAX_EXTRACTED_TEXT_CHARS} chars",
+                    attachment.id
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Canonical kind of a transcript message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -524,6 +562,42 @@ mod tests {
         let (text, attachments) = content.into_parts();
         assert_eq!(text, "see attached");
         assert_eq!(attachments, vec![sample_ref()]);
+    }
+
+    #[test]
+    fn validate_attachment_refs_accepts_distinct_ids() {
+        let mut second = sample_ref();
+        second.id = "att-2".to_string();
+        assert!(validate_attachment_refs(&[sample_ref(), second]).is_ok());
+    }
+
+    #[test]
+    fn validate_attachment_refs_rejects_duplicate_ids() {
+        let err = validate_attachment_refs(&[sample_ref(), sample_ref()])
+            .expect_err("duplicate attachment ids must be rejected");
+        assert!(matches!(
+            err,
+            crate::error::SessionThreadError::InvalidAttachment(_)
+        ));
+    }
+
+    #[test]
+    fn validate_attachment_refs_rejects_oversized_extracted_text() {
+        let mut oversized = sample_ref();
+        oversized.extracted_text = Some("x".repeat(MAX_EXTRACTED_TEXT_CHARS + 1));
+        let err = validate_attachment_refs(&[oversized])
+            .expect_err("extracted_text past the cap must be rejected");
+        assert!(matches!(
+            err,
+            crate::error::SessionThreadError::InvalidAttachment(_)
+        ));
+    }
+
+    #[test]
+    fn validate_attachment_refs_accepts_extracted_text_at_cap() {
+        let mut at_cap = sample_ref();
+        at_cap.extracted_text = Some("x".repeat(MAX_EXTRACTED_TEXT_CHARS));
+        assert!(validate_attachment_refs(&[at_cap]).is_ok());
     }
 
     #[test]

--- a/crates/ironclaw_threads/src/error.rs
+++ b/crates/ironclaw_threads/src/error.rs
@@ -46,6 +46,8 @@ pub enum SessionThreadError {
         start_sequence: u64,
         end_sequence: u64,
     },
+    #[error("invalid attachment on inbound message: {0}")]
+    InvalidAttachment(String),
     #[error("failed to create generated thread id: {0}")]
     GeneratedThreadId(String),
     #[error("serialization error: {0}")]

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -753,6 +753,7 @@ where
         // rather than deep-cloned on this per-message hot path.
         let idempotency_key = InboundIdempotencyKey::from_request(&request);
         let (content_text, attachments) = request.content.into_parts();
+        crate::contract::validate_attachment_refs(&attachments)?;
         let message = ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),
@@ -1200,6 +1201,9 @@ where
             |message| {
                 ensure_draft(message)?;
                 message.content = Some(request.content.clone().into_text());
+                // Keep content and attachments in lockstep (as redaction does):
+                // a content update must not leave stale attachment refs behind.
+                message.attachments = Vec::new();
                 Ok(())
             },
         )
@@ -1222,6 +1226,7 @@ where
             ensure_draft(message)?;
             message.status = MessageStatus::Finalized;
             message.content = Some(content.clone().into_text());
+            message.attachments = Vec::new();
             Ok(())
         })
         .await

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -748,6 +748,7 @@ where
             .reserve_sequence(&request.scope, &request.thread_id)
             .await?;
         let message_id = ThreadMessageId::new();
+        let (content_text, attachments) = request.content.clone().into_parts();
         let message = ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),
@@ -761,7 +762,8 @@ where
             turn_run_id: None,
             tool_result_ref: None,
             tool_result_provider_call: None,
-            content: Some(request.content.clone().into_text()),
+            content: Some(content_text),
+            attachments,
             redaction_ref: None,
         };
         self.write_new_message(&request.scope, &request.thread_id, &message, "message")
@@ -923,6 +925,7 @@ where
             tool_result_ref: None,
             tool_result_provider_call: None,
             content: Some(request.content.into_text()),
+            attachments: Vec::new(),
             redaction_ref: None,
         };
         self.write_new_message(
@@ -1032,6 +1035,7 @@ where
             tool_result_ref: Some(envelope.result_ref),
             tool_result_provider_call: provider_call,
             content: Some(content),
+            attachments: Vec::new(),
             redaction_ref: None,
         };
         self.write_new_message(
@@ -1088,6 +1092,7 @@ where
             tool_result_ref: request.preview.result_ref.clone(),
             tool_result_provider_call: None,
             content: Some(content),
+            attachments: Vec::new(),
             redaction_ref: None,
         };
         let path = message_record_path(&request.scope, &request.thread_id, message.message_id)?;
@@ -1234,6 +1239,7 @@ where
             |message| {
                 message.status = MessageStatus::Redacted;
                 message.content = None;
+                message.attachments = Vec::new();
                 message.tool_result_provider_call = None;
                 message.redaction_ref = Some(request.redaction_ref.clone());
                 Ok(())
@@ -2004,6 +2010,7 @@ fn history_message(message: &ThreadMessageRecord) -> ThreadMessageRecord {
         tool_result_ref: message.tool_result_ref.clone(),
         tool_result_provider_call: None,
         content: message.content.clone(),
+        attachments: message.attachments.clone(),
         redaction_ref: message.redaction_ref.clone(),
     }
 }

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -1995,6 +1995,11 @@ fn history_messages(messages: &[ThreadMessageRecord]) -> Vec<ThreadMessageRecord
     messages.iter().map(history_message).collect()
 }
 
+// Deny-by-default projection: every field is listed deliberately so a newly
+// added sensitive field does NOT auto-flow into persisted history. Do not
+// collapse to `..message.clone()` — `tool_result_provider_call` is dropped
+// here precisely because raw runtime/tool payloads must never surface as
+// ordinary transcript content (see crate guardrails).
 fn history_message(message: &ThreadMessageRecord) -> ThreadMessageRecord {
     ThreadMessageRecord {
         message_id: message.message_id,

--- a/crates/ironclaw_threads/src/filesystem_service.rs
+++ b/crates/ironclaw_threads/src/filesystem_service.rs
@@ -748,7 +748,11 @@ where
             .reserve_sequence(&request.scope, &request.thread_id)
             .await?;
         let message_id = ThreadMessageId::new();
-        let (content_text, attachments) = request.content.clone().into_parts();
+        // Borrow `request` for the idempotency key before moving `content` out,
+        // so the content (now carrying attachment refs) is consumed by move
+        // rather than deep-cloned on this per-message hot path.
+        let idempotency_key = InboundIdempotencyKey::from_request(&request);
+        let (content_text, attachments) = request.content.into_parts();
         let message = ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),
@@ -769,7 +773,7 @@ where
         self.write_new_message(&request.scope, &request.thread_id, &message, "message")
             .await?;
 
-        if let Some(idempotency_key) = InboundIdempotencyKey::from_request(&request) {
+        if let Some(idempotency_key) = idempotency_key {
             let idem_record = InboundIdempotencyRecord {
                 scope: idempotency_key.scope.clone(),
                 source_binding_id: idempotency_key.source_binding_id.clone(),

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -147,6 +147,7 @@ impl SessionThreadService for InMemorySessionThreadService {
         let sequence = thread.next_sequence;
         thread.next_sequence += 1;
         let (content_text, attachments) = request.content.into_parts();
+        crate::contract::validate_attachment_refs(&attachments)?;
         thread.messages.push(ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),
@@ -464,6 +465,10 @@ impl SessionThreadService for InMemorySessionThreadService {
         )?;
         ensure_draft(message)?;
         message.content = Some(request.content.into_text());
+        // Keep content and attachments in lockstep (as redaction does): an
+        // assistant draft carries no attachments, so a content update must not
+        // leave stale refs behind if a future draft path ever sets them.
+        message.attachments = Vec::new();
         Ok(message.clone())
     }
 
@@ -479,6 +484,7 @@ impl SessionThreadService for InMemorySessionThreadService {
         ensure_draft(message)?;
         message.status = MessageStatus::Finalized;
         message.content = Some(content.into_text());
+        message.attachments = Vec::new();
         Ok(message.clone())
     }
 

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -146,6 +146,7 @@ impl SessionThreadService for InMemorySessionThreadService {
         let message_id = ThreadMessageId::new();
         let sequence = thread.next_sequence;
         thread.next_sequence += 1;
+        let (content_text, attachments) = request.content.into_parts();
         thread.messages.push(ThreadMessageRecord {
             message_id,
             thread_id: request.thread_id.clone(),
@@ -159,7 +160,8 @@ impl SessionThreadService for InMemorySessionThreadService {
             turn_run_id: None,
             tool_result_ref: None,
             tool_result_provider_call: None,
-            content: Some(request.content.into_text()),
+            content: Some(content_text),
+            attachments,
             redaction_ref: None,
         });
 
@@ -276,6 +278,7 @@ impl SessionThreadService for InMemorySessionThreadService {
             tool_result_ref: None,
             tool_result_provider_call: None,
             content: Some(request.content.into_text()),
+            attachments: Vec::new(),
             redaction_ref: None,
         };
         thread.next_sequence += 1;
@@ -356,6 +359,7 @@ impl SessionThreadService for InMemorySessionThreadService {
             tool_result_ref: Some(envelope.result_ref),
             tool_result_provider_call: provider_call,
             content: Some(content),
+            attachments: Vec::new(),
             redaction_ref: None,
         };
         thread.next_sequence += 1;
@@ -403,6 +407,7 @@ impl SessionThreadService for InMemorySessionThreadService {
             tool_result_ref: request.preview.result_ref.clone(),
             tool_result_provider_call: None,
             content: Some(content),
+            attachments: Vec::new(),
             redaction_ref: None,
         };
         thread.next_sequence += 1;
@@ -490,6 +495,7 @@ impl SessionThreadService for InMemorySessionThreadService {
         )?;
         message.status = MessageStatus::Redacted;
         message.content = None;
+        message.attachments = Vec::new();
         message.tool_result_provider_call = None;
         message.redaction_ref = Some(request.redaction_ref);
         Ok(message.clone())
@@ -995,6 +1001,7 @@ fn history_message(message: &ThreadMessageRecord) -> ThreadMessageRecord {
         tool_result_ref: message.tool_result_ref.clone(),
         tool_result_provider_call: None,
         content: message.content.clone(),
+        attachments: message.attachments.clone(),
         redaction_ref: message.redaction_ref.clone(),
     }
 }

--- a/crates/ironclaw_threads/src/in_memory.rs
+++ b/crates/ironclaw_threads/src/in_memory.rs
@@ -986,6 +986,11 @@ fn history_messages(thread: &StoredThread) -> Vec<ThreadMessageRecord> {
     thread.messages.iter().map(history_message).collect()
 }
 
+// Deny-by-default projection: every field is listed deliberately so a newly
+// added sensitive field does NOT auto-flow into persisted history. Do not
+// collapse to `..message.clone()` — `tool_result_provider_call` is dropped
+// here precisely because raw runtime/tool payloads must never surface as
+// ordinary transcript content (see crate guardrails).
 fn history_message(message: &ThreadMessageRecord) -> ThreadMessageRecord {
     ThreadMessageRecord {
         message_id: message.message_id,

--- a/crates/ironclaw_threads/src/lib.rs
+++ b/crates/ironclaw_threads/src/lib.rs
@@ -34,19 +34,23 @@ pub use capability_display_preview::{
 pub use contract::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageReplay,
     AppendAssistantDraftRequest, AppendCapabilityDisplayPreviewRequest,
-    AppendToolResultReferenceRequest, ContextMessage, ContextMessages, ContextWindow,
-    CreateSummaryArtifactRequest, EnsureThreadRequest, FinalizedAssistantMessageByRunRequest,
-    GOAL_STATEMENT_MAX_CHARS, GoalStatement, LatestThreadMessageRequest,
-    ListThreadsForScopeRequest, ListThreadsForScopeResponse, LoadContextMessagesRequest,
-    LoadContextWindowRequest, MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
-    ReplayAcceptedInboundMessageRequest, SessionThreadRecord, SummaryArtifact, SummaryKind,
-    SummaryModelContextPolicy, ThreadGoal, ThreadHistory, ThreadHistoryRequest, ThreadMessageRange,
-    ThreadMessageRangeRequest, ThreadMessageRecord, ThreadScope, UpdateAssistantDraftRequest,
-    UpdateThreadGoalRequest, UpdateToolResultReferenceRequest,
+    AppendToolResultReferenceRequest, AttachmentRef, ContextMessage, ContextMessages,
+    ContextWindow, CreateSummaryArtifactRequest, EnsureThreadRequest,
+    FinalizedAssistantMessageByRunRequest, GOAL_STATEMENT_MAX_CHARS, GoalStatement,
+    LatestThreadMessageRequest, ListThreadsForScopeRequest, ListThreadsForScopeResponse,
+    LoadContextMessagesRequest, LoadContextWindowRequest, MessageContent, MessageKind,
+    MessageStatus, RedactMessageRequest, ReplayAcceptedInboundMessageRequest, SessionThreadRecord,
+    SummaryArtifact, SummaryKind, SummaryModelContextPolicy, ThreadGoal, ThreadHistory,
+    ThreadHistoryRequest, ThreadMessageRange, ThreadMessageRangeRequest, ThreadMessageRecord,
+    ThreadScope, UpdateAssistantDraftRequest, UpdateThreadGoalRequest,
+    UpdateToolResultReferenceRequest,
 };
 pub use error::SessionThreadError;
+// Re-exposed so transcript-contract consumers (`AttachmentRef`) don't need a
+// direct dependency on `ironclaw_common` for the attachment kind vocabulary.
 pub use identifiers::{SummaryArtifactId, ThreadMessageId};
 pub use in_memory::InMemorySessionThreadService;
+pub use ironclaw_common::AttachmentKind;
 pub use service::SessionThreadService;
 pub use tool_result_reference::{
     ProviderToolCallReferenceEnvelope, ToolResultReferenceEnvelope, ToolResultSafeSummary,

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -1272,3 +1272,57 @@ async fn filesystem_persists_multiple_attachment_refs_in_order() {
     assert_eq!(history.messages.len(), 1);
     assert_eq!(history.messages[0].attachments, attachments);
 }
+
+#[tokio::test]
+async fn filesystem_accept_rejects_duplicate_attachment_ids() {
+    // The accept path validates attachment refs before persisting. Drive the
+    // real caller (not just the helper) so a regression that drops the check
+    // would fail here, and assert nothing was written on rejection.
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-dup-att", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("dup-attachments");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-dup-att").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let dup = AttachmentRef {
+        id: "att-dup".into(),
+        kind: AttachmentKind::Image,
+        mime_type: "image/png".into(),
+        filename: Some("diagram.png".into()),
+        size_bytes: Some(4096),
+        storage_key: Some("attachments/2026-06-09/m1-0-diagram.png".into()),
+        extracted_text: None,
+    };
+    let err = service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: Some("event-dup-att".into()),
+            content: MessageContent::with_attachments("two refs, one id", vec![dup.clone(), dup]),
+        })
+        .await
+        .expect_err("duplicate attachment ids must be rejected at accept");
+    assert!(matches!(err, SessionThreadError::InvalidAttachment(_)));
+
+    // Rejection must not leave a half-written message behind.
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .unwrap();
+    assert!(history.messages.is_empty());
+}

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -17,13 +17,13 @@ use ironclaw_host_api::{
 };
 use ironclaw_threads::{
     AcceptInboundMessageRequest, AppendAssistantDraftRequest,
-    AppendCapabilityDisplayPreviewRequest, CapabilityDisplayPreviewEnvelope,
-    CapabilityDisplayPreviewEnvelopeInput, CapabilityDisplayPreviewStatus,
-    CreateSummaryArtifactRequest, EnsureThreadRequest, FilesystemSessionThreadService,
-    LoadContextMessagesRequest, LoadContextWindowRequest, MessageContent, MessageKind,
-    MessageStatus, RedactMessageRequest, ReplayAcceptedInboundMessageRequest, SessionThreadError,
-    SessionThreadService, SummaryKind, SummaryModelContextPolicy, ThreadHistoryRequest,
-    ThreadScope, UpdateAssistantDraftRequest,
+    AppendCapabilityDisplayPreviewRequest, AttachmentKind, AttachmentRef,
+    CapabilityDisplayPreviewEnvelope, CapabilityDisplayPreviewEnvelopeInput,
+    CapabilityDisplayPreviewStatus, CreateSummaryArtifactRequest, EnsureThreadRequest,
+    FilesystemSessionThreadService, LoadContextMessagesRequest, LoadContextWindowRequest,
+    MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
+    ReplayAcceptedInboundMessageRequest, SessionThreadError, SessionThreadService, SummaryKind,
+    SummaryModelContextPolicy, ThreadHistoryRequest, ThreadScope, UpdateAssistantDraftRequest,
 };
 
 #[tokio::test]
@@ -1119,4 +1119,78 @@ where
     )])
     .expect("mount view");
     Arc::new(ScopedFilesystem::with_fixed_view(backend, mounts))
+}
+
+#[tokio::test]
+async fn filesystem_persists_attachment_refs_and_clears_them_on_redaction() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-attachments", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("attachments");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-attachments").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let attachment = AttachmentRef {
+        id: "att-1".into(),
+        kind: AttachmentKind::Image,
+        mime_type: "image/png".into(),
+        filename: Some("diagram.png".into()),
+        size_bytes: Some(4096),
+        storage_key: Some("attachments/2026-06-09/m1-diagram.png".into()),
+        extracted_text: None,
+    };
+    let accepted = service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: Some("event-att".into()),
+            content: MessageContent::with_attachments("look at this", vec![attachment.clone()]),
+        })
+        .await
+        .unwrap();
+
+    // Re-open the store over the same backend to prove the refs survive a
+    // serialize → store → deserialize round trip, not just an in-process cache.
+    let reopened = FilesystemSessionThreadService::new(scoped);
+    let history = reopened
+        .list_thread_history(ThreadHistoryRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(history.messages.len(), 1);
+    assert_eq!(history.messages[0].attachments, vec![attachment]);
+
+    reopened
+        .redact_message(RedactMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            message_id: accepted.message_id,
+            redaction_ref: "redaction:test".into(),
+        })
+        .await
+        .unwrap();
+
+    let after = reopened
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(after.messages[0].status, MessageStatus::Redacted);
+    assert!(after.messages[0].content.is_none());
+    assert!(after.messages[0].attachments.is_empty());
 }

--- a/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/filesystem_session_thread_contract.rs
@@ -1194,3 +1194,81 @@ async fn filesystem_persists_attachment_refs_and_clears_them_on_redaction() {
     assert!(after.messages[0].content.is_none());
     assert!(after.messages[0].attachments.is_empty());
 }
+
+#[tokio::test]
+async fn filesystem_persists_multiple_attachment_refs_in_order() {
+    // The single-ref test can't catch an ordering or per-element bug in the
+    // JSON array round trip. Drive a multi-ref message — distinct kinds, one
+    // with `extracted_text: Some(..)` (which the single-ref test never sets) —
+    // through the real serialize → store → deserialize path and assert the full
+    // vec survives in order.
+    let backend = Arc::new(InMemoryBackend::new());
+    let scoped = scoped_threads_fs_at(backend, "tenant-multi-att", "alice");
+    let service = FilesystemSessionThreadService::new(Arc::clone(&scoped));
+    let scope = scope("multi-attachments");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-multi-att").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let attachments = vec![
+        AttachmentRef {
+            id: "att-1".into(),
+            kind: AttachmentKind::Image,
+            mime_type: "image/png".into(),
+            filename: Some("diagram.png".into()),
+            size_bytes: Some(4096),
+            storage_key: Some("attachments/2026-06-09/m1-0-diagram.png".into()),
+            extracted_text: None,
+        },
+        AttachmentRef {
+            id: "att-2".into(),
+            kind: AttachmentKind::Document,
+            mime_type: "application/pdf".into(),
+            filename: Some("report.pdf".into()),
+            size_bytes: Some(20_480),
+            storage_key: Some("attachments/2026-06-09/m1-1-report.pdf".into()),
+            extracted_text: Some("Quarterly revenue up 12%".into()),
+        },
+        AttachmentRef {
+            id: "att-3".into(),
+            kind: AttachmentKind::Audio,
+            mime_type: "audio/mpeg".into(),
+            filename: Some("note.mp3".into()),
+            size_bytes: Some(8192),
+            storage_key: Some("attachments/2026-06-09/m1-2-note.mp3".into()),
+            extracted_text: None,
+        },
+    ];
+    service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: Some("event-multi-att".into()),
+            content: MessageContent::with_attachments("three files", attachments.clone()),
+        })
+        .await
+        .unwrap();
+
+    // Re-open over the same backend so the assertion crosses the real JSON
+    // serialize → store → deserialize boundary.
+    let reopened = FilesystemSessionThreadService::new(scoped);
+    let history = reopened
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(history.messages.len(), 1);
+    assert_eq!(history.messages[0].attachments, attachments);
+}

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -2583,3 +2583,49 @@ async fn accept_inbound_message_carries_attachment_refs_through_history() {
     assert!(after.messages[0].content.is_none());
     assert!(after.messages[0].attachments.is_empty());
 }
+
+#[tokio::test]
+async fn accept_inbound_message_rejects_oversized_extracted_text() {
+    // Drive the real accept caller (not just the validator) with an attachment
+    // whose extracted_text exceeds the contract cap, and assert nothing was
+    // persisted on rejection.
+    let service = InMemorySessionThreadService::default();
+    let scope = scope("att-oversize");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-att-oversize").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let mut oversized = sample_attachment_ref();
+    // 200_001 chars — one past MAX_EXTRACTED_TEXT_CHARS (kept crate-internal, so
+    // assert the boundary by size rather than importing the constant).
+    oversized.extracted_text = Some("x".repeat(200_001));
+    let err = service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: Some("event-att-oversize".into()),
+            content: MessageContent::with_attachments("huge", vec![oversized]),
+        })
+        .await
+        .expect_err("oversized extracted_text must be rejected at accept");
+    assert!(matches!(err, SessionThreadError::InvalidAttachment(_)));
+
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .unwrap();
+    assert!(history.messages.is_empty());
+}

--- a/crates/ironclaw_threads/tests/session_thread_contract.rs
+++ b/crates/ironclaw_threads/tests/session_thread_contract.rs
@@ -5,8 +5,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_threads::{
     AcceptInboundMessageRequest, AppendAssistantDraftRequest,
-    AppendCapabilityDisplayPreviewRequest, AppendToolResultReferenceRequest,
-    CapabilityDisplayPreviewEnvelope, CapabilityDisplayPreviewEnvelopeInput,
+    AppendCapabilityDisplayPreviewRequest, AppendToolResultReferenceRequest, AttachmentKind,
+    AttachmentRef, CapabilityDisplayPreviewEnvelope, CapabilityDisplayPreviewEnvelopeInput,
     CapabilityDisplayPreviewStatus, CreateSummaryArtifactRequest, EnsureThreadRequest,
     InMemorySessionThreadService, ListThreadsForScopeRequest, LoadContextMessagesRequest,
     LoadContextWindowRequest, MessageContent, MessageKind, MessageStatus,
@@ -2503,4 +2503,83 @@ async fn list_threads_for_scope_title_stays_none_when_user_message_is_whitespace
         title, None,
         "whitespace-only user message must yield `title: None`, not an empty string",
     );
+}
+
+fn sample_attachment_ref() -> AttachmentRef {
+    AttachmentRef {
+        id: "att-1".into(),
+        kind: AttachmentKind::Document,
+        mime_type: "application/pdf".into(),
+        filename: Some("report.pdf".into()),
+        size_bytes: Some(2048),
+        storage_key: Some("attachments/2026-06-09/m1-report.pdf".into()),
+        extracted_text: Some("quarterly numbers".into()),
+    }
+}
+
+#[tokio::test]
+async fn accept_inbound_message_carries_attachment_refs_through_history() {
+    let service = InMemorySessionThreadService::default();
+    let scope = scope("attachments");
+    let thread = service
+        .ensure_thread(EnsureThreadRequest {
+            scope: scope.clone(),
+            thread_id: Some(ThreadId::new("thread-attachments").unwrap()),
+            created_by_actor_id: "actor-a".into(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .unwrap();
+
+    let attachment = sample_attachment_ref();
+    let accepted = service
+        .accept_inbound_message(AcceptInboundMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            actor_id: "actor-a".into(),
+            source_binding_id: None,
+            reply_target_binding_id: None,
+            external_event_id: Some("event-att".into()),
+            content: MessageContent::with_attachments("see attached", vec![attachment.clone()]),
+        })
+        .await
+        .unwrap();
+
+    let history = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(history.messages.len(), 1);
+    assert_eq!(history.messages[0].content.as_deref(), Some("see attached"));
+    assert_eq!(history.messages[0].attachments, vec![attachment]);
+
+    // Redaction clears attachment refs in parity with text content, while the
+    // message identity and sequence are preserved.
+    service
+        .redact_message(RedactMessageRequest {
+            scope: scope.clone(),
+            thread_id: thread.thread_id.clone(),
+            message_id: accepted.message_id,
+            redaction_ref: "redaction:test".into(),
+        })
+        .await
+        .unwrap();
+
+    let after = service
+        .list_thread_history(ThreadHistoryRequest {
+            scope,
+            thread_id: thread.thread_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(after.messages.len(), 1);
+    assert_eq!(after.messages[0].message_id, accepted.message_id);
+    assert_eq!(after.messages[0].sequence, accepted.sequence);
+    assert_eq!(after.messages[0].status, MessageStatus::Redacted);
+    assert!(after.messages[0].content.is_none());
+    assert!(after.messages[0].attachments.is_empty());
 }


### PR DESCRIPTION
## Summary

Track 2 of #4644 (stacked on the Track 1 registry PR #4654). The Reborn transcript contract was text-only, so any attachment a channel produced was silently dropped at persistence. This extends the contract to carry attachment **references** (never bytes) so an upload survives `accept → persist → history/projection reads`.

**Scope:** `crates/` only, no `src/` changes. Confined to the transcript contract + its two stores; the inbound pipeline (extraction, augment, model visibility, ingress upload, MountView landing) stays in later tracks.

## What changed

- **`AttachmentRef`** in `ironclaw_threads::contract` — `{ id, kind, mime_type, filename, size_bytes, storage_key, extracted_text }`. Per the crate guardrails it holds **no raw bytes / host paths / secrets**: bytes live behind the filesystem authority that owns `storage_key` (a rendered scoped path, populated when the attachment is landed in Track 6).
- **`MessageContent`** gains a private `attachments` vec + `with_attachments()` constructor and `into_parts()` accessor. The `text()` constructor and the ~118 `MessageContent::text()` call sites are unaffected (private field).
- **`ThreadMessageRecord`** gains `attachments` (`#[serde(default, skip_serializing_if = "Vec::is_empty")]` so legacy persisted rows still deserialize). Threaded through both stores (`in_memory`, `filesystem_service`) on accept + history reads; **cleared on redaction** in parity with `content`, preserving identity/sequence.
- **One kind vocabulary**: reuse `ironclaw_common::AttachmentKind` across the Track 1 registry, v1 channels, and the transcript. `AttachmentKind` gains `Serialize/Deserialize` (snake_case) + `Copy`; re-exported from `ironclaw_threads` so consumers need no direct `ironclaw_common` dep (new internal dep edge `ironclaw_threads → ironclaw_common`).
- **`ContextMessage` (model-visible) intentionally untouched** — folding attachments into model-visible content (text block + image parts) is Track 3 (`augment`).
- Cross-crate `ThreadMessageRecord` literals updated: `ironclaw_loop_support` compaction helper, `ironclaw_reborn` + `ironclaw_product_workflow` test fixtures.

## Tests

- Contract unit tests: `into_parts`/`with_attachments`, snake_case `AttachmentKind`, `AttachmentRef` round-trip + empty-optional omission, **legacy-row deserialization defaults `attachments` to empty**.
- Round-trip integration tests (in-memory **and** filesystem): attachments survive `accept → history` (filesystem via a reopen over the same backend, proving the serialize→store→deserialize path), and are cleared on redaction while identity/sequence are preserved.

```
cargo clippy -p ironclaw_common -p ironclaw_threads -p ironclaw_reborn \
  -p ironclaw_product_workflow -p ironclaw_loop_support --all-features --tests   # zero warnings
cargo test -p ironclaw_common -p ironclaw_threads --all-features                 # all pass
```

## Stacking

Based on `fix/4644-attachment-format-registry` (#4654). It does not depend on the registry at the code level, but is stacked to keep the epic linear; GitHub will retarget to `main` when #4654 merges.

## Follow-ups (#4644)

- Track 3: run document extraction / transcription / `augment_with_attachments` on the Reborn inbound path; surface attachments to `ContextMessage`; fix `chat_workflow.rs`'s `"[non_text_content]"` drop.
- Track 6: land bytes through the project `MountView` and record the resolved `ScopedPath` as `storage_key`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages now support file attachments alongside text, which persist with messages and restore in history.
  * Attachments carry ordering and are cleared when a message is redacted.

* **Bug Fixes / Validation**
  * Incoming attachments are validated: duplicate IDs or oversized extracted text are rejected and no partial message is stored.
  * Acceptance failures map to proper client-visible validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->