### PR TITLE
[codex] Fix per-caller Reborn extension auth state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4810,6 +4810,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures",
  "ironclaw_approvals",
  "ironclaw_auth",
  "ironclaw_authorization",

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -20,6 +20,7 @@ test-support = ["ironclaw_product_adapters/test-support"]
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
 ironclaw_common = { path = "../ironclaw_common", version = "0.4.1" }
 ironclaw_approvals = { path = "../ironclaw_approvals", version = "0.1.0" }
 ironclaw_authorization = { path = "../ironclaw_authorization", version = "0.1.0" }

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -54,6 +54,7 @@ use crate::{
 };
 
 mod error;
+mod extension_credentials;
 mod extension_onboarding;
 mod extension_setup_credentials;
 mod extensions;
@@ -1458,7 +1459,12 @@ impl RebornServicesApi for RebornServices {
         &self,
         caller: WebUiAuthenticatedCaller,
     ) -> Result<RebornExtensionListResponse, RebornServicesError> {
-        extensions::list_extensions(self.lifecycle_facade.as_ref(), caller).await
+        extensions::list_extensions(
+            self.lifecycle_facade.as_ref(),
+            self.extension_credentials.as_deref(),
+            caller,
+        )
+        .await
     }
 
     async fn list_skills(

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -1460,8 +1460,8 @@ impl RebornServicesApi for RebornServices {
         caller: WebUiAuthenticatedCaller,
     ) -> Result<RebornExtensionListResponse, RebornServicesError> {
         extensions::list_extensions(
-            self.lifecycle_facade.as_ref(),
-            self.extension_credentials.as_deref(),
+            Arc::clone(&self.lifecycle_facade),
+            self.extension_credentials.clone(),
             caller,
         )
         .await

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_credentials.rs
@@ -1,0 +1,224 @@
+use ironclaw_auth::{
+    AuthProductScope, AuthProviderId, AuthSurface, CredentialAccountProjection, ProviderScope,
+};
+use ironclaw_host_api::{ExtensionId, InvocationId, ResourceScope};
+use uuid::Uuid;
+
+use crate::{
+    LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
+    LifecyclePackageRef, RebornServicesError, RebornServicesErrorCode, RebornServicesErrorKind,
+    WebUiAuthenticatedCaller,
+};
+
+use super::{ExtensionCredentialSetupService, ExtensionCredentialStatusRequest};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExtensionCredentialReadiness {
+    NotRequired,
+    Configured,
+    MissingRequired,
+    Unknown,
+}
+
+enum RequirementCredentialReadiness {
+    Configured,
+    Missing,
+    Unknown,
+}
+
+pub(super) fn credential_scope(
+    caller: &WebUiAuthenticatedCaller,
+    package_ref: &LifecyclePackageRef,
+) -> AuthProductScope {
+    let seed = format!(
+        "webui-v2-extension-setup:{}:{}:{}:{}:{}",
+        caller.tenant_id.as_str(),
+        caller.user_id.as_str(),
+        caller.agent_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
+        caller
+            .project_id
+            .as_ref()
+            .map(|id| id.as_str())
+            .unwrap_or(""),
+        package_ref.id.as_str()
+    );
+    AuthProductScope::new(
+        ResourceScope {
+            tenant_id: caller.tenant_id.clone(),
+            user_id: caller.user_id.clone(),
+            agent_id: caller.agent_id.clone(),
+            project_id: caller.project_id.clone(),
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::from_uuid(Uuid::new_v5(
+                &Uuid::NAMESPACE_OID,
+                seed.as_bytes(),
+            )),
+        },
+        AuthSurface::Web,
+    )
+}
+
+pub(super) fn unique_requirements<'a>(
+    requirements: impl IntoIterator<Item = &'a LifecycleExtensionCredentialRequirement>,
+) -> Vec<LifecycleExtensionCredentialRequirement> {
+    let mut unique = Vec::new();
+    for requirement in requirements {
+        if unique
+            .iter()
+            .any(|seen: &LifecycleExtensionCredentialRequirement| seen.name == requirement.name)
+        {
+            continue;
+        }
+        unique.push(requirement.clone());
+    }
+    unique
+}
+
+pub(super) async fn readiness_for_requirements(
+    extension_credentials: Option<&dyn ExtensionCredentialSetupService>,
+    scope: AuthProductScope,
+    extension_id: &ExtensionId,
+    requirements: &[LifecycleExtensionCredentialRequirement],
+) -> Result<ExtensionCredentialReadiness, RebornServicesError> {
+    let requirements = unique_requirements(requirements);
+    if requirements.is_empty() {
+        return Ok(ExtensionCredentialReadiness::NotRequired);
+    }
+    let Some(service) = extension_credentials else {
+        return Ok(ExtensionCredentialReadiness::Unknown);
+    };
+    let mut saw_unknown = false;
+    for requirement in requirements
+        .iter()
+        .filter(|requirement| requirement.required)
+    {
+        match credential_readiness_for_requirement(
+            service,
+            scope.clone(),
+            extension_id,
+            requirement,
+        )
+        .await?
+        {
+            RequirementCredentialReadiness::Configured => {}
+            RequirementCredentialReadiness::Missing => {
+                return Ok(ExtensionCredentialReadiness::MissingRequired);
+            }
+            RequirementCredentialReadiness::Unknown => {
+                saw_unknown = true;
+            }
+        }
+    }
+    if saw_unknown {
+        return Ok(ExtensionCredentialReadiness::Unknown);
+    }
+    Ok(ExtensionCredentialReadiness::Configured)
+}
+
+async fn credential_readiness_for_requirement(
+    service: &dyn ExtensionCredentialSetupService,
+    scope: AuthProductScope,
+    extension_id: &ExtensionId,
+    requirement: &LifecycleExtensionCredentialRequirement,
+) -> Result<RequirementCredentialReadiness, RebornServicesError> {
+    let request = ExtensionCredentialStatusRequest {
+        scope,
+        provider: provider_for_requirement(requirement)?,
+        provider_scopes: provider_scopes_for_requirement(requirement)?,
+        requester_extension: extension_id.clone(),
+    };
+    match service.credential_status(request).await {
+        Ok(Some(_)) => Ok(RequirementCredentialReadiness::Configured),
+        Ok(None) => Ok(RequirementCredentialReadiness::Missing),
+        Err(error) if is_retryable_status_failure(&error) => {
+            tracing::warn!(
+                target: "ironclaw::reborn::extension_credentials",
+                extension_id = %extension_id.as_str(),
+                provider = %requirement.provider,
+                requirement = %requirement.name,
+                code = ?error.code,
+                kind = ?error.kind,
+                status_code = error.status_code,
+                retryable = error.retryable,
+                "credential status unavailable during extension readiness projection; preserving lifecycle-derived state"
+            );
+            Ok(RequirementCredentialReadiness::Unknown)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) async fn credential_status_for_requirement(
+    service: &dyn ExtensionCredentialSetupService,
+    scope: AuthProductScope,
+    extension_id: &ExtensionId,
+    requirement: &LifecycleExtensionCredentialRequirement,
+) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
+    let request = ExtensionCredentialStatusRequest {
+        scope,
+        provider: provider_for_requirement(requirement)?,
+        provider_scopes: provider_scopes_for_requirement(requirement)?,
+        requester_extension: extension_id.clone(),
+    };
+    match service.credential_status(request).await {
+        Ok(account) => Ok(account),
+        Err(error) if is_retryable_status_failure(&error) => {
+            tracing::warn!(
+                target: "ironclaw::reborn::extension_credentials",
+                extension_id = %extension_id.as_str(),
+                provider = %requirement.provider,
+                requirement = %requirement.name,
+                code = ?error.code,
+                kind = ?error.kind,
+                status_code = error.status_code,
+                retryable = error.retryable,
+                "credential status unavailable during extension projection; treating credential as unconfigured"
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) async fn credential_status_for_requirement_strict(
+    service: &dyn ExtensionCredentialSetupService,
+    scope: AuthProductScope,
+    extension_id: &ExtensionId,
+    requirement: &LifecycleExtensionCredentialRequirement,
+) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
+    let request = ExtensionCredentialStatusRequest {
+        scope,
+        provider: provider_for_requirement(requirement)?,
+        provider_scopes: provider_scopes_for_requirement(requirement)?,
+        requester_extension: extension_id.clone(),
+    };
+    service.credential_status(request).await
+}
+
+pub(super) fn provider_for_requirement(
+    requirement: &LifecycleExtensionCredentialRequirement,
+) -> Result<AuthProviderId, RebornServicesError> {
+    AuthProviderId::new(requirement.provider.as_str())
+        .map_err(|_| RebornServicesError::internal_invariant())
+}
+
+fn provider_scopes_for_requirement(
+    requirement: &LifecycleExtensionCredentialRequirement,
+) -> Result<Vec<ProviderScope>, RebornServicesError> {
+    let LifecycleExtensionCredentialSetup::OAuth { scopes } = &requirement.setup else {
+        return Ok(Vec::new());
+    };
+    scopes
+        .iter()
+        .map(|scope| {
+            ProviderScope::new(scope.clone()).map_err(|_| RebornServicesError::internal_invariant())
+        })
+        .collect()
+}
+
+fn is_retryable_status_failure(error: &RebornServicesError) -> bool {
+    error.retryable
+        && (error.code == RebornServicesErrorCode::Unavailable
+            || error.kind == RebornServicesErrorKind::ServiceUnavailable)
+}

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_credentials.rs
@@ -122,26 +122,16 @@ async fn credential_readiness_for_requirement(
     extension_id: &ExtensionId,
     requirement: &LifecycleExtensionCredentialRequirement,
 ) -> Result<RequirementCredentialReadiness, RebornServicesError> {
-    let request = ExtensionCredentialStatusRequest {
-        scope,
-        provider: provider_for_requirement(requirement)?,
-        provider_scopes: provider_scopes_for_requirement(requirement)?,
-        requester_extension: extension_id.clone(),
-    };
+    let request = credential_status_request(scope, extension_id, requirement)?;
     match service.credential_status(request).await {
         Ok(Some(_)) => Ok(RequirementCredentialReadiness::Configured),
         Ok(None) => Ok(RequirementCredentialReadiness::Missing),
         Err(error) if is_retryable_status_failure(&error) => {
-            tracing::warn!(
-                target: "ironclaw::reborn::extension_credentials",
-                extension_id = %extension_id.as_str(),
-                provider = %requirement.provider,
-                requirement = %requirement.name,
-                code = ?error.code,
-                kind = ?error.kind,
-                status_code = error.status_code,
-                retryable = error.retryable,
-                "credential status unavailable during extension readiness projection; preserving lifecycle-derived state"
+            warn_retryable_status_failure(
+                extension_id,
+                requirement,
+                &error,
+                "readiness_projection",
             );
             Ok(RequirementCredentialReadiness::Unknown)
         }
@@ -155,26 +145,11 @@ pub(super) async fn credential_status_for_requirement(
     extension_id: &ExtensionId,
     requirement: &LifecycleExtensionCredentialRequirement,
 ) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
-    let request = ExtensionCredentialStatusRequest {
-        scope,
-        provider: provider_for_requirement(requirement)?,
-        provider_scopes: provider_scopes_for_requirement(requirement)?,
-        requester_extension: extension_id.clone(),
-    };
+    let request = credential_status_request(scope, extension_id, requirement)?;
     match service.credential_status(request).await {
         Ok(account) => Ok(account),
         Err(error) if is_retryable_status_failure(&error) => {
-            tracing::warn!(
-                target: "ironclaw::reborn::extension_credentials",
-                extension_id = %extension_id.as_str(),
-                provider = %requirement.provider,
-                requirement = %requirement.name,
-                code = ?error.code,
-                kind = ?error.kind,
-                status_code = error.status_code,
-                retryable = error.retryable,
-                "credential status unavailable during extension projection; treating credential as unconfigured"
-            );
+            warn_retryable_status_failure(extension_id, requirement, &error, "setup_projection");
             Ok(None)
         }
         Err(error) => Err(error),
@@ -187,13 +162,21 @@ pub(super) async fn credential_status_for_requirement_strict(
     extension_id: &ExtensionId,
     requirement: &LifecycleExtensionCredentialRequirement,
 ) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
-    let request = ExtensionCredentialStatusRequest {
+    let request = credential_status_request(scope, extension_id, requirement)?;
+    service.credential_status(request).await
+}
+
+fn credential_status_request(
+    scope: AuthProductScope,
+    extension_id: &ExtensionId,
+    requirement: &LifecycleExtensionCredentialRequirement,
+) -> Result<ExtensionCredentialStatusRequest, RebornServicesError> {
+    Ok(ExtensionCredentialStatusRequest {
         scope,
         provider: provider_for_requirement(requirement)?,
         provider_scopes: provider_scopes_for_requirement(requirement)?,
         requester_extension: extension_id.clone(),
-    };
-    service.credential_status(request).await
+    })
 }
 
 pub(super) fn provider_for_requirement(
@@ -221,4 +204,24 @@ fn is_retryable_status_failure(error: &RebornServicesError) -> bool {
     error.retryable
         && (error.code == RebornServicesErrorCode::Unavailable
             || error.kind == RebornServicesErrorKind::ServiceUnavailable)
+}
+
+fn warn_retryable_status_failure(
+    extension_id: &ExtensionId,
+    requirement: &LifecycleExtensionCredentialRequirement,
+    error: &RebornServicesError,
+    usage: &'static str,
+) {
+    tracing::warn!(
+        target: "ironclaw::reborn::extension_credentials",
+        extension_id = %extension_id.as_str(),
+        provider = %requirement.provider,
+        requirement = %requirement.name,
+        usage,
+        code = ?error.code,
+        kind = ?error.kind,
+        status_code = error.status_code,
+        retryable = error.retryable,
+        "credential status unavailable during extension credential projection"
+    );
 }

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
@@ -40,10 +40,15 @@ pub(super) fn for_installed_with_credential_status(
     if readiness == ExtensionCredentialReadiness::Configured
         && matches!(
             extension.phase,
-            LifecyclePhase::Installed | LifecyclePhase::Configured
+            LifecyclePhase::Installed | LifecyclePhase::Configured | LifecyclePhase::Failed
         )
     {
-        return no_credential_onboarding(&extension.summary, LifecyclePhase::Configured);
+        let phase = if extension.phase == LifecyclePhase::Failed {
+            LifecyclePhase::Failed
+        } else {
+            LifecyclePhase::Configured
+        };
+        return no_credential_onboarding(&extension.summary, phase);
     }
     for_installed(extension)
 }
@@ -380,6 +385,43 @@ mod tests {
         assert_eq!(
             onboarding.instructions.as_deref(),
             Some("Gmail is installed. Activate it to make its tools available.")
+        );
+    }
+
+    #[test]
+    fn credential_ready_failed_extension_preserves_failed_state() {
+        let extension = installed_extension(
+            "gmail",
+            "Gmail",
+            LifecyclePhase::Failed,
+            vec![oauth_requirement("gmail_account", "google")],
+            LifecycleExtensionRuntimeKind::FirstParty,
+            Some(LifecycleExtensionOnboarding {
+                instructions: "Gmail activation failed.".to_string(),
+                credential_instructions: Some(
+                    "Authorize the Google account that IronClaw should use for Gmail.".to_string(),
+                ),
+                setup_url: None,
+                credential_next_step: Some(
+                    "After authorization completes, activate Gmail to publish its tools."
+                        .to_string(),
+                ),
+            }),
+        );
+
+        let onboarding = for_installed_with_credential_status(
+            &extension,
+            ExtensionCredentialReadiness::Configured,
+        );
+
+        assert_eq!(
+            onboarding.state,
+            Some(RebornExtensionOnboardingState::Failed)
+        );
+        assert_eq!(onboarding.awaiting_token, None);
+        assert_eq!(
+            onboarding.instructions.as_deref(),
+            Some("Gmail activation failed.")
         );
     }
 

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_onboarding.rs
@@ -4,6 +4,7 @@ use crate::{
     LifecycleProductResponse,
 };
 
+use super::extension_credentials::ExtensionCredentialReadiness;
 use super::types::{RebornExtensionOnboardingPayload, RebornExtensionOnboardingState};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,6 +28,24 @@ impl ExtensionOnboarding {
 
 pub(super) fn for_installed(extension: &LifecycleInstalledExtensionSummary) -> ExtensionOnboarding {
     for_summary(&extension.summary, extension.phase)
+}
+
+pub(super) fn for_installed_with_credential_status(
+    extension: &LifecycleInstalledExtensionSummary,
+    readiness: ExtensionCredentialReadiness,
+) -> ExtensionOnboarding {
+    if readiness == ExtensionCredentialReadiness::MissingRequired {
+        return credential_onboarding(&extension.summary);
+    }
+    if readiness == ExtensionCredentialReadiness::Configured
+        && matches!(
+            extension.phase,
+            LifecyclePhase::Installed | LifecyclePhase::Configured
+        )
+    {
+        return no_credential_onboarding(&extension.summary, LifecyclePhase::Configured);
+    }
+    for_installed(extension)
 }
 
 pub(super) fn from_lifecycle(lifecycle: &LifecycleProductResponse) -> ExtensionOnboarding {
@@ -323,6 +342,44 @@ mod tests {
         assert_eq!(
             onboarding.instructions.as_deref(),
             Some("GitHub is installed. Activate it to make its tools available.")
+        );
+    }
+
+    #[test]
+    fn credential_ready_installed_extension_projects_activation_message() {
+        let extension = installed_extension(
+            "gmail",
+            "Gmail",
+            LifecyclePhase::Installed,
+            vec![oauth_requirement("gmail_account", "google")],
+            LifecycleExtensionRuntimeKind::FirstParty,
+            Some(LifecycleExtensionOnboarding {
+                instructions: "Gmail needs Google OAuth authorization before mail tools can run."
+                    .to_string(),
+                credential_instructions: Some(
+                    "Authorize the Google account that IronClaw should use for Gmail.".to_string(),
+                ),
+                setup_url: None,
+                credential_next_step: Some(
+                    "After authorization completes, activate Gmail to publish its tools."
+                        .to_string(),
+                ),
+            }),
+        );
+
+        let onboarding = for_installed_with_credential_status(
+            &extension,
+            ExtensionCredentialReadiness::Configured,
+        );
+
+        assert_eq!(
+            onboarding.state,
+            Some(RebornExtensionOnboardingState::Installed)
+        );
+        assert_eq!(onboarding.awaiting_token, None);
+        assert_eq!(
+            onboarding.instructions.as_deref(),
+            Some("Gmail is installed. Activate it to make its tools available.")
         );
     }
 

--- a/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extension_setup_credentials.rs
@@ -1,9 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use ironclaw_auth::{
-    AuthProductScope, AuthProviderId, CredentialAccountProjection, CredentialAccountUpdateBinding,
-    ProviderScope,
-};
+use ironclaw_auth::{AuthProductScope, CredentialAccountUpdateBinding};
 use ironclaw_host_api::ExtensionId;
 use secrecy::SecretString;
 use serde::Deserialize;
@@ -11,13 +8,17 @@ use serde::Deserialize;
 use crate::{
     LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
     LifecycleProductPayload, LifecycleProductResponse, RebornExtensionCredentialSetup,
-    RebornExtensionSetupSecret, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind, WebUiInboundValidationCode, WebUiSetupExtensionRequest,
+    RebornExtensionSetupSecret, RebornServicesError, WebUiInboundValidationCode,
+    WebUiSetupExtensionRequest,
 };
 
 use super::{
-    ExtensionCredentialSetupService, ExtensionCredentialStatusRequest,
-    ExtensionCredentialSubmitRequest, lifecycle_setup::validation_error,
+    ExtensionCredentialSetupService, ExtensionCredentialSubmitRequest,
+    extension_credentials::{
+        credential_status_for_requirement, credential_status_for_requirement_strict,
+        provider_for_requirement, unique_requirements,
+    },
+    lifecycle_setup::validation_error,
 };
 
 pub(super) fn requirements(
@@ -26,19 +27,11 @@ pub(super) fn requirements(
     let Some(LifecycleProductPayload::ExtensionList { extensions, .. }) = &lifecycle.payload else {
         return Vec::new();
     };
-    let mut requirements = Vec::new();
-    for extension in extensions {
-        for requirement in &extension.summary.credential_requirements {
-            if requirements
-                .iter()
-                .any(|seen: &LifecycleExtensionCredentialRequirement| seen.name == requirement.name)
-            {
-                continue;
-            }
-            requirements.push(requirement.clone());
-        }
-    }
-    requirements
+    unique_requirements(
+        extensions
+            .iter()
+            .flat_map(|extension| extension.summary.credential_requirements.iter()),
+    )
 }
 
 pub(super) async fn project(
@@ -49,23 +42,10 @@ pub(super) async fn project(
 ) -> Result<Vec<RebornExtensionSetupSecret>, RebornServicesError> {
     let mut secrets = Vec::with_capacity(requirements.len());
     for requirement in requirements {
-        let provider = AuthProviderId::new(requirement.provider.as_str())
-            .map_err(|_| RebornServicesError::internal_invariant())?;
-        let provider_scopes = provider_scopes_for_requirement(requirement)?;
         let account = match extension_credentials {
             Some(service) => {
-                credential_status_for_setup(
-                    service,
-                    ExtensionCredentialStatusRequest {
-                        scope: scope.clone(),
-                        provider,
-                        provider_scopes,
-                        requester_extension: extension_id.clone(),
-                    },
-                    extension_id,
-                    requirement,
-                )
-                .await?
+                credential_status_for_requirement(service, scope.clone(), extension_id, requirement)
+                    .await?
             }
             None => None,
         };
@@ -81,38 +61,6 @@ pub(super) async fn project(
     }
     secrets.sort_by_key(|secret| !secret.provided);
     Ok(secrets)
-}
-
-async fn credential_status_for_setup(
-    service: &dyn ExtensionCredentialSetupService,
-    request: ExtensionCredentialStatusRequest,
-    extension_id: &ExtensionId,
-    requirement: &LifecycleExtensionCredentialRequirement,
-) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
-    match service.credential_status(request).await {
-        Ok(account) => Ok(account),
-        Err(error) if is_retryable_setup_status_failure(&error) => {
-            tracing::warn!(
-                target: "ironclaw::reborn::extension_setup",
-                extension_id = %extension_id.as_str(),
-                provider = %requirement.provider,
-                requirement = %requirement.name,
-                code = ?error.code,
-                kind = ?error.kind,
-                status_code = error.status_code,
-                retryable = error.retryable,
-                "credential status unavailable during extension setup projection; treating credential as unconfigured"
-            );
-            Ok(None)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-fn is_retryable_setup_status_failure(error: &RebornServicesError) -> bool {
-    error.retryable
-        && (error.code == RebornServicesErrorCode::Unavailable
-            || error.kind == RebornServicesErrorKind::ServiceUnavailable)
 }
 
 pub(super) async fn submit_manual_tokens(
@@ -177,17 +125,10 @@ async fn submit_manual_token_requirement(
     requirement: &LifecycleExtensionCredentialRequirement,
     raw_secret: Option<&String>,
 ) -> Result<(), RebornServicesError> {
-    let provider = AuthProviderId::new(requirement.provider.as_str())
-        .map_err(|_| RebornServicesError::internal_invariant())?;
-    let provider_scopes = provider_scopes_for_requirement(requirement)?;
-    let existing = service
-        .credential_status(ExtensionCredentialStatusRequest {
-            scope: scope.clone(),
-            provider: provider.clone(),
-            provider_scopes,
-            requester_extension: extension_id.clone(),
-        })
-        .await?;
+    let provider = provider_for_requirement(requirement)?;
+    let existing =
+        credential_status_for_requirement_strict(service, scope.clone(), extension_id, requirement)
+            .await?;
     let Some(raw_secret) = raw_secret else {
         if requirement.required && existing.is_none() {
             return Err(validation_error(
@@ -245,20 +186,6 @@ fn credential_prompt(requirement: &LifecycleExtensionCredentialRequirement) -> S
     format!("{} credential", requirement.provider)
 }
 
-fn provider_scopes_for_requirement(
-    requirement: &LifecycleExtensionCredentialRequirement,
-) -> Result<Vec<ProviderScope>, RebornServicesError> {
-    let LifecycleExtensionCredentialSetup::OAuth { scopes } = &requirement.setup else {
-        return Ok(Vec::new());
-    };
-    scopes
-        .iter()
-        .map(|scope| {
-            ProviderScope::new(scope.clone()).map_err(|_| RebornServicesError::internal_invariant())
-        })
-        .collect()
-}
-
 fn credential_label(
     extension_id: &ExtensionId,
     requirement: &LifecycleExtensionCredentialRequirement,
@@ -280,8 +207,12 @@ struct SetupSubmitPayload {
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use ironclaw_auth::{AuthSurface, CredentialAccountId};
+    use ironclaw_auth::{AuthSurface, CredentialAccountId, CredentialAccountProjection};
     use ironclaw_host_api::{InvocationId, ResourceScope, UserId};
+
+    use crate::{
+        ExtensionCredentialStatusRequest, RebornServicesErrorCode, RebornServicesErrorKind,
+    };
 
     use super::*;
 
@@ -375,6 +306,39 @@ mod tests {
         assert!(!error.retryable);
     }
 
+    #[tokio::test]
+    async fn submit_manual_tokens_preserves_retryable_status_unavailable() {
+        let service = FailingCredentialSetupService {
+            error: RebornServicesError {
+                code: RebornServicesErrorCode::Unavailable,
+                kind: RebornServicesErrorKind::ServiceUnavailable,
+                status_code: 503,
+                retryable: true,
+                field: None,
+                validation_code: None,
+            },
+        };
+        let extension_id = ExtensionId::new("github").expect("extension id");
+
+        let error = submit_manual_tokens(
+            Some(&service),
+            test_scope(),
+            &extension_id,
+            &[manual_requirement()],
+            WebUiSetupExtensionRequest {
+                action: Some("submit".to_string()),
+                payload: Some(serde_json::json!({ "secrets": {} })),
+            },
+        )
+        .await
+        .expect_err("submit should surface credential status outages");
+
+        assert_eq!(error.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(error.kind, RebornServicesErrorKind::ServiceUnavailable);
+        assert!(error.retryable);
+        assert!(error.field.is_none());
+    }
+
     struct FailingCredentialSetupService {
         error: RebornServicesError,
     }
@@ -404,6 +368,15 @@ mod tests {
             setup: LifecycleExtensionCredentialSetup::OAuth {
                 scopes: vec!["https://www.googleapis.com/auth/documents".to_string()],
             },
+        }
+    }
+
+    fn manual_requirement() -> LifecycleExtensionCredentialRequirement {
+        LifecycleExtensionCredentialRequirement {
+            name: "github_runtime_token".to_string(),
+            provider: "github".to_string(),
+            required: true,
+            setup: LifecycleExtensionCredentialSetup::ManualToken,
         }
     }
 

--- a/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
@@ -1,4 +1,7 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
+
+use futures::{StreamExt, TryStreamExt, stream};
+use ironclaw_host_api::ExtensionId;
 
 use crate::{
     LifecycleExtensionSummary, LifecycleInstalledExtensionSummary, LifecyclePackageRef,
@@ -8,7 +11,6 @@ use crate::{
     RebornExtensionRegistryEntry, RebornExtensionRegistryResponse, RebornServicesError,
     WebUiAuthenticatedCaller,
 };
-use ironclaw_host_api::ExtensionId;
 
 use super::{
     ExtensionCredentialSetupService,
@@ -19,16 +21,23 @@ use super::{
     lifecycle_setup::map_lifecycle_error,
 };
 
+const EXTENSION_READINESS_CONCURRENCY: usize = 8;
+
 pub(super) async fn list_extensions(
-    facade: &dyn LifecycleProductFacade,
-    extension_credentials: Option<&dyn ExtensionCredentialSetupService>,
+    facade: Arc<dyn LifecycleProductFacade>,
+    extension_credentials: Option<Arc<dyn ExtensionCredentialSetupService>>,
     caller: WebUiAuthenticatedCaller,
 ) -> Result<RebornExtensionListResponse, RebornServicesError> {
     let context = lifecycle_surface_context(caller.clone());
-    let lifecycle =
-        execute_lifecycle(facade, context, LifecycleProductAction::ExtensionList).await?;
+    let lifecycle = execute_lifecycle(
+        facade.as_ref(),
+        context,
+        LifecycleProductAction::ExtensionList,
+    )
+    .await?;
+    let installed = lifecycle_installed_extensions(&lifecycle);
     Ok(RebornExtensionListResponse {
-        extensions: lifecycle_extension_infos(&lifecycle, extension_credentials, &caller).await?,
+        extensions: lifecycle_extension_infos(installed, extension_credentials, caller).await?,
     })
 }
 
@@ -181,17 +190,31 @@ fn lifecycle_installed_extensions(
 }
 
 async fn lifecycle_extension_infos(
-    lifecycle: &LifecycleProductResponse,
-    extension_credentials: Option<&dyn ExtensionCredentialSetupService>,
-    caller: &WebUiAuthenticatedCaller,
+    installed: Vec<LifecycleInstalledExtensionSummary>,
+    extension_credentials: Option<Arc<dyn ExtensionCredentialSetupService>>,
+    caller: WebUiAuthenticatedCaller,
 ) -> Result<Vec<RebornExtensionInfo>, RebornServicesError> {
-    let mut infos = Vec::new();
-    for installed in lifecycle_installed_extensions(lifecycle) {
-        let readiness =
-            credential_readiness_for_extension(extension_credentials, caller, &installed).await?;
-        infos.push(extension_info(installed, readiness));
-    }
-    Ok(infos)
+    let resolved = stream::iter(installed.into_iter())
+        .map(|installed| {
+            let caller = caller.clone();
+            let extension_credentials = extension_credentials.clone();
+            async move {
+                let readiness = credential_readiness_for_extension(
+                    extension_credentials.as_deref(),
+                    &caller,
+                    &installed,
+                )
+                .await?;
+                Ok::<_, RebornServicesError>((installed, readiness))
+            }
+        })
+        .buffered(EXTENSION_READINESS_CONCURRENCY)
+        .try_collect::<Vec<_>>()
+        .await?;
+    Ok(resolved
+        .into_iter()
+        .map(|(installed, readiness)| extension_info(installed, readiness))
+        .collect())
 }
 
 fn registry_entry(
@@ -316,7 +339,10 @@ fn action_response(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     use async_trait::async_trait;
     use ironclaw_auth::{CredentialAccountId, CredentialAccountProjection};
@@ -384,10 +410,11 @@ mod tests {
                 phase: LifecyclePhase::Active,
             },
         };
-        let credentials = RecordingCredentials::default();
+        let credentials = Arc::new(RecordingCredentials::default());
         let caller = caller();
 
-        let response = list_extensions(&facade, Some(&credentials), caller.clone())
+        let credentials_service: Arc<dyn ExtensionCredentialSetupService> = credentials.clone();
+        let response = list_extensions(Arc::new(facade), Some(credentials_service), caller.clone())
             .await
             .expect("list extensions");
         let extension = response.extensions.first().expect("one extension");
@@ -424,7 +451,7 @@ mod tests {
         };
         let credentials = UnavailableCredentials;
 
-        let response = list_extensions(&facade, Some(&credentials), caller())
+        let response = list_extensions(Arc::new(facade), Some(Arc::new(credentials)), caller())
             .await
             .expect("list extensions");
         let extension = response.extensions.first().expect("one extension");
@@ -436,6 +463,37 @@ mod tests {
         );
         assert!(!extension.needs_setup);
         assert!(extension.onboarding_state.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_checks_extension_readiness_with_bounded_concurrency() {
+        let facade = MultiListingFacade {
+            extensions: (0..EXTENSION_READINESS_CONCURRENCY + 3)
+                .map(|index| LifecycleInstalledExtensionSummary {
+                    summary: summary_with_onboarding_for(&format!("fixture-{index}")),
+                    phase: LifecyclePhase::Active,
+                })
+                .collect(),
+        };
+        let credentials = Arc::new(ConcurrentCredentials::default());
+        let credentials_service: Arc<dyn ExtensionCredentialSetupService> = credentials.clone();
+
+        let response = list_extensions(Arc::new(facade), Some(credentials_service), caller())
+            .await
+            .expect("list extensions");
+
+        assert_eq!(
+            response.extensions.len(),
+            EXTENSION_READINESS_CONCURRENCY + 3
+        );
+        assert!(
+            credentials.max_active.load(Ordering::SeqCst) > 1,
+            "readiness checks should not run as a serialized page-load path"
+        );
+        assert!(
+            credentials.max_active.load(Ordering::SeqCst) <= EXTENSION_READINESS_CONCURRENCY,
+            "readiness checks must stay bounded"
+        );
     }
 
     #[derive(Default)]
@@ -487,6 +545,33 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct ConcurrentCredentials {
+        active: AtomicUsize,
+        max_active: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ExtensionCredentialSetupService for ConcurrentCredentials {
+        async fn credential_status(
+            &self,
+            _request: ExtensionCredentialStatusRequest,
+        ) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active.fetch_max(active, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok(None)
+        }
+
+        async fn submit_manual_token(
+            &self,
+            _request: ExtensionCredentialSubmitRequest,
+        ) -> Result<CredentialAccountId, RebornServicesError> {
+            Ok(CredentialAccountId::new())
+        }
+    }
+
     struct ListingFacade {
         extension: LifecycleInstalledExtensionSummary,
     }
@@ -507,6 +592,39 @@ mod tests {
                 payload: Some(LifecycleProductPayload::ExtensionList {
                     extensions: vec![self.extension.clone()],
                     count: 1,
+                }),
+            })
+        }
+
+        async fn project_package(
+            &self,
+            _context: LifecycleProductContext,
+            _package_ref: LifecyclePackageRef,
+        ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+            panic!("list_extensions should execute the list action, not project one package")
+        }
+    }
+
+    struct MultiListingFacade {
+        extensions: Vec<LifecycleInstalledExtensionSummary>,
+    }
+
+    #[async_trait]
+    impl LifecycleProductFacade for MultiListingFacade {
+        async fn execute(
+            &self,
+            _context: LifecycleProductContext,
+            action: LifecycleProductAction,
+        ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+            assert!(matches!(action, LifecycleProductAction::ExtensionList));
+            Ok(LifecycleProductResponse {
+                package_ref: None,
+                phase: LifecyclePhase::Active,
+                blockers: Vec::new(),
+                message: None,
+                payload: Some(LifecycleProductPayload::ExtensionList {
+                    extensions: self.extensions.clone(),
+                    count: self.extensions.len(),
                 }),
             })
         }
@@ -587,8 +705,13 @@ mod tests {
     }
 
     fn summary_with_onboarding() -> LifecycleExtensionSummary {
+        summary_with_onboarding_for("fixture")
+    }
+
+    fn summary_with_onboarding_for(package_id: &str) -> LifecycleExtensionSummary {
         LifecycleExtensionSummary {
-            package_ref: package_ref(),
+            package_ref: LifecyclePackageRef::new(LifecyclePackageKind::Extension, package_id)
+                .expect("valid package ref"),
             name: "Fixture".to_string(),
             version: "1.0.0".to_string(),
             description: "test extension".to_string(),

--- a/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
@@ -8,22 +8,27 @@ use crate::{
     RebornExtensionRegistryEntry, RebornExtensionRegistryResponse, RebornServicesError,
     WebUiAuthenticatedCaller,
 };
+use ironclaw_host_api::ExtensionId;
 
-use super::extension_onboarding;
-use super::lifecycle_setup::map_lifecycle_error;
+use super::{
+    ExtensionCredentialSetupService,
+    extension_credentials::{
+        ExtensionCredentialReadiness, credential_scope, readiness_for_requirements,
+    },
+    extension_onboarding,
+    lifecycle_setup::map_lifecycle_error,
+};
 
 pub(super) async fn list_extensions(
     facade: &dyn LifecycleProductFacade,
+    extension_credentials: Option<&dyn ExtensionCredentialSetupService>,
     caller: WebUiAuthenticatedCaller,
 ) -> Result<RebornExtensionListResponse, RebornServicesError> {
-    let lifecycle = execute_lifecycle(
-        facade,
-        lifecycle_surface_context(caller),
-        LifecycleProductAction::ExtensionList,
-    )
-    .await?;
+    let context = lifecycle_surface_context(caller.clone());
+    let lifecycle =
+        execute_lifecycle(facade, context, LifecycleProductAction::ExtensionList).await?;
     Ok(RebornExtensionListResponse {
-        extensions: lifecycle_extension_infos(&lifecycle),
+        extensions: lifecycle_extension_infos(&lifecycle, extension_credentials, &caller).await?,
     })
 }
 
@@ -175,11 +180,18 @@ fn lifecycle_installed_extensions(
     }
 }
 
-fn lifecycle_extension_infos(lifecycle: &LifecycleProductResponse) -> Vec<RebornExtensionInfo> {
-    lifecycle_installed_extensions(lifecycle)
-        .into_iter()
-        .map(extension_info)
-        .collect()
+async fn lifecycle_extension_infos(
+    lifecycle: &LifecycleProductResponse,
+    extension_credentials: Option<&dyn ExtensionCredentialSetupService>,
+    caller: &WebUiAuthenticatedCaller,
+) -> Result<Vec<RebornExtensionInfo>, RebornServicesError> {
+    let mut infos = Vec::new();
+    for installed in lifecycle_installed_extensions(lifecycle) {
+        let readiness =
+            credential_readiness_for_extension(extension_credentials, caller, &installed).await?;
+        infos.push(extension_info(installed, readiness));
+    }
+    Ok(infos)
 }
 
 fn registry_entry(
@@ -199,26 +211,56 @@ fn registry_entry(
     }
 }
 
-fn extension_info(installed: LifecycleInstalledExtensionSummary) -> RebornExtensionInfo {
+async fn credential_readiness_for_extension(
+    extension_credentials: Option<&dyn ExtensionCredentialSetupService>,
+    caller: &WebUiAuthenticatedCaller,
+    installed: &LifecycleInstalledExtensionSummary,
+) -> Result<ExtensionCredentialReadiness, RebornServicesError> {
+    let extension_id = ExtensionId::new(installed.summary.package_ref.id.as_str())
+        .map_err(|_| RebornServicesError::internal_invariant())?;
+    let scope = credential_scope(caller, &installed.summary.package_ref);
+    readiness_for_requirements(
+        extension_credentials,
+        scope,
+        &extension_id,
+        &installed.summary.credential_requirements,
+    )
+    .await
+}
+
+fn extension_info(
+    installed: LifecycleInstalledExtensionSummary,
+    readiness: ExtensionCredentialReadiness,
+) -> RebornExtensionInfo {
     let phase = installed.phase;
-    let onboarding = extension_onboarding::for_installed(&installed);
+    let has_auth = !installed.summary.credential_requirements.is_empty();
+    let lifecycle_authenticated = matches!(
+        phase,
+        LifecyclePhase::Active | LifecyclePhase::Activating | LifecyclePhase::Configured
+    );
+    let authenticated = match readiness {
+        ExtensionCredentialReadiness::NotRequired => lifecycle_authenticated,
+        ExtensionCredentialReadiness::Configured => true,
+        ExtensionCredentialReadiness::MissingRequired => false,
+        ExtensionCredentialReadiness::Unknown => lifecycle_authenticated,
+    };
+    let onboarding =
+        extension_onboarding::for_installed_with_credential_status(&installed, readiness);
     let summary = installed.summary;
     RebornExtensionInfo {
         package_ref: summary.package_ref,
         display_name: summary.name,
         kind: summary.runtime_kind.wire_kind().to_string(),
         description: summary.description,
-        authenticated: matches!(
-            phase,
-            LifecyclePhase::Active | LifecyclePhase::Activating | LifecyclePhase::Configured
-        ),
+        authenticated,
         active: phase == LifecyclePhase::Active,
         tools: summary.visible_capability_ids,
-        needs_setup: matches!(
-            phase,
-            LifecyclePhase::Installed | LifecyclePhase::Configured | LifecyclePhase::Failed
-        ),
-        has_auth: !summary.credential_requirements.is_empty(),
+        needs_setup: readiness == ExtensionCredentialReadiness::MissingRequired
+            || matches!(
+                phase,
+                LifecyclePhase::Installed | LifecyclePhase::Configured | LifecyclePhase::Failed
+            ),
+        has_auth,
         activation_status: Some(phase_status(phase).to_string()),
         activation_error: None,
         version: Some(summary.version),
@@ -274,15 +316,19 @@ fn action_response(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use async_trait::async_trait;
+    use ironclaw_auth::{CredentialAccountId, CredentialAccountProjection};
     use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
 
     use super::*;
     use crate::{
+        ExtensionCredentialStatusRequest, ExtensionCredentialSubmitRequest,
         LifecycleExtensionCredentialRequirement, LifecycleExtensionCredentialSetup,
         LifecycleExtensionOnboarding, LifecycleExtensionRuntimeKind, LifecycleExtensionSource,
         LifecycleInstalledExtensionSummary, LifecyclePackageKind, ProductWorkflowError,
-        RebornExtensionOnboardingState,
+        RebornExtensionOnboardingState, RebornServicesErrorCode, RebornServicesErrorKind,
     };
 
     #[tokio::test]
@@ -328,6 +374,150 @@ mod tests {
         assert_eq!(response.message, "Fixture installed.");
         assert!(response.onboarding_state.is_none());
         assert!(response.onboarding.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_marks_active_credentialed_extension_unauthenticated_without_caller_account() {
+        let facade = ListingFacade {
+            extension: LifecycleInstalledExtensionSummary {
+                summary: summary_with_onboarding(),
+                phase: LifecyclePhase::Active,
+            },
+        };
+        let credentials = RecordingCredentials::default();
+        let caller = caller();
+
+        let response = list_extensions(&facade, Some(&credentials), caller.clone())
+            .await
+            .expect("list extensions");
+        let extension = response.extensions.first().expect("one extension");
+
+        assert!(extension.active, "lifecycle activation remains visible");
+        assert!(
+            !extension.authenticated,
+            "credential readiness must be evaluated for the current caller"
+        );
+        assert!(extension.needs_setup);
+        assert_eq!(
+            extension.onboarding_state,
+            Some(RebornExtensionOnboardingState::SetupRequired)
+        );
+
+        let requests = credentials.status_requests.lock().expect("lock");
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        assert_eq!(request.scope.resource.tenant_id, caller.tenant_id);
+        assert_eq!(request.scope.resource.user_id, caller.user_id);
+        assert_eq!(request.scope.resource.agent_id, caller.agent_id);
+        assert_eq!(request.scope.resource.project_id, caller.project_id);
+        assert_eq!(request.provider.as_str(), "fixture");
+        assert_eq!(request.requester_extension.as_str(), "fixture");
+    }
+
+    #[tokio::test]
+    async fn list_preserves_lifecycle_state_when_credential_status_is_retryably_unavailable() {
+        let facade = ListingFacade {
+            extension: LifecycleInstalledExtensionSummary {
+                summary: summary_with_onboarding(),
+                phase: LifecyclePhase::Active,
+            },
+        };
+        let credentials = UnavailableCredentials;
+
+        let response = list_extensions(&facade, Some(&credentials), caller())
+            .await
+            .expect("list extensions");
+        let extension = response.extensions.first().expect("one extension");
+
+        assert!(extension.active);
+        assert!(
+            extension.authenticated,
+            "retryable status outages should not be projected as missing credentials"
+        );
+        assert!(!extension.needs_setup);
+        assert!(extension.onboarding_state.is_none());
+    }
+
+    #[derive(Default)]
+    struct RecordingCredentials {
+        status_requests: Mutex<Vec<ExtensionCredentialStatusRequest>>,
+    }
+
+    #[async_trait]
+    impl ExtensionCredentialSetupService for RecordingCredentials {
+        async fn credential_status(
+            &self,
+            request: ExtensionCredentialStatusRequest,
+        ) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
+            self.status_requests.lock().expect("lock").push(request);
+            Ok(None)
+        }
+
+        async fn submit_manual_token(
+            &self,
+            _request: ExtensionCredentialSubmitRequest,
+        ) -> Result<CredentialAccountId, RebornServicesError> {
+            Ok(CredentialAccountId::new())
+        }
+    }
+
+    struct UnavailableCredentials;
+
+    #[async_trait]
+    impl ExtensionCredentialSetupService for UnavailableCredentials {
+        async fn credential_status(
+            &self,
+            _request: ExtensionCredentialStatusRequest,
+        ) -> Result<Option<CredentialAccountProjection>, RebornServicesError> {
+            Err(RebornServicesError {
+                code: RebornServicesErrorCode::Unavailable,
+                kind: RebornServicesErrorKind::ServiceUnavailable,
+                status_code: 503,
+                retryable: true,
+                field: None,
+                validation_code: None,
+            })
+        }
+
+        async fn submit_manual_token(
+            &self,
+            _request: ExtensionCredentialSubmitRequest,
+        ) -> Result<CredentialAccountId, RebornServicesError> {
+            Ok(CredentialAccountId::new())
+        }
+    }
+
+    struct ListingFacade {
+        extension: LifecycleInstalledExtensionSummary,
+    }
+
+    #[async_trait]
+    impl LifecycleProductFacade for ListingFacade {
+        async fn execute(
+            &self,
+            _context: LifecycleProductContext,
+            action: LifecycleProductAction,
+        ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+            assert!(matches!(action, LifecycleProductAction::ExtensionList));
+            Ok(LifecycleProductResponse {
+                package_ref: None,
+                phase: self.extension.phase,
+                blockers: Vec::new(),
+                message: None,
+                payload: Some(LifecycleProductPayload::ExtensionList {
+                    extensions: vec![self.extension.clone()],
+                    count: 1,
+                }),
+            })
+        }
+
+        async fn project_package(
+            &self,
+            _context: LifecycleProductContext,
+            _package_ref: LifecyclePackageRef,
+        ) -> Result<LifecycleProductResponse, ProductWorkflowError> {
+            panic!("list_extensions should execute the list action, not project one package")
+        }
     }
 
     struct ActionProjectionFacade {

--- a/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/extensions.rs
@@ -194,7 +194,7 @@ async fn lifecycle_extension_infos(
     extension_credentials: Option<Arc<dyn ExtensionCredentialSetupService>>,
     caller: WebUiAuthenticatedCaller,
 ) -> Result<Vec<RebornExtensionInfo>, RebornServicesError> {
-    let resolved = stream::iter(installed.into_iter())
+    let resolved = stream::iter(installed)
         .map(|installed| {
             let caller = caller.clone();
             let extension_credentials = extension_credentials.clone();

--- a/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services/lifecycle_setup.rs
@@ -1,6 +1,5 @@
-use ironclaw_auth::{AuthProductScope, AuthSurface};
-use ironclaw_host_api::{ExtensionId, InvocationId, ResourceScope};
-use uuid::Uuid;
+use ironclaw_auth::AuthProductScope;
+use ironclaw_host_api::ExtensionId;
 
 use crate::{
     LifecycleExtensionCredentialRequirement, LifecyclePackageRef, LifecycleProductContext,
@@ -10,7 +9,10 @@ use crate::{
     WebUiInboundValidationError, WebUiSetupExtensionRequest,
 };
 
-use super::{ExtensionCredentialSetupService, extension_onboarding, extension_setup_credentials};
+use super::{
+    ExtensionCredentialSetupService, extension_credentials::credential_scope, extension_onboarding,
+    extension_setup_credentials,
+};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SetupAction {
@@ -26,7 +28,7 @@ pub(super) async fn setup_extension(
     request: WebUiSetupExtensionRequest,
 ) -> Result<RebornSetupExtensionResponse, RebornServicesError> {
     let action = setup_action(&request)?;
-    let scope = setup_scope(&caller, &package_ref);
+    let scope = credential_scope(&caller, &package_ref);
     let extension_id = ExtensionId::new(package_ref.id.as_str())
         .map_err(|_| RebornServicesError::internal_invariant())?;
     let context = LifecycleProductContext::Surface(LifecycleProductSurfaceContext {
@@ -106,39 +108,6 @@ async fn setup_extension_response(
         secrets,
         fields: Vec::new(),
     })
-}
-
-fn setup_scope(
-    caller: &WebUiAuthenticatedCaller,
-    package_ref: &LifecyclePackageRef,
-) -> AuthProductScope {
-    let seed = format!(
-        "webui-v2-extension-setup:{}:{}:{}:{}:{}",
-        caller.tenant_id.as_str(),
-        caller.user_id.as_str(),
-        caller.agent_id.as_ref().map(|id| id.as_str()).unwrap_or(""),
-        caller
-            .project_id
-            .as_ref()
-            .map(|id| id.as_str())
-            .unwrap_or(""),
-        package_ref.id.as_str()
-    );
-    AuthProductScope::new(
-        ResourceScope {
-            tenant_id: caller.tenant_id.clone(),
-            user_id: caller.user_id.clone(),
-            agent_id: caller.agent_id.clone(),
-            project_id: caller.project_id.clone(),
-            mission_id: None,
-            thread_id: None,
-            invocation_id: InvocationId::from_uuid(Uuid::new_v5(
-                &Uuid::NAMESPACE_OID,
-                seed.as_bytes(),
-            )),
-        },
-        AuthSurface::Web,
-    )
 }
 
 fn setup_action(request: &WebUiSetupExtensionRequest) -> Result<SetupAction, RebornServicesError> {

--- a/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
+++ b/crates/ironclaw_reborn_composition/src/product_auth_runtime_credentials.rs
@@ -315,6 +315,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolver_does_not_use_reusable_account_from_different_user() {
+        let accounts = Arc::new(InMemoryAuthProductServices::new());
+        let alice_scope =
+            ResourceScope::local_default(UserId::new("alice").unwrap(), InvocationId::new())
+                .unwrap();
+        let admin_scope =
+            ResourceScope::local_default(UserId::new("admin").unwrap(), InvocationId::new())
+                .unwrap();
+        accounts
+            .create_account(NewCredentialAccount {
+                scope: AuthProductScope::new(alice_scope, AuthSurface::Api),
+                provider: AuthProviderId::new("google").unwrap(),
+                label: CredentialAccountLabel::new("alice google").unwrap(),
+                status: CredentialAccountStatus::Configured,
+                ownership: CredentialOwnership::UserReusable,
+                owner_extension: None,
+                granted_extensions: Vec::new(),
+                access_secret: Some(SecretHandle::new("alice-google-access").unwrap()),
+                refresh_secret: None,
+                scopes: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let resolver = ProductAuthRuntimeCredentialResolver::new(Arc::new(
+            ProductAuthRuntimeCredentialAccountSelector::new(accounts),
+        ));
+
+        let error = resolver
+            .resolve_access_secret(RuntimeCredentialAccountRequest {
+                scope: &admin_scope,
+                provider: &RuntimeCredentialAccountProviderId::new("google").unwrap(),
+                provider_scopes: &[],
+                requester_extension: &ExtensionId::new("gmail").unwrap(),
+            })
+            .await
+            .expect_err("admin must not resolve alice's reusable account");
+
+        assert_eq!(error, CredentialStageError::AuthRequired);
+    }
+
+    #[tokio::test]
     async fn resolver_matches_callback_setup_account_from_runtime_invocation() {
         let accounts = Arc::new(InMemoryAuthProductServices::new());
         let mut setup_scope =


### PR DESCRIPTION
## Summary

Fixes Reborn WebUI extension listing so credential/auth state is projected for the current authenticated caller, instead of implying that globally installed or active extensions are already authenticated for every user.

## Root Cause

Extension lifecycle activation is shared/global in the current Reborn projection, while product-auth credentials are user-scoped. The list projection was effectively trusting lifecycle phase for `authenticated`/setup UI state, so after Alice authenticated an extension, Bob could see the extension as already authenticated even though runtime credential resolution would still correctly ask Bob to authenticate.

## Changes

- Add a neutral Reborn extension credential-readiness helper used by both extension list and setup flows.
- Make `GET /extensions` check credential readiness with the current `WebUiAuthenticatedCaller` scope.
- Preserve lifecycle active/installed visibility, but mark credentialed extensions unauthenticated/needs setup when the current caller lacks credentials.
- Preserve lifecycle-derived state when credential-status lookup is retryably unavailable, instead of falsely prompting reauth.
- Show activation onboarding once credentials are configured but the extension still needs activation.
- Keep manual-token submit strict so credential-status outages surface as retryable backend errors, not validation errors.
- Add a runtime regression test proving one user cannot resolve another user’s reusable credential.

## Validation

- `cargo fmt --check`
- `cargo test -p ironclaw_product_workflow reborn_services --lib --no-fail-fast`
- `cargo test -p ironclaw_reborn_composition product_auth_runtime_credentials --lib --no-fail-fast`
- `codex review -c 'service_tier="fast"' --uncommitted` -> no discrete correctness issues found

## Notes

This does not make extension installation/activation per-user. It makes the displayed credential/auth readiness and runtime credential guardrails per-user, matching the behavior users already hit when they actually invoke a credentialed tool.