### PR TITLE
[codex] Fix Reborn Docker production storage opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,6 +338,16 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # 0.0.0.0. `IRONCLAW_REBORN_CONFIRM_HOST_ACCESS` is only for
 # local-dev-yolo-style trusted host access and should stay unset for public
 # container deployments.
+#
+# The Reborn Docker image defaults to local-dev so local `docker run` does not
+# require Postgres. Set IRONCLAW_REBORN_PROFILE=production on Railway to seed
+# the production/Postgres config and keep user extension install/activation
+# state durable across image redeploys. If you keep local-dev/local-dev-yolo on
+# Railway, attach a persistent volume at /data or set IRONCLAW_REBORN_HOME under
+# RAILWAY_VOLUME_MOUNT_PATH; otherwise local-dev extension state under
+# `$IRONCLAW_REBORN_HOME/local-dev/system/extensions` is container-local. The
+# entrypoint fails closed for Railway local-dev profiles without a volume unless
+# IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true is set for disposable tests.
 # IRONCLAW_REBORN_HOME=/data/ironclaw-reborn
 # IRONCLAW_REBORN_PROFILE=local-dev
 # IRONCLAW_REBORN_LOG=info

--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -74,7 +74,6 @@ COPY docker/reborn/config.production.toml /opt/ironclaw/reborn/config.production
 COPY docker/reborn/entrypoint.sh /usr/local/bin/ironclaw-reborn-entrypoint
 
 ENV HOME=/home/ironclaw \
-    IRONCLAW_REBORN_HOME=/data/ironclaw-reborn \
     IRONCLAW_REBORN_LOG=info \
     IRONCLAW_REBORN_SERVE_HOST=127.0.0.1
 

--- a/Dockerfile.reborn
+++ b/Dockerfile.reborn
@@ -8,7 +8,9 @@
 #
 # Railway:
 #   Set Dockerfile path to Dockerfile.reborn and IRONCLAW_REBORN_SERVE_HOST=0.0.0.0.
-#   Railway supplies PORT.
+#   Railway supplies PORT. Set IRONCLAW_REBORN_PROFILE=production plus
+#   IRONCLAW_REBORN_POSTGRES_URL and IRONCLAW_REBORN_SECRET_MASTER_KEY for
+#   durable production storage.
 
 FROM rust:1.92-bookworm AS chef
 
@@ -39,7 +41,7 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook \
     --profile dist \
     --package ironclaw_reborn_cli \
-    --features webui-v2-beta,slack-v2-host-beta \
+    --features webui-v2-beta,slack-v2-host-beta,postgres \
     --recipe-path recipe.json
 
 FROM deps AS builder
@@ -57,7 +59,7 @@ RUN mkdir -p src \
 RUN cargo build \
     --profile dist \
     --package ironclaw_reborn_cli \
-    --features webui-v2-beta,slack-v2-host-beta \
+    --features webui-v2-beta,slack-v2-host-beta,postgres \
     --bin ironclaw-reborn
 
 FROM debian:bookworm-slim AS runtime
@@ -68,6 +70,7 @@ RUN apt-get update \
 
 COPY --from=builder /app/target/dist/ironclaw-reborn /usr/local/bin/ironclaw-reborn
 COPY docker/reborn/config.toml /opt/ironclaw/reborn/config.toml
+COPY docker/reborn/config.production.toml /opt/ironclaw/reborn/config.production.toml
 COPY docker/reborn/entrypoint.sh /usr/local/bin/ironclaw-reborn-entrypoint
 
 ENV HOME=/home/ironclaw \
@@ -79,6 +82,8 @@ RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
     && mkdir -p /data/ironclaw-reborn /workspace \
     && chown -R ironclaw:ironclaw /home/ironclaw /data/ironclaw-reborn /workspace \
     && chmod +x /usr/local/bin/ironclaw-reborn-entrypoint
+
+VOLUME ["/data/ironclaw-reborn"]
 
 WORKDIR /workspace
 

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -83,9 +83,17 @@ fn fake_bin_path(bin_dir: &Path) -> String {
 #[cfg(unix)]
 fn write_reborn_config(reborn_home: &Path, profile: &str) {
     std::fs::create_dir_all(reborn_home).expect("reborn home");
+    let production_sections = match profile {
+        "production" | "migration-dry-run" => {
+            "\n[policy]\ndeployment_mode = \"hosted_multi_tenant\"\ndefault_profile = \"secure_default\"\n\n[storage]\nbackend = \"postgres\"\nurl_env = \"IRONCLAW_REBORN_POSTGRES_URL\"\nsecret_master_key_env = \"IRONCLAW_REBORN_SECRET_MASTER_KEY\"\n"
+        }
+        _ => "",
+    };
     std::fs::write(
         reborn_home.join("config.toml"),
-        format!("api_version = \"ironclaw.runtime/v1\"\n\n[boot]\nprofile = \"{profile}\"\n"),
+        format!(
+            "api_version = \"ironclaw.runtime/v1\"\n\n[boot]\nprofile = \"{profile}\"\n{production_sections}"
+        ),
     )
     .expect("config");
 }
@@ -105,6 +113,10 @@ fn dockerfile_reborn_builds_with_postgres_feature() {
     assert!(
         dockerfile.contains("config.production.toml"),
         "Dockerfile.reborn must ship the opt-in production config: {dockerfile}"
+    );
+    assert!(
+        !dockerfile.contains("IRONCLAW_REBORN_HOME=/data/ironclaw-reborn"),
+        "Dockerfile.reborn must let the entrypoint resolve Railway volume mounts before falling back to /data: {dockerfile}"
     );
 }
 
@@ -267,6 +279,36 @@ fn docker_reborn_entrypoint_allows_railway_production_without_volume() {
         "stdout: {stdout}"
     );
     assert!(stdout.contains("args=--help"), "stdout: {stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_reborn_entrypoint_rejects_stale_local_dev_config_for_production() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    fake_reborn_bin(&bin_dir);
+    let reborn_home = temp.path().join("reborn-home");
+    write_reborn_config(&reborn_home, "local-dev");
+
+    let output = Command::new("/bin/sh")
+        .arg(workspace_root().join("docker/reborn/entrypoint.sh"))
+        .arg("--help")
+        .env_clear()
+        .env("PATH", fake_bin_path(&bin_dir))
+        .env("HOME", temp.path().join("home"))
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_REBORN_PROFILE", "production")
+        .env("RAILWAY_ENVIRONMENT", "production")
+        .output()
+        .expect("entrypoint should run");
+
+    assert!(!output.status.success(), "entrypoint should fail closed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("IRONCLAW_REBORN_PROFILE=production requires"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("stale local-dev seed"), "stderr: {stderr}");
 }
 
 #[test]

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -98,6 +98,16 @@ fn write_reborn_config(reborn_home: &Path, profile: &str) {
     .expect("config");
 }
 
+#[cfg(unix)]
+fn write_sparse_reborn_config(reborn_home: &Path) {
+    std::fs::create_dir_all(reborn_home).expect("reborn home");
+    std::fs::write(
+        reborn_home.join("config.toml"),
+        "api_version = \"ironclaw.runtime/v1\"\n",
+    )
+    .expect("config");
+}
+
 #[test]
 fn dockerfile_reborn_builds_with_postgres_feature() {
     let dockerfile = std::fs::read_to_string(workspace_root().join("Dockerfile.reborn"))
@@ -243,6 +253,63 @@ fn docker_reborn_entrypoint_rejects_ephemeral_railway_without_volume() {
     );
     assert!(
         stderr.contains("IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true"),
+        "stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_reborn_entrypoint_rejects_sparse_config_as_local_dev_on_railway() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    fake_reborn_bin(&bin_dir);
+    let reborn_home = temp.path().join("reborn-home");
+    write_sparse_reborn_config(&reborn_home);
+
+    let output = Command::new("/bin/sh")
+        .arg(workspace_root().join("docker/reborn/entrypoint.sh"))
+        .env_clear()
+        .env("PATH", fake_bin_path(&bin_dir))
+        .env("HOME", temp.path().join("home"))
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("RAILWAY_ENVIRONMENT", "production")
+        .output()
+        .expect("entrypoint should run");
+
+    assert!(!output.status.success(), "entrypoint should fail closed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Railway deployment using profile=local-dev requires a persistent volume"),
+        "stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_reborn_entrypoint_rejects_local_dev_home_outside_railway_volume() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    fake_reborn_bin(&bin_dir);
+    let volume = temp.path().join("railway-volume");
+    let reborn_home = temp.path().join("ephemeral-home");
+    write_reborn_config(&reborn_home, "local-dev");
+
+    let output = Command::new("/bin/sh")
+        .arg(workspace_root().join("docker/reborn/entrypoint.sh"))
+        .arg("--help")
+        .env_clear()
+        .env("PATH", fake_bin_path(&bin_dir))
+        .env("HOME", temp.path().join("home"))
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("RAILWAY_ENVIRONMENT", "production")
+        .env("RAILWAY_VOLUME_MOUNT_PATH", &volume)
+        .output()
+        .expect("entrypoint should run");
+
+    assert!(!output.status.success(), "entrypoint should fail closed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("to be under RAILWAY_VOLUME_MOUNT_PATH"),
         "stderr: {stderr}"
     );
 }

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -2,7 +2,7 @@
 use std::io::BufRead;
 use std::{
     io::Write,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -48,6 +48,225 @@ fn isolated_no_llm_command(workspace: &Path, reborn_home: &Path) -> Command {
         .env("OLLAMA_BASE_URL", "")
         .env("IRONCLAW_REBORN_HOME", reborn_home);
     command
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+#[cfg(unix)]
+fn fake_reborn_bin(bin_dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::create_dir_all(bin_dir).expect("fake bin dir");
+    let bin = bin_dir.join("ironclaw-reborn");
+    std::fs::write(
+        &bin,
+        "#!/bin/sh\nprintf 'home=%s\\n' \"$IRONCLAW_REBORN_HOME\"\nprintf 'args=%s\\n' \"$*\"\n",
+    )
+    .expect("write fake reborn bin");
+    let mut permissions = std::fs::metadata(&bin)
+        .expect("fake bin metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&bin, permissions).expect("chmod fake bin");
+}
+
+#[cfg(unix)]
+fn fake_bin_path(bin_dir: &Path) -> String {
+    format!("{}:/usr/bin:/bin", bin_dir.display())
+}
+
+#[cfg(unix)]
+fn write_reborn_config(reborn_home: &Path, profile: &str) {
+    std::fs::create_dir_all(reborn_home).expect("reborn home");
+    std::fs::write(
+        reborn_home.join("config.toml"),
+        format!("api_version = \"ironclaw.runtime/v1\"\n\n[boot]\nprofile = \"{profile}\"\n"),
+    )
+    .expect("config");
+}
+
+#[test]
+fn dockerfile_reborn_builds_with_postgres_feature() {
+    let dockerfile = std::fs::read_to_string(workspace_root().join("Dockerfile.reborn"))
+        .expect("Dockerfile.reborn");
+
+    assert!(
+        dockerfile
+            .matches("webui-v2-beta,slack-v2-host-beta,postgres")
+            .count()
+            >= 2,
+        "Dockerfile.reborn must compile both cargo-chef deps and final binary with postgres: {dockerfile}"
+    );
+    assert!(
+        dockerfile.contains("config.production.toml"),
+        "Dockerfile.reborn must ship the opt-in production config: {dockerfile}"
+    );
+}
+
+#[test]
+fn docker_reborn_config_defaults_to_local_dev() {
+    let config = std::fs::read_to_string(workspace_root().join("docker/reborn/config.toml"))
+        .expect("docker reborn config");
+    let parsed = ironclaw_reborn_config::RebornConfigFile::parse_text(
+        &config,
+        &workspace_root().join("docker/reborn/config.toml"),
+    )
+    .expect("docker reborn config parses");
+
+    let boot = parsed.boot.expect("docker config must have [boot]");
+    assert_eq!(boot.profile.as_deref(), Some("local-dev"));
+    assert!(
+        parsed.storage.is_none(),
+        "local Docker config must not require production storage"
+    );
+    assert!(
+        parsed.policy.is_none(),
+        "local Docker config must not include production-only policy"
+    );
+}
+
+#[test]
+fn docker_reborn_production_config_uses_postgres_storage() {
+    let config =
+        std::fs::read_to_string(workspace_root().join("docker/reborn/config.production.toml"))
+            .expect("docker reborn production config");
+    let parsed = ironclaw_reborn_config::RebornConfigFile::parse_text(
+        &config,
+        &workspace_root().join("docker/reborn/config.production.toml"),
+    )
+    .expect("docker reborn production config parses");
+
+    let boot = parsed
+        .boot
+        .expect("docker production config must have [boot]");
+    assert_eq!(boot.profile.as_deref(), Some("production"));
+
+    let storage = parsed.storage.expect("docker config must have [storage]");
+    assert_eq!(
+        storage.backend,
+        Some(ironclaw_reborn_config::StorageBackend::Postgres)
+    );
+    assert_eq!(
+        storage.url_env.as_deref(),
+        Some("IRONCLAW_REBORN_POSTGRES_URL")
+    );
+    assert_eq!(
+        storage.secret_master_key_env.as_deref(),
+        Some("IRONCLAW_REBORN_SECRET_MASTER_KEY")
+    );
+
+    let policy = parsed
+        .policy
+        .expect("docker config must provide the production runtime policy required by #4645");
+    assert_eq!(
+        policy.deployment_mode.as_deref(),
+        Some("hosted_multi_tenant")
+    );
+    assert_eq!(policy.default_profile.as_deref(), Some("secure_default"));
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_reborn_entrypoint_uses_railway_volume_mount_for_home() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    fake_reborn_bin(&bin_dir);
+    let volume = temp.path().join("railway-volume");
+    let reborn_home = volume.join("ironclaw-reborn");
+    write_reborn_config(&reborn_home, "local-dev");
+
+    let output = Command::new("/bin/sh")
+        .arg(workspace_root().join("docker/reborn/entrypoint.sh"))
+        .arg("--help")
+        .env_clear()
+        .env("PATH", fake_bin_path(&bin_dir))
+        .env("HOME", temp.path().join("home"))
+        .env("RAILWAY_ENVIRONMENT", "production")
+        .env("RAILWAY_VOLUME_MOUNT_PATH", &volume)
+        .output()
+        .expect("entrypoint should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!("home={}", reborn_home.display())),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("args=--help"), "stdout: {stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_reborn_entrypoint_rejects_ephemeral_railway_without_volume() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    fake_reborn_bin(&bin_dir);
+    let reborn_home = temp.path().join("reborn-home");
+    write_reborn_config(&reborn_home, "local-dev");
+
+    let output = Command::new("/bin/sh")
+        .arg(workspace_root().join("docker/reborn/entrypoint.sh"))
+        .env_clear()
+        .env("PATH", fake_bin_path(&bin_dir))
+        .env("HOME", temp.path().join("home"))
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("RAILWAY_ENVIRONMENT", "production")
+        .output()
+        .expect("entrypoint should run");
+
+    assert!(!output.status.success(), "entrypoint should fail closed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Railway deployment using profile=local-dev requires a persistent volume"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true"),
+        "stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn docker_reborn_entrypoint_allows_railway_production_without_volume() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    fake_reborn_bin(&bin_dir);
+    let reborn_home = temp.path().join("reborn-home");
+    write_reborn_config(&reborn_home, "production");
+
+    let output = Command::new("/bin/sh")
+        .arg(workspace_root().join("docker/reborn/entrypoint.sh"))
+        .arg("--help")
+        .env_clear()
+        .env("PATH", fake_bin_path(&bin_dir))
+        .env("HOME", temp.path().join("home"))
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_REBORN_PROFILE", "production")
+        .env("RAILWAY_ENVIRONMENT", "production")
+        .output()
+        .expect("entrypoint should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!("home={}", reborn_home.display())),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("args=--help"), "stdout: {stdout}");
 }
 
 #[test]

--- a/docker/reborn/config.production.toml
+++ b/docker/reborn/config.production.toml
@@ -1,0 +1,39 @@
+api_version = "ironclaw.runtime/v1"
+
+[boot]
+profile = "production"
+
+[identity]
+default_owner = "reborn-cli"
+tenant = "reborn-cli"
+default_agent = "reborn-cli-agent"
+
+[policy]
+deployment_mode = "hosted_multi_tenant"
+default_profile = "secure_default"
+
+[runner]
+heartbeat_interval_secs = 5
+poll_interval_ms = 200
+
+[skills]
+regex_activation_enabled = true
+
+[storage]
+backend = "postgres"
+url_env = "IRONCLAW_REBORN_POSTGRES_URL"
+secret_master_key_env = "IRONCLAW_REBORN_SECRET_MASTER_KEY"
+
+[webui]
+env_token_var = "IRONCLAW_REBORN_WEBUI_TOKEN"
+env_user_id_var = "IRONCLAW_REBORN_WEBUI_USER_ID"
+
+[llm.default]
+provider_id = "nearai"
+model = "anthropic/claude-sonnet-4-5"
+api_key_env = "NEARAI_API_KEY"
+
+[slack]
+enabled = false
+signing_secret_env = "IRONCLAW_REBORN_SLACK_SIGNING_SECRET"
+bot_token_env = "IRONCLAW_REBORN_SLACK_BOT_TOKEN"

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -14,13 +14,20 @@ railway_runtime_detected() {
     || [ -n "${RAILWAY_SERVICE_ID:-}" ]
 }
 
+railway_volume_mount=""
+if [ -n "${RAILWAY_VOLUME_MOUNT_PATH:-}" ]; then
+  railway_volume_mount="${RAILWAY_VOLUME_MOUNT_PATH%/}"
+  if [ -z "$railway_volume_mount" ]; then
+    railway_volume_mount="/"
+  fi
+fi
+
 if [ -n "${IRONCLAW_REBORN_HOME:-}" ]; then
   IRONCLAW_REBORN_HOME="${IRONCLAW_REBORN_HOME%/}"
-elif [ -n "${RAILWAY_VOLUME_MOUNT_PATH:-}" ]; then
-  volume_mount="${RAILWAY_VOLUME_MOUNT_PATH%/}"
-  case "$volume_mount" in
-    */ironclaw-reborn) IRONCLAW_REBORN_HOME="$volume_mount" ;;
-    *) IRONCLAW_REBORN_HOME="$volume_mount/ironclaw-reborn" ;;
+elif [ -n "$railway_volume_mount" ]; then
+  case "$railway_volume_mount" in
+    */ironclaw-reborn) IRONCLAW_REBORN_HOME="$railway_volume_mount" ;;
+    *) IRONCLAW_REBORN_HOME="$railway_volume_mount/ironclaw-reborn" ;;
   esac
 else
   IRONCLAW_REBORN_HOME="/data/ironclaw-reborn"
@@ -67,6 +74,9 @@ effective_profile="${IRONCLAW_REBORN_PROFILE:-}"
 if [ -z "$effective_profile" ]; then
   effective_profile="$(sed -n 's/^[[:space:]]*profile[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$config_path" | sed -n '1p')"
 fi
+if [ -z "$effective_profile" ]; then
+  effective_profile="local-dev"
+fi
 
 case "$effective_profile" in
   production|migration-dry-run)
@@ -81,15 +91,24 @@ case "$effective_profile" in
 esac
 
 if railway_runtime_detected \
-  && [ -z "${RAILWAY_VOLUME_MOUNT_PATH:-}" ] \
   && ! is_truthy "${IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY:-}"
 then
   case "$effective_profile" in
     local-dev|local-dev-yolo)
-      echo "Railway deployment using profile=$effective_profile requires a persistent volume for IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME." >&2
-      echo "Attach a Railway volume mounted at /data (or set IRONCLAW_REBORN_HOME under RAILWAY_VOLUME_MOUNT_PATH)." >&2
-      echo "Set IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true only for disposable test deployments." >&2
-      exit 1
+      if [ -z "$railway_volume_mount" ]; then
+        echo "Railway deployment using profile=$effective_profile requires a persistent volume for IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME." >&2
+        echo "Attach a Railway volume mounted at /data (or set IRONCLAW_REBORN_HOME under RAILWAY_VOLUME_MOUNT_PATH)." >&2
+        echo "Set IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true only for disposable test deployments." >&2
+        exit 1
+      fi
+      case "$IRONCLAW_REBORN_HOME" in
+        "$railway_volume_mount"|"$railway_volume_mount"/*) ;;
+        *)
+          echo "Railway deployment using profile=$effective_profile requires IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME to be under RAILWAY_VOLUME_MOUNT_PATH=$railway_volume_mount." >&2
+          echo "Unset IRONCLAW_REBORN_HOME to use $railway_volume_mount/ironclaw-reborn, or set IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true only for disposable tests." >&2
+          exit 1
+          ;;
+      esac
       ;;
   esac
 fi

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -1,9 +1,38 @@
 #!/bin/sh
 set -eu
 
-IRONCLAW_REBORN_HOME="${IRONCLAW_REBORN_HOME:-/data/ironclaw-reborn}"
+is_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+railway_runtime_detected() {
+  [ -n "${RAILWAY_ENVIRONMENT:-}" ] \
+    || [ -n "${RAILWAY_PROJECT_ID:-}" ] \
+    || [ -n "${RAILWAY_SERVICE_ID:-}" ]
+}
+
+if [ -n "${IRONCLAW_REBORN_HOME:-}" ]; then
+  IRONCLAW_REBORN_HOME="${IRONCLAW_REBORN_HOME%/}"
+elif [ -n "${RAILWAY_VOLUME_MOUNT_PATH:-}" ]; then
+  volume_mount="${RAILWAY_VOLUME_MOUNT_PATH%/}"
+  case "$volume_mount" in
+    */ironclaw-reborn) IRONCLAW_REBORN_HOME="$volume_mount" ;;
+    *) IRONCLAW_REBORN_HOME="$volume_mount/ironclaw-reborn" ;;
+  esac
+else
+  IRONCLAW_REBORN_HOME="/data/ironclaw-reborn"
+fi
 export IRONCLAW_REBORN_HOME
-default_config="${IRONCLAW_REBORN_DEFAULT_CONFIG:-/opt/ironclaw/reborn/config.toml}"
+if [ -n "${IRONCLAW_REBORN_DEFAULT_CONFIG:-}" ]; then
+  default_config="$IRONCLAW_REBORN_DEFAULT_CONFIG"
+elif [ "${IRONCLAW_REBORN_PROFILE:-}" = "production" ] || [ "${IRONCLAW_REBORN_PROFILE:-}" = "migration-dry-run" ]; then
+  default_config="/opt/ironclaw/reborn/config.production.toml"
+else
+  default_config="/opt/ironclaw/reborn/config.toml"
+fi
 config_path="$IRONCLAW_REBORN_HOME/config.toml"
 
 case "$default_config" in
@@ -32,6 +61,25 @@ if [ ! -f "$config_path" ]; then
   fi
   rm -f "$tmp_config"
   trap - EXIT HUP INT TERM
+fi
+
+effective_profile="${IRONCLAW_REBORN_PROFILE:-}"
+if [ -z "$effective_profile" ]; then
+  effective_profile="$(sed -n 's/^[[:space:]]*profile[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$config_path" | sed -n '1p')"
+fi
+
+if railway_runtime_detected \
+  && [ -z "${RAILWAY_VOLUME_MOUNT_PATH:-}" ] \
+  && ! is_truthy "${IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY:-}"
+then
+  case "$effective_profile" in
+    local-dev|local-dev-yolo)
+      echo "Railway deployment using profile=$effective_profile requires a persistent volume for IRONCLAW_REBORN_HOME=$IRONCLAW_REBORN_HOME." >&2
+      echo "Attach a Railway volume mounted at /data (or set IRONCLAW_REBORN_HOME under RAILWAY_VOLUME_MOUNT_PATH)." >&2
+      echo "Set IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY=true only for disposable test deployments." >&2
+      exit 1
+      ;;
+  esac
 fi
 
 host="${IRONCLAW_REBORN_SERVE_HOST:-127.0.0.1}"
@@ -64,10 +112,8 @@ fi
 
 set -- serve --host "$host" --port "$port"
 
-case "${IRONCLAW_REBORN_CONFIRM_HOST_ACCESS:-}" in
-  1|true|TRUE|yes|YES)
-    set -- "$@" --confirm-host-access
-    ;;
-esac
+if is_truthy "${IRONCLAW_REBORN_CONFIRM_HOST_ACCESS:-}"; then
+  set -- "$@" --confirm-host-access
+fi
 
 exec ironclaw-reborn "$@"

--- a/docker/reborn/entrypoint.sh
+++ b/docker/reborn/entrypoint.sh
@@ -68,6 +68,18 @@ if [ -z "$effective_profile" ]; then
   effective_profile="$(sed -n 's/^[[:space:]]*profile[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$config_path" | sed -n '1p')"
 fi
 
+case "$effective_profile" in
+  production|migration-dry-run)
+    if ! grep -q '^[[:space:]]*\[storage\][[:space:]]*$' "$config_path" \
+      || ! grep -q '^[[:space:]]*\[policy\][[:space:]]*$' "$config_path"
+    then
+      echo "IRONCLAW_REBORN_PROFILE=$effective_profile requires $config_path to contain [storage] and [policy]." >&2
+      echo "The existing config looks like a stale local-dev seed; remove it to let the entrypoint install $default_config, or migrate it manually." >&2
+      exit 1
+    fi
+    ;;
+esac
+
 if railway_runtime_detected \
   && [ -z "${RAILWAY_VOLUME_MOUNT_PATH:-}" ] \
   && ! is_truthy "${IRONCLAW_REBORN_ALLOW_EPHEMERAL_RAILWAY:-}"


### PR DESCRIPTION
## Summary

- build `Dockerfile.reborn` with the `postgres` feature so the image can run the production Reborn storage path enabled by #4645
- keep the default Docker config on `local-dev` for local users, and add an opt-in `config.production.toml` selected when `IRONCLAW_REBORN_PROFILE=production` or `migration-dry-run`
- make the Docker entrypoint use Railway volume mounts for local-dev state, fail closed for Railway local-dev without a volume, and allow production/Postgres without requiring a Railway volume
- add smoke coverage for Docker feature selection, config parsing, and entrypoint Railway behavior

## Root Cause

#4645 made the production Reborn runtime launchable, but the Railway Docker path still built the CLI without the `postgres` feature and seeded only the local-dev config. In local-dev, extension install/activation state is stored under `$IRONCLAW_REBORN_HOME/local-dev/system/extensions`, so a Railway image redeploy without a persistent volume forces users to set extensions from scratch again.

## Operator Impact

Local Docker users still get the simple local-dev default and do not need Postgres. Railway/production deployments can opt into durable extension state with:

```text
IRONCLAW_REBORN_PROFILE=production
IRONCLAW_REBORN_POSTGRES_URL=postgres://...?sslmode=require
IRONCLAW_REBORN_SECRET_MASTER_KEY=...
IRONCLAW_REBORN_SERVE_HOST=0.0.0.0
```

## Validation

- `/bin/sh -n docker/reborn/entrypoint.sh`
- `cargo fmt -p ironclaw_reborn_cli`
- `cargo test -p ironclaw_reborn_cli docker --features webui-v2-beta,slack-v2-host-beta,postgres -- --nocapture`
- `git diff --check`

Note: the targeted cargo test still emits the existing unrelated `openai_user_id` unused-variable warning in `crates/ironclaw_reborn_composition/src/webui_serve.rs:830`.