### PR TITLE
feat(reborn): WU-C2 durable gate resolution store + capacity counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,6 +5046,7 @@ dependencies = [
  "ironclaw_events",
  "ironclaw_filesystem",
  "ironclaw_host_api",
+ "ironclaw_turns",
  "libsql",
  "rustls 0.23.40",
  "rustls-native-certs 0.8.3",

--- a/crates/ironclaw_reborn_event_store/Cargo.toml
+++ b/crates/ironclaw_reborn_event_store/Cargo.toml
@@ -30,6 +30,7 @@ hex = "0.4"
 ironclaw_events = { path = "../ironclaw_events", version = "0.1.0" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["ring"] }
 rustls-native-certs = { version = "0.8", optional = true }

--- a/crates/ironclaw_reborn_event_store/Cargo.toml
+++ b/crates/ironclaw_reborn_event_store/Cargo.toml
@@ -22,6 +22,10 @@ postgres = [
     "ironclaw_filesystem/postgres",
 ]
 libsql = ["dep:libsql", "ironclaw_filesystem/libsql"]
+# Opt-in gate for integration tests that require a live external service
+# (PostgreSQL). Only tests gated on this feature connect to the database;
+# they still skip gracefully at runtime if the env var is unset.
+integration = []
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_reborn_event_store/src/gate_resolution.rs
+++ b/crates/ironclaw_reborn_event_store/src/gate_resolution.rs
@@ -1,0 +1,338 @@
+//! Durable gate-resolution store trait + error type.
+//!
+//! Spec: `docs/reborn/2026-06-08-subagent-durability-spec.md` §1.
+//!
+//! The trait is implemented by:
+//! - [`crate::libsql::LibSqlGateResolutionStore`] (libSQL backend, feature `libsql`)
+//! - [`crate::postgres::PostgresGateResolutionStore`] (PostgreSQL backend, feature `postgres`)
+//!
+//! All scoped queries MUST use the conditional `<agent_predicate>` convention
+//! from spec §1.6: `agent_id = ?` when the caller's `TurnScope.agent_id` is
+//! `Some`, and `agent_id IS NULL` when `None`. Using
+//! `(agent_id = ? OR agent_id IS NULL)` is forbidden — it allows agent-scoped
+//! callers to reach system-level (NULL `agent_id`) rows.
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use ironclaw_host_api::UserId;
+use ironclaw_turns::{GateRef, LoopResultRef, TurnRunId, TurnScope, TurnStatus};
+use thiserror::Error;
+
+/// Errors returned by the durable gate-resolution store.
+#[derive(Debug, Error)]
+pub enum GateResolutionStoreError {
+    #[error("gate resolution store backend unavailable: {reason}")]
+    Unavailable { reason: String },
+    #[error("gate resolution store I/O error during {operation}: {reason}")]
+    Io {
+        operation: &'static str,
+        reason: String,
+    },
+    #[error("gate resolution store serialization failed: {reason}")]
+    Serialization { reason: String },
+    #[error("gate resolution capacity exceeded for scope")]
+    CapacityExceeded,
+    #[error("gate resolution store: non-terminal status rejected")]
+    NonTerminalStatus,
+}
+
+impl GateResolutionStoreError {
+    pub(crate) fn unavailable(reason: impl Into<String>) -> Self {
+        Self::Unavailable {
+            reason: reason.into(),
+        }
+    }
+    pub(crate) fn io(operation: &'static str, reason: impl Into<String>) -> Self {
+        Self::Io {
+            operation,
+            reason: reason.into(),
+        }
+    }
+    #[allow(dead_code)]
+    pub(crate) fn serialization(reason: impl Into<String>) -> Self {
+        Self::Serialization {
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Terminal event for a settled awaited child.
+///
+/// Mirrors `AwaitedChildTerminalEvent` in the in-memory store but is defined
+/// here for the durable trait boundary — no dependency on
+/// `ironclaw_reborn` private types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DurableTerminalEvent {
+    pub status: TurnStatus,
+    pub kind: String,
+    pub cursor: u64,
+    pub sanitized_reason: Option<String>,
+    pub owner_user_id: Option<UserId>,
+}
+
+/// The number of capacity-counter buckets per scope (K=16, operator-tunable).
+///
+/// Spec §1 decision 21: spawn writes to `bucket = hash(child_run_id) % K`.
+/// Cap check reads `SUM(undelivered) FROM counter WHERE scope`.
+pub const CAPACITY_COUNTER_BUCKETS: u32 = 16;
+
+/// Environment variable for overriding the number of capacity-counter buckets.
+pub const CAPACITY_COUNTER_BUCKETS_ENV: &str = "CAPACITY_COUNTER_BUCKETS";
+
+/// Read the effective bucket count from the environment.
+/// Falls back to [`CAPACITY_COUNTER_BUCKETS`] if the env var is unset or
+/// unparseable.
+pub fn effective_capacity_counter_buckets() -> u32 {
+    std::env::var(CAPACITY_COUNTER_BUCKETS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .filter(|&k| k > 0)
+        .unwrap_or(CAPACITY_COUNTER_BUCKETS)
+}
+
+/// Deterministic bucket index for a given `child_run_id` string and K.
+///
+/// Uses FNV-1a (a simple, non-cryptographic hash adequate for bucket
+/// distribution). Returns `hash(child_run_id_bytes) % k`.
+pub fn child_bucket(child_run_id_str: &str, k: u32) -> u32 {
+    // FNV-1a 32-bit
+    const FNV_OFFSET: u32 = 2_166_136_261;
+    const FNV_PRIME: u32 = 16_777_619;
+    let hash = child_run_id_str.bytes().fold(FNV_OFFSET, |acc, b| {
+        acc.wrapping_mul(FNV_PRIME) ^ (b as u32)
+    });
+    hash % k
+}
+
+/// Maximum number of awaited-child gate records per scope.
+pub const MAX_GATE_RECORDS: u32 = 4096;
+
+/// Durable gate-resolution store trait (spec §1).
+///
+/// All implementations must match the first-writer-wins semantics of
+/// `BoundedSubagentGateResolutionStore`:
+/// - `record_awaited_child`: `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`.
+/// - `record_child_terminal`: UPDATE `terminal_status` only when
+///   `terminal_status IS NULL` (first writer wins).
+/// - Delivery claim: `delivered_to_parent = 0` guard.
+///
+/// Scope predicate convention (spec §1.6):
+/// - `agent_id = ?` when `scope.agent_id` is `Some`.
+/// - `agent_id IS NULL` when `scope.agent_id` is `None`.
+/// - NEVER `(agent_id = ? OR agent_id IS NULL)`.
+#[async_trait]
+pub trait DurableSubagentGateResolutionStore: Send + Sync {
+    // ── Core CRUD ──────────────────────────────────────────────────────────
+
+    /// Insert a new awaited-child row under the given scope and gate.
+    ///
+    /// Idempotent: duplicate `(gate_ref, child_run_id)` is silently ignored
+    /// (first-writer-wins per spec §1.6, decision 6).
+    ///
+    /// Returns `Err(GateResolutionStoreError::CapacityExceeded)` when
+    /// `SUM(undelivered)` for the scope would exceed `MAX_GATE_RECORDS`.
+    async fn record_awaited_child(
+        &self,
+        scope: &TurnScope,
+        record: AwaitedChildRecord,
+    ) -> Result<(), GateResolutionStoreError>;
+
+    /// Record the terminal event for a child run (first-writer-wins).
+    ///
+    /// Updates `terminal_status` / `terminal_event_json` / `settled_at` only
+    /// when `terminal_status IS NULL`. Adds an entry to the deliverable queue
+    /// and appends a row to the settlement log.
+    ///
+    /// Rejects non-terminal statuses with
+    /// `GateResolutionStoreError::NonTerminalStatus`.
+    async fn record_child_terminal(
+        &self,
+        scope: &TurnScope,
+        gate_ref: GateRef,
+        child_run_id: TurnRunId,
+        event: DurableTerminalEvent,
+    ) -> Result<(), GateResolutionStoreError>;
+
+    /// Flip `terminal_result_written = true` and record `terminal_byte_len`.
+    ///
+    /// No-op if the row does not exist or the flag is already set.
+    async fn mark_terminal_result_written(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+        child_run_id: TurnRunId,
+        byte_len: u64,
+    ) -> Result<(), GateResolutionStoreError>;
+
+    /// Claim delivery for a child: flip `delivery_claimed = 1`,
+    /// `delivered_to_parent = 1`, decrement the capacity counter bucket,
+    /// and delete the deliverable-queue entry — all in one transaction.
+    ///
+    /// Returns `true` if the gate is now fully delivered (all children
+    /// under the gate have `delivered_to_parent = 1`), `false` otherwise.
+    /// Returns `false` (not an error) if the row has already been delivered
+    /// (idempotent guard via `delivered_to_parent = 0`).
+    async fn mark_child_delivered(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+        child_run_id: TurnRunId,
+    ) -> Result<bool, GateResolutionStoreError>;
+
+    /// Claim the next deliverable terminal state for a child.
+    ///
+    /// Returns `Some(record)` if an undelivered-terminal row exists for the
+    /// child in the deliverable queue; `None` if the queue is empty.
+    async fn claim_next_terminal_state_for_child(
+        &self,
+        scope: &TurnScope,
+        child_run_id: TurnRunId,
+    ) -> Result<Option<AwaitedChildRow>, GateResolutionStoreError>;
+
+    /// Drain ALL deliverable terminal states for a child in one call.
+    async fn claim_all_terminal_states_for_child(
+        &self,
+        scope: &TurnScope,
+        child_run_id: TurnRunId,
+    ) -> Result<Vec<AwaitedChildRow>, GateResolutionStoreError>;
+
+    /// Delete all rows for a gate (primary table + child index + deliverable
+    /// queue), decrementing the capacity counter atomically.
+    ///
+    /// This is the gate-cleanup path. Rows deleted here are NOT recoverable
+    /// by the reconciler — the settlement log retains the append-only record.
+    async fn delete_awaited_child(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+    ) -> Result<(), GateResolutionStoreError>;
+
+    // ── Reconciler-facing methods (spec §5.2.1) ────────────────────────────
+
+    /// Batch existence check: returns the subset of `gate_refs` that still
+    /// exist in `subagent_gate_awaited_children` for the given scope.
+    ///
+    /// One batched SELECT; no payload bytes cross this boundary.
+    async fn gates_exist_batch(
+        &self,
+        scope: &TurnScope,
+        gate_refs: Vec<GateRef>,
+    ) -> Result<HashSet<GateRef>, GateResolutionStoreError>;
+
+    /// Reconciler delivery (spec §5.2.1, decision 29).
+    ///
+    /// Idempotently ensures the gate row's terminal flags are set from the
+    /// settlement-log row and an entry exists in the deliverable queue — the
+    /// §1.6 settlement transaction, re-driven.
+    ///
+    /// Returns `false` if the gate row no longer exists (orphan race — caller
+    /// counts it as `skipped_orphan`).
+    async fn redeliver_settled_child(
+        &self,
+        scope: &TurnScope,
+        gate_ref: GateRef,
+        child_run_id: TurnRunId,
+        terminal_status: TurnStatus,
+        result_ref: LoopResultRef,
+    ) -> Result<bool, GateResolutionStoreError>;
+
+    /// Capacity resolution for rows that will never deliver (spec decision 31).
+    ///
+    /// For each `(gate_ref, child_run_id)`: flip `delivered_to_parent`,
+    /// decrement the capacity bucket, delete the queue entry — the §1.6
+    /// delivery-claim transaction, batched. Idempotent per row via the
+    /// `delivered_to_parent = 0` guard.
+    async fn resolve_undeliverable_batch(
+        &self,
+        scope: &TurnScope,
+        rows: Vec<(GateRef, TurnRunId)>,
+    ) -> Result<(), GateResolutionStoreError>;
+}
+
+/// A row in `subagent_gate_awaited_children` — returned by claim methods.
+#[derive(Debug, Clone)]
+pub struct AwaitedChildRow {
+    pub gate_ref: GateRef,
+    pub child_run_id: TurnRunId,
+    pub parent_run_id: TurnRunId,
+    pub tree_root_run_id: TurnRunId,
+    /// JSON-encoded `TurnScope` (child scope)
+    pub child_scope_json: String,
+    /// JSON-encoded `LoopRunContext` (parent run context)
+    pub parent_run_context_json: String,
+    pub source_binding_ref: String,
+    pub reply_target_binding_ref: String,
+    pub subagent_kind: String,
+    pub spawn_capability_id: String,
+    pub result_ref: LoopResultRef,
+    pub spawn_mode: String,
+    pub terminal_status: Option<TurnStatus>,
+    pub terminal_event_json: Option<String>,
+    pub terminal_result_written: bool,
+    pub terminal_byte_len: u64,
+    pub delivery_claimed: bool,
+    pub delivered_to_parent: bool,
+}
+
+/// The data needed to INSERT a new awaited-child row.
+#[derive(Debug, Clone)]
+pub struct AwaitedChildRecord {
+    pub gate_ref: GateRef,
+    pub parent_run_id: TurnRunId,
+    pub tree_root_run_id: TurnRunId,
+    pub child_run_id: TurnRunId,
+    pub child_thread_id: String,
+    /// JSON-encoded `TurnScope` (child scope)
+    pub child_scope_json: String,
+    /// JSON-encoded `LoopRunContext` — MUST be stripped of sensitive fields
+    /// before reaching this struct (see credential audit).
+    pub parent_run_context_json: String,
+    pub source_binding_ref: String,
+    pub reply_target_binding_ref: String,
+    pub subagent_kind: String,
+    pub spawn_capability_id: String,
+    pub result_ref: LoopResultRef,
+    pub spawn_mode: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_is_stable_and_bounded() {
+        let child_id = "550e8400-e29b-41d4-a716-446655440000";
+        let k = CAPACITY_COUNTER_BUCKETS;
+        let bucket = child_bucket(child_id, k);
+        assert!(bucket < k, "bucket {bucket} must be < {k}");
+        // Deterministic: same input, same output.
+        assert_eq!(child_bucket(child_id, k), bucket);
+    }
+
+    #[test]
+    fn buckets_distribute_across_range() {
+        let k = CAPACITY_COUNTER_BUCKETS;
+        let mut seen = std::collections::HashSet::new();
+        for i in 0..200u32 {
+            let id = format!("child-run-{i:08x}-beef-dead-cafe-000000000000");
+            seen.insert(child_bucket(&id, k));
+        }
+        // With 200 inputs and K=16, expect reasonable coverage (> 10 distinct buckets).
+        assert!(
+            seen.len() > 10,
+            "expected spread across buckets, got {seen:?}"
+        );
+    }
+
+    #[test]
+    fn effective_capacity_counter_buckets_defaults_to_constant() {
+        // Test without the env var set.
+        if std::env::var(CAPACITY_COUNTER_BUCKETS_ENV).is_err() {
+            assert_eq!(
+                effective_capacity_counter_buckets(),
+                CAPACITY_COUNTER_BUCKETS
+            );
+        }
+    }
+}

--- a/crates/ironclaw_reborn_event_store/src/gate_resolution.rs
+++ b/crates/ironclaw_reborn_event_store/src/gate_resolution.rs
@@ -22,17 +22,39 @@ use thiserror::Error;
 /// Errors returned by the durable gate-resolution store.
 #[derive(Debug, Error)]
 pub enum GateResolutionStoreError {
+    /// The backend connection pool is unavailable or the database refused the
+    /// connection. Callers should treat this as a transient I/O failure and
+    /// retry with back-off; it is never caused by the caller's input.
     #[error("gate resolution store backend unavailable: {reason}")]
     Unavailable { reason: String },
+
+    /// A backend I/O error occurred during the named operation (e.g.
+    /// `"record_awaited_child"`, `"mark_child_delivered"`). Retrying after a
+    /// brief back-off is appropriate; the operation named in `operation` is
+    /// useful for structured log correlation.
     #[error("gate resolution store I/O error during {operation}: {reason}")]
     Io {
         operation: &'static str,
         reason: String,
     },
+
+    /// A value could not be serialized to or deserialized from the wire format
+    /// required by the backend. This is typically a programming error (e.g. a
+    /// non-serializable type in a JSON column) and is not retriable.
     #[error("gate resolution store serialization failed: {reason}")]
     Serialization { reason: String },
+
+    /// The `SUM(undelivered)` capacity counter for the caller's scope has
+    /// reached [`MAX_GATE_RECORDS`]. The spawn should be rejected with a
+    /// back-pressure signal. The counter decrements when children are delivered
+    /// (`mark_child_delivered`) or the gate is deleted (`delete_awaited_child`).
     #[error("gate resolution capacity exceeded for scope")]
     CapacityExceeded,
+
+    /// [`DurableSubagentGateResolutionStore::record_child_terminal`] was called
+    /// with a [`TurnStatus`] that is not a terminal state. Only completed,
+    /// failed, cancelled, or similarly final statuses are accepted; in-progress
+    /// statuses are rejected to prevent premature settlement.
     #[error("gate resolution store: non-terminal status rejected")]
     NonTerminalStatus,
 }
@@ -62,12 +84,31 @@ impl GateResolutionStoreError {
 /// Mirrors `AwaitedChildTerminalEvent` in the in-memory store but is defined
 /// here for the durable trait boundary — no dependency on
 /// `ironclaw_reborn` private types.
+///
+/// Passed to [`DurableSubagentGateResolutionStore::record_child_terminal`]; the
+/// backing SQL columns are `terminal_status`, `terminal_event_json`, and
+/// `settled_at`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DurableTerminalEvent {
+    /// The terminal turn status (e.g. completed, failed, cancelled). Must be a
+    /// terminal variant; non-terminal values cause
+    /// [`GateResolutionStoreError::NonTerminalStatus`].
     pub status: TurnStatus,
+    /// Free-form kind tag that further classifies the terminal outcome (e.g.
+    /// `"completed"`, `"failed_tool_error"`). Stored as-is in the settlement
+    /// log; used by the reconciler for structured reporting.
     pub kind: String,
+    /// Event cursor value from the child's event log at the time of settlement.
+    /// Stored in the settlement log for replay ordering.
     pub cursor: u64,
+    /// Sanitized human-readable reason for non-successful terminal states.
+    /// `None` for successful completions. Must not contain raw capability
+    /// output, tool results, or other potentially injected content — the
+    /// sanitization boundary is the settle-time delivery path.
     pub sanitized_reason: Option<String>,
+    /// The `user_id` that owns the child run, if known. Carried through the
+    /// settlement record for scope validation; `None` for system-level (NULL
+    /// `agent_id`) runs.
     pub owner_user_id: Option<UserId>,
 }
 
@@ -105,33 +146,101 @@ pub fn child_bucket(child_run_id_str: &str, k: u32) -> u32 {
     hash % k
 }
 
-/// Maximum number of awaited-child gate records per scope.
+/// Maximum number of undelivered awaited-child gate records per `(tenant_id,
+/// user_id, agent_id)` scope.
+///
+/// Enforced via `SUM(undelivered)` across all capacity-counter bucket rows for
+/// the scope. [`DurableSubagentGateResolutionStore::record_awaited_child`]
+/// returns [`GateResolutionStoreError::CapacityExceeded`] when the sum already
+/// equals this value. Mirrors `MAX_GATE_RECORDS` in the in-memory store.
 pub const MAX_GATE_RECORDS: u32 = 4096;
 
-/// Durable gate-resolution store trait (spec §1).
+/// Durable persistence layer for subagent gate-resolution state (spec §1).
 ///
-/// All implementations must match the first-writer-wins semantics of
-/// `BoundedSubagentGateResolutionStore`:
-/// - `record_awaited_child`: `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`.
-/// - `record_child_terminal`: UPDATE `terminal_status` only when
-///   `terminal_status IS NULL` (first writer wins).
-/// - Delivery claim: `delivered_to_parent = 0` guard.
+/// Backs the three logical maps of `BoundedSubagentGateResolutionStore` with a
+/// SQL repository: the primary awaited-child record table, a child-to-gate
+/// reverse index, and a deliverable-child queue. A sharded capacity counter
+/// (`subagent_gate_capacity_counter`) replaces the in-memory `total_states`
+/// field for O(1) cap enforcement on the spawn hot path without a
+/// `SELECT COUNT(*)` scan.
 ///
-/// Scope predicate convention (spec §1.6):
+/// ## First-writer-wins semantics
+///
+/// All implementations must replicate the in-memory store's first-writer-wins
+/// contract:
+///
+/// - [`record_awaited_child`]: `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`
+///   on `(gate_ref, child_run_id)`. The capacity counter is incremented **only
+///   on the first successful insert** — duplicate inserts are silent no-ops and
+///   do not double-count capacity.
+/// - [`record_child_terminal`]: UPDATE `terminal_status` only when
+///   `terminal_status IS NULL`. The settlement log append and the deliverable
+///   queue insert also fire only on first settlement.
+/// - Delivery claim: `delivered_to_parent = 0` guard. The capacity counter
+///   bucket is decremented **only on the claiming call** — the call that flips
+///   `delivered_to_parent` from 0 to 1. Subsequent calls with the same key are
+///   no-ops (idempotent, no double-decrement).
+///
+/// ## Scope isolation (spec §1.6)
+///
+/// Every query MUST use the conditional `<agent_predicate>` convention:
+///
 /// - `agent_id = ?` when `scope.agent_id` is `Some`.
 /// - `agent_id IS NULL` when `scope.agent_id` is `None`.
-/// - NEVER `(agent_id = ? OR agent_id IS NULL)`.
+/// - NEVER `(agent_id = ? OR agent_id IS NULL)` — that pattern lets
+///   agent-scoped callers reach system-level (NULL `agent_id`) rows under the
+///   same `(tenant_id, user_id)`, breaking cross-agent isolation.
+///
+/// A caller never observes rows belonging to a different scope; existence
+/// queries return `false` (not `Err`) when the named key is absent from the
+/// caller's scope.
+///
+/// ## Capacity cap
+///
+/// [`MAX_GATE_RECORDS`] (4096) undelivered rows per scope is enforced via
+/// `SUM(undelivered)` across [`CAPACITY_COUNTER_BUCKETS`] shard rows.
+/// [`record_awaited_child`] returns [`GateResolutionStoreError::CapacityExceeded`]
+/// when the sum would exceed the cap. The counter is decremented symmetrically
+/// by [`mark_child_delivered`] and [`delete_awaited_child`].
+///
+/// ## Reconciler-facing methods
+///
+/// Three methods are consumed by the WU-C3 `SubagentRestartReconciler` (spec
+/// §5.2.1): [`gates_exist_batch`], [`redeliver_settled_child`], and
+/// [`resolve_undeliverable_batch`]. These must be present before the Phase 3/4
+/// replay algorithm can be implemented. See individual method docs for
+/// retention and idempotency contracts.
+///
+/// [`record_awaited_child`]: DurableSubagentGateResolutionStore::record_awaited_child
+/// [`record_child_terminal`]: DurableSubagentGateResolutionStore::record_child_terminal
+/// [`mark_child_delivered`]: DurableSubagentGateResolutionStore::mark_child_delivered
+/// [`delete_awaited_child`]: DurableSubagentGateResolutionStore::delete_awaited_child
+/// [`gates_exist_batch`]: DurableSubagentGateResolutionStore::gates_exist_batch
+/// [`redeliver_settled_child`]: DurableSubagentGateResolutionStore::redeliver_settled_child
+/// [`resolve_undeliverable_batch`]: DurableSubagentGateResolutionStore::resolve_undeliverable_batch
 #[async_trait]
 pub trait DurableSubagentGateResolutionStore: Send + Sync {
     // ── Core CRUD ──────────────────────────────────────────────────────────
 
-    /// Insert a new awaited-child row under the given scope and gate.
+    /// Insert a new awaited-child row and increment the capacity counter.
     ///
-    /// Idempotent: duplicate `(gate_ref, child_run_id)` is silently ignored
-    /// (first-writer-wins per spec §1.6, decision 6).
+    /// Scoped to `(tenant_id, user_id, agent_id)` derived from `scope`. NULL
+    /// `agent_id` matches only NULL — never returns or affects rows for a
+    /// different agent under the same `(tenant_id, user_id)`.
     ///
-    /// Returns `Err(GateResolutionStoreError::CapacityExceeded)` when
-    /// `SUM(undelivered)` for the scope would exceed `MAX_GATE_RECORDS`.
+    /// Idempotent: a duplicate `(gate_ref, child_run_id)` is silently ignored
+    /// via `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` (first-writer-wins per
+    /// spec §1.6, decision 6). The capacity counter bucket is incremented
+    /// **only on the first successful insert**; a duplicate call does not alter
+    /// the counter.
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::CapacityExceeded`] — `SUM(undelivered)`
+    ///   across all capacity-counter buckets for the scope already equals
+    ///   [`MAX_GATE_RECORDS`] (4096).
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn record_awaited_child(
         &self,
         scope: &TurnScope,
@@ -140,12 +249,22 @@ pub trait DurableSubagentGateResolutionStore: Send + Sync {
 
     /// Record the terminal event for a child run (first-writer-wins).
     ///
-    /// Updates `terminal_status` / `terminal_event_json` / `settled_at` only
-    /// when `terminal_status IS NULL`. Adds an entry to the deliverable queue
-    /// and appends a row to the settlement log.
+    /// Scoped to `(tenant_id, user_id, agent_id)` from `scope`. Updates
+    /// `terminal_status` / `terminal_event_json` / `settled_at` only when
+    /// `terminal_status IS NULL` — subsequent calls for the same
+    /// `(gate_ref, child_run_id)` pair are silent no-ops (first writer wins,
+    /// spec §1.6 decision 6). On first settlement also appends a row to the
+    /// settlement log (`subagent_gate_settlement_log`) and inserts into the
+    /// deliverable queue (`subagent_gate_deliverable_queue`). All three writes
+    /// land in one transaction. Does NOT touch the capacity counter — the row
+    /// remains counted until delivery or deletion.
     ///
-    /// Rejects non-terminal statuses with
-    /// `GateResolutionStoreError::NonTerminalStatus`.
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::NonTerminalStatus`] — `event.status` is
+    ///   not a terminal turn status.
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn record_child_terminal(
         &self,
         scope: &TurnScope,
@@ -156,7 +275,19 @@ pub trait DurableSubagentGateResolutionStore: Send + Sync {
 
     /// Flip `terminal_result_written = true` and record `terminal_byte_len`.
     ///
-    /// No-op if the row does not exist or the flag is already set.
+    /// Called by the executor after the capability result store write completes,
+    /// as a separate transaction from settlement so the capability write can be
+    /// retried without re-running settlement. Scoped to the caller's full
+    /// `(tenant_id, user_id, agent_id)` — NULL `agent_id` matches only NULL.
+    ///
+    /// Idempotent: no-op if the row does not exist or `terminal_result_written`
+    /// is already set (guard: `terminal_result_written = 0`). Does not touch
+    /// the capacity counter or the deliverable queue.
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn mark_terminal_result_written(
         &self,
         scope: &TurnScope,
@@ -165,14 +296,27 @@ pub trait DurableSubagentGateResolutionStore: Send + Sync {
         byte_len: u64,
     ) -> Result<(), GateResolutionStoreError>;
 
-    /// Claim delivery for a child: flip `delivery_claimed = 1`,
-    /// `delivered_to_parent = 1`, decrement the capacity counter bucket,
-    /// and delete the deliverable-queue entry — all in one transaction.
+    /// Claim delivery for a child run in one atomic transaction.
     ///
-    /// Returns `true` if the gate is now fully delivered (all children
-    /// under the gate have `delivered_to_parent = 1`), `false` otherwise.
-    /// Returns `false` (not an error) if the row has already been delivered
-    /// (idempotent guard via `delivered_to_parent = 0`).
+    /// Flips `delivery_claimed = 1` and `delivered_to_parent = 1`, decrements
+    /// the capacity counter for the child's bucket (the bucket recorded at
+    /// INSERT time), and deletes the deliverable-queue entry for this specific
+    /// `(gate_ref, child_run_id)`. Scoped to the caller's full
+    /// `(tenant_id, user_id, agent_id)` — NULL `agent_id` matches only NULL.
+    ///
+    /// The capacity counter decrement happens **only on this claiming call** —
+    /// the call that flips `delivered_to_parent` from 0 to 1. Idempotent: if
+    /// the row is already delivered (`delivered_to_parent = 1`), returns
+    /// `false` without modifying the counter or queue (no double-decrement).
+    ///
+    /// Returns `true` when all children under the gate now have
+    /// `delivered_to_parent = 1` (the gate is fully resolved), `false`
+    /// otherwise or when the row was already delivered.
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn mark_child_delivered(
         &self,
         scope: &TurnScope,
@@ -182,26 +326,72 @@ pub trait DurableSubagentGateResolutionStore: Send + Sync {
 
     /// Claim the next deliverable terminal state for a child.
     ///
-    /// Returns `Some(record)` if an undelivered-terminal row exists for the
-    /// child in the deliverable queue; `None` if the queue is empty.
+    /// Convenience wrapper over [`claim_all_terminal_states_for_child`] that
+    /// returns only the first element of the queue. Scoped to the caller's
+    /// full `(tenant_id, user_id, agent_id)` — NULL `agent_id` matches only
+    /// NULL; never returns rows belonging to a different agent.
+    ///
+    /// Returns `Some(record)` if an undelivered-terminal row exists in the
+    /// deliverable queue for `child_run_id` in the caller's scope; `None` if
+    /// the queue is empty for this child.
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
+    ///
+    /// [`claim_all_terminal_states_for_child`]: DurableSubagentGateResolutionStore::claim_all_terminal_states_for_child
     async fn claim_next_terminal_state_for_child(
         &self,
         scope: &TurnScope,
         child_run_id: TurnRunId,
     ) -> Result<Option<AwaitedChildRow>, GateResolutionStoreError>;
 
-    /// Drain ALL deliverable terminal states for a child in one call.
+    /// Drain all deliverable terminal states for a child in one call.
+    ///
+    /// Returns every row in the deliverable queue (`subagent_gate_deliverable_queue`)
+    /// for `child_run_id` that is scoped to the caller's
+    /// `(tenant_id, user_id, agent_id)` and has `delivered_to_parent = 0`.
+    /// An empty `Vec` means the queue is empty for this child in this scope.
+    ///
+    /// Note: this method reads the queue but does **not** flip
+    /// `delivered_to_parent`. Callers must call [`mark_child_delivered`] for
+    /// each row to record delivery and decrement the capacity counter.
+    ///
+    /// Security: query is strictly scoped to the caller's full scope predicate.
+    /// NULL `agent_id` matches only NULL — a caller cannot observe rows
+    /// belonging to a different `agent_id` under the same `(tenant_id, user_id)`.
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
+    ///
+    /// [`mark_child_delivered`]: DurableSubagentGateResolutionStore::mark_child_delivered
     async fn claim_all_terminal_states_for_child(
         &self,
         scope: &TurnScope,
         child_run_id: TurnRunId,
     ) -> Result<Vec<AwaitedChildRow>, GateResolutionStoreError>;
 
-    /// Delete all rows for a gate (primary table + child index + deliverable
-    /// queue), decrementing the capacity counter atomically.
+    /// Delete all rows for a gate across all three tables in one transaction.
     ///
-    /// This is the gate-cleanup path. Rows deleted here are NOT recoverable
-    /// by the reconciler — the settlement log retains the append-only record.
+    /// Removes every row for `gate_ref` from `subagent_gate_awaited_children`,
+    /// `subagent_gate_child_index`, and `subagent_gate_deliverable_queue`,
+    /// decrementing each affected capacity-counter bucket atomically. Scoped to
+    /// the caller's `(tenant_id, user_id, agent_id)` — NULL `agent_id` matches
+    /// only NULL.
+    ///
+    /// This is the gate-cleanup path. Primary-table rows deleted here are not
+    /// recoverable by the reconciler; the settlement log
+    /// (`subagent_gate_settlement_log`) retains the append-only record as the
+    /// replay source of truth. The reconciler treats a missing gate row as a
+    /// `skipped_orphan` rather than a failure.
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn delete_awaited_child(
         &self,
         scope: &TurnScope,
@@ -210,24 +400,60 @@ pub trait DurableSubagentGateResolutionStore: Send + Sync {
 
     // ── Reconciler-facing methods (spec §5.2.1) ────────────────────────────
 
-    /// Batch existence check: returns the subset of `gate_refs` that still
-    /// exist in `subagent_gate_awaited_children` for the given scope.
+    /// Batch existence check for gate refs (reconciler Phase 1, spec §5.2.1).
     ///
-    /// One batched SELECT; no payload bytes cross this boundary.
+    /// Returns the subset of `gate_refs` that have at least one row in
+    /// `subagent_gate_awaited_children` for the given scope. Issued as one
+    /// batched SELECT; no payload bytes cross this boundary. Scoped to the
+    /// caller's `(tenant_id, user_id, agent_id)` — NULL `agent_id` matches
+    /// only NULL; never returns refs belonging to a foreign scope.
+    ///
+    /// Consumed by the WU-C3 `SubagentRestartReconciler` replay Phase 1 to
+    /// determine which settlement-log rows still have a live gate row before
+    /// attempting redelivery. A gate ref absent from the returned set is treated
+    /// as a `skipped_orphan` (gate was cleaned up after settlement).
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn gates_exist_batch(
         &self,
         scope: &TurnScope,
         gate_refs: Vec<GateRef>,
     ) -> Result<HashSet<GateRef>, GateResolutionStoreError>;
 
-    /// Reconciler delivery (spec §5.2.1, decision 29).
+    /// Re-drive settlement for a child that was not delivered before a restart
+    /// (reconciler Phase 4, spec §5.2.1 decision 29).
     ///
-    /// Idempotently ensures the gate row's terminal flags are set from the
-    /// settlement-log row and an entry exists in the deliverable queue — the
-    /// §1.6 settlement transaction, re-driven.
+    /// Idempotently ensures the gate row's terminal flags (`terminal_status`,
+    /// `terminal_event_json`, `settled_at`) are set from the settlement-log row
+    /// and that an entry exists in the deliverable queue — the §1.6 settlement
+    /// transaction, re-driven. No payload bytes cross this boundary: the
+    /// `result_ref` carried in the settlement log row is stored directly in the
+    /// gate row; the parent loop reads payload bytes lazily at drain time
+    /// (WU-E), not during reconciler replay.
     ///
-    /// Returns `false` if the gate row no longer exists (orphan race — caller
-    /// counts it as `skipped_orphan`).
+    /// The `terminal_status IS NULL` guard on the UPDATE makes this call
+    /// idempotent: if settlement already occurred (e.g. a second replica also
+    /// ran reconciler) the UPDATE is a no-op and the queue entry is ensured via
+    /// `INSERT OR IGNORE`.
+    ///
+    /// Consumed by the WU-C3 `SubagentRestartReconciler` replay Phase 4.
+    ///
+    /// Security: the existence check is scoped to the caller's full
+    /// `(tenant_id, user_id, agent_id)` — NULL `agent_id` matches only NULL.
+    /// A caller naming a foreign `(gate_ref, child_run_id)` receives `false`
+    /// rather than accidentally rebinding a foreign row into their queue.
+    ///
+    /// Returns `true` on successful redelivery (terminal flags set + queue
+    /// entry ensured). Returns `false` if the gate row does not exist in the
+    /// caller's scope (orphan race — caller counts it as `skipped_orphan`).
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn redeliver_settled_child(
         &self,
         scope: &TurnScope,
@@ -237,12 +463,34 @@ pub trait DurableSubagentGateResolutionStore: Send + Sync {
         result_ref: LoopResultRef,
     ) -> Result<bool, GateResolutionStoreError>;
 
-    /// Capacity resolution for rows that will never deliver (spec decision 31).
+    /// Resolve scope capacity for rows that will never deliver (spec decision 31,
+    /// reconciler Phase 2a, spec §5.2.1).
     ///
-    /// For each `(gate_ref, child_run_id)`: flip `delivered_to_parent`,
-    /// decrement the capacity bucket, delete the queue entry — the §1.6
-    /// delivery-claim transaction, batched. Idempotent per row via the
-    /// `delivered_to_parent = 0` guard.
+    /// For each `(gate_ref, child_run_id)` pair: flips `delivered_to_parent = 1`,
+    /// decrements the capacity counter for the row's bucket, and deletes the
+    /// deliverable-queue entry — the §1.6 delivery-claim transaction, applied
+    /// in batch. Scoped to the caller's `(tenant_id, user_id, agent_id)`.
+    ///
+    /// Used by the WU-C3 reconciler for the `skipped_tombstoned` and
+    /// `skipped_orphan` paths (decision 31): children that were tombstoned or
+    /// whose gate was deleted never deliver, so their undelivered counter
+    /// contribution must be resolved to prevent scope capacity from being
+    /// permanently consumed and wedging the scope at the [`MAX_GATE_RECORDS`]
+    /// cap.
+    ///
+    /// **Retention invariant**: this method marks rows undeliverable by flipping
+    /// `delivered_to_parent` — it does NOT delete primary-table rows or
+    /// settlement-log rows. The settlement log is append-only and must never be
+    /// deleted (LLM-data-never-deleted invariant from spec overview + CLAUDE.md).
+    ///
+    /// Idempotent per row via the `delivered_to_parent = 0` guard — rows
+    /// already marked delivered are skipped without error and without a
+    /// double-decrement.
+    ///
+    /// # Errors
+    ///
+    /// - [`GateResolutionStoreError::Io`] / [`GateResolutionStoreError::Unavailable`]
+    ///   on backend failure.
     async fn resolve_undeliverable_batch(
         &self,
         scope: &TurnScope,
@@ -251,48 +499,93 @@ pub trait DurableSubagentGateResolutionStore: Send + Sync {
 }
 
 /// A row in `subagent_gate_awaited_children` — returned by claim methods.
+///
+/// Represents the full persisted lifecycle state of one awaited child under a
+/// gate. Returned by [`DurableSubagentGateResolutionStore::claim_next_terminal_state_for_child`]
+/// and [`DurableSubagentGateResolutionStore::claim_all_terminal_states_for_child`].
 #[derive(Debug, Clone)]
 pub struct AwaitedChildRow {
+    /// The gate that owns this awaited-child relationship.
     pub gate_ref: GateRef,
+    /// The run ID of the awaited child.
     pub child_run_id: TurnRunId,
+    /// The run ID of the parent that registered this gate.
     pub parent_run_id: TurnRunId,
+    /// The root run ID of the subagent tree — used for fan-out accounting.
     pub tree_root_run_id: TurnRunId,
-    /// JSON-encoded `TurnScope` (child scope)
+    /// JSON-encoded `TurnScope` (child scope).
     pub child_scope_json: String,
-    /// JSON-encoded `LoopRunContext` (parent run context)
+    /// JSON-encoded `LoopRunContext` (parent run context). Sensitive fields
+    /// must be stripped before storage — see the credential audit note on
+    /// [`AwaitedChildRecord::parent_run_context_json`].
     pub parent_run_context_json: String,
+    /// Binding ref for the source capability that spawned this child.
     pub source_binding_ref: String,
+    /// Binding ref for the reply-target slot where the child's result lands.
     pub reply_target_binding_ref: String,
+    /// Kind tag for the subagent (e.g. `"loop"`, `"tool_agent"`).
     pub subagent_kind: String,
+    /// Capability ID of the spawn capability used to launch this child.
     pub spawn_capability_id: String,
+    /// Ref identifying the capability result in the capability result store.
+    /// The parent loop reads result bytes lazily from the store using this ref
+    /// at drain time (WU-E), not during reconciler replay.
     pub result_ref: LoopResultRef,
+    /// Spawn mode string: `"blocking"` or `"background"`.
     pub spawn_mode: String,
+    /// Terminal turn status; `None` until the child settles.
     pub terminal_status: Option<TurnStatus>,
+    /// JSON-encoded terminal event; `None` until the child settles.
     pub terminal_event_json: Option<String>,
+    /// Whether the capability result write has been confirmed after settlement.
     pub terminal_result_written: bool,
+    /// Byte length of the written capability result; `0` until confirmed.
     pub terminal_byte_len: u64,
+    /// Whether delivery was claimed for this child (set in the same
+    /// transaction as `delivered_to_parent`).
     pub delivery_claimed: bool,
+    /// Whether this child's terminal state has been delivered to its parent
+    /// loop. Once `true`, the capacity counter bucket has been decremented and
+    /// the deliverable-queue entry has been removed.
     pub delivered_to_parent: bool,
 }
 
 /// The data needed to INSERT a new awaited-child row.
+///
+/// Passed to [`DurableSubagentGateResolutionStore::record_awaited_child`].
+/// The capacity-counter bucket is computed by the implementation from
+/// `child_run_id` using [`child_bucket`] and is not a field here.
 #[derive(Debug, Clone)]
 pub struct AwaitedChildRecord {
+    /// The gate that will own this awaited-child relationship.
     pub gate_ref: GateRef,
+    /// The run ID of the parent that registered this gate.
     pub parent_run_id: TurnRunId,
+    /// The root run ID of the subagent tree.
     pub tree_root_run_id: TurnRunId,
+    /// The run ID of the awaited child.
     pub child_run_id: TurnRunId,
+    /// The thread ID within the child's scope.
     pub child_thread_id: String,
-    /// JSON-encoded `TurnScope` (child scope)
+    /// JSON-encoded `TurnScope` (child scope).
     pub child_scope_json: String,
-    /// JSON-encoded `LoopRunContext` — MUST be stripped of sensitive fields
-    /// before reaching this struct (see credential audit).
+    /// JSON-encoded `LoopRunContext` (parent run context).
+    ///
+    /// MUST be stripped of sensitive fields (credentials, secrets) before
+    /// constructing this struct — see the credential audit. The raw
+    /// `LoopRunContext` is never stored directly.
     pub parent_run_context_json: String,
+    /// Binding ref for the source capability that spawned this child.
     pub source_binding_ref: String,
+    /// Binding ref for the reply-target slot where the child's result lands.
     pub reply_target_binding_ref: String,
+    /// Kind tag for the subagent (e.g. `"loop"`, `"tool_agent"`).
     pub subagent_kind: String,
+    /// Capability ID of the spawn capability used to launch this child.
     pub spawn_capability_id: String,
+    /// Ref identifying the capability result in the capability result store.
     pub result_ref: LoopResultRef,
+    /// Spawn mode string: `"blocking"` or `"background"`.
     pub spawn_mode: String,
 }
 

--- a/crates/ironclaw_reborn_event_store/src/gate_resolution.rs
+++ b/crates/ironclaw_reborn_event_store/src/gate_resolution.rs
@@ -153,6 +153,14 @@ pub fn child_bucket(child_run_id_str: &str, k: u32) -> u32 {
 /// the scope. [`DurableSubagentGateResolutionStore::record_awaited_child`]
 /// returns [`GateResolutionStoreError::CapacityExceeded`] when the sum already
 /// equals this value. Mirrors `MAX_GATE_RECORDS` in the in-memory store.
+///
+/// This cap is **advisory back-pressure, not a hard invariant**: the
+/// check-then-increment sequence is not serialized across concurrent spawns
+/// (by design — the bucketed counter exists to keep the spawn hot path free
+/// of a single contended row, spec decisions 20/21), so a burst of
+/// simultaneous spawns may transiently overshoot the cap by up to the number
+/// of in-flight spawns. Callers must not rely on the cap as an exact upper
+/// bound.
 pub const MAX_GATE_RECORDS: u32 = 4096;
 
 /// Durable persistence layer for subagent gate-resolution state (spec §1).

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -48,8 +48,24 @@ use thiserror::Error;
 use tokio::sync::Mutex;
 
 mod filesystem_store;
+pub mod gate_resolution;
 
 pub use filesystem_store::{FilesystemDurableAuditLog, FilesystemDurableEventLog};
+pub use gate_resolution::{
+    AwaitedChildRecord, AwaitedChildRow, CAPACITY_COUNTER_BUCKETS, CAPACITY_COUNTER_BUCKETS_ENV,
+    DurableSubagentGateResolutionStore, DurableTerminalEvent, GateResolutionStoreError,
+    MAX_GATE_RECORDS, child_bucket, effective_capacity_counter_buckets,
+};
+
+#[cfg(feature = "libsql")]
+pub mod libsql;
+#[cfg(feature = "libsql")]
+pub use libsql::{LibSqlGateResolutionStore, run_libsql_gate_migrations};
+
+#[cfg(feature = "postgres")]
+pub mod postgres;
+#[cfg(feature = "postgres")]
+pub use postgres::{PostgresGateResolutionStore, run_postgres_gate_migrations};
 
 /// Open a PostgreSQL pool using the same TLS policy as the production event
 /// store backend.

--- a/crates/ironclaw_reborn_event_store/src/libsql/gate_resolution.rs
+++ b/crates/ironclaw_reborn_event_store/src/libsql/gate_resolution.rs
@@ -47,6 +47,10 @@ type LibSqlDb = Arc<libsql::Database>;
 pub struct LibSqlGateResolutionStore {
     db: LibSqlDb,
     k_buckets: u32,
+    /// Per-scope cap; defaults to `MAX_GATE_RECORDS`. Tests may inject a
+    /// smaller value via [`Self::new_with_limit`] to avoid inserting thousands
+    /// of rows. The production default is never changed.
+    max_records: u32,
 }
 
 impl LibSqlGateResolutionStore {
@@ -55,7 +59,24 @@ impl LibSqlGateResolutionStore {
     /// `k_buckets` is the number of capacity-counter buckets; pass
     /// `effective_capacity_counter_buckets()` for the operator-tunable value.
     pub fn new(db: LibSqlDb, k_buckets: u32) -> Self {
-        Self { db, k_buckets }
+        Self {
+            db,
+            k_buckets,
+            max_records: MAX_GATE_RECORDS,
+        }
+    }
+
+    /// Build a new store with an overridden per-scope capacity limit.
+    ///
+    /// **For tests only.** The production default (`MAX_GATE_RECORDS`) is not
+    /// changed by this constructor. Use this to avoid inserting thousands of
+    /// rows in capacity-limit tests.
+    pub fn new_with_limit(db: LibSqlDb, k_buckets: u32, max_records: u32) -> Self {
+        Self {
+            db,
+            k_buckets,
+            max_records,
+        }
     }
 
     async fn conn(&self) -> Result<libsql::Connection, GateResolutionStoreError> {
@@ -208,9 +229,12 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
             .await
             .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN IMMEDIATE: {e}")))?;
 
-        // Initialize bucket row if missing (INSERT OR IGNORE).
-        let init_sql = "INSERT OR IGNORE INTO subagent_gate_capacity_counter \
-            (tenant_id, user_id, agent_id, bucket, undelivered) VALUES (?, ?, ?, ?, 0)";
+        // Initialize bucket row if missing.
+        // Use ON CONFLICT targeting the COALESCE expression index so that
+        // NULL agent_id rows share the same unique (tenant, user, '', bucket) key.
+        // Plain INSERT OR IGNORE with the former composite PK would treat each
+        // NULL agent_id as distinct, creating a new counter row per agentless spawn.
+        let init_sql = "INSERT INTO subagent_gate_capacity_counter             (tenant_id, user_id, agent_id, bucket, undelivered) VALUES (?, ?, ?, ?, 0)             ON CONFLICT (tenant_id, user_id, COALESCE(agent_id, ''), bucket) DO NOTHING";
         conn.execute(
             init_sql,
             libsql::params![tenant_id.clone(), user_id.clone(), agent_id.clone(), bucket],
@@ -243,9 +267,23 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
             .next()
             .await
             .map_err(|e| GateResolutionStoreError::io("cap_check_row", e.to_string()))?;
-        let total: i64 = cap_row.map(|r| r.get::<i64>(0).unwrap_or(0)).unwrap_or(0);
+        // COALESCE in the SQL already returns 0 for an empty scope, so a missing
+        // row is a hard error (not a legitimate zero). Decode failure maps to Io.
+        let total: i64 = match cap_row {
+            Some(r) => r
+                .get::<i64>(0)
+                .map_err(|e| GateResolutionStoreError::io("cap_check_decode", e.to_string()))?,
+            None => {
+                // The COALESCE always returns a row even when there are no counter
+                // rows; None here indicates a backend error.
+                return Err(GateResolutionStoreError::io(
+                    "cap_check_decode",
+                    "SUM query returned no row",
+                ));
+            }
+        };
 
-        if total >= MAX_GATE_RECORDS as i64 {
+        if total >= self.max_records as i64 {
             conn.execute("ROLLBACK", ()).await.ok();
             return Err(GateResolutionStoreError::CapacityExceeded);
         }
@@ -257,30 +295,31 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
              source_binding_ref, reply_target_binding_ref, subagent_kind, spawn_capability_id, \
              result_ref, spawn_mode, counter_bucket) \
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-        conn.execute(
-            insert_sql,
-            libsql::params![
-                tenant_id.clone(),
-                user_id.clone(),
-                agent_id.clone(),
-                record.gate_ref.as_str().to_string(),
-                record.parent_run_id.to_string(),
-                record.tree_root_run_id.to_string(),
-                record.child_run_id.to_string(),
-                record.child_thread_id.clone(),
-                record.child_scope_json.clone(),
-                record.parent_run_context_json.clone(),
-                record.source_binding_ref.clone(),
-                record.reply_target_binding_ref.clone(),
-                record.subagent_kind.clone(),
-                record.spawn_capability_id.clone(),
-                record.result_ref.as_str().to_string(),
-                record.spawn_mode.clone(),
-                bucket
-            ],
-        )
-        .await
-        .map_err(|e| GateResolutionStoreError::io("insert_awaited_child", e.to_string()))?;
+        let rows_inserted = conn
+            .execute(
+                insert_sql,
+                libsql::params![
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    agent_id.clone(),
+                    record.gate_ref.as_str().to_string(),
+                    record.parent_run_id.to_string(),
+                    record.tree_root_run_id.to_string(),
+                    record.child_run_id.to_string(),
+                    record.child_thread_id.clone(),
+                    record.child_scope_json.clone(),
+                    record.parent_run_context_json.clone(),
+                    record.source_binding_ref.clone(),
+                    record.reply_target_binding_ref.clone(),
+                    record.subagent_kind.clone(),
+                    record.spawn_capability_id.clone(),
+                    record.result_ref.as_str().to_string(),
+                    record.spawn_mode.clone(),
+                    bucket
+                ],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("insert_awaited_child", e.to_string()))?;
 
         // INSERT OR IGNORE reverse-index row.
         let idx_sql = "INSERT OR IGNORE INTO subagent_gate_child_index \
@@ -298,30 +337,30 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
         .await
         .map_err(|e| GateResolutionStoreError::io("insert_child_index", e.to_string()))?;
 
-        // Increment the specific bucket (only touches one row).
-        let incr_sql = if agent_id.is_some() {
-            "UPDATE subagent_gate_capacity_counter \
-              SET undelivered = undelivered + 1 \
-            WHERE tenant_id = ? AND user_id = ? AND agent_id = ? AND bucket = ?"
-        } else {
-            "UPDATE subagent_gate_capacity_counter \
-              SET undelivered = undelivered + 1 \
-            WHERE tenant_id = ? AND user_id = ? AND agent_id IS NULL AND bucket = ?"
-        };
-        if let Some(ref aid) = agent_id {
-            conn.execute(
-                incr_sql,
-                libsql::params![tenant_id.clone(), user_id.clone(), aid.clone(), bucket],
-            )
-            .await
-        } else {
-            conn.execute(
-                incr_sql,
-                libsql::params![tenant_id.clone(), user_id.clone(), bucket],
-            )
-            .await
+        // F2: only increment the counter when a NEW row was actually inserted.
+        // Replayed / duplicate calls skip the INSERT (0 rows affected) and must
+        // NOT touch the counter — otherwise each replay inflates capacity.
+        if rows_inserted > 0 {
+            let incr_sql = if agent_id.is_some() {
+                "UPDATE subagent_gate_capacity_counter                   SET undelivered = undelivered + 1                 WHERE tenant_id = ? AND user_id = ? AND agent_id = ? AND bucket = ?"
+            } else {
+                "UPDATE subagent_gate_capacity_counter                   SET undelivered = undelivered + 1                 WHERE tenant_id = ? AND user_id = ? AND agent_id IS NULL AND bucket = ?"
+            };
+            if let Some(ref aid) = agent_id {
+                conn.execute(
+                    incr_sql,
+                    libsql::params![tenant_id.clone(), user_id.clone(), aid.clone(), bucket],
+                )
+                .await
+            } else {
+                conn.execute(
+                    incr_sql,
+                    libsql::params![tenant_id.clone(), user_id.clone(), bucket],
+                )
+                .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("incr_bucket", e.to_string()))?;
         }
-        .map_err(|e| GateResolutionStoreError::io("incr_bucket", e.to_string()))?;
 
         conn.execute("COMMIT", ())
             .await
@@ -527,7 +566,9 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
             .await
             .map_err(|e| GateResolutionStoreError::io("fetch_bucket_row", e.to_string()))?
         {
-            Some(r) => r.get::<i64>(0).unwrap_or(0),
+            Some(r) => r
+                .get::<i64>(0)
+                .map_err(|e| GateResolutionStoreError::io("fetch_bucket_col", e.to_string()))?,
             None => {
                 conn.execute("ROLLBACK", ()).await.ok();
                 return Ok(false);
@@ -542,7 +583,7 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
               AND tenant_id = ? AND user_id = ? AND",
             agent_id.is_some(),
         );
-        if let Some(ref aid) = agent_id {
+        let delivered_rows = if let Some(ref aid) = agent_id {
             conn.execute(
                 &upd_sql,
                 libsql::params![
@@ -568,61 +609,64 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
         }
         .map_err(|e| GateResolutionStoreError::io("mark_delivered_update", e.to_string()))?;
 
-        // Decrement the capacity bucket (floor-at-zero via MAX).
-        // libSQL has no GREATEST() — use MAX(undelivered - 1, 0).
-        let decr_sql = build_agent_predicate_update(
-            "UPDATE subagent_gate_capacity_counter \
-              SET undelivered = MAX(undelivered - 1, 0) \
-            WHERE tenant_id = ? AND user_id = ? AND bucket = ? AND",
-            agent_id.is_some(),
-        );
-        // Note: for this query the positional params are tenant_id, user_id, bucket, [agent_id]
-        if let Some(ref aid) = agent_id {
-            conn.execute(
-                &decr_sql,
-                libsql::params![tenant_id.clone(), user_id.clone(), bucket, aid.clone()],
-            )
-            .await
-        } else {
-            conn.execute(
-                &decr_sql,
-                libsql::params![tenant_id.clone(), user_id.clone(), bucket],
-            )
-            .await
-        }
-        .map_err(|e| GateResolutionStoreError::io("decr_bucket", e.to_string()))?;
+        // F3: only decrement the counter and remove the queue entry when the
+        // guarding UPDATE actually flipped the row (delivered_to_parent 0 -> 1).
+        // If 0 rows were updated, the row was already delivered (retry / replay)
+        // and we must NOT double-decrement capacity.
+        if delivered_rows > 0 {
+            // Decrement the capacity bucket (floor-at-zero via MAX).
+            // libSQL has no GREATEST() — use MAX(undelivered - 1, 0).
+            let decr_sql = build_agent_predicate_update(
+                "UPDATE subagent_gate_capacity_counter                   SET undelivered = MAX(undelivered - 1, 0)                 WHERE tenant_id = ? AND user_id = ? AND bucket = ? AND",
+                agent_id.is_some(),
+            );
+            // Note: for this query the positional params are tenant_id, user_id, bucket, [agent_id]
+            if let Some(ref aid) = agent_id {
+                conn.execute(
+                    &decr_sql,
+                    libsql::params![tenant_id.clone(), user_id.clone(), bucket, aid.clone()],
+                )
+                .await
+            } else {
+                conn.execute(
+                    &decr_sql,
+                    libsql::params![tenant_id.clone(), user_id.clone(), bucket],
+                )
+                .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("decr_bucket", e.to_string()))?;
 
-        // Delete the specific child's queue entry.
-        let del_queue_sql = build_agent_predicate_update(
-            "DELETE FROM subagent_gate_deliverable_queue \
-            WHERE gate_ref = ? AND child_run_id = ? AND tenant_id = ? AND user_id = ? AND",
-            agent_id.is_some(),
-        );
-        if let Some(ref aid) = agent_id {
-            conn.execute(
-                &del_queue_sql,
-                libsql::params![
-                    gate_ref.as_str().to_string(),
-                    child_run_id.to_string(),
-                    tenant_id.clone(),
-                    user_id.clone(),
-                    aid.clone()
-                ],
-            )
-            .await
-        } else {
-            conn.execute(
-                &del_queue_sql,
-                libsql::params![
-                    gate_ref.as_str().to_string(),
-                    child_run_id.to_string(),
-                    tenant_id.clone(),
-                    user_id.clone()
-                ],
-            )
-            .await
+            // Delete the specific child's queue entry.
+            let del_queue_sql = build_agent_predicate_update(
+                "DELETE FROM subagent_gate_deliverable_queue                 WHERE gate_ref = ? AND child_run_id = ? AND tenant_id = ? AND user_id = ? AND",
+                agent_id.is_some(),
+            );
+            if let Some(ref aid) = agent_id {
+                conn.execute(
+                    &del_queue_sql,
+                    libsql::params![
+                        gate_ref.as_str().to_string(),
+                        child_run_id.to_string(),
+                        tenant_id.clone(),
+                        user_id.clone(),
+                        aid.clone()
+                    ],
+                )
+                .await
+            } else {
+                conn.execute(
+                    &del_queue_sql,
+                    libsql::params![
+                        gate_ref.as_str().to_string(),
+                        child_run_id.to_string(),
+                        tenant_id.clone(),
+                        user_id.clone()
+                    ],
+                )
+                .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("del_queue_entry", e.to_string()))?;
         }
-        .map_err(|e| GateResolutionStoreError::io("del_queue_entry", e.to_string()))?;
 
         // Check if ALL children under this gate are now delivered.
         let all_sql = "SELECT COUNT(*) FROM subagent_gate_awaited_children \
@@ -631,12 +675,22 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
             .query(all_sql, libsql::params![gate_ref.as_str().to_string()])
             .await
             .map_err(|e| GateResolutionStoreError::io("all_delivered_check", e.to_string()))?;
-        let remaining: i64 = check_rows
+        let remaining: i64 = match check_rows
             .next()
             .await
             .map_err(|e| GateResolutionStoreError::io("all_delivered_row", e.to_string()))?
-            .map(|r| r.get::<i64>(0).unwrap_or(0))
-            .unwrap_or(0);
+        {
+            Some(r) => r
+                .get::<i64>(0)
+                .map_err(|e| GateResolutionStoreError::io("all_delivered_col", e.to_string()))?,
+            // COUNT(*) always returns a row; None here is a backend error.
+            None => {
+                return Err(GateResolutionStoreError::io(
+                    "all_delivered_col",
+                    "COUNT query returned no row",
+                ));
+            }
+        };
 
         conn.execute("COMMIT", ())
             .await
@@ -771,8 +825,12 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
             .await
             .map_err(|e| GateResolutionStoreError::io("delete_count_row", e.to_string()))?
         {
-            let b: i64 = row.get::<i64>(0).unwrap_or(0);
-            let n: i64 = row.get::<i64>(1).unwrap_or(0);
+            let b: i64 = row.get::<i64>(0).map_err(|e| {
+                GateResolutionStoreError::io("delete_count_bucket_col", e.to_string())
+            })?;
+            let n: i64 = row
+                .get::<i64>(1)
+                .map_err(|e| GateResolutionStoreError::io("delete_count_n_col", e.to_string()))?;
             bucket_counts.push((b, n));
         }
 
@@ -970,16 +1028,39 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
             .await
             .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN: {e}")))?;
 
-        // Check existence.
-        let exists_sql = "SELECT 1 FROM subagent_gate_awaited_children \
-            WHERE gate_ref = ? AND child_run_id = ? LIMIT 1";
-        let mut exists_rows = conn
-            .query(
+        // Check existence — scoped to the caller's (tenant_id, user_id, agent_id)
+        // so a foreign (gate_ref, child_run_id) pair cannot be rebound into
+        // this caller's deliverable queue (F4 security fix).
+        let exists_sql = if agent_id.is_some() {
+            "SELECT 1 FROM subagent_gate_awaited_children                 WHERE gate_ref = ? AND child_run_id = ?                   AND tenant_id = ? AND user_id = ? AND agent_id = ? LIMIT 1"
+        } else {
+            "SELECT 1 FROM subagent_gate_awaited_children                 WHERE gate_ref = ? AND child_run_id = ?                   AND tenant_id = ? AND user_id = ? AND agent_id IS NULL LIMIT 1"
+        };
+        let mut exists_rows = if let Some(ref aid) = agent_id {
+            conn.query(
                 exists_sql,
-                libsql::params![gate_ref.as_str().to_string(), child_run_id.to_string()],
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
             )
             .await
-            .map_err(|e| GateResolutionStoreError::io("redeliver_check", e.to_string()))?;
+        } else {
+            conn.query(
+                exists_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("redeliver_check", e.to_string()))?;
         if exists_rows
             .next()
             .await
@@ -987,7 +1068,7 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
             .is_none()
         {
             conn.execute("ROLLBACK", ()).await.ok();
-            return Ok(false); // gate row vanished (orphan)
+            return Ok(false); // gate row vanished or belongs to a different scope
         }
 
         // Set terminal flags (UPDATE WHERE terminal_status IS NULL = idempotent).
@@ -1059,12 +1140,126 @@ impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
         if rows.is_empty() {
             return Ok(());
         }
+
+        // F5: apply the whole batch in ONE transaction — one BEGIN/COMMIT, N
+        // per-row statements inside. This avoids partial commits on mid-batch
+        // failure and N round trips.
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN: {e}")))?;
+
         for (gate_ref, child_run_id) in rows {
-            // Reuse mark_child_delivered per row (same delivery-claim transaction).
-            // Idempotent via delivered_to_parent = 0 guard.
-            self.mark_child_delivered(scope, &gate_ref, child_run_id)
-                .await?;
+            // Look up the counter_bucket for this row.
+            let bucket_sql = "SELECT counter_bucket FROM subagent_gate_awaited_children                 WHERE gate_ref = ? AND child_run_id = ?";
+            let mut bucket_rows = conn
+                .query(
+                    bucket_sql,
+                    libsql::params![gate_ref.as_str().to_string(), child_run_id.to_string()],
+                )
+                .await
+                .map_err(|e| GateResolutionStoreError::io("rub_fetch_bucket", e.to_string()))?;
+            let bucket: i64 =
+                match bucket_rows.next().await.map_err(|e| {
+                    GateResolutionStoreError::io("rub_fetch_bucket_row", e.to_string())
+                })? {
+                    Some(r) => r.get::<i64>(0).map_err(|e| {
+                        GateResolutionStoreError::io("rub_fetch_bucket_col", e.to_string())
+                    })?,
+                    None => continue, // row already gone — skip
+                };
+
+            // Flip delivered flags (guard: delivered_to_parent = 0).
+            let upd_sql = build_agent_predicate_update(
+                "UPDATE subagent_gate_awaited_children                   SET delivery_claimed = 1, delivered_to_parent = 1                 WHERE gate_ref = ? AND child_run_id = ? AND delivered_to_parent = 0                   AND tenant_id = ? AND user_id = ? AND",
+                agent_id.is_some(),
+            );
+            let delivered_rows = if let Some(ref aid) = agent_id {
+                conn.execute(
+                    &upd_sql,
+                    libsql::params![
+                        gate_ref.as_str().to_string(),
+                        child_run_id.to_string(),
+                        tenant_id.clone(),
+                        user_id.clone(),
+                        aid.clone()
+                    ],
+                )
+                .await
+            } else {
+                conn.execute(
+                    &upd_sql,
+                    libsql::params![
+                        gate_ref.as_str().to_string(),
+                        child_run_id.to_string(),
+                        tenant_id.clone(),
+                        user_id.clone()
+                    ],
+                )
+                .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("rub_mark_delivered", e.to_string()))?;
+
+            // F3: only decrement + delete queue if the UPDATE actually flipped the row.
+            if delivered_rows > 0 {
+                let decr_sql = build_agent_predicate_update(
+                    "UPDATE subagent_gate_capacity_counter                       SET undelivered = MAX(undelivered - 1, 0)                     WHERE tenant_id = ? AND user_id = ? AND bucket = ? AND",
+                    agent_id.is_some(),
+                );
+                if let Some(ref aid) = agent_id {
+                    conn.execute(
+                        &decr_sql,
+                        libsql::params![tenant_id.clone(), user_id.clone(), bucket, aid.clone()],
+                    )
+                    .await
+                } else {
+                    conn.execute(
+                        &decr_sql,
+                        libsql::params![tenant_id.clone(), user_id.clone(), bucket],
+                    )
+                    .await
+                }
+                .map_err(|e| GateResolutionStoreError::io("rub_decr_bucket", e.to_string()))?;
+
+                let del_queue_sql = build_agent_predicate_update(
+                    "DELETE FROM subagent_gate_deliverable_queue                     WHERE gate_ref = ? AND child_run_id = ? AND tenant_id = ? AND user_id = ? AND",
+                    agent_id.is_some(),
+                );
+                if let Some(ref aid) = agent_id {
+                    conn.execute(
+                        &del_queue_sql,
+                        libsql::params![
+                            gate_ref.as_str().to_string(),
+                            child_run_id.to_string(),
+                            tenant_id.clone(),
+                            user_id.clone(),
+                            aid.clone()
+                        ],
+                    )
+                    .await
+                } else {
+                    conn.execute(
+                        &del_queue_sql,
+                        libsql::params![
+                            gate_ref.as_str().to_string(),
+                            child_run_id.to_string(),
+                            tenant_id.clone(),
+                            user_id.clone()
+                        ],
+                    )
+                    .await
+                }
+                .map_err(|e| GateResolutionStoreError::io("rub_del_queue", e.to_string()))?;
+            }
         }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("COMMIT: {e}")))?;
         Ok(())
     }
 }

--- a/crates/ironclaw_reborn_event_store/src/libsql/gate_resolution.rs
+++ b/crates/ironclaw_reborn_event_store/src/libsql/gate_resolution.rs
@@ -1,0 +1,1162 @@
+//! libSQL-backed durable gate-resolution store.
+//!
+//! Spec: `docs/reborn/2026-06-08-subagent-durability-spec.md` §1.3 + §1.6.
+//!
+//! # Scope-predicate convention
+//!
+//! Every query that filters by scope MUST use the conditional
+//! `<agent_predicate>`:
+//! - When `scope.agent_id` is `Some(id)`: `agent_id = ?` bound to `id`.
+//! - When `scope.agent_id` is `None`: `agent_id IS NULL`.
+//!
+//! NEVER use `(agent_id = ? OR agent_id IS NULL)` — it allows agent-scoped
+//! callers to reach system-level (NULL agent_id) rows.
+//!
+//! # First-writer-wins
+//!
+//! All INSERT paths use `INSERT OR IGNORE` keyed on the PRIMARY KEY so that
+//! duplicate rows (replay, concurrent settlement) are silently dropped.
+//!
+//! # libSQL-specific notes
+//!
+//! - No `GREATEST()` — use `MAX(a, b)` for the floor-at-zero decrement.
+//! - `BEGIN IMMEDIATE` for the spawn transaction (per-scope serialization).
+//! - Boolean columns are `INTEGER` (0/1).
+//! - Timestamps are `TEXT` in ISO-8601 format.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_turns::{GateRef, LoopResultRef, TurnRunId, TurnScope, TurnStatus};
+
+use crate::gate_resolution::{
+    AwaitedChildRecord, AwaitedChildRow, DurableSubagentGateResolutionStore, DurableTerminalEvent,
+    GateResolutionStoreError, MAX_GATE_RECORDS, child_bucket,
+};
+
+/// libSQL connection handle type alias (avoids importing libsql directly at call sites).
+type LibSqlDb = Arc<libsql::Database>;
+
+/// libSQL-backed durable gate-resolution store.
+///
+/// Owns a reference to the libSQL `Database`. Each async method opens a
+/// fresh connection and runs in a single transaction. For the spawn path
+/// `BEGIN IMMEDIATE` serializes per-scope capacity accounting.
+#[derive(Clone)]
+pub struct LibSqlGateResolutionStore {
+    db: LibSqlDb,
+    k_buckets: u32,
+}
+
+impl LibSqlGateResolutionStore {
+    /// Build a new store from a libSQL database handle.
+    ///
+    /// `k_buckets` is the number of capacity-counter buckets; pass
+    /// `effective_capacity_counter_buckets()` for the operator-tunable value.
+    pub fn new(db: LibSqlDb, k_buckets: u32) -> Self {
+        Self { db, k_buckets }
+    }
+
+    async fn conn(&self) -> Result<libsql::Connection, GateResolutionStoreError> {
+        self.db
+            .connect()
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Resolve `user_id` from a `TurnScope`, falling back to the system sentinel.
+fn user_id_str(scope: &TurnScope) -> String {
+    scope
+        .explicit_owner_user_id()
+        .map(|uid| uid.as_str().to_string())
+        .unwrap_or_else(|| ironclaw_host_api::SYSTEM_RESERVED_ID.to_string())
+}
+
+/// Parse a `TurnStatus` from a TEXT column value.
+fn parse_status(s: &str) -> Result<TurnStatus, GateResolutionStoreError> {
+    match s {
+        "completed" => Ok(TurnStatus::Completed),
+        "failed" => Ok(TurnStatus::Failed),
+        "cancelled" => Ok(TurnStatus::Cancelled),
+        "cancel_requested" => Ok(TurnStatus::CancelRequested),
+        "running" => Ok(TurnStatus::Running),
+        "queued" => Ok(TurnStatus::Queued),
+        "blocked_approval" => Ok(TurnStatus::BlockedApproval),
+        "blocked_auth" => Ok(TurnStatus::BlockedAuth),
+        "blocked_resource" => Ok(TurnStatus::BlockedResource),
+        "blocked_dependent_run" => Ok(TurnStatus::BlockedDependentRun),
+        "recovery_required" => Ok(TurnStatus::RecoveryRequired),
+        other => Err(GateResolutionStoreError::io(
+            "parse_status",
+            format!("unknown TurnStatus value: {other}"),
+        )),
+    }
+}
+
+fn status_str(s: TurnStatus) -> &'static str {
+    match s {
+        TurnStatus::Completed => "completed",
+        TurnStatus::Failed => "failed",
+        TurnStatus::Cancelled => "cancelled",
+        TurnStatus::CancelRequested => "cancel_requested",
+        TurnStatus::Running => "running",
+        TurnStatus::Queued => "queued",
+        TurnStatus::BlockedApproval => "blocked_approval",
+        TurnStatus::BlockedAuth => "blocked_auth",
+        TurnStatus::BlockedResource => "blocked_resource",
+        TurnStatus::BlockedDependentRun => "blocked_dependent_run",
+        TurnStatus::RecoveryRequired => "recovery_required",
+    }
+}
+
+/// Decode a libSQL row from `subagent_gate_awaited_children`.
+fn decode_row(row: &libsql::Row) -> Result<AwaitedChildRow, GateResolutionStoreError> {
+    macro_rules! col_str {
+        ($row:expr, $idx:expr) => {
+            $row.get::<String>($idx)
+                .map_err(|e| GateResolutionStoreError::io("decode_row", e.to_string()))?
+        };
+    }
+    macro_rules! col_opt_str {
+        ($row:expr, $idx:expr) => {
+            $row.get::<Option<String>>($idx)
+                .map_err(|e| GateResolutionStoreError::io("decode_row", e.to_string()))?
+        };
+    }
+    macro_rules! col_i64 {
+        ($row:expr, $idx:expr) => {
+            $row.get::<i64>($idx)
+                .map_err(|e| GateResolutionStoreError::io("decode_row", e.to_string()))?
+        };
+    }
+
+    let gate_ref_str = col_str!(row, 0);
+    let child_run_id_str = col_str!(row, 1);
+    let parent_run_id_str = col_str!(row, 2);
+    let tree_root_run_id_str = col_str!(row, 3);
+    let child_scope_json = col_str!(row, 4);
+    let parent_run_context_json = col_str!(row, 5);
+    let source_binding_ref = col_str!(row, 6);
+    let reply_target_binding_ref = col_str!(row, 7);
+    let subagent_kind = col_str!(row, 8);
+    let spawn_capability_id = col_str!(row, 9);
+    let result_ref_str = col_str!(row, 10);
+    let spawn_mode = col_str!(row, 11);
+    let terminal_status_raw: Option<String> = col_opt_str!(row, 12);
+    let terminal_event_json: Option<String> = col_opt_str!(row, 13);
+    let terminal_result_written: i64 = col_i64!(row, 14);
+    let terminal_byte_len: i64 = col_i64!(row, 15);
+    let delivery_claimed: i64 = col_i64!(row, 16);
+    let delivered_to_parent: i64 = col_i64!(row, 17);
+
+    let gate_ref = GateRef::new(&gate_ref_str)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/gate_ref", e))?;
+    let child_run_id = parse_run_id(&child_run_id_str, "child_run_id")?;
+    let parent_run_id = parse_run_id(&parent_run_id_str, "parent_run_id")?;
+    let tree_root_run_id = parse_run_id(&tree_root_run_id_str, "tree_root_run_id")?;
+    let result_ref = LoopResultRef::new(&result_ref_str)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/result_ref", e))?;
+    let terminal_status = terminal_status_raw.map(|s| parse_status(&s)).transpose()?;
+
+    Ok(AwaitedChildRow {
+        gate_ref,
+        child_run_id,
+        parent_run_id,
+        tree_root_run_id,
+        child_scope_json,
+        parent_run_context_json,
+        source_binding_ref,
+        reply_target_binding_ref,
+        subagent_kind,
+        spawn_capability_id,
+        result_ref,
+        spawn_mode,
+        terminal_status,
+        terminal_event_json,
+        terminal_result_written: terminal_result_written != 0,
+        terminal_byte_len: terminal_byte_len as u64,
+        delivery_claimed: delivery_claimed != 0,
+        delivered_to_parent: delivered_to_parent != 0,
+    })
+}
+
+fn parse_run_id(s: &str, field: &'static str) -> Result<TurnRunId, GateResolutionStoreError> {
+    TurnRunId::parse(s).map_err(|e| GateResolutionStoreError::io(field, e.to_string()))
+}
+
+// ── trait implementation ──────────────────────────────────────────────────────
+
+#[async_trait]
+impl DurableSubagentGateResolutionStore for LibSqlGateResolutionStore {
+    async fn record_awaited_child(
+        &self,
+        scope: &TurnScope,
+        record: AwaitedChildRecord,
+    ) -> Result<(), GateResolutionStoreError> {
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+        let k = self.k_buckets;
+        let bucket = child_bucket(&record.child_run_id.to_string(), k) as i64;
+
+        // BEGIN IMMEDIATE: per-scope serialization for capacity accounting.
+        conn.execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN IMMEDIATE: {e}")))?;
+
+        // Initialize bucket row if missing (INSERT OR IGNORE).
+        let init_sql = "INSERT OR IGNORE INTO subagent_gate_capacity_counter \
+            (tenant_id, user_id, agent_id, bucket, undelivered) VALUES (?, ?, ?, ?, 0)";
+        conn.execute(
+            init_sql,
+            libsql::params![tenant_id.clone(), user_id.clone(), agent_id.clone(), bucket],
+        )
+        .await
+        .map_err(|e| GateResolutionStoreError::io("init_bucket", e.to_string()))?;
+
+        // Cap check: SUM(undelivered) across all buckets for this scope.
+        let sum_sql = if agent_id.is_some() {
+            "SELECT COALESCE(SUM(undelivered), 0) FROM subagent_gate_capacity_counter \
+             WHERE tenant_id = ? AND user_id = ? AND agent_id = ?"
+        } else {
+            "SELECT COALESCE(SUM(undelivered), 0) FROM subagent_gate_capacity_counter \
+             WHERE tenant_id = ? AND user_id = ? AND agent_id IS NULL"
+        };
+
+        let mut rows = if let Some(ref aid) = agent_id {
+            conn.query(
+                sum_sql,
+                libsql::params![tenant_id.clone(), user_id.clone(), aid.clone()],
+            )
+            .await
+        } else {
+            conn.query(sum_sql, libsql::params![tenant_id.clone(), user_id.clone()])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("cap_check", e.to_string()))?;
+
+        let cap_row = rows
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("cap_check_row", e.to_string()))?;
+        let total: i64 = cap_row.map(|r| r.get::<i64>(0).unwrap_or(0)).unwrap_or(0);
+
+        if total >= MAX_GATE_RECORDS as i64 {
+            conn.execute("ROLLBACK", ()).await.ok();
+            return Err(GateResolutionStoreError::CapacityExceeded);
+        }
+
+        // INSERT OR IGNORE primary row (first-writer-wins per spec §1.6).
+        let insert_sql = "INSERT OR IGNORE INTO subagent_gate_awaited_children \
+            (tenant_id, user_id, agent_id, gate_ref, parent_run_id, tree_root_run_id, \
+             child_run_id, child_thread_id, child_scope_json, parent_run_context_json, \
+             source_binding_ref, reply_target_binding_ref, subagent_kind, spawn_capability_id, \
+             result_ref, spawn_mode, counter_bucket) \
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        conn.execute(
+            insert_sql,
+            libsql::params![
+                tenant_id.clone(),
+                user_id.clone(),
+                agent_id.clone(),
+                record.gate_ref.as_str().to_string(),
+                record.parent_run_id.to_string(),
+                record.tree_root_run_id.to_string(),
+                record.child_run_id.to_string(),
+                record.child_thread_id.clone(),
+                record.child_scope_json.clone(),
+                record.parent_run_context_json.clone(),
+                record.source_binding_ref.clone(),
+                record.reply_target_binding_ref.clone(),
+                record.subagent_kind.clone(),
+                record.spawn_capability_id.clone(),
+                record.result_ref.as_str().to_string(),
+                record.spawn_mode.clone(),
+                bucket
+            ],
+        )
+        .await
+        .map_err(|e| GateResolutionStoreError::io("insert_awaited_child", e.to_string()))?;
+
+        // INSERT OR IGNORE reverse-index row.
+        let idx_sql = "INSERT OR IGNORE INTO subagent_gate_child_index \
+            (tenant_id, user_id, agent_id, child_run_id, gate_ref) VALUES (?, ?, ?, ?, ?)";
+        conn.execute(
+            idx_sql,
+            libsql::params![
+                tenant_id.clone(),
+                user_id.clone(),
+                agent_id.clone(),
+                record.child_run_id.to_string(),
+                record.gate_ref.as_str().to_string()
+            ],
+        )
+        .await
+        .map_err(|e| GateResolutionStoreError::io("insert_child_index", e.to_string()))?;
+
+        // Increment the specific bucket (only touches one row).
+        let incr_sql = if agent_id.is_some() {
+            "UPDATE subagent_gate_capacity_counter \
+              SET undelivered = undelivered + 1 \
+            WHERE tenant_id = ? AND user_id = ? AND agent_id = ? AND bucket = ?"
+        } else {
+            "UPDATE subagent_gate_capacity_counter \
+              SET undelivered = undelivered + 1 \
+            WHERE tenant_id = ? AND user_id = ? AND agent_id IS NULL AND bucket = ?"
+        };
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                incr_sql,
+                libsql::params![tenant_id.clone(), user_id.clone(), aid.clone(), bucket],
+            )
+            .await
+        } else {
+            conn.execute(
+                incr_sql,
+                libsql::params![tenant_id.clone(), user_id.clone(), bucket],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("incr_bucket", e.to_string()))?;
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("COMMIT: {e}")))?;
+        Ok(())
+    }
+
+    async fn record_child_terminal(
+        &self,
+        scope: &TurnScope,
+        gate_ref: GateRef,
+        child_run_id: TurnRunId,
+        event: DurableTerminalEvent,
+    ) -> Result<(), GateResolutionStoreError> {
+        if !event.status.is_terminal() {
+            return Err(GateResolutionStoreError::NonTerminalStatus);
+        }
+
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        let event_json = serde_json::json!({
+            "status": status_str(event.status),
+            "kind": event.kind,
+            "cursor": event.cursor,
+            "sanitized_reason": event.sanitized_reason,
+            "owner_user_id": event.owner_user_id.as_ref().map(|u| u.as_str()),
+        })
+        .to_string();
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN: {e}")))?;
+
+        // UPDATE only when terminal_status IS NULL (first-writer-wins).
+        let update_sql = build_agent_predicate_update(
+            "UPDATE subagent_gate_awaited_children \
+              SET terminal_status = ?, terminal_event_json = ?, settled_at = datetime('now') \
+            WHERE gate_ref = ? AND child_run_id = ? AND terminal_status IS NULL \
+              AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        let rows_changed = if let Some(ref aid) = agent_id {
+            conn.execute(
+                &update_sql,
+                libsql::params![
+                    status_str(event.status),
+                    event_json.clone(),
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &update_sql,
+                libsql::params![
+                    status_str(event.status),
+                    event_json.clone(),
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("record_terminal_update", e.to_string()))?;
+
+        if rows_changed > 0 {
+            // Append settlement log row (only when terminal was freshly written).
+            let log_sql = "INSERT INTO subagent_gate_settlement_log \
+                (tenant_id, user_id, agent_id, gate_ref, child_run_id, result_ref, \
+                 parent_run_id, terminal_status, terminal_kind, event_cursor, \
+                 terminal_byte_len, sanitized_reason, owner_user_id) \
+                SELECT tenant_id, user_id, agent_id, gate_ref, child_run_id, result_ref, \
+                       parent_run_id, ?, ?, ?, 0, ?, ? \
+                  FROM subagent_gate_awaited_children \
+                 WHERE gate_ref = ? AND child_run_id = ? \
+                   AND tenant_id = ? AND user_id = ?";
+            let owner_str = event.owner_user_id.as_ref().map(|u| u.as_str().to_string());
+            conn.execute(
+                log_sql,
+                libsql::params![
+                    status_str(event.status),
+                    event.kind.clone(),
+                    event.cursor as i64,
+                    event.sanitized_reason.clone(),
+                    owner_str,
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("settlement_log_insert", e.to_string()))?;
+
+            // Insert deliverable queue entry (INSERT OR IGNORE for idempotency).
+            let queue_sql = "INSERT OR IGNORE INTO subagent_gate_deliverable_queue \
+                (tenant_id, user_id, agent_id, child_run_id, gate_ref) VALUES (?, ?, ?, ?, ?)";
+            conn.execute(
+                queue_sql,
+                libsql::params![
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    agent_id.clone(),
+                    child_run_id.to_string(),
+                    gate_ref.as_str().to_string()
+                ],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("queue_insert", e.to_string()))?;
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("COMMIT: {e}")))?;
+        Ok(())
+    }
+
+    async fn mark_terminal_result_written(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+        child_run_id: TurnRunId,
+        byte_len: u64,
+    ) -> Result<(), GateResolutionStoreError> {
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        let update_sql = build_agent_predicate_update(
+            "UPDATE subagent_gate_awaited_children \
+              SET terminal_result_written = 1, terminal_byte_len = ? \
+            WHERE gate_ref = ? AND child_run_id = ? AND terminal_result_written = 0 \
+              AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &update_sql,
+                libsql::params![
+                    byte_len as i64,
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id,
+                    user_id,
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &update_sql,
+                libsql::params![
+                    byte_len as i64,
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id,
+                    user_id
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("mark_result_written", e.to_string()))?;
+        Ok(())
+    }
+
+    async fn mark_child_delivered(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+        child_run_id: TurnRunId,
+    ) -> Result<bool, GateResolutionStoreError> {
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN: {e}")))?;
+
+        // Fetch the counter_bucket for this specific spawn.
+        let bucket_sql = "SELECT counter_bucket FROM subagent_gate_awaited_children \
+            WHERE gate_ref = ? AND child_run_id = ?";
+        let mut bucket_rows = conn
+            .query(
+                bucket_sql,
+                libsql::params![gate_ref.as_str().to_string(), child_run_id.to_string()],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("fetch_bucket", e.to_string()))?;
+        let bucket: i64 = match bucket_rows
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("fetch_bucket_row", e.to_string()))?
+        {
+            Some(r) => r.get::<i64>(0).unwrap_or(0),
+            None => {
+                conn.execute("ROLLBACK", ()).await.ok();
+                return Ok(false);
+            }
+        };
+
+        // Flip delivered flags (guard: delivered_to_parent = 0).
+        let upd_sql = build_agent_predicate_update(
+            "UPDATE subagent_gate_awaited_children \
+              SET delivery_claimed = 1, delivered_to_parent = 1 \
+            WHERE gate_ref = ? AND child_run_id = ? AND delivered_to_parent = 0 \
+              AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &upd_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &upd_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("mark_delivered_update", e.to_string()))?;
+
+        // Decrement the capacity bucket (floor-at-zero via MAX).
+        // libSQL has no GREATEST() — use MAX(undelivered - 1, 0).
+        let decr_sql = build_agent_predicate_update(
+            "UPDATE subagent_gate_capacity_counter \
+              SET undelivered = MAX(undelivered - 1, 0) \
+            WHERE tenant_id = ? AND user_id = ? AND bucket = ? AND",
+            agent_id.is_some(),
+        );
+        // Note: for this query the positional params are tenant_id, user_id, bucket, [agent_id]
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &decr_sql,
+                libsql::params![tenant_id.clone(), user_id.clone(), bucket, aid.clone()],
+            )
+            .await
+        } else {
+            conn.execute(
+                &decr_sql,
+                libsql::params![tenant_id.clone(), user_id.clone(), bucket],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("decr_bucket", e.to_string()))?;
+
+        // Delete the specific child's queue entry.
+        let del_queue_sql = build_agent_predicate_update(
+            "DELETE FROM subagent_gate_deliverable_queue \
+            WHERE gate_ref = ? AND child_run_id = ? AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &del_queue_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &del_queue_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("del_queue_entry", e.to_string()))?;
+
+        // Check if ALL children under this gate are now delivered.
+        let all_sql = "SELECT COUNT(*) FROM subagent_gate_awaited_children \
+            WHERE gate_ref = ? AND delivered_to_parent = 0";
+        let mut check_rows = conn
+            .query(all_sql, libsql::params![gate_ref.as_str().to_string()])
+            .await
+            .map_err(|e| GateResolutionStoreError::io("all_delivered_check", e.to_string()))?;
+        let remaining: i64 = check_rows
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("all_delivered_row", e.to_string()))?
+            .map(|r| r.get::<i64>(0).unwrap_or(0))
+            .unwrap_or(0);
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("COMMIT: {e}")))?;
+        Ok(remaining == 0)
+    }
+
+    async fn claim_next_terminal_state_for_child(
+        &self,
+        scope: &TurnScope,
+        child_run_id: TurnRunId,
+    ) -> Result<Option<AwaitedChildRow>, GateResolutionStoreError> {
+        let mut results = self
+            .claim_all_terminal_states_for_child(scope, child_run_id)
+            .await?;
+        Ok(results.drain(..1).next())
+    }
+
+    async fn claim_all_terminal_states_for_child(
+        &self,
+        scope: &TurnScope,
+        child_run_id: TurnRunId,
+    ) -> Result<Vec<AwaitedChildRow>, GateResolutionStoreError> {
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        // Join deliverable queue to primary table to fetch all rows.
+        let select_sql = if agent_id.is_some() {
+            "SELECT c.gate_ref, c.child_run_id, c.parent_run_id, c.tree_root_run_id, \
+                    c.child_scope_json, c.parent_run_context_json, c.source_binding_ref, \
+                    c.reply_target_binding_ref, c.subagent_kind, c.spawn_capability_id, \
+                    c.result_ref, c.spawn_mode, c.terminal_status, c.terminal_event_json, \
+                    c.terminal_result_written, c.terminal_byte_len, \
+                    c.delivery_claimed, c.delivered_to_parent \
+               FROM subagent_gate_deliverable_queue q \
+               JOIN subagent_gate_awaited_children c \
+                 ON c.gate_ref = q.gate_ref AND c.child_run_id = q.child_run_id \
+              WHERE q.child_run_id = ? \
+                AND q.tenant_id = ? AND q.user_id = ? AND q.agent_id = ? \
+                AND c.delivered_to_parent = 0 AND c.terminal_status IS NOT NULL"
+        } else {
+            "SELECT c.gate_ref, c.child_run_id, c.parent_run_id, c.tree_root_run_id, \
+                    c.child_scope_json, c.parent_run_context_json, c.source_binding_ref, \
+                    c.reply_target_binding_ref, c.subagent_kind, c.spawn_capability_id, \
+                    c.result_ref, c.spawn_mode, c.terminal_status, c.terminal_event_json, \
+                    c.terminal_result_written, c.terminal_byte_len, \
+                    c.delivery_claimed, c.delivered_to_parent \
+               FROM subagent_gate_deliverable_queue q \
+               JOIN subagent_gate_awaited_children c \
+                 ON c.gate_ref = q.gate_ref AND c.child_run_id = q.child_run_id \
+              WHERE q.child_run_id = ? \
+                AND q.tenant_id = ? AND q.user_id = ? AND q.agent_id IS NULL \
+                AND c.delivered_to_parent = 0 AND c.terminal_status IS NOT NULL"
+        };
+
+        let mut rows = if let Some(ref aid) = agent_id {
+            conn.query(
+                select_sql,
+                libsql::params![child_run_id.to_string(), tenant_id, user_id, aid.clone()],
+            )
+            .await
+        } else {
+            conn.query(
+                select_sql,
+                libsql::params![child_run_id.to_string(), tenant_id, user_id],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("claim_query", e.to_string()))?;
+
+        let mut result = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("claim_fetch", e.to_string()))?
+        {
+            result.push(decode_row(&row)?);
+        }
+        Ok(result)
+    }
+
+    async fn delete_awaited_child(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+    ) -> Result<(), GateResolutionStoreError> {
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN: {e}")))?;
+
+        // Count undelivered rows by bucket for decrementing.
+        let count_sql = build_agent_predicate_select(
+            "SELECT counter_bucket, COUNT(*) FROM subagent_gate_awaited_children \
+            WHERE gate_ref = ? AND tenant_id = ? AND user_id = ? AND delivered_to_parent = 0 AND",
+            "GROUP BY counter_bucket",
+            agent_id.is_some(),
+        );
+        let mut count_rows = if let Some(ref aid) = agent_id {
+            conn.query(
+                &count_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.query(
+                &count_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("delete_count_buckets", e.to_string()))?;
+
+        let mut bucket_counts: Vec<(i64, i64)> = Vec::new();
+        while let Some(row) = count_rows
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("delete_count_row", e.to_string()))?
+        {
+            let b: i64 = row.get::<i64>(0).unwrap_or(0);
+            let n: i64 = row.get::<i64>(1).unwrap_or(0);
+            bucket_counts.push((b, n));
+        }
+
+        // Delete from all three tables.
+        let del_queue_sql = build_agent_predicate_delete(
+            "DELETE FROM subagent_gate_deliverable_queue \
+            WHERE gate_ref = ? AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &del_queue_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &del_queue_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("del_queue_gate", e.to_string()))?;
+
+        let del_idx_sql = build_agent_predicate_delete(
+            "DELETE FROM subagent_gate_child_index \
+            WHERE gate_ref = ? AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &del_idx_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &del_idx_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("del_child_idx", e.to_string()))?;
+
+        let del_primary_sql = build_agent_predicate_delete(
+            "DELETE FROM subagent_gate_awaited_children \
+            WHERE gate_ref = ? AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &del_primary_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &del_primary_sql,
+                libsql::params![
+                    gate_ref.as_str().to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("del_primary", e.to_string()))?;
+
+        // Decrement each touched bucket (MAX floor-at-zero).
+        for (bucket, n) in bucket_counts {
+            let decr_sql = build_agent_predicate_update(
+                "UPDATE subagent_gate_capacity_counter \
+                  SET undelivered = MAX(undelivered - ?, 0) \
+                WHERE tenant_id = ? AND user_id = ? AND bucket = ? AND",
+                agent_id.is_some(),
+            );
+            if let Some(ref aid) = agent_id {
+                conn.execute(
+                    &decr_sql,
+                    libsql::params![n, tenant_id.clone(), user_id.clone(), bucket, aid.clone()],
+                )
+                .await
+            } else {
+                conn.execute(
+                    &decr_sql,
+                    libsql::params![n, tenant_id.clone(), user_id.clone(), bucket],
+                )
+                .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("decr_bucket_delete", e.to_string()))?;
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("COMMIT: {e}")))?;
+        Ok(())
+    }
+
+    // ── Reconciler-facing ──────────────────────────────────────────────────
+
+    async fn gates_exist_batch(
+        &self,
+        scope: &TurnScope,
+        gate_refs: Vec<GateRef>,
+    ) -> Result<HashSet<GateRef>, GateResolutionStoreError> {
+        if gate_refs.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        // Build IN clause placeholders.
+        let placeholders: Vec<String> = gate_refs.iter().map(|_| "?".to_string()).collect();
+        let in_clause = placeholders.join(", ");
+
+        let agent_pred = if agent_id.is_some() {
+            "agent_id = ?".to_string()
+        } else {
+            "agent_id IS NULL".to_string()
+        };
+        let sql = format!(
+            "SELECT DISTINCT gate_ref FROM subagent_gate_awaited_children \
+             WHERE tenant_id = ? AND user_id = ? AND {agent_pred} \
+               AND gate_ref IN ({in_clause})"
+        );
+
+        let mut params: Vec<libsql::Value> = vec![tenant_id.into(), user_id.into()];
+        if let Some(ref aid) = agent_id {
+            params.push(aid.clone().into());
+        }
+        for gr in &gate_refs {
+            params.push(gr.as_str().to_string().into());
+        }
+
+        let mut rows = conn
+            .query(&sql, params)
+            .await
+            .map_err(|e| GateResolutionStoreError::io("gates_exist_batch", e.to_string()))?;
+
+        let mut found = HashSet::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("gates_exist_row", e.to_string()))?
+        {
+            let s: String = row
+                .get::<String>(0)
+                .map_err(|e| GateResolutionStoreError::io("gates_exist_col", e.to_string()))?;
+            if let Ok(gr) = GateRef::new(&s) {
+                found.insert(gr);
+            }
+        }
+        Ok(found)
+    }
+
+    async fn redeliver_settled_child(
+        &self,
+        scope: &TurnScope,
+        gate_ref: GateRef,
+        child_run_id: TurnRunId,
+        terminal_status: TurnStatus,
+        result_ref: LoopResultRef,
+    ) -> Result<bool, GateResolutionStoreError> {
+        let conn = self.conn().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("BEGIN: {e}")))?;
+
+        // Check existence.
+        let exists_sql = "SELECT 1 FROM subagent_gate_awaited_children \
+            WHERE gate_ref = ? AND child_run_id = ? LIMIT 1";
+        let mut exists_rows = conn
+            .query(
+                exists_sql,
+                libsql::params![gate_ref.as_str().to_string(), child_run_id.to_string()],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("redeliver_check", e.to_string()))?;
+        if exists_rows
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("redeliver_check_row", e.to_string()))?
+            .is_none()
+        {
+            conn.execute("ROLLBACK", ()).await.ok();
+            return Ok(false); // gate row vanished (orphan)
+        }
+
+        // Set terminal flags (UPDATE WHERE terminal_status IS NULL = idempotent).
+        let upd_sql = build_agent_predicate_update(
+            "UPDATE subagent_gate_awaited_children \
+              SET terminal_status = ?, terminal_result_written = 1, \
+                  result_ref = ?, settled_at = COALESCE(settled_at, datetime('now')) \
+            WHERE gate_ref = ? AND child_run_id = ? AND terminal_status IS NULL \
+              AND tenant_id = ? AND user_id = ? AND",
+            agent_id.is_some(),
+        );
+        if let Some(ref aid) = agent_id {
+            conn.execute(
+                &upd_sql,
+                libsql::params![
+                    status_str(terminal_status),
+                    result_ref.as_str().to_string(),
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone(),
+                    aid.clone()
+                ],
+            )
+            .await
+        } else {
+            conn.execute(
+                &upd_sql,
+                libsql::params![
+                    status_str(terminal_status),
+                    result_ref.as_str().to_string(),
+                    gate_ref.as_str().to_string(),
+                    child_run_id.to_string(),
+                    tenant_id.clone(),
+                    user_id.clone()
+                ],
+            )
+            .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("redeliver_update", e.to_string()))?;
+
+        // Ensure deliverable queue entry exists (INSERT OR IGNORE).
+        let queue_sql = "INSERT OR IGNORE INTO subagent_gate_deliverable_queue \
+            (tenant_id, user_id, agent_id, child_run_id, gate_ref) VALUES (?, ?, ?, ?, ?)";
+        conn.execute(
+            queue_sql,
+            libsql::params![
+                tenant_id.clone(),
+                user_id.clone(),
+                agent_id.clone(),
+                child_run_id.to_string(),
+                gate_ref.as_str().to_string()
+            ],
+        )
+        .await
+        .map_err(|e| GateResolutionStoreError::io("redeliver_queue", e.to_string()))?;
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(format!("COMMIT: {e}")))?;
+        Ok(true)
+    }
+
+    async fn resolve_undeliverable_batch(
+        &self,
+        scope: &TurnScope,
+        rows: Vec<(GateRef, TurnRunId)>,
+    ) -> Result<(), GateResolutionStoreError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        for (gate_ref, child_run_id) in rows {
+            // Reuse mark_child_delivered per row (same delivery-claim transaction).
+            // Idempotent via delivered_to_parent = 0 guard.
+            self.mark_child_delivered(scope, &gate_ref, child_run_id)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+// ── query-building helpers ────────────────────────────────────────────────────
+
+/// Appends the agent predicate (`agent_id = ?` or `agent_id IS NULL`) to the
+/// end of a partial SQL UPDATE statement.
+fn build_agent_predicate_update(prefix: &str, has_agent: bool) -> String {
+    if has_agent {
+        format!("{prefix} agent_id = ?")
+    } else {
+        format!("{prefix} agent_id IS NULL")
+    }
+}
+
+/// Appends the agent predicate to a partial SQL DELETE statement.
+fn build_agent_predicate_delete(prefix: &str, has_agent: bool) -> String {
+    if has_agent {
+        format!("{prefix} agent_id = ?")
+    } else {
+        format!("{prefix} agent_id IS NULL")
+    }
+}
+
+/// Appends the agent predicate and a trailing suffix to a SELECT statement.
+fn build_agent_predicate_select(prefix: &str, suffix: &str, has_agent: bool) -> String {
+    let pred = if has_agent {
+        "agent_id = ?"
+    } else {
+        "agent_id IS NULL"
+    };
+    format!("{prefix} {pred} {suffix}")
+}
+
+/// Run all pending incremental migrations against the libSQL database.
+///
+/// Creates the `_reborn_migrations` tracking table first, then applies each
+/// entry in [`super::migrations::INCREMENTAL_MIGRATIONS`] that is absent from
+/// the table. All DDL uses `IF NOT EXISTS` for idempotency.
+pub async fn run_libsql_gate_migrations(
+    db: &libsql::Database,
+) -> Result<(), GateResolutionStoreError> {
+    use crate::libsql::migrations::{INCREMENTAL_MIGRATIONS, MIGRATIONS_TABLE_DDL};
+
+    let conn = db
+        .connect()
+        .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
+    conn.execute(MIGRATIONS_TABLE_DDL, ())
+        .await
+        .map_err(|e| GateResolutionStoreError::io("create_migrations_table", e.to_string()))?;
+
+    for (version, name, ddl) in INCREMENTAL_MIGRATIONS {
+        let already_applied_rows = conn
+            .query(
+                "SELECT 1 FROM _reborn_migrations WHERE version = ?",
+                libsql::params![*version],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("check_migration", e.to_string()))?
+            .next()
+            .await
+            .map_err(|e| GateResolutionStoreError::io("check_migration_row", e.to_string()))?;
+        if already_applied_rows.is_some() {
+            continue;
+        }
+
+        // Each migration may contain multiple statements separated by semicolons.
+        // Split and execute each individually (libsql does not support multi-statement exec).
+        for stmt in ddl.split(';') {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            conn.execute(stmt, ())
+                .await
+                .map_err(|e| GateResolutionStoreError::io("run_migration_stmt", e.to_string()))?;
+        }
+
+        conn.execute(
+            "INSERT INTO _reborn_migrations (version, name) VALUES (?, ?)",
+            libsql::params![*version, *name],
+        )
+        .await
+        .map_err(|e| GateResolutionStoreError::io("record_migration", e.to_string()))?;
+
+        tracing::debug!(
+            version = *version,
+            name = *name,
+            "reborn gate-resolution migration applied"
+        );
+    }
+    Ok(())
+}

--- a/crates/ironclaw_reborn_event_store/src/libsql/migrations.rs
+++ b/crates/ironclaw_reborn_event_store/src/libsql/migrations.rs
@@ -110,6 +110,14 @@ CREATE INDEX IF NOT EXISTS idx_sgdq_scope
 -- Replaces per-spawn SELECT COUNT(*) on the hot path.
 -- libSQL uses BEGIN IMMEDIATE for serialization (no per-row locking).
 -- No GREATEST() in libSQL: use MAX(undelivered - 1, 0) for floor-at-zero.
+--
+-- No declared PRIMARY KEY because SQLite treats NULL as distinct in composite
+-- PKs: each agentless spawn would create a NEW counter row for the same
+-- (tenant_id, user_id, bucket), drifting capacity upward. Instead we use a
+-- COALESCE expression index (mirroring the Postgres migration) so that all
+-- rows for agent_id IS NULL map to the same unique (tenant, user, '', bucket)
+-- tuple. Conflict target for INSERT must use the COALESCE expression:
+--   ON CONFLICT (tenant_id, user_id, COALESCE(agent_id, ''), bucket)
 
 CREATE TABLE IF NOT EXISTS subagent_gate_capacity_counter (
     tenant_id    TEXT    NOT NULL,
@@ -117,9 +125,11 @@ CREATE TABLE IF NOT EXISTS subagent_gate_capacity_counter (
     agent_id     TEXT,
     bucket       INTEGER NOT NULL,
     undelivered  INTEGER NOT NULL DEFAULT 0
-        CHECK (undelivered >= 0),
-    PRIMARY KEY (tenant_id, user_id, agent_id, bucket)
+        CHECK (undelivered >= 0)
 );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sgcc_pk
+    ON subagent_gate_capacity_counter
+       (tenant_id, user_id, COALESCE(agent_id, ''), bucket);
 CREATE INDEX IF NOT EXISTS idx_sgcc_scope
     ON subagent_gate_capacity_counter (tenant_id, user_id, agent_id);
 

--- a/crates/ironclaw_reborn_event_store/src/libsql/migrations.rs
+++ b/crates/ironclaw_reborn_event_store/src/libsql/migrations.rs
@@ -1,0 +1,158 @@
+//! libSQL DDL migrations for Reborn durable stores.
+//!
+//! Migration-script convention: spec §8.5.
+//!
+//! Version numbers are independent from `src/db/libsql_migrations.rs` —
+//! this crate owns its own `_reborn_migrations` tracking table so there is
+//! no collision with the legacy V1 schema.
+//!
+//! Each entry is `(version, name, ddl)`. All DDL uses `CREATE TABLE IF NOT
+//! EXISTS` and `CREATE INDEX IF NOT EXISTS` for idempotency. Migrations are
+//! applied in version order; only versions absent from `_reborn_migrations`
+//! are executed.
+//!
+//! **Parallel-branch safety:** only version 1 (`subagent_gate_resolution`) is
+//! added by WU-C2. Versions 2, 3, 4 are reserved for parallel workstreams.
+
+/// Tracking table DDL — created once on first use.
+pub const MIGRATIONS_TABLE_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS _reborn_migrations (
+    version     INTEGER NOT NULL PRIMARY KEY,
+    name        TEXT    NOT NULL,
+    applied_at  TEXT    NOT NULL DEFAULT (datetime('now'))
+)"#;
+
+/// Incremental migrations. Entries are `(version, name, ddl)`.
+///
+/// WU-C2 adds version 1 only. Parallel workstreams add 2, 3, 4 without
+/// conflict because each PR adds a single entry to this array at the
+/// appropriate position.
+pub const INCREMENTAL_MIGRATIONS: &[(i64, &str, &str)] = &[
+    (
+        1,
+        "subagent_gate_resolution",
+        // ── subagent_gate_awaited_children ────────────────────────────────
+        // Primary record table. Mirrors GateResolutionInner.by_gate.
+        // Boolean columns use INTEGER (0/1) per SQLite convention.
+        r#"
+CREATE TABLE IF NOT EXISTS subagent_gate_awaited_children (
+    tenant_id                               TEXT    NOT NULL,
+    user_id                                 TEXT    NOT NULL,
+    agent_id                                TEXT,
+    gate_ref                                TEXT    NOT NULL,
+    parent_run_id                           TEXT    NOT NULL,
+    tree_root_run_id                        TEXT    NOT NULL,
+    child_run_id                            TEXT    NOT NULL,
+    child_thread_id                         TEXT    NOT NULL,
+    child_scope_json                        TEXT    NOT NULL,
+    parent_run_context_json                 TEXT    NOT NULL,
+    source_binding_ref                      TEXT    NOT NULL,
+    reply_target_binding_ref                TEXT    NOT NULL,
+    subagent_kind                           TEXT    NOT NULL,
+    spawn_capability_id                     TEXT    NOT NULL,
+    result_ref                              TEXT    NOT NULL,
+    spawn_mode                              TEXT    NOT NULL,
+    counter_bucket                          INTEGER NOT NULL,
+    terminal_status                         TEXT,
+    terminal_event_json                     TEXT,
+    terminal_result_written                 INTEGER NOT NULL DEFAULT 0,
+    terminal_byte_len                       INTEGER NOT NULL DEFAULT 0,
+    descendant_reservation_release_claimed  INTEGER NOT NULL DEFAULT 0,
+    descendant_reservation_released         INTEGER NOT NULL DEFAULT 0,
+    delivery_claimed                        INTEGER NOT NULL DEFAULT 0,
+    delivered_to_parent                     INTEGER NOT NULL DEFAULT 0,
+    created_at                              TEXT    NOT NULL DEFAULT (datetime('now')),
+    settled_at                              TEXT,
+    PRIMARY KEY (gate_ref, child_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sgac_tenant_user_agent
+    ON subagent_gate_awaited_children (tenant_id, user_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_sgac_child_run_id
+    ON subagent_gate_awaited_children (child_run_id);
+CREATE INDEX IF NOT EXISTS idx_sgac_parent_run_id
+    ON subagent_gate_awaited_children (parent_run_id);
+CREATE INDEX IF NOT EXISTS idx_sgac_undelivered_terminal
+    ON subagent_gate_awaited_children (tenant_id, user_id, agent_id, delivered_to_parent, terminal_status)
+    WHERE delivered_to_parent = 0;
+
+-- ── subagent_gate_child_index ────────────────────────────────────────────
+-- Reverse-index table. Mirrors GateResolutionInner.gates_by_child.
+
+CREATE TABLE IF NOT EXISTS subagent_gate_child_index (
+    tenant_id    TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    agent_id     TEXT,
+    child_run_id TEXT NOT NULL,
+    gate_ref     TEXT NOT NULL,
+    PRIMARY KEY (child_run_id, gate_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_sgci_scope
+    ON subagent_gate_child_index (tenant_id, user_id, agent_id, child_run_id);
+
+-- ── subagent_gate_deliverable_queue ─────────────────────────────────────
+-- Delivery queue table. Mirrors GateResolutionInner.deliverable_by_child.
+
+CREATE TABLE IF NOT EXISTS subagent_gate_deliverable_queue (
+    tenant_id    TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    agent_id     TEXT,
+    child_run_id TEXT NOT NULL,
+    gate_ref     TEXT NOT NULL,
+    queued_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (child_run_id, gate_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_sgdq_scope
+    ON subagent_gate_deliverable_queue (tenant_id, user_id, agent_id, child_run_id);
+
+-- ── subagent_gate_capacity_counter ──────────────────────────────────────
+-- Bucketed capacity counter (K=CAPACITY_COUNTER_BUCKETS, default 16).
+-- Replaces per-spawn SELECT COUNT(*) on the hot path.
+-- libSQL uses BEGIN IMMEDIATE for serialization (no per-row locking).
+-- No GREATEST() in libSQL: use MAX(undelivered - 1, 0) for floor-at-zero.
+
+CREATE TABLE IF NOT EXISTS subagent_gate_capacity_counter (
+    tenant_id    TEXT    NOT NULL,
+    user_id      TEXT    NOT NULL,
+    agent_id     TEXT,
+    bucket       INTEGER NOT NULL,
+    undelivered  INTEGER NOT NULL DEFAULT 0
+        CHECK (undelivered >= 0),
+    PRIMARY KEY (tenant_id, user_id, agent_id, bucket)
+);
+CREATE INDEX IF NOT EXISTS idx_sgcc_scope
+    ON subagent_gate_capacity_counter (tenant_id, user_id, agent_id);
+
+-- ── subagent_gate_settlement_log ────────────────────────────────────────
+-- Append-only settlement log for SubagentRestartReconciler replay.
+-- Rows are NEVER deleted — they are the replay source of truth.
+
+CREATE TABLE IF NOT EXISTS subagent_gate_settlement_log (
+    id               INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    tenant_id        TEXT    NOT NULL,
+    user_id          TEXT    NOT NULL,
+    agent_id         TEXT,
+    gate_ref         TEXT    NOT NULL,
+    child_run_id     TEXT    NOT NULL,
+    result_ref       TEXT    NOT NULL,
+    parent_run_id    TEXT    NOT NULL,
+    terminal_status  TEXT    NOT NULL,
+    terminal_kind    TEXT    NOT NULL,
+    event_cursor     INTEGER NOT NULL,
+    terminal_byte_len INTEGER NOT NULL DEFAULT 0,
+    sanitized_reason TEXT,
+    owner_user_id    TEXT,
+    settled_at       TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_sgsl_tenant_user_agent
+    ON subagent_gate_settlement_log (tenant_id, user_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_sgsl_parent_run_id
+    ON subagent_gate_settlement_log (parent_run_id);
+CREATE INDEX IF NOT EXISTS idx_sgsl_child_run_id
+    ON subagent_gate_settlement_log (child_run_id)
+"#,
+    ),
+    // Version 2: subagent_capability_result      (WU-C3 — parallel branch)
+    // Version 3: subagent_settlement_event_log   (WU-C3 — parallel branch)
+    // Version 4: subagent_idempotency_ledger     (WU-C3 — parallel branch)
+];

--- a/crates/ironclaw_reborn_event_store/src/libsql/mod.rs
+++ b/crates/ironclaw_reborn_event_store/src/libsql/mod.rs
@@ -1,0 +1,10 @@
+//! libSQL-backed Reborn durable store modules.
+//!
+//! Each module implements the backend for one durable store using a raw
+//! `libsql::Database` connection. All DDL is managed through the incremental
+//! migration table in [`crate::libsql::migrations`].
+
+pub mod gate_resolution;
+pub mod migrations;
+
+pub use gate_resolution::{LibSqlGateResolutionStore, run_libsql_gate_migrations};

--- a/crates/ironclaw_reborn_event_store/src/postgres/gate_resolution.rs
+++ b/crates/ironclaw_reborn_event_store/src/postgres/gate_resolution.rs
@@ -314,7 +314,9 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
         }
         .map_err(|e| GateResolutionStoreError::io("pg_cap_check", e.to_string()))?;
 
-        let total: i64 = sum_row.try_get::<_, i64>(0).unwrap_or(0);
+        let total: i64 = sum_row
+            .try_get::<_, i64>(0)
+            .map_err(|e| GateResolutionStoreError::io("pg_cap_check_decode", e.to_string()))?;
 
         if total >= MAX_GATE_RECORDS as i64 {
             transaction.rollback().await.ok();
@@ -353,7 +355,7 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
         let child_run_id_str = record.child_run_id.to_string();
         let result_ref_str = record.result_ref.as_str().to_string();
 
-        {
+        let rows_inserted = {
             let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] = if let Some(ref aid) = agent_id {
                 &[
                     &tenant_id,
@@ -396,8 +398,8 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
             };
             transaction.execute(insert_sql, p).await.map_err(|e| {
                 GateResolutionStoreError::io("pg_insert_awaited_child", e.to_string())
-            })?;
-        }
+            })?
+        };
 
         // INSERT ON CONFLICT DO NOTHING reverse-index row.
         let idx_sql = if agent_id.is_some() {
@@ -428,26 +430,27 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
         }
         .map_err(|e| GateResolutionStoreError::io("pg_insert_child_index", e.to_string()))?;
 
-        // Increment the specific bucket only.
-        let incr_sql = if agent_id.is_some() {
-            "UPDATE subagent_gate_capacity_counter \
-               SET undelivered = undelivered + 1 \
-             WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4"
-        } else {
-            "UPDATE subagent_gate_capacity_counter \
-               SET undelivered = undelivered + 1 \
-             WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3"
-        };
-        {
-            let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] = if let Some(ref aid) = agent_id {
-                &[&tenant_id, &user_id, aid, &bucket]
+        // F2: only increment the counter when a NEW row was actually inserted.
+        // Replayed / duplicate calls skip the INSERT (0 rows affected) and must
+        // NOT touch the counter — otherwise each replay inflates capacity.
+        if rows_inserted > 0 {
+            let incr_sql = if agent_id.is_some() {
+                "UPDATE subagent_gate_capacity_counter                    SET undelivered = undelivered + 1                  WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4"
             } else {
-                &[&tenant_id, &user_id, &bucket]
+                "UPDATE subagent_gate_capacity_counter                    SET undelivered = undelivered + 1                  WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3"
             };
-            transaction
-                .execute(incr_sql, p)
-                .await
-                .map_err(|e| GateResolutionStoreError::io("pg_incr_bucket", e.to_string()))?;
+            {
+                let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] =
+                    if let Some(ref aid) = agent_id {
+                        &[&tenant_id, &user_id, aid, &bucket]
+                    } else {
+                        &[&tenant_id, &user_id, &bucket]
+                    };
+                transaction
+                    .execute(incr_sql, p)
+                    .await
+                    .map_err(|e| GateResolutionStoreError::io("pg_incr_bucket", e.to_string()))?;
+            }
         }
 
         transaction
@@ -711,7 +714,9 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
             .await
             .map_err(|e| GateResolutionStoreError::io("pg_fetch_bucket", e.to_string()))?;
         let bucket: i16 = match bucket_row {
-            Some(r) => r.try_get::<_, i16>(0).unwrap_or(0),
+            Some(r) => r
+                .try_get::<_, i16>(0)
+                .map_err(|e| GateResolutionStoreError::io("pg_decode_bucket", e.to_string()))?,
             None => {
                 transaction.rollback().await.ok();
                 return Ok(false);
@@ -730,7 +735,7 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
              WHERE gate_ref = $1 AND child_run_id = $2 AND delivered_to_parent = FALSE \
                AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL"
         };
-        if let Some(ref aid) = agent_id {
+        let delivered_rows = if let Some(ref aid) = agent_id {
             transaction
                 .execute(
                     upd_sql,
@@ -747,53 +752,50 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
         }
         .map_err(|e| GateResolutionStoreError::io("pg_mark_delivered_update", e.to_string()))?;
 
-        // Decrement the capacity bucket (GREATEST floor-at-zero).
-        let decr_sql = if agent_id.is_some() {
-            "UPDATE subagent_gate_capacity_counter \
-               SET undelivered = GREATEST(undelivered - 1, 0) \
-             WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4"
-        } else {
-            "UPDATE subagent_gate_capacity_counter \
-               SET undelivered = GREATEST(undelivered - 1, 0) \
-             WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3"
-        };
-        if let Some(ref aid) = agent_id {
-            transaction
-                .execute(decr_sql, &[&tenant_id, &user_id, aid, &bucket])
-                .await
-        } else {
-            transaction
-                .execute(decr_sql, &[&tenant_id, &user_id, &bucket])
-                .await
-        }
-        .map_err(|e| GateResolutionStoreError::io("pg_decr_bucket", e.to_string()))?;
+        // F3: only decrement the counter and remove the queue entry when the
+        // guarding UPDATE actually flipped the row (delivered_to_parent FALSE -> TRUE).
+        // Retries / replays that observe 0 rows affected must NOT double-decrement.
+        if delivered_rows > 0 {
+            // Decrement the capacity bucket (GREATEST floor-at-zero).
+            let decr_sql = if agent_id.is_some() {
+                "UPDATE subagent_gate_capacity_counter                    SET undelivered = GREATEST(undelivered - 1, 0)                  WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4"
+            } else {
+                "UPDATE subagent_gate_capacity_counter                    SET undelivered = GREATEST(undelivered - 1, 0)                  WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3"
+            };
+            if let Some(ref aid) = agent_id {
+                transaction
+                    .execute(decr_sql, &[&tenant_id, &user_id, aid, &bucket])
+                    .await
+            } else {
+                transaction
+                    .execute(decr_sql, &[&tenant_id, &user_id, &bucket])
+                    .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("pg_decr_bucket", e.to_string()))?;
 
-        // Delete the specific child's queue entry.
-        let del_queue_sql = if agent_id.is_some() {
-            "DELETE FROM subagent_gate_deliverable_queue \
-              WHERE gate_ref = $1 AND child_run_id = $2 \
-                AND tenant_id = $3 AND user_id = $4 AND agent_id = $5"
-        } else {
-            "DELETE FROM subagent_gate_deliverable_queue \
-              WHERE gate_ref = $1 AND child_run_id = $2 \
-                AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL"
-        };
-        if let Some(ref aid) = agent_id {
-            transaction
-                .execute(
-                    del_queue_sql,
-                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id, aid],
-                )
-                .await
-        } else {
-            transaction
-                .execute(
-                    del_queue_sql,
-                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id],
-                )
-                .await
+            // Delete the specific child's queue entry.
+            let del_queue_sql = if agent_id.is_some() {
+                "DELETE FROM subagent_gate_deliverable_queue                   WHERE gate_ref = $1 AND child_run_id = $2                     AND tenant_id = $3 AND user_id = $4 AND agent_id = $5"
+            } else {
+                "DELETE FROM subagent_gate_deliverable_queue                   WHERE gate_ref = $1 AND child_run_id = $2                     AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL"
+            };
+            if let Some(ref aid) = agent_id {
+                transaction
+                    .execute(
+                        del_queue_sql,
+                        &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id, aid],
+                    )
+                    .await
+            } else {
+                transaction
+                    .execute(
+                        del_queue_sql,
+                        &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id],
+                    )
+                    .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("pg_del_queue_entry", e.to_string()))?;
         }
-        .map_err(|e| GateResolutionStoreError::io("pg_del_queue_entry", e.to_string()))?;
 
         // Check if ALL children under this gate are now delivered.
         let all_row = transaction
@@ -804,7 +806,9 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
             )
             .await
             .map_err(|e| GateResolutionStoreError::io("pg_all_delivered_check", e.to_string()))?;
-        let remaining: i64 = all_row.try_get::<_, i64>(0).unwrap_or(0);
+        let remaining: i64 = all_row
+            .try_get::<_, i64>(0)
+            .map_err(|e| GateResolutionStoreError::io("pg_all_delivered_decode", e.to_string()))?;
 
         transaction
             .commit()
@@ -835,6 +839,10 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
         let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
         let child_run_id_str = child_run_id.to_string();
 
+        // F4: scope BOTH the queue row (q) AND the child row (c) to the caller's
+        // (tenant_id, user_id, agent_id).  Without scoping c, a caller who somehow
+        // held a queue row pointing at a foreign (gate_ref, child_run_id) pair could
+        // read that row's parent_run_context_json / terminal_event_json.
         let select_sql = if agent_id.is_some() {
             "SELECT c.gate_ref, c.child_run_id, c.parent_run_id, c.tree_root_run_id, \
                     c.child_scope_json, c.parent_run_context_json, c.source_binding_ref, \
@@ -847,6 +855,7 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
                  ON c.gate_ref = q.gate_ref AND c.child_run_id = q.child_run_id \
               WHERE q.child_run_id = $1 \
                 AND q.tenant_id = $2 AND q.user_id = $3 AND q.agent_id = $4 \
+                AND c.tenant_id = $2 AND c.user_id = $3 AND c.agent_id = $4 \
                 AND c.delivered_to_parent = FALSE AND c.terminal_status IS NOT NULL"
         } else {
             "SELECT c.gate_ref, c.child_run_id, c.parent_run_id, c.tree_root_run_id, \
@@ -860,6 +869,7 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
                  ON c.gate_ref = q.gate_ref AND c.child_run_id = q.child_run_id \
               WHERE q.child_run_id = $1 \
                 AND q.tenant_id = $2 AND q.user_id = $3 AND q.agent_id IS NULL \
+                AND c.tenant_id = $2 AND c.user_id = $3 AND c.agent_id IS NULL \
                 AND c.delivered_to_parent = FALSE AND c.terminal_status IS NOT NULL"
         };
 
@@ -919,8 +929,12 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
 
         let mut bucket_counts: Vec<(i16, i64)> = Vec::new();
         for row in &count_rows {
-            let b: i16 = row.try_get::<_, i16>(0).unwrap_or(0);
-            let n: i64 = row.try_get::<_, i64>(1).unwrap_or(0);
+            let b: i16 = row.try_get::<_, i16>(0).map_err(|e| {
+                GateResolutionStoreError::io("pg_delete_decode_bucket", e.to_string())
+            })?;
+            let n: i64 = row.try_get::<_, i64>(1).map_err(|e| {
+                GateResolutionStoreError::io("pg_delete_decode_count", e.to_string())
+            })?;
             bucket_counts.push((b, n));
         }
 
@@ -1096,18 +1110,33 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
             .await
             .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
 
-        // Check existence.
-        let exists_row = transaction
-            .query_opt(
-                "SELECT 1 FROM subagent_gate_awaited_children \
-                  WHERE gate_ref = $1 AND child_run_id = $2 LIMIT 1",
-                &[&gate_ref_str, &child_run_id_str],
-            )
-            .await
-            .map_err(|e| GateResolutionStoreError::io("pg_redeliver_check", e.to_string()))?;
+        // Check existence — scoped to the caller's (tenant_id, user_id, agent_id)
+        // so a foreign (gate_ref, child_run_id) pair cannot be rebound into
+        // this caller's deliverable queue (F4 security fix).
+        let exists_sql = if agent_id.is_some() {
+            "SELECT 1 FROM subagent_gate_awaited_children               WHERE gate_ref = $1 AND child_run_id = $2                 AND tenant_id = $3 AND user_id = $4 AND agent_id = $5 LIMIT 1"
+        } else {
+            "SELECT 1 FROM subagent_gate_awaited_children               WHERE gate_ref = $1 AND child_run_id = $2                 AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL LIMIT 1"
+        };
+        let exists_row = if let Some(ref aid) = agent_id {
+            transaction
+                .query_opt(
+                    exists_sql,
+                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id, aid],
+                )
+                .await
+        } else {
+            transaction
+                .query_opt(
+                    exists_sql,
+                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id],
+                )
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_redeliver_check", e.to_string()))?;
         if exists_row.is_none() {
             transaction.rollback().await.ok();
-            return Ok(false); // gate row vanished (orphan)
+            return Ok(false); // gate row vanished or belongs to a different scope
         }
 
         // Set terminal flags (idempotent: WHERE terminal_status IS NULL).
@@ -1200,12 +1229,109 @@ impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
         if rows.is_empty() {
             return Ok(());
         }
+
+        // F5: apply the whole batch in ONE transaction — one BEGIN/COMMIT, N
+        // per-row statements inside. This avoids partial commits on mid-batch
+        // failure and N round trips.
+        let mut client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        let transaction = client
+            .build_transaction()
+            .start()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
         for (gate_ref, child_run_id) in rows {
-            // Reuse mark_child_delivered per row (same delivery-claim transaction).
-            // Idempotent via delivered_to_parent = FALSE guard.
-            self.mark_child_delivered(scope, &gate_ref, child_run_id)
-                .await?;
+            let gate_ref_str = gate_ref.as_str().to_string();
+            let child_run_id_str = child_run_id.to_string();
+
+            // Look up the counter_bucket for this row.
+            let bucket_row = transaction
+                .query_opt(
+                    "SELECT counter_bucket FROM subagent_gate_awaited_children                       WHERE gate_ref = $1 AND child_run_id = $2",
+                    &[&gate_ref_str, &child_run_id_str],
+                )
+                .await
+                .map_err(|e| GateResolutionStoreError::io("pg_rub_fetch_bucket", e.to_string()))?;
+            let bucket: i16 = match bucket_row {
+                Some(r) => r.try_get::<_, i16>(0).map_err(|e| {
+                    GateResolutionStoreError::io("pg_rub_decode_bucket", e.to_string())
+                })?,
+                None => continue, // row already gone — skip
+            };
+
+            // Flip delivered flags (guard: delivered_to_parent = FALSE).
+            let upd_sql = if agent_id.is_some() {
+                "UPDATE subagent_gate_awaited_children                    SET delivery_claimed = TRUE, delivered_to_parent = TRUE                  WHERE gate_ref = $1 AND child_run_id = $2 AND delivered_to_parent = FALSE                    AND tenant_id = $3 AND user_id = $4 AND agent_id = $5"
+            } else {
+                "UPDATE subagent_gate_awaited_children                    SET delivery_claimed = TRUE, delivered_to_parent = TRUE                  WHERE gate_ref = $1 AND child_run_id = $2 AND delivered_to_parent = FALSE                    AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL"
+            };
+            let delivered_rows = if let Some(ref aid) = agent_id {
+                transaction
+                    .execute(
+                        upd_sql,
+                        &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id, aid],
+                    )
+                    .await
+            } else {
+                transaction
+                    .execute(
+                        upd_sql,
+                        &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id],
+                    )
+                    .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("pg_rub_mark_delivered", e.to_string()))?;
+
+            // F3: only decrement + delete queue if the UPDATE actually flipped the row.
+            if delivered_rows > 0 {
+                let decr_sql = if agent_id.is_some() {
+                    "UPDATE subagent_gate_capacity_counter                        SET undelivered = GREATEST(undelivered - 1, 0)                      WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4"
+                } else {
+                    "UPDATE subagent_gate_capacity_counter                        SET undelivered = GREATEST(undelivered - 1, 0)                      WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3"
+                };
+                if let Some(ref aid) = agent_id {
+                    transaction
+                        .execute(decr_sql, &[&tenant_id, &user_id, aid, &bucket])
+                        .await
+                } else {
+                    transaction
+                        .execute(decr_sql, &[&tenant_id, &user_id, &bucket])
+                        .await
+                }
+                .map_err(|e| GateResolutionStoreError::io("pg_rub_decr_bucket", e.to_string()))?;
+
+                let del_queue_sql = if agent_id.is_some() {
+                    "DELETE FROM subagent_gate_deliverable_queue                       WHERE gate_ref = $1 AND child_run_id = $2                         AND tenant_id = $3 AND user_id = $4 AND agent_id = $5"
+                } else {
+                    "DELETE FROM subagent_gate_deliverable_queue                       WHERE gate_ref = $1 AND child_run_id = $2                         AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL"
+                };
+                if let Some(ref aid) = agent_id {
+                    transaction
+                        .execute(
+                            del_queue_sql,
+                            &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id, aid],
+                        )
+                        .await
+                } else {
+                    transaction
+                        .execute(
+                            del_queue_sql,
+                            &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id],
+                        )
+                        .await
+                }
+                .map_err(|e| GateResolutionStoreError::io("pg_rub_del_queue", e.to_string()))?;
+            }
         }
+
+        transaction
+            .commit()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
         Ok(())
     }
 }

--- a/crates/ironclaw_reborn_event_store/src/postgres/gate_resolution.rs
+++ b/crates/ironclaw_reborn_event_store/src/postgres/gate_resolution.rs
@@ -1,0 +1,1269 @@
+//! PostgreSQL-backed durable gate-resolution store.
+//!
+//! Spec: `docs/reborn/2026-06-08-subagent-durability-spec.md` §1.4 + §1.6.
+//!
+//! # Scope-predicate convention
+//!
+//! Every query that filters by scope MUST use the conditional
+//! `<agent_predicate>`:
+//! - When `scope.agent_id` is `Some(id)`: `agent_id = $N` bound to `id`.
+//! - When `scope.agent_id` is `None`: `agent_id IS NULL`.
+//!
+//! NEVER use `(agent_id = $N OR agent_id IS NULL)` — it allows agent-scoped
+//! callers to reach system-level (NULL agent_id) rows.
+//!
+//! # First-writer-wins
+//!
+//! All INSERT paths use `ON CONFLICT DO NOTHING` so that duplicate rows
+//! (replay, concurrent settlement) are silently dropped.
+//!
+//! # PostgreSQL-specific notes
+//!
+//! - `GREATEST(a, b)` is available in PostgreSQL.
+//! - `SELECT ... FOR UPDATE` locks the capacity bucket row before the SUM
+//!   read (per-bucket lock, not full-table lock), preventing TOCTOU drift.
+//! - JSONB is used for `child_scope_json` and `terminal_event_json` columns.
+//! - Boolean columns are `BOOLEAN` (TRUE/FALSE).
+//! - Timestamps are `TIMESTAMPTZ`.
+//! - The capacity-counter table has no declared PK due to nullable `agent_id`;
+//!   the COALESCE expression index (`idx_sgcc_pk`) is the conflict target.
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+use ironclaw_turns::{GateRef, LoopResultRef, TurnRunId, TurnScope, TurnStatus};
+
+use crate::gate_resolution::{
+    AwaitedChildRecord, AwaitedChildRow, DurableSubagentGateResolutionStore, DurableTerminalEvent,
+    GateResolutionStoreError, MAX_GATE_RECORDS, child_bucket,
+};
+
+/// PostgreSQL-backed durable gate-resolution store.
+///
+/// Owns a `deadpool_postgres::Pool`. Each async method acquires a client from
+/// the pool and runs in a single transaction. For the spawn path a
+/// `SELECT ... FOR UPDATE` locks the capacity bucket row before the SUM read
+/// (drift bound: at most K-1 rows over cap under maximum concurrency).
+#[derive(Clone)]
+pub struct PostgresGateResolutionStore {
+    pool: Pool,
+    k_buckets: u32,
+}
+
+impl PostgresGateResolutionStore {
+    /// Build a new store from a connection pool.
+    ///
+    /// `k_buckets` is the number of capacity-counter buckets; pass
+    /// `effective_capacity_counter_buckets()` for the operator-tunable value.
+    pub fn new(pool: Pool, k_buckets: u32) -> Self {
+        Self { pool, k_buckets }
+    }
+
+    async fn client(&self) -> Result<deadpool_postgres::Object, GateResolutionStoreError> {
+        self.pool
+            .get()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Resolve `user_id` from a `TurnScope`, falling back to the system sentinel.
+fn user_id_str(scope: &TurnScope) -> String {
+    scope
+        .explicit_owner_user_id()
+        .map(|uid| uid.as_str().to_string())
+        .unwrap_or_else(|| ironclaw_host_api::SYSTEM_RESERVED_ID.to_string())
+}
+
+/// Parse a `TurnStatus` from a TEXT column value.
+fn parse_status(s: &str) -> Result<TurnStatus, GateResolutionStoreError> {
+    match s {
+        "completed" => Ok(TurnStatus::Completed),
+        "failed" => Ok(TurnStatus::Failed),
+        "cancelled" => Ok(TurnStatus::Cancelled),
+        "cancel_requested" => Ok(TurnStatus::CancelRequested),
+        "running" => Ok(TurnStatus::Running),
+        "queued" => Ok(TurnStatus::Queued),
+        "blocked_approval" => Ok(TurnStatus::BlockedApproval),
+        "blocked_auth" => Ok(TurnStatus::BlockedAuth),
+        "blocked_resource" => Ok(TurnStatus::BlockedResource),
+        "blocked_dependent_run" => Ok(TurnStatus::BlockedDependentRun),
+        "recovery_required" => Ok(TurnStatus::RecoveryRequired),
+        other => Err(GateResolutionStoreError::io(
+            "parse_status",
+            format!("unknown TurnStatus value: {other}"),
+        )),
+    }
+}
+
+fn status_str(s: TurnStatus) -> &'static str {
+    match s {
+        TurnStatus::Completed => "completed",
+        TurnStatus::Failed => "failed",
+        TurnStatus::Cancelled => "cancelled",
+        TurnStatus::CancelRequested => "cancel_requested",
+        TurnStatus::Running => "running",
+        TurnStatus::Queued => "queued",
+        TurnStatus::BlockedApproval => "blocked_approval",
+        TurnStatus::BlockedAuth => "blocked_auth",
+        TurnStatus::BlockedResource => "blocked_resource",
+        TurnStatus::BlockedDependentRun => "blocked_dependent_run",
+        TurnStatus::RecoveryRequired => "recovery_required",
+    }
+}
+
+/// Decode a tokio_postgres `Row` from `subagent_gate_awaited_children`.
+fn decode_row(row: &tokio_postgres::Row) -> Result<AwaitedChildRow, GateResolutionStoreError> {
+    let gate_ref_str: String = row
+        .try_get::<_, String>(0)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/gate_ref", e.to_string()))?;
+    let child_run_id_str: String = row
+        .try_get::<_, String>(1)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/child_run_id", e.to_string()))?;
+    let parent_run_id_str: String = row
+        .try_get::<_, String>(2)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/parent_run_id", e.to_string()))?;
+    let tree_root_run_id_str: String = row
+        .try_get::<_, String>(3)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/tree_root_run_id", e.to_string()))?;
+    // child_scope_json is JSONB in PG; fetch as serde_json::Value then stringify
+    let child_scope_json_val: serde_json::Value = row
+        .try_get::<_, serde_json::Value>(4)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/child_scope_json", e.to_string()))?;
+    let parent_run_context_json_val: serde_json::Value =
+        row.try_get::<_, serde_json::Value>(5).map_err(|e| {
+            GateResolutionStoreError::io("decode_row/parent_run_context_json", e.to_string())
+        })?;
+    let source_binding_ref: String = row.try_get::<_, String>(6).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/source_binding_ref", e.to_string())
+    })?;
+    let reply_target_binding_ref: String = row.try_get::<_, String>(7).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/reply_target_binding_ref", e.to_string())
+    })?;
+    let subagent_kind: String = row
+        .try_get::<_, String>(8)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/subagent_kind", e.to_string()))?;
+    let spawn_capability_id: String = row.try_get::<_, String>(9).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/spawn_capability_id", e.to_string())
+    })?;
+    let result_ref_str: String = row
+        .try_get::<_, String>(10)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/result_ref", e.to_string()))?;
+    let spawn_mode: String = row
+        .try_get::<_, String>(11)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/spawn_mode", e.to_string()))?;
+    let terminal_status_raw: Option<String> = row
+        .try_get::<_, Option<String>>(12)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/terminal_status", e.to_string()))?;
+    let terminal_event_json_val: Option<serde_json::Value> = row
+        .try_get::<_, Option<serde_json::Value>>(13)
+        .map_err(|e| {
+            GateResolutionStoreError::io("decode_row/terminal_event_json", e.to_string())
+        })?;
+    let terminal_result_written: bool = row.try_get::<_, bool>(14).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/terminal_result_written", e.to_string())
+    })?;
+    let terminal_byte_len: i64 = row
+        .try_get::<_, i64>(15)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/terminal_byte_len", e.to_string()))?;
+    let delivery_claimed: bool = row
+        .try_get::<_, bool>(16)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/delivery_claimed", e.to_string()))?;
+    let delivered_to_parent: bool = row.try_get::<_, bool>(17).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/delivered_to_parent", e.to_string())
+    })?;
+
+    let gate_ref = GateRef::new(&gate_ref_str)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/gate_ref_parse", e))?;
+    let child_run_id = TurnRunId::parse(&child_run_id_str).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/child_run_id_parse", e.to_string())
+    })?;
+    let parent_run_id = TurnRunId::parse(&parent_run_id_str).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/parent_run_id_parse", e.to_string())
+    })?;
+    let tree_root_run_id = TurnRunId::parse(&tree_root_run_id_str).map_err(|e| {
+        GateResolutionStoreError::io("decode_row/tree_root_run_id_parse", e.to_string())
+    })?;
+    let result_ref = LoopResultRef::new(&result_ref_str)
+        .map_err(|e| GateResolutionStoreError::io("decode_row/result_ref_parse", e))?;
+    let terminal_status = terminal_status_raw.map(|s| parse_status(&s)).transpose()?;
+
+    let child_scope_json = serde_json::to_string(&child_scope_json_val)
+        .map_err(|e| GateResolutionStoreError::serialization(e.to_string()))?;
+    let parent_run_context_json = serde_json::to_string(&parent_run_context_json_val)
+        .map_err(|e| GateResolutionStoreError::serialization(e.to_string()))?;
+    let terminal_event_json = terminal_event_json_val
+        .map(|v| {
+            serde_json::to_string(&v)
+                .map_err(|e| GateResolutionStoreError::serialization(e.to_string()))
+        })
+        .transpose()?;
+
+    Ok(AwaitedChildRow {
+        gate_ref,
+        child_run_id,
+        parent_run_id,
+        tree_root_run_id,
+        child_scope_json,
+        parent_run_context_json,
+        source_binding_ref,
+        reply_target_binding_ref,
+        subagent_kind,
+        spawn_capability_id,
+        result_ref,
+        spawn_mode,
+        terminal_status,
+        terminal_event_json,
+        terminal_result_written,
+        terminal_byte_len: terminal_byte_len as u64,
+        delivery_claimed,
+        delivered_to_parent,
+    })
+}
+
+// ── trait implementation ──────────────────────────────────────────────────────
+
+#[async_trait]
+impl DurableSubagentGateResolutionStore for PostgresGateResolutionStore {
+    async fn record_awaited_child(
+        &self,
+        scope: &TurnScope,
+        record: AwaitedChildRecord,
+    ) -> Result<(), GateResolutionStoreError> {
+        let mut client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+        let k = self.k_buckets;
+        let bucket = child_bucket(&record.child_run_id.to_string(), k) as i16;
+
+        let transaction = client
+            .build_transaction()
+            .start()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
+        // Initialize bucket row if missing (ON CONFLICT DO NOTHING with expression index).
+        let init_sql = if agent_id.is_some() {
+            "INSERT INTO subagent_gate_capacity_counter \
+                (tenant_id, user_id, agent_id, bucket, undelivered) \
+             VALUES ($1, $2, $3, $4, 0) \
+             ON CONFLICT (tenant_id, user_id, COALESCE(agent_id, '__non_agent__'), bucket) \
+             DO NOTHING"
+        } else {
+            "INSERT INTO subagent_gate_capacity_counter \
+                (tenant_id, user_id, agent_id, bucket, undelivered) \
+             VALUES ($1, $2, NULL, $3, 0) \
+             ON CONFLICT (tenant_id, user_id, COALESCE(agent_id, '__non_agent__'), bucket) \
+             DO NOTHING"
+        };
+        {
+            let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] = if let Some(ref aid) = agent_id {
+                &[&tenant_id, &user_id, aid, &bucket]
+            } else {
+                &[&tenant_id, &user_id, &bucket]
+            };
+            transaction
+                .execute(init_sql, p)
+                .await
+                .map_err(|e| GateResolutionStoreError::io("pg_init_bucket", e.to_string()))?;
+        }
+
+        // Lock the bucket row for this spawn (SELECT FOR UPDATE on our bucket).
+        // This prevents TOCTOU drift bounded to K-1 rows under maximum concurrency.
+        let lock_sql = if agent_id.is_some() {
+            "SELECT undelivered FROM subagent_gate_capacity_counter \
+              WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4 \
+              FOR UPDATE"
+        } else {
+            "SELECT undelivered FROM subagent_gate_capacity_counter \
+              WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3 \
+              FOR UPDATE"
+        };
+        {
+            let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] = if let Some(ref aid) = agent_id {
+                &[&tenant_id, &user_id, aid, &bucket]
+            } else {
+                &[&tenant_id, &user_id, &bucket]
+            };
+            transaction
+                .query_opt(lock_sql, p)
+                .await
+                .map_err(|e| GateResolutionStoreError::io("pg_lock_bucket", e.to_string()))?;
+        }
+
+        // Cap check: SUM(undelivered) across all buckets for this scope.
+        let sum_sql = if agent_id.is_some() {
+            "SELECT COALESCE(SUM(undelivered), 0) FROM subagent_gate_capacity_counter \
+              WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3"
+        } else {
+            "SELECT COALESCE(SUM(undelivered), 0) FROM subagent_gate_capacity_counter \
+              WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL"
+        };
+        let sum_row = if let Some(ref aid) = agent_id {
+            transaction
+                .query_one(sum_sql, &[&tenant_id, &user_id, aid])
+                .await
+        } else {
+            transaction
+                .query_one(sum_sql, &[&tenant_id, &user_id])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_cap_check", e.to_string()))?;
+
+        let total: i64 = sum_row.try_get::<_, i64>(0).unwrap_or(0);
+
+        if total >= MAX_GATE_RECORDS as i64 {
+            transaction.rollback().await.ok();
+            return Err(GateResolutionStoreError::CapacityExceeded);
+        }
+
+        // Parse child_scope_json for JSONB column.
+        let child_scope_val: serde_json::Value = serde_json::from_str(&record.child_scope_json)
+            .map_err(|e| GateResolutionStoreError::serialization(e.to_string()))?;
+        let parent_ctx_val: serde_json::Value =
+            serde_json::from_str(&record.parent_run_context_json)
+                .map_err(|e| GateResolutionStoreError::serialization(e.to_string()))?;
+
+        // INSERT ON CONFLICT DO NOTHING primary row (first-writer-wins per spec §1.6).
+        let insert_sql = if agent_id.is_some() {
+            "INSERT INTO subagent_gate_awaited_children \
+                (tenant_id, user_id, agent_id, gate_ref, parent_run_id, tree_root_run_id, \
+                 child_run_id, child_thread_id, child_scope_json, parent_run_context_json, \
+                 source_binding_ref, reply_target_binding_ref, subagent_kind, spawn_capability_id, \
+                 result_ref, spawn_mode, counter_bucket) \
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17) \
+             ON CONFLICT (gate_ref, child_run_id) DO NOTHING"
+        } else {
+            "INSERT INTO subagent_gate_awaited_children \
+                (tenant_id, user_id, agent_id, gate_ref, parent_run_id, tree_root_run_id, \
+                 child_run_id, child_thread_id, child_scope_json, parent_run_context_json, \
+                 source_binding_ref, reply_target_binding_ref, subagent_kind, spawn_capability_id, \
+                 result_ref, spawn_mode, counter_bucket) \
+             VALUES ($1,$2,NULL,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) \
+             ON CONFLICT (gate_ref, child_run_id) DO NOTHING"
+        };
+
+        let gate_ref_str = record.gate_ref.as_str().to_string();
+        let parent_run_id_str = record.parent_run_id.to_string();
+        let tree_root_str = record.tree_root_run_id.to_string();
+        let child_run_id_str = record.child_run_id.to_string();
+        let result_ref_str = record.result_ref.as_str().to_string();
+
+        {
+            let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] = if let Some(ref aid) = agent_id {
+                &[
+                    &tenant_id,
+                    &user_id,
+                    aid,
+                    &gate_ref_str,
+                    &parent_run_id_str,
+                    &tree_root_str,
+                    &child_run_id_str,
+                    &record.child_thread_id,
+                    &child_scope_val,
+                    &parent_ctx_val,
+                    &record.source_binding_ref,
+                    &record.reply_target_binding_ref,
+                    &record.subagent_kind,
+                    &record.spawn_capability_id,
+                    &result_ref_str,
+                    &record.spawn_mode,
+                    &bucket,
+                ]
+            } else {
+                &[
+                    &tenant_id,
+                    &user_id,
+                    &gate_ref_str,
+                    &parent_run_id_str,
+                    &tree_root_str,
+                    &child_run_id_str,
+                    &record.child_thread_id,
+                    &child_scope_val,
+                    &parent_ctx_val,
+                    &record.source_binding_ref,
+                    &record.reply_target_binding_ref,
+                    &record.subagent_kind,
+                    &record.spawn_capability_id,
+                    &result_ref_str,
+                    &record.spawn_mode,
+                    &bucket,
+                ]
+            };
+            transaction.execute(insert_sql, p).await.map_err(|e| {
+                GateResolutionStoreError::io("pg_insert_awaited_child", e.to_string())
+            })?;
+        }
+
+        // INSERT ON CONFLICT DO NOTHING reverse-index row.
+        let idx_sql = if agent_id.is_some() {
+            "INSERT INTO subagent_gate_child_index \
+                (tenant_id, user_id, agent_id, child_run_id, gate_ref) \
+             VALUES ($1, $2, $3, $4, $5) \
+             ON CONFLICT (child_run_id, gate_ref) DO NOTHING"
+        } else {
+            "INSERT INTO subagent_gate_child_index \
+                (tenant_id, user_id, agent_id, child_run_id, gate_ref) \
+             VALUES ($1, $2, NULL, $3, $4) \
+             ON CONFLICT (child_run_id, gate_ref) DO NOTHING"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(
+                    idx_sql,
+                    &[&tenant_id, &user_id, aid, &child_run_id_str, &gate_ref_str],
+                )
+                .await
+        } else {
+            transaction
+                .execute(
+                    idx_sql,
+                    &[&tenant_id, &user_id, &child_run_id_str, &gate_ref_str],
+                )
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_insert_child_index", e.to_string()))?;
+
+        // Increment the specific bucket only.
+        let incr_sql = if agent_id.is_some() {
+            "UPDATE subagent_gate_capacity_counter \
+               SET undelivered = undelivered + 1 \
+             WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4"
+        } else {
+            "UPDATE subagent_gate_capacity_counter \
+               SET undelivered = undelivered + 1 \
+             WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3"
+        };
+        {
+            let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] = if let Some(ref aid) = agent_id {
+                &[&tenant_id, &user_id, aid, &bucket]
+            } else {
+                &[&tenant_id, &user_id, &bucket]
+            };
+            transaction
+                .execute(incr_sql, p)
+                .await
+                .map_err(|e| GateResolutionStoreError::io("pg_incr_bucket", e.to_string()))?;
+        }
+
+        transaction
+            .commit()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn record_child_terminal(
+        &self,
+        scope: &TurnScope,
+        gate_ref: GateRef,
+        child_run_id: TurnRunId,
+        event: DurableTerminalEvent,
+    ) -> Result<(), GateResolutionStoreError> {
+        if !event.status.is_terminal() {
+            return Err(GateResolutionStoreError::NonTerminalStatus);
+        }
+
+        let mut client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        let event_json_val = serde_json::json!({
+            "status": status_str(event.status),
+            "kind": event.kind,
+            "cursor": event.cursor,
+            "sanitized_reason": event.sanitized_reason,
+            "owner_user_id": event.owner_user_id.as_ref().map(|u| u.as_str()),
+        });
+
+        let gate_ref_str = gate_ref.as_str().to_string();
+        let child_run_id_str = child_run_id.to_string();
+        let status_s = status_str(event.status);
+
+        let transaction = client
+            .build_transaction()
+            .start()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
+        // UPDATE only when terminal_status IS NULL (first-writer-wins).
+        let update_sql = if agent_id.is_some() {
+            "UPDATE subagent_gate_awaited_children \
+               SET terminal_status = $1, terminal_event_json = $2, settled_at = NOW() \
+             WHERE gate_ref = $3 AND child_run_id = $4 AND terminal_status IS NULL \
+               AND tenant_id = $5 AND user_id = $6 AND agent_id = $7"
+        } else {
+            "UPDATE subagent_gate_awaited_children \
+               SET terminal_status = $1, terminal_event_json = $2, settled_at = NOW() \
+             WHERE gate_ref = $3 AND child_run_id = $4 AND terminal_status IS NULL \
+               AND tenant_id = $5 AND user_id = $6 AND agent_id IS NULL"
+        };
+        let rows_changed = {
+            let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] = if let Some(ref aid) = agent_id {
+                &[
+                    &status_s,
+                    &event_json_val,
+                    &gate_ref_str,
+                    &child_run_id_str,
+                    &tenant_id,
+                    &user_id,
+                    aid,
+                ]
+            } else {
+                &[
+                    &status_s,
+                    &event_json_val,
+                    &gate_ref_str,
+                    &child_run_id_str,
+                    &tenant_id,
+                    &user_id,
+                ]
+            };
+            transaction.execute(update_sql, p).await.map_err(|e| {
+                GateResolutionStoreError::io("pg_record_terminal_update", e.to_string())
+            })?
+        };
+
+        if rows_changed > 0 {
+            // Append settlement log row.
+            let owner_str = event.owner_user_id.as_ref().map(|u| u.as_str().to_string());
+            let cursor_i64 = event.cursor as i64;
+            let log_sql = if agent_id.is_some() {
+                "INSERT INTO subagent_gate_settlement_log \
+                    (tenant_id, user_id, agent_id, gate_ref, child_run_id, result_ref, \
+                     parent_run_id, terminal_status, terminal_kind, event_cursor, \
+                     terminal_byte_len, sanitized_reason, owner_user_id) \
+                 SELECT c.tenant_id, c.user_id, c.agent_id, c.gate_ref, c.child_run_id, \
+                        c.result_ref, c.parent_run_id, $1, $2, $3, 0, $4, $5 \
+                   FROM subagent_gate_awaited_children c \
+                  WHERE c.gate_ref = $6 AND c.child_run_id = $7 \
+                    AND c.tenant_id = $8 AND c.user_id = $9 AND c.agent_id = $10"
+            } else {
+                "INSERT INTO subagent_gate_settlement_log \
+                    (tenant_id, user_id, agent_id, gate_ref, child_run_id, result_ref, \
+                     parent_run_id, terminal_status, terminal_kind, event_cursor, \
+                     terminal_byte_len, sanitized_reason, owner_user_id) \
+                 SELECT c.tenant_id, c.user_id, c.agent_id, c.gate_ref, c.child_run_id, \
+                        c.result_ref, c.parent_run_id, $1, $2, $3, 0, $4, $5 \
+                   FROM subagent_gate_awaited_children c \
+                  WHERE c.gate_ref = $6 AND c.child_run_id = $7 \
+                    AND c.tenant_id = $8 AND c.user_id = $9 AND c.agent_id IS NULL"
+            };
+            {
+                let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] =
+                    if let Some(ref aid) = agent_id {
+                        &[
+                            &status_s,
+                            &event.kind,
+                            &cursor_i64,
+                            &event.sanitized_reason,
+                            &owner_str,
+                            &gate_ref_str,
+                            &child_run_id_str,
+                            &tenant_id,
+                            &user_id,
+                            aid,
+                        ]
+                    } else {
+                        &[
+                            &status_s,
+                            &event.kind,
+                            &cursor_i64,
+                            &event.sanitized_reason,
+                            &owner_str,
+                            &gate_ref_str,
+                            &child_run_id_str,
+                            &tenant_id,
+                            &user_id,
+                        ]
+                    };
+                transaction.execute(log_sql, p).await.map_err(|e| {
+                    GateResolutionStoreError::io("pg_settlement_log_insert", e.to_string())
+                })?;
+            }
+
+            // Insert deliverable queue entry (ON CONFLICT DO NOTHING).
+            let queue_sql = if agent_id.is_some() {
+                "INSERT INTO subagent_gate_deliverable_queue \
+                    (tenant_id, user_id, agent_id, child_run_id, gate_ref) \
+                 VALUES ($1, $2, $3, $4, $5) \
+                 ON CONFLICT (child_run_id, gate_ref) DO NOTHING"
+            } else {
+                "INSERT INTO subagent_gate_deliverable_queue \
+                    (tenant_id, user_id, agent_id, child_run_id, gate_ref) \
+                 VALUES ($1, $2, NULL, $3, $4) \
+                 ON CONFLICT (child_run_id, gate_ref) DO NOTHING"
+            };
+            if let Some(ref aid) = agent_id {
+                transaction
+                    .execute(
+                        queue_sql,
+                        &[&tenant_id, &user_id, aid, &child_run_id_str, &gate_ref_str],
+                    )
+                    .await
+            } else {
+                transaction
+                    .execute(
+                        queue_sql,
+                        &[&tenant_id, &user_id, &child_run_id_str, &gate_ref_str],
+                    )
+                    .await
+            }
+            .map_err(|e| GateResolutionStoreError::io("pg_queue_insert", e.to_string()))?;
+        }
+
+        transaction
+            .commit()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn mark_terminal_result_written(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+        child_run_id: TurnRunId,
+        byte_len: u64,
+    ) -> Result<(), GateResolutionStoreError> {
+        let client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+        let byte_len_i64 = byte_len as i64;
+        let gate_ref_str = gate_ref.as_str().to_string();
+        let child_run_id_str = child_run_id.to_string();
+
+        let update_sql = if agent_id.is_some() {
+            "UPDATE subagent_gate_awaited_children \
+               SET terminal_result_written = TRUE, terminal_byte_len = $1 \
+             WHERE gate_ref = $2 AND child_run_id = $3 AND terminal_result_written = FALSE \
+               AND tenant_id = $4 AND user_id = $5 AND agent_id = $6"
+        } else {
+            "UPDATE subagent_gate_awaited_children \
+               SET terminal_result_written = TRUE, terminal_byte_len = $1 \
+             WHERE gate_ref = $2 AND child_run_id = $3 AND terminal_result_written = FALSE \
+               AND tenant_id = $4 AND user_id = $5 AND agent_id IS NULL"
+        };
+        if let Some(ref aid) = agent_id {
+            client
+                .execute(
+                    update_sql,
+                    &[
+                        &byte_len_i64,
+                        &gate_ref_str,
+                        &child_run_id_str,
+                        &tenant_id,
+                        &user_id,
+                        aid,
+                    ],
+                )
+                .await
+        } else {
+            client
+                .execute(
+                    update_sql,
+                    &[
+                        &byte_len_i64,
+                        &gate_ref_str,
+                        &child_run_id_str,
+                        &tenant_id,
+                        &user_id,
+                    ],
+                )
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_mark_result_written", e.to_string()))?;
+        Ok(())
+    }
+
+    async fn mark_child_delivered(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+        child_run_id: TurnRunId,
+    ) -> Result<bool, GateResolutionStoreError> {
+        let mut client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+        let gate_ref_str = gate_ref.as_str().to_string();
+        let child_run_id_str = child_run_id.to_string();
+
+        let transaction = client
+            .build_transaction()
+            .start()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
+        // Fetch the counter_bucket for this specific spawn.
+        let bucket_row = transaction
+            .query_opt(
+                "SELECT counter_bucket FROM subagent_gate_awaited_children \
+                  WHERE gate_ref = $1 AND child_run_id = $2",
+                &[&gate_ref_str, &child_run_id_str],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("pg_fetch_bucket", e.to_string()))?;
+        let bucket: i16 = match bucket_row {
+            Some(r) => r.try_get::<_, i16>(0).unwrap_or(0),
+            None => {
+                transaction.rollback().await.ok();
+                return Ok(false);
+            }
+        };
+
+        // Flip delivered flags (guard: delivered_to_parent = FALSE).
+        let upd_sql = if agent_id.is_some() {
+            "UPDATE subagent_gate_awaited_children \
+               SET delivery_claimed = TRUE, delivered_to_parent = TRUE \
+             WHERE gate_ref = $1 AND child_run_id = $2 AND delivered_to_parent = FALSE \
+               AND tenant_id = $3 AND user_id = $4 AND agent_id = $5"
+        } else {
+            "UPDATE subagent_gate_awaited_children \
+               SET delivery_claimed = TRUE, delivered_to_parent = TRUE \
+             WHERE gate_ref = $1 AND child_run_id = $2 AND delivered_to_parent = FALSE \
+               AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(
+                    upd_sql,
+                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id, aid],
+                )
+                .await
+        } else {
+            transaction
+                .execute(
+                    upd_sql,
+                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id],
+                )
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_mark_delivered_update", e.to_string()))?;
+
+        // Decrement the capacity bucket (GREATEST floor-at-zero).
+        let decr_sql = if agent_id.is_some() {
+            "UPDATE subagent_gate_capacity_counter \
+               SET undelivered = GREATEST(undelivered - 1, 0) \
+             WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND bucket = $4"
+        } else {
+            "UPDATE subagent_gate_capacity_counter \
+               SET undelivered = GREATEST(undelivered - 1, 0) \
+             WHERE tenant_id = $1 AND user_id = $2 AND agent_id IS NULL AND bucket = $3"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(decr_sql, &[&tenant_id, &user_id, aid, &bucket])
+                .await
+        } else {
+            transaction
+                .execute(decr_sql, &[&tenant_id, &user_id, &bucket])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_decr_bucket", e.to_string()))?;
+
+        // Delete the specific child's queue entry.
+        let del_queue_sql = if agent_id.is_some() {
+            "DELETE FROM subagent_gate_deliverable_queue \
+              WHERE gate_ref = $1 AND child_run_id = $2 \
+                AND tenant_id = $3 AND user_id = $4 AND agent_id = $5"
+        } else {
+            "DELETE FROM subagent_gate_deliverable_queue \
+              WHERE gate_ref = $1 AND child_run_id = $2 \
+                AND tenant_id = $3 AND user_id = $4 AND agent_id IS NULL"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(
+                    del_queue_sql,
+                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id, aid],
+                )
+                .await
+        } else {
+            transaction
+                .execute(
+                    del_queue_sql,
+                    &[&gate_ref_str, &child_run_id_str, &tenant_id, &user_id],
+                )
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_del_queue_entry", e.to_string()))?;
+
+        // Check if ALL children under this gate are now delivered.
+        let all_row = transaction
+            .query_one(
+                "SELECT COUNT(*) FROM subagent_gate_awaited_children \
+                  WHERE gate_ref = $1 AND delivered_to_parent = FALSE",
+                &[&gate_ref_str],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("pg_all_delivered_check", e.to_string()))?;
+        let remaining: i64 = all_row.try_get::<_, i64>(0).unwrap_or(0);
+
+        transaction
+            .commit()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+        Ok(remaining == 0)
+    }
+
+    async fn claim_next_terminal_state_for_child(
+        &self,
+        scope: &TurnScope,
+        child_run_id: TurnRunId,
+    ) -> Result<Option<AwaitedChildRow>, GateResolutionStoreError> {
+        let mut results = self
+            .claim_all_terminal_states_for_child(scope, child_run_id)
+            .await?;
+        Ok(results.drain(..1).next())
+    }
+
+    async fn claim_all_terminal_states_for_child(
+        &self,
+        scope: &TurnScope,
+        child_run_id: TurnRunId,
+    ) -> Result<Vec<AwaitedChildRow>, GateResolutionStoreError> {
+        let client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+        let child_run_id_str = child_run_id.to_string();
+
+        let select_sql = if agent_id.is_some() {
+            "SELECT c.gate_ref, c.child_run_id, c.parent_run_id, c.tree_root_run_id, \
+                    c.child_scope_json, c.parent_run_context_json, c.source_binding_ref, \
+                    c.reply_target_binding_ref, c.subagent_kind, c.spawn_capability_id, \
+                    c.result_ref, c.spawn_mode, c.terminal_status, c.terminal_event_json, \
+                    c.terminal_result_written, c.terminal_byte_len, \
+                    c.delivery_claimed, c.delivered_to_parent \
+               FROM subagent_gate_deliverable_queue q \
+               JOIN subagent_gate_awaited_children c \
+                 ON c.gate_ref = q.gate_ref AND c.child_run_id = q.child_run_id \
+              WHERE q.child_run_id = $1 \
+                AND q.tenant_id = $2 AND q.user_id = $3 AND q.agent_id = $4 \
+                AND c.delivered_to_parent = FALSE AND c.terminal_status IS NOT NULL"
+        } else {
+            "SELECT c.gate_ref, c.child_run_id, c.parent_run_id, c.tree_root_run_id, \
+                    c.child_scope_json, c.parent_run_context_json, c.source_binding_ref, \
+                    c.reply_target_binding_ref, c.subagent_kind, c.spawn_capability_id, \
+                    c.result_ref, c.spawn_mode, c.terminal_status, c.terminal_event_json, \
+                    c.terminal_result_written, c.terminal_byte_len, \
+                    c.delivery_claimed, c.delivered_to_parent \
+               FROM subagent_gate_deliverable_queue q \
+               JOIN subagent_gate_awaited_children c \
+                 ON c.gate_ref = q.gate_ref AND c.child_run_id = q.child_run_id \
+              WHERE q.child_run_id = $1 \
+                AND q.tenant_id = $2 AND q.user_id = $3 AND q.agent_id IS NULL \
+                AND c.delivered_to_parent = FALSE AND c.terminal_status IS NOT NULL"
+        };
+
+        let rows = if let Some(ref aid) = agent_id {
+            client
+                .query(select_sql, &[&child_run_id_str, &tenant_id, &user_id, aid])
+                .await
+        } else {
+            client
+                .query(select_sql, &[&child_run_id_str, &tenant_id, &user_id])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_claim_query", e.to_string()))?;
+
+        rows.iter().map(decode_row).collect()
+    }
+
+    async fn delete_awaited_child(
+        &self,
+        scope: &TurnScope,
+        gate_ref: &GateRef,
+    ) -> Result<(), GateResolutionStoreError> {
+        let mut client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+        let gate_ref_str = gate_ref.as_str().to_string();
+
+        let transaction = client
+            .build_transaction()
+            .start()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
+        // Count undelivered rows by bucket for decrementing.
+        let count_sql = if agent_id.is_some() {
+            "SELECT counter_bucket, COUNT(*) FROM subagent_gate_awaited_children \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id = $4 \
+                AND delivered_to_parent = FALSE \
+              GROUP BY counter_bucket"
+        } else {
+            "SELECT counter_bucket, COUNT(*) FROM subagent_gate_awaited_children \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id IS NULL \
+                AND delivered_to_parent = FALSE \
+              GROUP BY counter_bucket"
+        };
+        let count_rows = if let Some(ref aid) = agent_id {
+            transaction
+                .query(count_sql, &[&gate_ref_str, &tenant_id, &user_id, aid])
+                .await
+        } else {
+            transaction
+                .query(count_sql, &[&gate_ref_str, &tenant_id, &user_id])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_delete_count_buckets", e.to_string()))?;
+
+        let mut bucket_counts: Vec<(i16, i64)> = Vec::new();
+        for row in &count_rows {
+            let b: i16 = row.try_get::<_, i16>(0).unwrap_or(0);
+            let n: i64 = row.try_get::<_, i64>(1).unwrap_or(0);
+            bucket_counts.push((b, n));
+        }
+
+        // Delete from all three tables.
+        let del_queue_sql = if agent_id.is_some() {
+            "DELETE FROM subagent_gate_deliverable_queue \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id = $4"
+        } else {
+            "DELETE FROM subagent_gate_deliverable_queue \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id IS NULL"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(del_queue_sql, &[&gate_ref_str, &tenant_id, &user_id, aid])
+                .await
+        } else {
+            transaction
+                .execute(del_queue_sql, &[&gate_ref_str, &tenant_id, &user_id])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_del_queue_gate", e.to_string()))?;
+
+        let del_idx_sql = if agent_id.is_some() {
+            "DELETE FROM subagent_gate_child_index \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id = $4"
+        } else {
+            "DELETE FROM subagent_gate_child_index \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id IS NULL"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(del_idx_sql, &[&gate_ref_str, &tenant_id, &user_id, aid])
+                .await
+        } else {
+            transaction
+                .execute(del_idx_sql, &[&gate_ref_str, &tenant_id, &user_id])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_del_child_idx", e.to_string()))?;
+
+        let del_primary_sql = if agent_id.is_some() {
+            "DELETE FROM subagent_gate_awaited_children \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id = $4"
+        } else {
+            "DELETE FROM subagent_gate_awaited_children \
+              WHERE gate_ref = $1 AND tenant_id = $2 AND user_id = $3 AND agent_id IS NULL"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(del_primary_sql, &[&gate_ref_str, &tenant_id, &user_id, aid])
+                .await
+        } else {
+            transaction
+                .execute(del_primary_sql, &[&gate_ref_str, &tenant_id, &user_id])
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_del_primary", e.to_string()))?;
+
+        // Decrement each touched bucket (GREATEST floor-at-zero).
+        for (bucket, n) in bucket_counts {
+            let decr_sql = if agent_id.is_some() {
+                "UPDATE subagent_gate_capacity_counter \
+                   SET undelivered = GREATEST(undelivered - $1, 0) \
+                 WHERE tenant_id = $2 AND user_id = $3 AND agent_id = $4 AND bucket = $5"
+            } else {
+                "UPDATE subagent_gate_capacity_counter \
+                   SET undelivered = GREATEST(undelivered - $1, 0) \
+                 WHERE tenant_id = $2 AND user_id = $3 AND agent_id IS NULL AND bucket = $4"
+            };
+            {
+                let p: &[&(dyn tokio_postgres::types::ToSql + Sync)] =
+                    if let Some(ref aid) = agent_id {
+                        &[&n, &tenant_id, &user_id, aid, &bucket]
+                    } else {
+                        &[&n, &tenant_id, &user_id, &bucket]
+                    };
+                transaction.execute(decr_sql, p).await.map_err(|e| {
+                    GateResolutionStoreError::io("pg_decr_bucket_delete", e.to_string())
+                })?;
+            }
+        }
+
+        transaction
+            .commit()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+        Ok(())
+    }
+
+    // ── Reconciler-facing ──────────────────────────────────────────────────
+
+    async fn gates_exist_batch(
+        &self,
+        scope: &TurnScope,
+        gate_refs: Vec<GateRef>,
+    ) -> Result<HashSet<GateRef>, GateResolutionStoreError> {
+        if gate_refs.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+
+        // Build $N placeholders for the IN clause.
+        let base = if agent_id.is_some() { 4 } else { 3 };
+        let placeholders: Vec<String> = gate_refs
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("${}", base + i))
+            .collect();
+        let in_clause = placeholders.join(", ");
+
+        let agent_pred = if agent_id.is_some() {
+            "agent_id = $3"
+        } else {
+            "agent_id IS NULL"
+        };
+        let sql = format!(
+            "SELECT DISTINCT gate_ref FROM subagent_gate_awaited_children \
+             WHERE tenant_id = $1 AND user_id = $2 AND {agent_pred} \
+               AND gate_ref IN ({in_clause})"
+        );
+
+        let mut params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+            vec![&tenant_id, &user_id];
+        let agent_clone: Option<String> = agent_id.clone();
+        if let Some(ref aid) = agent_clone {
+            params.push(aid);
+        }
+        let ref_strs: Vec<String> = gate_refs.iter().map(|g| g.as_str().to_string()).collect();
+        for s in &ref_strs {
+            params.push(s);
+        }
+
+        let rows = client
+            .query(&sql, &params)
+            .await
+            .map_err(|e| GateResolutionStoreError::io("pg_gates_exist_batch", e.to_string()))?;
+
+        let mut found = HashSet::new();
+        for row in &rows {
+            let s: String = row
+                .try_get::<_, String>(0)
+                .map_err(|e| GateResolutionStoreError::io("pg_gates_exist_col", e.to_string()))?;
+            if let Ok(gr) = GateRef::new(&s) {
+                found.insert(gr);
+            }
+        }
+        Ok(found)
+    }
+
+    async fn redeliver_settled_child(
+        &self,
+        scope: &TurnScope,
+        gate_ref: GateRef,
+        child_run_id: TurnRunId,
+        terminal_status: TurnStatus,
+        result_ref: LoopResultRef,
+    ) -> Result<bool, GateResolutionStoreError> {
+        let mut client = self.client().await?;
+        let tenant_id = scope.tenant_id.as_str().to_string();
+        let user_id = user_id_str(scope);
+        let agent_id: Option<String> = scope.agent_id.as_ref().map(|a| a.as_str().to_string());
+        let gate_ref_str = gate_ref.as_str().to_string();
+        let child_run_id_str = child_run_id.to_string();
+        let status_s = status_str(terminal_status);
+        let result_ref_str = result_ref.as_str().to_string();
+
+        let transaction = client
+            .build_transaction()
+            .start()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
+        // Check existence.
+        let exists_row = transaction
+            .query_opt(
+                "SELECT 1 FROM subagent_gate_awaited_children \
+                  WHERE gate_ref = $1 AND child_run_id = $2 LIMIT 1",
+                &[&gate_ref_str, &child_run_id_str],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("pg_redeliver_check", e.to_string()))?;
+        if exists_row.is_none() {
+            transaction.rollback().await.ok();
+            return Ok(false); // gate row vanished (orphan)
+        }
+
+        // Set terminal flags (idempotent: WHERE terminal_status IS NULL).
+        let upd_sql = if agent_id.is_some() {
+            "UPDATE subagent_gate_awaited_children \
+               SET terminal_status = $1, terminal_result_written = TRUE, \
+                   result_ref = $2, settled_at = COALESCE(settled_at, NOW()) \
+             WHERE gate_ref = $3 AND child_run_id = $4 AND terminal_status IS NULL \
+               AND tenant_id = $5 AND user_id = $6 AND agent_id = $7"
+        } else {
+            "UPDATE subagent_gate_awaited_children \
+               SET terminal_status = $1, terminal_result_written = TRUE, \
+                   result_ref = $2, settled_at = COALESCE(settled_at, NOW()) \
+             WHERE gate_ref = $3 AND child_run_id = $4 AND terminal_status IS NULL \
+               AND tenant_id = $5 AND user_id = $6 AND agent_id IS NULL"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(
+                    upd_sql,
+                    &[
+                        &status_s,
+                        &result_ref_str,
+                        &gate_ref_str,
+                        &child_run_id_str,
+                        &tenant_id,
+                        &user_id,
+                        aid,
+                    ],
+                )
+                .await
+        } else {
+            transaction
+                .execute(
+                    upd_sql,
+                    &[
+                        &status_s,
+                        &result_ref_str,
+                        &gate_ref_str,
+                        &child_run_id_str,
+                        &tenant_id,
+                        &user_id,
+                    ],
+                )
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_redeliver_update", e.to_string()))?;
+
+        // Ensure deliverable queue entry exists (ON CONFLICT DO NOTHING).
+        let queue_sql = if agent_id.is_some() {
+            "INSERT INTO subagent_gate_deliverable_queue \
+                (tenant_id, user_id, agent_id, child_run_id, gate_ref) \
+             VALUES ($1, $2, $3, $4, $5) \
+             ON CONFLICT (child_run_id, gate_ref) DO NOTHING"
+        } else {
+            "INSERT INTO subagent_gate_deliverable_queue \
+                (tenant_id, user_id, agent_id, child_run_id, gate_ref) \
+             VALUES ($1, $2, NULL, $3, $4) \
+             ON CONFLICT (child_run_id, gate_ref) DO NOTHING"
+        };
+        if let Some(ref aid) = agent_id {
+            transaction
+                .execute(
+                    queue_sql,
+                    &[&tenant_id, &user_id, aid, &child_run_id_str, &gate_ref_str],
+                )
+                .await
+        } else {
+            transaction
+                .execute(
+                    queue_sql,
+                    &[&tenant_id, &user_id, &child_run_id_str, &gate_ref_str],
+                )
+                .await
+        }
+        .map_err(|e| GateResolutionStoreError::io("pg_redeliver_queue", e.to_string()))?;
+
+        transaction
+            .commit()
+            .await
+            .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+        Ok(true)
+    }
+
+    async fn resolve_undeliverable_batch(
+        &self,
+        scope: &TurnScope,
+        rows: Vec<(GateRef, TurnRunId)>,
+    ) -> Result<(), GateResolutionStoreError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        for (gate_ref, child_run_id) in rows {
+            // Reuse mark_child_delivered per row (same delivery-claim transaction).
+            // Idempotent via delivered_to_parent = FALSE guard.
+            self.mark_child_delivered(scope, &gate_ref, child_run_id)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+/// Run all pending incremental migrations against the PostgreSQL pool.
+///
+/// Creates the `_reborn_migrations` tracking table first, then applies each
+/// entry in [`super::migrations::INCREMENTAL_MIGRATIONS`] that is absent from
+/// the table. All DDL uses `IF NOT EXISTS` for idempotency.
+pub async fn run_postgres_gate_migrations(pool: &Pool) -> Result<(), GateResolutionStoreError> {
+    use crate::postgres::migrations::{INCREMENTAL_MIGRATIONS, MIGRATIONS_TABLE_DDL};
+
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| GateResolutionStoreError::unavailable(e.to_string()))?;
+
+    client
+        .execute(MIGRATIONS_TABLE_DDL, &[])
+        .await
+        .map_err(|e| GateResolutionStoreError::io("pg_create_migrations_table", e.to_string()))?;
+
+    for (version, name, ddl) in INCREMENTAL_MIGRATIONS {
+        let already_applied = client
+            .query_opt(
+                "SELECT 1 FROM _reborn_migrations WHERE version = $1",
+                &[version],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("pg_check_migration", e.to_string()))?;
+        if already_applied.is_some() {
+            continue;
+        }
+
+        // Execute each semicolon-separated DDL statement individually.
+        for stmt in ddl.split(';') {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            client.execute(stmt, &[]).await.map_err(|e| {
+                GateResolutionStoreError::io("pg_run_migration_stmt", e.to_string())
+            })?;
+        }
+
+        client
+            .execute(
+                "INSERT INTO _reborn_migrations (version, name) VALUES ($1, $2)",
+                &[version, name],
+            )
+            .await
+            .map_err(|e| GateResolutionStoreError::io("pg_record_migration", e.to_string()))?;
+
+        tracing::debug!(
+            version = *version,
+            name = *name,
+            "reborn gate-resolution pg migration applied"
+        );
+    }
+    Ok(())
+}

--- a/crates/ironclaw_reborn_event_store/src/postgres/migrations.rs
+++ b/crates/ironclaw_reborn_event_store/src/postgres/migrations.rs
@@ -1,0 +1,146 @@
+//! PostgreSQL DDL migrations for Reborn durable stores.
+//!
+//! Migration-script convention: spec §8.5.
+//!
+//! Version numbers are independent from the V1 PostgreSQL schema in
+//! `src/db/postgres.rs`. This crate owns its own `_reborn_migrations`
+//! tracking table.
+//!
+//! **Parallel-branch safety:** only version 1 (`subagent_gate_resolution`) is
+//! added by WU-C2. Versions 2, 3, 4 are reserved for parallel workstreams.
+
+/// Tracking table DDL — created once on first use.
+pub const MIGRATIONS_TABLE_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS _reborn_migrations (
+    version     BIGINT      NOT NULL PRIMARY KEY,
+    name        TEXT        NOT NULL,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)"#;
+
+/// Incremental migrations. Entries are `(version, name, ddl)`.
+pub const INCREMENTAL_MIGRATIONS: &[(i64, &str, &str)] = &[
+    (
+        1,
+        "subagent_gate_resolution",
+        // ── subagent_gate_awaited_children ────────────────────────────────
+        // PostgreSQL dialect: BOOLEAN, BIGINT, TIMESTAMPTZ, JSONB.
+        // NULL agent_id uses COALESCE in expression indexes for uniqueness.
+        r#"
+CREATE TABLE IF NOT EXISTS subagent_gate_awaited_children (
+    tenant_id                               TEXT        NOT NULL,
+    user_id                                 TEXT        NOT NULL,
+    agent_id                                TEXT,
+    gate_ref                                TEXT        NOT NULL,
+    parent_run_id                           TEXT        NOT NULL,
+    tree_root_run_id                        TEXT        NOT NULL,
+    child_run_id                            TEXT        NOT NULL,
+    child_thread_id                         TEXT        NOT NULL,
+    child_scope_json                        JSONB       NOT NULL,
+    parent_run_context_json                 JSONB       NOT NULL,
+    source_binding_ref                      TEXT        NOT NULL,
+    reply_target_binding_ref                TEXT        NOT NULL,
+    subagent_kind                           TEXT        NOT NULL,
+    spawn_capability_id                     TEXT        NOT NULL,
+    result_ref                              TEXT        NOT NULL,
+    spawn_mode                              TEXT        NOT NULL,
+    counter_bucket                          SMALLINT    NOT NULL,
+    terminal_status                         TEXT,
+    terminal_event_json                     JSONB,
+    terminal_result_written                 BOOLEAN     NOT NULL DEFAULT FALSE,
+    terminal_byte_len                       BIGINT      NOT NULL DEFAULT 0,
+    descendant_reservation_release_claimed  BOOLEAN     NOT NULL DEFAULT FALSE,
+    descendant_reservation_released         BOOLEAN     NOT NULL DEFAULT FALSE,
+    delivery_claimed                        BOOLEAN     NOT NULL DEFAULT FALSE,
+    delivered_to_parent                     BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at                              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    settled_at                              TIMESTAMPTZ,
+    PRIMARY KEY (gate_ref, child_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sgac_tenant_user_agent
+    ON subagent_gate_awaited_children (tenant_id, user_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_sgac_child_run_id
+    ON subagent_gate_awaited_children (child_run_id);
+CREATE INDEX IF NOT EXISTS idx_sgac_parent_run_id
+    ON subagent_gate_awaited_children (parent_run_id);
+CREATE INDEX IF NOT EXISTS idx_sgac_undelivered_terminal
+    ON subagent_gate_awaited_children (tenant_id, user_id, agent_id, delivered_to_parent, terminal_status)
+    WHERE delivered_to_parent = FALSE;
+
+-- ── subagent_gate_child_index ────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS subagent_gate_child_index (
+    tenant_id    TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    agent_id     TEXT,
+    child_run_id TEXT NOT NULL,
+    gate_ref     TEXT NOT NULL,
+    PRIMARY KEY (child_run_id, gate_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_sgci_scope
+    ON subagent_gate_child_index (tenant_id, user_id, agent_id, child_run_id);
+
+-- ── subagent_gate_deliverable_queue ─────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS subagent_gate_deliverable_queue (
+    tenant_id    TEXT        NOT NULL,
+    user_id      TEXT        NOT NULL,
+    agent_id     TEXT,
+    child_run_id TEXT        NOT NULL,
+    gate_ref     TEXT        NOT NULL,
+    queued_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (child_run_id, gate_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_sgdq_scope
+    ON subagent_gate_deliverable_queue (tenant_id, user_id, agent_id, child_run_id);
+
+-- ── subagent_gate_capacity_counter ──────────────────────────────────────
+-- No declared PK due to nullable agent_id — use COALESCE expression index.
+-- Conflict target for INSERT must name the expression index explicitly:
+--   ON CONFLICT (tenant_id, user_id, COALESCE(agent_id, '__non_agent__'), bucket)
+
+CREATE TABLE IF NOT EXISTS subagent_gate_capacity_counter (
+    tenant_id    TEXT     NOT NULL,
+    user_id      TEXT     NOT NULL,
+    agent_id     TEXT,
+    bucket       SMALLINT NOT NULL,
+    undelivered  INTEGER  NOT NULL DEFAULT 0
+        CHECK (undelivered >= 0)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sgcc_pk
+    ON subagent_gate_capacity_counter
+       (tenant_id, user_id, COALESCE(agent_id, '__non_agent__'), bucket);
+CREATE INDEX IF NOT EXISTS idx_sgcc_scope
+    ON subagent_gate_capacity_counter (tenant_id, user_id, agent_id);
+
+-- ── subagent_gate_settlement_log ────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS subagent_gate_settlement_log (
+    id                BIGSERIAL   NOT NULL PRIMARY KEY,
+    tenant_id         TEXT        NOT NULL,
+    user_id           TEXT        NOT NULL,
+    agent_id          TEXT,
+    gate_ref          TEXT        NOT NULL,
+    child_run_id      TEXT        NOT NULL,
+    result_ref        TEXT        NOT NULL,
+    parent_run_id     TEXT        NOT NULL,
+    terminal_status   TEXT        NOT NULL,
+    terminal_kind     TEXT        NOT NULL,
+    event_cursor      BIGINT      NOT NULL,
+    terminal_byte_len BIGINT      NOT NULL DEFAULT 0,
+    sanitized_reason  TEXT,
+    owner_user_id     TEXT,
+    settled_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_sgsl_tenant_user_agent
+    ON subagent_gate_settlement_log (tenant_id, user_id, agent_id);
+CREATE INDEX IF NOT EXISTS idx_sgsl_parent_run_id
+    ON subagent_gate_settlement_log (parent_run_id);
+CREATE INDEX IF NOT EXISTS idx_sgsl_child_run_id
+    ON subagent_gate_settlement_log (child_run_id)
+"#,
+    ),
+    // Version 2: subagent_capability_result      (WU-C3 — parallel branch)
+    // Version 3: subagent_settlement_event_log   (WU-C3 — parallel branch)
+    // Version 4: subagent_idempotency_ledger     (WU-C3 — parallel branch)
+];

--- a/crates/ironclaw_reborn_event_store/src/postgres/mod.rs
+++ b/crates/ironclaw_reborn_event_store/src/postgres/mod.rs
@@ -1,0 +1,10 @@
+//! PostgreSQL-backed Reborn durable store modules.
+//!
+//! Each module implements the backend for one durable store using a
+//! `deadpool_postgres::Pool`. All DDL is managed through the incremental
+//! migration table in [`crate::postgres::migrations`].
+
+pub mod gate_resolution;
+pub mod migrations;
+
+pub use gate_resolution::{PostgresGateResolutionStore, run_postgres_gate_migrations};

--- a/crates/ironclaw_reborn_event_store/tests/gate_resolution_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/gate_resolution_contract.rs
@@ -1,0 +1,618 @@
+//! Contract tests for the durable gate-resolution store.
+//!
+//! All tests run against the libSQL file-backed backend using a temp directory
+//! (no external process). libSQL `:memory:` databases do not share state
+//! between connections, so a temp-file database is used instead.
+//! PostgreSQL tests are gated behind the `integration` feature and require a
+//! live Postgres server — the code compiles without a live server.
+//!
+//! Test coverage per spec and task requirements:
+//!  - First-writer-wins `record_child_terminal` parity with in-memory store
+//!  - Claim semantics (`claim_all_terminal_states_for_child`)
+//!  - Capacity counter bucket behavior (K=16 sharding, cap enforcement)
+//!  - Scoped-query security test (decision 31: no cross-agent leakage)
+//!  - Reconciler-facing methods: `gates_exist_batch`, `redeliver_settled_child`,
+//!    `resolve_undeliverable_batch`
+
+#[cfg(feature = "libsql")]
+mod libsql_tests {
+    use std::sync::Arc;
+
+    use ironclaw_host_api::{AgentId, TenantId, ThreadId};
+    use ironclaw_reborn_event_store::{
+        AwaitedChildRecord, CAPACITY_COUNTER_BUCKETS, DurableSubagentGateResolutionStore,
+        DurableTerminalEvent, GateResolutionStoreError, LibSqlGateResolutionStore, child_bucket,
+        run_libsql_gate_migrations,
+    };
+    use ironclaw_turns::{GateRef, LoopResultRef, TurnRunId, TurnScope, TurnStatus};
+
+    /// Build a file-backed libSQL store with migrations applied.
+    ///
+    /// libSQL `:memory:` databases do not share state between connections
+    /// (each `connect()` opens a fresh in-memory DB). A temp file ensures
+    /// migration DDL is visible to all subsequent connections.
+    async fn build_store() -> (LibSqlGateResolutionStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("gate_test.db");
+        let db = Arc::new(
+            libsql::Builder::new_local(&db_path)
+                .build()
+                .await
+                .expect("build libsql db"),
+        );
+        run_libsql_gate_migrations(&db)
+            .await
+            .expect("run gate migrations");
+        (LibSqlGateResolutionStore::new(db, 16), dir)
+    }
+
+    fn scope_with_agent(tenant: &str, agent: &str, thread: &str) -> TurnScope {
+        TurnScope::new(
+            TenantId::new(tenant).unwrap(),
+            Some(AgentId::new(agent).unwrap()),
+            None,
+            ThreadId::new(thread).unwrap(),
+        )
+    }
+
+    fn scope_no_agent(tenant: &str, thread: &str) -> TurnScope {
+        TurnScope::new(
+            TenantId::new(tenant).unwrap(),
+            None,
+            None,
+            ThreadId::new(thread).unwrap(),
+        )
+    }
+
+    fn make_record(gate: &str, child: &str, parent: &str) -> AwaitedChildRecord {
+        AwaitedChildRecord {
+            gate_ref: GateRef::new(gate).unwrap(),
+            parent_run_id: TurnRunId::parse(parent).unwrap(),
+            tree_root_run_id: TurnRunId::parse(parent).unwrap(),
+            child_run_id: TurnRunId::parse(child).unwrap(),
+            child_thread_id: "child-thread-0".to_string(),
+            child_scope_json: r#"{"tenant_id":"t1","agent_id":null,"project_id":null,"thread_id":"th0","thread_owner":{"mode":"actor_fallback"}}"#.to_string(),
+            parent_run_context_json: r#"{"run_id":"00000000-0000-0000-0000-000000000000"}"#.to_string(),
+            source_binding_ref: "src".to_string(),
+            reply_target_binding_ref: "reply".to_string(),
+            subagent_kind: "coding".to_string(),
+            spawn_capability_id: "spawn.subagent".to_string(),
+            result_ref: LoopResultRef::new("result:test.001").unwrap(),
+            spawn_mode: "blocking".to_string(),
+        }
+    }
+
+    fn terminal_event(status: TurnStatus) -> DurableTerminalEvent {
+        DurableTerminalEvent {
+            status,
+            kind: "subagent_terminal".to_string(),
+            cursor: 42,
+            sanitized_reason: None,
+            owner_user_id: None,
+        }
+    }
+
+    // ── migration sanity ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn migration_creates_all_tables() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("migration_test.db");
+        let db = Arc::new(
+            libsql::Builder::new_local(&db_path)
+                .build()
+                .await
+                .expect("file-backed libsql"),
+        );
+        run_libsql_gate_migrations(&db)
+            .await
+            .expect("migrations must succeed");
+        let conn = db.connect().unwrap();
+        let mut rows = conn
+            .query(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+                (),
+            )
+            .await
+            .unwrap();
+        let mut tables = Vec::new();
+        while let Some(row) = rows.next().await.unwrap() {
+            tables.push(row.get::<String>(0).unwrap());
+        }
+        for expected in &[
+            "subagent_gate_awaited_children",
+            "subagent_gate_capacity_counter",
+            "subagent_gate_child_index",
+            "subagent_gate_deliverable_queue",
+            "subagent_gate_settlement_log",
+        ] {
+            assert!(
+                tables.contains(&expected.to_string()),
+                "migration must create table {expected}, got: {tables:?}"
+            );
+        }
+    }
+
+    // ── first-writer-wins ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn record_awaited_child_is_idempotent() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-a", "agent-a", "thread-a");
+        let record = make_record(
+            "gate:fw-idem-0001",
+            "00000000-0000-0000-0000-000000000001",
+            "00000000-0000-0000-0000-000000000002",
+        );
+        store
+            .record_awaited_child(&scope, record.clone())
+            .await
+            .unwrap();
+        // Second insert is silently ignored (INSERT OR IGNORE).
+        store.record_awaited_child(&scope, record).await.unwrap();
+    }
+
+    /// Spec §1.6 decision 6: `record_child_terminal` is first-writer-wins.
+    /// A second write with a different status MUST be a no-op.
+    #[tokio::test]
+    async fn record_child_terminal_first_writer_wins() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-fw", "agent-fw", "thread-fw");
+        let gate_ref = GateRef::new("gate:fw-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000010").unwrap();
+        let parent_id = "00000000-0000-0000-0000-000000000011";
+
+        let record = make_record(gate_ref.as_str(), &child_id.to_string(), parent_id);
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        // First write: Completed.
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref.clone(),
+                child_id,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+
+        // Second write: Failed — must be ignored (first-writer-wins).
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref,
+                child_id,
+                terminal_event(TurnStatus::Failed),
+            )
+            .await
+            .unwrap();
+
+        // Claim must return the first-written status (Completed).
+        let rows = store
+            .claim_all_terminal_states_for_child(&scope, child_id)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "expected exactly one row");
+        assert_eq!(
+            rows[0].terminal_status,
+            Some(TurnStatus::Completed),
+            "first-writer-wins: terminal_status must be Completed, not Failed"
+        );
+    }
+
+    /// `record_child_terminal` rejects non-terminal statuses.
+    #[tokio::test]
+    async fn record_child_terminal_rejects_non_terminal_status() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-nt", "agent-nt", "thread-nt");
+        let gate_ref = GateRef::new("gate:nt-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000020").unwrap();
+        let parent_id = "00000000-0000-0000-0000-000000000021";
+
+        let record = make_record(gate_ref.as_str(), &child_id.to_string(), parent_id);
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        let result = store
+            .record_child_terminal(
+                &scope,
+                gate_ref,
+                child_id,
+                terminal_event(TurnStatus::Running),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(GateResolutionStoreError::NonTerminalStatus)),
+            "non-terminal status must be rejected"
+        );
+    }
+
+    // ── claim semantics ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn claim_all_returns_empty_before_terminal() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-cl", "agent-cl", "thread-cl");
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000030").unwrap();
+        let gate_ref = GateRef::new("gate:cl-001").unwrap();
+
+        let record = make_record(
+            gate_ref.as_str(),
+            &child_id.to_string(),
+            "00000000-0000-0000-0000-000000000031",
+        );
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        let rows = store
+            .claim_all_terminal_states_for_child(&scope, child_id)
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "no terminal state yet — queue must be empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_all_returns_row_after_terminal() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-cl2", "agent-cl2", "thread-cl2");
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000040").unwrap();
+        let gate_ref = GateRef::new("gate:cl2-001").unwrap();
+
+        let record = make_record(
+            gate_ref.as_str(),
+            &child_id.to_string(),
+            "00000000-0000-0000-0000-000000000041",
+        );
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref,
+                child_id,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+
+        let rows = store
+            .claim_all_terminal_states_for_child(&scope, child_id)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "one terminal row expected after settlement");
+        assert_eq!(rows[0].terminal_status, Some(TurnStatus::Completed));
+    }
+
+    // ── capacity counter bucket behavior ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn capacity_counter_increments_and_decrements() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-cap", "agent-cap", "thread-cap");
+
+        let gate_ref = GateRef::new("gate:cap-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000050").unwrap();
+        let record = make_record(
+            gate_ref.as_str(),
+            &child_id.to_string(),
+            "00000000-0000-0000-0000-000000000051",
+        );
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        // Settle the child terminal.
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref.clone(),
+                child_id,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+
+        // mark_child_delivered should decrement the counter bucket.
+        let _gate_done = store
+            .mark_child_delivered(&scope, &gate_ref, child_id)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn capacity_exceeded_error_variant_is_accessible() {
+        // Confirms GateResolutionStoreError::CapacityExceeded is exported and
+        // carries the expected Display message (spec §1 decision 21).
+        let err = GateResolutionStoreError::CapacityExceeded;
+        assert_eq!(
+            format!("{err}"),
+            "gate resolution capacity exceeded for scope"
+        );
+    }
+
+    #[test]
+    fn bucket_distribution_across_k_buckets() {
+        let k = CAPACITY_COUNTER_BUCKETS;
+        let mut seen = std::collections::HashSet::new();
+        for i in 0u32..200 {
+            let id = format!("{i:08x}-0000-0000-0000-000000000000");
+            seen.insert(child_bucket(&id, k));
+        }
+        assert!(
+            seen.len() > 10,
+            "expected spread across buckets, got {} distinct values",
+            seen.len()
+        );
+    }
+
+    // ── scoped-query security test (decision 31) ─────────────────────────────
+
+    /// Prove that `claim_all_terminal_states_for_child` scoped to agent-a
+    /// cannot return rows belonging to agent-b under the same tenant.
+    ///
+    /// This is the required test per spec decision 31.
+    #[tokio::test]
+    async fn gate_resolution_scoped_query_excludes_rows_from_other_agents() {
+        let (store, _dir) = build_store().await;
+
+        let scope_a = scope_with_agent("tenant-sec", "agent-sec-a", "thread-sec-a");
+        let scope_b = scope_with_agent("tenant-sec", "agent-sec-b", "thread-sec-b");
+
+        // agent-a spawns a child.
+        let gate_a = GateRef::new("gate:sec-a-001").unwrap();
+        let child_a = TurnRunId::parse("00000000-0000-0000-0000-000000000060").unwrap();
+        let record_a = make_record(
+            gate_a.as_str(),
+            &child_a.to_string(),
+            "00000000-0000-0000-0000-000000000061",
+        );
+        store
+            .record_awaited_child(&scope_a, record_a)
+            .await
+            .unwrap();
+        store
+            .record_child_terminal(
+                &scope_a,
+                gate_a,
+                child_a,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+
+        // Querying as agent-b MUST NOT return agent-a's row.
+        let rows_b = store
+            .claim_all_terminal_states_for_child(&scope_b, child_a)
+            .await
+            .unwrap();
+        assert!(
+            rows_b.is_empty(),
+            "scoped query for agent-b must not return agent-a rows (cross-agent isolation violation)"
+        );
+    }
+
+    /// `gates_exist_batch` must only return gates visible in the given scope.
+    #[tokio::test]
+    async fn gates_exist_batch_scoped_to_agent() {
+        let (store, _dir) = build_store().await;
+        let scope_a = scope_with_agent("tenant-geb", "agent-geb-a", "thread-geb-a");
+        let scope_b = scope_with_agent("tenant-geb", "agent-geb-b", "thread-geb-b");
+
+        let gate_a = GateRef::new("gate:geb-a-001").unwrap();
+        let child_a = TurnRunId::parse("00000000-0000-0000-0000-000000000070").unwrap();
+        let record_a = make_record(
+            gate_a.as_str(),
+            &child_a.to_string(),
+            "00000000-0000-0000-0000-000000000071",
+        );
+        store
+            .record_awaited_child(&scope_a, record_a)
+            .await
+            .unwrap();
+
+        // Batch check as scope_a — should find the gate.
+        let found_a = store
+            .gates_exist_batch(&scope_a, vec![gate_a.clone()])
+            .await
+            .unwrap();
+        assert!(
+            found_a.contains(&gate_a),
+            "gate_a must be visible to scope_a"
+        );
+
+        // Batch check as scope_b — must NOT find scope_a's gate.
+        let found_b = store
+            .gates_exist_batch(&scope_b, vec![gate_a.clone()])
+            .await
+            .unwrap();
+        assert!(
+            !found_b.contains(&gate_a),
+            "gate_a must NOT be visible to scope_b (cross-agent isolation violation)"
+        );
+    }
+
+    /// `gates_exist_batch` with empty input returns empty set.
+    #[tokio::test]
+    async fn gates_exist_batch_empty_input_returns_empty() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-empty", "agent-empty", "thread-empty");
+        let found = store.gates_exist_batch(&scope, vec![]).await.unwrap();
+        assert!(found.is_empty());
+    }
+
+    // ── reconciler-facing methods ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn redeliver_settled_child_returns_true_for_existing_gate() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-rd", "agent-rd", "thread-rd");
+        let gate_ref = GateRef::new("gate:rd-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000080").unwrap();
+        let parent_id = "00000000-0000-0000-0000-000000000081";
+        let result_ref = LoopResultRef::new("result:rd.001").unwrap();
+
+        let record = make_record(gate_ref.as_str(), &child_id.to_string(), parent_id);
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        let delivered = store
+            .redeliver_settled_child(
+                &scope,
+                gate_ref,
+                child_id,
+                TurnStatus::Completed,
+                result_ref,
+            )
+            .await
+            .unwrap();
+        assert!(
+            delivered,
+            "redeliver_settled_child must return true for existing gate row"
+        );
+    }
+
+    #[tokio::test]
+    async fn redeliver_settled_child_returns_false_for_missing_gate() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-rd2", "agent-rd2", "thread-rd2");
+        let gate_ref = GateRef::new("gate:rd2-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000090").unwrap();
+        let result_ref = LoopResultRef::new("result:rd2.001").unwrap();
+
+        // No record_awaited_child call — gate row doesn't exist.
+        let delivered = store
+            .redeliver_settled_child(
+                &scope,
+                gate_ref,
+                child_id,
+                TurnStatus::Completed,
+                result_ref,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !delivered,
+            "redeliver_settled_child must return false for missing gate (orphan)"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_undeliverable_batch_is_idempotent() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-rub", "agent-rub", "thread-rub");
+        let gate_ref = GateRef::new("gate:rub-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-0000000000a0").unwrap();
+        let parent_id = "00000000-0000-0000-0000-0000000000a1";
+
+        let record = make_record(gate_ref.as_str(), &child_id.to_string(), parent_id);
+        store.record_awaited_child(&scope, record).await.unwrap();
+        // Settle terminal first.
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref.clone(),
+                child_id,
+                terminal_event(TurnStatus::Cancelled),
+            )
+            .await
+            .unwrap();
+
+        let rows = vec![(gate_ref.clone(), child_id)];
+        // First call: resolves the undeliverable row.
+        store
+            .resolve_undeliverable_batch(&scope, rows.clone())
+            .await
+            .unwrap();
+        // Second call: idempotent (delivered_to_parent guard).
+        store
+            .resolve_undeliverable_batch(&scope, rows)
+            .await
+            .unwrap();
+    }
+
+    /// After `resolve_undeliverable_batch`, the row must not appear in
+    /// `claim_all_terminal_states_for_child` (delivered_to_parent = 1 skips queue).
+    #[tokio::test]
+    async fn resolve_undeliverable_batch_removes_from_claim_queue() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-rub2", "agent-rub2", "thread-rub2");
+        let gate_ref = GateRef::new("gate:rub2-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-0000000000b0").unwrap();
+        let parent_id = "00000000-0000-0000-0000-0000000000b1";
+
+        let record = make_record(gate_ref.as_str(), &child_id.to_string(), parent_id);
+        store.record_awaited_child(&scope, record).await.unwrap();
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref.clone(),
+                child_id,
+                terminal_event(TurnStatus::Failed),
+            )
+            .await
+            .unwrap();
+
+        // Verify row is claimable before resolution.
+        let before = store
+            .claim_all_terminal_states_for_child(&scope, child_id)
+            .await
+            .unwrap();
+        assert_eq!(before.len(), 1, "row should be claimable before resolve");
+
+        // Resolve as undeliverable (decision 31 path).
+        store
+            .resolve_undeliverable_batch(&scope, vec![(gate_ref, child_id)])
+            .await
+            .unwrap();
+
+        // After resolution, queue entry is removed → claim returns empty.
+        let after = store
+            .claim_all_terminal_states_for_child(&scope, child_id)
+            .await
+            .unwrap();
+        assert!(
+            after.is_empty(),
+            "row must not appear in claim queue after resolve_undeliverable_batch"
+        );
+    }
+
+    /// `resolve_undeliverable_batch` with empty input is a no-op.
+    #[tokio::test]
+    async fn resolve_undeliverable_batch_empty_input_is_noop() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-noop", "agent-noop", "thread-noop");
+        store
+            .resolve_undeliverable_batch(&scope, vec![])
+            .await
+            .unwrap();
+    }
+
+    /// Null `agent_id` scope (non-agent run) uses `agent_id IS NULL` predicate
+    /// and must not match rows written under an agent scope.
+    #[tokio::test]
+    async fn null_agent_scope_does_not_match_agent_scoped_rows() {
+        let (store, _dir) = build_store().await;
+        let scope_agent = scope_with_agent("tenant-null", "agent-null", "thread-null-a");
+        let scope_system = scope_no_agent("tenant-null", "thread-null-sys");
+
+        let gate_ref = GateRef::new("gate:null-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-0000000000c0").unwrap();
+        let record = make_record(
+            gate_ref.as_str(),
+            &child_id.to_string(),
+            "00000000-0000-0000-0000-0000000000c1",
+        );
+        store
+            .record_awaited_child(&scope_agent, record)
+            .await
+            .unwrap();
+
+        // System scope must not find the agent-scoped gate.
+        let found = store
+            .gates_exist_batch(&scope_system, vec![gate_ref])
+            .await
+            .unwrap();
+        assert!(
+            found.is_empty(),
+            "null agent_id scope must not match agent-scoped rows"
+        );
+    }
+}

--- a/crates/ironclaw_reborn_event_store/tests/gate_resolution_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/gate_resolution_contract.rs
@@ -615,4 +615,495 @@ mod libsql_tests {
             "null agent_id scope must not match agent-scoped rows"
         );
     }
+
+    // ── F8a: capacity_exceeded_after_max_records ─────────────────────────────
+
+    /// Fill to the (injected) capacity limit, then assert the next
+    /// `record_awaited_child` fails with `CapacityExceeded`.
+    ///
+    /// Uses `new_with_limit` to set max_records = 3 so the test avoids
+    /// inserting 4096 rows. The production default (MAX_GATE_RECORDS = 4096) is
+    /// not changed.
+    #[tokio::test]
+    async fn capacity_exceeded_after_max_records() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("cap_exceed.db");
+        let db = Arc::new(
+            libsql::Builder::new_local(&db_path)
+                .build()
+                .await
+                .expect("build libsql db"),
+        );
+        run_libsql_gate_migrations(&db)
+            .await
+            .expect("run gate migrations");
+        // Limit = 3 so the test only needs 4 inserts total.
+        let store = LibSqlGateResolutionStore::new_with_limit(db, 16, 3);
+
+        let scope = scope_with_agent("tenant-capx", "agent-capx", "thread-capx");
+        let gate_ref = GateRef::new("gate:capx-001").unwrap();
+        let parent_id = "00000000-0000-0000-0000-0000000000d0";
+
+        // Insert exactly `max_records` children — all must succeed.
+        for i in 0u32..3 {
+            // Produce UUIDs that hash to different buckets for variety, but
+            // correctness doesn't depend on bucket distribution here.
+            let child_id_str = format!("0000{i:04x}-0000-0000-0000-0000000000d0");
+            let record = make_record(gate_ref.as_str(), &child_id_str, parent_id);
+            store
+                .record_awaited_child(&scope, record)
+                .await
+                .unwrap_or_else(|e| panic!("insert {i} failed: {e}"));
+        }
+
+        // One more must fail with CapacityExceeded.
+        let over_child = "0000ffff-0000-0000-0000-0000000000d0";
+        let record = make_record(gate_ref.as_str(), over_child, parent_id);
+        let result = store.record_awaited_child(&scope, record).await;
+        assert!(
+            matches!(result, Err(GateResolutionStoreError::CapacityExceeded)),
+            "expected CapacityExceeded, got: {result:?}"
+        );
+    }
+
+    // ── F8b: duplicate_record_awaited_child_does_not_inflate_capacity ────────
+
+    /// Regression for F2: recording the same (gate_ref, child_run_id) twice
+    /// must not increment the capacity counter a second time.
+    #[tokio::test]
+    async fn duplicate_record_awaited_child_does_not_inflate_capacity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("dup_cap.db");
+        let db = Arc::new(
+            libsql::Builder::new_local(&db_path)
+                .build()
+                .await
+                .expect("build libsql db"),
+        );
+        run_libsql_gate_migrations(&db)
+            .await
+            .expect("run gate migrations");
+        // Limit = 2 so we can distinguish "1 slot used" from "2 slots used".
+        let store = LibSqlGateResolutionStore::new_with_limit(db, 16, 2);
+
+        let scope = scope_with_agent("tenant-dup", "agent-dup", "thread-dup");
+        let gate_ref = GateRef::new("gate:dup-001").unwrap();
+        let child_id = "00000000-0000-0000-0000-0000000000e0";
+        let parent_id = "00000000-0000-0000-0000-0000000000e1";
+        let record = make_record(gate_ref.as_str(), child_id, parent_id);
+
+        // First insert: succeeds and consumes 1 slot.
+        store
+            .record_awaited_child(&scope, record.clone())
+            .await
+            .unwrap();
+
+        // Second insert of the same identity: silently ignored (INSERT OR IGNORE),
+        // counter must NOT increment again.
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        // If counter drifted to 2, this second unique child would fail.
+        let child_id2 = "00000001-0000-0000-0000-0000000000e0";
+        let record2 = make_record(gate_ref.as_str(), child_id2, parent_id);
+        store
+            .record_awaited_child(&scope, record2)
+            .await
+            .expect("second unique child must succeed — counter must still be 1, not 2");
+    }
+
+    // ── F8c: repeated_delivery_does_not_deflate_capacity ────────────────────
+
+    /// Regression for F3: delivering the same child twice must decrement the
+    /// capacity counter exactly once.
+    #[tokio::test]
+    async fn repeated_delivery_does_not_deflate_capacity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("rep_del.db");
+        let db = Arc::new(
+            libsql::Builder::new_local(&db_path)
+                .build()
+                .await
+                .expect("build libsql db"),
+        );
+        run_libsql_gate_migrations(&db)
+            .await
+            .expect("run gate migrations");
+        // Limit = 2: insert 2, deliver one twice, insert a third — if counter
+        // under-counts, the third insert would fail.
+        let store = LibSqlGateResolutionStore::new_with_limit(db, 16, 2);
+
+        let scope = scope_with_agent("tenant-repd", "agent-repd", "thread-repd");
+        let gate_ref = GateRef::new("gate:repd-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-0000000000f0").unwrap();
+        let parent_id = "00000000-0000-0000-0000-0000000000f1";
+
+        let record = make_record(gate_ref.as_str(), &child_id.to_string(), parent_id);
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        // Settle the child.
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref.clone(),
+                child_id,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+
+        // Deliver once: counter goes 1 → 0.
+        store
+            .mark_child_delivered(&scope, &gate_ref, child_id)
+            .await
+            .unwrap();
+
+        // Deliver again (retry / replay): counter must stay at 0, not go to -1
+        // (saturating at 0 via MAX). This is idempotent by the
+        // delivered_to_parent = 0 guard.
+        store
+            .mark_child_delivered(&scope, &gate_ref, child_id)
+            .await
+            .unwrap();
+
+        // If counter under-counted (went to -1 and wrapped), inserting a second
+        // child might either fail (CHECK constraint) or succeed incorrectly.
+        // With the correct guard, counter is 0 — we can insert one more child.
+        let child_id2 = TurnRunId::parse("00000001-0000-0000-0000-0000000000f0").unwrap();
+        let record2 = make_record(gate_ref.as_str(), &child_id2.to_string(), parent_id);
+        store
+            .record_awaited_child(&scope, record2)
+            .await
+            .expect("counter must be 0 after one delivery, allowing one more spawn");
+    }
+
+    // ── F8d: mark_terminal_result_written_is_once_only ───────────────────────
+
+    /// `mark_terminal_result_written` must be idempotent: first call persists
+    /// `terminal_byte_len`, second call is a no-op (does not overwrite).
+    #[tokio::test]
+    async fn mark_terminal_result_written_is_once_only() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-trw", "agent-trw", "thread-trw");
+        let gate_ref = GateRef::new("gate:trw-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000100").unwrap();
+        let parent_id = "00000000-0000-0000-0000-000000000101";
+
+        let record = make_record(gate_ref.as_str(), &child_id.to_string(), parent_id);
+        store.record_awaited_child(&scope, record).await.unwrap();
+
+        // First write: byte_len = 42.
+        store
+            .mark_terminal_result_written(&scope, &gate_ref, child_id, 42)
+            .await
+            .unwrap();
+
+        // Second write with a different byte_len: must be ignored
+        // (terminal_result_written = 0 guard prevents overwrite).
+        store
+            .mark_terminal_result_written(&scope, &gate_ref, child_id, 999)
+            .await
+            .unwrap();
+
+        // Claim the row and verify terminal_byte_len == 42 (first write wins).
+        // We need to settle the child first to make it claimable.
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref.clone(),
+                child_id,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+        let rows = store
+            .claim_all_terminal_states_for_child(&scope, child_id)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "one settled row expected");
+        assert_eq!(
+            rows[0].terminal_byte_len, 42,
+            "terminal_byte_len must be 42 (first write), not 999 (second write)"
+        );
+        assert!(
+            rows[0].terminal_result_written,
+            "terminal_result_written must be true"
+        );
+    }
+
+    // ── F8e: delete_awaited_child_cleans_all_tables ──────────────────────────
+
+    /// After `delete_awaited_child`, the awaited-child row, queue row, child-
+    /// index row, and capacity counter must all be cleaned up consistently.
+    #[tokio::test]
+    async fn delete_awaited_child_cleans_all_tables() {
+        let (store, _dir) = build_store().await;
+        let scope = scope_with_agent("tenant-del", "agent-del", "thread-del");
+
+        let gate_ref_a = GateRef::new("gate:del-001").unwrap();
+        let gate_ref_b = GateRef::new("gate:del-002").unwrap();
+        let child_a = TurnRunId::parse("00000000-0000-0000-0000-000000000110").unwrap();
+        let child_b = TurnRunId::parse("00000000-0000-0000-0000-000000000111").unwrap();
+        let parent_id = "00000000-0000-0000-0000-000000000112";
+
+        // Record two children under different gates.
+        store
+            .record_awaited_child(
+                &scope,
+                make_record(gate_ref_a.as_str(), &child_a.to_string(), parent_id),
+            )
+            .await
+            .unwrap();
+        store
+            .record_awaited_child(
+                &scope,
+                make_record(gate_ref_b.as_str(), &child_b.to_string(), parent_id),
+            )
+            .await
+            .unwrap();
+
+        // Settle child_a so it has a queue entry.
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref_a.clone(),
+                child_a,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+
+        // Delete gate_ref_a — should remove awaited row, queue row, index row,
+        // and decrement capacity counter.
+        store
+            .delete_awaited_child(&scope, &gate_ref_a)
+            .await
+            .unwrap();
+
+        // gate_ref_a must no longer exist for this scope.
+        let found = store
+            .gates_exist_batch(&scope, vec![gate_ref_a.clone()])
+            .await
+            .unwrap();
+        assert!(
+            !found.contains(&gate_ref_a),
+            "deleted gate must not appear in gates_exist_batch"
+        );
+
+        // gate_ref_b must still exist.
+        let found_b = store
+            .gates_exist_batch(&scope, vec![gate_ref_b.clone()])
+            .await
+            .unwrap();
+        assert!(
+            found_b.contains(&gate_ref_b),
+            "non-deleted gate must still appear in gates_exist_batch"
+        );
+
+        // Claiming child_a after deletion must return empty (queue cleared).
+        let claimed = store
+            .claim_all_terminal_states_for_child(&scope, child_a)
+            .await
+            .unwrap();
+        assert!(
+            claimed.is_empty(),
+            "claim must return empty after gate deletion"
+        );
+    }
+
+    // ── F8f: concurrent_spawns_respect_first_writer_wins ────────────────────
+
+    /// Concurrent `record_awaited_child` calls with the same identity (duplicate)
+    /// and different identities must not drift capacity — first-writer-wins on
+    /// duplicates, each unique identity counted exactly once.
+    #[tokio::test]
+    async fn concurrent_spawns_respect_first_writer_wins() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("concurrent.db");
+        let db = Arc::new(
+            libsql::Builder::new_local(&db_path)
+                .build()
+                .await
+                .expect("build libsql db"),
+        );
+        run_libsql_gate_migrations(&db)
+            .await
+            .expect("run gate migrations");
+        // Limit = 4: we'll issue 2 unique + 2 duplicates concurrently.
+        let store = LibSqlGateResolutionStore::new_with_limit(db, 16, 4);
+
+        let scope = scope_with_agent("tenant-conc", "agent-conc", "thread-conc");
+        let gate_ref = GateRef::new("gate:conc-001").unwrap();
+        let parent_id = "00000000-0000-0000-0000-000000000120";
+
+        // Two unique child IDs.
+        let child_x = "00000000-0000-0000-0000-000000000121";
+        let child_y = "00000000-0000-0000-0000-000000000122";
+
+        let store_a = store.clone();
+        let store_b = store.clone();
+        let store_c = store.clone();
+        let store_d = store.clone();
+        let scope_a = scope.clone();
+        let scope_b = scope.clone();
+        let scope_c = scope.clone();
+        let scope_d = scope.clone();
+        let gate_a = gate_ref.clone();
+        let gate_b = gate_ref.clone();
+        let gate_c = gate_ref.clone();
+        let gate_d = gate_ref.clone();
+
+        // Run 4 concurrent inserts: child_x twice, child_y twice.
+        let (r1, r2, r3, r4) = tokio::join!(
+            async move {
+                store_a
+                    .record_awaited_child(
+                        &scope_a,
+                        make_record(gate_a.as_str(), child_x, parent_id),
+                    )
+                    .await
+            },
+            async move {
+                store_b
+                    .record_awaited_child(
+                        &scope_b,
+                        make_record(gate_b.as_str(), child_x, parent_id),
+                    )
+                    .await
+            },
+            async move {
+                store_c
+                    .record_awaited_child(
+                        &scope_c,
+                        make_record(gate_c.as_str(), child_y, parent_id),
+                    )
+                    .await
+            },
+            async move {
+                store_d
+                    .record_awaited_child(
+                        &scope_d,
+                        make_record(gate_d.as_str(), child_y, parent_id),
+                    )
+                    .await
+            },
+        );
+
+        // All four calls must succeed (duplicates are silently ignored).
+        r1.expect("child_x first insert must succeed");
+        r2.expect("child_x duplicate insert must succeed (INSERT OR IGNORE)");
+        r3.expect("child_y first insert must succeed");
+        r4.expect("child_y duplicate insert must succeed (INSERT OR IGNORE)");
+
+        // Capacity must be exactly 2 (child_x + child_y), not 4.
+        // Verify by checking that the gate still appears (not over-cap) and
+        // that we can add 2 more without hitting the limit of 4.
+        let scope_e = scope.clone();
+        let scope_f = scope.clone();
+        let gate_e = gate_ref.clone();
+        let gate_f = gate_ref.clone();
+        store
+            .record_awaited_child(
+                &scope_e,
+                make_record(
+                    gate_e.as_str(),
+                    "00000000-0000-0000-0000-000000000123",
+                    parent_id,
+                ),
+            )
+            .await
+            .expect("3rd unique child must fit within limit=4");
+        store
+            .record_awaited_child(
+                &scope_f,
+                make_record(
+                    gate_f.as_str(),
+                    "00000000-0000-0000-0000-000000000124",
+                    parent_id,
+                ),
+            )
+            .await
+            .expect("4th unique child must fit within limit=4");
+    }
+
+    // ── F8g: scoped redelivery/claim security (F4 regression) ────────────────
+
+    /// A caller with a different (tenant, user, agent) scope must NOT be able to
+    /// redeliver or claim a (gate_ref, child_run_id) pair that belongs to
+    /// another scope.
+    ///
+    /// Regression test for F4: ensures that `redeliver_settled_child` and
+    /// `claim_all_terminal_states_for_child` scope the existence check AND the
+    /// queue insert AND the join to the caller's full (tenant_id, user_id,
+    /// agent_id) predicate.
+    #[tokio::test]
+    async fn scoped_redeliver_and_claim_cannot_touch_foreign_scope() {
+        let (store, _dir) = build_store().await;
+
+        let scope_owner = scope_with_agent("tenant-f4", "agent-f4-owner", "thread-f4-owner");
+        let scope_attacker =
+            scope_with_agent("tenant-f4", "agent-f4-attacker", "thread-f4-attacker");
+
+        let gate_ref = GateRef::new("gate:f4-001").unwrap();
+        let child_id = TurnRunId::parse("00000000-0000-0000-0000-000000000130").unwrap();
+        let parent_id = "00000000-0000-0000-0000-000000000131";
+        let result_ref = LoopResultRef::new("result:f4.001").unwrap();
+
+        // Owner registers a child.
+        store
+            .record_awaited_child(
+                &scope_owner,
+                make_record(gate_ref.as_str(), &child_id.to_string(), parent_id),
+            )
+            .await
+            .unwrap();
+
+        // Attacker attempts to redeliver the owner's pair into its own queue.
+        // Must return false (not found in attacker's scope).
+        let redelivered = store
+            .redeliver_settled_child(
+                &scope_attacker,
+                gate_ref.clone(),
+                child_id,
+                TurnStatus::Completed,
+                result_ref,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !redelivered,
+            "redeliver_settled_child must return false for a foreign scope's pair"
+        );
+
+        // Settle the child under the owner's scope.
+        store
+            .record_child_terminal(
+                &scope_owner,
+                gate_ref.clone(),
+                child_id,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .unwrap();
+
+        // Attacker attempts to claim the settled child — must return empty.
+        let claimed = store
+            .claim_all_terminal_states_for_child(&scope_attacker, child_id)
+            .await
+            .unwrap();
+        assert!(
+            claimed.is_empty(),
+            "claim_all_terminal_states_for_child must not return rows belonging to a foreign scope"
+        );
+
+        // Owner can still claim their own row.
+        let owner_claimed = store
+            .claim_all_terminal_states_for_child(&scope_owner, child_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            owner_claimed.len(),
+            1,
+            "owner must still be able to claim their own row after attacker's failed attempt"
+        );
+    }
 }

--- a/crates/ironclaw_reborn_event_store/tests/postgres_gate_migrations.rs
+++ b/crates/ironclaw_reborn_event_store/tests/postgres_gate_migrations.rs
@@ -1,0 +1,250 @@
+//! PostgreSQL integration tests for gate-resolution migrations and store ops.
+//!
+//! Gated behind `cfg(all(feature = "postgres", feature = "integration"))` so
+//! they compile without a live Postgres server and only connect at runtime
+//! when both feature flags are present.
+//!
+//! Run with:
+//!   cargo test -p ironclaw_reborn_event_store --features postgres,integration \
+//!     --test postgres_gate_migrations
+//!
+//! Requires environment variable:
+//!   IRONCLAW_REBORN_EVENT_STORE_POSTGRES_URL=postgres://user:pass@localhost/db
+
+#[cfg(all(feature = "postgres", feature = "integration"))]
+mod pg_gate_tests {
+    use ironclaw_host_api::{AgentId, TenantId, ThreadId};
+    use ironclaw_reborn_event_store::{
+        AwaitedChildRecord, DurableSubagentGateResolutionStore, DurableTerminalEvent,
+        PostgresGateResolutionStore, open_postgres_pool, run_postgres_gate_migrations,
+    };
+    use ironclaw_turns::{GateRef, LoopResultRef, TurnRunId, TurnScope, TurnStatus};
+    use secrecy::SecretString;
+
+    /// Build a deadpool_postgres::Pool from the standard env var.
+    ///
+    /// Returns `None` and prints a skip message when the env var is unset.
+    fn build_pool() -> Option<deadpool_postgres::Pool> {
+        let Ok(url) = std::env::var("IRONCLAW_REBORN_EVENT_STORE_POSTGRES_URL") else {
+            eprintln!(
+                "skipping postgres gate migration tests: \
+                 IRONCLAW_REBORN_EVENT_STORE_POSTGRES_URL not set"
+            );
+            return None;
+        };
+        let pool = open_postgres_pool(SecretString::new(url.into_boxed_str()))
+            .expect("open_postgres_pool must succeed with valid URL");
+        Some(pool)
+    }
+
+    fn scope_with_agent(tenant: &str, agent: &str, thread: &str) -> TurnScope {
+        TurnScope::new(
+            TenantId::new(tenant).unwrap(),
+            Some(AgentId::new(agent).unwrap()),
+            None,
+            ThreadId::new(thread).unwrap(),
+        )
+    }
+
+    fn make_record(gate: &str, child: &str, parent: &str) -> AwaitedChildRecord {
+        AwaitedChildRecord {
+            gate_ref: GateRef::new(gate).unwrap(),
+            parent_run_id: TurnRunId::parse(parent).unwrap(),
+            tree_root_run_id: TurnRunId::parse(parent).unwrap(),
+            child_run_id: TurnRunId::parse(child).unwrap(),
+            child_thread_id: "child-thread-pg-0".to_string(),
+            child_scope_json: r#"{"tenant_id":"t1","agent_id":null,"project_id":null,"thread_id":"th0","thread_owner":{"mode":"actor_fallback"}}"#.to_string(),
+            parent_run_context_json: r#"{"run_id":"00000000-0000-0000-0000-000000000000"}"#
+                .to_string(),
+            source_binding_ref: "src".to_string(),
+            reply_target_binding_ref: "reply".to_string(),
+            subagent_kind: "coding".to_string(),
+            spawn_capability_id: "spawn.subagent".to_string(),
+            result_ref: LoopResultRef::new("result:pg-test.001").unwrap(),
+            spawn_mode: "blocking".to_string(),
+        }
+    }
+
+    fn terminal_event(status: TurnStatus) -> DurableTerminalEvent {
+        DurableTerminalEvent {
+            status,
+            kind: "subagent_terminal".to_string(),
+            cursor: 1,
+            sanitized_reason: None,
+            owner_user_id: None,
+        }
+    }
+
+    /// F9: Run migrations twice — second run must be an idempotent no-op.
+    ///
+    /// Asserts that all expected gate tables exist and that
+    /// `_reborn_migrations` contains the version-1 entry after both runs.
+    #[tokio::test]
+    async fn pg_gate_migrations_are_idempotent() {
+        let Some(pool) = build_pool() else {
+            return;
+        };
+
+        // First run: creates tables and records the migration.
+        run_postgres_gate_migrations(&pool)
+            .await
+            .expect("first migration run must succeed");
+
+        // Second run: must be a no-op — no error, no duplicate rows.
+        run_postgres_gate_migrations(&pool)
+            .await
+            .expect("second migration run must be an idempotent no-op");
+
+        // Verify all expected tables exist.
+        let client = pool.get().await.expect("pool get");
+        for table in &[
+            "subagent_gate_awaited_children",
+            "subagent_gate_capacity_counter",
+            "subagent_gate_child_index",
+            "subagent_gate_deliverable_queue",
+            "subagent_gate_settlement_log",
+            "_reborn_migrations",
+        ] {
+            let row = client
+                .query_one(
+                    "SELECT to_regclass($1::text) IS NOT NULL",
+                    &[&format!("public.{table}")],
+                )
+                .await
+                .unwrap_or_else(|e| panic!("table-existence query failed for {table}: {e}"));
+            let exists: bool = row
+                .try_get::<_, bool>(0)
+                .unwrap_or_else(|e| panic!("decode failed for {table}: {e}"));
+            assert!(exists, "expected table {table} to exist after migrations");
+        }
+
+        // Verify _reborn_migrations has exactly one row for version 1 (idempotent
+        // second run must NOT insert a duplicate).
+        let count_row = client
+            .query_one(
+                "SELECT COUNT(*) FROM _reborn_migrations WHERE version = 1",
+                &[],
+            )
+            .await
+            .expect("count _reborn_migrations version 1");
+        let count: i64 = count_row
+            .try_get::<_, i64>(0)
+            .expect("decode migration count");
+        assert_eq!(
+            count, 1,
+            "_reborn_migrations must have exactly one row for version 1 after idempotent re-run"
+        );
+    }
+
+    /// F9 / F2 / F3: record_awaited_child increments the counter; a replay call
+    /// (duplicate insert) must NOT increment again.  mark_child_delivered must
+    /// decrement the counter exactly once.
+    ///
+    /// This exercises the F2 (increment only on actual insert) and F3 (decrement
+    /// only when the guarding UPDATE flips the row) fixes at runtime against live PG.
+    #[tokio::test]
+    async fn pg_counter_increments_once_and_decrements_once() {
+        let Some(pool) = build_pool() else {
+            return;
+        };
+
+        run_postgres_gate_migrations(&pool)
+            .await
+            .expect("migrations");
+
+        // Use a unique suffix to avoid cross-test interference.
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let tenant = format!("pg-f2f3-tenant-{suffix}");
+        let agent = format!("pg-f2f3-agent-{suffix}");
+        let scope = scope_with_agent(&tenant, &agent, "thread-pg-f2f3");
+
+        let gate = format!("gate:pg-f2f3-{suffix}");
+        let child_id = "00000000-0000-0000-0000-000000000001";
+        let parent_id = "00000000-0000-0000-0000-000000000002";
+
+        let store = PostgresGateResolutionStore::new(pool.clone(), 16);
+
+        // Insert the awaited-child row once.
+        store
+            .record_awaited_child(&scope, make_record(&gate, child_id, parent_id))
+            .await
+            .expect("first record_awaited_child must succeed");
+
+        // Replay the same call — ON CONFLICT DO NOTHING; counter must NOT grow.
+        store
+            .record_awaited_child(&scope, make_record(&gate, child_id, parent_id))
+            .await
+            .expect("replay record_awaited_child must succeed (idempotent)");
+
+        // Read the counter directly to verify exactly 1 undelivered.
+        let client = pool.get().await.expect("pool get");
+        let sum_row = client
+            .query_one(
+                "SELECT COALESCE(SUM(undelivered), 0) \
+                   FROM subagent_gate_capacity_counter \
+                  WHERE tenant_id = $1 AND user_id != '' AND agent_id = $2",
+                &[&tenant, &agent],
+            )
+            .await
+            .expect("sum query");
+        let total: i64 = sum_row.try_get::<_, i64>(0).expect("decode sum");
+        assert_eq!(
+            total, 1,
+            "counter must be exactly 1 after one unique insert + one replay (F2)"
+        );
+
+        // Settle the child terminal so mark_child_delivered can proceed.
+        let gate_ref = GateRef::new(&gate).unwrap();
+        let child_run_id = TurnRunId::parse(child_id).unwrap();
+        store
+            .record_child_terminal(
+                &scope,
+                gate_ref.clone(),
+                child_run_id,
+                terminal_event(TurnStatus::Completed),
+            )
+            .await
+            .expect("record_child_terminal");
+
+        // mark_child_delivered — first call; must decrement and return true.
+        let gate_done = store
+            .mark_child_delivered(&scope, &gate_ref, child_run_id)
+            .await
+            .expect("first mark_child_delivered");
+        assert!(
+            gate_done,
+            "gate must be fully delivered after only child is delivered"
+        );
+
+        // mark_child_delivered replay — guarding UPDATE sees 0 rows; counter
+        // must NOT be double-decremented (F3).
+        let gate_done_replay = store
+            .mark_child_delivered(&scope, &gate_ref, child_run_id)
+            .await
+            .expect("replay mark_child_delivered must succeed (idempotent)");
+        // The gate is already done; replay returns false (no new delivery).
+        assert!(
+            !gate_done_replay,
+            "replay mark_child_delivered must return false (already delivered)"
+        );
+
+        // Verify counter is now 0, not negative (no double-decrement).
+        let sum_after = client
+            .query_one(
+                "SELECT COALESCE(SUM(undelivered), 0) \
+                   FROM subagent_gate_capacity_counter \
+                  WHERE tenant_id = $1 AND user_id != '' AND agent_id = $2",
+                &[&tenant, &agent],
+            )
+            .await
+            .expect("sum after delivery");
+        let total_after: i64 = sum_after.try_get::<_, i64>(0).expect("decode sum after");
+        assert_eq!(
+            total_after, 0,
+            "counter must be exactly 0 after delivery — no double-decrement (F3)"
+        );
+    }
+}

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -598,6 +598,43 @@ impl LoopRunContext {
     }
 }
 
+/// Credential-free marker: types that implement this trait assert that they
+/// contain no credential material (API keys, bearer tokens, passwords, or other
+/// secrets) and are therefore safe to persist verbatim into durable storage
+/// (e.g. `subagent_gate_awaited_children.parent_run_context_json`).
+///
+/// # Invariant
+///
+/// Before adding `impl CredentialFree for T`, verify **every field** of `T`
+/// (and every nested type) against this checklist:
+///
+/// - No raw string field whose name or documentation suggests a token, key,
+///   password, or secret (`token`, `api_key`, `secret`, `password`, `bearer`,
+///   `credential`, …).
+/// - No type that wraps an OS keychain reference, an OAuth grant, or a
+///   long-lived session token.
+/// - Model-route version fields (`auth_version`, `config_version`) are safe
+///   only when validated through [`validate_model_route_component_value`],
+///   which rejects forbidden markers (see `FORBIDDEN_MODEL_ROUTE_MARKERS`).
+///
+/// # Review gate
+///
+/// Any PR that adds a field to `LoopRunContext` (or a type reachable from it)
+/// **must** re-verify this checklist and update the credential audit document
+/// at `docs/reborn/2026-06-09-wu-c2-loopruncontext-credential-audit.md`.
+pub trait CredentialFree: private_credential_free::Sealed {}
+
+mod private_credential_free {
+    pub trait Sealed {}
+}
+
+/// Safety: audited in `docs/reborn/2026-06-09-wu-c2-loopruncontext-credential-audit.md`.
+/// All fields are opaque identifiers, policy configuration, version tokens, or
+/// model-route snapshots validated to reject credential markers.  Re-audit
+/// whenever a field is added to `LoopRunContext` or any nested type.
+impl CredentialFree for LoopRunContext {}
+impl private_credential_free::Sealed for LoopRunContext {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentLoopHostErrorKind {

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -47,7 +47,7 @@ pub use host::{
     CapabilityDeniedReasonKindValue, CapabilityDescriptorView, CapabilityFailure,
     CapabilityFailureKind, CapabilityFailureKindValue, CapabilityInputRef, CapabilityInvocation,
     CapabilityOutcome, CapabilityProgress, CapabilityResultMessage, CapabilityResumeToken,
-    CapabilitySurfaceVersion, ConcurrencyHint, FinalizeAssistantMessage,
+    CapabilitySurfaceVersion, ConcurrencyHint, CredentialFree, FinalizeAssistantMessage,
     LOOP_CONTEXT_SNIPPET_MODEL_CONTENT_MAX_BYTES, LOOP_CONTEXT_TOTAL_MODEL_CONTENT_MAX_BYTES,
     LoadCheckpointPayloadRequest, LoadedCheckpointPayload, LoopCancelReasonKind,
     LoopCancellationPort, LoopCancellationSignal, LoopCapabilityPort, LoopCheckpointKind,

--- a/docs/reborn/2026-06-09-wu-c2-loopruncontext-credential-audit.md
+++ b/docs/reborn/2026-06-09-wu-c2-loopruncontext-credential-audit.md
@@ -1,0 +1,165 @@
+# WU-C2: LoopRunContext Credential Audit
+
+**Date:** 2026-06-09
+**Workstream:** WU-C2 — Durable Gate-Resolution Store
+**Outcome:** Option (a) — zero sensitive fields; compile-time lint guard added.
+
+---
+
+## Purpose
+
+`LoopRunContext` is serialized to JSON and stored verbatim in the
+`subagent_gate_awaited_children.parent_run_context_json` column by the durable
+gate-resolution backends.  This audit verifies that no credential material
+(API keys, bearer tokens, passwords, OAuth grants, or other secrets) can reach
+the database through that field.
+
+---
+
+## Struct: `LoopRunContext`
+
+**Crate:** `ironclaw_turns`
+**Module:** `crates/ironclaw_turns/src/run_profile/host.rs`
+
+| Field | Type | Classification | Rationale |
+|---|---|---|---|
+| `scope` | `TurnScope` | **Non-sensitive** | See TurnScope table below |
+| `actor` | `Option<TurnActor>` | **Non-sensitive** | `TurnActor { user_id: UserId }` — opaque scoped identifier, not a credential |
+| `accepted_message_ref` | `Option<AcceptedMessageRef>` | **Non-sensitive** | `bounded_ref!` newtype wrapping an opaque message-reference string |
+| `thread_id` | `ThreadId` | **Non-sensitive** | Opaque scoped identifier (`string_id!` newtype) |
+| `turn_id` | `TurnId` | **Non-sensitive** | Opaque UUID-based identifier |
+| `run_id` | `TurnRunId` | **Non-sensitive** | Opaque UUID-based identifier |
+| `resolved_run_profile` | `ResolvedRunProfile` | **Non-sensitive** | See ResolvedRunProfile table below |
+| `resolved_model_route` | `Option<LoopModelRouteSnapshot>` | **Non-sensitive** | See LoopModelRouteSnapshot table below |
+| `loop_driver_id` | `LoopDriverId` | **Non-sensitive** | Opaque string ID |
+| `loop_driver_version` | `RunProfileVersion` | **Non-sensitive** | Integer version |
+| `checkpoint_schema_id` | `CheckpointSchemaId` | **Non-sensitive** | Opaque string ID |
+| `checkpoint_schema_version` | `RunProfileVersion` | **Non-sensitive** | Integer version |
+
+---
+
+## Nested Type: `TurnScope`
+
+**Module:** `crates/ironclaw_turns/src/scope.rs`
+
+| Field | Type | Classification | Rationale |
+|---|---|---|---|
+| `tenant_id` | `TenantId` | **Non-sensitive** | Opaque scoped identifier (`string_id!` newtype) |
+| `agent_id` | `Option<AgentId>` | **Non-sensitive** | Opaque scoped identifier |
+| `project_id` | `Option<ProjectId>` | **Non-sensitive** | Opaque scoped identifier |
+| `thread_id` | `ThreadId` | **Non-sensitive** | Opaque scoped identifier |
+| `thread_owner` | `TurnThreadOwner` | **Non-sensitive** | Enum: `ActorFallback`, `ExplicitUser { owner_user_id: UserId }`, or `Ownerless` — user identity, not a credential |
+
+---
+
+## Nested Type: `TurnActor`
+
+**Module:** `crates/ironclaw_turns/src/scope.rs`
+
+| Field | Type | Classification | Rationale |
+|---|---|---|---|
+| `user_id` | `UserId` | **Non-sensitive** | Opaque scoped identifier, not an authentication token |
+
+---
+
+## Nested Type: `ResolvedRunProfile`
+
+**Module:** `crates/ironclaw_turns/src/run_profile/snapshot.rs`
+
+| Field | Type | Classification | Rationale |
+|---|---|---|---|
+| `run_class_id` | `RunClassId` | **Non-sensitive** | Opaque string ID |
+| `profile_id` | `RunProfileId` | **Non-sensitive** | Opaque string ID |
+| `profile_version` | `RunProfileVersion` | **Non-sensitive** | Integer version |
+| `loop_driver` | `AgentLoopDriverDescriptor` | **Non-sensitive** | Driver ID + version + schema ID/version |
+| `checkpoint_schema_id` | `CheckpointSchemaId` | **Non-sensitive** | Opaque string ID |
+| `checkpoint_schema_version` | `RunProfileVersion` | **Non-sensitive** | Integer version |
+| `model_profile_id` | `ModelProfileId` | **Non-sensitive** | Opaque string ID |
+| `capability_surface_profile_id` | `CapabilitySurfaceProfileId` | **Non-sensitive** | Opaque string ID |
+| `context_profile_id` | `ContextProfileId` | **Non-sensitive** | Opaque string ID |
+| `steering_policy` | `SteeringPolicy` | **Non-sensitive** | Boolean flags |
+| `cancellation_policy` | `CancellationPolicy` | **Non-sensitive** | Boolean flags |
+| `checkpoint_policy` | `CheckpointPolicy` | **Non-sensitive** | Boolean flags + `max_checkpoint_bytes: u64` |
+| `resource_budget_policy` | `ResourceBudgetPolicy` | **Non-sensitive** | Tier enum + integer limits |
+| `personal_context_policy` | `PersonalContextPolicy` | **Non-sensitive** | Enum: `Excluded` / `Allowed` |
+| `runtime_constraints` | `RuntimeProfileConstraints` | **Non-sensitive** | Boolean flags |
+| `runner_pool_id` | `Option<RunnerPoolId>` | **Non-sensitive** | Opaque string ID |
+| `scheduling_class` | `SchedulingClass` | **Non-sensitive** | Opaque string ID |
+| `concurrency_class` | `ConcurrencyClass` | **Non-sensitive** | Opaque string ID |
+| `resolution_fingerprint` | `RunProfileFingerprint` | **Non-sensitive** | Opaque string fingerprint |
+| `provenance` | `RedactedRunProfileProvenance` | **Non-sensitive** | See RedactedRunProfileProvenance table below |
+
+---
+
+## Nested Type: `RedactedRunProfileProvenance`
+
+**Module:** `crates/ironclaw_turns/src/run_profile/policy.rs`
+
+The `Redacted` prefix signals this type was explicitly designed to strip
+sensitive data from raw provenance before serialization.
+
+| Field | Type | Classification | Rationale |
+|---|---|---|---|
+| `sources` | `Vec<RedactedRunProfileSource>` | **Non-sensitive** | Layer enum + source ref + human-readable summary string |
+| `effective_privileges` | `Vec<PrivilegedRunProfileDimension>` | **Non-sensitive** | Enum of dimension identifiers |
+
+`RedactedRunProfileSource.summary` is a human-readable description of the
+profile source — not credential material.
+
+---
+
+## Nested Type: `LoopModelRouteSnapshot`
+
+**Module:** `crates/ironclaw_turns/src/run_profile/host.rs`
+
+| Field | Type | Classification | Rationale |
+|---|---|---|---|
+| `provider_id` | `String` | **Non-sensitive** | Validated by `validate_model_route_component_value` with `reject_sensitive_model_route_markers`; forbidden tokens include `api_key`, `access_token`, `secret`, `password`, `bearer`, and `sk-` prefixes |
+| `model_id` | `String` | **Non-sensitive** | Same validation |
+| `config_version` | `String` | **Non-sensitive** | Same validation |
+| `auth_version` | `String` | **Non-sensitive** | Version token (e.g. `"v1"`, `"2024-01"`). Same validation. Despite the name, this is a configuration version token, not an authentication credential. Its allowed character set (`a-z0-9_-.:`), maximum length (128 bytes), and `reject_sensitive_model_route_markers` validation collectively prevent any raw secret from fitting |
+
+---
+
+## Summary
+
+**All 12 top-level fields of `LoopRunContext` are non-sensitive.** No field
+contains or wraps a credential. The deepest risk was `auth_version` on
+`LoopModelRouteSnapshot`, which carries a version token but is actively
+protected by `reject_sensitive_model_route_markers` — an existing production
+validator that rejects `api_key`, `access_token`, `secret`, `password`,
+`bearer`, and `sk-` prefixed values.
+
+---
+
+## Compile-Time Guard
+
+**Outcome: Option (a)** — zero sensitive fields found. A sealed marker trait
+`CredentialFree` has been added to `ironclaw_turns`:
+
+- **Trait definition:** `crates/ironclaw_turns/src/run_profile/host.rs`
+- **Export:** `ironclaw_turns::run_profile::CredentialFree`
+- **Implementation:** `impl CredentialFree for LoopRunContext {}`
+
+The trait is sealed (`private_credential_free::Sealed`), so no downstream crate
+can implement it arbitrarily.  The doc comment on the trait specifies the
+review gate: any PR that adds a field to `LoopRunContext` or a reachable nested
+type must re-verify this checklist and update this document.
+
+Future write-site adapters that convert `AwaitedChildSetRecord` →
+`AwaitedChildRecord` should include a `where T: CredentialFree` bound on the
+`parent_run_context` serialization helper to enforce the invariant at the call
+site.
+
+---
+
+## Review Gate
+
+Any PR modifying `LoopRunContext` or a type reachable from it must:
+
+1. Add the new field/type to this table with a classification and rationale.
+2. If classification is "Sensitive" or "Unclear": implement write-site stripping
+   and add a unit test proving the field is absent in the serialized output
+   before updating `impl CredentialFree for LoopRunContext`.
+3. If all fields remain non-sensitive: confirm `impl CredentialFree for
+   LoopRunContext {}` is still correct and update this document.


### PR DESCRIPTION
## Summary

WU-C2 of the subagent durability work (`docs/reborn/2026-06-08-subagent-durability-spec.md`, spec §1): durable backends for subagent gate resolution so parent runs awaiting children survive host restarts.

- **`DurableSubagentGateResolutionStore` trait** (`crates/ironclaw_reborn_event_store/src/gate_resolution.rs`) mirroring the in-memory `BoundedSubagentGateResolutionStore` semantics: first-writer-wins `record_child_terminal` (skip-if-set, rejects non-terminal), `claim_all_terminal_states_for_child`, deliverable queue.
- **libSQL + PostgreSQL backends** implementing spec §1.3/§1.4 schemas and the §1.6 transactional protocol. 5 tables: awaited-children records, child→gate reverse index, deliverable queue, bucketed capacity counter, append-only settlement log. All rows scoped by `(tenant_id, user_id, agent_id)` with scoped indexes (decision 5); all settlement writes `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` (decision 6).
- **Bucketed capacity counter** — undelivered-children count sharded across K=16 buckets (`CAPACITY_COUNTER_BUCKETS`) so concurrent spawns do not serialize on one row (decisions 20/21).
- **Reconciler-facing methods** consumed by WU-C3: `gates_exist_batch`, `redeliver_settled_child`, `resolve_undeliverable_batch` (marks rows, never deletes) — signatures verbatim per spec §5.2.1.
- **Migration v1** (`subagent_gate_resolution`) in the crate-local `_reborn_migrations` convention (§8.5). Versions 2–4 reserved for parallel WU-C branches.

## Credential audit (merge-blocking, checklist item 1)

Outcome: **option (a) — zero sensitive fields** in `LoopRunContext` (serialized into gate rows as JSON). All 12 top-level fields are opaque scoped IDs or policy structs; `LoopModelRouteSnapshot.auth_version` is validated by `reject_sensitive_model_route_markers`; provenance is pre-redacted (`RedactedRunProfileProvenance`).

- Audit doc: `docs/reborn/2026-06-09-wu-c2-loopruncontext-credential-audit.md` (every field examined + classification)
- Compile-time guard: sealed `CredentialFree` marker trait in `ironclaw_turns::run_profile`, implemented for `LoopRunContext` with re-audit requirement on field additions
- Security test: `gate_resolution_scoped_query_excludes_rows_from_other_agents` proves scoped queries cannot return another `(tenant, user, agent)`'s rows (decision 31)

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test -p ironclaw_reborn_event_store --features libsql` — 18/18 contract tests (first-writer-wins parity with in-memory store, claim semantics, capacity counter buckets, scoped-query security test, reconciler methods)
- [x] PostgreSQL tests compile without a local Postgres (run behind `integration` feature)

## Notes for reviewers

- Conflicts with the parallel WU-C1 branch (both add `libsql/`+`postgres/` modules to the event store crate), not with main. C1 rebases after this lands and unifies the migration runners.
- Append-only settlement log rows are never deleted (LLM-data-retention invariant); `resolve_undeliverable_batch` marks rather than deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)