### PR TITLE
[codex] fix SSO operator WebUI auth

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/webui_auth.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/webui_auth.rs
@@ -148,7 +148,7 @@ mod tests {
     use super::*;
 
     use async_trait::async_trait;
-    use ironclaw_reborn_composition::host_api::UserId;
+    use ironclaw_reborn_composition::WebuiAuthentication;
     use ironclaw_reborn_webui_ingress::{
         OAuthError, OAuthProvider, OAuthProviderName, OAuthUserProfile,
     };
@@ -159,7 +159,7 @@ mod tests {
 
     #[async_trait]
     impl WebuiAuthenticator for RejectingAuth {
-        async fn authenticate(&self, _token: &str) -> Option<UserId> {
+        async fn authenticate(&self, _token: &str) -> Option<WebuiAuthentication> {
             None
         }
     }

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -107,10 +107,10 @@ Inbound order (outer → inner → handler):
    honored ONLY on `GET /api/webchat/v2/threads/{id}/events` because
    the browser's `EventSource` cannot set headers. Mutations and
    timeline reads stay bearer-only. On success the middleware inserts
-  a `WebUiAuthenticatedCaller` extension built from
-  `config.tenant_id` plus the authenticator's `UserId`, and a
-  request-scoped `WebUiV2Capabilities` extension from the same
-  authentication result.
+   a `WebUiAuthenticatedCaller` extension built from
+   `config.tenant_id` plus the authentication result's `UserId`, and a
+   request-scoped `WebUiV2Capabilities` extension from the same
+   authentication result.
    When `openai-compat-beta` is enabled, the same verified bearer result also
    inserts an `OpenAiCompatAuthenticatedCaller` extension for protected
    OpenAI-compatible route mounts; route crates must not mint this evidence.

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -62,7 +62,7 @@ middleware with v1's `src/channels/web/`.
 | `RebornWebuiBundle` (in [`src/webui.rs`](src/webui.rs)) | `{ api: Arc<dyn RebornServicesApi>, product_auth: Option<Arc<RebornProductAuthServices>>, readiness }` — the v2 facade, optional product-auth route service, plus readiness snapshot |
 | `build_webui_services(runtime, event_stream)` | Compose a `RebornWebuiBundle` from an already-built `RebornRuntime`; reuses the runtime's thread service / turn coordinator, product-auth services, and runtime-owned `EventStreamManager` projection stream unless a caller supplies a custom stream |
 | `RebornProjectionServices` (in `src/projection.rs`) | Runtime-owned projection/event-stream composition; owns the single local-dev `EventStreamManager` and creates product-specific `ProjectionStream` adapters over it |
-| `WebuiAuthenticator` trait | Host-supplied bearer-token verifier; returns `Option<UserId>` |
+| `WebuiAuthenticator` trait | Host-supplied bearer-token verifier; returns `Option<WebuiAuthentication>` so identity and request-scoped WebUI capabilities travel together |
 | `WebuiServeConfig { tenant_id, authenticator, max_body_bytes, allowed_origins, csp_header }` | Required config for `webui_v2_app`; no defaults that silently disable security |
 | `webui_v2_app(bundle, config) -> Router` | Build the fully-composed axum `Router`. This is the seam between this product/API crate and host-owned HTTP ingress: tests drive it via `tower::ServiceExt::oneshot`; the `ironclaw-reborn serve` subcommand (follow-up PR) hands it to `axum::serve` from a host-owned listener |
 | `ProtectedRouteMount` | Host-supplied protected API route fragment merged inside the WebUI bearer-auth layer with descriptor-driven body/rate limits. Reborn OpenAI-compatible routes use this seam; do not use it for v1 gateway routers. |
@@ -107,8 +107,10 @@ Inbound order (outer → inner → handler):
    honored ONLY on `GET /api/webchat/v2/threads/{id}/events` because
    the browser's `EventSource` cannot set headers. Mutations and
    timeline reads stay bearer-only. On success the middleware inserts
-   a `WebUiAuthenticatedCaller` extension built from
-   `config.tenant_id` plus the authenticator's `UserId`.
+  a `WebUiAuthenticatedCaller` extension built from
+  `config.tenant_id` plus the authenticator's `UserId`, and a
+  request-scoped `WebUiV2Capabilities` extension from the same
+  authentication result.
    When `openai-compat-beta` is enabled, the same verified bearer result also
    inserts an `OpenAiCompatAuthenticatedCaller` extension for protected
    OpenAI-compatible route mounts; route crates must not mint this evidence.
@@ -273,7 +275,7 @@ rows are inventoried here, not implemented in the current PR.
 |---|---|---|---|
 | Send message | `POST /api/chat/send` | `POST /api/webchat/v2/threads/{thread_id}/messages` | Mapped |
 | Create thread | `POST /api/chat/thread/new` | `POST /api/webchat/v2/threads` | Mapped |
-| Session/profile capabilities | `GET /api/profile` | `GET /api/webchat/v2/session` | Mapped to authenticated tenant/user plus server-issued WebUI capabilities; `operator_webui_config` follows `allows_operator_webui_config` |
+| Session/profile capabilities | `GET /api/profile` | `GET /api/webchat/v2/session` | Mapped to authenticated tenant/user plus request-scoped WebUI capabilities; `operator_webui_config` follows the matched bearer token, not just the deployment-wide route-mount decision |
 | List threads | `GET /api/chat/threads` | `GET /api/webchat/v2/threads` | Mapped |
 | Delete thread | (none) | `DELETE /api/webchat/v2/threads/{thread_id}` | Mapped |
 | Read history / timeline | `GET /api/chat/history` | `GET /api/webchat/v2/threads/{thread_id}/timeline` | Mapped |
@@ -295,10 +297,13 @@ rows are inventoried here, not implemented in the current PR.
   whatever the host wires) and supplies it via `WebuiServeConfig`.
 - **Operator WebUI config** — the `/api/webchat/v2/llm/*` routes and
   Slack channel-route admin mutate operator-wide provider settings,
-  secrets, or channel ownership. `webui_v2_app` only mounts them when
-  the host authenticator opts into `allows_operator_webui_config`;
-  multi-user authenticators must leave them unmounted until a real admin
-  authorization boundary exists.
+  secrets, or channel ownership. `webui_v2_app` mounts them only when
+  the host authenticator opts into
+  `mounts_operator_webui_config_routes()`, then authorizes each request
+  from the matched token's `WebUiV2Capabilities`. Multi-user
+  session/OIDC authenticators must not grant
+  `operator_webui_config` unless a real admin authorization boundary
+  exists.
 - **`?token=` exception** — only `GET /api/webchat/v2/threads/{id}/events`;
   any other v2 route receiving a `?token=` query parameter ignores it
   and falls through to bearer-header check (so a stale referer link

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -128,6 +128,8 @@ mod webui;
 mod webui_body_limit;
 mod webui_extension_credentials;
 #[cfg(feature = "webui-v2-beta")]
+mod webui_operator_auth;
+#[cfg(feature = "webui-v2-beta")]
 mod webui_rate_limit;
 #[cfg(feature = "webui-v2-beta")]
 mod webui_route_match;
@@ -294,9 +296,9 @@ pub use webui::{RebornWebuiBundle, build_webui_services};
 pub use webui_rate_limit::RateLimitConfigError;
 #[cfg(feature = "webui-v2-beta")]
 pub use webui_serve::{
-    ProtectedRouteMount, PublicRouteDrain, PublicRouteDrains, PublicRouteMount, WebuiAuthenticator,
-    WebuiServeConfig, WebuiServeConfigError, WebuiServeError, WebuiV2App, webui_v2_app,
-    webui_v2_app_with_lifecycle,
+    ProtectedRouteMount, PublicRouteDrain, PublicRouteDrains, PublicRouteMount,
+    WebuiAuthentication, WebuiAuthenticator, WebuiServeConfig, WebuiServeConfigError,
+    WebuiServeError, WebuiV2App, webui_v2_app, webui_v2_app_with_lifecycle,
 };
 
 /// Re-exported identity vocabulary host binaries need to construct

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -5068,8 +5068,7 @@ mod tests {
         use axum::body::Body;
         use axum::http::{Request, StatusCode};
         use ironclaw_webui_v2::{
-            DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER, WebUiV2Capabilities, WebUiV2State,
-            webui_v2_router,
+            DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER, WebUiV2State, webui_v2_router,
         };
         use tower::ServiceExt;
 
@@ -5108,7 +5107,6 @@ mod tests {
         );
         let router = webui_v2_router(WebUiV2State::new(
             bundle.api,
-            WebUiV2Capabilities::default(),
             DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER,
         ))
         .layer(axum::Extension(caller_without_agent));

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -992,8 +992,8 @@ mod tests {
     };
     use crate::{
         RebornBuildError, RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput,
-        SLACK_EVENTS_PATH, WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime,
-        local_dev_runtime_policy, webui_v2_app,
+        SLACK_EVENTS_PATH, WebuiAuthentication, WebuiAuthenticator, WebuiServeConfig,
+        build_reborn_runtime, local_dev_runtime_policy, webui_v2_app,
     };
 
     const TENANT: &str = "tenant:slack-host";
@@ -1013,15 +1013,17 @@ mod tests {
 
     #[async_trait]
     impl WebuiAuthenticator for OperatorTokenAuthenticator {
-        async fn authenticate(&self, token: &str) -> Option<UserId> {
+        async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
             if token == "operator-token" {
-                Some(UserId::new(USER).expect("user"))
+                Some(WebuiAuthentication::operator(
+                    UserId::new(USER).expect("user"),
+                ))
             } else {
                 None
             }
         }
 
-        fn allows_operator_webui_config(&self) -> bool {
+        fn mounts_operator_webui_config_routes(&self) -> bool {
             true
         }
     }
@@ -1030,9 +1032,9 @@ mod tests {
 
     #[async_trait]
     impl WebuiAuthenticator for MultiUserTokenAuthenticator {
-        async fn authenticate(&self, token: &str) -> Option<UserId> {
+        async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
             if token == "operator-token" {
-                Some(UserId::new(USER).expect("user"))
+                Some(WebuiAuthentication::user(UserId::new(USER).expect("user")))
             } else {
                 None
             }

--- a/crates/ironclaw_reborn_composition/src/webui_operator_auth.rs
+++ b/crates/ironclaw_reborn_composition/src/webui_operator_auth.rs
@@ -52,10 +52,15 @@ impl OperatorWebuiConfigRouteState {
     pub(crate) fn requires_operator_webui_config(&self, request: &Request) -> bool {
         let method = request.method();
         let path = request.uri().path();
-        self.routes
-            .iter()
-            .any(|route| route.method == *method && segments_match(&route.segments, path))
+        self.routes.iter().any(|route| {
+            method_matches_route(&route.method, method) && segments_match(&route.segments, path)
+        })
     }
+}
+
+fn method_matches_route(route_method: &Method, request_method: &Method) -> bool {
+    route_method == request_method
+        || (request_method == &Method::HEAD && route_method == &Method::GET)
 }
 
 #[cfg(test)]
@@ -88,6 +93,10 @@ mod tests {
             "/api/webchat/v2/llm/providers",
         )));
         assert!(state.requires_operator_webui_config(&request(
+            Method::HEAD,
+            "/api/webchat/v2/llm/providers",
+        )));
+        assert!(state.requires_operator_webui_config(&request(
             Method::POST,
             "/api/webchat/v2/llm/providers/openai/delete",
         )));
@@ -98,6 +107,10 @@ mod tests {
         assert!(
             !state
                 .requires_operator_webui_config(&request(Method::POST, "/api/webchat/v2/threads",))
+        );
+        assert!(
+            !state
+                .requires_operator_webui_config(&request(Method::HEAD, "/api/webchat/v2/threads",))
         );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/webui_operator_auth.rs
+++ b/crates/ironclaw_reborn_composition/src/webui_operator_auth.rs
@@ -60,7 +60,7 @@ impl OperatorWebuiConfigRouteState {
 
 fn method_matches_route(route_method: &Method, request_method: &Method) -> bool {
     route_method == request_method
-        || (request_method == &Method::HEAD && route_method == &Method::GET)
+        || (request_method == Method::HEAD && route_method == Method::GET)
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_composition/src/webui_operator_auth.rs
+++ b/crates/ironclaw_reborn_composition/src/webui_operator_auth.rs
@@ -1,0 +1,103 @@
+//! Descriptor-driven operator WebUI route authorization.
+//!
+//! The WebUI v2 descriptors are the route-policy contract. This module
+//! derives the operator-only request matcher from descriptors so auth
+//! enforcement cannot drift from the route table mounted by composition.
+
+use std::sync::Arc;
+
+use axum::extract::Request;
+use axum::http::Method;
+use ironclaw_host_api::ingress::IngressRouteDescriptor;
+
+use crate::webui_route_match::{network_method_to_axum, parse_pattern, segments_match};
+
+#[derive(Debug, Clone)]
+struct OperatorWebuiConfigRoute {
+    method: Method,
+    segments: Vec<Option<String>>,
+}
+
+/// Shared state for checking whether an authenticated request targets an
+/// operator-only WebUI configuration route.
+#[derive(Clone, Default)]
+pub(crate) struct OperatorWebuiConfigRouteState {
+    routes: Arc<Vec<OperatorWebuiConfigRoute>>,
+}
+
+impl std::fmt::Debug for OperatorWebuiConfigRouteState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OperatorWebuiConfigRouteState")
+            .field("routes", &self.routes.len())
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) fn build_operator_webui_config_route_state(
+    descriptors: &[IngressRouteDescriptor],
+) -> OperatorWebuiConfigRouteState {
+    let routes = descriptors
+        .iter()
+        .map(|descriptor| OperatorWebuiConfigRoute {
+            method: network_method_to_axum(descriptor.method()),
+            segments: parse_pattern(descriptor.route_pattern().as_str()),
+        })
+        .collect();
+    OperatorWebuiConfigRouteState {
+        routes: Arc::new(routes),
+    }
+}
+
+impl OperatorWebuiConfigRouteState {
+    pub(crate) fn requires_operator_webui_config(&self, request: &Request) -> bool {
+        let method = request.method();
+        let path = request.uri().path();
+        self.routes
+            .iter()
+            .any(|route| route.method == *method && segments_match(&route.segments, path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Method;
+    use ironclaw_webui_v2::is_webui_v2_operator_webui_config_route_id;
+
+    fn request(method: Method, path: &str) -> Request {
+        Request::builder()
+            .method(method)
+            .uri(path)
+            .body(Body::empty())
+            .expect("request")
+    }
+
+    #[test]
+    fn operator_routes_are_matched_from_descriptors() {
+        let descriptors: Vec<_> = ironclaw_webui_v2::webui_v2_routes()
+            .into_iter()
+            .filter(|descriptor| {
+                is_webui_v2_operator_webui_config_route_id(descriptor.route_id().as_str())
+            })
+            .collect();
+        let state = build_operator_webui_config_route_state(&descriptors);
+
+        assert!(state.requires_operator_webui_config(&request(
+            Method::GET,
+            "/api/webchat/v2/llm/providers",
+        )));
+        assert!(state.requires_operator_webui_config(&request(
+            Method::POST,
+            "/api/webchat/v2/llm/providers/openai/delete",
+        )));
+        assert!(!state.requires_operator_webui_config(&request(
+            Method::GET,
+            "/api/webchat/v2/llm/providers/openai/delete",
+        )));
+        assert!(
+            !state
+                .requires_operator_webui_config(&request(Method::POST, "/api/webchat/v2/threads",))
+        );
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/webui_serve.rs
+++ b/crates/ironclaw_reborn_composition/src/webui_serve.rs
@@ -73,6 +73,9 @@ use crate::slack_personal_binding_serve::{
 };
 use crate::webui::RebornWebuiBundle;
 use crate::webui_body_limit::{build_body_limit_state, enforce_body_limit};
+use crate::webui_operator_auth::{
+    OperatorWebuiConfigRouteState, build_operator_webui_config_route_state,
+};
 use crate::webui_rate_limit::{build_rate_limit_state, enforce_rate_limit};
 use crate::webui_ws_origin::{build_websocket_origin_state, enforce_websocket_origin};
 use ironclaw_product_workflow::WebUiAuthenticatedCaller;
@@ -106,21 +109,63 @@ const REBORN_HEALTH_PATH: &str = "/api/health";
 /// auth evidence is host-owned and never leaks to clients.
 #[async_trait::async_trait]
 pub trait WebuiAuthenticator: Send + Sync + 'static {
-    async fn authenticate(&self, token: &str) -> Option<UserId>;
+    /// Authenticate a bearer and return the caller identity plus capabilities
+    /// that apply to this exact token.
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication>;
 
     /// Whether bearer tokens accepted by this authenticator represent a
     /// single trusted operator. Operator-wide WebUI config routes mutate
     /// shared host configuration such as provider catalogs, secrets, active
     /// models, or Slack channel routes, so host composition only mounts them
     /// for authenticators that explicitly opt in.
+    fn mounts_operator_webui_config_routes(&self) -> bool {
+        #[allow(deprecated)]
+        self.allows_operator_webui_config()
+    }
+
+    #[deprecated(
+        since = "0.1.0",
+        note = "Use `mounts_operator_webui_config_routes`; this asks about route availability, not per-token capability."
+    )]
     fn allows_operator_webui_config(&self) -> bool {
         #[allow(deprecated)]
         self.allows_operator_llm_config()
     }
 
-    #[deprecated(since = "0.1.0", note = "Renamed to allows_operator_webui_config")]
+    #[deprecated(
+        since = "0.1.0",
+        note = "Use `mounts_operator_webui_config_routes`; this asks about route availability, not per-token capability."
+    )]
     fn allows_operator_llm_config(&self) -> bool {
         false
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebuiAuthentication {
+    pub user_id: UserId,
+    pub capabilities: WebUiV2Capabilities,
+}
+
+impl WebuiAuthentication {
+    pub fn new(user_id: UserId, capabilities: WebUiV2Capabilities) -> Self {
+        Self {
+            user_id,
+            capabilities,
+        }
+    }
+
+    pub fn user(user_id: UserId) -> Self {
+        Self::new(user_id, WebUiV2Capabilities::default())
+    }
+
+    pub fn operator(user_id: UserId) -> Self {
+        Self::new(
+            user_id,
+            WebUiV2Capabilities {
+                operator_webui_config: true,
+            },
+        )
     }
 }
 
@@ -539,13 +584,6 @@ pub fn webui_v2_app_with_lifecycle(
         ]))
         .allow_credentials(true);
 
-    let auth_state = AuthLayerState {
-        tenant_id: config.tenant_id.clone(),
-        default_agent_id: config.default_agent_id.clone(),
-        default_project_id: config.default_project_id.clone(),
-        authenticator: config.authenticator.clone(),
-    };
-
     let product_auth_mount = bundle.product_auth.clone().map(|product_auth| {
         let mut state = ProductAuthRouteState::new(
             product_auth,
@@ -569,7 +607,7 @@ pub fn webui_v2_app_with_lifecycle(
         .slack_personal_binding_pairing
         .clone()
         .map(slack_personal_binding_pairing_route_mount);
-    let mount_operator_routes = config.authenticator.allows_operator_webui_config();
+    let mount_operator_routes = config.authenticator.mounts_operator_webui_config_routes();
     #[cfg(feature = "slack-v2-host-beta")]
     let slack_channel_routes_mount = config
         .slack_channel_routes
@@ -585,10 +623,18 @@ pub fn webui_v2_app_with_lifecycle(
             .collect(),
     );
     let mut descriptors = ironclaw_webui_v2::webui_v2_routes();
+    let mut operator_descriptors: Vec<IngressRouteDescriptor> = descriptors
+        .iter()
+        .filter(|descriptor| {
+            is_webui_v2_operator_webui_config_route_id(descriptor.route_id().as_str())
+        })
+        .cloned()
+        .collect();
     if !mount_operator_routes {
         descriptors.retain(|descriptor| {
             !is_webui_v2_operator_webui_config_route_id(descriptor.route_id().as_str())
         });
+        operator_descriptors.clear();
     }
     if let Some(mount) = &product_auth_mount {
         descriptors.extend(mount.descriptors.iter().cloned());
@@ -603,6 +649,7 @@ pub fn webui_v2_app_with_lifecycle(
     }
     #[cfg(feature = "slack-v2-host-beta")]
     if let Some(mount) = &slack_channel_routes_mount {
+        operator_descriptors.extend(mount.descriptors.iter().cloned());
         descriptors.extend(mount.descriptors.iter().cloned());
     }
     for mount in &public_mounts {
@@ -618,6 +665,14 @@ pub fn webui_v2_app_with_lifecycle(
         &config.allowed_origins,
         config.canonical_host.clone(),
     );
+    let operator_routes = build_operator_webui_config_route_state(&operator_descriptors);
+    let auth_state = AuthLayerState {
+        tenant_id: config.tenant_id.clone(),
+        default_agent_id: config.default_agent_id.clone(),
+        default_project_id: config.default_project_id.clone(),
+        authenticator: config.authenticator.clone(),
+        operator_routes,
+    };
 
     // Inner: the v2 route surface, retagged to `Router<()>` so it can
     // merge into the outer stateless router. `webui_v2_router` has
@@ -627,13 +682,7 @@ pub fn webui_v2_app_with_lifecycle(
     } else {
         WebUiV2RouteOptions::without_operator_routes()
     };
-    let v2_state = WebUiV2State::new(
-        bundle.api.clone(),
-        WebUiV2Capabilities {
-            operator_webui_config: mount_operator_routes,
-        },
-        DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER,
-    );
+    let v2_state = WebUiV2State::new(bundle.api.clone(), DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER);
     let v2_inner: Router<()> = webui_v2_router_with_options(v2_state, route_options).with_state(());
 
     let mut protected_inner = Router::new().merge(v2_inner);
@@ -796,6 +845,7 @@ struct AuthLayerState {
     default_agent_id: Option<AgentId>,
     default_project_id: Option<ProjectId>,
     authenticator: Arc<dyn WebuiAuthenticator>,
+    operator_routes: OperatorWebuiConfigRouteState,
 }
 
 /// Resolve `Authorization: Bearer <token>` for any v2 route, OR the
@@ -815,10 +865,17 @@ async fn authenticate_request(
         None => return unauthorized(),
     };
 
-    let user_id = match state.authenticator.authenticate(&token).await {
-        Some(uid) => uid,
+    let auth = match state.authenticator.authenticate(&token).await {
+        Some(auth) => auth,
         None => return unauthorized(),
     };
+    if state
+        .operator_routes
+        .requires_operator_webui_config(&request)
+        && !auth.capabilities.operator_webui_config
+    {
+        return forbidden();
+    }
 
     // Stamp the trusted agent/project from host installation config
     // onto every authenticated caller. The downstream facade builds
@@ -827,14 +884,16 @@ async fn authenticate_request(
     // authenticate users only to reject every v2 mutation/read. The
     // browser body cannot influence either of these identifiers — by
     // contract `WebuiServeConfig` is host-owned.
-    let openai_user_id = user_id.clone();
+    #[cfg(feature = "openai-compat-beta")]
+    let openai_user_id = auth.user_id.clone();
     let caller = WebUiAuthenticatedCaller::new(
         state.tenant_id.clone(),
-        user_id,
+        auth.user_id,
         state.default_agent_id.clone(),
         state.default_project_id.clone(),
     );
     request.extensions_mut().insert(caller);
+    request.extensions_mut().insert(auth.capabilities);
     #[cfg(feature = "openai-compat-beta")]
     {
         let scope = ironclaw_reborn_openai_compat::OpenAiCompatActorScope::new(
@@ -859,6 +918,14 @@ async fn authenticate_request(
 
 fn unauthorized() -> Response {
     (StatusCode::UNAUTHORIZED, "Invalid or missing auth token").into_response()
+}
+
+fn forbidden() -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        "Operator WebUI configuration privileges required",
+    )
+        .into_response()
 }
 
 fn extract_bearer_token(request: &Request) -> Option<String> {

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_e2e.rs
@@ -40,7 +40,8 @@ use ironclaw_loop_support::{
 };
 use ironclaw_reborn_composition::{
     PollSettings, RebornBuildInput, RebornRuntime, RebornRuntimeIdentity, RebornRuntimeInput,
-    WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime, build_webui_services, webui_v2_app,
+    WebuiAuthentication, WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime,
+    build_webui_services, webui_v2_app,
 };
 use ironclaw_turns::run_profile::{LoopCapabilityPort, ProviderToolCall};
 use serde_json::{Value, json};
@@ -60,9 +61,11 @@ struct OnlyValidToken;
 
 #[async_trait]
 impl WebuiAuthenticator for OnlyValidToken {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
         if token == VALID_TOKEN {
-            Some(UserId::new(USER).expect("user id"))
+            Some(WebuiAuthentication::user(
+                UserId::new(USER).expect("user id"),
+            ))
         } else {
             None
         }

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth.rs
@@ -40,7 +40,8 @@ use ironclaw_product_workflow::{
 };
 use ironclaw_reborn_composition::{
     GoogleOAuthRouteConfig, RebornAuthContinuationDispatcher, RebornProductAuthServices,
-    RebornReadiness, RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig, webui_v2_app,
+    RebornReadiness, RebornWebuiBundle, WebuiAuthentication, WebuiAuthenticator, WebuiServeConfig,
+    webui_v2_app,
 };
 use serde_json::json;
 use tower::ServiceExt;
@@ -57,8 +58,9 @@ struct OnlyValidToken;
 
 #[async_trait]
 impl WebuiAuthenticator for OnlyValidToken {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
-        (token == VALID_TOKEN).then(|| UserId::new(USER).expect("user id"))
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
+        (token == VALID_TOKEN)
+            .then(|| WebuiAuthentication::user(UserId::new(USER).expect("user id")))
     }
 }
 

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_product_auth_4201.rs
@@ -37,7 +37,7 @@ use ironclaw_product_workflow::{
 };
 use ironclaw_reborn_composition::{
     RebornAuthContinuationDispatcher, RebornProductAuthServices, RebornReadiness,
-    RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig, webui_v2_app,
+    RebornWebuiBundle, WebuiAuthentication, WebuiAuthenticator, WebuiServeConfig, webui_v2_app,
 };
 use serde_json::{Value, json};
 use tower::ServiceExt;
@@ -52,8 +52,9 @@ struct OnlyValidToken;
 
 #[async_trait]
 impl WebuiAuthenticator for OnlyValidToken {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
-        (token == VALID_TOKEN).then(|| UserId::new(USER).expect("user id"))
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
+        (token == VALID_TOKEN)
+            .then(|| WebuiAuthentication::user(UserId::new(USER).expect("user id")))
     }
 }
 

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
@@ -35,8 +35,8 @@ use ironclaw_product_workflow::{
     WebUiSendMessageRequest, WebUiSetupExtensionRequest,
 };
 use ironclaw_reborn_composition::{
-    PublicRouteMount, RebornReadiness, RebornWebuiBundle, WebuiAuthenticator, WebuiServeConfig,
-    webui_v2_app,
+    PublicRouteMount, RebornReadiness, RebornWebuiBundle, WebuiAuthentication, WebuiAuthenticator,
+    WebuiServeConfig, webui_v2_app,
 };
 use ironclaw_threads::{SessionThreadRecord, ThreadScope};
 use ironclaw_turns::{EventCursor, RunProfileId, RunProfileVersion, TurnRunId, TurnStatus};
@@ -65,15 +65,17 @@ struct OnlyValidToken;
 
 #[async_trait]
 impl WebuiAuthenticator for OnlyValidToken {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
         if token == VALID_TOKEN {
-            Some(UserId::new(USER).expect("user id"))
+            Some(WebuiAuthentication::operator(
+                UserId::new(USER).expect("user id"),
+            ))
         } else {
             None
         }
     }
 
-    fn allows_operator_webui_config(&self) -> bool {
+    fn mounts_operator_webui_config_routes(&self) -> bool {
         true
     }
 }
@@ -82,9 +84,11 @@ struct MultiUserToken;
 
 #[async_trait]
 impl WebuiAuthenticator for MultiUserToken {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
         if token == VALID_TOKEN {
-            Some(UserId::new(USER).expect("user id"))
+            Some(WebuiAuthentication::user(
+                UserId::new(USER).expect("user id"),
+            ))
         } else {
             None
         }
@@ -1288,7 +1292,7 @@ async fn malformed_user_id_from_authenticator_rejects_with_401() {
     struct AlwaysReject;
     #[async_trait]
     impl WebuiAuthenticator for AlwaysReject {
-        async fn authenticate(&self, _token: &str) -> Option<UserId> {
+        async fn authenticate(&self, _token: &str) -> Option<WebuiAuthentication> {
             None
         }
     }
@@ -1753,10 +1757,12 @@ async fn rate_limit_is_independent_per_caller() {
     struct UserSwitch;
     #[async_trait]
     impl WebuiAuthenticator for UserSwitch {
-        async fn authenticate(&self, token: &str) -> Option<UserId> {
+        async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
             match token {
-                "tok-alice" => Some(UserId::new("alice").expect("user")),
-                "tok-bob" => Some(UserId::new("bob").expect("user")),
+                "tok-alice" => Some(WebuiAuthentication::user(
+                    UserId::new("alice").expect("user"),
+                )),
+                "tok-bob" => Some(WebuiAuthentication::user(UserId::new("bob").expect("user"))),
                 _ => None,
             }
         }

--- a/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
+++ b/crates/ironclaw_reborn_composition/tests/webui_v2_serve.rs
@@ -1285,10 +1285,11 @@ async fn cors_allows_configured_origin() {
 async fn malformed_user_id_from_authenticator_rejects_with_401() {
     // If a host authenticator returns a user id that doesn't satisfy
     // `UserId`'s grammar at construction time it never reaches the
-    // composition. The authenticator's contract is `Option<UserId>`,
-    // so the only way to produce a "malformed" id is to return None —
-    // which the composition treats as auth failure. This test locks
-    // the contract: a `None` decision becomes 401, never 500.
+    // composition. The authenticator's contract only accepts validated
+    // `UserId`s inside `WebuiAuthentication`, so the only way to
+    // produce a "malformed" id is to return None — which the
+    // composition treats as auth failure. This test locks the contract:
+    // a `None` decision becomes 401, never 500.
     struct AlwaysReject;
     #[async_trait]
     impl WebuiAuthenticator for AlwaysReject {

--- a/crates/ironclaw_reborn_webui_ingress/AGENTS.md
+++ b/crates/ironclaw_reborn_webui_ingress/AGENTS.md
@@ -15,7 +15,9 @@ the axum serve loop with the `Router` it gets handed.
   code, not product/API.
 - Provide concrete `WebuiAuthenticator` implementations the standalone
   `ironclaw-reborn` binary can wire (env-bearer first; DB / OIDC are
-  follow-ups). Token comparison must be constant-time (`subtle::ConstantTimeEq`).
+  follow-ups). Each accepted token must return both the `UserId` and
+  the request-scoped WebUI capabilities for that exact token. Token
+  comparison must be constant-time (`subtle::ConstantTimeEq`).
 - Do not touch `ProductAdapter`, `ExternalActorRef`, `ProtocolAuthEvidence`,
   or other external-protocol shims — WebUI is a Path A native host
   surface (see `docs/reborn/how-to-port-channel-to-reborn.md`).
@@ -42,7 +44,7 @@ update + explicit PR rationale.
 2. Implement `WebuiAuthenticator` from `ironclaw_reborn_composition`.
 3. Use constant-time comparison for any secret material.
 4. Add a unit test that exercises `authenticate` against a known
-   token + a wrong token.
+   token + a wrong token, including the returned capability shape.
 5. Add a caller-level test in `tests/` that spins up `serve_webui_v2`
    with the new authenticator on a random port and verifies bearer
    accept / reject through a real `reqwest::Client`.

--- a/crates/ironclaw_reborn_webui_ingress/CLAUDE.md
+++ b/crates/ironclaw_reborn_webui_ingress/CLAUDE.md
@@ -16,10 +16,10 @@ v1 secrets / settings / DB.
 |---|---|
 | `serve_webui_v2(opts)` | Bind a `TcpListener` + run `axum::serve` with graceful shutdown |
 | `RebornWebuiServeOptions` | Owner-supplied input (addr, router, shutdown receiver) |
-| `EnvBearerAuthenticator` | Single-token `WebuiAuthenticator` for the standalone CLI / local dev |
+| `EnvBearerAuthenticator` | Single-token `WebuiAuthenticator` for the standalone CLI / local dev; accepted tokens map to operator WebUI capabilities |
 | `SessionStore` trait | Pluggable session storage; durable impl is host's; `InMemorySessionStore` for local dev / tests |
-| `SessionAuthenticator` | `WebuiAuthenticator` that resolves bearer tokens through a `SessionStore` |
-| `OidcAuthenticator` | OIDC bearer-token verifier (JWKS + standard claims) |
+| `SessionAuthenticator` | `WebuiAuthenticator` that resolves bearer tokens through a `SessionStore`; accepted tokens map to non-operator WebUI capabilities |
+| `OidcAuthenticator` | OIDC bearer-token verifier (JWKS + standard claims); accepted tokens map to non-operator WebUI capabilities |
 | `webui_v2_auth_router(config) -> PublicRouteMount` | OAuth login router + route descriptors. The descriptors travel with the router so composition can fold them into the descriptor-driven per-route rate-limit / body-limit middleware — same machinery the v2 facade and product-auth callback already use, no side door. |
 | `PublicRouteMount` | `{ router, descriptors }` pair handed to `WebuiServeConfig::with_public_route_mount` |
 | `OAuthProvider` trait (in `auth/provider.rs`) | Extension point for per-provider URL / code-exchange logic. Deliberately lives in its own module so each provider does not depend on the others. `GoogleProvider` and `GitHubProvider` ship today. |
@@ -36,6 +36,12 @@ the session lifecycle types. The OAuth callback's job is exactly that
 — turn a provider profile into a `SessionStore::create_session` call
 — so the login mint path belongs in the same host-owned crate, not
 behind the product/API seam in `ironclaw_reborn_composition`.
+
+SSO sessions are user identity only. They must not inherit operator
+WebUI configuration privileges from the deployment. When the CLI
+composes SSO plus the env bearer token, the env token remains the
+separate operator credential and session/OIDC bearers remain
+non-operator.
 
 Composition merges the `PublicRouteMount` supplied by
 `webui_v2_auth_router` through

--- a/crates/ironclaw_reborn_webui_ingress/src/lib.rs
+++ b/crates/ironclaw_reborn_webui_ingress/src/lib.rs
@@ -179,7 +179,10 @@ pub enum EnvBearerConfigError {
 
 #[async_trait]
 impl WebuiAuthenticator for EnvBearerAuthenticator {
-    async fn authenticate(&self, candidate: &str) -> Option<UserId> {
+    async fn authenticate(
+        &self,
+        candidate: &str,
+    ) -> Option<ironclaw_reborn_composition::WebuiAuthentication> {
         // Constant-time comparison so an attacker cannot use response
         // timing to learn the prefix of the configured token. Both
         // operands are coerced to `&[u8]` of the same length to make
@@ -189,13 +192,15 @@ impl WebuiAuthenticator for EnvBearerAuthenticator {
         let expected = self.token.expose_secret().as_bytes();
         let candidate = candidate.as_bytes();
         if expected.ct_eq(candidate).into() {
-            Some(self.user_id.clone())
+            Some(ironclaw_reborn_composition::WebuiAuthentication::operator(
+                self.user_id.clone(),
+            ))
         } else {
             None
         }
     }
 
-    fn allows_operator_webui_config(&self) -> bool {
+    fn mounts_operator_webui_config_routes(&self) -> bool {
         true
     }
 }
@@ -217,7 +222,16 @@ mod tests {
         )
         .expect("auth");
         let result = auth.authenticate("right-token").await;
-        assert_eq!(result.as_ref().map(|u| u.as_str()), Some("user-alpha"));
+        assert_eq!(
+            result.as_ref().map(|auth| auth.user_id.as_str()),
+            Some("user-alpha")
+        );
+        assert_eq!(
+            result
+                .as_ref()
+                .map(|auth| auth.capabilities.operator_webui_config),
+            Some(true)
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_webui_ingress/src/oidc.rs
+++ b/crates/ironclaw_reborn_webui_ingress/src/oidc.rs
@@ -29,7 +29,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use ironclaw_host_api::UserId;
-use ironclaw_reborn_composition::WebuiAuthenticator;
+use ironclaw_reborn_composition::{WebuiAuthentication, WebuiAuthenticator};
 use jsonwebtoken::{Algorithm, DecodingKey, TokenData, Validation, decode, decode_header};
 use parking_lot::RwLock;
 use serde::Deserialize;
@@ -657,7 +657,7 @@ fn build_decoding_key(jwk: &Jwk, algorithm: Algorithm) -> Option<DecodingKey> {
 
 #[async_trait]
 impl WebuiAuthenticator for OidcAuthenticator {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
         let token_data = match self.decode_token(token).await {
             Ok(Some(data)) => data,
             Ok(None) => return None,
@@ -689,7 +689,7 @@ impl WebuiAuthenticator for OidcAuthenticator {
         {
             return None;
         }
-        (self.claim_to_user_id)(&claims)
+        (self.claim_to_user_id)(&claims).map(WebuiAuthentication::user)
     }
 }
 

--- a/crates/ironclaw_reborn_webui_ingress/src/session.rs
+++ b/crates/ironclaw_reborn_webui_ingress/src/session.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use ironclaw_host_api::{TenantId, UserId};
-use ironclaw_reborn_composition::WebuiAuthenticator;
+use ironclaw_reborn_composition::{WebuiAuthentication, WebuiAuthenticator};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -247,8 +247,8 @@ impl std::fmt::Debug for SessionAuthenticator {
 
 #[async_trait]
 impl WebuiAuthenticator for SessionAuthenticator {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
-        // The `WebuiAuthenticator` contract is `Option<UserId>` —
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
+        // The `WebuiAuthenticator` contract is `Option<WebuiAuthentication>` —
         // every failure must collapse to `None` so the gateway
         // emits a generic 401 and never leaks the reason to the
         // client. But "session not found" (auth miss) and
@@ -280,7 +280,7 @@ impl WebuiAuthenticator for SessionAuthenticator {
             );
             return None;
         }
-        Some(record.user_id)
+        Some(WebuiAuthentication::user(record.user_id))
     }
 }
 
@@ -341,7 +341,8 @@ mod tests {
             .authenticate(token.expose_secret())
             .await
             .expect("authenticated");
-        assert_eq!(resolved.as_str(), "alice");
+        assert_eq!(resolved.user_id.as_str(), "alice");
+        assert!(!resolved.capabilities.operator_webui_config);
     }
 
     // Regression for the session-token-leak review (Medium): the

--- a/crates/ironclaw_reborn_webui_ingress/src/signed_session_login.rs
+++ b/crates/ironclaw_reborn_webui_ingress/src/signed_session_login.rs
@@ -38,7 +38,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use hmac::{Hmac, Mac};
 use ironclaw_host_api::{TenantId, UserId};
-use ironclaw_reborn_composition::WebuiAuthenticator;
+use ironclaw_reborn_composition::{WebuiAuthentication, WebuiAuthenticator};
 use parking_lot::RwLock;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -336,11 +336,15 @@ impl CompositeAuthenticator {
 
 #[async_trait]
 impl WebuiAuthenticator for CompositeAuthenticator {
-    async fn authenticate(&self, token: &str) -> Option<UserId> {
-        if let Some(user) = self.session.authenticate(token).await {
-            return Some(user);
+    async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
+        if let Some(auth) = self.env_token.authenticate(token).await {
+            return Some(auth);
         }
-        self.env_token.authenticate(token).await
+        self.session.authenticate(token).await
+    }
+
+    fn mounts_operator_webui_config_routes(&self) -> bool {
+        self.env_token.mounts_operator_webui_config_routes()
     }
 }
 
@@ -569,16 +573,26 @@ mod tests {
     struct OneToken {
         token: &'static str,
         user: &'static str,
+        operator: bool,
     }
 
     #[async_trait]
     impl WebuiAuthenticator for OneToken {
-        async fn authenticate(&self, token: &str) -> Option<UserId> {
+        async fn authenticate(&self, token: &str) -> Option<WebuiAuthentication> {
             if token == self.token {
-                Some(UserId::new(self.user).expect("valid user id"))
+                let user = UserId::new(self.user).expect("valid user id");
+                Some(if self.operator {
+                    WebuiAuthentication::operator(user)
+                } else {
+                    WebuiAuthentication::user(user)
+                })
             } else {
                 None
             }
+        }
+
+        fn mounts_operator_webui_config_routes(&self) -> bool {
+            self.operator
         }
     }
 
@@ -588,10 +602,12 @@ mod tests {
             Arc::new(OneToken {
                 token: "session-tok",
                 user: "alice@example.com",
+                operator: false,
             }),
             Arc::new(OneToken {
                 token: "env-tok",
                 user: "operator",
+                operator: true,
             }),
         );
 
@@ -600,14 +616,51 @@ mod tests {
                 .authenticate("session-tok")
                 .await
                 .unwrap()
+                .user_id
                 .as_str(),
             "alice@example.com"
         );
         assert_eq!(
-            composite.authenticate("env-tok").await.unwrap().as_str(),
+            composite
+                .authenticate("env-tok")
+                .await
+                .unwrap()
+                .user_id
+                .as_str(),
             "operator"
         );
         assert!(composite.authenticate("nope").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn composite_marks_only_env_token_as_operator_capable() {
+        let composite = CompositeAuthenticator::new(
+            Arc::new(OneToken {
+                token: "session-tok",
+                user: "alice@example.com",
+                operator: false,
+            }),
+            Arc::new(OneToken {
+                token: "env-tok",
+                user: "operator",
+                operator: true,
+            }),
+        );
+
+        let session = composite
+            .authenticate("session-tok")
+            .await
+            .expect("session token authenticates");
+        assert_eq!(session.user_id.as_str(), "alice@example.com");
+        assert!(!session.capabilities.operator_webui_config);
+
+        let env = composite
+            .authenticate("env-tok")
+            .await
+            .expect("env token authenticates");
+        assert_eq!(env.user_id.as_str(), "operator");
+        assert!(env.capabilities.operator_webui_config);
+        assert!(composite.mounts_operator_webui_config_routes());
     }
 
     /// Minimal host-supplied directory for the builder wiring tests.
@@ -657,6 +710,7 @@ mod tests {
             env_authenticator: Arc::new(OneToken {
                 token: "env-tok",
                 user: "operator",
+                operator: true,
             }),
         }
     }

--- a/crates/ironclaw_reborn_webui_ingress/tests/auth_route_contract.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/auth_route_contract.rs
@@ -837,7 +837,7 @@ async fn cookie_session_not_honored_on_protected_route() {
 
 /// `GET /api/webchat/v2/llm/providers` with no auth. Whether this route
 /// exists at all depends on the authenticator's
-/// `allows_operator_webui_config()`; sending no credential lets us read
+/// `mounts_operator_webui_config_routes()`; sending no credential lets us read
 /// the verdict as 401 (mounted, behind bearer auth) vs 404 (not
 /// mounted) without invoking the facade.
 fn llm_providers_unauthenticated() -> Request<Body> {
@@ -853,7 +853,7 @@ fn llm_providers_unauthenticated() -> Request<Body> {
 #[tokio::test]
 async fn operator_config_route_mounted_for_operator_authenticator() {
     // `EnvBearerAuthenticator` is a single trusted operator
-    // (`allows_operator_webui_config() == true`), so the operator-only
+    // (`mounts_operator_webui_config_routes() == true`), so the operator-only
     // LLM config routes are mounted and sit behind bearer auth.
     let (app, _services) = env_bearer_app();
     let response = app
@@ -870,7 +870,7 @@ async fn operator_config_route_mounted_for_operator_authenticator() {
 #[tokio::test]
 async fn operator_config_route_absent_for_multi_user_authenticator() {
     // `SessionAuthenticator` is multi-user
-    // (`allows_operator_webui_config() == false`), so operator-only LLM
+    // (`mounts_operator_webui_config_routes() == false`), so operator-only LLM
     // config routes must NOT be mounted — there is no admin boundary yet.
     let (app, _services, _store) = session_app();
     let response = app

--- a/crates/ironclaw_reborn_webui_ingress/tests/oidc_e2e.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/oidc_e2e.rs
@@ -166,7 +166,7 @@ async fn oidc_authenticator_accepts_valid_jwks_signed_token_and_rejects_bad_clai
         .authenticate(&valid)
         .await
         .expect("valid JWKS-signed token must be accepted");
-    assert_eq!(user.as_str(), "alice");
+    assert_eq!(user.user_id.as_str(), "alice");
 
     // (2) Wrong issuer → rejected.
     let wrong_iss = sign_token(
@@ -247,7 +247,7 @@ async fn oidc_authenticator_refetches_jwks_on_kid_miss_during_rotation() {
         .authenticate(&token_two)
         .await
         .expect("rotated-key token must trigger force-refresh + accept");
-    assert_eq!(user.as_str(), "alice");
+    assert_eq!(user.user_id.as_str(), "alice");
     // The force-refresh produced exactly one additional JWKS fetch.
     assert_eq!(
         state.fetch_count(),
@@ -284,7 +284,7 @@ async fn oidc_jwks_refresh_is_single_flight_under_concurrent_authenticate() {
     }
     for handle in handles {
         let user = handle.await.expect("join").expect("auth accepted");
-        assert_eq!(user.as_str(), "alice");
+        assert_eq!(user.user_id.as_str(), "alice");
     }
     assert_eq!(
         state.fetch_count(),
@@ -517,7 +517,7 @@ async fn oidc_authenticator_rejects_future_nbf() {
         .authenticate(&past_nbf)
         .await
         .expect("a token with a past nbf must authenticate (isolates nbf as the cause)");
-    assert_eq!(user.as_str(), "alice");
+    assert_eq!(user.user_id.as_str(), "alice");
 
     server.abort();
 }

--- a/crates/ironclaw_reborn_webui_ingress/tests/signed_session_multi_user.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/signed_session_multi_user.rs
@@ -493,6 +493,44 @@ async fn create_thread(app: &axum::Router, bearer: &str) -> StatusCode {
         .status()
 }
 
+async fn session_payload(app: &axum::Router, bearer: &str) -> serde_json::Value {
+    let response = app
+        .clone()
+        .oneshot(with_peer(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/webchat/v2/session")
+                .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+                .body(Body::empty())
+                .expect("request"),
+        ))
+        .await
+        .expect("oneshot");
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("session json")
+}
+
+async fn llm_providers_status(app: &axum::Router, bearer: &str) -> StatusCode {
+    app.clone()
+        .oneshot(with_peer(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/webchat/v2/llm/providers")
+                .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+                .body(Body::empty())
+                .expect("request"),
+        ))
+        .await
+        .expect("oneshot")
+        .status()
+}
+
 // ─── test ─────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -528,6 +566,41 @@ async fn two_oauth_users_reach_protected_routes_as_distinct_callers() {
     );
     // Both callers carry the host-trusted tenant, never a browser value.
     assert!(callers.iter().all(|c| c.tenant_id.as_str() == TENANT));
+}
+
+#[tokio::test]
+async fn sso_sessions_stay_non_operator_while_env_token_can_configure_operator_routes() {
+    // This mirrors the Railway deployment shape: SSO login is enabled,
+    // but the env bearer remains the separate operator credential.
+    let (app, _services) = build_app(vec![profile("alice-sub", "alice@example.com")]);
+    let sso_bearer = login(&app).await;
+
+    let sso_session = session_payload(&app, &sso_bearer).await;
+    assert_eq!(sso_session["user_id"], "user-alice-sub");
+    assert_eq!(
+        sso_session["capabilities"]["operator_webui_config"], false,
+        "SSO session tokens must not inherit operator privileges"
+    );
+    assert_eq!(
+        llm_providers_status(&app, &sso_bearer).await,
+        StatusCode::FORBIDDEN,
+        "SSO session tokens must be denied on operator LLM config routes"
+    );
+
+    let operator_session = session_payload(&app, "env-operator-token").await;
+    assert_eq!(operator_session["user_id"], "operator");
+    assert_eq!(
+        operator_session["capabilities"]["operator_webui_config"], true,
+        "the env bearer token must keep operator capability when SSO is mounted"
+    );
+    let operator_status = llm_providers_status(&app, "env-operator-token").await;
+    assert_ne!(operator_status, StatusCode::UNAUTHORIZED);
+    assert_ne!(operator_status, StatusCode::FORBIDDEN);
+    assert_ne!(
+        operator_status,
+        StatusCode::NOT_FOUND,
+        "operator routes must be mounted when the composite authenticator contains an env operator token"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn_webui_ingress/tests/signed_session_multi_user.rs
+++ b/crates/ironclaw_reborn_webui_ingress/tests/signed_session_multi_user.rs
@@ -516,11 +516,11 @@ async fn session_payload(app: &axum::Router, bearer: &str) -> serde_json::Value 
     serde_json::from_slice(&bytes).expect("session json")
 }
 
-async fn llm_providers_status(app: &axum::Router, bearer: &str) -> StatusCode {
+async fn llm_providers_status(app: &axum::Router, bearer: &str, method: Method) -> StatusCode {
     app.clone()
         .oneshot(with_peer(
             Request::builder()
-                .method(Method::GET)
+                .method(method)
                 .uri("/api/webchat/v2/llm/providers")
                 .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
                 .body(Body::empty())
@@ -582,9 +582,14 @@ async fn sso_sessions_stay_non_operator_while_env_token_can_configure_operator_r
         "SSO session tokens must not inherit operator privileges"
     );
     assert_eq!(
-        llm_providers_status(&app, &sso_bearer).await,
+        llm_providers_status(&app, &sso_bearer, Method::GET).await,
         StatusCode::FORBIDDEN,
         "SSO session tokens must be denied on operator LLM config routes"
+    );
+    assert_eq!(
+        llm_providers_status(&app, &sso_bearer, Method::HEAD).await,
+        StatusCode::FORBIDDEN,
+        "SSO session tokens must be denied on operator LLM config routes before Axum routes HEAD through GET"
     );
 
     let operator_session = session_payload(&app, "env-operator-token").await;
@@ -593,7 +598,7 @@ async fn sso_sessions_stay_non_operator_while_env_token_can_configure_operator_r
         operator_session["capabilities"]["operator_webui_config"], true,
         "the env bearer token must keep operator capability when SSO is mounted"
     );
-    let operator_status = llm_providers_status(&app, "env-operator-token").await;
+    let operator_status = llm_providers_status(&app, "env-operator-token", Method::GET).await;
     assert_ne!(operator_status, StatusCode::UNAUTHORIZED);
     assert_ne!(operator_status, StatusCode::FORBIDDEN);
     assert_ne!(

--- a/crates/ironclaw_webui_v2/CLAUDE.md
+++ b/crates/ironclaw_webui_v2/CLAUDE.md
@@ -25,8 +25,9 @@ owns:
    the same path prefix the descriptors declare.
 2. **Bearer-token middleware.** Authenticate `Authorization: Bearer
    …` (or the matching session form) and inject a
-   `WebUiAuthenticatedCaller` as an `axum::Extension` *before* the
-   handler runs. The handlers fail closed (`500`) when this layer is
+   `WebUiAuthenticatedCaller` and request-scoped
+   `WebUiV2Capabilities` as `axum::Extension`s *before* the handler
+   runs. The handlers fail closed (`500`) when this layer is
    missing — verified by
    `missing_caller_extension_returns_500`.
 3. **Query-token path for the SSE route.** The browser's
@@ -86,14 +87,17 @@ browser-reachable.
 
 All routes require `BearerToken` auth with `AuthenticatedCaller`
 scope source. The host's bearer middleware is responsible for
-constructing the `WebUiAuthenticatedCaller` and injecting it as an
-axum `Extension` before the handler runs.
+constructing the `WebUiAuthenticatedCaller`, carrying the matched
+token's `WebUiV2Capabilities`, and injecting both as axum
+`Extension`s before the handler runs.
 
 The LLM configuration and operator command-plane routes are operator-wide. Host
-composition must only mount them for authenticators that represent a single
-trusted operator; multi-user session/OIDC authenticators should leave those
-routes unmounted until an admin role boundary exists in
-`WebUiAuthenticatedCaller`. Unwired operator command-plane facade methods fail
+composition mounts them only when the authenticator says the deployment
+has an operator configuration surface, and must still authorize each
+request from the matched token's `operator_webui_config` capability.
+Multi-user session/OIDC authenticators should leave those routes
+unmounted or return non-operator capabilities until an admin role
+boundary exists. Unwired operator command-plane facade methods fail
 closed with sanitized `503 service_unavailable` responses.
 
 ### List-threads

--- a/crates/ironclaw_webui_v2/src/handlers.rs
+++ b/crates/ironclaw_webui_v2/src/handlers.rs
@@ -56,13 +56,13 @@ pub struct WebUiV2SessionResponse {
 
 /// `GET /api/webchat/v2/session`
 pub async fn get_session(
-    State(state): State<WebUiV2State>,
     Extension(caller): Extension<WebUiAuthenticatedCaller>,
+    Extension(capabilities): Extension<WebUiV2Capabilities>,
 ) -> Json<WebUiV2SessionResponse> {
     Json(WebUiV2SessionResponse {
         tenant_id: caller.tenant_id.to_string(),
         user_id: caller.user_id.to_string(),
-        capabilities: state.capabilities(),
+        capabilities,
     })
 }
 

--- a/crates/ironclaw_webui_v2/src/router.rs
+++ b/crates/ironclaw_webui_v2/src/router.rs
@@ -74,7 +74,6 @@ impl WebUiV2RouteOptions {
 pub struct WebUiV2State {
     services: Arc<dyn RebornServicesApi>,
     sse_capacity: Arc<SseCapacity>,
-    capabilities: WebUiV2Capabilities,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
@@ -85,13 +84,11 @@ pub struct WebUiV2Capabilities {
 impl WebUiV2State {
     pub fn new(
         services: Arc<dyn RebornServicesApi>,
-        capabilities: WebUiV2Capabilities,
         max_concurrent_streams_per_caller: usize,
     ) -> Self {
         Self {
             services,
             sse_capacity: Arc::new(SseCapacity::new(max_concurrent_streams_per_caller)),
-            capabilities,
         }
     }
 
@@ -101,10 +98,6 @@ impl WebUiV2State {
 
     pub(crate) fn sse_capacity(&self) -> &Arc<SseCapacity> {
         &self.sse_capacity
-    }
-
-    pub(crate) fn capabilities(&self) -> WebUiV2Capabilities {
-        self.capabilities
     }
 }
 

--- a/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
+++ b/crates/ironclaw_webui_v2/tests/webui_v2_handlers_contract.rs
@@ -79,13 +79,13 @@ fn router_with_capabilities(
 ) -> Router {
     webui_v2_router(WebUiV2State::new(
         services,
-        capabilities,
         DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER,
     ))
     // Production composition runs the bearer-token middleware that
     // constructs this `Extension`; tests bypass auth and inject the
     // caller directly so the regression target is the handler itself.
     .layer(axum::Extension(caller()))
+    .layer(axum::Extension(capabilities))
 }
 
 fn service_unavailable_error(retryable: bool) -> RebornServicesError {
@@ -1901,12 +1901,7 @@ async fn stream_events_ws_shares_capacity_with_sse_streams() {
     let services: Arc<dyn RebornServicesApi> = Arc::new(StubServices::default());
     // Pool size 1: any one open stream (SSE or WS) must exhaust the
     // budget for the caller.
-    let router = webui_v2_router(WebUiV2State::new(
-        services,
-        WebUiV2Capabilities::default(),
-        1,
-    ))
-    .layer(axum::Extension(caller()));
+    let router = webui_v2_router(WebUiV2State::new(services, 1)).layer(axum::Extension(caller()));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -2014,12 +2009,7 @@ async fn stream_events_ws_shares_capacity_with_sse_streams() {
 async fn stream_events_caps_concurrent_streams_per_caller() {
     let services: Arc<dyn RebornServicesApi> = Arc::new(StubServices::default());
     // Use a low custom cap so the test runs without burning resources.
-    let router = webui_v2_router(WebUiV2State::new(
-        services,
-        WebUiV2Capabilities::default(),
-        2,
-    ))
-    .layer(axum::Extension(caller()));
+    let router = webui_v2_router(WebUiV2State::new(services, 2)).layer(axum::Extension(caller()));
 
     let open_stream = || {
         router.clone().oneshot(
@@ -2264,12 +2254,7 @@ async fn stream_events_releases_slot_when_facade_drain_stalls_past_max_lifetime(
     // Cap of 1 so we can observe slot release directly: a second open
     // returns 429 while the first is held, and 200 once it's released.
     let services: Arc<dyn RebornServicesApi> = Arc::new(StallingServices);
-    let router = webui_v2_router(WebUiV2State::new(
-        services,
-        WebUiV2Capabilities::default(),
-        1,
-    ))
-    .layer(axum::Extension(caller()));
+    let router = webui_v2_router(WebUiV2State::new(services, 1)).layer(axum::Extension(caller()));
 
     let open_stream = || {
         router.clone().oneshot(
@@ -2738,7 +2723,6 @@ async fn missing_caller_extension_returns_500() {
     let services: Arc<dyn RebornServicesApi> = Arc::new(StubServices::default());
     let router = webui_v2_router(WebUiV2State::new(
         services,
-        WebUiV2Capabilities::default(),
         DEFAULT_SSE_MAX_CONCURRENT_PER_CALLER,
     ));
 
@@ -2973,12 +2957,7 @@ async fn stream_events_ws_releases_slot_on_peer_close() {
     use futures::SinkExt;
 
     let services: Arc<dyn RebornServicesApi> = Arc::new(StubServices::default());
-    let router = webui_v2_router(WebUiV2State::new(
-        services,
-        WebUiV2Capabilities::default(),
-        1,
-    ))
-    .layer(axum::Extension(caller()));
+    let router = webui_v2_router(WebUiV2State::new(services, 1)).layer(axum::Extension(caller()));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await


### PR DESCRIPTION
## Summary

Fixes SSO-enabled WebUI deployments so the env bearer token remains the operator/admin credential while ordinary SSO sessions stay non-operator.

## What changed

- Make WebUI authentication return request-scoped capabilities with the authenticated user.
- Split route mounting capability from per-token operator capability.
- Add descriptor-driven operator route authorization instead of hardcoded URL prefix checks.
- Require `/api/webchat/v2/session` to use request-scoped capabilities, removing the global fallback.
- Keep SSO sessions non-operator while allowing the env bearer token to access LLM/channel/operator settings.

## Root cause

When SSO was enabled, the session authenticator and env-token authenticator were wrapped in a composite authenticator. The composite did not preserve the env-token operator capability in a per-token way, so operator routes/capabilities were treated as unavailable or unsafe globally.

## Validation

- `cargo test -p ironclaw_reborn_composition --test webui_v2_serve --features webui-v2-beta,slack-v2-host-beta`
- `cargo test -p ironclaw_reborn_webui_ingress --test signed_session_multi_user --all-features`
- `cargo test -p ironclaw_reborn_webui_ingress --test auth_route_contract operator_config_route --all-features`
- `cargo test -p ironclaw_webui_v2 get_session_returns --features webui-v2-beta`
- `cargo test -p ironclaw_reborn_webui_ingress composite_marks_only_env_token_as_operator_capable --all-features`
- `cargo test -p ironclaw_reborn_composition operator_routes_are_matched_from_descriptors --features webui-v2-beta`
- `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth --features webui-v2-beta`
- `cargo test -p ironclaw_reborn_composition --test webui_v2_product_auth_4201 --features webui-v2-beta`
- `cargo test -p ironclaw_reborn_composition --test webui_v2_e2e --features webui-v2-beta`
- `git diff --check`