### PR TITLE
feat(reborn): project-scoped automation ownership core model

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -823,7 +823,7 @@ Trace Commons issuer/TenantCtx note: the server-side `zmanian/tracedao-server` s
 
 ### P1 - High Priority
 
-- 🚧 Slack channel (real implementation): Reborn host-beta route can be explicitly mounted by `ironclaw-reborn serve` with Slack Events API signing, DM/app-mention routing through Product Workflow/Reborn, final-reply delivery, host-state-backed personal binding pairing, WebUI v2 admin-managed allowed-channel picker, durable WebUI channel-route assignment APIs, and deterministic chat-side connect action metadata; DMs execute as the paired actor, while shared channel turns route to allowed dynamic or static channel subjects and fail closed for unrouted channels in admin-managed mode; production install/setup hardening and fuller E2E coverage remain follow-up.
+- 🚧 Slack channel (real implementation): Reborn host-beta route can be explicitly mounted by `ironclaw-reborn serve` with Slack Events API signing, DM/app-mention routing through Product Workflow/Reborn, final-reply delivery, host-state-backed personal binding pairing, WebUI v2 admin-managed allowed-channel picker, durable WebUI channel-route assignment APIs, provider-side default outbound target inventory for shared channels and explicitly provisioned personal DMs, and deterministic chat-side connect action metadata; DMs execute as the paired actor, while shared channel turns route to allowed dynamic or static channel subjects and fail closed for unrouted channels in admin-managed mode; production install/setup hardening and fuller E2E coverage remain follow-up.
 - ✅ Telegram channel (WASM, polling-first setup, DM pairing, caption, /start)
 - ❌ WhatsApp channel
 - ✅ Multi-provider failover (`FailoverProvider` with retryable error classification)

--- a/crates/ironclaw_conversations/src/filesystem_store.rs
+++ b/crates/ironclaw_conversations/src/filesystem_store.rs
@@ -49,7 +49,7 @@ use crate::{
     ConversationActorPairingService, ConversationBindingResolution, ConversationBindingService,
     ExternalActorRef, ExternalConversationIdentity, InMemoryConversationServices, InboundTurnError,
     LinkConversationRequest, LinkedConversationBinding, ReplyTargetBinding,
-    ResolveConversationRequest, SessionThreadService, ThreadMessageRecord,
+    ResolveConversationRequest, SessionThreadService, ThreadMessageRecord, TrustedOwnerScope,
     ValidateReplyTargetRequest,
     memory::{
         AcceptedMessageReplayKey, ActorKey, BindingKey, BindingRecord, ExternalEventRouteKey,
@@ -506,14 +506,14 @@ impl ConversationBindingService for RebornFilesystemConversationServices {
         request: ResolveConversationRequest,
         trusted_agent_id: Option<ironclaw_host_api::AgentId>,
         trusted_project_id: Option<ironclaw_host_api::ProjectId>,
-        trusted_owner_user_id: Option<ironclaw_host_api::UserId>,
+        trusted_owner: TrustedOwnerScope,
     ) -> Result<ConversationBindingResolution, InboundTurnError> {
         self.inner
             .resolve_or_create_binding_with_trusted_scope(
                 request,
                 trusted_agent_id,
                 trusted_project_id,
-                trusted_owner_user_id,
+                trusted_owner,
             )
             .await
     }

--- a/crates/ironclaw_conversations/src/inbound.rs
+++ b/crates/ironclaw_conversations/src/inbound.rs
@@ -17,7 +17,7 @@ use crate::{
     AdapterInstallationId, AdapterKind, ConversationBindingResolution, ConversationBindingService,
     ConversationRouteKind, ExternalActorRef, ExternalConversationRef, ExternalEventId,
     InboundMessageContentRef, InboundTurnError, InboundTurnRequest, InboundTurnResponse,
-    MessageIdempotencyStatus, ResolveConversationRequest, SessionThreadService,
+    MessageIdempotencyStatus, ResolveConversationRequest, SessionThreadService, TrustedOwnerScope,
 };
 
 #[derive(Clone)]
@@ -53,12 +53,13 @@ where
         &self,
         request: TrustedInboundTurnRequest,
     ) -> Result<InboundTurnResponse, InboundTurnError> {
-        let (request, trusted_agent_id, trusted_project_id) = request.into_parts();
+        let (request, trusted_agent_id, trusted_project_id, trusted_owner) = request.into_parts();
         self.handle_inbound_turn_inner(
             request,
             BindingResolutionPolicy::Trusted {
                 trusted_agent_id,
                 trusted_project_id,
+                trusted_owner,
             },
         )
         .await
@@ -126,13 +127,14 @@ where
             BindingResolutionPolicy::Trusted {
                 trusted_agent_id,
                 trusted_project_id,
+                trusted_owner,
             } => {
                 self.binding_service
                     .resolve_or_create_binding_with_trusted_scope(
                         resolve_request,
                         trusted_agent_id,
                         trusted_project_id,
-                        None,
+                        trusted_owner,
                     )
                     .await?
             }
@@ -350,6 +352,7 @@ enum BindingResolutionPolicy {
     Trusted {
         trusted_agent_id: Option<ironclaw_host_api::AgentId>,
         trusted_project_id: Option<ironclaw_host_api::ProjectId>,
+        trusted_owner: TrustedOwnerScope,
     },
 }
 
@@ -964,7 +967,7 @@ mod tests {
             request: crate::ResolveConversationRequest,
             trusted_agent_id: Option<AgentId>,
             trusted_project_id: Option<ProjectId>,
-            trusted_owner_user_id: Option<UserId>,
+            trusted_owner: crate::TrustedOwnerScope,
         ) -> Result<ConversationBindingResolution, InboundTurnError> {
             self.resolve_requests.lock().unwrap().push(request.clone());
             self.trusted_scopes
@@ -976,7 +979,7 @@ mod tests {
                     request,
                     trusted_agent_id,
                     trusted_project_id,
-                    trusted_owner_user_id,
+                    trusted_owner,
                 )
                 .await
         }
@@ -1040,7 +1043,7 @@ mod tests {
             request: crate::ResolveConversationRequest,
             trusted_agent_id: Option<AgentId>,
             trusted_project_id: Option<ProjectId>,
-            _trusted_owner_user_id: Option<UserId>,
+            _trusted_owner: crate::TrustedOwnerScope,
         ) -> Result<ConversationBindingResolution, InboundTurnError> {
             self.resolve_requests.lock().unwrap().push(request);
             self.trusted_scopes

--- a/crates/ironclaw_conversations/src/lib.rs
+++ b/crates/ironclaw_conversations/src/lib.rs
@@ -41,5 +41,5 @@ pub use types::{
     AcceptedInboundMessageReplay, ConversationBindingResolution, ConversationRouteKind,
     InboundTurnRequest, InboundTurnResponse, LinkConversationRequest, LinkedConversationBinding,
     MessageIdempotencyStatus, ReplyTargetBinding, ResolveConversationRequest, ThreadAccessDecision,
-    ThreadMessageRecord, ValidateReplyTargetRequest,
+    ThreadMessageRecord, TrustedOwnerScope, ValidateReplyTargetRequest,
 };

--- a/crates/ironclaw_conversations/src/memory.rs
+++ b/crates/ironclaw_conversations/src/memory.rs
@@ -21,7 +21,7 @@ use crate::{
     ConversationRouteKind, ExternalActorRef, ExternalConversationIdentity, ExternalConversationRef,
     InboundTurnError, LinkConversationRequest, LinkedConversationBinding, MessageIdempotencyStatus,
     ReplyTargetBinding, ResolveConversationRequest, SessionThreadService, ThreadAccessDecision,
-    ThreadMessageRecord, ValidateReplyTargetRequest,
+    ThreadMessageRecord, TrustedOwnerScope, ValidateReplyTargetRequest,
 };
 
 #[derive(Clone)]
@@ -234,7 +234,8 @@ impl ConversationBindingService for InMemoryConversationServices {
         &self,
         request: ResolveConversationRequest,
     ) -> Result<ConversationBindingResolution, InboundTurnError> {
-        self.resolve_or_create_binding_inner(request, None, None, None)
+        // Untrusted path never carries an ownership claim.
+        self.resolve_or_create_binding_inner(request, None, None, TrustedOwnerScope::Unspecified)
             .await
     }
 
@@ -243,13 +244,13 @@ impl ConversationBindingService for InMemoryConversationServices {
         request: ResolveConversationRequest,
         trusted_agent_id: Option<AgentId>,
         trusted_project_id: Option<ProjectId>,
-        trusted_owner_user_id: Option<UserId>,
+        trusted_owner: TrustedOwnerScope,
     ) -> Result<ConversationBindingResolution, InboundTurnError> {
         self.resolve_or_create_binding_inner(
             request,
             trusted_agent_id,
             trusted_project_id,
-            trusted_owner_user_id,
+            trusted_owner,
         )
         .await
     }
@@ -386,7 +387,7 @@ impl ConversationBindingService for InMemoryConversationServices {
                         request.target_thread_id,
                         target_thread.agent_id,
                         target_thread.project_id,
-                        None,
+                        TrustedOwnerScope::Unspecified,
                     ),
                 )?;
                 let linked = LinkedConversationBinding {
@@ -467,7 +468,7 @@ impl InMemoryConversationServices {
         request: ResolveConversationRequest,
         trusted_agent_id: Option<AgentId>,
         trusted_project_id: Option<ProjectId>,
-        trusted_owner_user_id: Option<UserId>,
+        trusted_owner: TrustedOwnerScope,
     ) -> Result<ConversationBindingResolution, InboundTurnError> {
         let _mutation = self.mutation_lock.lock().await;
         self.refresh_state_from_repository().await?;
@@ -520,10 +521,21 @@ impl InMemoryConversationServices {
                 )?;
                 if request.route_kind == ConversationRouteKind::Shared {
                     state.widen_binding_route_access(&binding_key)?;
-                    if binding.owner_user_id.is_none()
-                        && let Some(owner_user_id) = trusted_owner_user_id.clone()
-                    {
-                        state.set_binding_owner(&binding_key, owner_user_id)?;
+                    // Owner adoption: only for User; Project marks the
+                    // binding explicitly ownerless; Unspecified leaves state
+                    // unchanged.
+                    match &trusted_owner {
+                        TrustedOwnerScope::User(owner_user_id)
+                            if binding.owner_scope() == StoredOwnerScope::Unspecified =>
+                        {
+                            state.set_binding_owner(&binding_key, owner_user_id.clone())?;
+                        }
+                        TrustedOwnerScope::Project
+                            if binding.owner_scope() == StoredOwnerScope::Unspecified =>
+                        {
+                            state.set_binding_ownerless(&binding_key)?;
+                        }
+                        _ => {}
                     }
                 }
                 state.record_external_event_route(
@@ -565,7 +577,7 @@ impl InMemoryConversationServices {
                         thread_id,
                         trusted_agent_id,
                         trusted_project_id,
-                        trusted_owner_user_id,
+                        trusted_owner,
                     ),
                 )?;
                 let resolution =
@@ -909,11 +921,30 @@ impl InMemoryState {
             .get_mut(binding_key)
             .ok_or(InboundTurnError::StatePoisoned)?;
         binding.owner_user_id = Some(owner_user_id.clone());
+        binding.owner_explicitly_ownerless = false;
         if let Some(source_binding) = self
             .source_bindings
             .get_mut(binding.source_binding_ref.as_str())
         {
             source_binding.owner_user_id = Some(owner_user_id.clone());
+            source_binding.owner_explicitly_ownerless = false;
+        }
+        Ok(())
+    }
+
+    fn set_binding_ownerless(&mut self, binding_key: &BindingKey) -> Result<(), InboundTurnError> {
+        let binding = self
+            .bindings
+            .get_mut(binding_key)
+            .ok_or(InboundTurnError::StatePoisoned)?;
+        binding.owner_user_id = None;
+        binding.owner_explicitly_ownerless = true;
+        if let Some(source_binding) = self
+            .source_bindings
+            .get_mut(binding.source_binding_ref.as_str())
+        {
+            source_binding.owner_user_id = None;
+            source_binding.owner_explicitly_ownerless = true;
         }
         Ok(())
     }
@@ -1254,12 +1285,74 @@ impl ReplyTargetRecord {
     }
 }
 
+/// Stored tri-state for thread ownership on a [`BindingRecord`].
+///
+/// This is the persisted representation of [`TrustedOwnerScope`]. The serde
+/// design preserves backward-compat with pre-existing JSON blobs that only
+/// had `owner_user_id: Option<UserId>` and no `owner_explicitly_ownerless`
+/// field:
+///
+/// - Old record with `owner_user_id: Some(u)` → deserializes as `Owned(u)`
+///   (the `owner_explicitly_ownerless` field defaults to `false`, so the
+///   `Some` wins).
+/// - Old record with `owner_user_id` absent or `null` → deserializes as
+///   `Unspecified` (both fields at their defaults).
+/// - New record written as `Ownerless` → `owner_user_id: null` (or absent)
+///   plus `owner_explicitly_ownerless: true`.
+///
+/// Invariant: `Owned(u)` always has `owner_explicitly_ownerless == false`.
+/// `Ownerless` always has `owner_user_id == None`.  `Unspecified` has both
+/// at default.  The `from_fields` / `to_fields` helpers enforce this on
+/// every round-trip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StoredOwnerScope {
+    /// No ownership claim was stored (legacy default).
+    Unspecified,
+    /// Binding is owned by the given user.
+    Owned(UserId),
+    /// Binding is explicitly ownerless (project/shared automation).
+    Ownerless,
+}
+
+impl StoredOwnerScope {
+    /// Decode from the two wire fields that persist on [`BindingRecord`] /
+    /// [`BindingTarget`].
+    fn from_fields(owner_user_id: Option<UserId>, explicitly_ownerless: bool) -> Self {
+        match (owner_user_id, explicitly_ownerless) {
+            (Some(u), _) => Self::Owned(u),
+            (None, true) => Self::Ownerless,
+            (None, false) => Self::Unspecified,
+        }
+    }
+
+    /// Encode into the two wire fields.
+    fn to_fields(&self) -> (Option<UserId>, bool) {
+        match self {
+            Self::Owned(u) => (Some(u.clone()), false),
+            Self::Ownerless => (None, true),
+            Self::Unspecified => (None, false),
+        }
+    }
+}
+
+impl From<TrustedOwnerScope> for StoredOwnerScope {
+    fn from(scope: TrustedOwnerScope) -> Self {
+        match scope {
+            TrustedOwnerScope::Unspecified => Self::Unspecified,
+            TrustedOwnerScope::User(u) => Self::Owned(u),
+            TrustedOwnerScope::Project => Self::Ownerless,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct BindingTarget {
     pub(crate) thread_id: ThreadId,
     pub(crate) agent_id: Option<AgentId>,
     pub(crate) project_id: Option<ProjectId>,
     pub(crate) owner_user_id: Option<UserId>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) owner_explicitly_ownerless: bool,
 }
 
 impl BindingTarget {
@@ -1267,13 +1360,15 @@ impl BindingTarget {
         thread_id: ThreadId,
         agent_id: Option<AgentId>,
         project_id: Option<ProjectId>,
-        owner_user_id: Option<UserId>,
+        owner: TrustedOwnerScope,
     ) -> Self {
+        let (owner_user_id, owner_explicitly_ownerless) = StoredOwnerScope::from(owner).to_fields();
         Self {
             thread_id,
             agent_id,
             project_id,
             owner_user_id,
+            owner_explicitly_ownerless,
         }
     }
 }
@@ -1288,8 +1383,11 @@ pub(crate) struct BindingRecord {
     pub(crate) thread_id: ThreadId,
     pub(crate) agent_id: Option<AgentId>,
     pub(crate) project_id: Option<ProjectId>,
+    /// Stored as two legacy-compat wire fields; use `owner_scope()` to read.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) owner_user_id: Option<UserId>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) owner_explicitly_ownerless: bool,
     pub(crate) route_access: ReplyRouteAccess,
     pub(crate) source_binding_ref: SourceBindingRef,
     pub(crate) reply_target_binding_ref: ReplyTargetBindingRef,
@@ -1320,10 +1418,16 @@ impl BindingRecord {
             agent_id: target.agent_id,
             project_id: target.project_id,
             owner_user_id: target.owner_user_id,
+            owner_explicitly_ownerless: target.owner_explicitly_ownerless,
             route_access,
             source_binding_ref,
             reply_target_binding_ref,
         })
+    }
+
+    /// The decoded tri-state ownership of this binding.
+    pub(crate) fn owner_scope(&self) -> StoredOwnerScope {
+        StoredOwnerScope::from_fields(self.owner_user_id.clone(), self.owner_explicitly_ownerless)
     }
 
     fn resolution(
@@ -1331,15 +1435,25 @@ impl BindingRecord {
         actor_user_id: UserId,
         tenant_id: TenantId,
     ) -> ConversationBindingResolution {
-        let turn_scope = match self.owner_user_id.clone() {
-            Some(owner_user_id) => TurnScope::new_with_owner(
+        // User    -> TurnScope::new_with_owner(..., Some(u))  — explicit personal owner
+        // Project -> TurnScope::new_with_owner(..., None)   — explicit ownerless (project run)
+        // Unspecified -> TurnScope::new(...)                  — legacy, no owner marker
+        let turn_scope = match self.owner_scope() {
+            StoredOwnerScope::Owned(owner_user_id) => TurnScope::new_with_owner(
                 tenant_id.clone(),
                 self.agent_id.clone(),
                 self.project_id.clone(),
                 self.thread_id.clone(),
                 Some(owner_user_id),
             ),
-            None => TurnScope::new(
+            StoredOwnerScope::Ownerless => TurnScope::new_with_owner(
+                tenant_id.clone(),
+                self.agent_id.clone(),
+                self.project_id.clone(),
+                self.thread_id.clone(),
+                None,
+            ),
+            StoredOwnerScope::Unspecified => TurnScope::new(
                 tenant_id.clone(),
                 self.agent_id.clone(),
                 self.project_id.clone(),
@@ -1395,4 +1509,287 @@ pub(crate) struct MessageIdempotencyKey {
     pub(crate) tenant_id: TenantId,
     pub(crate) source_binding_ref: String,
     pub(crate) external_event_id: crate::ExternalEventId,
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{TenantId, ThreadId, UserId};
+
+    use super::{ActorKey, BindingRecord, BindingTarget, ReplyRouteAccess, StoredOwnerScope};
+    use crate::ids::ExternalConversationRef;
+    use crate::{AdapterInstallationId, AdapterKind, ExternalActorRef, TrustedOwnerScope};
+
+    // ── StoredOwnerScope codec round-trips ────────────────────────────────────
+
+    #[test]
+    fn stored_owner_scope_owned_round_trips_through_fields() {
+        let user = UserId::new("alice").unwrap();
+        let scope = StoredOwnerScope::Owned(user.clone());
+        let (owner_user_id, explicitly_ownerless) = scope.to_fields();
+        assert_eq!(owner_user_id.as_ref().map(UserId::as_str), Some("alice"));
+        assert!(!explicitly_ownerless);
+        let decoded = StoredOwnerScope::from_fields(owner_user_id, explicitly_ownerless);
+        assert_eq!(decoded, StoredOwnerScope::Owned(user));
+    }
+
+    #[test]
+    fn stored_owner_scope_ownerless_round_trips_through_fields() {
+        let scope = StoredOwnerScope::Ownerless;
+        let (owner_user_id, explicitly_ownerless) = scope.to_fields();
+        assert!(owner_user_id.is_none());
+        assert!(explicitly_ownerless);
+        let decoded = StoredOwnerScope::from_fields(owner_user_id, explicitly_ownerless);
+        assert_eq!(decoded, StoredOwnerScope::Ownerless);
+    }
+
+    #[test]
+    fn stored_owner_scope_unspecified_round_trips_through_fields() {
+        let scope = StoredOwnerScope::Unspecified;
+        let (owner_user_id, explicitly_ownerless) = scope.to_fields();
+        assert!(owner_user_id.is_none());
+        assert!(!explicitly_ownerless);
+        let decoded = StoredOwnerScope::from_fields(owner_user_id, explicitly_ownerless);
+        assert_eq!(decoded, StoredOwnerScope::Unspecified);
+    }
+
+    // ── Legacy serde compat ───────────────────────────────────────────────────
+
+    /// Legacy records with `owner_user_id: Some(u)` and no
+    /// `owner_explicitly_ownerless` field must deserialize as `Owned(u)`.
+    #[test]
+    fn legacy_binding_record_with_owner_user_id_deserializes_as_owned() {
+        let json = serde_json::json!({
+            "tenant_id": "t1",
+            "adapter_kind": "telegram",
+            "adapter_installation_id": "install-1",
+            "external_conversation_ref": {
+                "space_id": null,
+                "conversation_id": "chat-1",
+                "thread_id": null,
+                "message_id": null
+            },
+            "external_conversation_identity": {
+                "space_id": null,
+                "conversation_id": "chat-1"
+            },
+            "thread_id": "thread-1",
+            "agent_id": null,
+            "project_id": null,
+            "owner_user_id": "alice",
+            // no owner_explicitly_ownerless field — legacy shape
+            "route_access": {
+                "owner_actor_key": {
+                    "tenant_id": "t1",
+                    "adapter_kind": "telegram",
+                    "adapter_installation_id": "install-1",
+                    "external_actor_ref": {
+                        "kind": "user",
+                        "id": "u1"
+                    }
+                },
+                "shared": false
+            },
+            "source_binding_ref": "source:test-1",
+            "reply_target_binding_ref": "reply:test-1"
+        });
+
+        let record: BindingRecord =
+            serde_json::from_value(json).expect("legacy binding must deserialize");
+        assert_eq!(
+            record.owner_scope(),
+            StoredOwnerScope::Owned(UserId::new("alice").unwrap()),
+            "legacy record with owner_user_id must decode as Owned"
+        );
+    }
+
+    /// Legacy records with no `owner_user_id` and no `owner_explicitly_ownerless`
+    /// must deserialize as `Unspecified`.
+    #[test]
+    fn legacy_binding_record_without_owner_user_id_deserializes_as_unspecified() {
+        let json = serde_json::json!({
+            "tenant_id": "t1",
+            "adapter_kind": "telegram",
+            "adapter_installation_id": "install-1",
+            "external_conversation_ref": {
+                "space_id": null,
+                "conversation_id": "chat-2",
+                "thread_id": null,
+                "message_id": null
+            },
+            "external_conversation_identity": {
+                "space_id": null,
+                "conversation_id": "chat-2"
+            },
+            "thread_id": "thread-2",
+            "agent_id": null,
+            "project_id": null,
+            // no owner_user_id, no owner_explicitly_ownerless — legacy shape
+            "route_access": {
+                "owner_actor_key": {
+                    "tenant_id": "t1",
+                    "adapter_kind": "telegram",
+                    "adapter_installation_id": "install-1",
+                    "external_actor_ref": {
+                        "kind": "user",
+                        "id": "u1"
+                    }
+                },
+                "shared": false
+            },
+            "source_binding_ref": "source:test-2",
+            "reply_target_binding_ref": "reply:test-2"
+        });
+
+        let record: BindingRecord =
+            serde_json::from_value(json).expect("legacy binding must deserialize");
+        assert_eq!(
+            record.owner_scope(),
+            StoredOwnerScope::Unspecified,
+            "legacy record without owner_user_id must decode as Unspecified"
+        );
+    }
+
+    /// New records with `owner_explicitly_ownerless: true` must decode as `Ownerless`.
+    #[test]
+    fn new_binding_record_with_explicitly_ownerless_deserializes_as_ownerless() {
+        let json = serde_json::json!({
+            "tenant_id": "t1",
+            "adapter_kind": "telegram",
+            "adapter_installation_id": "install-1",
+            "external_conversation_ref": {
+                "space_id": null,
+                "conversation_id": "chat-3",
+                "thread_id": null,
+                "message_id": null
+            },
+            "external_conversation_identity": {
+                "space_id": null,
+                "conversation_id": "chat-3"
+            },
+            "thread_id": "thread-3",
+            "agent_id": null,
+            "project_id": null,
+            "owner_explicitly_ownerless": true,
+            "route_access": {
+                "owner_actor_key": {
+                    "tenant_id": "t1",
+                    "adapter_kind": "telegram",
+                    "adapter_installation_id": "install-1",
+                    "external_actor_ref": {
+                        "kind": "user",
+                        "id": "u1"
+                    }
+                },
+                "shared": false
+            },
+            "source_binding_ref": "source:test-3",
+            "reply_target_binding_ref": "reply:test-3"
+        });
+
+        let record: BindingRecord =
+            serde_json::from_value(json).expect("ownerless binding must deserialize");
+        assert_eq!(
+            record.owner_scope(),
+            StoredOwnerScope::Ownerless,
+            "record with owner_explicitly_ownerless:true must decode as Ownerless"
+        );
+    }
+
+    // ── BindingRecord::resolution() TurnScope output ──────────────────────────
+
+    fn make_binding_record(target: BindingTarget) -> BindingRecord {
+        let actor_key = ActorKey::new(
+            &TenantId::new("t").unwrap(),
+            &AdapterKind::new("telegram").unwrap(),
+            &AdapterInstallationId::new("inst").unwrap(),
+            &ExternalActorRef::new("user", "u1").unwrap(),
+        );
+        BindingRecord::new(
+            TenantId::new("t").unwrap(),
+            AdapterKind::new("telegram").unwrap(),
+            AdapterInstallationId::new("inst").unwrap(),
+            ExternalConversationRef::new(None, "c1", None, None).unwrap(),
+            ReplyRouteAccess::new(actor_key, crate::ConversationRouteKind::Direct),
+            target,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn resolution_user_emits_turn_scope_with_explicit_owner() {
+        let record = make_binding_record(BindingTarget::new(
+            ThreadId::new("th1").unwrap(),
+            None,
+            None,
+            TrustedOwnerScope::User(UserId::new("alice").unwrap()),
+        ));
+        let resolution =
+            record.resolution(UserId::new("actor").unwrap(), TenantId::new("t").unwrap());
+
+        assert_eq!(
+            resolution
+                .turn_scope
+                .explicit_owner_user_id()
+                .map(UserId::as_str),
+            Some("alice")
+        );
+        assert!(resolution.turn_scope.has_explicit_thread_owner());
+    }
+
+    #[test]
+    fn resolution_project_emits_turn_scope_with_explicit_ownerless_marker() {
+        let record = make_binding_record(BindingTarget::new(
+            ThreadId::new("th2").unwrap(),
+            None,
+            None,
+            TrustedOwnerScope::Project,
+        ));
+        let resolution =
+            record.resolution(UserId::new("actor").unwrap(), TenantId::new("t").unwrap());
+
+        assert_eq!(resolution.turn_scope.explicit_owner_user_id(), None);
+        assert!(
+            resolution.turn_scope.has_explicit_thread_owner(),
+            "Project must produce has_explicit_thread_owner=true"
+        );
+    }
+
+    #[test]
+    fn resolution_unspecified_emits_turn_scope_without_owner_marker() {
+        let record = make_binding_record(BindingTarget::new(
+            ThreadId::new("th3").unwrap(),
+            None,
+            None,
+            TrustedOwnerScope::Unspecified,
+        ));
+        let resolution =
+            record.resolution(UserId::new("actor").unwrap(), TenantId::new("t").unwrap());
+
+        assert_eq!(resolution.turn_scope.explicit_owner_user_id(), None);
+        assert!(
+            !resolution.turn_scope.has_explicit_thread_owner(),
+            "Unspecified must produce has_explicit_thread_owner=false"
+        );
+    }
+
+    // ── from(TrustedOwnerScope) codec ─────────────────────────────────────────
+
+    #[test]
+    fn trusted_owner_scope_user_converts_to_stored_owned() {
+        let user = UserId::new("bob").unwrap();
+        let stored = StoredOwnerScope::from(TrustedOwnerScope::User(user.clone()));
+        assert_eq!(stored, StoredOwnerScope::Owned(user));
+    }
+
+    #[test]
+    fn trusted_owner_scope_project_converts_to_stored_ownerless() {
+        let stored = StoredOwnerScope::from(TrustedOwnerScope::Project);
+        assert_eq!(stored, StoredOwnerScope::Ownerless);
+    }
+
+    #[test]
+    fn trusted_owner_scope_unspecified_converts_to_stored_unspecified() {
+        let stored = StoredOwnerScope::from(TrustedOwnerScope::Unspecified);
+        assert_eq!(stored, StoredOwnerScope::Unspecified);
+    }
 }

--- a/crates/ironclaw_conversations/src/memory.rs
+++ b/crates/ironclaw_conversations/src/memory.rs
@@ -1292,16 +1292,16 @@ impl ReplyTargetRecord {
 /// had `owner_user_id: Option<UserId>` and no `owner_explicitly_ownerless`
 /// field:
 ///
-/// - Old record with `owner_user_id: Some(u)` → deserializes as `Owned(u)`
+/// - Old record with `owner_user_id: Some(u)` → deserializes as `User(u)`
 ///   (the `owner_explicitly_ownerless` field defaults to `false`, so the
 ///   `Some` wins).
 /// - Old record with `owner_user_id` absent or `null` → deserializes as
 ///   `Unspecified` (both fields at their defaults).
-/// - New record written as `Ownerless` → `owner_user_id: null` (or absent)
+/// - New record written as `Project` → `owner_user_id: null` (or absent)
 ///   plus `owner_explicitly_ownerless: true`.
 ///
-/// Invariant: `Owned(u)` always has `owner_explicitly_ownerless == false`.
-/// `Ownerless` always has `owner_user_id == None`.  `Unspecified` has both
+/// Invariant: `User(u)` always has `owner_explicitly_ownerless == false`.
+/// `Project` always has `owner_user_id == None`.  `Unspecified` has both
 /// at default.  The `from_fields` / `to_fields` helpers enforce this on
 /// every round-trip.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1309,9 +1309,9 @@ pub(crate) enum StoredOwnerScope {
     /// No ownership claim was stored (legacy default).
     Unspecified,
     /// Binding is owned by the given user.
-    Owned(UserId),
-    /// Binding is explicitly ownerless (project/shared automation).
-    Ownerless,
+    User(UserId),
+    /// Binding is owned by its project scope (explicitly absent user owner).
+    Project,
 }
 
 impl StoredOwnerScope {
@@ -1319,8 +1319,8 @@ impl StoredOwnerScope {
     /// [`BindingTarget`].
     fn from_fields(owner_user_id: Option<UserId>, explicitly_ownerless: bool) -> Self {
         match (owner_user_id, explicitly_ownerless) {
-            (Some(u), _) => Self::Owned(u),
-            (None, true) => Self::Ownerless,
+            (Some(u), _) => Self::User(u),
+            (None, true) => Self::Project,
             (None, false) => Self::Unspecified,
         }
     }
@@ -1328,8 +1328,8 @@ impl StoredOwnerScope {
     /// Encode into the two wire fields.
     fn to_fields(&self) -> (Option<UserId>, bool) {
         match self {
-            Self::Owned(u) => (Some(u.clone()), false),
-            Self::Ownerless => (None, true),
+            Self::User(u) => (Some(u.clone()), false),
+            Self::Project => (None, true),
             Self::Unspecified => (None, false),
         }
     }
@@ -1339,8 +1339,8 @@ impl From<TrustedOwnerScope> for StoredOwnerScope {
     fn from(scope: TrustedOwnerScope) -> Self {
         match scope {
             TrustedOwnerScope::Unspecified => Self::Unspecified,
-            TrustedOwnerScope::User(u) => Self::Owned(u),
-            TrustedOwnerScope::Project => Self::Ownerless,
+            TrustedOwnerScope::User(u) => Self::User(u),
+            TrustedOwnerScope::Project => Self::Project,
         }
     }
 }
@@ -1436,17 +1436,17 @@ impl BindingRecord {
         tenant_id: TenantId,
     ) -> ConversationBindingResolution {
         // User    -> TurnScope::new_with_owner(..., Some(u))  — explicit personal owner
-        // Project -> TurnScope::new_with_owner(..., None)   — explicit ownerless (project run)
+        // Project -> TurnScope::new_with_owner(..., None)   — explicit project-owned (no user)
         // Unspecified -> TurnScope::new(...)                  — legacy, no owner marker
         let turn_scope = match self.owner_scope() {
-            StoredOwnerScope::Owned(owner_user_id) => TurnScope::new_with_owner(
+            StoredOwnerScope::User(owner_user_id) => TurnScope::new_with_owner(
                 tenant_id.clone(),
                 self.agent_id.clone(),
                 self.project_id.clone(),
                 self.thread_id.clone(),
                 Some(owner_user_id),
             ),
-            StoredOwnerScope::Ownerless => TurnScope::new_with_owner(
+            StoredOwnerScope::Project => TurnScope::new_with_owner(
                 tenant_id.clone(),
                 self.agent_id.clone(),
                 self.project_id.clone(),
@@ -1522,24 +1522,24 @@ mod tests {
     // ── StoredOwnerScope codec round-trips ────────────────────────────────────
 
     #[test]
-    fn stored_owner_scope_owned_round_trips_through_fields() {
+    fn stored_owner_scope_user_round_trips_through_fields() {
         let user = UserId::new("alice").unwrap();
-        let scope = StoredOwnerScope::Owned(user.clone());
+        let scope = StoredOwnerScope::User(user.clone());
         let (owner_user_id, explicitly_ownerless) = scope.to_fields();
         assert_eq!(owner_user_id.as_ref().map(UserId::as_str), Some("alice"));
         assert!(!explicitly_ownerless);
         let decoded = StoredOwnerScope::from_fields(owner_user_id, explicitly_ownerless);
-        assert_eq!(decoded, StoredOwnerScope::Owned(user));
+        assert_eq!(decoded, StoredOwnerScope::User(user));
     }
 
     #[test]
-    fn stored_owner_scope_ownerless_round_trips_through_fields() {
-        let scope = StoredOwnerScope::Ownerless;
+    fn stored_owner_scope_project_round_trips_through_fields() {
+        let scope = StoredOwnerScope::Project;
         let (owner_user_id, explicitly_ownerless) = scope.to_fields();
         assert!(owner_user_id.is_none());
         assert!(explicitly_ownerless);
         let decoded = StoredOwnerScope::from_fields(owner_user_id, explicitly_ownerless);
-        assert_eq!(decoded, StoredOwnerScope::Ownerless);
+        assert_eq!(decoded, StoredOwnerScope::Project);
     }
 
     #[test]
@@ -1555,9 +1555,9 @@ mod tests {
     // ── Legacy serde compat ───────────────────────────────────────────────────
 
     /// Legacy records with `owner_user_id: Some(u)` and no
-    /// `owner_explicitly_ownerless` field must deserialize as `Owned(u)`.
+    /// `owner_explicitly_ownerless` field must deserialize as `User(u)`.
     #[test]
-    fn legacy_binding_record_with_owner_user_id_deserializes_as_owned() {
+    fn legacy_binding_record_with_owner_user_id_deserializes_as_user() {
         let json = serde_json::json!({
             "tenant_id": "t1",
             "adapter_kind": "telegram",
@@ -1597,8 +1597,8 @@ mod tests {
             serde_json::from_value(json).expect("legacy binding must deserialize");
         assert_eq!(
             record.owner_scope(),
-            StoredOwnerScope::Owned(UserId::new("alice").unwrap()),
-            "legacy record with owner_user_id must decode as Owned"
+            StoredOwnerScope::User(UserId::new("alice").unwrap()),
+            "legacy record with owner_user_id must decode as User"
         );
     }
 
@@ -1649,9 +1649,9 @@ mod tests {
         );
     }
 
-    /// New records with `owner_explicitly_ownerless: true` must decode as `Ownerless`.
+    /// New records with `owner_explicitly_ownerless: true` must decode as `Project`.
     #[test]
-    fn new_binding_record_with_explicitly_ownerless_deserializes_as_ownerless() {
+    fn new_binding_record_with_explicitly_ownerless_deserializes_as_project() {
         let json = serde_json::json!({
             "tenant_id": "t1",
             "adapter_kind": "telegram",
@@ -1690,8 +1690,8 @@ mod tests {
             serde_json::from_value(json).expect("ownerless binding must deserialize");
         assert_eq!(
             record.owner_scope(),
-            StoredOwnerScope::Ownerless,
-            "record with owner_explicitly_ownerless:true must decode as Ownerless"
+            StoredOwnerScope::Project,
+            "record with owner_explicitly_ownerless:true must decode as Project"
         );
     }
 
@@ -1775,16 +1775,16 @@ mod tests {
     // ── from(TrustedOwnerScope) codec ─────────────────────────────────────────
 
     #[test]
-    fn trusted_owner_scope_user_converts_to_stored_owned() {
+    fn trusted_owner_scope_user_converts_to_stored_user() {
         let user = UserId::new("bob").unwrap();
         let stored = StoredOwnerScope::from(TrustedOwnerScope::User(user.clone()));
-        assert_eq!(stored, StoredOwnerScope::Owned(user));
+        assert_eq!(stored, StoredOwnerScope::User(user));
     }
 
     #[test]
-    fn trusted_owner_scope_project_converts_to_stored_ownerless() {
+    fn trusted_owner_scope_project_converts_to_stored_project() {
         let stored = StoredOwnerScope::from(TrustedOwnerScope::Project);
-        assert_eq!(stored, StoredOwnerScope::Ownerless);
+        assert_eq!(stored, StoredOwnerScope::Project);
     }
 
     #[test]

--- a/crates/ironclaw_conversations/src/traits.rs
+++ b/crates/ironclaw_conversations/src/traits.rs
@@ -5,7 +5,7 @@ use crate::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageLookup,
     AcceptedInboundMessageReplay, AdapterInstallationId, AdapterKind,
     ConversationBindingResolution, ExternalActorRef, InboundTurnError, LinkConversationRequest,
-    LinkedConversationBinding, ReplyTargetBinding, ResolveConversationRequest,
+    LinkedConversationBinding, ReplyTargetBinding, ResolveConversationRequest, TrustedOwnerScope,
     ValidateReplyTargetRequest,
 };
 
@@ -23,14 +23,26 @@ pub trait ConversationBindingService: Send + Sync {
     /// The trusted scope must come from host configuration, not adapter input.
     /// Implementations that persist bindings should persist these values on
     /// first bind so later configuration changes do not silently reinterpret
-    /// the existing external conversation route. `trusted_owner_user_id`, when
-    /// present, is the explicit thread owner for that first-bound route.
+    /// the existing external conversation route.
+    ///
+    /// `trusted_owner` controls thread ownership for the binding:
+    /// - `TrustedOwnerScope::Unspecified` — no ownership claim; no stored-state
+    ///   change (equivalent to the former `trusted_owner_user_id: None`).
+    /// - `TrustedOwnerScope::User(user_id)` — the binding is owned by the named
+    ///   user on first bind; may be adopted on shared-route re-entry when the
+    ///   stored owner is absent (equivalent to the former `Some(user_id)`).
+    /// - `TrustedOwnerScope::Project` — the binding is explicitly owned by the
+    ///   binding's project scope (no personal user owner).
+    ///   `BindingRecord::resolution()` emits
+    ///   `TurnScope::new_with_owner(..., None)`, carrying the explicit-ownerless
+    ///   marker through to the run's scope. Raw adapter paths must not reach
+    ///   this variant; `resolve_or_create_binding` always uses `Unspecified`.
     async fn resolve_or_create_binding_with_trusted_scope(
         &self,
         request: ResolveConversationRequest,
         trusted_agent_id: Option<ironclaw_host_api::AgentId>,
         trusted_project_id: Option<ironclaw_host_api::ProjectId>,
-        trusted_owner_user_id: Option<ironclaw_host_api::UserId>,
+        trusted_owner: TrustedOwnerScope,
     ) -> Result<ConversationBindingResolution, InboundTurnError>;
 
     /// Look up an existing binding without creating or widening binding state.

--- a/crates/ironclaw_conversations/src/traits.rs
+++ b/crates/ironclaw_conversations/src/traits.rs
@@ -31,10 +31,11 @@ pub trait ConversationBindingService: Send + Sync {
     /// - `TrustedOwnerScope::User(user_id)` — the binding is owned by the named
     ///   user on first bind; may be adopted on shared-route re-entry when the
     ///   stored owner is absent (equivalent to the former `Some(user_id)`).
-    /// - `TrustedOwnerScope::Project` — the binding is explicitly owned by the
-    ///   binding's project scope (no personal user owner).
-    ///   `BindingRecord::resolution()` emits
-    ///   `TurnScope::new_with_owner(..., None)`, carrying the explicit-ownerless
+    /// - `TrustedOwnerScope::Project` — the binding is owned by its project scope
+    ///   (no personal user owner); encoded as an explicitly absent user owner
+    ///   (the explicit-None turn-scope encoding) until the ownership-principal
+    ///   enum lands. `BindingRecord::resolution()` emits
+    ///   `TurnScope::new_with_owner(..., None)`, carrying the explicit-absent-user
     ///   marker through to the run's scope. Raw adapter paths must not reach
     ///   this variant; `resolve_or_create_binding` always uses `Unspecified`.
     async fn resolve_or_create_binding_with_trusted_scope(

--- a/crates/ironclaw_conversations/src/types.rs
+++ b/crates/ironclaw_conversations/src/types.rs
@@ -11,6 +11,35 @@ use crate::{
     InboundMessageContentRef,
 };
 
+/// Host-owned authority over a binding's thread ownership that a trusted caller
+/// may supply when resolving or creating a conversation binding.
+///
+/// This enum is trusted-scope–only input. Raw adapter paths (i.e.
+/// `resolve_or_create_binding` without trusted scope) must not be able to
+/// express `Project`; they must always pass or receive `Unspecified`.
+///
+/// Variants:
+/// - `Unspecified` – the caller makes no ownership claim; existing stored
+///   ownership is unchanged and new bindings receive no stored owner.
+///   Equivalent to the former `trusted_owner_user_id: None` path.
+/// - `User(UserId)` – the binding is owned by the named user; stored on first
+///   bind and may be adopted on shared-route re-entry when the binding has no
+///   stored owner. Equivalent to the former `trusted_owner_user_id: Some(u)`.
+/// - `Project` – the caller explicitly asserts the binding has no personal
+///   owner (owned by the binding's project scope). The binding's ownerless
+///   state is stored and `BindingRecord::resolution()` emits
+///   `TurnScope::new_with_owner(..., None)`, carrying the explicit-ownerless
+///   marker through to the run's scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustedOwnerScope {
+    /// No ownership claim from the caller; no stored-state change.
+    Unspecified,
+    /// Explicit personal ownership by the given user.
+    User(UserId),
+    /// Explicitly project-owned (no personal user owner).
+    Project,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConversationRouteKind {
@@ -170,6 +199,7 @@ pub(crate) struct TrustedInboundTurnRequest {
     request: InboundTurnRequest,
     trusted_agent_id: Option<AgentId>,
     trusted_project_id: Option<ProjectId>,
+    trusted_owner: TrustedOwnerScope,
 }
 
 impl TrustedInboundTurnRequest {
@@ -182,11 +212,45 @@ impl TrustedInboundTurnRequest {
             request,
             trusted_agent_id,
             trusted_project_id,
+            // Default to Unspecified when the caller (e.g. existing trigger
+            // materializer) does not yet supply an explicit owner scope.
+            trusted_owner: TrustedOwnerScope::Unspecified,
         }
     }
 
-    pub(crate) fn into_parts(self) -> (InboundTurnRequest, Option<AgentId>, Option<ProjectId>) {
-        (self.request, self.trusted_agent_id, self.trusted_project_id)
+    /// Construct a trusted request with an explicit owner scope.
+    ///
+    /// Called by the composition materializer (wave-2 workstream) to pass
+    /// `Owned(creator)` for personal fires and `Ownerless` for project fires.
+    #[allow(dead_code)] // used by ironclaw_reborn_composition (wave 2)
+    pub(crate) fn new_with_owner(
+        request: InboundTurnRequest,
+        trusted_agent_id: Option<AgentId>,
+        trusted_project_id: Option<ProjectId>,
+        trusted_owner: TrustedOwnerScope,
+    ) -> Self {
+        Self {
+            request,
+            trusted_agent_id,
+            trusted_project_id,
+            trusted_owner,
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        InboundTurnRequest,
+        Option<AgentId>,
+        Option<ProjectId>,
+        TrustedOwnerScope,
+    ) {
+        (
+            self.request,
+            self.trusted_agent_id,
+            self.trusted_project_id,
+            self.trusted_owner,
+        )
     }
 }
 

--- a/crates/ironclaw_conversations/src/types.rs
+++ b/crates/ironclaw_conversations/src/types.rs
@@ -221,7 +221,7 @@ impl TrustedInboundTurnRequest {
     /// Construct a trusted request with an explicit owner scope.
     ///
     /// Called by the composition materializer (wave-2 workstream) to pass
-    /// `Owned(creator)` for personal fires and `Ownerless` for project fires.
+    /// `User(creator)` for personal fires and `Project` for project fires.
     #[allow(dead_code)] // used by ironclaw_reborn_composition (wave 2)
     pub(crate) fn new_with_owner(
         request: InboundTurnRequest,

--- a/crates/ironclaw_conversations/tests/inbound_contract.rs
+++ b/crates/ironclaw_conversations/tests/inbound_contract.rs
@@ -10,7 +10,7 @@ use ironclaw_conversations::{
     InMemoryConversationServices, InboundMessageContentRef, InboundTurnError, InboundTurnRequest,
     InboundTurnService, LinkConversationRequest, LinkedConversationBinding,
     MessageIdempotencyStatus, ReplyTargetBinding, SessionThreadService, ThreadAccessDecision,
-    ValidateReplyTargetRequest,
+    TrustedOwnerScope, ValidateReplyTargetRequest,
 };
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
@@ -219,7 +219,7 @@ async fn trusted_scope_is_persisted_on_first_bind() {
             ),
             Some(AgentId::new("agent-alpha").unwrap()),
             Some(ProjectId::new("project-alpha").unwrap()),
-            None,
+            TrustedOwnerScope::Unspecified,
         )
         .await
         .expect("first bind");
@@ -239,7 +239,7 @@ async fn trusted_scope_is_persisted_on_first_bind() {
             ),
             Some(AgentId::new("agent-beta").unwrap()),
             Some(ProjectId::new("project-beta").unwrap()),
-            None,
+            TrustedOwnerScope::Unspecified,
         )
         .await
         .expect("existing bind");
@@ -277,7 +277,7 @@ async fn trusted_owner_is_persisted_on_first_bind() {
             ),
             Some(AgentId::new("agent-alpha").unwrap()),
             Some(ProjectId::new("project-alpha").unwrap()),
-            Some(user("owner-alpha")),
+            TrustedOwnerScope::User(user("owner-alpha")),
         )
         .await
         .expect("first bind");
@@ -299,7 +299,7 @@ async fn trusted_owner_is_persisted_on_first_bind() {
             ),
             Some(AgentId::new("agent-alpha").unwrap()),
             Some(ProjectId::new("project-alpha").unwrap()),
-            Some(user("owner-beta")),
+            TrustedOwnerScope::User(user("owner-beta")),
         )
         .await
         .expect("existing bind");
@@ -362,7 +362,7 @@ async fn trusted_scope_rejects_existing_unscoped_binding() {
             trusted_shared,
             Some(AgentId::new("agent-alpha").unwrap()),
             Some(ProjectId::new("project-alpha").unwrap()),
-            None,
+            TrustedOwnerScope::Unspecified,
         )
         .await
         .expect_err("trusted scope must not reinterpret legacy bindings");
@@ -419,7 +419,7 @@ async fn trusted_owner_backfills_legacy_shared_binding() {
             trusted_owner_shared,
             None,
             None,
-            Some(user("owner-alpha")),
+            TrustedOwnerScope::User(user("owner-alpha")),
         )
         .await
         .expect("trusted owner should backfill legacy shared binding");
@@ -2881,7 +2881,7 @@ impl ConversationBindingService for DriftBindingService {
         request: ironclaw_conversations::ResolveConversationRequest,
         _trusted_agent_id: Option<AgentId>,
         _trusted_project_id: Option<ProjectId>,
-        _trusted_owner_user_id: Option<UserId>,
+        _trusted_owner: TrustedOwnerScope,
     ) -> Result<ConversationBindingResolution, InboundTurnError> {
         self.resolve_or_create_binding(request).await
     }
@@ -2955,7 +2955,7 @@ impl ConversationBindingService for UntrustedOnlyBindingService {
         _request: ironclaw_conversations::ResolveConversationRequest,
         _trusted_agent_id: Option<AgentId>,
         _trusted_project_id: Option<ProjectId>,
-        _trusted_owner_user_id: Option<UserId>,
+        _trusted_owner: TrustedOwnerScope,
     ) -> Result<ConversationBindingResolution, InboundTurnError> {
         *self.trusted_calls.lock().unwrap() += 1;
         panic!("untrusted inbound must not call trusted resolver path")
@@ -3218,4 +3218,370 @@ fn accepted_response(request: SubmitTurnRequest) -> SubmitTurnResponse {
         accepted_message_ref: request.accepted_message_ref,
         reply_target_binding_ref: request.reply_target_binding_ref,
     }
+}
+
+// ── TrustedOwnerScope / TurnScope contract tests ─────────────────────────────
+
+#[tokio::test]
+async fn owned_scope_produces_turn_scope_with_explicit_owner() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    let resolution = services
+        .resolve_or_create_binding_with_trusted_scope(
+            resolve_request(
+                telegram(),
+                external_actor("telegram-user-1"),
+                external_conversation("chat-owned-scope", None),
+                "event-owned-scope-1",
+            ),
+            Some(agent()),
+            Some(project()),
+            TrustedOwnerScope::User(user("alice")),
+        )
+        .await
+        .expect("owned scope binding");
+
+    assert_eq!(
+        resolution
+            .turn_scope
+            .explicit_owner_user_id()
+            .map(UserId::as_str),
+        Some("alice"),
+        "Owned scope must produce explicit owner in TurnScope"
+    );
+    assert!(
+        resolution.turn_scope.has_explicit_thread_owner(),
+        "has_explicit_thread_owner must be true for Owned scope"
+    );
+}
+
+#[tokio::test]
+async fn ownerless_scope_produces_turn_scope_with_explicit_ownerless_marker() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    let resolution = services
+        .resolve_or_create_binding_with_trusted_scope(
+            resolve_request(
+                telegram(),
+                external_actor("telegram-user-1"),
+                external_conversation("chat-ownerless-scope", None),
+                "event-ownerless-scope-1",
+            ),
+            Some(agent()),
+            Some(project()),
+            TrustedOwnerScope::Project,
+        )
+        .await
+        .expect("ownerless scope binding");
+
+    assert_eq!(
+        resolution.turn_scope.explicit_owner_user_id(),
+        None,
+        "Ownerless scope must carry no owner user id"
+    );
+    assert!(
+        resolution.turn_scope.has_explicit_thread_owner(),
+        "has_explicit_thread_owner must be true for explicitly ownerless scope"
+    );
+}
+
+#[tokio::test]
+async fn unspecified_scope_produces_turn_scope_without_owner_marker() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    let resolution = services
+        .resolve_or_create_binding_with_trusted_scope(
+            resolve_request(
+                telegram(),
+                external_actor("telegram-user-1"),
+                external_conversation("chat-unspecified-scope", None),
+                "event-unspecified-scope-1",
+            ),
+            Some(agent()),
+            Some(project()),
+            TrustedOwnerScope::Unspecified,
+        )
+        .await
+        .expect("unspecified scope binding");
+
+    assert_eq!(
+        resolution.turn_scope.explicit_owner_user_id(),
+        None,
+        "Unspecified scope must carry no owner user id"
+    );
+    assert!(
+        !resolution.turn_scope.has_explicit_thread_owner(),
+        "has_explicit_thread_owner must be false for Unspecified scope"
+    );
+}
+
+// ── Adoption rule tests ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn owned_adopts_binding_when_stored_scope_is_unspecified_on_shared_route() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    // First bind: no owner (Unspecified)
+    let legacy = services
+        .resolve_or_create_binding(resolve_request(
+            telegram(),
+            external_actor("telegram-user-1"),
+            external_conversation("chat-adopt-owned", None),
+            "event-adopt-owned-1",
+        ))
+        .await
+        .expect("legacy unscoped bind");
+    assert!(!legacy.turn_scope.has_explicit_thread_owner());
+
+    // Shared re-entry with Owned: should adopt the owner
+    let mut shared_req = resolve_request(
+        telegram(),
+        external_actor("telegram-user-1"),
+        external_conversation("chat-adopt-owned", None),
+        "event-adopt-owned-2",
+    );
+    shared_req.route_kind = ConversationRouteKind::Shared;
+    let adopted = services
+        .resolve_or_create_binding_with_trusted_scope(
+            shared_req,
+            None,
+            None,
+            TrustedOwnerScope::User(user("alice")),
+        )
+        .await
+        .expect("adoption should succeed");
+
+    assert_eq!(
+        adopted
+            .turn_scope
+            .explicit_owner_user_id()
+            .map(UserId::as_str),
+        Some("alice"),
+        "Owned adoption must store and return the owner"
+    );
+    assert!(adopted.turn_scope.has_explicit_thread_owner());
+}
+
+#[tokio::test]
+async fn ownerless_marks_binding_when_stored_scope_is_unspecified_on_shared_route() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    // First bind: no owner (Unspecified)
+    let legacy = services
+        .resolve_or_create_binding(resolve_request(
+            telegram(),
+            external_actor("telegram-user-1"),
+            external_conversation("chat-adopt-ownerless", None),
+            "event-adopt-ownerless-1",
+        ))
+        .await
+        .expect("legacy unscoped bind");
+    assert!(!legacy.turn_scope.has_explicit_thread_owner());
+
+    // Shared re-entry with Ownerless: should mark binding as explicitly ownerless
+    let mut shared_req = resolve_request(
+        telegram(),
+        external_actor("telegram-user-1"),
+        external_conversation("chat-adopt-ownerless", None),
+        "event-adopt-ownerless-2",
+    );
+    shared_req.route_kind = ConversationRouteKind::Shared;
+    let marked = services
+        .resolve_or_create_binding_with_trusted_scope(
+            shared_req,
+            None,
+            None,
+            TrustedOwnerScope::Project,
+        )
+        .await
+        .expect("ownerless mark should succeed");
+
+    assert_eq!(marked.turn_scope.explicit_owner_user_id(), None);
+    assert!(
+        marked.turn_scope.has_explicit_thread_owner(),
+        "has_explicit_thread_owner must be true after Ownerless adoption"
+    );
+}
+
+#[tokio::test]
+async fn unspecified_does_not_change_stored_scope_on_re_entry() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    // First bind: no owner (Unspecified)
+    services
+        .resolve_or_create_binding(resolve_request(
+            telegram(),
+            external_actor("telegram-user-1"),
+            external_conversation("chat-unspecified-adopt", None),
+            "event-unspecified-adopt-1",
+        ))
+        .await
+        .expect("legacy unscoped bind");
+
+    // Shared re-entry with Unspecified: must not change stored scope
+    let mut shared_req = resolve_request(
+        telegram(),
+        external_actor("telegram-user-1"),
+        external_conversation("chat-unspecified-adopt", None),
+        "event-unspecified-adopt-2",
+    );
+    shared_req.route_kind = ConversationRouteKind::Shared;
+    let unchanged = services
+        .resolve_or_create_binding_with_trusted_scope(
+            shared_req,
+            None,
+            None,
+            TrustedOwnerScope::Unspecified,
+        )
+        .await
+        .expect("unspecified re-entry should succeed");
+
+    assert!(!unchanged.turn_scope.has_explicit_thread_owner());
+    assert_eq!(unchanged.turn_scope.explicit_owner_user_id(), None);
+}
+
+#[tokio::test]
+async fn owned_does_not_overwrite_already_owned_binding() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    // First bind with owner-alpha
+    services
+        .resolve_or_create_binding_with_trusted_scope(
+            resolve_request(
+                telegram(),
+                external_actor("telegram-user-1"),
+                external_conversation("chat-no-overwrite-owned", None),
+                "event-no-overwrite-owned-1",
+            ),
+            None,
+            None,
+            TrustedOwnerScope::User(user("owner-alpha")),
+        )
+        .await
+        .expect("first owned bind");
+
+    // Shared re-entry with different Owned: must not overwrite
+    let mut shared_req = resolve_request(
+        telegram(),
+        external_actor("telegram-user-1"),
+        external_conversation("chat-no-overwrite-owned", None),
+        "event-no-overwrite-owned-2",
+    );
+    shared_req.route_kind = ConversationRouteKind::Shared;
+    let second = services
+        .resolve_or_create_binding_with_trusted_scope(
+            shared_req,
+            None,
+            None,
+            TrustedOwnerScope::User(user("owner-beta")),
+        )
+        .await
+        .expect("second owned re-entry");
+
+    assert_eq!(
+        second
+            .turn_scope
+            .explicit_owner_user_id()
+            .map(UserId::as_str),
+        Some("owner-alpha"),
+        "Owned adoption must not overwrite an already-Owned binding"
+    );
+}
+
+// ── Legacy serde round-trip tests ────────────────────────────────────────────
+// BindingRecord is pub(crate) — these tests use the public binding service
+// to exercise the serde round-trip indirectly via FilesystemConversationStateStore.
+// The internal serde unit tests live in memory.rs (in-crate mod tests).
+
+/// Raw (untrusted) adapter path must never reach Ownerless scope — it always
+/// passes `TrustedOwnerScope::Unspecified` internally.
+#[tokio::test]
+async fn untrusted_resolve_or_create_binding_never_sets_ownerless_marker() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await;
+
+    let resolution = services
+        .resolve_or_create_binding(resolve_request(
+            telegram(),
+            external_actor("telegram-user-1"),
+            external_conversation("chat-untrusted-no-ownerless", None),
+            "event-untrusted-no-ownerless-1",
+        ))
+        .await
+        .expect("untrusted bind");
+
+    // Untrusted path: no explicit owner marker regardless of input.
+    assert!(!resolution.turn_scope.has_explicit_thread_owner());
+    assert_eq!(resolution.turn_scope.explicit_owner_user_id(), None);
 }

--- a/crates/ironclaw_conversations/tests/inbound_contract.rs
+++ b/crates/ironclaw_conversations/tests/inbound_contract.rs
@@ -3295,11 +3295,11 @@ async fn ownerless_scope_produces_turn_scope_with_explicit_ownerless_marker() {
     assert_eq!(
         resolution.turn_scope.explicit_owner_user_id(),
         None,
-        "Ownerless scope must carry no owner user id"
+        "Project scope must carry no owner user id"
     );
     assert!(
         resolution.turn_scope.has_explicit_thread_owner(),
-        "has_explicit_thread_owner must be true for explicitly ownerless scope"
+        "has_explicit_thread_owner must be true for explicitly project-owned scope"
     );
 }
 
@@ -3423,7 +3423,7 @@ async fn ownerless_marks_binding_when_stored_scope_is_unspecified_on_shared_rout
         .expect("legacy unscoped bind");
     assert!(!legacy.turn_scope.has_explicit_thread_owner());
 
-    // Shared re-entry with Ownerless: should mark binding as explicitly ownerless
+    // Shared re-entry with Project: should mark binding as project-owned (explicitly absent user)
     let mut shared_req = resolve_request(
         telegram(),
         external_actor("telegram-user-1"),
@@ -3444,7 +3444,7 @@ async fn ownerless_marks_binding_when_stored_scope_is_unspecified_on_shared_rout
     assert_eq!(marked.turn_scope.explicit_owner_user_id(), None);
     assert!(
         marked.turn_scope.has_explicit_thread_owner(),
-        "has_explicit_thread_owner must be true after Ownerless adoption"
+        "has_explicit_thread_owner must be true after Project-scope adoption"
     );
 }
 
@@ -3556,7 +3556,7 @@ async fn owned_does_not_overwrite_already_owned_binding() {
 // to exercise the serde round-trip indirectly via FilesystemConversationStateStore.
 // The internal serde unit tests live in memory.rs (in-crate mod tests).
 
-/// Raw (untrusted) adapter path must never reach Ownerless scope — it always
+/// Raw (untrusted) adapter path must never reach Project scope — it always
 /// passes `TrustedOwnerScope::Unspecified` internally.
 #[tokio::test]
 async fn untrusted_resolve_or_create_binding_never_sets_ownerless_marker() {

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -218,6 +218,22 @@ pub fn builtin_first_party_handlers_with_trigger_create_hook(
     Ok(registry)
 }
 
+/// Create handlers for all built-in first-party capabilities with project
+/// trigger creation authority. Use only on trusted surfaces where the
+/// `project` ownership scope is permitted.
+pub fn builtin_first_party_handlers_with_project_trigger_authority(
+    trigger_repository: Arc<dyn ironclaw_triggers::TriggerRepository>,
+    trigger_create_hook: Arc<dyn TriggerCreateHook>,
+) -> Result<FirstPartyCapabilityRegistry, HostApiError> {
+    let mut registry = builtin_first_party_base_registry()?;
+    trigger_management::insert_handlers_with_project_authority(
+        &mut registry,
+        trigger_repository,
+        trigger_create_hook,
+    )?;
+    Ok(registry)
+}
+
 #[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]
 pub fn builtin_first_party_handlers_with_trigger_clock(

--- a/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/schemas.rs
@@ -316,7 +316,12 @@ pub(crate) fn resolve_builtin_input_schema_ref(reference: &str) -> Option<Value>
                     "type": "string",
                     "description": "Prompt submitted when the trigger fires. Runtime validation caps UTF-8 content at 32768 bytes."
                 },
-                "cron": { "type": "string", "description": "Five-, six-, or seven-field cron expression; fire cadence must be at least one minute" }
+                "cron": { "type": "string", "description": "Five-, six-, or seven-field cron expression; fire cadence must be at least one minute" },
+                "ownership_scope": {
+                    "type": "string",
+                    "enum": ["personal", "project"],
+                    "description": "Delivery ownership for trigger fires. Defaults to personal. Use project only for project automation contexts where the trigger belongs to a project rather than an individual user."
+                }
             },
             "required": ["name", "prompt", "cron"],
             "additionalProperties": false

--- a/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/trigger_management.rs
@@ -8,8 +8,8 @@ use ironclaw_host_api::{
     RuntimeDispatchErrorKind,
 };
 use ironclaw_triggers::{
-    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
-    TriggerRunRecord, TriggerSchedule, TriggerSourceKind, TriggerState,
+    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerOwnershipScope, TriggerRecord,
+    TriggerRepository, TriggerRunRecord, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -76,6 +76,23 @@ pub(super) fn insert_handlers_with_create_hook(
             repository,
             create_hook,
             clock: Arc::new(SystemTriggerManagementClock),
+            allow_project_ownership: false,
+        }),
+    )
+}
+
+pub(super) fn insert_handlers_with_project_authority(
+    registry: &mut FirstPartyCapabilityRegistry,
+    repository: Arc<dyn TriggerRepository>,
+    create_hook: Arc<dyn TriggerCreateHook>,
+) -> Result<(), HostApiError> {
+    insert_trigger_handlers(
+        registry,
+        Arc::new(TriggerManagementToolHandler {
+            repository,
+            create_hook,
+            clock: Arc::new(SystemTriggerManagementClock),
+            allow_project_ownership: true,
         }),
     )
 }
@@ -92,6 +109,7 @@ pub(super) fn insert_handlers_with_clock(
             repository,
             create_hook: Arc::new(NoopTriggerCreateHook),
             clock,
+            allow_project_ownership: false,
         }),
     )
 }
@@ -151,6 +169,7 @@ struct TriggerManagementToolHandler {
     repository: Arc<dyn TriggerRepository>,
     create_hook: Arc<dyn TriggerCreateHook>,
     clock: Arc<dyn TriggerManagementClock>,
+    allow_project_ownership: bool,
 }
 
 #[async_trait]
@@ -169,6 +188,7 @@ impl FirstPartyCapabilityHandler for TriggerManagementToolHandler {
                     &request.scope,
                     request.input,
                     self.clock.now(),
+                    self.allow_project_ownership,
                 )
                 .await?
             }
@@ -197,6 +217,8 @@ struct TriggerCreateInput {
     name: String,
     prompt: String,
     cron: String,
+    #[serde(default)]
+    ownership_scope: TriggerOwnershipScope,
 }
 
 #[derive(Deserialize)]
@@ -216,8 +238,12 @@ async fn create_trigger(
     scope: &ResourceScope,
     input: Value,
     now: DateTime<Utc>,
+    allow_project_ownership: bool,
 ) -> Result<Value, FirstPartyCapabilityError> {
     let input: TriggerCreateInput = serde_json::from_value(input).map_err(|_| input_error())?;
+    if input.ownership_scope == TriggerOwnershipScope::Project && !allow_project_ownership {
+        return Err(trigger_project_authority_error());
+    }
     let schedule = TriggerSchedule::cron(input.cron).map_err(trigger_input_error)?;
     let next_run_at = next_run_at_for_schedule(&schedule, now)?;
     let record = TriggerRecord {
@@ -226,6 +252,7 @@ async fn create_trigger(
         creator_user_id: scope.user_id.clone(),
         agent_id: scope.agent_id.clone(),
         project_id: scope.project_id.clone(),
+        ownership_scope: input.ownership_scope,
         name: input.name,
         source: TriggerSourceKind::Schedule,
         schedule,
@@ -335,6 +362,7 @@ fn trigger_output(record: &TriggerRecord, recent_runs: &[TriggerRunRecord]) -> V
         "trigger_id": record.trigger_id.to_string(),
         "agent_id": record.agent_id.as_ref().map(|id| id.as_str()),
         "project_id": record.project_id.as_ref().map(|id| id.as_str()),
+        "ownership_scope": record.ownership_scope.as_str(),
         "name": record.name,
         "source": record.source,
         "schedule": record.schedule,
@@ -375,6 +403,15 @@ fn next_run_at_for_schedule(
         .next_slot_after(now)
         .map_err(trigger_input_error)?
         .ok_or_else(input_error)
+}
+
+fn trigger_project_authority_error() -> FirstPartyCapabilityError {
+    tracing::debug!(
+        runtime_dispatch_error_kind = %RuntimeDispatchErrorKind::InputEncode,
+        rejection_reason = "project_ownership_authority_required",
+        "trigger_create rejected: project ownership requires a trusted shared-creation surface"
+    );
+    input_error()
 }
 
 fn trigger_input_error(error: TriggerError) -> FirstPartyCapabilityError {

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -82,8 +82,8 @@ pub use first_party_tools::{
     SKILL_LIST_CAPABILITY_ID, SKILL_REMOVE_CAPABILITY_ID, SPAWN_SUBAGENT_CAPABILITY_ID,
     TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID,
     TRIGGER_REMOVE_CAPABILITY_ID, TriggerCreateHook, WRITE_FILE_CAPABILITY_ID,
-    builtin_first_party_handlers, builtin_first_party_handlers_with_trigger_create_hook,
-    builtin_first_party_package,
+    builtin_first_party_handlers, builtin_first_party_handlers_with_project_trigger_authority,
+    builtin_first_party_handlers_with_trigger_create_hook, builtin_first_party_package,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use first_party_tools::{

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -36,8 +36,8 @@ use ironclaw_host_runtime::{
     TIME_CAPABILITY_ID, TRIGGER_CREATE_CAPABILITY_ID, TRIGGER_LIST_CAPABILITY_ID,
     TRIGGER_REMOVE_CAPABILITY_ID, TenantSandboxProcessPort, ToolCallHttpEgress, TriggerCreateHook,
     VisibleCapabilityAccess, VisibleCapabilityRequest, WRITE_FILE_CAPABILITY_ID,
-    builtin_first_party_handlers, builtin_first_party_handlers_with_trigger_create_hook,
-    builtin_first_party_package,
+    builtin_first_party_handlers, builtin_first_party_handlers_with_project_trigger_authority,
+    builtin_first_party_handlers_with_trigger_create_hook, builtin_first_party_package,
 };
 #[cfg(feature = "test-support")]
 use ironclaw_host_runtime::{
@@ -51,8 +51,8 @@ use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount};
 use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_triggers::{
     ClaimDueFireRequest, ClearActiveFireRequest, FireAcceptedRequest, InMemoryTriggerRepository,
-    MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerError, TriggerRecord,
-    TriggerRepository, TriggerRunHistoryStatus, TriggerRunRecord,
+    MAX_TRIGGER_NAME_BYTES, MAX_TRIGGER_PROMPT_BYTES, TriggerError, TriggerOwnershipScope,
+    TriggerRecord, TriggerRepository, TriggerRunHistoryStatus, TriggerRunRecord,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -317,6 +317,196 @@ async fn builtin_trigger_create_stamps_caller_scope_and_persists_record() {
     assert_eq!(records[0].creator_user_id, context.resource_scope.user_id);
     assert_eq!(records[0].agent_id, context.resource_scope.agent_id);
     assert_eq!(records[0].project_id, context.resource_scope.project_id);
+    assert_eq!(records[0].ownership_scope, TriggerOwnershipScope::Personal);
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_persists_project_ownership_scope() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_project_trigger_authority(repository.clone());
+    let context = execution_context_with_project_id(
+        [TRIGGER_CREATE_CAPABILITY_ID],
+        Some(ProjectId::new("proj-shared").unwrap()),
+    );
+
+    let output = invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Project digest",
+            "prompt": "Summarize project queue",
+            "cron": "0 8 * * *",
+            "ownership_scope": "project"
+        }),
+        context.clone(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(output["trigger"]["ownership_scope"], json!("project"));
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].ownership_scope, TriggerOwnershipScope::Project);
+    assert_eq!(records[0].creator_user_id, context.resource_scope.user_id);
+    assert_eq!(records[0].project_id, context.resource_scope.project_id);
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_rejects_project_ownership_without_project_scope() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_project_trigger_authority(repository.clone());
+    let mut context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+    // authority=true but project_id is None — TriggerRecord::validate() must reject
+    context.project_id = None;
+    context.resource_scope.project_id = None;
+
+    let error = invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Project digest",
+            "prompt": "Summarize project queue",
+            "cron": "0 8 * * *",
+            "ownership_scope": "project"
+        }),
+        context.clone(),
+    )
+    .await
+    .expect_err("project trigger ownership requires project_id even when authority flag is set");
+
+    assert_eq!(error, RuntimeFailureKind::InvalidInput);
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_rejects_project_ownership_when_authority_flag_is_false() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    // runtime_with_trigger_repository uses builtin_first_party_handlers which has
+    // allow_project_ownership = false; project_id IS present to isolate the flag gate
+    let runtime = runtime_with_trigger_repository(repository.clone());
+    let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+
+    let error = invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Project digest",
+            "prompt": "Summarize project queue",
+            "cron": "0 8 * * *",
+            "ownership_scope": "project"
+        }),
+        context.clone(),
+    )
+    .await
+    .expect_err("project ownership requires trusted shared-creation surface");
+
+    assert_eq!(error, RuntimeFailureKind::InvalidInput);
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_accepts_project_ownership_when_authority_flag_is_true_and_project_id_present()
+ {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    let runtime = runtime_with_project_trigger_authority(repository.clone());
+    let context = execution_context_with_project_id(
+        [TRIGGER_CREATE_CAPABILITY_ID],
+        Some(ProjectId::new("proj-trusted").unwrap()),
+    );
+
+    let output = invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Trusted project digest",
+            "prompt": "Summarize project queue",
+            "cron": "0 8 * * *",
+            "ownership_scope": "project"
+        }),
+        context.clone(),
+    )
+    .await
+    .expect("project ownership accepted on trusted surface");
+
+    assert_eq!(output["trigger"]["ownership_scope"], json!("project"));
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].ownership_scope, TriggerOwnershipScope::Project);
+    assert_eq!(records[0].project_id, context.resource_scope.project_id);
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_rejects_project_ownership_when_authority_is_true_but_project_id_missing()
+ {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    // authority=true but the resource scope has no project_id — TriggerRecord::validate() must reject
+    let runtime = runtime_with_project_trigger_authority(repository.clone());
+    let mut context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+    context.project_id = None;
+    context.resource_scope.project_id = None;
+
+    let error = invoke_with_context(
+        &runtime,
+        TRIGGER_CREATE_CAPABILITY_ID,
+        json!({
+            "name": "Project digest",
+            "prompt": "Summarize project queue",
+            "cron": "0 8 * * *",
+            "ownership_scope": "project"
+        }),
+        context.clone(),
+    )
+    .await
+    .expect_err("project trigger ownership requires project_id even when authority flag is set");
+
+    assert_eq!(error, RuntimeFailureKind::InvalidInput);
+    let records = repository
+        .list_triggers(context.resource_scope.tenant_id.clone())
+        .await
+        .unwrap();
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn builtin_trigger_create_personal_ownership_unaffected_by_authority_flag() {
+    let repository = Arc::new(InMemoryTriggerRepository::default());
+    // Verify personal scope works on both authority variants
+    for runtime in [
+        Box::new(runtime_with_trigger_repository(repository.clone())) as Box<dyn HostRuntime>,
+        Box::new(runtime_with_project_trigger_authority(repository.clone()))
+            as Box<dyn HostRuntime>,
+    ] {
+        let context = execution_context([TRIGGER_CREATE_CAPABILITY_ID]);
+
+        let output = invoke_with_context(
+            runtime.as_ref(),
+            TRIGGER_CREATE_CAPABILITY_ID,
+            json!({
+                "name": "Personal trigger",
+                "prompt": "Daily summary",
+                "cron": "0 8 * * *"
+            }),
+            context.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(output["trigger"]["ownership_scope"], json!("personal"));
+    }
 }
 
 #[tokio::test]
@@ -6352,6 +6542,31 @@ fn runtime_with_trigger_repository_and_create_hook(
     .host_runtime_for_local_testing()
 }
 
+fn runtime_with_project_trigger_authority(
+    trigger_repository: Arc<dyn TriggerRepository>,
+) -> impl HostRuntime {
+    HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(
+        builtin_first_party_handlers_with_project_trigger_authority(
+            trigger_repository,
+            Arc::new(NoopTriggerCreateHook),
+        )
+        .unwrap(),
+    ))
+    .with_runtime_http_egress(Arc::new(RecordingRuntimeHttpEgress::default()))
+    .with_audit_sink(Arc::new(InMemoryAuditSink::new()))
+    .with_runtime_policy(local_dev_policy())
+    .with_trust_policy(Arc::new(trust_policy()))
+    .host_runtime_for_local_testing()
+}
+
 #[cfg(feature = "test-support")]
 fn runtime_with_trigger_repository_and_clock(
     trigger_repository: Arc<dyn TriggerRepository>,
@@ -6432,6 +6647,16 @@ impl TriggerCreateHook for PersistedRecordTriggerCreateHook {
             Some(record.trigger_id)
         );
         self.records.lock().unwrap().push(record.clone());
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct NoopTriggerCreateHook;
+
+#[async_trait]
+impl TriggerCreateHook for NoopTriggerCreateHook {
+    async fn after_trigger_persisted(&self, _record: &TriggerRecord) -> Result<(), TriggerError> {
         Ok(())
     }
 }
@@ -7625,6 +7850,20 @@ where
         MountView::default(),
     )
     .unwrap()
+}
+
+fn execution_context_with_project_id<I>(
+    grants: I,
+    project_id: Option<ProjectId>,
+) -> ExecutionContext
+where
+    I: IntoIterator,
+    I::Item: AsRef<str>,
+{
+    let mut ctx = execution_context(grants);
+    ctx.project_id = project_id.clone();
+    ctx.resource_scope.project_id = project_id;
+    ctx
 }
 
 fn execution_context_with_mounts<I>(grants: I, mounts: MountView) -> ExecutionContext

--- a/crates/ironclaw_outbound/src/communication_preferences.rs
+++ b/crates/ironclaw_outbound/src/communication_preferences.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
+use ironclaw_host_api::{ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_turns::ReplyTargetBindingRef;
 use serde::{Deserialize, Serialize};
 
@@ -13,11 +13,9 @@ pub enum DeliveryDefaultScope {
         tenant_id: TenantId,
         user_id: UserId,
     },
-    SharedAgent {
+    Project {
         tenant_id: TenantId,
-        agent_id: AgentId,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        project_id: Option<ProjectId>,
+        project_id: ProjectId,
     },
 }
 
@@ -26,21 +24,16 @@ impl DeliveryDefaultScope {
         Self::Personal { tenant_id, user_id }
     }
 
-    pub fn shared_agent(
-        tenant_id: TenantId,
-        agent_id: AgentId,
-        project_id: Option<ProjectId>,
-    ) -> Self {
-        Self::SharedAgent {
+    pub fn project(tenant_id: TenantId, project_id: ProjectId) -> Self {
+        Self::Project {
             tenant_id,
-            agent_id,
             project_id,
         }
     }
 
     pub fn tenant_id(&self) -> &TenantId {
         match self {
-            Self::Personal { tenant_id, .. } | Self::SharedAgent { tenant_id, .. } => tenant_id,
+            Self::Personal { tenant_id, .. } | Self::Project { tenant_id, .. } => tenant_id,
         }
     }
 }
@@ -62,13 +55,9 @@ impl CommunicationPreferenceKey {
         }
     }
 
-    pub fn shared_agent(
-        tenant_id: TenantId,
-        agent_id: AgentId,
-        project_id: Option<ProjectId>,
-    ) -> Self {
+    pub fn project(tenant_id: TenantId, project_id: ProjectId) -> Self {
         Self {
-            scope: DeliveryDefaultScope::shared_agent(tenant_id, agent_id, project_id),
+            scope: DeliveryDefaultScope::project(tenant_id, project_id),
         }
     }
 }
@@ -221,7 +210,7 @@ pub trait CommunicationPreferenceRepository: Send + Sync {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+    use ironclaw_host_api::{ProjectId, TenantId, UserId};
 
     use super::*;
 
@@ -237,10 +226,9 @@ mod tests {
     fn communication_preference_record_deserializes_scoped_and_legacy_payloads() {
         let updated_at = Utc::now();
         let scoped = CommunicationPreferenceRecord {
-            scope: DeliveryDefaultScope::shared_agent(
+            scope: DeliveryDefaultScope::project(
                 TenantId::new("tenant-pref-json").unwrap(),
-                AgentId::new("agent-pref-json").unwrap(),
-                Some(ProjectId::new("project-pref-json").unwrap()),
+                ProjectId::new("project-pref-json").unwrap(),
             ),
             final_reply_target: None,
             progress_target: None,

--- a/crates/ironclaw_outbound/src/filesystem_store.rs
+++ b/crates/ironclaw_outbound/src/filesystem_store.rs
@@ -641,21 +641,13 @@ fn hash_delivery_default_scope(hasher: &mut Sha256, scope: &DeliveryDefaultScope
             update_hash_part(hasher, tenant_id.as_str());
             update_hash_part(hasher, user_id.as_str());
         }
-        DeliveryDefaultScope::SharedAgent {
+        DeliveryDefaultScope::Project {
             tenant_id,
-            agent_id,
             project_id,
         } => {
-            update_hash_part(hasher, "shared_agent");
+            update_hash_part(hasher, "project");
             update_hash_part(hasher, tenant_id.as_str());
-            update_hash_part(hasher, agent_id.as_str());
-            match project_id {
-                Some(project_id) => {
-                    update_hash_part(hasher, "project");
-                    update_hash_part(hasher, project_id.as_str());
-                }
-                None => update_hash_part(hasher, "no_project"),
-            }
+            update_hash_part(hasher, project_id.as_str());
         }
     }
 }
@@ -672,14 +664,12 @@ fn communication_preference_resource_scope(scope: &DeliveryDefaultScope) -> Reso
             resource_scope.tenant_id = tenant_id.clone();
             resource_scope.user_id = user_id.clone();
         }
-        DeliveryDefaultScope::SharedAgent {
+        DeliveryDefaultScope::Project {
             tenant_id,
-            agent_id,
             project_id,
         } => {
             resource_scope.tenant_id = tenant_id.clone();
-            resource_scope.agent_id = Some(agent_id.clone());
-            resource_scope.project_id = project_id.clone();
+            resource_scope.project_id = Some(project_id.clone());
         }
     }
     resource_scope

--- a/crates/ironclaw_outbound/src/resolution_engine.rs
+++ b/crates/ironclaw_outbound/src/resolution_engine.rs
@@ -33,7 +33,7 @@ impl<'a> OutboundResolutionEngine<'a> {
     ) -> Result<CommunicationDeliveryResolution, OutboundError> {
         let CommunicationDeliveryResolutionRequest {
             scope,
-            actor,
+            actor: _,
             modality: _,
             intent,
         } = request;
@@ -44,8 +44,7 @@ impl<'a> OutboundResolutionEngine<'a> {
                 ))
             }
             CommunicationDeliveryIntent::RunNotification(context) => {
-                self.resolve_run_notification_context(scope, actor, context)
-                    .await
+                self.resolve_run_notification_context(scope, context).await
             }
         }
     }
@@ -64,7 +63,6 @@ impl<'a> OutboundResolutionEngine<'a> {
     async fn resolve_run_notification_context(
         &self,
         scope: &ironclaw_turns::TurnScope,
-        actor: &ironclaw_turns::TurnActor,
         context: &RunNotificationContext,
     ) -> Result<CommunicationDeliveryResolution, OutboundError> {
         let kind = context.delivery_kind();
@@ -73,16 +71,10 @@ impl<'a> OutboundResolutionEngine<'a> {
                 source_route.reply_target_binding_ref.clone()
             }
             RunNotificationOrigin::Triggered { .. } => {
-                self.resolve_triggered_target(scope, actor, kind).await?
+                self.resolve_triggered_target(scope, kind).await?
             }
-            RunNotificationOrigin::TriggeredFromSourceRoute { source_route, .. } => {
-                self.resolve_triggered_from_source_route_target(
-                    kind,
-                    &source_route.reply_target_binding_ref,
-                    scope,
-                    actor,
-                )
-                .await?
+            RunNotificationOrigin::TriggeredFromSourceRoute { .. } => {
+                self.resolve_triggered_target(scope, kind).await?
             }
             RunNotificationOrigin::SystemEvent { reason } => {
                 return Ok(CommunicationDeliveryResolution::NoDelivery { reason: *reason });
@@ -94,100 +86,86 @@ impl<'a> OutboundResolutionEngine<'a> {
         ))
     }
 
-    async fn resolve_triggered_from_source_route_target(
-        &self,
-        kind: CommunicationDeliveryKind,
-        source_route_target: &ReplyTargetBindingRef,
-        scope: &ironclaw_turns::TurnScope,
-        actor: &ironclaw_turns::TurnActor,
-    ) -> Result<ReplyTargetBindingRef, OutboundError> {
-        match kind {
-            CommunicationDeliveryKind::ApprovalPrompt => {
-                self.load_preference_target(scope, actor, PreferenceTargetKind::ApprovalPrompt)
-                    .await
-            }
-            CommunicationDeliveryKind::AuthPrompt => {
-                self.load_preference_target(scope, actor, PreferenceTargetKind::AuthPrompt)
-                    .await
-            }
-            CommunicationDeliveryKind::FinalReply
-            | CommunicationDeliveryKind::ProgressUpdate
-            | CommunicationDeliveryKind::DeliveryStatus => Ok(source_route_target.clone()),
-        }
-    }
-
     async fn resolve_triggered_target(
         &self,
         scope: &ironclaw_turns::TurnScope,
-        actor: &ironclaw_turns::TurnActor,
         kind: CommunicationDeliveryKind,
     ) -> Result<ReplyTargetBindingRef, OutboundError> {
+        let key = triggered_preference_key(scope)?;
+        let record = self
+            .communication_preferences
+            .load_communication_preference(key)
+            .await?;
+
         match kind {
             CommunicationDeliveryKind::FinalReply => {
-                self.load_preference_target(scope, actor, PreferenceTargetKind::FinalReply)
-                    .await
+                let record = record
+                    .ok_or_else(|| missing_preference_error(PreferenceTargetKind::FinalReply))?;
+                record
+                    .record
+                    .final_reply_target
+                    .ok_or_else(|| missing_preference_error(PreferenceTargetKind::FinalReply))
             }
             CommunicationDeliveryKind::ProgressUpdate
             | CommunicationDeliveryKind::DeliveryStatus => {
-                self.load_preference_target(scope, actor, PreferenceTargetKind::Progress)
-                    .await
+                let record = record
+                    .ok_or_else(|| missing_preference_error(PreferenceTargetKind::Progress))?;
+                record
+                    .record
+                    .progress_target
+                    .ok_or_else(|| missing_preference_error(PreferenceTargetKind::Progress))
             }
             CommunicationDeliveryKind::ApprovalPrompt => {
-                self.load_preference_target(scope, actor, PreferenceTargetKind::ApprovalPrompt)
-                    .await
+                let record = record.ok_or_else(|| {
+                    missing_preference_error(PreferenceTargetKind::ApprovalPrompt)
+                })?;
+                let targets = record.record;
+                targets
+                    .approval_prompt_target
+                    .or(targets.final_reply_target)
+                    .ok_or_else(|| missing_preference_error(PreferenceTargetKind::ApprovalPrompt))
             }
             CommunicationDeliveryKind::AuthPrompt => {
-                self.load_preference_target(scope, actor, PreferenceTargetKind::AuthPrompt)
-                    .await
+                let record = record
+                    .ok_or_else(|| missing_preference_error(PreferenceTargetKind::AuthPrompt))?;
+                let targets = record.record;
+                targets
+                    .auth_prompt_target
+                    .or(targets.final_reply_target)
+                    .ok_or_else(|| missing_preference_error(PreferenceTargetKind::AuthPrompt))
             }
         }
-    }
-
-    async fn load_preference_target(
-        &self,
-        scope: &ironclaw_turns::TurnScope,
-        actor: &ironclaw_turns::TurnActor,
-        kind: PreferenceTargetKind,
-    ) -> Result<ReplyTargetBindingRef, OutboundError> {
-        let key = default_preference_key(scope, actor);
-        let Some(record) = self
-            .communication_preferences
-            .load_communication_preference(key)
-            .await?
-        else {
-            return Err(missing_preference_error(kind));
-        };
-        let record = record.record;
-
-        let target = match kind {
-            PreferenceTargetKind::FinalReply => record.final_reply_target,
-            PreferenceTargetKind::Progress => record.progress_target,
-            PreferenceTargetKind::ApprovalPrompt => record.approval_prompt_target,
-            PreferenceTargetKind::AuthPrompt => record.auth_prompt_target,
-        };
-
-        target.ok_or_else(|| missing_preference_error(kind))
     }
 }
 
-fn default_preference_key(
+/// Resolve the preference key for triggered-origin runs.
+///
+/// Returns `Err` when ownership is ambiguous or insufficient:
+/// - no explicit owner and no explicit ownerless marker with a project id
+///   both fail closed, because silently falling back to the actor's personal
+///   default would deliver to the wrong recipient.
+fn triggered_preference_key(
     scope: &ironclaw_turns::TurnScope,
-    actor: &ironclaw_turns::TurnActor,
-) -> CommunicationPreferenceKey {
+) -> Result<CommunicationPreferenceKey, OutboundError> {
     match (
         scope.explicit_owner_user_id(),
         scope.has_explicit_thread_owner(),
-        scope.agent_id.clone(),
+        scope.project_id.clone(),
     ) {
-        (Some(owner_user_id), _, _) => {
-            CommunicationPreferenceKey::personal(scope.tenant_id.clone(), owner_user_id.clone())
-        }
-        (None, true, Some(agent_id)) => CommunicationPreferenceKey::shared_agent(
+        (Some(owner_user_id), _, _) => Ok(CommunicationPreferenceKey::personal(
             scope.tenant_id.clone(),
-            agent_id,
-            scope.project_id.clone(),
-        ),
-        _ => CommunicationPreferenceKey::personal(scope.tenant_id.clone(), actor.user_id.clone()),
+            owner_user_id.clone(),
+        )),
+        (None, true, Some(project_id)) => Ok(CommunicationPreferenceKey::project(
+            scope.tenant_id.clone(),
+            project_id,
+        )),
+        (None, true, None) => Err(OutboundError::InvalidRequest {
+            reason: "triggered run is explicitly ownerless but has no project id; cannot resolve delivery default",
+        }),
+        _ => Err(OutboundError::InvalidRequest {
+            reason: "triggered run has ambiguous ownership: no explicit owner marker; cannot resolve delivery default",
+        }),
     }
 }
 
@@ -444,27 +422,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn triggered_final_reply_actor_fallback_uses_actor_personal_default_even_with_agent() {
+    async fn triggered_ambiguous_ownership_with_agent_fails_closed() {
+        // Scope built with TurnScope::new (no explicit owner / no ownerless marker).
+        // For Triggered origin this must error rather than silently fall back to the
+        // actor's personal default, which would deliver to the wrong recipient.
         let store = InMemoryOutboundStateStore::default();
         let engine = OutboundResolutionEngine::new(&store);
 
         store
             .put_communication_preference(CommunicationPreferenceRecord {
-                scope: DeliveryDefaultScope::shared_agent(
+                scope: DeliveryDefaultScope::project(
                     TenantId::new("tenant-a").expect("valid tenant"),
-                    AgentId::new("agent-a").expect("valid agent"),
-                    Some(ProjectId::new("project-a").expect("valid project")),
+                    ProjectId::new("project-a").expect("valid project"),
                 ),
-                final_reply_target: Some(reply_ref("reply:shared-default")),
-                progress_target: Some(reply_ref("reply:shared-progress")),
-                approval_prompt_target: Some(reply_ref("reply:shared-approval")),
-                auth_prompt_target: Some(reply_ref("reply:shared-auth")),
+                final_reply_target: Some(reply_ref("reply:project-default")),
+                progress_target: Some(reply_ref("reply:project-progress")),
+                approval_prompt_target: Some(reply_ref("reply:project-approval")),
+                auth_prompt_target: Some(reply_ref("reply:project-auth")),
                 default_modality: Some(CommunicationModality::Text),
                 updated_at: now(),
                 updated_by: UserId::new("tenant-admin").expect("valid updater"),
             })
             .await
-            .expect("seed shared-agent preference");
+            .expect("seed project preference");
         store
             .put_communication_preference(preference_record(
                 Some("reply:personal-default"),
@@ -475,7 +455,7 @@ mod tests {
             .await
             .expect("seed personal preference");
 
-        let candidate = engine
+        let err = engine
             .resolve(&CommunicationDeliveryResolutionRequest {
                 scope: actor_fallback_agent_scope(),
                 actor: actor("user-a"),
@@ -488,15 +468,18 @@ mod tests {
                 }),
             })
             .await
-            .expect("actor-fallback triggered final reply resolves");
-        let candidate = expect_candidate(candidate);
+            .expect_err("ambiguous triggered ownership must fail closed");
 
-        assert_eq!(candidate.target, reply_ref("reply:personal-default"));
-        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest for ambiguous triggered ownership, got {err:?}"
+        );
     }
 
     #[tokio::test]
-    async fn triggered_final_reply_actor_fallback_without_agent_uses_actor_personal_default() {
+    async fn triggered_ambiguous_ownership_without_agent_fails_closed() {
+        // Scope built with TurnScope::new (no explicit owner / no ownerless marker),
+        // no agent. Must fail closed for Triggered origin.
         let store = InMemoryOutboundStateStore::default();
         let engine = OutboundResolutionEngine::new(&store);
 
@@ -510,7 +493,7 @@ mod tests {
             .await
             .expect("seed personal preference");
 
-        let candidate = engine
+        let err = engine
             .resolve(&CommunicationDeliveryResolutionRequest {
                 scope: actor_fallback_agentless_scope(),
                 actor: actor("user-a"),
@@ -523,35 +506,35 @@ mod tests {
                 }),
             })
             .await
-            .expect("actor-fallback triggered final reply resolves");
-        let candidate = expect_candidate(candidate);
+            .expect_err("ambiguous triggered ownership without agent must fail closed");
 
-        assert_eq!(candidate.target, reply_ref("reply:personal-default"));
-        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest for ambiguous triggered ownership, got {err:?}"
+        );
     }
 
     #[tokio::test]
-    async fn triggered_final_reply_ownerless_agent_scope_uses_shared_agent_default() {
+    async fn triggered_final_reply_ownerless_project_scope_uses_project_default() {
         let store = InMemoryOutboundStateStore::default();
         let engine = OutboundResolutionEngine::new(&store);
 
         store
             .put_communication_preference(CommunicationPreferenceRecord {
-                scope: DeliveryDefaultScope::shared_agent(
+                scope: DeliveryDefaultScope::project(
                     TenantId::new("tenant-a").expect("valid tenant"),
-                    AgentId::new("agent-a").expect("valid agent"),
-                    Some(ProjectId::new("project-a").expect("valid project")),
+                    ProjectId::new("project-a").expect("valid project"),
                 ),
-                final_reply_target: Some(reply_ref("reply:shared-default")),
-                progress_target: Some(reply_ref("reply:shared-progress")),
-                approval_prompt_target: Some(reply_ref("reply:shared-approval")),
-                auth_prompt_target: Some(reply_ref("reply:shared-auth")),
+                final_reply_target: Some(reply_ref("reply:project-default")),
+                progress_target: Some(reply_ref("reply:project-progress")),
+                approval_prompt_target: Some(reply_ref("reply:project-approval")),
+                auth_prompt_target: Some(reply_ref("reply:project-auth")),
                 default_modality: Some(CommunicationModality::Text),
                 updated_at: now(),
                 updated_by: UserId::new("tenant-admin").expect("valid updater"),
             })
             .await
-            .expect("seed shared-agent preference");
+            .expect("seed project preference");
         store
             .put_communication_preference(preference_record(
                 Some("reply:personal-default"),
@@ -564,7 +547,7 @@ mod tests {
 
         let candidate = engine
             .resolve(&CommunicationDeliveryResolutionRequest {
-                scope: ownerless_agent_scope(),
+                scope: ownerless_project_scope(),
                 actor: actor("user-a"),
                 modality: CommunicationModality::Text,
                 intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
@@ -575,15 +558,17 @@ mod tests {
                 }),
             })
             .await
-            .expect("shared-agent triggered final reply resolves");
+            .expect("project triggered final reply resolves");
         let candidate = expect_candidate(candidate);
 
-        assert_eq!(candidate.target, reply_ref("reply:shared-default"));
+        assert_eq!(candidate.target, reply_ref("reply:project-default"));
         assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
     }
 
     #[tokio::test]
-    async fn triggered_final_reply_ownerless_without_agent_uses_actor_personal_default() {
+    async fn triggered_ownerless_with_agent_but_no_project_id_fails_closed() {
+        // Explicitly ownerless scope with an agent_id but no project_id must
+        // fail closed: the new project key requires project_id to be present.
         let store = InMemoryOutboundStateStore::default();
         let engine = OutboundResolutionEngine::new(&store);
 
@@ -597,9 +582,9 @@ mod tests {
             .await
             .expect("seed personal preference");
 
-        let candidate = engine
+        let err = engine
             .resolve(&CommunicationDeliveryResolutionRequest {
-                scope: ownerless_agentless_scope(),
+                scope: ownerless_agentful_no_project_scope(),
                 actor: actor("user-a"),
                 modality: CommunicationModality::Text,
                 intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
@@ -610,11 +595,51 @@ mod tests {
                 }),
             })
             .await
-            .expect("ownerless agentless triggered final reply resolves");
-        let candidate = expect_candidate(candidate);
+            .expect_err("ownerless with agent but no project_id must fail closed");
 
-        assert_eq!(candidate.target, reply_ref("reply:personal-default"));
-        assert_eq!(candidate.kind, CommunicationDeliveryKind::FinalReply);
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest for ownerless scope with agent but no project_id, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn triggered_ownerless_agentless_no_project_id_fails_closed() {
+        // Scope built with TurnScope::new_with_owner(..., None) and no agent, no
+        // project_id — explicitly ownerless but no project_id to resolve project key.
+        // Must fail closed for Triggered origin.
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:personal-default"),
+                Some("reply:personal-progress"),
+                Some("reply:personal-approval"),
+                Some("reply:personal-auth"),
+            ))
+            .await
+            .expect("seed personal preference");
+
+        let err = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: ownerless_no_project_scope(),
+                actor: actor("user-a"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::Triggered {
+                        trigger: trigger_context(),
+                    },
+                }),
+            })
+            .await
+            .expect_err("ownerless no-project triggered run must fail closed");
+
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest for ownerless no-project triggered run, got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -708,6 +733,36 @@ mod tests {
             },
             "reply:approval",
             CommunicationDeliveryKind::ApprovalPrompt,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn triggered_from_source_route_final_reply_uses_the_final_reply_preference() {
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                Some("reply:progress"),
+                Some("reply:approval"),
+                Some("reply:auth"),
+            ))
+            .await
+            .expect("seed preference");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::FinalReplyReady,
+            RunNotificationOrigin::TriggeredFromSourceRoute {
+                trigger: trigger_context(),
+                source_route: SourceRouteContext {
+                    reply_target_binding_ref: reply_ref("reply:source-route"),
+                },
+            },
+            "reply:final",
+            CommunicationDeliveryKind::FinalReply,
         )
         .await;
     }
@@ -868,7 +923,7 @@ mod tests {
                     reply_target_binding_ref: reply_ref("reply:source-route"),
                 },
             },
-            "reply:source-route",
+            "reply:progress",
             CommunicationDeliveryKind::ProgressUpdate,
         )
         .await;
@@ -881,10 +936,239 @@ mod tests {
                     reply_target_binding_ref: reply_ref("reply:source-route"),
                 },
             },
-            "reply:source-route",
+            "reply:progress",
             CommunicationDeliveryKind::DeliveryStatus,
         )
         .await;
+    }
+
+    // ── Approval/auth final-reply fallback (product decision 9) ──────────────
+
+    #[tokio::test]
+    async fn triggered_approval_prompt_falls_back_to_final_reply_when_approval_slot_unset() {
+        // (a) explicit approval_prompt_target unset → falls back to final_reply_target
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                None,
+                None, // approval_prompt_target unset
+                None,
+            ))
+            .await
+            .expect("seed preference with only final reply target");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ApprovalNeeded,
+            RunNotificationOrigin::Triggered {
+                trigger: trigger_context(),
+            },
+            "reply:final",
+            CommunicationDeliveryKind::ApprovalPrompt,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn triggered_explicit_approval_slot_wins_over_final_reply_fallback() {
+        // (b) explicit approval_prompt_target wins over final_reply_target
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                None,
+                Some("reply:approval-explicit"),
+                None,
+            ))
+            .await
+            .expect("seed preference with both final reply and explicit approval target");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::ApprovalNeeded,
+            RunNotificationOrigin::Triggered {
+                trigger: trigger_context(),
+            },
+            "reply:approval-explicit",
+            CommunicationDeliveryKind::ApprovalPrompt,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn triggered_approval_prompt_fails_closed_when_neither_slot_set() {
+        // (c) neither approval_prompt_target nor final_reply_target set → fail closed
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                None, // final_reply_target also unset
+                None, None, // approval_prompt_target unset
+                None,
+            ))
+            .await
+            .expect("seed preference with no targets");
+
+        let err = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::ApprovalNeeded,
+                RunNotificationOrigin::Triggered {
+                    trigger: trigger_context(),
+                },
+            ))
+            .await
+            .expect_err("both slots unset must fail closed");
+
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest when neither approval nor final-reply target is set, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn triggered_auth_prompt_falls_back_to_final_reply_when_auth_slot_unset() {
+        // (d) auth_prompt_target unset → falls back to final_reply_target
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                None,
+                None,
+                None, // auth_prompt_target unset
+            ))
+            .await
+            .expect("seed preference with only final reply target");
+
+        assert_resolves_to(
+            &engine,
+            RunNotificationEventKind::AuthRequired,
+            RunNotificationOrigin::Triggered {
+                trigger: trigger_context(),
+            },
+            "reply:final",
+            CommunicationDeliveryKind::AuthPrompt,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn triggered_progress_update_does_not_fall_back_to_final_reply() {
+        // (e) ProgressUpdate gets NO fallback to final_reply_target
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:final"),
+                None, // progress_target unset
+                None,
+                None,
+            ))
+            .await
+            .expect("seed preference with only final reply target");
+
+        let err = engine
+            .resolve(&run_notification_request(
+                RunNotificationEventKind::ProgressUpdate,
+                RunNotificationOrigin::Triggered {
+                    trigger: trigger_context(),
+                },
+            ))
+            .await
+            .expect_err("ProgressUpdate must not fall back to final_reply_target");
+
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest when progress target is unset (no fallback), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn triggered_from_source_route_ambiguous_ownership_fails_closed() {
+        // (f) TriggeredFromSourceRoute with ambiguous scope also fails closed
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:personal-default"),
+                Some("reply:personal-progress"),
+                Some("reply:personal-approval"),
+                Some("reply:personal-auth"),
+            ))
+            .await
+            .expect("seed personal preference");
+
+        let err = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: actor_fallback_agent_scope(),
+                actor: actor("user-a"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::TriggeredFromSourceRoute {
+                        trigger: trigger_context(),
+                        source_route: SourceRouteContext {
+                            reply_target_binding_ref: reply_ref("reply:source-route"),
+                        },
+                    },
+                }),
+            })
+            .await
+            .expect_err("TriggeredFromSourceRoute with ambiguous ownership must fail closed");
+
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest for ambiguous TriggeredFromSourceRoute ownership, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn triggered_from_source_route_ambiguous_ownership_agentless_fails_closed() {
+        // (f) TriggeredFromSourceRoute with ambiguous scope (no agent) also fails closed
+        let store = InMemoryOutboundStateStore::default();
+        let engine = OutboundResolutionEngine::new(&store);
+
+        store
+            .put_communication_preference(preference_record(
+                Some("reply:personal-default"),
+                None,
+                None,
+                None,
+            ))
+            .await
+            .expect("seed personal preference");
+
+        let err = engine
+            .resolve(&CommunicationDeliveryResolutionRequest {
+                scope: actor_fallback_agentless_scope(),
+                actor: actor("user-a"),
+                modality: CommunicationModality::Text,
+                intent: CommunicationDeliveryIntent::RunNotification(RunNotificationContext {
+                    event_kind: RunNotificationEventKind::FinalReplyReady,
+                    origin: RunNotificationOrigin::TriggeredFromSourceRoute {
+                        trigger: trigger_context(),
+                        source_route: SourceRouteContext {
+                            reply_target_binding_ref: reply_ref("reply:source-route"),
+                        },
+                    },
+                }),
+            })
+            .await
+            .expect_err("TriggeredFromSourceRoute with agentless ambiguous scope must fail closed");
+
+        assert!(
+            matches!(err, OutboundError::InvalidRequest { .. }),
+            "expected InvalidRequest for agentless ambiguous TriggeredFromSourceRoute, got {err:?}"
+        );
     }
 
     fn requested_request(requested_target: &str) -> CommunicationDeliveryResolutionRequest {
@@ -974,7 +1258,7 @@ mod tests {
         )
     }
 
-    fn ownerless_agent_scope() -> TurnScope {
+    fn ownerless_project_scope() -> TurnScope {
         TurnScope::new_with_owner(
             TenantId::new("tenant-a").expect("valid tenant"),
             Some(AgentId::new("agent-a").expect("valid agent")),
@@ -984,11 +1268,23 @@ mod tests {
         )
     }
 
-    fn ownerless_agentless_scope() -> TurnScope {
+    /// Explicitly ownerless, has an agent, but no project_id — must fail closed.
+    fn ownerless_agentful_no_project_scope() -> TurnScope {
+        TurnScope::new_with_owner(
+            TenantId::new("tenant-a").expect("valid tenant"),
+            Some(AgentId::new("agent-a").expect("valid agent")),
+            None,
+            thread_id("thread-a"),
+            None,
+        )
+    }
+
+    /// Explicitly ownerless, no agent, no project_id — must fail closed.
+    fn ownerless_no_project_scope() -> TurnScope {
         TurnScope::new_with_owner(
             TenantId::new("tenant-a").expect("valid tenant"),
             None,
-            Some(ProjectId::new("project-a").expect("valid project")),
+            None,
             thread_id("thread-a"),
             None,
         )

--- a/crates/ironclaw_outbound/src/validation.rs
+++ b/crates/ironclaw_outbound/src/validation.rs
@@ -189,9 +189,8 @@ pub(crate) fn validate_communication_preference(
                 });
             }
         }
-        DeliveryDefaultScope::SharedAgent {
+        DeliveryDefaultScope::Project {
             tenant_id,
-            agent_id,
             project_id,
         } => {
             if tenant_id.as_str().is_empty() {
@@ -199,17 +198,9 @@ pub(crate) fn validate_communication_preference(
                     reason: "communication preference tenant is required",
                 });
             }
-            if agent_id.as_str().is_empty() {
+            if project_id.as_str().is_empty() {
                 return Err(OutboundError::InvalidRequest {
-                    reason: "communication preference shared agent is required",
-                });
-            }
-            if project_id
-                .as_ref()
-                .is_some_and(|project_id| project_id.as_str().is_empty())
-            {
-                return Err(OutboundError::InvalidRequest {
-                    reason: "communication preference project is required when present",
+                    reason: "communication preference project is required",
                 });
             }
         }

--- a/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_policy_service_contract.rs
@@ -397,12 +397,12 @@ async fn communication_delivery_triggered_default_target_validates_preference_ta
 }
 
 #[tokio::test]
-async fn communication_delivery_triggered_shared_agent_scope_validates_shared_preference_target() {
+async fn communication_delivery_triggered_project_scope_validates_project_preference_target() {
     let store = InMemoryOutboundStateStore::default();
     let access_policy = FakeThreadProjectionAccessPolicy::default();
     let validator = FakeReplyTargetBindingValidator::default();
     let service = OutboundPolicyService::new(&store, &access_policy, &validator);
-    let scope = ownerless_agent_scope("thread-1");
+    let scope = ownerless_project_scope("thread-1");
     let request = run_notification_request_with_scope(
         scope.clone(),
         RunNotificationEventKind::FinalReplyReady,
@@ -410,7 +410,7 @@ async fn communication_delivery_triggered_shared_agent_scope_validates_shared_pr
             trigger: trigger_context(),
         },
     );
-    validator.allow(reply_ref("reply:shared-default"));
+    validator.allow(reply_ref("reply:project-default"));
     store
         .put_communication_preference(preference_record(
             Some("reply:personal-default"),
@@ -421,26 +421,26 @@ async fn communication_delivery_triggered_shared_agent_scope_validates_shared_pr
         .await
         .expect("seed personal preference");
     store
-        .put_communication_preference(shared_agent_preference_record(
-            Some("reply:shared-default"),
-            Some("reply:shared-progress"),
+        .put_communication_preference(project_preference_record(
+            Some("reply:project-default"),
+            Some("reply:project-progress"),
             None,
             None,
         ))
         .await
-        .expect("seed shared-agent preference");
+        .expect("seed project preference");
 
     let decision = service
         .prepare_communication_delivery_attempt(prepare_communication_request(request), &store)
         .await
-        .expect("shared-agent triggered default resolves and prepares")
-        .expect("shared-agent triggered default has a delivery target");
+        .expect("project triggered default resolves and prepares")
+        .expect("project triggered default has a delivery target");
 
     let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
         panic!("expected authorized delivery");
     };
-    assert_eq!(target.target(), &reply_ref("reply:shared-default"));
-    assert_eq!(attempt.candidate.target, reply_ref("reply:shared-default"));
+    assert_eq!(target.target(), &reply_ref("reply:project-default"));
+    assert_eq!(attempt.candidate.target, reply_ref("reply:project-default"));
     assert_eq!(attempt.candidate.kind, OutboundPushKind::FinalReply);
     assert_eq!(validator.calls(), 1);
     assert_eq!(
@@ -596,7 +596,7 @@ async fn communication_delivery_propagates_preference_repository_errors() {
 }
 
 #[tokio::test]
-async fn communication_delivery_triggered_from_source_route_final_reply_prefers_source_target() {
+async fn communication_delivery_triggered_from_source_route_final_reply_uses_preference_target() {
     let store = InMemoryOutboundStateStore::default();
     let access_policy = FakeThreadProjectionAccessPolicy::default();
     let validator = FakeReplyTargetBindingValidator::default();
@@ -610,7 +610,7 @@ async fn communication_delivery_triggered_from_source_route_final_reply_prefers_
             },
         },
     );
-    validator.allow(reply_ref("reply:source-route"));
+    validator.allow(reply_ref("reply:triggered-default"));
     store
         .put_communication_preference(preference_record(
             Some("reply:triggered-default"),
@@ -630,8 +630,11 @@ async fn communication_delivery_triggered_from_source_route_final_reply_prefers_
     let OutboundDeliveryDecision::Authorized { attempt, target } = decision else {
         panic!("expected authorized delivery");
     };
-    assert_eq!(target.target(), &reply_ref("reply:source-route"));
-    assert_eq!(attempt.candidate.target, reply_ref("reply:source-route"));
+    assert_eq!(target.target(), &reply_ref("reply:triggered-default"));
+    assert_eq!(
+        attempt.candidate.target,
+        reply_ref("reply:triggered-default")
+    );
     assert_eq!(validator.calls(), 1);
 }
 
@@ -1207,17 +1210,16 @@ fn preference_record(
     }
 }
 
-fn shared_agent_preference_record(
+fn project_preference_record(
     final_reply_target: Option<&str>,
     progress_target: Option<&str>,
     approval_prompt_target: Option<&str>,
     auth_prompt_target: Option<&str>,
 ) -> CommunicationPreferenceRecord {
     CommunicationPreferenceRecord {
-        scope: DeliveryDefaultScope::shared_agent(
+        scope: DeliveryDefaultScope::project(
             TenantId::new("tenant-a").expect("valid tenant"),
-            AgentId::new("agent-a").expect("valid agent"),
-            Some(ProjectId::new("project-a").expect("valid project")),
+            ProjectId::new("project-a").expect("valid project"),
         ),
         final_reply_target: final_reply_target.map(reply_ref),
         progress_target: progress_target.map(reply_ref),
@@ -1252,7 +1254,7 @@ fn turn_scope(thread: &str) -> TurnScope {
     )
 }
 
-fn ownerless_agent_scope(thread: &str) -> TurnScope {
+fn ownerless_project_scope(thread: &str) -> TurnScope {
     TurnScope::new_with_owner(
         TenantId::new("tenant-a").expect("valid tenant"),
         Some(AgentId::new("agent-a").expect("valid agent")),

--- a/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
+++ b/crates/ironclaw_outbound/tests/outbound_state_store_contract.rs
@@ -46,9 +46,9 @@ fn build_outbound_store_for_backend(
 async fn in_memory_defaults_policy_progress_opt_in_and_subscription_scope() {
     let store = InMemoryOutboundStateStore::default();
     communication_preferences_are_tenant_user_scoped(&store).await;
-    communication_preferences_are_shared_agent_scoped(&store).await;
+    communication_preferences_are_project_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
-    communication_preferences_reject_empty_shared_agent_scope(&store).await;
+    communication_preferences_reject_empty_project_scope(&store).await;
     communication_preference_put_existing_conflicts_without_writing(&store).await;
     communication_preference_atomic_update_preserves_existing_slots(&store).await;
     communication_preference_update_inserts_absent_record(&store).await;
@@ -73,9 +73,9 @@ async fn filesystem_store_satisfies_outbound_contract_on_in_memory_backend() {
     let backend = std::sync::Arc::new(ironclaw_filesystem::InMemoryBackend::new());
     let store = build_outbound_store_for_backend(Arc::clone(&backend));
     communication_preferences_are_tenant_user_scoped(&store).await;
-    communication_preferences_are_shared_agent_scoped(&store).await;
+    communication_preferences_are_project_scoped(&store).await;
     communication_preferences_reject_empty_updated_by(&store).await;
-    communication_preferences_reject_empty_shared_agent_scope(&store).await;
+    communication_preferences_reject_empty_project_scope(&store).await;
     communication_preference_put_existing_conflicts_without_writing(&store).await;
     communication_preference_atomic_update_preserves_existing_slots(&store).await;
     communication_preference_update_inserts_absent_record(&store).await;
@@ -209,32 +209,23 @@ where
     );
 }
 
-async fn communication_preferences_are_shared_agent_scoped<S>(store: &S)
+async fn communication_preferences_are_project_scoped<S>(store: &S)
 where
     S: CommunicationPreferenceRepository + OutboundStateStore,
 {
-    let tenant_id = TenantId::new("tenant-outbound-shared").unwrap();
-    let agent_id = AgentId::new("agent-outbound-shared").unwrap();
-    let project_id = ProjectId::new("project-outbound-shared").unwrap();
-    let updated_by = UserId::new("tenant-admin-outbound-shared").unwrap();
-    let project_key = CommunicationPreferenceKey::shared_agent(
-        tenant_id.clone(),
-        agent_id.clone(),
-        Some(project_id.clone()),
-    );
+    let tenant_id = TenantId::new("tenant-outbound-project").unwrap();
+    let project_id = ProjectId::new("project-outbound-project").unwrap();
+    let updated_by = UserId::new("tenant-admin-outbound-project").unwrap();
+    let project_key = CommunicationPreferenceKey::project(tenant_id.clone(), project_id.clone());
     let project_record = CommunicationPreferenceRecord {
-        scope: DeliveryDefaultScope::shared_agent(
-            tenant_id.clone(),
-            agent_id.clone(),
-            Some(project_id.clone()),
-        ),
-        final_reply_target: Some(reply_ref("reply-pref-shared-project")),
+        scope: DeliveryDefaultScope::project(tenant_id.clone(), project_id.clone()),
+        final_reply_target: Some(reply_ref("reply-pref-project")),
         progress_target: None,
         approval_prompt_target: None,
         auth_prompt_target: None,
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
-        updated_by: updated_by.clone(),
+        updated_by,
     };
     store
         .put_communication_preference(project_record.clone())
@@ -246,30 +237,9 @@ where
         Some(project_record)
     );
 
-    let projectless_key =
-        CommunicationPreferenceKey::shared_agent(tenant_id.clone(), agent_id.clone(), None);
-    let projectless_record = CommunicationPreferenceRecord {
-        scope: DeliveryDefaultScope::shared_agent(tenant_id.clone(), agent_id.clone(), None),
-        final_reply_target: Some(reply_ref("reply-pref-shared-projectless")),
-        progress_target: None,
-        approval_prompt_target: None,
-        auth_prompt_target: None,
-        default_modality: Some(CommunicationModality::Voice),
-        updated_at: now(),
-        updated_by,
-    };
-    store
-        .put_communication_preference(projectless_record.clone())
-        .await
-        .unwrap();
-    assert_eq!(
-        load_preference_record(store, projectless_key).await,
-        Some(projectless_record)
-    );
-
     let personal_key = CommunicationPreferenceKey::personal(
         tenant_id,
-        UserId::new("user-outbound-shared").unwrap(),
+        UserId::new("user-outbound-project").unwrap(),
     );
     assert!(
         store
@@ -280,10 +250,9 @@ where
     );
     assert!(
         store
-            .load_communication_preference(CommunicationPreferenceKey::shared_agent(
-                TenantId::new("tenant-outbound-shared-other").unwrap(),
-                agent_id,
-                Some(project_id),
+            .load_communication_preference(CommunicationPreferenceKey::project(
+                TenantId::new("tenant-outbound-project-other").unwrap(),
+                project_id,
             ))
             .await
             .unwrap()
@@ -331,48 +300,36 @@ where
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 }
 
-async fn communication_preferences_reject_empty_shared_agent_scope<S>(store: &S)
+async fn communication_preferences_reject_empty_project_scope<S>(store: &S)
 where
     S: CommunicationPreferenceRepository + OutboundStateStore,
 {
     let valid_record = CommunicationPreferenceRecord {
-        scope: DeliveryDefaultScope::shared_agent(
-            TenantId::new("tenant-outbound-shared-validation").unwrap(),
-            AgentId::new("agent-outbound-shared-validation").unwrap(),
-            None,
+        scope: DeliveryDefaultScope::project(
+            TenantId::new("tenant-outbound-project-validation").unwrap(),
+            ProjectId::new("project-outbound-project-validation").unwrap(),
         ),
-        final_reply_target: Some(reply_ref("reply-pref-shared-validation")),
+        final_reply_target: Some(reply_ref("reply-pref-project-validation")),
         progress_target: None,
         approval_prompt_target: None,
         auth_prompt_target: None,
         default_modality: Some(CommunicationModality::Text),
         updated_at: now(),
-        updated_by: UserId::new("tenant-admin-outbound-shared-validation").unwrap(),
+        updated_by: UserId::new("tenant-admin-outbound-project-validation").unwrap(),
     };
 
     let mut missing_tenant = valid_record.clone();
-    missing_tenant.scope = DeliveryDefaultScope::shared_agent(
+    missing_tenant.scope = DeliveryDefaultScope::project(
         TenantId::from_trusted(String::new()),
-        AgentId::new("agent-outbound-shared-validation").unwrap(),
-        None,
+        ProjectId::new("project-outbound-project-validation").unwrap(),
     );
     let result = store.put_communication_preference(missing_tenant).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
 
-    let mut missing_agent = valid_record.clone();
-    missing_agent.scope = DeliveryDefaultScope::shared_agent(
-        TenantId::new("tenant-outbound-shared-validation").unwrap(),
-        AgentId::from_trusted(String::new()),
-        None,
-    );
-    let result = store.put_communication_preference(missing_agent).await;
-    assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
-
     let mut missing_project = valid_record;
-    missing_project.scope = DeliveryDefaultScope::shared_agent(
-        TenantId::new("tenant-outbound-shared-validation").unwrap(),
-        AgentId::new("agent-outbound-shared-validation").unwrap(),
-        Some(ProjectId::from_trusted(String::new())),
+    missing_project.scope = DeliveryDefaultScope::project(
+        TenantId::new("tenant-outbound-project-validation").unwrap(),
+        ProjectId::from_trusted(String::new()),
     );
     let result = store.put_communication_preference(missing_project).await;
     assert!(matches!(result, Err(OutboundError::InvalidRequest { .. })));
@@ -676,7 +633,7 @@ async fn filesystem_store_rejects_mismatched_communication_preference_identity(
 }
 
 #[tokio::test]
-async fn filesystem_store_personal_and_shared_agent_hashes_are_always_distinct() {
+async fn filesystem_store_personal_and_project_hashes_are_always_distinct() {
     let backend = Arc::new(InMemoryBackend::new());
     let store = build_outbound_store_for_backend(Arc::clone(&backend));
     let tenant_id = TenantId::new("tenant-outbound-hash-distinct").unwrap();
@@ -696,24 +653,24 @@ async fn filesystem_store_personal_and_shared_agent_hashes_are_always_distinct()
     let (_, personal_path) =
         put_preference_and_find_virtual_path(&backend, &store, personal_record.clone()).await;
 
-    let shared_key =
-        CommunicationPreferenceKey::shared_agent(tenant_id, AgentId::new(shared_id).unwrap(), None);
-    let shared_record = CommunicationPreferenceRecord {
-        scope: shared_key.scope.clone(),
-        final_reply_target: Some(reply_ref("reply-pref-hash-shared")),
+    let project_key =
+        CommunicationPreferenceKey::project(tenant_id, ProjectId::new(shared_id).unwrap());
+    let project_record = CommunicationPreferenceRecord {
+        scope: project_key.scope.clone(),
+        final_reply_target: Some(reply_ref("reply-pref-hash-project")),
         progress_target: None,
         approval_prompt_target: None,
         auth_prompt_target: None,
         default_modality: Some(CommunicationModality::Voice),
         updated_at: now(),
-        updated_by: UserId::new("tenant-admin-outbound-hash-shared").unwrap(),
+        updated_by: UserId::new("tenant-admin-outbound-hash-project").unwrap(),
     };
-    let (_, shared_path) =
-        put_preference_and_find_virtual_path(&backend, &store, shared_record.clone()).await;
+    let (_, project_path) =
+        put_preference_and_find_virtual_path(&backend, &store, project_record.clone()).await;
 
     assert_ne!(
-        personal_path, shared_path,
-        "personal and shared-agent preference scopes with the same id text must not share a v2 hash path",
+        personal_path, project_path,
+        "personal and project preference scopes with the same id text must not share a v2 hash path",
     );
     assert_eq!(
         communication_preference_virtual_paths(&backend).await.len(),
@@ -724,8 +681,8 @@ async fn filesystem_store_personal_and_shared_agent_hashes_are_always_distinct()
         Some(personal_record)
     );
     assert_eq!(
-        load_preference_record(&store, shared_key).await,
-        Some(shared_record)
+        load_preference_record(&store, project_key).await,
+        Some(project_record)
     );
 }
 
@@ -1887,18 +1844,18 @@ async fn filesystem_outbound_store_isolates_two_tenants_with_same_user_project_i
     // only thing that should keep them apart is the mount-time tenant
     // prefix. The TurnScope still carries each store's own tenant_id so
     // policy/cursor lookups validate end-to-end.
-    let shared_agent = AgentId::new("agent-shared").unwrap();
+    let agent_id = AgentId::new("agent-shared").unwrap();
     let shared_project = ProjectId::new("project-shared").unwrap();
     let shared_thread = ThreadId::new("thread-shared").unwrap();
     let scope_a = TurnScope::new(
         TenantId::new("tenant-a").unwrap(),
-        Some(shared_agent.clone()),
+        Some(agent_id.clone()),
         Some(shared_project.clone()),
         shared_thread.clone(),
     );
     let scope_b = TurnScope::new(
         TenantId::new("tenant-b").unwrap(),
-        Some(shared_agent),
+        Some(agent_id),
         Some(shared_project),
         shared_thread,
     );

--- a/crates/ironclaw_product_workflow/src/conversation_binding.rs
+++ b/crates/ironclaw_product_workflow/src/conversation_binding.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use ironclaw_conversations::TrustedOwnerScope;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
 use ironclaw_product_adapters::{
     AdapterInstallationId, ExternalActorRef, ExternalConversationRef, ProductAdapterId,
@@ -585,6 +586,9 @@ impl ConversationBindingService for ProductConversationBindingService {
                         &resolution,
                     )?;
                     let owner_user_id = resolution.turn_scope.explicit_owner_user_id().cloned();
+                    let trusted_owner = owner_user_id
+                        .map(TrustedOwnerScope::User)
+                        .unwrap_or(TrustedOwnerScope::Unspecified);
                     let expected_user_id =
                         resolve_actor_user(&installation_scope, &request).await?;
                     if let Some(user_id) = expected_user_id.as_ref() {
@@ -597,7 +601,7 @@ impl ConversationBindingService for ProductConversationBindingService {
                             conversation_request,
                             installation_scope.default_agent_id.clone(),
                             installation_scope.default_project_id.clone(),
-                            owner_user_id,
+                            trusted_owner,
                         )
                         .await
                         .map_err(map_conversation_error)?;
@@ -624,13 +628,17 @@ impl ConversationBindingService for ProductConversationBindingService {
             self.apply_resolved_actor_binding(&installation_scope, &request, user_id)
                 .await?;
         }
+        let trusted_owner_for_subject = configured_subject_user_id
+            .clone()
+            .map(TrustedOwnerScope::User)
+            .unwrap_or(TrustedOwnerScope::Unspecified);
         let resolution = self
             .conversations
             .resolve_or_create_binding_with_trusted_scope(
                 conversation_request,
                 installation_scope.default_agent_id.clone(),
                 installation_scope.default_project_id.clone(),
-                configured_subject_user_id.clone(),
+                trusted_owner_for_subject,
             )
             .await
             .map_err(map_conversation_error)?;

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -3267,7 +3267,9 @@ async fn shared_lookup_binding_rejects_existing_binding_when_resolved_actor_diff
         },
         Some(AgentId::new("agent:alpha").expect("agent")),
         Some(ProjectId::new("project:alpha").expect("project")),
-        Some(UserId::new("user:subject").expect("subject")),
+        ironclaw_conversations::TrustedOwnerScope::User(
+            UserId::new("user:subject").expect("subject"),
+        ),
     )
     .await
     .expect("seed binding");
@@ -4400,7 +4402,7 @@ impl ironclaw_conversations::ConversationBindingService for CountingConversation
         request: ironclaw_conversations::ResolveConversationRequest,
         trusted_agent_id: Option<AgentId>,
         trusted_project_id: Option<ProjectId>,
-        trusted_owner_user_id: Option<UserId>,
+        trusted_owner: ironclaw_conversations::TrustedOwnerScope,
     ) -> Result<
         ironclaw_conversations::ConversationBindingResolution,
         ironclaw_conversations::InboundTurnError,
@@ -4411,7 +4413,7 @@ impl ironclaw_conversations::ConversationBindingService for CountingConversation
                 request,
                 trusted_agent_id,
                 trusted_project_id,
-                trusted_owner_user_id,
+                trusted_owner,
             )
             .await
     }

--- a/crates/ironclaw_reborn/src/milestone_events.rs
+++ b/crates/ironclaw_reborn/src/milestone_events.rs
@@ -87,9 +87,21 @@ impl DurableLoopHostMilestoneScope {
         &self,
         milestone: &LoopHostMilestone,
     ) -> Result<ResourceScope, AgentLoopHostError> {
-        if milestone.scope.tenant_id != self.tenant_id
-            || milestone.scope.agent_id != self.agent_id
-            || milestone.scope.project_id != self.project_id
+        // Tenant is the hard authority boundary bound at construction time.
+        // Agent/project follow the milestone's run scope: one runtime serves
+        // runs across projects (e.g. project-owned trigger fires), so pinning
+        // them at composition time would reject legitimate cross-project runs.
+        if milestone.scope.tenant_id != self.tenant_id {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::ScopeMismatch,
+                "loop milestone scope does not match durable event scope",
+            ));
+        }
+        // A run-pinned sink (thread/run bound) keeps the strict agent check
+        // so per-run adapters cannot stitch events across runs.
+        if self.thread_id.is_some()
+            && self.agent_id.is_some()
+            && milestone.scope.agent_id != self.agent_id
         {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::ScopeMismatch,
@@ -114,11 +126,23 @@ impl DurableLoopHostMilestoneScope {
             }
             _ => {}
         }
+        // Event storage owner: the run's explicit thread owner wins; an
+        // ownerless (project-owned) run files under the run actor when one is
+        // bound, else the sink's composition-time fallback user. Mirrors
+        // `local_dev_resource_scope_for_run`. Membership-based projection
+        // (project principal storage) is the follow-up that replaces the
+        // actor fallback for project-owned runs.
+        let user_id = milestone
+            .scope
+            .explicit_owner_user_id()
+            .cloned()
+            .or_else(|| milestone.actor.as_ref().map(|actor| actor.user_id.clone()))
+            .unwrap_or_else(|| self.user_id.clone());
         Ok(ResourceScope {
             tenant_id: self.tenant_id.clone(),
-            user_id: self.user_id.clone(),
-            agent_id: self.agent_id.clone(),
-            project_id: self.project_id.clone(),
+            user_id,
+            agent_id: milestone.scope.agent_id.clone(),
+            project_id: milestone.scope.project_id.clone(),
             mission_id: self.mission_id.clone(),
             thread_id: Some(milestone.scope.thread_id.clone()),
             invocation_id: InvocationId::from_uuid(milestone.run_id.as_uuid()),
@@ -664,5 +688,120 @@ mod tests {
             Some("fail_closed")
         );
         assert_eq!(event.hook_id.as_deref(), Some(HOOK_HEX_ID));
+    }
+
+    fn composition_sink() -> DurableLoopHostMilestoneSink {
+        // Mirrors the runtime-composition sink: tenant + fallback user pinned,
+        // no thread/run pin, agent/project from the runtime identity.
+        let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+        let scope = DurableLoopHostMilestoneScope::new(
+            TenantId::new("tenant-hook-projection").unwrap(),
+            UserId::new("composition-fallback-user").unwrap(),
+            Some(AgentId::new("agent-hook-projection").unwrap()),
+            None,
+            None,
+        );
+        DurableLoopHostMilestoneSink::new(event_log, scope)
+    }
+
+    fn model_started_milestone_with_scope(scope: TurnScope) -> LoopHostMilestone {
+        LoopHostMilestone {
+            scope,
+            actor: None,
+            turn_id: TurnId::new(),
+            run_id: TurnRunId::new(),
+            loop_driver_id: LoopDriverId::new("hook-projection-driver").unwrap(),
+            kind: LoopHostMilestoneKind::ModelStarted {
+                requested_model_profile_id: None,
+            },
+        }
+    }
+
+    #[test]
+    fn composition_sink_rejects_cross_tenant_milestone() {
+        let sink = composition_sink();
+        let scope = TurnScope::new(
+            TenantId::new("other-tenant").unwrap(),
+            Some(AgentId::new("agent-hook-projection").unwrap()),
+            None,
+            ThreadId::new("thread-cross-tenant").unwrap(),
+        );
+        let error = sink
+            .runtime_event_for_milestone(&model_started_milestone_with_scope(scope))
+            .expect_err("cross-tenant milestone must be rejected");
+        assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
+    }
+
+    #[test]
+    fn composition_sink_follows_run_project_and_explicit_owner() {
+        let sink = composition_sink();
+        let scope = TurnScope::new_with_owner(
+            TenantId::new("tenant-hook-projection").unwrap(),
+            Some(AgentId::new("agent-hook-projection").unwrap()),
+            Some(ProjectId::new("run-project").unwrap()),
+            ThreadId::new("thread-run-project").unwrap(),
+            Some(UserId::new("run-owner").unwrap()),
+        );
+        let event = sink
+            .runtime_event_for_milestone(&model_started_milestone_with_scope(scope))
+            .expect("projection succeeds")
+            .expect("model started milestone projects");
+        assert_eq!(
+            event.scope.project_id,
+            Some(ProjectId::new("run-project").unwrap())
+        );
+        assert_eq!(event.scope.user_id, UserId::new("run-owner").unwrap());
+    }
+
+    #[test]
+    fn composition_sink_project_owned_run_files_under_actor_then_fallback() {
+        let sink = composition_sink();
+        // Explicitly ownerless (project-owned) run scope.
+        let ownerless = TurnScope::new_with_owner(
+            TenantId::new("tenant-hook-projection").unwrap(),
+            Some(AgentId::new("agent-hook-projection").unwrap()),
+            Some(ProjectId::new("run-project").unwrap()),
+            ThreadId::new("thread-ownerless").unwrap(),
+            None,
+        );
+        let mut milestone = model_started_milestone_with_scope(ownerless);
+        milestone.actor = Some(ironclaw_turns::TurnActor::new(
+            UserId::new("run-actor").unwrap(),
+        ));
+        let event = sink
+            .runtime_event_for_milestone(&milestone)
+            .expect("projection succeeds")
+            .expect("milestone projects");
+        assert_eq!(event.scope.user_id, UserId::new("run-actor").unwrap());
+
+        let mut actorless = milestone.clone();
+        actorless.actor = None;
+        let event = sink
+            .runtime_event_for_milestone(&actorless)
+            .expect("projection succeeds")
+            .expect("milestone projects");
+        assert_eq!(
+            event.scope.user_id,
+            UserId::new("composition-fallback-user").unwrap()
+        );
+    }
+
+    #[test]
+    fn run_pinned_sink_still_rejects_agent_mismatch() {
+        let thread_id = ThreadId::new("thread-hook-projection").unwrap();
+        let run_id = TurnRunId::new();
+        let sink = projector_for(thread_id.clone(), run_id);
+        let scope = TurnScope::new(
+            TenantId::new("tenant-hook-projection").unwrap(),
+            Some(AgentId::new("other-agent").unwrap()),
+            Some(ProjectId::new("project-hook-projection").unwrap()),
+            thread_id,
+        );
+        let mut milestone = model_started_milestone_with_scope(scope);
+        milestone.run_id = run_id;
+        let error = sink
+            .runtime_event_for_milestone(&milestone)
+            .expect_err("agent mismatch on a run-pinned sink must be rejected");
+        assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
     }
 }

--- a/crates/ironclaw_reborn/src/thread_scope.rs
+++ b/crates/ironclaw_reborn/src/thread_scope.rs
@@ -44,6 +44,14 @@ impl ThreadScopeResolver {
         if turn_scope.has_explicit_thread_owner() {
             let mut scope = base.clone();
             scope.owner_user_id = turn_scope.explicit_owner_user_id().cloned();
+            // The turn scope carries the canonical project_id from the
+            // conversation binding. Override the base (which reflects the
+            // runtime's default project, possibly None) so the resolved
+            // ThreadScope matches the thread that was stored at materialize
+            // time — especially for project-scoped automation triggers
+            // where the trigger's project_id may differ from the runtime
+            // default.
+            scope.project_id = turn_scope.project_id.clone();
             return scope;
         }
         Self::resolve(base, actor)
@@ -113,5 +121,37 @@ mod tests {
             ThreadScopeResolver::resolve_for_turn(&base, &turn_scope, Some(&actor("alice")));
 
         assert_eq!(resolved.owner_user_id, None);
+    }
+
+    #[test]
+    fn explicit_ownerless_turn_with_project_id_overrides_base_project() {
+        // Trigger fires for project-scoped automations carry a project_id on
+        // the TurnScope that may differ from (or be absent on) the runtime
+        // base scope. resolve_for_turn must propagate the turn's project_id
+        // so the resolved ThreadScope matches the thread stored at
+        // materialize time.
+        use ironclaw_host_api::ProjectId;
+        let base = scope(Some("runtime-owner")); // base has project_id: None
+        let project_id = ProjectId::new("trigger-project").expect("project id");
+        let turn_scope = TurnScope::new_with_owner(
+            base.tenant_id.clone(),
+            Some(base.agent_id.clone()),
+            Some(project_id.clone()),
+            ironclaw_host_api::ThreadId::new("thread").unwrap(),
+            None, // Ownerless
+        );
+
+        let resolved =
+            ThreadScopeResolver::resolve_for_turn(&base, &turn_scope, Some(&actor("alice")));
+
+        assert_eq!(
+            resolved.owner_user_id, None,
+            "project-owned turn must be ownerless"
+        );
+        assert_eq!(
+            resolved.project_id.as_ref(),
+            Some(&project_id),
+            "project_id must come from turn_scope, not base"
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2930,6 +2930,7 @@ mod tests {
             creator_user_id: UserId::new("pairing-test-user").expect("user id"),
             agent_id: None,
             project_id: None,
+            ownership_scope: ironclaw_triggers::TriggerOwnershipScope::Personal,
             name: "pairing test".to_string(),
             source: ironclaw_triggers::TriggerSourceKind::Schedule,
             schedule: ironclaw_triggers::TriggerSchedule::cron("* * * * *")

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -94,11 +94,15 @@ mod slack_connectable_channel;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_delivery;
 #[cfg(feature = "slack-v2-host-beta")]
+mod slack_dm_open;
+#[cfg(feature = "slack-v2-host-beta")]
 mod slack_egress;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_host_beta;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_host_state;
+#[cfg(feature = "slack-v2-host-beta")]
+mod slack_outbound_targets;
 #[cfg(feature = "slack-v2-host-beta")]
 mod slack_pairing_notifier;
 #[cfg(feature = "slack-v2-host-beta")]

--- a/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
+++ b/crates/ironclaw_reborn_composition/src/outbound_preferences.rs
@@ -31,6 +31,14 @@ pub(crate) trait OutboundDeliveryTargetProvider: Send + Sync {
         caller: &WebUiAuthenticatedCaller,
     ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError>;
 
+    #[allow(dead_code, reason = "consumed by the project preference facade in the stacked surface PR")]
+    async fn list_project_delivery_targets(
+        &self,
+        _caller: &WebUiAuthenticatedCaller,
+    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        Ok(Vec::new())
+    }
+
     async fn resolve_outbound_delivery_target(
         &self,
         caller: &WebUiAuthenticatedCaller,
@@ -53,6 +61,38 @@ pub(crate) trait OutboundDeliveryTargetProvider: Send + Sync {
     ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
         Ok(self
             .list_outbound_delivery_targets(caller)
+            .await?
+            .into_iter()
+            .find(|entry| {
+                entry.capabilities.final_replies
+                    && entry.reply_target_binding_ref.as_str() == target.as_str()
+            }))
+    }
+
+    #[allow(dead_code, reason = "consumed by the project preference facade in the stacked surface PR")]
+    async fn resolve_project_outbound_delivery_target(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target_id: &RebornOutboundDeliveryTargetId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        Ok(self
+            .list_project_delivery_targets(caller)
+            .await?
+            .into_iter()
+            .find(|entry| {
+                entry.capabilities.final_replies
+                    && entry.summary.target_id.as_str() == target_id.as_str()
+            }))
+    }
+
+    #[allow(dead_code, reason = "consumed by the project preference facade in the stacked surface PR")]
+    async fn resolve_project_reply_target_binding(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target: &ReplyTargetBindingRef,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        Ok(self
+            .list_project_delivery_targets(caller)
             .await?
             .into_iter()
             .find(|entry| {

--- a/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_channel_routes.rs
@@ -204,6 +204,49 @@ pub(crate) trait SlackChannelRouteStore: Send + Sync + std::fmt::Debug {
         &self,
         key: &SlackChannelRouteKey,
     ) -> Result<Option<UserId>, SlackChannelRouteError>;
+
+    /// List routes that belong to `subject_user_id`, paging through the store
+    /// `limit` entries at a time.  The default implementation re-uses
+    /// `list_routes` and filters each page in memory; it never materialises
+    /// more than `limit` entries at once and returns early once `cap` routes
+    /// have been accumulated.
+    ///
+    /// Implementors whose storage layout is subject-indexed may override this
+    /// with a cheaper query.  A true subject index remains a tracked follow-up
+    /// for stores where full-inventory scans become expensive at scale.
+    async fn list_routes_for_subject(
+        &self,
+        tenant_id: &TenantId,
+        installation_id: &AdapterInstallationId,
+        team_id: &str,
+        subject_user_id: &UserId,
+        page_size: usize,
+        cap: usize,
+    ) -> Result<Vec<SlackChannelRoute>, SlackChannelRouteError> {
+        let mut cursor = 0;
+        let mut result = Vec::new();
+        loop {
+            let page = self
+                .list_routes(tenant_id, installation_id, team_id, cursor, page_size)
+                .await?;
+            for route in page.routes {
+                if route.subject_user_id == subject_user_id.as_str() {
+                    if result.len() >= cap {
+                        return Err(SlackChannelRouteError::StoreUnavailable);
+                    }
+                    result.push(route);
+                }
+            }
+            let Some(next_cursor) = page.next_cursor else {
+                break;
+            };
+            if next_cursor <= cursor {
+                return Err(SlackChannelRouteError::StoreUnavailable);
+            }
+            cursor = next_cursor;
+        }
+        Ok(result)
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -175,6 +175,22 @@ mod tests {
         assert!(matches!(error, SlackDmOpenError::Backend(_)));
     }
 
+    #[tokio::test]
+    async fn open_slack_dm_channel_returns_channel_id_on_success() {
+        let channel_id = open_slack_dm_channel(
+            &ScriptedEgress::new(EgressResponse::new(
+                200,
+                br#"{"ok":true,"channel":{"id":"D123ABCD"}}"#.to_vec(),
+            )),
+            credential_handle(),
+            "U123",
+        )
+        .await
+        .expect("happy path succeeds");
+
+        assert_eq!(channel_id, "D123ABCD");
+    }
+
     #[test]
     fn validate_slack_dm_channel_id_rejects_invalid_shapes() {
         for value in ["", "C123", "G123", "D 123", "D/123", "D\x01123"] {

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -9,12 +9,14 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 
 const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
-const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
+pub(crate) const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub(crate) enum SlackDmOpenError {
     #[error("Slack DM open failed: {0}")]
     Backend(String),
+    #[error("Slack conversations.open response did not return a direct-message channel")]
+    InvalidChannel,
     #[error("Slack conversations.open response did not include a channel id")]
     MissingChannel,
 }
@@ -52,6 +54,21 @@ pub(crate) async fn open_slack_dm_channel(
         .map(|channel| channel.id)
         .filter(|id| !id.is_empty())
         .ok_or(SlackDmOpenError::MissingChannel)
+}
+
+pub(crate) fn validate_slack_dm_channel_id(value: &str) -> Result<(), SlackDmOpenError> {
+    if value.is_empty()
+        || value.len() > 128
+        || value.chars().any(|c| {
+            c == '\0' || c.is_control() || c.is_whitespace() || matches!(c, '/' | '\\' | ':' | ';')
+        })
+    {
+        return Err(SlackDmOpenError::InvalidChannel);
+    }
+    if !value.starts_with('D') {
+        return Err(SlackDmOpenError::InvalidChannel);
+    }
+    Ok(())
 }
 
 #[derive(Debug, Serialize)]
@@ -101,4 +118,106 @@ where
     serde_json::from_slice(body).map_err(|error| {
         SlackDmOpenError::Backend(format!("{label} response was invalid JSON: {error}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use ironclaw_product_adapters::{EgressResponse, ProtocolHttpEgressError};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn open_slack_dm_channel_returns_missing_channel_when_id_empty() {
+        for body in [
+            br#"{"ok":true}"#.to_vec(),
+            br#"{"ok":true,"channel":{"id":""}}"#.to_vec(),
+        ] {
+            let error = open_slack_dm_channel(
+                &ScriptedEgress::new(EgressResponse::new(200, body)),
+                credential_handle(),
+                "U123",
+            )
+            .await
+            .expect_err("missing channel fails");
+
+            assert!(matches!(error, SlackDmOpenError::MissingChannel));
+        }
+    }
+
+    #[tokio::test]
+    async fn open_slack_dm_channel_fails_on_non_2xx() {
+        let error = open_slack_dm_channel(
+            &ScriptedEgress::new(EgressResponse::new(503, b"unavailable".to_vec())),
+            credential_handle(),
+            "U123",
+        )
+        .await
+        .expect_err("non-2xx fails");
+
+        assert!(matches!(error, SlackDmOpenError::Backend(_)));
+    }
+
+    #[tokio::test]
+    async fn open_slack_dm_channel_fails_on_oversized_body() {
+        let error = open_slack_dm_channel(
+            &ScriptedEgress::new(EgressResponse::new(
+                200,
+                vec![b'{'; SLACK_API_RESPONSE_LIMIT + 1],
+            )),
+            credential_handle(),
+            "U123",
+        )
+        .await
+        .expect_err("oversized body fails");
+
+        assert!(matches!(error, SlackDmOpenError::Backend(_)));
+    }
+
+    #[test]
+    fn validate_slack_dm_channel_id_rejects_invalid_shapes() {
+        for value in ["", "C123", "G123", "D 123", "D/123", "D\x01123"] {
+            assert!(matches!(
+                validate_slack_dm_channel_id(value),
+                Err(SlackDmOpenError::InvalidChannel)
+            ));
+        }
+        assert!(matches!(
+            validate_slack_dm_channel_id(&format!("D{}", "1".repeat(128))),
+            Err(SlackDmOpenError::InvalidChannel)
+        ));
+        validate_slack_dm_channel_id("D123").expect("valid DM channel");
+    }
+
+    fn credential_handle() -> EgressCredentialHandle {
+        EgressCredentialHandle::new("slack_bot_token").expect("credential handle")
+    }
+
+    #[derive(Debug)]
+    struct ScriptedEgress {
+        response: Mutex<Option<EgressResponse>>,
+    }
+
+    impl ScriptedEgress {
+        fn new(response: EgressResponse) -> Self {
+            Self {
+                response: Mutex::new(Some(response)),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ProtocolHttpEgress for ScriptedEgress {
+        async fn send(
+            &self,
+            _request: EgressRequest,
+        ) -> Result<EgressResponse, ProtocolHttpEgressError> {
+            self.response
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .ok_or(ProtocolHttpEgressError::Timeout)
+        }
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -1,0 +1,104 @@
+//! Shared Slack conversations.open client for host-beta DM flows.
+
+use ironclaw_product_adapters::{
+    DeclaredEgressHost, EgressCredentialHandle, EgressHeader, EgressMethod, EgressPath,
+    EgressRequest, ProtocolHttpEgress,
+};
+use ironclaw_slack_v2_adapter::SLACK_API_HOST;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use thiserror::Error;
+
+const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
+const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum SlackDmOpenError {
+    #[error("Slack DM open failed: {0}")]
+    Backend(String),
+    #[error("Slack conversations.open response did not include a channel id")]
+    MissingChannel,
+}
+
+pub(crate) async fn open_slack_dm_channel(
+    egress: &dyn ProtocolHttpEgress,
+    credential_handle: EgressCredentialHandle,
+    slack_user_id: &str,
+) -> Result<String, SlackDmOpenError> {
+    let body = serde_json::to_vec(&SlackConversationsOpenRequest {
+        users: slack_user_id.to_string(),
+    })
+    .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    let request = slack_api_request(SLACK_CONVERSATIONS_OPEN_PATH, body, credential_handle)?;
+    let response = egress
+        .send(request)
+        .await
+        .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    if !(200..300).contains(&response.status()) {
+        return Err(SlackDmOpenError::Backend(format!(
+            "Slack API request {SLACK_CONVERSATIONS_OPEN_PATH} failed with HTTP {}",
+            response.status()
+        )));
+    }
+    let opened: SlackConversationsOpenResponse =
+        slack_json_response("Slack conversations.open", response.body())?;
+    if !opened.ok {
+        return Err(SlackDmOpenError::Backend(format!(
+            "Slack rejected conversations.open ({})",
+            opened.error.unwrap_or_else(|| "unknown_error".into())
+        )));
+    }
+    opened
+        .channel
+        .map(|channel| channel.id)
+        .filter(|id| !id.is_empty())
+        .ok_or(SlackDmOpenError::MissingChannel)
+}
+
+#[derive(Debug, Serialize)]
+struct SlackConversationsOpenRequest {
+    users: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenResponse {
+    ok: bool,
+    error: Option<String>,
+    channel: Option<SlackConversationsOpenChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsOpenChannel {
+    id: String,
+}
+
+fn slack_api_request(
+    path: &'static str,
+    body: Vec<u8>,
+    credential_handle: EgressCredentialHandle,
+) -> Result<EgressRequest, SlackDmOpenError> {
+    let host = DeclaredEgressHost::new(SLACK_API_HOST)
+        .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    let method = EgressMethod::post();
+    let path =
+        EgressPath::new(path).map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    let content_type = EgressHeader::new("content-type", "application/json")
+        .map_err(|error| SlackDmOpenError::Backend(error.to_string()))?;
+    Ok(EgressRequest::new(host, method, path)
+        .with_header(content_type)
+        .with_body(body)
+        .with_credential_handle(Some(credential_handle)))
+}
+
+fn slack_json_response<T>(label: &'static str, body: &[u8]) -> Result<T, SlackDmOpenError>
+where
+    T: DeserializeOwned,
+{
+    if body.len() > SLACK_API_RESPONSE_LIMIT {
+        return Err(SlackDmOpenError::Backend(format!(
+            "{label} response exceeded body limit"
+        )));
+    }
+    serde_json::from_slice(body).map_err(|error| {
+        SlackDmOpenError::Backend(format!("{label} response was invalid JSON: {error}"))
+    })
+}

--- a/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_dm_open.rs
@@ -206,6 +206,25 @@ mod tests {
         validate_slack_dm_channel_id("D123").expect("valid DM channel");
     }
 
+    #[test]
+    fn validate_slack_dm_channel_id_accepts_exactly_128_bytes_and_rejects_129() {
+        // Boundary: "D" + 127 ASCII chars = 128 bytes total — must be accepted.
+        let at_limit = format!("D{}", "X".repeat(127));
+        assert_eq!(at_limit.len(), 128, "fixture must be exactly 128 bytes");
+        validate_slack_dm_channel_id(&at_limit).expect("exactly 128-byte id must be valid");
+
+        // One byte over the limit — must be rejected.
+        let over_limit = format!("D{}", "X".repeat(128));
+        assert_eq!(over_limit.len(), 129, "fixture must be exactly 129 bytes");
+        assert!(
+            matches!(
+                validate_slack_dm_channel_id(&over_limit),
+                Err(SlackDmOpenError::InvalidChannel)
+            ),
+            "129-byte id must be rejected"
+        );
+    }
+
     fn credential_handle() -> EgressCredentialHandle {
         EgressCredentialHandle::new("slack_bot_token").expect("credential handle")
     }

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -669,7 +669,8 @@ mod tests {
     };
     use crate::slack_outbound_targets::{
         InMemorySlackPersonalDmTargetStore, SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
-        SlackPersonalDmTargetError, SlackPersonalDmTargetProvisioner, SlackPersonalDmTargetStore,
+        SlackPersonalDmTarget, SlackPersonalDmTargetError, SlackPersonalDmTargetKey,
+        SlackPersonalDmTargetProvisioner, SlackPersonalDmTargetStore,
         slack_reply_target_binding_ref_from_raw, slack_shared_channel_reply_target_binding_ref,
     };
     use crate::slack_personal_binding_pairing_serve::{
@@ -1955,6 +1956,47 @@ mod tests {
             Some("slack:personal-dm:T0HOST:user:slack-host")
         );
         runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_reply_target_binding_ref_round_trips_authorized_dm() {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("personal target key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("personal DM target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("personal DM target stores");
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config_without_channel_routes()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store,
+        );
+        let listed = provider
+            .list_outbound_delivery_targets(&operator_caller())
+            .await
+            .expect("target list");
+        let binding_ref = listed[0].reply_target_binding_ref.clone();
+
+        let resolved = provider
+            .resolve_reply_target_binding(&operator_caller(), &binding_ref)
+            .await
+            .expect("binding resolves")
+            .expect("personal DM binding is authorized");
+
+        assert_eq!(
+            resolved.summary.target_id.as_str(),
+            "slack:personal-dm:T0HOST:user:slack-host"
+        );
+        assert_eq!(resolved.reply_target_binding_ref, binding_ref);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -14,23 +14,20 @@ use ironclaw_host_api::{AgentId, ProjectId, ResourceScope, TenantId, UserId};
 use ironclaw_outbound::{FilesystemOutboundStateStore, OutboundStateStore};
 use ironclaw_product_adapters::{
     AdapterInstallationId, DeclaredEgressHost, DeclaredEgressTarget, DeliveryStatus,
-    EgressCredentialHandle, ExternalActorRef, ExternalConversationRef, OutboundDeliverySink,
-    ProductAdapter, ProductAdapterId, ProtocolHttpEgress,
+    EgressCredentialHandle, ExternalActorRef, OutboundDeliverySink, ProductAdapter,
+    ProductAdapterId, ProtocolHttpEgress,
 };
 use ironclaw_product_workflow::{
     DefaultInboundTurnService, DefaultProductWorkflow, ProductActorUserResolutionRequest,
     ProductActorUserResolver, ProductConversationBindingService, ProductConversationRouteKey,
     ProductConversationSubjectRouteResolver, ProductInstallationKey, ProductInstallationScope,
-    ProductWorkflowError, RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
-    RebornOutboundDeliveryTargetSummary, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind, StaticProductInstallationResolver, WebUiAuthenticatedCaller,
+    ProductWorkflowError, StaticProductInstallationResolver,
 };
 use ironclaw_product_workflow_storage::RebornFilesystemIdempotencyLedger;
 use ironclaw_slack_v2_adapter::{
     SLACK_API_HOST, SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID, SlackV2Adapter,
     SlackV2AdapterConfig, slack_request_signature_auth_requirement,
 };
-use ironclaw_turns::ReplyTargetBindingRef;
 use ironclaw_wasm_product_adapters::{
     EgressPolicy, HmacWebhookAuth, NativeProductAdapterRunner, NativeProductAdapterRunnerConfig,
     WebhookAuth,
@@ -39,11 +36,10 @@ use secrecy::{ExposeSecret, SecretString};
 use thiserror::Error;
 
 use crate::RebornRuntime;
-use crate::outbound_preferences::{OutboundDeliveryTargetEntry, OutboundDeliveryTargetProvider};
+use crate::outbound_preferences::OutboundDeliveryTargetProvider;
 use crate::slack_actor_identity::SlackUserIdentityActorResolver;
 use crate::slack_channel_routes::{
-    SlackChannelRouteAdminRouteConfig, SlackChannelRouteError, SlackChannelRouteKey,
-    SlackChannelRouteStore, SlackChannelRouteSubjectResolver,
+    SlackChannelRouteAdminRouteConfig, SlackChannelRouteStore, SlackChannelRouteSubjectResolver,
 };
 use crate::slack_delivery::{
     SlackFinalReplyDeliveryObserver, SlackFinalReplyDeliveryServices,
@@ -51,6 +47,10 @@ use crate::slack_delivery::{
 };
 use crate::slack_egress::{SlackProtocolHttpEgress, StaticSlackEgressCredentialProvider};
 use crate::slack_host_state::FilesystemSlackHostState;
+use crate::slack_outbound_targets::{
+    SlackConfiguredChannelRoute, SlackHostBetaOutboundTargetProvider,
+    SlackOutboundTargetProviderConfig, SlackPersonalDmTargetStore,
+};
 use crate::slack_pairing_notifier::SlackPairingChallengeHttpNotifier;
 use crate::slack_personal_binding::{
     RebornUserIdentityBindingStore, SlackPersonalBindingInstallation,
@@ -74,10 +74,6 @@ const SLACK_WEBHOOK_WORKFLOW_TIMEOUT: Duration = Duration::from_secs(2);
 const SLACK_MAX_IN_FLIGHT_WEBHOOKS: usize = 64;
 const SLACK_IDEMPOTENCY_LEDGER_SETTLED_LIMIT: usize = 10_000;
 const SLACK_IDEMPOTENCY_LEDGER_PRUNE_INTERVAL: usize = 1_000;
-// `ReplyTargetBindingRef` permits 256 bytes; this raw cap leaves room for the
-// `reply:` prefix that is added before constructing the typed ref.
-const SLACK_BINDING_REF_RAW_MAX_BYTES: usize = 240;
-const SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE: usize = 500;
 
 struct NoopSlackDeliverySink;
 
@@ -286,6 +282,7 @@ pub fn build_slack_host_beta_mounts(
         )),
     ));
     let channel_route_store: Arc<dyn SlackChannelRouteStore> = state.clone();
+    let personal_dm_target_store: Arc<dyn SlackPersonalDmTargetStore> = state.clone();
     let subject_route_resolver: Arc<dyn ProductConversationSubjectRouteResolver> =
         Arc::new(SlackChannelRouteSubjectResolver::new(
             config.tenant_id.clone(),
@@ -320,271 +317,27 @@ pub fn build_slack_host_beta_mounts(
         personal_binding_pairing: SlackPersonalBindingPairingRouteConfig::new(pairing),
         channel_routes,
         outbound_delivery_target_provider: Arc::new(SlackHostBetaOutboundTargetProvider::new(
-            config,
+            SlackOutboundTargetProviderConfig {
+                tenant_id: config.tenant_id.clone(),
+                agent_id: config.agent_id.clone(),
+                project_id: config.project_id.clone(),
+                installation_id: config.installation_id.clone(),
+                team_id: config.team_id.clone(),
+                configured_channel_routes: config
+                    .channel_routes
+                    .iter()
+                    .map(|route| {
+                        SlackConfiguredChannelRoute::new(
+                            route.channel_id.clone(),
+                            route.subject_user_id.clone(),
+                        )
+                    })
+                    .collect(),
+            },
             channel_route_store,
+            Arc::clone(&personal_dm_target_store),
         )),
     })
-}
-
-#[derive(Debug)]
-struct SlackHostBetaOutboundTargetProvider {
-    tenant_id: TenantId,
-    agent_id: AgentId,
-    project_id: Option<ProjectId>,
-    installation_id: AdapterInstallationId,
-    team_id: SlackTeamId,
-    target_id_prefix: String,
-    configured_channel_routes: Vec<SlackHostBetaChannelRoute>,
-    channel_route_store: Arc<dyn SlackChannelRouteStore>,
-}
-
-impl SlackHostBetaOutboundTargetProvider {
-    fn new(
-        config: SlackHostBetaConfig,
-        channel_route_store: Arc<dyn SlackChannelRouteStore>,
-    ) -> Self {
-        Self {
-            tenant_id: config.tenant_id,
-            agent_id: config.agent_id,
-            project_id: config.project_id,
-            installation_id: config.installation_id,
-            target_id_prefix: format!("slack:shared-channel:{}:", config.team_id.as_str()),
-            team_id: config.team_id,
-            configured_channel_routes: config.channel_routes,
-            channel_route_store,
-        }
-    }
-
-    fn target_id_for_shared_channel(
-        &self,
-        channel_id: &str,
-    ) -> Result<RebornOutboundDeliveryTargetId, RebornServicesError> {
-        RebornOutboundDeliveryTargetId::new(format!(
-            "slack:shared-channel:{}:{}",
-            self.team_id.as_str(),
-            channel_id
-        ))
-        .map_err(|_| slack_target_backend_error())
-    }
-
-    fn channel_id_for_target_id<'a>(
-        &self,
-        target_id: &'a RebornOutboundDeliveryTargetId,
-    ) -> Option<&'a str> {
-        target_id
-            .as_str()
-            .strip_prefix(&self.target_id_prefix)
-            .filter(|channel_id| !channel_id.is_empty())
-    }
-
-    fn channel_id_for_reply_target_binding_ref<'a>(
-        &self,
-        target: &'a ReplyTargetBindingRef,
-    ) -> Option<&'a str> {
-        let mut raw = target.as_str().strip_prefix("reply:")?;
-        let (adapter_id, rest) = take_product_binding_segment(raw, "adapter")?;
-        if adapter_id != SLACK_V2_ADAPTER_ID {
-            return None;
-        }
-        raw = rest;
-        let (installation_id, rest) = take_product_binding_segment(raw, "installation")?;
-        if installation_id != self.installation_id.as_str() {
-            return None;
-        }
-        raw = rest;
-        let (agent_id, rest) = take_product_binding_segment(raw, "agent")?;
-        if agent_id != self.agent_id.as_str() {
-            return None;
-        }
-        raw = rest;
-        let (project_id, rest) = take_product_binding_segment(raw, "project")?;
-        if project_id != self.project_id.as_ref().map_or("", |id| id.as_str()) {
-            return None;
-        }
-        raw = rest;
-        let (space_id, rest) = take_product_binding_segment(raw, "space")?;
-        if space_id != self.team_id.as_str() {
-            return None;
-        }
-        raw = rest;
-        let (channel_id, rest) = take_product_binding_segment(raw, "conversation")?;
-        let (topic_id, rest) = take_product_binding_segment(rest, "topic")?;
-        if channel_id.is_empty() || !topic_id.is_empty() || !rest.is_empty() {
-            return None;
-        }
-        Some(channel_id)
-    }
-
-    async fn shared_channel_route_for_channel(
-        &self,
-        channel_id: &str,
-    ) -> Result<Option<SlackHostBetaChannelRoute>, RebornServicesError> {
-        let key = match SlackChannelRouteKey::new(
-            self.tenant_id.clone(),
-            self.installation_id.clone(),
-            self.team_id.as_str().to_string(),
-            channel_id.to_string(),
-        ) {
-            Ok(key) => key,
-            Err(SlackChannelRouteError::InvalidRoute) => return Ok(None),
-            Err(error) => return Err(map_slack_target_route_error(error)),
-        };
-        if let Some(subject_user_id) = self
-            .channel_route_store
-            .resolve_subject_user_id(&key)
-            .await
-            .map_err(map_slack_target_route_error)?
-        {
-            return Ok(Some(SlackHostBetaChannelRoute::new(
-                channel_id.to_string(),
-                subject_user_id,
-            )));
-        }
-        Ok(self
-            .configured_channel_routes
-            .iter()
-            .find(|route| route.channel_id == channel_id)
-            .cloned())
-    }
-
-    async fn shared_channel_routes(
-        &self,
-    ) -> Result<Vec<SlackHostBetaChannelRoute>, RebornServicesError> {
-        let mut cursor = 0;
-        let mut stored_channel_ids = HashSet::new();
-        let mut routes = Vec::new();
-        loop {
-            let stored = self
-                .channel_route_store
-                .list_routes(
-                    &self.tenant_id,
-                    &self.installation_id,
-                    self.team_id.as_str(),
-                    cursor,
-                    SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
-                )
-                .await
-                .map_err(map_slack_target_route_error)?;
-            for route in stored.routes {
-                stored_channel_ids.insert(route.channel_id.clone());
-                routes.push(SlackHostBetaChannelRoute::new(
-                    route.channel_id,
-                    UserId::new(route.subject_user_id).map_err(|_| slack_target_backend_error())?,
-                ));
-            }
-            let Some(next_cursor) = stored.next_cursor else {
-                break;
-            };
-            if next_cursor <= cursor {
-                return Err(map_slack_target_route_error(
-                    SlackChannelRouteError::StoreUnavailable,
-                ));
-            }
-            cursor = next_cursor;
-        }
-        routes.extend(
-            self.configured_channel_routes
-                .iter()
-                .filter(|route| !stored_channel_ids.contains(&route.channel_id))
-                .cloned(),
-        );
-        Ok(routes)
-    }
-
-    fn entry_for_shared_channel_route(
-        &self,
-        route: &SlackHostBetaChannelRoute,
-    ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
-        let target_id = self.target_id_for_shared_channel(&route.channel_id)?;
-        let display_name = format!("Slack channel {}", route.channel_id);
-        Ok(OutboundDeliveryTargetEntry {
-            summary: RebornOutboundDeliveryTargetSummary::new(
-                target_id,
-                "slack",
-                display_name,
-                Some(format!(
-                    "Slack channel {} in team {}",
-                    route.channel_id,
-                    self.team_id.as_str()
-                )),
-            )
-            .map_err(|_| slack_target_backend_error())?,
-            capabilities: RebornOutboundDeliveryTargetCapabilities {
-                final_replies: true,
-                gate_prompts: true,
-                auth_prompts: true,
-            },
-            reply_target_binding_ref: slack_shared_channel_reply_target_binding_ref(
-                &self.installation_id,
-                &self.agent_id,
-                self.project_id.as_ref(),
-                &self.team_id,
-                &route.channel_id,
-            )?,
-        })
-    }
-
-    async fn resolve_for_channel_id(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-        channel_id: &str,
-    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        if caller.tenant_id != self.tenant_id {
-            return Ok(None);
-        }
-        let Some(route) = self.shared_channel_route_for_channel(channel_id).await? else {
-            return Ok(None);
-        };
-        if route.subject_user_id != caller.user_id {
-            return Ok(None);
-        }
-        self.entry_for_shared_channel_route(&route).map(Some)
-    }
-}
-
-#[async_trait::async_trait]
-impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
-    async fn list_outbound_delivery_targets(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        if caller.tenant_id != self.tenant_id {
-            return Ok(Vec::new());
-        }
-        let mut routes = self
-            .shared_channel_routes()
-            .await?
-            .into_iter()
-            .filter(|route| route.subject_user_id == caller.user_id)
-            .collect::<Vec<_>>();
-        routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
-        routes
-            .into_iter()
-            .map(|route| self.entry_for_shared_channel_route(&route))
-            .collect()
-    }
-
-    async fn resolve_outbound_delivery_target(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-        target_id: &RebornOutboundDeliveryTargetId,
-    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        let Some(channel_id) = self.channel_id_for_target_id(target_id) else {
-            return Ok(None);
-        };
-        self.resolve_for_channel_id(caller, channel_id).await
-    }
-
-    async fn resolve_reply_target_binding(
-        &self,
-        caller: &WebUiAuthenticatedCaller,
-        target: &ReplyTargetBindingRef,
-    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
-        let Some(channel_id) = self.channel_id_for_reply_target_binding_ref(target) else {
-            return Ok(None);
-        };
-        self.resolve_for_channel_id(caller, channel_id).await
-    }
 }
 
 pub fn build_slack_events_route_mount_with_actor_user_resolver(
@@ -743,81 +496,6 @@ fn slack_channel_route_key(
         .map_err(|reason| invalid_config("channel_routes", reason.to_string()))
 }
 
-fn slack_shared_channel_reply_target_binding_ref(
-    installation_id: &AdapterInstallationId,
-    agent_id: &AgentId,
-    project_id: Option<&ProjectId>,
-    team_id: &SlackTeamId,
-    channel_id: &str,
-) -> Result<ReplyTargetBindingRef, RebornServicesError> {
-    let conversation = ExternalConversationRef::new(Some(team_id.as_str()), channel_id, None, None)
-        .map_err(|_| slack_target_backend_error())?;
-    let raw = format!(
-        "{}{}{}{}{}",
-        product_binding_segment("adapter", SLACK_V2_ADAPTER_ID),
-        product_binding_segment("installation", installation_id.as_str()),
-        product_binding_segment("agent", agent_id.as_str()),
-        product_binding_segment("project", project_id.map_or("", |id| id.as_str())),
-        conversation.conversation_fingerprint()
-    );
-    slack_reply_target_binding_ref_from_raw(raw)
-}
-
-fn slack_reply_target_binding_ref_from_raw(
-    raw: String,
-) -> Result<ReplyTargetBindingRef, RebornServicesError> {
-    if raw.len() > SLACK_BINDING_REF_RAW_MAX_BYTES
-        || raw.chars().any(|c| c == '\0' || c.is_control())
-    {
-        return Err(slack_target_backend_error());
-    }
-    ReplyTargetBindingRef::new(format!("reply:{raw}")).map_err(|_| slack_target_backend_error())
-}
-
-// Keep this segment format in parity with
-// `ExternalConversationRef::conversation_fingerprint`.
-fn product_binding_segment(name: &str, value: &str) -> String {
-    format!("{name}:{}:{value};", value.len())
-}
-
-fn take_product_binding_segment<'a>(raw: &'a str, name: &str) -> Option<(&'a str, &'a str)> {
-    let raw = raw.strip_prefix(name)?.strip_prefix(':')?;
-    let (length, raw) = raw.split_once(':')?;
-    let length = length.parse::<usize>().ok()?;
-    let value = raw.get(..length)?;
-    let raw = raw.get(length..)?.strip_prefix(';')?;
-    Some((value, raw))
-}
-
-fn map_slack_target_route_error(error: SlackChannelRouteError) -> RebornServicesError {
-    match error {
-        SlackChannelRouteError::InvalidRoute => slack_target_not_found_error(),
-        SlackChannelRouteError::StoreUnavailable => slack_target_backend_error(),
-    }
-}
-
-fn slack_target_not_found_error() -> RebornServicesError {
-    RebornServicesError {
-        code: RebornServicesErrorCode::NotFound,
-        kind: RebornServicesErrorKind::NotFound,
-        status_code: 404,
-        retryable: false,
-        field: None,
-        validation_code: None,
-    }
-}
-
-fn slack_target_backend_error() -> RebornServicesError {
-    RebornServicesError {
-        code: RebornServicesErrorCode::Unavailable,
-        kind: RebornServicesErrorKind::ServiceUnavailable,
-        status_code: 503,
-        retryable: true,
-        field: None,
-        validation_code: None,
-    }
-}
-
 fn slack_bot_token_handle() -> Result<EgressCredentialHandle, SlackHostBetaBuildError> {
     EgressCredentialHandle::new(SLACK_BOT_TOKEN_HANDLE)
         .map_err(|reason| invalid_config("bot_token_handle", reason.to_string()))
@@ -965,7 +643,8 @@ mod tests {
     use ironclaw_processes::{InMemoryProcessResultStore, InMemoryProcessStore, ProcessServices};
     use ironclaw_product_workflow::{
         ProductActorUserResolutionRequest, ProductWorkflowError, RebornChannelConnectStrategy,
-        RebornOutboundDeliveryTargetStatus, RebornSetOutboundPreferencesRequest,
+        RebornOutboundDeliveryTargetId, RebornOutboundDeliveryTargetStatus,
+        RebornServicesErrorCode, RebornServicesErrorKind, RebornSetOutboundPreferencesRequest,
         WebUiAuthenticatedCaller,
     };
     use ironclaw_resources::InMemoryResourceGovernor;
@@ -981,15 +660,22 @@ mod tests {
     use super::*;
     use crate::slack_channel_routes::{
         InMemorySlackChannelRouteStore, SlackChannelRoute, SlackChannelRouteAdminRouteMount,
-        SlackChannelRouteListPage, WEBUI_V2_CHANNELS_SLACK_ALLOWED_PATH,
-        WEBUI_V2_CHANNELS_SLACK_ROUTES_PATH, slack_channel_route_admin_route_mount,
+        SlackChannelRouteError, SlackChannelRouteKey, SlackChannelRouteListPage,
+        WEBUI_V2_CHANNELS_SLACK_ALLOWED_PATH, WEBUI_V2_CHANNELS_SLACK_ROUTES_PATH,
+        slack_channel_route_admin_route_mount,
     };
     use crate::slack_connectable_channel::{
         SlackOperatorRouteVisibility, build_webui_services_with_slack_host_beta_mounts,
     };
+    use crate::slack_outbound_targets::{
+        InMemorySlackPersonalDmTargetStore, SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+        SlackPersonalDmTargetError, SlackPersonalDmTargetProvisioner, SlackPersonalDmTargetStore,
+        slack_reply_target_binding_ref_from_raw, slack_shared_channel_reply_target_binding_ref,
+    };
     use crate::slack_personal_binding_pairing_serve::{
         WEBUI_V2_EXTENSION_PAIRING_REDEEM_PATH, slack_personal_binding_pairing_route_mount,
     };
+    use crate::slack_serve::SlackUserId;
     use crate::{
         RebornBuildError, RebornBuildInput, RebornRuntimeIdentity, RebornRuntimeInput,
         SLACK_EVENTS_PATH, WebuiAuthenticator, WebuiServeConfig, build_reborn_runtime,
@@ -2093,8 +1779,7 @@ mod tests {
                 .await
                 .expect("route upserts");
         }
-        let provider =
-            SlackHostBetaOutboundTargetProvider::new(config_without_channel_routes(), store);
+        let provider = outbound_target_provider(config_without_channel_routes(), store);
 
         let targets = provider
             .list_outbound_delivery_targets(&shared_subject_caller())
@@ -2115,8 +1800,210 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slack_host_beta_targets_reject_non_advancing_route_cursor() {
+    async fn slack_shared_channel_targets_survive_personal_dm_store_failure() {
         let provider = SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            Arc::new(FailingSlackPersonalDmTargetStore),
+        );
+
+        let targets = provider
+            .list_outbound_delivery_targets(&shared_subject_caller())
+            .await
+            .expect("target list falls back to shared targets");
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(
+            targets[0].summary.target_id.as_str(),
+            "slack:shared-channel:T0HOST:C0HOST"
+        );
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_is_not_listed_without_provisioned_authority() {
+        let (runtime, _root) = runtime().await;
+        let mounts = build_slack_host_beta_mounts(&runtime, config_without_channel_routes())
+            .expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(operator_caller())
+            .await
+            .expect("target list");
+
+        assert!(
+            targets.targets.is_empty(),
+            "identity-only Slack state must not synthesize a personal DM target"
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_lists_after_explicit_provisioning() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
+        let config = config_without_channel_routes();
+        personal_dm_target_provisioner_for_test(&runtime, &config)
+            .provision_for_user(
+                UserId::new(USER).expect("user"),
+                SlackUserId::new(SLACK_USER),
+            )
+            .await
+            .expect("DM target provisions");
+        let mounts = build_slack_host_beta_mounts(&runtime, config).expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(operator_caller())
+            .await
+            .expect("target list");
+
+        assert_eq!(targets.targets.len(), 1);
+        assert_eq!(
+            targets.targets[0].target.target_id.as_str(),
+            "slack:personal-dm:T0HOST:user:slack-host"
+        );
+        assert!(targets.targets[0].capabilities.final_replies);
+        assert_eq!(
+            egress
+                .requests()
+                .iter()
+                .filter(|request| request.url.contains("/api/conversations.open"))
+                .count(),
+            1
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_round_trips_through_outbound_preferences() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
+        let config = config_without_channel_routes();
+        personal_dm_target_provisioner_for_test(&runtime, &config)
+            .provision_for_user(
+                UserId::new(USER).expect("user"),
+                SlackUserId::new(SLACK_USER),
+            )
+            .await
+            .expect("DM target provisions");
+        let mounts = build_slack_host_beta_mounts(&runtime, config).expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+        let caller = operator_caller();
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(caller.clone())
+            .await
+            .expect("target list");
+        let target = targets.targets.first().expect("personal DM target");
+
+        let selected = bundle
+            .api
+            .set_outbound_preferences(
+                caller.clone(),
+                RebornSetOutboundPreferencesRequest {
+                    final_reply_target_id: Some(target.target.target_id.clone()),
+                },
+            )
+            .await
+            .expect("set personal DM target");
+        assert_eq!(
+            selected.final_reply_target_status,
+            RebornOutboundDeliveryTargetStatus::Available
+        );
+
+        let preference = bundle
+            .api
+            .get_outbound_preferences(caller)
+            .await
+            .expect("get personal DM target preference");
+        assert_eq!(
+            preference.final_reply_target_status,
+            RebornOutboundDeliveryTargetStatus::Available
+        );
+        assert_eq!(
+            preference
+                .final_reply_target
+                .as_ref()
+                .map(|target| target.target_id.as_str()),
+            Some("slack:personal-dm:T0HOST:user:slack-host")
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_target_provisioning_fails_closed_on_slack_api_error() {
+        let egress = Arc::new(RecordingRuntimeHttpEgress::conversations_open_response(
+            200,
+            br#"{"ok":false,"error":"not_allowed"}"#,
+        ));
+        let (runtime, _root) = runtime_with_host_egress_override(Some(Some(
+            host_egress_port_for_test(Arc::clone(&egress)),
+        )))
+        .await;
+        let config = config_without_channel_routes();
+        let error = personal_dm_target_provisioner_for_test(&runtime, &config)
+            .provision_for_user(
+                UserId::new(USER).expect("user"),
+                SlackUserId::new(SLACK_USER),
+            )
+            .await
+            .expect_err("Slack rejection must fail provisioning");
+        assert!(matches!(
+            error,
+            SlackPersonalDmTargetError::ProvisioningFailed(_)
+        ));
+        let mounts = build_slack_host_beta_mounts(&runtime, config).expect("mounts");
+        let bundle = build_webui_services_with_slack_host_beta_mounts(
+            &runtime,
+            None,
+            Some(&mounts),
+            SlackOperatorRouteVisibility::Hidden,
+        )
+        .expect("webui bundle");
+
+        let targets = bundle
+            .api
+            .list_outbound_delivery_targets(operator_caller())
+            .await
+            .expect("target list");
+
+        assert!(
+            targets.targets.is_empty(),
+            "failed Slack DM provisioning must not persist a target authority"
+        );
+        runtime.shutdown().await.expect("runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn slack_host_beta_targets_reject_non_advancing_route_cursor() {
+        let provider = outbound_target_provider(
             config_without_channel_routes(),
             Arc::new(NonAdvancingCursorRouteStore),
         );
@@ -2187,12 +2074,12 @@ mod tests {
     #[test]
     fn slack_shared_channel_reply_target_binding_ref_rejects_oversized_raw() {
         let installation_id =
-            AdapterInstallationId::new("i".repeat(SLACK_BINDING_REF_RAW_MAX_BYTES))
-                .expect("long installation id still validates");
+            AdapterInstallationId::new("i".repeat(120)).expect("long installation id validates");
+        let agent_id = AgentId::new("a".repeat(120)).expect("long agent id validates");
 
         let error = slack_shared_channel_reply_target_binding_ref(
             &installation_id,
-            &AgentId::new(AGENT).expect("agent"),
+            &agent_id,
             Some(&ProjectId::new(PROJECT).expect("project")),
             &SlackTeamId::new(TEAM),
             "C0HOST",
@@ -2218,10 +2105,8 @@ mod tests {
 
     #[test]
     fn slack_shared_channel_reply_target_binding_ref_round_trips_channel_id() {
-        let provider = SlackHostBetaOutboundTargetProvider::new(
-            config(),
-            Arc::new(InMemorySlackChannelRouteStore::new()),
-        );
+        let provider =
+            outbound_target_provider(config(), Arc::new(InMemorySlackChannelRouteStore::new()));
         let binding_ref = slack_shared_channel_reply_target_binding_ref(
             &AdapterInstallationId::new(INSTALLATION).expect("installation"),
             &AgentId::new(AGENT).expect("agent"),
@@ -2233,16 +2118,14 @@ mod tests {
 
         assert_eq!(
             provider.channel_id_for_reply_target_binding_ref(&binding_ref),
-            Some("C0HOST")
+            Some("C0HOST".to_string())
         );
     }
 
     #[test]
     fn slack_host_beta_target_id_parser_rejects_empty_channel_suffix() {
-        let provider = SlackHostBetaOutboundTargetProvider::new(
-            config(),
-            Arc::new(InMemorySlackChannelRouteStore::new()),
-        );
+        let provider =
+            outbound_target_provider(config(), Arc::new(InMemorySlackChannelRouteStore::new()));
         let target_id =
             RebornOutboundDeliveryTargetId::new("slack:shared-channel:T0HOST:").expect("target id");
 
@@ -2699,6 +2582,36 @@ mod tests {
         .expect("valid config")
     }
 
+    fn outbound_target_provider_config(
+        config: SlackHostBetaConfig,
+    ) -> SlackOutboundTargetProviderConfig {
+        SlackOutboundTargetProviderConfig {
+            tenant_id: config.tenant_id,
+            agent_id: config.agent_id,
+            project_id: config.project_id,
+            installation_id: config.installation_id,
+            team_id: config.team_id,
+            configured_channel_routes: config
+                .channel_routes
+                .into_iter()
+                .map(|route| {
+                    SlackConfiguredChannelRoute::new(route.channel_id, route.subject_user_id)
+                })
+                .collect(),
+        }
+    }
+
+    fn outbound_target_provider(
+        config: SlackHostBetaConfig,
+        channel_route_store: Arc<dyn SlackChannelRouteStore>,
+    ) -> SlackHostBetaOutboundTargetProvider {
+        SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config),
+            channel_route_store,
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        )
+    }
+
     fn operator_caller() -> WebUiAuthenticatedCaller {
         WebUiAuthenticatedCaller::new(
             TenantId::new(TENANT).expect("tenant"),
@@ -2715,6 +2628,39 @@ mod tests {
             Some(AgentId::new(AGENT).expect("agent")),
             Some(ProjectId::new(PROJECT).expect("project")),
         )
+    }
+
+    fn personal_dm_target_provisioner_for_test(
+        runtime: &RebornRuntime,
+        config: &SlackHostBetaConfig,
+    ) -> SlackPersonalDmTargetProvisioner {
+        let token_handle = slack_bot_token_handle().expect("bot token handle");
+        SlackPersonalDmTargetProvisioner::new(
+            config.tenant_id.clone(),
+            config.installation_id.clone(),
+            config.team_id.clone(),
+            slack_protocol_egress(runtime, config, token_handle.clone()).expect("Slack egress"),
+            token_handle,
+            personal_dm_target_store_for_test(runtime, config),
+        )
+    }
+
+    fn personal_dm_target_store_for_test(
+        runtime: &RebornRuntime,
+        config: &SlackHostBetaConfig,
+    ) -> Arc<dyn SlackPersonalDmTargetStore> {
+        let local_runtime = runtime
+            .services()
+            .local_runtime
+            .as_ref()
+            .expect("local runtime");
+        Arc::new(FilesystemSlackHostState::new(
+            Arc::clone(&local_runtime.host_state_filesystem),
+            config.tenant_id.clone(),
+            config.user_id.clone(),
+            config.agent_id.clone(),
+            config.project_id.clone(),
+        ))
     }
 
     async fn upsert_slack_channel_route(
@@ -3166,6 +3112,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingRuntimeHttpEgress {
         requests: std::sync::Mutex<Vec<NetworkHttpRequest>>,
+        conversations_open_response: Option<(u16, Vec<u8>)>,
     }
 
     #[async_trait]
@@ -3174,17 +3121,19 @@ mod tests {
             &self,
             request: NetworkHttpRequest,
         ) -> Result<NetworkHttpResponse, NetworkHttpError> {
-            let response = if request.url.contains("/api/conversations.open") {
-                br#"{"ok":true,"channel":{"id":"D0HOST"}}"#.to_vec()
+            let (status, response) = if request.url.contains("/api/conversations.open") {
+                self.conversations_open_response
+                    .clone()
+                    .unwrap_or_else(|| (200, br#"{"ok":true,"channel":{"id":"D0HOST"}}"#.to_vec()))
             } else {
-                br#"{"ok":true}"#.to_vec()
+                (200, br#"{"ok":true}"#.to_vec())
             };
             self.requests
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(request);
             Ok(NetworkHttpResponse {
-                status: 200,
+                status,
                 headers: Vec::new(),
                 body: response,
                 usage: NetworkUsage {
@@ -3235,7 +3184,45 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct FailingSlackPersonalDmTargetStore;
+
+    #[async_trait]
+    impl SlackPersonalDmTargetStore for FailingSlackPersonalDmTargetStore {
+        async fn load_personal_dm_target(
+            &self,
+            _key: &crate::slack_outbound_targets::SlackPersonalDmTargetKey,
+        ) -> Result<
+            Option<crate::slack_outbound_targets::SlackPersonalDmTarget>,
+            SlackPersonalDmTargetError,
+        > {
+            Err(SlackPersonalDmTargetError::StoreUnavailable)
+        }
+
+        async fn upsert_personal_dm_target(
+            &self,
+            target: crate::slack_outbound_targets::SlackPersonalDmTarget,
+        ) -> Result<crate::slack_outbound_targets::SlackPersonalDmTarget, SlackPersonalDmTargetError>
+        {
+            Ok(target)
+        }
+    }
+
     impl RecordingRuntimeHttpEgress {
+        fn conversations_open_response(status: u16, body: &[u8]) -> Self {
+            Self {
+                requests: std::sync::Mutex::new(Vec::new()),
+                conversations_open_response: Some((status, body.to_vec())),
+            }
+        }
+
+        fn requests(&self) -> Vec<NetworkHttpRequest> {
+            self.requests
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+
         fn request_bodies(&self) -> Vec<serde_json::Value> {
             self.requests
                 .lock()

--- a/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_beta.rs
@@ -651,8 +651,8 @@ mod tests {
     use ironclaw_secrets::InMemorySecretStore;
     use ironclaw_threads::{ListThreadsForScopeRequest, ThreadHistoryRequest, ThreadScope};
     use ironclaw_turns::{
-        GetRunStateRequest, TurnCoordinator, TurnRunId, TurnScope, TurnStatus,
-        run_profile::LoopCapabilityPort,
+        GetRunStateRequest, ReplyTargetBindingRef, TurnCoordinator, TurnRunId, TurnScope,
+        TurnStatus, run_profile::LoopCapabilityPort,
     };
     use secrecy::ExposeSecret;
     use tower::ServiceExt;
@@ -1997,6 +1997,49 @@ mod tests {
             "slack:personal-dm:T0HOST:user:slack-host"
         );
         assert_eq!(resolved.reply_target_binding_ref, binding_ref);
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_resolve_binding_rejects_mismatched_dm_channel_id() {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("personal target key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("personal DM target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("personal DM target stores");
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            outbound_target_provider_config(config_without_channel_routes()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store,
+        );
+        let listed = provider
+            .list_outbound_delivery_targets(&operator_caller())
+            .await
+            .expect("target list");
+        let mismatched_binding_ref = ReplyTargetBindingRef::new(
+            listed[0]
+                .reply_target_binding_ref
+                .as_str()
+                .replace("D0HOST", "D1HOST"),
+        )
+        .expect("mismatched binding ref still validates");
+
+        assert!(
+            provider
+                .resolve_reply_target_binding(&operator_caller(), &mismatched_binding_ref)
+                .await
+                .expect("binding lookup succeeds")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -1339,11 +1339,12 @@ fn stored_personal_dm_target(
     record: StoredSlackPersonalDmTarget,
 ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
     let key = SlackPersonalDmTargetKey::new(
-        TenantId::new(record.tenant_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        TenantId::new(record.tenant_id)
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
         AdapterInstallationId::new(record.installation_id)
-            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
         record.team_id,
-        UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
     )?;
     SlackPersonalDmTarget::new(
         key,
@@ -1737,6 +1738,40 @@ mod tests {
                 .expect("foreign tenant load fails closed"),
             None
         );
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_reports_corrupt_personal_dm_target_as_unavailable() {
+        let state = state();
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let path =
+            FilesystemSlackHostState::<InMemoryBackend>::personal_dm_target_path(&key).unwrap();
+        let record = StoredSlackPersonalDmTarget {
+            tenant_id: String::new(),
+            installation_id: installation().as_str().to_string(),
+            team_id: "T123".to_string(),
+            user_id: "user:alice".to_string(),
+            slack_user_id: "U123".to_string(),
+            dm_channel_id: "D123".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        state
+            .write_record(&path, &record, CasExpectation::Any)
+            .await
+            .expect("write corrupt personal DM record");
+
+        assert!(matches!(
+            state.load_personal_dm_target(&key).await,
+            Err(SlackPersonalDmTargetError::StoreUnavailable)
+        ));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -844,6 +844,14 @@ where
         match self.write_record(&path, &record, cas).await {
             Ok(_) => Ok(target),
             Err(FilesystemError::VersionMismatch { .. }) => {
+                // CAS lost to a concurrent writer. Read back and return the winning record.
+                // This is last-write-wins semantics: whichever writer committed first wins.
+                // This is safe today because provisioning the same (tenant, user) DM target is
+                // idempotent — both concurrent writers store the same DM channel ID for the same
+                // Slack user. If a future change makes the payload non-idempotent (e.g. storing a
+                // caller-chosen dm_channel_id that could differ between writers), this branch must
+                // be replaced with explicit conflict semantics (e.g. reject the loser with a
+                // retriable error rather than silently discarding the losing value).
                 let Some((record, _)) = self.read_personal_dm_target_record(&path).await? else {
                     return Err(SlackPersonalDmTargetError::StoreUnavailable);
                 };
@@ -1345,12 +1353,14 @@ fn stored_personal_dm_target(
             .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
         record.team_id,
         UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?,
-    )?;
+    )
+    .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?;
     SlackPersonalDmTarget::new(
         key,
         SlackUserId::new(record.slack_user_id),
         record.dm_channel_id,
     )
+    .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1615,7 +1625,7 @@ fn map_route_fs_error(error: FilesystemError) -> SlackChannelRouteError {
 }
 
 fn map_personal_dm_target_fs_error(error: FilesystemError) -> SlackPersonalDmTargetError {
-    tracing::error!(%error, "Slack personal DM target filesystem operation failed");
+    tracing::debug!(%error, "Slack personal DM target filesystem operation failed");
     SlackPersonalDmTargetError::StoreUnavailable
 }
 
@@ -1772,6 +1782,71 @@ mod tests {
             state.load_personal_dm_target(&key).await,
             Err(SlackPersonalDmTargetError::StoreUnavailable)
         ));
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_reports_corrupt_personal_dm_target_key_fields_as_unavailable()
+     {
+        // Regression guard: corrupt team_id (fails SlackPersonalDmTargetKey::new validation)
+        // and corrupt dm_channel_id (fails SlackPersonalDmTarget::new validation) must both map
+        // to StoreUnavailable (503), not InvalidTarget (404). A stored record that exists on disk
+        // with an invalid field is a data-integrity problem, not an absence.
+        let state = state();
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let path =
+            FilesystemSlackHostState::<InMemoryBackend>::personal_dm_target_path(&key).unwrap();
+
+        // Corrupt team_id — fails SlackPersonalDmTargetKey::new (validate_slack_id)
+        let record_bad_team = StoredSlackPersonalDmTarget {
+            tenant_id: "tenant-alpha".to_string(),
+            installation_id: installation().as_str().to_string(),
+            team_id: String::new(), // empty string fails Slack-ID validation
+            user_id: "user:alice".to_string(),
+            slack_user_id: "U123".to_string(),
+            dm_channel_id: "D123".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        state
+            .write_record(&path, &record_bad_team, CasExpectation::Any)
+            .await
+            .expect("write corrupt personal DM record with bad team_id");
+        assert!(
+            matches!(
+                state.load_personal_dm_target(&key).await,
+                Err(SlackPersonalDmTargetError::StoreUnavailable)
+            ),
+            "corrupt team_id must surface as StoreUnavailable, not InvalidTarget"
+        );
+
+        // Corrupt dm_channel_id — fails SlackPersonalDmTarget::new (validate_slack_dm_channel_id)
+        let record_bad_dm = StoredSlackPersonalDmTarget {
+            tenant_id: "tenant-alpha".to_string(),
+            installation_id: installation().as_str().to_string(),
+            team_id: "T123".to_string(),
+            user_id: "user:alice".to_string(),
+            slack_user_id: "U123".to_string(),
+            dm_channel_id: "NOTADM".to_string(), // must start with "D"
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        state
+            .write_record(&path, &record_bad_dm, CasExpectation::Any)
+            .await
+            .expect("write corrupt personal DM record with bad dm_channel_id");
+        assert!(
+            matches!(
+                state.load_personal_dm_target(&key).await,
+                Err(SlackPersonalDmTargetError::StoreUnavailable)
+            ),
+            "corrupt dm_channel_id must surface as StoreUnavailable, not InvalidTarget"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -30,6 +30,10 @@ use crate::slack_channel_routes::{
     SlackChannelRoute, SlackChannelRouteAssignment, SlackChannelRouteError, SlackChannelRouteKey,
     SlackChannelRouteListPage, SlackChannelRouteStore,
 };
+use crate::slack_outbound_targets::{
+    SlackPersonalDmTarget, SlackPersonalDmTargetError, SlackPersonalDmTargetKey,
+    SlackPersonalDmTargetStore,
+};
 use crate::slack_personal_binding::{
     RebornUserIdentityBinding, RebornUserIdentityBindingError, RebornUserIdentityBindingStore,
 };
@@ -45,6 +49,7 @@ const IDENTITY_ROOT: &str = "/tenant-shared/slack-personal-binding/identities";
 const PAIRING_CODE_ROOT: &str = "/tenant-shared/slack-personal-binding/pairing/codes";
 const PAIRING_ACTOR_ROOT: &str = "/tenant-shared/slack-personal-binding/pairing/actors";
 const CHANNEL_ROUTE_ROOT: &str = "/tenant-shared/slack-channel-routes";
+const PERSONAL_DM_TARGET_ROOT: &str = "/tenant-shared/slack-personal-binding/dm-targets";
 const PAIRING_CODE_LEN: usize = 8;
 const PAIRING_CODE_RETRIES: usize = 16;
 const DEFAULT_PAIRING_TTL: Duration = Duration::from_secs(10 * 60);
@@ -559,6 +564,18 @@ where
         ))
     }
 
+    fn personal_dm_target_path(
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<ScopedPath, FilesystemError> {
+        scoped_path(&format!(
+            "{}/{}/{}/{}.json",
+            PERSONAL_DM_TARGET_ROOT,
+            path_segment(key.installation_id.as_str()),
+            path_segment(&key.team_id),
+            path_segment(key.user_id.as_str())
+        ))
+    }
+
     fn listed_channel_route_path(
         installation_id: &AdapterInstallationId,
         team_id: &str,
@@ -760,6 +777,80 @@ where
         Err(RebornUserIdentityBindingError::Backend(
             "Slack actor is already bound to a different user".into(),
         ))
+    }
+}
+
+impl<F> FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn read_personal_dm_target_record(
+        &self,
+        path: &ScopedPath,
+    ) -> Result<Option<(StoredSlackPersonalDmTarget, RecordVersion)>, SlackPersonalDmTargetError>
+    {
+        match self.read_record::<StoredSlackPersonalDmTarget>(path).await {
+            Ok(record) => Ok(record),
+            Err(FilesystemError::NotFound { .. }) => Ok(None),
+            Err(error) => Err(map_personal_dm_target_fs_error(error)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<F> SlackPersonalDmTargetStore for FilesystemSlackHostState<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn load_personal_dm_target(
+        &self,
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError> {
+        if key.tenant_id != self.scope.tenant_id {
+            return Ok(None);
+        }
+        let path = Self::personal_dm_target_path(key).map_err(map_personal_dm_target_fs_error)?;
+        let Some((record, _)) = self.read_personal_dm_target_record(&path).await? else {
+            return Ok(None);
+        };
+        stored_personal_dm_target(record).map(Some)
+    }
+
+    async fn upsert_personal_dm_target(
+        &self,
+        target: SlackPersonalDmTarget,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+        if target.key.tenant_id != self.scope.tenant_id {
+            return Err(SlackPersonalDmTargetError::InvalidTarget);
+        }
+        let path =
+            Self::personal_dm_target_path(&target.key).map_err(map_personal_dm_target_fs_error)?;
+        let lock = self.lock_for(format!(
+            "personal-dm:{}:{}:{}",
+            target.key.installation_id.as_str(),
+            target.key.team_id,
+            target.key.user_id.as_str()
+        ));
+        let _guard = lock.lock().await;
+        let existing = self.read_personal_dm_target_record(&path).await?;
+        let created_at = existing
+            .as_ref()
+            .map(|(record, _)| record.created_at)
+            .unwrap_or_else(Utc::now);
+        let record = StoredSlackPersonalDmTarget::from_target(&target, created_at);
+        let cas = existing
+            .map(|(_, version)| CasExpectation::Version(version))
+            .unwrap_or(CasExpectation::Absent);
+        match self.write_record(&path, &record, cas).await {
+            Ok(_) => Ok(target),
+            Err(FilesystemError::VersionMismatch { .. }) => {
+                let Some((record, _)) = self.read_personal_dm_target_record(&path).await? else {
+                    return Err(SlackPersonalDmTargetError::StoreUnavailable);
+                };
+                stored_personal_dm_target(record)
+            }
+            Err(error) => Err(map_personal_dm_target_fs_error(error)),
+        }
     }
 }
 
@@ -1217,6 +1308,50 @@ impl StoredSlackUserIdentity {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredSlackPersonalDmTarget {
+    tenant_id: String,
+    installation_id: String,
+    team_id: String,
+    user_id: String,
+    slack_user_id: String,
+    dm_channel_id: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl StoredSlackPersonalDmTarget {
+    fn from_target(target: &SlackPersonalDmTarget, created_at: DateTime<Utc>) -> Self {
+        Self {
+            tenant_id: target.key.tenant_id.as_str().to_string(),
+            installation_id: target.key.installation_id.as_str().to_string(),
+            team_id: target.key.team_id.clone(),
+            user_id: target.key.user_id.as_str().to_string(),
+            slack_user_id: target.slack_user_id.as_str().to_string(),
+            dm_channel_id: target.dm_channel_id.clone(),
+            created_at,
+            updated_at: Utc::now(),
+        }
+    }
+}
+
+fn stored_personal_dm_target(
+    record: StoredSlackPersonalDmTarget,
+) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+    let key = SlackPersonalDmTargetKey::new(
+        TenantId::new(record.tenant_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        AdapterInstallationId::new(record.installation_id)
+            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+        record.team_id,
+        UserId::new(record.user_id).map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?,
+    )?;
+    SlackPersonalDmTarget::new(
+        key,
+        SlackUserId::new(record.slack_user_id),
+        record.dm_channel_id,
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum StoredSlackPairingStatus {
@@ -1478,6 +1613,11 @@ fn map_route_fs_error(error: FilesystemError) -> SlackChannelRouteError {
     SlackChannelRouteError::StoreUnavailable
 }
 
+fn map_personal_dm_target_fs_error(error: FilesystemError) -> SlackPersonalDmTargetError {
+    tracing::error!(%error, "Slack personal DM target filesystem operation failed");
+    SlackPersonalDmTargetError::StoreUnavailable
+}
+
 fn is_unsupported_delete_error(error: &FilesystemError) -> bool {
     match error {
         FilesystemError::Unsupported {
@@ -1530,6 +1670,73 @@ mod tests {
         assert_eq!(resolved, Some(user("user:alice")));
         let stored = read_identity(&state, "slack", "install-alpha:U123").await;
         assert_eq!(stored.binding(), Some(binding));
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_persists_personal_dm_targets_across_state_recreation() {
+        let root = Arc::new(InMemoryBackend::default());
+        let writer = state_with_root(root.clone());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let target =
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D123".to_string())
+                .unwrap();
+
+        writer
+            .upsert_personal_dm_target(target.clone())
+            .await
+            .expect("upsert personal DM target succeeds");
+        assert_eq!(
+            writer
+                .load_personal_dm_target(&key)
+                .await
+                .expect("load personal DM target succeeds"),
+            Some(target.clone())
+        );
+
+        let reader = state_with_root(root);
+        assert_eq!(
+            reader
+                .load_personal_dm_target(&key)
+                .await
+                .expect("load persisted personal DM target succeeds"),
+            Some(target)
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_slack_host_state_rejects_cross_tenant_personal_dm_target_operations() {
+        let state = state();
+        let foreign_key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-foreign").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let foreign_target = SlackPersonalDmTarget::new(
+            foreign_key.clone(),
+            SlackUserId::new("U123"),
+            "D123".to_string(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            state.upsert_personal_dm_target(foreign_target).await,
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+        assert_eq!(
+            state
+                .load_personal_dm_target(&foreign_key)
+                .await
+                .expect("foreign tenant load fails closed"),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -806,6 +806,11 @@ where
         &self,
         key: &SlackPersonalDmTargetKey,
     ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError> {
+        // Cross-tenant reads return Ok(None) (not an error) so a caller
+        // cannot distinguish "other tenant has this key" from "no target
+        // exists" — reads stay free of a tenant-existence oracle. Writes
+        // below differ deliberately: a cross-tenant upsert is a caller bug
+        // and fails loudly with InvalidTarget.
         if key.tenant_id != self.scope.tenant_id {
             return Ok(None);
         }
@@ -825,6 +830,11 @@ where
         }
         let path =
             Self::personal_dm_target_path(&target.key).map_err(map_personal_dm_target_fs_error)?;
+        // Lock key omits tenant_id: this store instance is pinned to one
+        // tenant (cross-tenant writes are rejected above before locking),
+        // so installation/team/user uniquely identify the record within
+        // the instance. Revisit if a multi-tenant store instance ever
+        // shares this lock map.
         let lock = self.lock_for(format!(
             "personal-dm:{}:{}:{}",
             target.key.installation_id.as_str(),

--- a/crates/ironclaw_reborn_composition/src/slack_host_state.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_host_state.rs
@@ -1775,6 +1775,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filesystem_slack_host_state_upsert_personal_dm_target_concurrent_write_returns_winner()
+    {
+        let root = Arc::new(RouteLockTestBackend::barrier_personal_dm_writes());
+        let writer_one = state_with_backend(root.clone());
+        let writer_two = state_with_backend(root.clone());
+        let reader = state_with_backend(root);
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").unwrap(),
+            installation(),
+            "T123".to_string(),
+            user("user:alice"),
+        )
+        .unwrap();
+        let target_one =
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D123".to_string())
+                .unwrap();
+        let target_two =
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D456".to_string())
+                .unwrap();
+
+        let (stored_one, stored_two) = tokio::join!(
+            writer_one.upsert_personal_dm_target(target_one),
+            writer_two.upsert_personal_dm_target(target_two)
+        );
+        let stored_one = stored_one.expect("first upsert succeeds");
+        let stored_two = stored_two.expect("second upsert succeeds");
+        let persisted = reader
+            .load_personal_dm_target(&key)
+            .await
+            .expect("load personal DM target succeeds")
+            .expect("personal DM target persists");
+
+        assert_eq!(stored_one, stored_two);
+        assert_eq!(persisted, stored_one);
+        assert!(matches!(persisted.dm_channel_id.as_str(), "D123" | "D456"));
+    }
+
+    #[tokio::test]
     async fn filesystem_slack_host_state_rejects_rebinding_actor_to_different_user() {
         let state = state();
         state
@@ -2600,6 +2638,7 @@ mod tests {
         inner: InMemoryBackend,
         reject_lock_renewal: bool,
         route_write_delay: Option<Duration>,
+        personal_dm_write_barrier: Option<Arc<tokio::sync::Barrier>>,
         route_write_failures: AtomicUsize,
         lock_puts: AtomicUsize,
     }
@@ -2610,6 +2649,7 @@ mod tests {
                 inner: InMemoryBackend::default(),
                 reject_lock_renewal: false,
                 route_write_delay: None,
+                personal_dm_write_barrier: None,
                 route_write_failures: AtomicUsize::new(0),
                 lock_puts: AtomicUsize::new(0),
             }
@@ -2620,6 +2660,7 @@ mod tests {
                 inner: InMemoryBackend::default(),
                 reject_lock_renewal: false,
                 route_write_delay: Some(delay),
+                personal_dm_write_barrier: None,
                 route_write_failures: AtomicUsize::new(0),
                 lock_puts: AtomicUsize::new(0),
             }
@@ -2630,6 +2671,18 @@ mod tests {
                 inner: InMemoryBackend::default(),
                 reject_lock_renewal: true,
                 route_write_delay: Some(delay),
+                personal_dm_write_barrier: None,
+                route_write_failures: AtomicUsize::new(0),
+                lock_puts: AtomicUsize::new(0),
+            }
+        }
+
+        fn barrier_personal_dm_writes() -> Self {
+            Self {
+                inner: InMemoryBackend::default(),
+                reject_lock_renewal: false,
+                route_write_delay: None,
+                personal_dm_write_barrier: Some(Arc::new(tokio::sync::Barrier::new(2))),
                 route_write_failures: AtomicUsize::new(0),
                 lock_puts: AtomicUsize::new(0),
             }
@@ -2669,6 +2722,10 @@ mod tests {
                 && let Some(delay) = self.route_write_delay
             {
                 tokio::time::sleep(delay).await;
+            } else if is_personal_dm_target_record_path(path)
+                && let Some(barrier) = &self.personal_dm_write_barrier
+            {
+                barrier.wait().await;
             }
             if is_channel_route_record_path(path)
                 && self.route_write_failures.load(Ordering::SeqCst) > 0
@@ -2717,6 +2774,12 @@ mod tests {
         path.as_str().contains("/slack-channel-routes/")
             && path.as_str().ends_with(".json")
             && !is_replace_lock_path(path)
+    }
+
+    fn is_personal_dm_target_record_path(path: &VirtualPath) -> bool {
+        path.as_str()
+            .contains("/slack-personal-binding/dm-targets/")
+            && path.as_str().ends_with(".json")
     }
 
     fn binding(user_id: &str) -> RebornUserIdentityBinding {

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -11,13 +11,18 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+use ironclaw_outbound::{
+    CommunicationModality, OutboundError, ReplyTargetBindingClaim, ReplyTargetBindingValidator,
+    ReplyTargetValidationRequest, ValidatedReplyTargetBinding,
+};
 use ironclaw_product_adapters::{AdapterInstallationId, ExternalActorRef, ExternalConversationRef};
 #[cfg(test)]
 use ironclaw_product_adapters::{EgressCredentialHandle, ProtocolHttpEgress};
 use ironclaw_product_workflow::{
-    RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
-    RebornOutboundDeliveryTargetSummary, RebornServicesError, RebornServicesErrorCode,
-    RebornServicesErrorKind, WebUiAuthenticatedCaller,
+    ProductOutboundTargetResolver, ProductWorkflowError, RebornOutboundDeliveryTargetCapabilities,
+    RebornOutboundDeliveryTargetId, RebornOutboundDeliveryTargetSummary, RebornServicesError,
+    RebornServicesErrorCode, RebornServicesErrorKind, VerifiedProductOutboundTargetMetadata,
+    WebUiAuthenticatedCaller,
 };
 use ironclaw_slack_v2_adapter::{SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID};
 use ironclaw_turns::ReplyTargetBindingRef;
@@ -382,12 +387,18 @@ impl SlackHostBetaOutboundTargetProvider {
             });
         }
         let (actor_kind, rest) = take_product_binding_segment(rest, "actor_kind")?;
+        let (user_id, rest) = take_product_binding_segment(rest, "user")?;
         let (actor_id, rest) = take_product_binding_segment(rest, "actor")?;
-        if actor_kind != SLACK_USER_ACTOR_KIND || actor_id.is_empty() || !rest.is_empty() {
+        if actor_kind != SLACK_USER_ACTOR_KIND
+            || actor_id.is_empty()
+            || user_id.is_empty()
+            || !rest.is_empty()
+        {
             return None;
         }
         Some(ParsedSlackReplyTarget::PersonalDm {
             dm_channel_id: conversation_id.to_string(),
+            user_id: UserId::new(user_id).ok()?,
             slack_user_id: SlackUserId::new(actor_id),
         })
     }
@@ -492,6 +503,7 @@ impl SlackHostBetaOutboundTargetProvider {
                 self.project_id.as_ref(),
                 &self.team_id,
                 &target.dm_channel_id,
+                &target.key.user_id,
                 &target.slack_user_id,
             )?,
         })
@@ -543,10 +555,16 @@ impl SlackHostBetaOutboundTargetProvider {
     async fn resolve_personal_dm_for_binding(
         &self,
         caller: &WebUiAuthenticatedCaller,
+        binding_user_id: &UserId,
         dm_channel_id: &str,
         slack_user_id: &SlackUserId,
     ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
         if caller.tenant_id != self.tenant_id {
+            return Ok(None);
+        }
+        // Defense-in-depth: reject if the binding's user_id differs from the
+        // authenticated caller even when the call site already checks this.
+        if binding_user_id != &caller.user_id {
             return Ok(None);
         }
         let key = SlackPersonalDmTargetKey::new(
@@ -568,6 +586,120 @@ impl SlackHostBetaOutboundTargetProvider {
             return Ok(None);
         }
         self.entry_for_personal_dm_target(&target).map(Some)
+    }
+
+    fn scope_matches(&self, request: &ReplyTargetValidationRequest) -> bool {
+        request.scope.tenant_id == self.tenant_id
+            && request.scope.agent_id.as_ref() == Some(&self.agent_id)
+            && request.scope.project_id == self.project_id
+            && request.modality == CommunicationModality::Text
+    }
+
+    async fn validate_shared_channel_target(
+        &self,
+        request: &ReplyTargetValidationRequest,
+        channel_id: &str,
+    ) -> Result<(), OutboundError> {
+        if !self.scope_matches(request) {
+            return Err(OutboundError::AccessDenied);
+        }
+        let route = self
+            .shared_channel_route_for_channel(channel_id)
+            .await
+            .map_err(reborn_services_error_to_outbound_error)?
+            .ok_or(OutboundError::AccessDenied)?;
+        if let Some(owner_user_id) = request.scope.explicit_owner_user_id()
+            && &route.subject_user_id != owner_user_id
+        {
+            return Err(OutboundError::AccessDenied);
+        }
+        Ok(())
+    }
+
+    async fn validate_personal_dm_target(
+        &self,
+        request: &ReplyTargetValidationRequest,
+        dm_channel_id: &str,
+        user_id: &UserId,
+        slack_user_id: &SlackUserId,
+    ) -> Result<(), OutboundError> {
+        if !self.scope_matches(request) {
+            return Err(OutboundError::AccessDenied);
+        }
+        let Some(owner_user_id) = request.scope.explicit_owner_user_id() else {
+            return Err(OutboundError::AccessDenied);
+        };
+        if owner_user_id != user_id {
+            return Err(OutboundError::AccessDenied);
+        }
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            user_id.clone(),
+        )
+        .map_err(personal_dm_error_to_outbound_error)?;
+        let target = self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+            .map_err(personal_dm_error_to_outbound_error)?
+            .ok_or(OutboundError::AccessDenied)?;
+        if target.dm_channel_id != dm_channel_id || target.slack_user_id != *slack_user_id {
+            return Err(OutboundError::AccessDenied);
+        }
+        Ok(())
+    }
+
+    async fn metadata_for_shared_channel(
+        &self,
+        channel_id: &str,
+    ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
+        self.shared_channel_route_for_channel(channel_id)
+            .await
+            .map_err(reborn_services_error_to_product_workflow_error)?
+            .ok_or(ProductWorkflowError::BindingAccessDenied)?;
+        let conversation =
+            ExternalConversationRef::new(Some(self.team_id.as_str()), channel_id, None, None)
+                .map_err(|_| ProductWorkflowError::BindingAccessDenied)?;
+        Ok(VerifiedProductOutboundTargetMetadata {
+            external_conversation_ref: conversation,
+            external_actor_ref: None,
+        })
+    }
+
+    async fn metadata_for_personal_dm(
+        &self,
+        dm_channel_id: &str,
+        user_id: &UserId,
+        slack_user_id: &SlackUserId,
+    ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            user_id.clone(),
+        )
+        .map_err(personal_dm_error_to_product_workflow_error)?;
+        let target = self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+            .map_err(personal_dm_error_to_product_workflow_error)?
+            .ok_or(ProductWorkflowError::BindingAccessDenied)?;
+        if target.dm_channel_id != dm_channel_id || target.slack_user_id != *slack_user_id {
+            return Err(ProductWorkflowError::BindingAccessDenied);
+        }
+        let conversation =
+            ExternalConversationRef::new(Some(self.team_id.as_str()), dm_channel_id, None, None)
+                .map_err(|_| ProductWorkflowError::BindingAccessDenied)?;
+        let actor =
+            ExternalActorRef::new(SLACK_USER_ACTOR_KIND, slack_user_id.as_str(), None::<&str>)
+                .map_err(|_| ProductWorkflowError::BindingAccessDenied)?;
+        Ok(VerifiedProductOutboundTargetMetadata {
+            external_conversation_ref: conversation,
+            external_actor_ref: Some(actor),
+        })
     }
 }
 
@@ -690,6 +822,25 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
         Ok(targets)
     }
 
+    async fn list_project_delivery_targets(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id {
+            return Ok(Vec::new());
+        }
+        let mut routes = self
+            .shared_channel_routes()
+            .await?
+            .into_iter()
+            .collect::<Vec<_>>();
+        routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
+        routes
+            .into_iter()
+            .map(|route| self.entry_for_shared_channel_route(&route))
+            .collect()
+    }
+
     async fn resolve_outbound_delivery_target(
         &self,
         caller: &WebUiAuthenticatedCaller,
@@ -704,6 +855,23 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
         self.resolve_personal_dm_for_user(caller, &user_id).await
     }
 
+    async fn resolve_project_outbound_delivery_target(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target_id: &RebornOutboundDeliveryTargetId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if let Some(channel_id) = self.channel_id_for_target_id(target_id) {
+            if caller.tenant_id != self.tenant_id {
+                return Ok(None);
+            }
+            let Some(route) = self.shared_channel_route_for_channel(channel_id).await? else {
+                return Ok(None);
+            };
+            return self.entry_for_shared_channel_route(&route).map(Some);
+        }
+        Ok(None)
+    }
+
     async fn resolve_reply_target_binding(
         &self,
         caller: &WebUiAuthenticatedCaller,
@@ -715,12 +883,94 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
             }
             Some(ParsedSlackReplyTarget::PersonalDm {
                 dm_channel_id,
+                user_id,
                 slack_user_id,
             }) => {
-                self.resolve_personal_dm_for_binding(caller, &dm_channel_id, &slack_user_id)
-                    .await
+                if caller.user_id != user_id {
+                    return Ok(None);
+                }
+                self.resolve_personal_dm_for_binding(
+                    caller,
+                    &user_id,
+                    &dm_channel_id,
+                    &slack_user_id,
+                )
+                .await
             }
             None => Ok(None),
+        }
+    }
+
+    async fn resolve_project_reply_target_binding(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target: &ReplyTargetBindingRef,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        match self.route_for_reply_target_binding_ref(target) {
+            Some(ParsedSlackReplyTarget::SharedChannel { channel_id }) => {
+                if caller.tenant_id != self.tenant_id {
+                    return Ok(None);
+                }
+                let Some(route) = self.shared_channel_route_for_channel(&channel_id).await? else {
+                    return Ok(None);
+                };
+                self.entry_for_shared_channel_route(&route).map(Some)
+            }
+            Some(ParsedSlackReplyTarget::PersonalDm { .. }) => Ok(None),
+            None => Ok(None),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ReplyTargetBindingValidator for SlackHostBetaOutboundTargetProvider {
+    async fn validate_reply_target(
+        &self,
+        request: ReplyTargetValidationRequest,
+    ) -> Result<ReplyTargetBindingClaim, OutboundError> {
+        match self.route_for_reply_target_binding_ref(&request.candidate.target) {
+            Some(ParsedSlackReplyTarget::SharedChannel { channel_id }) => {
+                self.validate_shared_channel_target(&request, &channel_id)
+                    .await?;
+            }
+            Some(ParsedSlackReplyTarget::PersonalDm {
+                dm_channel_id,
+                user_id,
+                slack_user_id,
+            }) => {
+                self.validate_personal_dm_target(
+                    &request,
+                    &dm_channel_id,
+                    &user_id,
+                    &slack_user_id,
+                )
+                .await?;
+            }
+            None => return Err(OutboundError::AccessDenied),
+        }
+        Ok(ReplyTargetBindingClaim::new(request.candidate.target))
+    }
+}
+
+#[async_trait::async_trait]
+impl ProductOutboundTargetResolver for SlackHostBetaOutboundTargetProvider {
+    async fn resolve_product_outbound_target_metadata(
+        &self,
+        target: &ValidatedReplyTargetBinding,
+    ) -> Result<VerifiedProductOutboundTargetMetadata, ProductWorkflowError> {
+        match self.route_for_reply_target_binding_ref(target.target()) {
+            Some(ParsedSlackReplyTarget::SharedChannel { channel_id }) => {
+                self.metadata_for_shared_channel(&channel_id).await
+            }
+            Some(ParsedSlackReplyTarget::PersonalDm {
+                dm_channel_id,
+                user_id,
+                slack_user_id,
+            }) => {
+                self.metadata_for_personal_dm(&dm_channel_id, &user_id, &slack_user_id)
+                    .await
+            }
+            None => Err(ProductWorkflowError::BindingAccessDenied),
         }
     }
 }
@@ -731,6 +981,7 @@ enum ParsedSlackReplyTarget {
     },
     PersonalDm {
         dm_channel_id: String,
+        user_id: UserId,
         slack_user_id: SlackUserId,
     },
 }
@@ -761,6 +1012,7 @@ fn slack_personal_dm_reply_target_binding_ref(
     project_id: Option<&ProjectId>,
     team_id: &SlackTeamId,
     dm_channel_id: &str,
+    user_id: &UserId,
     slack_user_id: &SlackUserId,
 ) -> Result<ReplyTargetBindingRef, RebornServicesError> {
     let conversation =
@@ -769,13 +1021,14 @@ fn slack_personal_dm_reply_target_binding_ref(
     let actor = ExternalActorRef::new(SLACK_USER_ACTOR_KIND, slack_user_id.as_str(), None::<&str>)
         .map_err(|_| slack_target_backend_error())?;
     let raw = format!(
-        "{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}",
         product_binding_segment("adapter", SLACK_V2_ADAPTER_ID),
         product_binding_segment("installation", installation_id.as_str()),
         product_binding_segment("agent", agent_id.as_str()),
         product_binding_segment("project", project_id.map_or("", |id| id.as_str())),
         conversation.conversation_fingerprint(),
         product_binding_segment("actor_kind", actor.kind()),
+        product_binding_segment("user", user_id.as_str()),
         product_binding_segment("actor", actor.id())
     );
     slack_reply_target_binding_ref_from_raw(raw)
@@ -818,6 +1071,46 @@ fn map_slack_personal_dm_target_error(error: SlackPersonalDmTargetError) -> Rebo
         SlackPersonalDmTargetError::InvalidTarget => slack_target_not_found_error(),
         SlackPersonalDmTargetError::StoreUnavailable
         | SlackPersonalDmTargetError::ProvisioningFailed(_) => slack_target_backend_error(),
+    }
+}
+
+fn reborn_services_error_to_outbound_error(error: RebornServicesError) -> OutboundError {
+    if error.retryable {
+        OutboundError::Backend
+    } else {
+        OutboundError::AccessDenied
+    }
+}
+
+fn reborn_services_error_to_product_workflow_error(
+    error: RebornServicesError,
+) -> ProductWorkflowError {
+    if error.retryable {
+        ProductWorkflowError::Transient {
+            reason: "Slack outbound target lookup failed".to_string(),
+        }
+    } else {
+        ProductWorkflowError::BindingAccessDenied
+    }
+}
+
+fn personal_dm_error_to_outbound_error(error: SlackPersonalDmTargetError) -> OutboundError {
+    match error {
+        SlackPersonalDmTargetError::InvalidTarget => OutboundError::AccessDenied,
+        SlackPersonalDmTargetError::StoreUnavailable
+        | SlackPersonalDmTargetError::ProvisioningFailed(_) => OutboundError::Backend,
+    }
+}
+
+fn personal_dm_error_to_product_workflow_error(
+    error: SlackPersonalDmTargetError,
+) -> ProductWorkflowError {
+    match error {
+        SlackPersonalDmTargetError::InvalidTarget => ProductWorkflowError::BindingAccessDenied,
+        SlackPersonalDmTargetError::StoreUnavailable
+        | SlackPersonalDmTargetError::ProvisioningFailed(_) => ProductWorkflowError::Transient {
+            reason: "Slack personal DM target lookup failed".to_string(),
+        },
     }
 }
 
@@ -937,6 +1230,14 @@ mod tests {
 
     // ── validate_slack_id ─────────────────────────────────────────────────────
 
+    use ironclaw_host_api::ThreadId;
+    use ironclaw_outbound::{OutboundPushCandidate, OutboundPushKind, ProjectionUpdateRef};
+    use ironclaw_turns::{TurnActor, TurnScope};
+
+    const THREAD: &str = "thread:slack";
+    const SHARED_CHANNEL: &str = "C123";
+    const DM_CHANNEL: &str = "D123";
+
     #[test]
     fn validate_slack_id_accepts_128_char_id_and_rejects_129_char_id() {
         validate_slack_id("slack id", &"A".repeat(128)).expect("128 chars is valid");
@@ -997,12 +1298,14 @@ mod tests {
         let team_id = SlackTeamId::new(TEAM);
         let slack_user_id = SlackUserId::new(SLACK_USER);
 
+        let user_id = UserId::new(USER).expect("user");
         let binding_ref = slack_personal_dm_reply_target_binding_ref(
             &installation_id,
             &agent_id,
             Some(&project_id),
             &team_id,
             "D0HOST",
+            &user_id,
             &slack_user_id,
         )
         .expect("binding ref builds");
@@ -1015,6 +1318,7 @@ mod tests {
         match parsed {
             ParsedSlackReplyTarget::PersonalDm {
                 dm_channel_id,
+                user_id: _,
                 slack_user_id: parsed_slack_user_id,
             } => {
                 assert_eq!(dm_channel_id, "D0HOST", "dm_channel_id must round-trip");
@@ -1066,12 +1370,14 @@ mod tests {
         let team_id = SlackTeamId::new(TEAM);
         let slack_user_id = SlackUserId::new(SLACK_USER);
 
+        let user_id = UserId::new(USER).expect("user");
         let binding_ref = slack_personal_dm_reply_target_binding_ref(
             &installation_id,
             &agent_id,
             Some(&project_id),
             &team_id,
             "D0HOST",
+            &user_id,
             &slack_user_id,
         )
         .expect("binding ref builds");
@@ -1407,5 +1713,213 @@ mod tests {
             "cross-tenant caller must not resolve personal DM target; got: {:?}",
             result.map(|e| e.summary.target_id.as_str().to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn slack_reply_target_validator_accepts_ownerless_shared_channel_scope() {
+        let provider = provider_with_configured_channel_route(USER);
+        let target = slack_shared_channel_reply_target_binding_ref(
+            &installation_id(),
+            &agent_id(),
+            Some(&project_id()),
+            &SlackTeamId::new(TEAM),
+            SHARED_CHANNEL,
+        )
+        .expect("shared channel target");
+        let request = validation_request(ownerless_scope(), USER, target.clone());
+
+        let claim = ReplyTargetBindingValidator::validate_reply_target(&provider, request)
+            .await
+            .expect("shared channel target validates");
+
+        assert_eq!(claim.target, target);
+    }
+
+    #[tokio::test]
+    async fn slack_reply_target_validator_accepts_explicit_owner_personal_dm() {
+        let store = personal_dm_store_for(USER).await;
+        let provider = provider_with_personal_dm_store(store);
+        let target = slack_personal_dm_reply_target_binding_ref(
+            &installation_id(),
+            &agent_id(),
+            Some(&project_id()),
+            &SlackTeamId::new(TEAM),
+            DM_CHANNEL,
+            &UserId::new(USER).expect("user"),
+            &SlackUserId::new(SLACK_USER),
+        )
+        .expect("personal DM target");
+        let request = validation_request(explicit_owner_scope(USER), USER, target.clone());
+
+        let claim = ReplyTargetBindingValidator::validate_reply_target(&provider, request)
+            .await
+            .expect("personal DM target validates for explicit owner");
+
+        assert_eq!(claim.target, target);
+    }
+
+    #[tokio::test]
+    async fn slack_reply_target_validator_rejects_personal_dm_without_explicit_owner() {
+        let store = personal_dm_store_for(USER).await;
+        let provider = provider_with_personal_dm_store(store);
+        let target = slack_personal_dm_reply_target_binding_ref(
+            &installation_id(),
+            &agent_id(),
+            Some(&project_id()),
+            &SlackTeamId::new(TEAM),
+            DM_CHANNEL,
+            &UserId::new(USER).expect("user"),
+            &SlackUserId::new(SLACK_USER),
+        )
+        .expect("personal DM target");
+        let request = validation_request(actor_fallback_scope(), USER, target);
+
+        let error = ReplyTargetBindingValidator::validate_reply_target(&provider, request)
+            .await
+            .expect_err("personal DM target requires an explicit owner");
+
+        assert!(matches!(error, OutboundError::AccessDenied));
+    }
+
+    #[tokio::test]
+    async fn slack_reply_target_validator_rejects_mismatched_owner_personal_dm() {
+        let store = personal_dm_store_for(USER).await;
+        let provider = provider_with_personal_dm_store(store);
+        let target = slack_personal_dm_reply_target_binding_ref(
+            &installation_id(),
+            &agent_id(),
+            Some(&project_id()),
+            &SlackTeamId::new(TEAM),
+            DM_CHANNEL,
+            &UserId::new(USER).expect("user"),
+            &SlackUserId::new(SLACK_USER),
+        )
+        .expect("personal DM target");
+        let request = validation_request(explicit_owner_scope(OTHER_USER), OTHER_USER, target);
+
+        let error = ReplyTargetBindingValidator::validate_reply_target(&provider, request)
+            .await
+            .expect_err("personal DM target must match owner authority");
+
+        assert!(matches!(error, OutboundError::AccessDenied));
+    }
+
+    fn provider_with_configured_channel_route(
+        subject_user_id: &str,
+    ) -> SlackHostBetaOutboundTargetProvider {
+        let mut config = provider_config(Vec::new());
+        config
+            .configured_channel_routes
+            .push(SlackConfiguredChannelRoute::new(
+                SHARED_CHANNEL.to_string(),
+                UserId::new(subject_user_id).expect("subject user"),
+            ));
+        SlackHostBetaOutboundTargetProvider::new(
+            config,
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        )
+    }
+
+    fn provider_with_personal_dm_store(
+        store: Arc<dyn SlackPersonalDmTargetStore>,
+    ) -> SlackHostBetaOutboundTargetProvider {
+        SlackHostBetaOutboundTargetProvider::new(
+            provider_config(Vec::new()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store,
+        )
+    }
+
+    async fn personal_dm_store_for(user_id: &str) -> Arc<dyn SlackPersonalDmTargetStore> {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            tenant_id(),
+            installation_id(),
+            TEAM.to_string(),
+            UserId::new(user_id).expect("user"),
+        )
+        .expect("personal target key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), DM_CHANNEL.to_string())
+                .expect("personal DM target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("personal DM target stores");
+        store
+    }
+
+    fn validation_request(
+        scope: TurnScope,
+        actor_user_id: &str,
+        target: ReplyTargetBindingRef,
+    ) -> ReplyTargetValidationRequest {
+        ReplyTargetValidationRequest {
+            actor: TurnActor::new(UserId::new(actor_user_id).expect("actor")),
+            modality: CommunicationModality::Text,
+            candidate: OutboundPushCandidate {
+                tenant_id: tenant_id(),
+                agent_id: Some(agent_id()),
+                project_id: Some(project_id()),
+                thread_id: thread_id(),
+                turn_run_id: None,
+                target,
+                kind: OutboundPushKind::FinalReply,
+                projection_ref: ProjectionUpdateRef::new("projection:slack")
+                    .expect("projection ref"),
+                requires_reply_target_revalidation: true,
+            },
+            scope,
+        }
+    }
+
+    fn explicit_owner_scope(owner_user_id: &str) -> TurnScope {
+        TurnScope::new_with_owner(
+            tenant_id(),
+            Some(agent_id()),
+            Some(project_id()),
+            thread_id(),
+            Some(UserId::new(owner_user_id).expect("owner")),
+        )
+    }
+
+    fn ownerless_scope() -> TurnScope {
+        TurnScope::new_with_owner(
+            tenant_id(),
+            Some(agent_id()),
+            Some(project_id()),
+            thread_id(),
+            None,
+        )
+    }
+
+    fn actor_fallback_scope() -> TurnScope {
+        TurnScope::new(
+            tenant_id(),
+            Some(agent_id()),
+            Some(project_id()),
+            thread_id(),
+        )
+    }
+
+    fn tenant_id() -> TenantId {
+        TenantId::new(TENANT).expect("tenant")
+    }
+
+    fn installation_id() -> AdapterInstallationId {
+        AdapterInstallationId::new(INSTALLATION).expect("installation")
+    }
+
+    fn agent_id() -> AgentId {
+        AgentId::new(AGENT).expect("agent")
+    }
+
+    fn project_id() -> ProjectId {
+        ProjectId::new(PROJECT).expect("project")
+    }
+
+    fn thread_id() -> ThreadId {
+        ThreadId::new(THREAD).expect("thread")
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -674,7 +674,7 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
                 Ok(target) => targets.push(target),
                 Err(error) => {
                     tracing::warn!(
-                        ?error,
+                        %error,
                         "Slack personal DM target was skipped while listing outbound targets"
                     );
                 }
@@ -785,6 +785,10 @@ fn slack_personal_dm_reply_target_binding_ref(
 pub(crate) fn slack_reply_target_binding_ref_from_raw(
     raw: String,
 ) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    // Safety: all callers must pre-validate inputs via validate_slack_id /
+    // validate_slack_dm_channel_id which reject control characters (including NUL).
+    // ReplyTargetBindingRef::new enforces the 256-byte limit and rejects control chars
+    // as the primary defense — these caller-side validators are defense-in-depth.
     ReplyTargetBindingRef::new(format!("reply:{raw}")).map_err(|_| slack_target_backend_error())
 }
 
@@ -856,6 +860,83 @@ fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPerson
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::slack_channel_routes::{
+        InMemorySlackChannelRouteStore, SlackChannelRouteError, SlackChannelRouteKey,
+        SlackChannelRouteListPage,
+    };
+
+    // ── test constants ────────────────────────────────────────────────────────
+    const TENANT: &str = "tenant:alpha";
+    const INSTALLATION: &str = "install-alpha";
+    const TEAM: &str = "T123";
+    const USER: &str = "user:alice";
+    const OTHER_TENANT: &str = "tenant:other";
+    const OTHER_USER: &str = "user:bob";
+    const SLACK_USER: &str = "U123";
+    const AGENT: &str = "agent:alpha";
+    const PROJECT: &str = "project:alpha";
+
+    // ── test helpers ──────────────────────────────────────────────────────────
+
+    fn caller() -> WebUiAuthenticatedCaller {
+        WebUiAuthenticatedCaller::new(
+            TenantId::new(TENANT).expect("tenant"),
+            UserId::new(USER).expect("user"),
+            Some(AgentId::new(AGENT).expect("agent")),
+            Some(ProjectId::new(PROJECT).expect("project")),
+        )
+    }
+
+    fn provider_config(
+        channel_routes: Vec<SlackConfiguredChannelRoute>,
+    ) -> SlackOutboundTargetProviderConfig {
+        SlackOutboundTargetProviderConfig {
+            tenant_id: TenantId::new(TENANT).expect("tenant"),
+            agent_id: AgentId::new(AGENT).expect("agent"),
+            project_id: Some(ProjectId::new(PROJECT).expect("project")),
+            installation_id: AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            team_id: SlackTeamId::new(TEAM),
+            configured_channel_routes: channel_routes,
+        }
+    }
+
+    fn empty_provider() -> SlackHostBetaOutboundTargetProvider {
+        SlackHostBetaOutboundTargetProvider::new(
+            provider_config(Vec::new()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        )
+    }
+
+    async fn provider_with_provisioned_dm() -> (
+        SlackHostBetaOutboundTargetProvider,
+        Arc<InMemorySlackPersonalDmTargetStore>,
+    ) {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("stores");
+        let store_dyn: Arc<dyn SlackPersonalDmTargetStore> = Arc::clone(&store) as _;
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(Vec::new()),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store_dyn,
+        );
+        (provider, store)
+    }
+
+    // ── validate_slack_id ─────────────────────────────────────────────────────
 
     #[test]
     fn validate_slack_id_accepts_128_char_id_and_rejects_129_char_id() {
@@ -876,6 +957,8 @@ mod tests {
         }
     }
 
+    // ── validate_slack_dm_channel_id ──────────────────────────────────────────
+
     #[test]
     fn slack_personal_dm_target_rejects_non_d_prefixed_channel_id() {
         let key = SlackPersonalDmTargetKey::new(
@@ -890,7 +973,345 @@ mod tests {
             SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "C123".to_string()),
             Err(SlackPersonalDmTargetError::InvalidTarget)
         ));
-        SlackPersonalDmTarget::new(key, SlackUserId::new("U123"), "D123".to_string())
+        SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "D123".to_string())
             .expect("DM-prefixed channel is valid");
+        // lowercase 'd' prefix is also invalid (must be uppercase 'D')
+        assert!(matches!(
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "d123".to_string()),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+        // empty is invalid
+        assert!(matches!(
+            SlackPersonalDmTarget::new(key, SlackUserId::new("U123"), String::new()),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+    }
+
+    // ── slack_personal_dm_reply_target_binding_ref round-trip ────────────────
+
+    #[test]
+    fn slack_personal_dm_reply_target_binding_ref_round_trips_dm_channel_and_slack_user() {
+        let provider = empty_provider();
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let agent_id = AgentId::new(AGENT).expect("agent");
+        let project_id = ProjectId::new(PROJECT).expect("project");
+        let team_id = SlackTeamId::new(TEAM);
+        let slack_user_id = SlackUserId::new(SLACK_USER);
+
+        let binding_ref = slack_personal_dm_reply_target_binding_ref(
+            &installation_id,
+            &agent_id,
+            Some(&project_id),
+            &team_id,
+            "D0HOST",
+            &slack_user_id,
+        )
+        .expect("binding ref builds");
+
+        // parse it back via route_for_reply_target_binding_ref
+        let parsed = provider
+            .route_for_reply_target_binding_ref(&binding_ref)
+            .expect("binding ref parses to a Slack reply target");
+
+        match parsed {
+            ParsedSlackReplyTarget::PersonalDm {
+                dm_channel_id,
+                slack_user_id: parsed_slack_user_id,
+            } => {
+                assert_eq!(dm_channel_id, "D0HOST", "dm_channel_id must round-trip");
+                assert_eq!(
+                    parsed_slack_user_id.as_str(),
+                    SLACK_USER,
+                    "slack_user_id must round-trip"
+                );
+            }
+            ParsedSlackReplyTarget::SharedChannel { .. } => {
+                panic!("personal DM binding ref must not parse as shared channel");
+            }
+        }
+    }
+
+    // ── resolve_reply_target_binding PersonalDm branch ────────────────────────
+
+    #[tokio::test]
+    async fn slack_personal_dm_reply_target_binding_resolves_to_stored_target() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        let listed = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect("target list");
+        assert_eq!(listed.len(), 1, "provisioned DM target must appear");
+        let binding_ref = listed[0].reply_target_binding_ref.clone();
+
+        let resolved = provider
+            .resolve_reply_target_binding(&caller(), &binding_ref)
+            .await
+            .expect("binding resolves without error")
+            .expect("stored DM target must resolve to Some");
+
+        assert_eq!(
+            resolved.summary.target_id.as_str(),
+            format!("slack:personal-dm:{}:{}", TEAM, USER)
+        );
+        assert_eq!(resolved.reply_target_binding_ref, binding_ref);
+    }
+
+    #[tokio::test]
+    async fn slack_personal_dm_reply_target_binding_returns_none_when_no_target_stored() {
+        // Build binding ref for a user that has no provisioned DM target.
+        let provider = empty_provider();
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let agent_id = AgentId::new(AGENT).expect("agent");
+        let project_id = ProjectId::new(PROJECT).expect("project");
+        let team_id = SlackTeamId::new(TEAM);
+        let slack_user_id = SlackUserId::new(SLACK_USER);
+
+        let binding_ref = slack_personal_dm_reply_target_binding_ref(
+            &installation_id,
+            &agent_id,
+            Some(&project_id),
+            &team_id,
+            "D0HOST",
+            &slack_user_id,
+        )
+        .expect("binding ref builds");
+
+        // No target stored → should return Ok(None) (not an error).
+        let result = provider
+            .resolve_reply_target_binding(&caller(), &binding_ref)
+            .await
+            .expect("lookup succeeds");
+        assert!(result.is_none(), "ownerless binding ref must return None");
+    }
+
+    // ── mismatch-guard: stored slack_user_id differs from binding ref ─────────
+
+    #[tokio::test]
+    async fn slack_personal_dm_resolve_binding_rejects_mismatched_slack_user_id() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        // Listing gives us a real binding ref that encodes SLACK_USER + D0HOST.
+        let listed = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect("target list");
+        assert_eq!(listed.len(), 1);
+
+        // Replace the SLACK_USER segment in the raw binding ref string with a
+        // different Slack user id, keeping the dm_channel_id the same.
+        let original = listed[0].reply_target_binding_ref.as_str();
+        let tampered_raw = original.replace(SLACK_USER, "U_OTHER_USER");
+        let mismatched = ReplyTargetBindingRef::new(tampered_raw)
+            .expect("tampered ref is still syntactically valid");
+
+        let result = provider
+            .resolve_reply_target_binding(&caller(), &mismatched)
+            .await
+            .expect("lookup succeeds");
+        assert!(
+            result.is_none(),
+            "mismatched slack_user_id in binding ref must return None"
+        );
+    }
+
+    // ── cross-user: caller.user_id != requested user_id ──────────────────────
+
+    #[tokio::test]
+    async fn slack_personal_dm_resolve_personal_dm_for_user_returns_none_for_cross_user_caller() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        // Target was provisioned for USER ("user:alice").  A different user
+        // ("user:bob") tries to resolve the same target_id.
+        let target_id =
+            RebornOutboundDeliveryTargetId::new(format!("slack:personal-dm:{}:{}", TEAM, USER))
+                .expect("target id");
+
+        let cross_user_caller = WebUiAuthenticatedCaller::new(
+            TenantId::new(TENANT).expect("tenant"),
+            UserId::new(OTHER_USER).expect("other user"),
+            None,
+            None,
+        );
+
+        let result = provider
+            .resolve_outbound_delivery_target(&cross_user_caller, &target_id)
+            .await
+            .expect("lookup succeeds");
+        assert!(
+            result.is_none(),
+            "user B must not resolve user A's personal DM target"
+        );
+    }
+
+    // ── list: both shared-channel route AND personal DM appear together ───────
+
+    #[tokio::test]
+    async fn slack_list_outbound_delivery_targets_returns_shared_channels_and_personal_dm_together()
+    {
+        let store = Arc::new(InMemorySlackPersonalDmTargetStore::new());
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new(TENANT).expect("tenant"),
+            AdapterInstallationId::new(INSTALLATION).expect("installation"),
+            TEAM.to_string(),
+            UserId::new(USER).expect("user"),
+        )
+        .expect("key");
+        let target =
+            SlackPersonalDmTarget::new(key, SlackUserId::new(SLACK_USER), "D0HOST".to_string())
+                .expect("target");
+        store
+            .upsert_personal_dm_target(target)
+            .await
+            .expect("stores");
+
+        // Add a static shared-channel route for the same caller.
+        let shared_route = SlackConfiguredChannelRoute::new(
+            "C0HOST".to_string(),
+            UserId::new(USER).expect("user"),
+        );
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(vec![shared_route]),
+            Arc::new(InMemorySlackChannelRouteStore::new()),
+            store,
+        );
+
+        let listed = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect("target list");
+
+        let target_ids: Vec<&str> = listed
+            .iter()
+            .map(|e| e.summary.target_id.as_str())
+            .collect();
+        assert!(
+            target_ids.iter().any(|id| id.contains("shared-channel")),
+            "shared-channel target must appear: {:?}",
+            target_ids
+        );
+        assert!(
+            target_ids.iter().any(|id| id.contains("personal-dm")),
+            "personal-DM target must appear: {:?}",
+            target_ids
+        );
+        assert_eq!(listed.len(), 2, "exactly one shared + one DM target");
+    }
+
+    // ── shared_channel_routes cap guard ──────────────────────────────────────
+
+    #[derive(Debug)]
+    struct OversizedPageRouteStore;
+
+    #[async_trait::async_trait]
+    impl SlackChannelRouteStore for OversizedPageRouteStore {
+        async fn list_routes(
+            &self,
+            _tenant_id: &TenantId,
+            _installation_id: &AdapterInstallationId,
+            _team_id: &str,
+            _cursor: usize,
+            _limit: usize,
+        ) -> Result<SlackChannelRouteListPage, SlackChannelRouteError> {
+            // Return more routes than the cap in a single page (no next cursor,
+            // so the loop will try the cap check on this batch).
+            let routes = (0..=SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES)
+                .map(|i| crate::slack_channel_routes::SlackChannelRoute {
+                    tenant_id: TENANT.to_string(),
+                    installation_id: INSTALLATION.to_string(),
+                    team_id: TEAM.to_string(),
+                    channel_id: format!("C{i:05}"),
+                    subject_user_id: USER.to_string(),
+                })
+                .collect();
+            Ok(SlackChannelRouteListPage {
+                routes,
+                next_cursor: None,
+            })
+        }
+
+        async fn upsert_route(
+            &self,
+            _key: SlackChannelRouteKey,
+            _subject_user_id: UserId,
+        ) -> Result<crate::slack_channel_routes::SlackChannelRoute, SlackChannelRouteError>
+        {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+
+        async fn delete_route(
+            &self,
+            _key: &SlackChannelRouteKey,
+        ) -> Result<bool, SlackChannelRouteError> {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+
+        async fn replace_managed_routes(
+            &self,
+            _tenant_id: &TenantId,
+            _installation_id: &AdapterInstallationId,
+            _team_id: &str,
+            _assignments: Vec<crate::slack_channel_routes::SlackChannelRouteAssignment>,
+        ) -> Result<Vec<crate::slack_channel_routes::SlackChannelRoute>, SlackChannelRouteError>
+        {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+
+        async fn resolve_subject_user_id(
+            &self,
+            _key: &SlackChannelRouteKey,
+        ) -> Result<Option<UserId>, SlackChannelRouteError> {
+            Err(SlackChannelRouteError::StoreUnavailable)
+        }
+    }
+
+    #[tokio::test]
+    async fn slack_shared_channel_routes_fails_when_stored_batch_exceeds_max_total() {
+        let provider = SlackHostBetaOutboundTargetProvider::new(
+            provider_config(Vec::new()),
+            Arc::new(OversizedPageRouteStore),
+            Arc::new(InMemorySlackPersonalDmTargetStore::new()),
+        );
+
+        let error = provider
+            .list_outbound_delivery_targets(&caller())
+            .await
+            .expect_err("oversized batch must fail closed");
+
+        assert_eq!(error.code, RebornServicesErrorCode::Unavailable);
+        assert_eq!(error.kind, RebornServicesErrorKind::ServiceUnavailable);
+        assert_eq!(error.status_code, 503);
+        assert!(error.retryable);
+    }
+
+    // ── cross-tenant personal-DM resolve ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn slack_host_beta_targets_ignore_cross_tenant_personal_dm_resolve() {
+        let (provider, _store) = provider_with_provisioned_dm().await;
+
+        // Build a personal-DM target_id that matches the provisioned target.
+        let target_id =
+            RebornOutboundDeliveryTargetId::new(format!("slack:personal-dm:{}:{}", TEAM, USER))
+                .expect("target id");
+
+        // A caller from a different tenant with the same user_id.
+        let foreign_tenant_caller = WebUiAuthenticatedCaller::new(
+            TenantId::new(OTHER_TENANT).expect("other tenant"),
+            UserId::new(USER).expect("user"),
+            None,
+            None,
+        );
+
+        let result = provider
+            .resolve_outbound_delivery_target(&foreign_tenant_caller, &target_id)
+            .await
+            .expect("lookup succeeds without error");
+
+        assert!(
+            result.is_none(),
+            "cross-tenant caller must not resolve personal DM target; got: {:?}",
+            result.map(|e| e.summary.target_id.as_str().to_string())
+        );
     }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -27,6 +27,7 @@ use crate::outbound_preferences::{OutboundDeliveryTargetEntry, OutboundDeliveryT
 use crate::slack_channel_routes::{
     SlackChannelRouteError, SlackChannelRouteKey, SlackChannelRouteStore,
 };
+use crate::slack_dm_open::validate_slack_dm_channel_id;
 #[cfg(test)]
 use crate::slack_dm_open::{SlackDmOpenError, open_slack_dm_channel};
 use crate::slack_serve::{SlackTeamId, SlackUserId};
@@ -97,7 +98,8 @@ impl SlackPersonalDmTarget {
         dm_channel_id: String,
     ) -> Result<Self, SlackPersonalDmTargetError> {
         validate_slack_id("slack user", slack_user_id.as_str())?;
-        validate_slack_dm_channel_id(&dm_channel_id)?;
+        validate_slack_dm_channel_id(&dm_channel_id)
+            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?;
         Ok(Self {
             key,
             slack_user_id,
@@ -113,6 +115,7 @@ pub(crate) enum SlackPersonalDmTargetError {
     #[error("Slack personal DM target store unavailable")]
     StoreUnavailable,
     #[error("Slack personal DM provisioning failed: {0}")]
+    // arch-exempt: dead_code, reserved for explicit Slack DM provisioning product route, plan #4600
     #[allow(dead_code)]
     ProvisioningFailed(String),
 }
@@ -124,6 +127,7 @@ pub(crate) trait SlackPersonalDmTargetStore: Send + Sync + std::fmt::Debug {
         key: &SlackPersonalDmTargetKey,
     ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError>;
 
+    // arch-exempt: dead_code, reserved for explicit Slack DM provisioning product route, plan #4600
     #[allow(dead_code)]
     async fn upsert_personal_dm_target(
         &self,
@@ -216,7 +220,6 @@ impl SlackPersonalDmTargetProvisioner {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn provision_for_user(
         &self,
         user_id: UserId,
@@ -233,7 +236,6 @@ impl SlackPersonalDmTargetProvisioner {
         self.store.upsert_personal_dm_target(target).await
     }
 
-    #[allow(dead_code)]
     async fn open_dm_channel(
         &self,
         slack_user_id: &str,
@@ -245,12 +247,15 @@ impl SlackPersonalDmTargetProvisioner {
         )
         .await
         .map_err(|error| match error {
-            SlackDmOpenError::MissingChannel => SlackPersonalDmTargetError::InvalidTarget,
+            SlackDmOpenError::InvalidChannel | SlackDmOpenError::MissingChannel => {
+                SlackPersonalDmTargetError::InvalidTarget
+            }
             SlackDmOpenError::Backend(reason) => {
                 SlackPersonalDmTargetError::ProvisioningFailed(reason)
             }
         })?;
-        validate_slack_dm_channel_id(&channel_id)?;
+        validate_slack_dm_channel_id(&channel_id)
+            .map_err(|_| SlackPersonalDmTargetError::InvalidTarget)?;
         Ok(channel_id)
     }
 }
@@ -386,7 +391,7 @@ impl SlackHostBetaOutboundTargetProvider {
         })
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn channel_id_for_reply_target_binding_ref(
         &self,
         target: &ReplyTargetBindingRef,
@@ -629,13 +634,21 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
             .into_iter()
             .map(|route| self.entry_for_shared_channel_route(&route))
             .collect::<Result<Vec<_>, _>>()?;
-        let key = SlackPersonalDmTargetKey::new(
+        let key = match SlackPersonalDmTargetKey::new(
             self.tenant_id.clone(),
             self.installation_id.clone(),
             self.team_id.as_str().to_string(),
             caller.user_id.clone(),
-        )
-        .map_err(map_slack_personal_dm_target_error)?;
+        ) {
+            Ok(key) => key,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "Slack personal DM target key could not be built while listing outbound targets"
+                );
+                return Ok(targets);
+            }
+        };
         match self
             .personal_dm_target_store
             .load_personal_dm_target(&key)
@@ -818,14 +831,6 @@ fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPerson
         })
     {
         tracing::debug!(field, "invalid Slack id for personal DM target");
-        return Err(SlackPersonalDmTargetError::InvalidTarget);
-    }
-    Ok(())
-}
-
-fn validate_slack_dm_channel_id(value: &str) -> Result<(), SlackPersonalDmTargetError> {
-    validate_slack_id("slack dm channel", value)?;
-    if !value.starts_with('D') {
         return Err(SlackPersonalDmTargetError::InvalidTarget);
     }
     Ok(())

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -1,0 +1,832 @@
+//! Slack outbound target authority for default delivery.
+//!
+//! Core outbound preferences only see opaque target ids and validated reply
+//! target bindings. Slack-specific channel and DM authority stays here.
+
+#[cfg(test)]
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::RwLock;
+
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+use ironclaw_product_adapters::{AdapterInstallationId, ExternalActorRef, ExternalConversationRef};
+#[cfg(test)]
+use ironclaw_product_adapters::{EgressCredentialHandle, ProtocolHttpEgress};
+use ironclaw_product_workflow::{
+    RebornOutboundDeliveryTargetCapabilities, RebornOutboundDeliveryTargetId,
+    RebornOutboundDeliveryTargetSummary, RebornServicesError, RebornServicesErrorCode,
+    RebornServicesErrorKind, WebUiAuthenticatedCaller,
+};
+use ironclaw_slack_v2_adapter::{SLACK_USER_ACTOR_KIND, SLACK_V2_ADAPTER_ID};
+use ironclaw_turns::ReplyTargetBindingRef;
+use thiserror::Error;
+
+use crate::outbound_preferences::{OutboundDeliveryTargetEntry, OutboundDeliveryTargetProvider};
+use crate::slack_channel_routes::{
+    SlackChannelRouteError, SlackChannelRouteKey, SlackChannelRouteStore,
+};
+#[cfg(test)]
+use crate::slack_dm_open::{SlackDmOpenError, open_slack_dm_channel};
+use crate::slack_serve::{SlackTeamId, SlackUserId};
+
+pub(crate) const SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE: usize = 500;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SlackConfiguredChannelRoute {
+    pub(crate) channel_id: String,
+    pub(crate) subject_user_id: UserId,
+}
+
+impl SlackConfiguredChannelRoute {
+    pub(crate) fn new(channel_id: String, subject_user_id: UserId) -> Self {
+        Self {
+            channel_id,
+            subject_user_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SlackOutboundTargetProviderConfig {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) agent_id: AgentId,
+    pub(crate) project_id: Option<ProjectId>,
+    pub(crate) installation_id: AdapterInstallationId,
+    pub(crate) team_id: SlackTeamId,
+    pub(crate) configured_channel_routes: Vec<SlackConfiguredChannelRoute>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SlackPersonalDmTargetKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) installation_id: AdapterInstallationId,
+    pub(crate) team_id: String,
+    pub(crate) user_id: UserId,
+}
+
+impl SlackPersonalDmTargetKey {
+    pub(crate) fn new(
+        tenant_id: TenantId,
+        installation_id: AdapterInstallationId,
+        team_id: String,
+        user_id: UserId,
+    ) -> Result<Self, SlackPersonalDmTargetError> {
+        validate_slack_id("slack team", &team_id)?;
+        Ok(Self {
+            tenant_id,
+            installation_id,
+            team_id,
+            user_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SlackPersonalDmTarget {
+    pub(crate) key: SlackPersonalDmTargetKey,
+    pub(crate) slack_user_id: SlackUserId,
+    pub(crate) dm_channel_id: String,
+}
+
+impl SlackPersonalDmTarget {
+    pub(crate) fn new(
+        key: SlackPersonalDmTargetKey,
+        slack_user_id: SlackUserId,
+        dm_channel_id: String,
+    ) -> Result<Self, SlackPersonalDmTargetError> {
+        validate_slack_id("slack user", slack_user_id.as_str())?;
+        validate_slack_dm_channel_id(&dm_channel_id)?;
+        Ok(Self {
+            key,
+            slack_user_id,
+            dm_channel_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum SlackPersonalDmTargetError {
+    #[error("invalid Slack personal DM target")]
+    InvalidTarget,
+    #[error("Slack personal DM target store unavailable")]
+    StoreUnavailable,
+    #[error("Slack personal DM provisioning failed: {0}")]
+    #[allow(dead_code)]
+    ProvisioningFailed(String),
+}
+
+#[async_trait::async_trait]
+pub(crate) trait SlackPersonalDmTargetStore: Send + Sync + std::fmt::Debug {
+    async fn load_personal_dm_target(
+        &self,
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError>;
+
+    #[allow(dead_code)]
+    async fn upsert_personal_dm_target(
+        &self,
+        target: SlackPersonalDmTarget,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError>;
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub(crate) struct InMemorySlackPersonalDmTargetStore {
+    targets: RwLock<HashMap<SlackPersonalDmTargetKey, SlackPersonalDmTarget>>,
+}
+
+#[cfg(test)]
+impl InMemorySlackPersonalDmTargetStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl SlackPersonalDmTargetStore for InMemorySlackPersonalDmTargetStore {
+    async fn load_personal_dm_target(
+        &self,
+        key: &SlackPersonalDmTargetKey,
+    ) -> Result<Option<SlackPersonalDmTarget>, SlackPersonalDmTargetError> {
+        Ok(self
+            .targets
+            .read()
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?
+            .get(key)
+            .cloned())
+    }
+
+    async fn upsert_personal_dm_target(
+        &self,
+        target: SlackPersonalDmTarget,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+        self.targets
+            .write()
+            .map_err(|_| SlackPersonalDmTargetError::StoreUnavailable)?
+            .insert(target.key.clone(), target.clone());
+        Ok(target)
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct SlackPersonalDmTargetProvisioner {
+    tenant_id: TenantId,
+    installation_id: AdapterInstallationId,
+    team_id: SlackTeamId,
+    egress: Arc<dyn ProtocolHttpEgress>,
+    credential_handle: EgressCredentialHandle,
+    store: Arc<dyn SlackPersonalDmTargetStore>,
+}
+
+#[cfg(test)]
+impl std::fmt::Debug for SlackPersonalDmTargetProvisioner {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SlackPersonalDmTargetProvisioner")
+            .field("tenant_id", &self.tenant_id)
+            .field("installation_id", &self.installation_id)
+            .field("team_id", &self.team_id)
+            .field("egress", &"Arc<dyn ProtocolHttpEgress>")
+            .field("credential_handle", &self.credential_handle)
+            .field("store", &self.store)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+impl SlackPersonalDmTargetProvisioner {
+    pub(crate) fn new(
+        tenant_id: TenantId,
+        installation_id: AdapterInstallationId,
+        team_id: SlackTeamId,
+        egress: Arc<dyn ProtocolHttpEgress>,
+        credential_handle: EgressCredentialHandle,
+        store: Arc<dyn SlackPersonalDmTargetStore>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            installation_id,
+            team_id,
+            egress,
+            credential_handle,
+            store,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn provision_for_user(
+        &self,
+        user_id: UserId,
+        slack_user_id: SlackUserId,
+    ) -> Result<SlackPersonalDmTarget, SlackPersonalDmTargetError> {
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            user_id,
+        )?;
+        let dm_channel_id = self.open_dm_channel(slack_user_id.as_str()).await?;
+        let target = SlackPersonalDmTarget::new(key, slack_user_id, dm_channel_id)?;
+        self.store.upsert_personal_dm_target(target).await
+    }
+
+    #[allow(dead_code)]
+    async fn open_dm_channel(
+        &self,
+        slack_user_id: &str,
+    ) -> Result<String, SlackPersonalDmTargetError> {
+        let channel_id = open_slack_dm_channel(
+            self.egress.as_ref(),
+            self.credential_handle.clone(),
+            slack_user_id,
+        )
+        .await
+        .map_err(|error| match error {
+            SlackDmOpenError::MissingChannel => SlackPersonalDmTargetError::InvalidTarget,
+            SlackDmOpenError::Backend(reason) => {
+                SlackPersonalDmTargetError::ProvisioningFailed(reason)
+            }
+        })?;
+        validate_slack_dm_channel_id(&channel_id)?;
+        Ok(channel_id)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SlackHostBetaOutboundTargetProvider {
+    tenant_id: TenantId,
+    agent_id: AgentId,
+    project_id: Option<ProjectId>,
+    installation_id: AdapterInstallationId,
+    team_id: SlackTeamId,
+    shared_target_id_prefix: String,
+    personal_target_id_prefix: String,
+    configured_channel_routes: Vec<SlackConfiguredChannelRoute>,
+    channel_route_store: Arc<dyn SlackChannelRouteStore>,
+    personal_dm_target_store: Arc<dyn SlackPersonalDmTargetStore>,
+}
+
+impl SlackHostBetaOutboundTargetProvider {
+    pub(crate) fn new(
+        config: SlackOutboundTargetProviderConfig,
+        channel_route_store: Arc<dyn SlackChannelRouteStore>,
+        personal_dm_target_store: Arc<dyn SlackPersonalDmTargetStore>,
+    ) -> Self {
+        Self {
+            tenant_id: config.tenant_id,
+            agent_id: config.agent_id,
+            project_id: config.project_id,
+            installation_id: config.installation_id,
+            shared_target_id_prefix: format!("slack:shared-channel:{}:", config.team_id.as_str()),
+            personal_target_id_prefix: format!("slack:personal-dm:{}:", config.team_id.as_str()),
+            team_id: config.team_id,
+            configured_channel_routes: config.configured_channel_routes,
+            channel_route_store,
+            personal_dm_target_store,
+        }
+    }
+
+    fn target_id_for_shared_channel(
+        &self,
+        channel_id: &str,
+    ) -> Result<RebornOutboundDeliveryTargetId, RebornServicesError> {
+        RebornOutboundDeliveryTargetId::new(format!(
+            "slack:shared-channel:{}:{}",
+            self.team_id.as_str(),
+            channel_id
+        ))
+        .map_err(|_| slack_target_backend_error())
+    }
+
+    fn target_id_for_personal_dm(
+        &self,
+        user_id: &UserId,
+    ) -> Result<RebornOutboundDeliveryTargetId, RebornServicesError> {
+        RebornOutboundDeliveryTargetId::new(format!(
+            "slack:personal-dm:{}:{}",
+            self.team_id.as_str(),
+            user_id.as_str()
+        ))
+        .map_err(|_| slack_target_backend_error())
+    }
+
+    pub(crate) fn channel_id_for_target_id<'a>(
+        &self,
+        target_id: &'a RebornOutboundDeliveryTargetId,
+    ) -> Option<&'a str> {
+        target_id
+            .as_str()
+            .strip_prefix(&self.shared_target_id_prefix)
+            .filter(|channel_id| !channel_id.is_empty())
+    }
+
+    fn user_id_for_personal_target_id(
+        &self,
+        target_id: &RebornOutboundDeliveryTargetId,
+    ) -> Option<UserId> {
+        UserId::new(
+            target_id
+                .as_str()
+                .strip_prefix(&self.personal_target_id_prefix)?,
+        )
+        .ok()
+    }
+
+    fn route_for_reply_target_binding_ref(
+        &self,
+        target: &ReplyTargetBindingRef,
+    ) -> Option<ParsedSlackReplyTarget> {
+        let mut raw = target.as_str().strip_prefix("reply:")?;
+        let (adapter_id, rest) = take_product_binding_segment(raw, "adapter")?;
+        if adapter_id != SLACK_V2_ADAPTER_ID {
+            return None;
+        }
+        raw = rest;
+        let (installation_id, rest) = take_product_binding_segment(raw, "installation")?;
+        if installation_id != self.installation_id.as_str() {
+            return None;
+        }
+        raw = rest;
+        let (agent_id, rest) = take_product_binding_segment(raw, "agent")?;
+        if agent_id != self.agent_id.as_str() {
+            return None;
+        }
+        raw = rest;
+        let (project_id, rest) = take_product_binding_segment(raw, "project")?;
+        if project_id != self.project_id.as_ref().map_or("", |id| id.as_str()) {
+            return None;
+        }
+        raw = rest;
+        let (space_id, rest) = take_product_binding_segment(raw, "space")?;
+        if space_id != self.team_id.as_str() {
+            return None;
+        }
+        raw = rest;
+        let (conversation_id, rest) = take_product_binding_segment(raw, "conversation")?;
+        let (topic_id, rest) = take_product_binding_segment(rest, "topic")?;
+        if conversation_id.is_empty() || !topic_id.is_empty() {
+            return None;
+        }
+        if rest.is_empty() {
+            return Some(ParsedSlackReplyTarget::SharedChannel {
+                channel_id: conversation_id.to_string(),
+            });
+        }
+        let (actor_kind, rest) = take_product_binding_segment(rest, "actor_kind")?;
+        let (actor_id, rest) = take_product_binding_segment(rest, "actor")?;
+        if actor_kind != SLACK_USER_ACTOR_KIND || actor_id.is_empty() || !rest.is_empty() {
+            return None;
+        }
+        Some(ParsedSlackReplyTarget::PersonalDm {
+            dm_channel_id: conversation_id.to_string(),
+            slack_user_id: SlackUserId::new(actor_id),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn channel_id_for_reply_target_binding_ref(
+        &self,
+        target: &ReplyTargetBindingRef,
+    ) -> Option<String> {
+        match self.route_for_reply_target_binding_ref(target)? {
+            ParsedSlackReplyTarget::SharedChannel { channel_id } => Some(channel_id),
+            ParsedSlackReplyTarget::PersonalDm { .. } => None,
+        }
+    }
+
+    async fn shared_channel_route_for_channel(
+        &self,
+        channel_id: &str,
+    ) -> Result<Option<SlackConfiguredChannelRoute>, RebornServicesError> {
+        let key = match SlackChannelRouteKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            channel_id.to_string(),
+        ) {
+            Ok(key) => key,
+            Err(SlackChannelRouteError::InvalidRoute) => return Ok(None),
+            Err(error) => return Err(map_slack_target_route_error(error)),
+        };
+        if let Some(subject_user_id) = self
+            .channel_route_store
+            .resolve_subject_user_id(&key)
+            .await
+            .map_err(map_slack_target_route_error)?
+        {
+            return Ok(Some(SlackConfiguredChannelRoute::new(
+                channel_id.to_string(),
+                subject_user_id,
+            )));
+        }
+        Ok(self
+            .configured_channel_routes
+            .iter()
+            .find(|route| route.channel_id == channel_id)
+            .cloned())
+    }
+
+    async fn shared_channel_routes(
+        &self,
+    ) -> Result<Vec<SlackConfiguredChannelRoute>, RebornServicesError> {
+        let mut cursor = 0;
+        let mut stored_channel_ids = HashSet::new();
+        let mut routes = Vec::new();
+        loop {
+            let stored = self
+                .channel_route_store
+                .list_routes(
+                    &self.tenant_id,
+                    &self.installation_id,
+                    self.team_id.as_str(),
+                    cursor,
+                    SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+                )
+                .await
+                .map_err(map_slack_target_route_error)?;
+            for route in stored.routes {
+                stored_channel_ids.insert(route.channel_id.clone());
+                routes.push(SlackConfiguredChannelRoute::new(
+                    route.channel_id,
+                    UserId::new(route.subject_user_id).map_err(|_| slack_target_backend_error())?,
+                ));
+            }
+            let Some(next_cursor) = stored.next_cursor else {
+                break;
+            };
+            if next_cursor <= cursor {
+                return Err(map_slack_target_route_error(
+                    SlackChannelRouteError::StoreUnavailable,
+                ));
+            }
+            cursor = next_cursor;
+        }
+        routes.extend(
+            self.configured_channel_routes
+                .iter()
+                .filter(|route| !stored_channel_ids.contains(&route.channel_id))
+                .cloned(),
+        );
+        Ok(routes)
+    }
+
+    fn entry_for_shared_channel_route(
+        &self,
+        route: &SlackConfiguredChannelRoute,
+    ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
+        let target_id = self.target_id_for_shared_channel(&route.channel_id)?;
+        let display_name = format!("Slack channel {}", route.channel_id);
+        Ok(OutboundDeliveryTargetEntry {
+            summary: RebornOutboundDeliveryTargetSummary::new(
+                target_id,
+                "slack",
+                display_name,
+                Some(format!(
+                    "Slack channel {} in team {}",
+                    route.channel_id,
+                    self.team_id.as_str()
+                )),
+            )
+            .map_err(|_| slack_target_backend_error())?,
+            capabilities: RebornOutboundDeliveryTargetCapabilities {
+                final_replies: true,
+                gate_prompts: true,
+                auth_prompts: true,
+            },
+            reply_target_binding_ref: slack_shared_channel_reply_target_binding_ref(
+                &self.installation_id,
+                &self.agent_id,
+                self.project_id.as_ref(),
+                &self.team_id,
+                &route.channel_id,
+            )?,
+        })
+    }
+
+    fn entry_for_personal_dm_target(
+        &self,
+        target: &SlackPersonalDmTarget,
+    ) -> Result<OutboundDeliveryTargetEntry, RebornServicesError> {
+        let target_id = self.target_id_for_personal_dm(&target.key.user_id)?;
+        Ok(OutboundDeliveryTargetEntry {
+            summary: RebornOutboundDeliveryTargetSummary::new(
+                target_id,
+                "slack",
+                "Slack DM".to_string(),
+                Some(format!("Slack DM in team {}", self.team_id.as_str())),
+            )
+            .map_err(|_| slack_target_backend_error())?,
+            capabilities: RebornOutboundDeliveryTargetCapabilities {
+                final_replies: true,
+                gate_prompts: true,
+                auth_prompts: true,
+            },
+            reply_target_binding_ref: slack_personal_dm_reply_target_binding_ref(
+                &self.installation_id,
+                &self.agent_id,
+                self.project_id.as_ref(),
+                &self.team_id,
+                &target.dm_channel_id,
+                &target.slack_user_id,
+            )?,
+        })
+    }
+
+    async fn resolve_for_channel_id(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        channel_id: &str,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id {
+            return Ok(None);
+        }
+        let Some(route) = self.shared_channel_route_for_channel(channel_id).await? else {
+            return Ok(None);
+        };
+        if route.subject_user_id != caller.user_id {
+            return Ok(None);
+        }
+        self.entry_for_shared_channel_route(&route).map(Some)
+    }
+
+    async fn resolve_personal_dm_for_user(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        user_id: &UserId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id || &caller.user_id != user_id {
+            return Ok(None);
+        }
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        )
+        .map_err(map_slack_personal_dm_target_error)?;
+        let Some(target) = self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+            .map_err(map_slack_personal_dm_target_error)?
+        else {
+            return Ok(None);
+        };
+        self.entry_for_personal_dm_target(&target).map(Some)
+    }
+
+    async fn resolve_personal_dm_for_binding(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        dm_channel_id: &str,
+        slack_user_id: &SlackUserId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id {
+            return Ok(None);
+        }
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        )
+        .map_err(map_slack_personal_dm_target_error)?;
+        let Some(target) = self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+            .map_err(map_slack_personal_dm_target_error)?
+        else {
+            return Ok(None);
+        };
+        if target.dm_channel_id != dm_channel_id || target.slack_user_id != *slack_user_id {
+            return Ok(None);
+        }
+        self.entry_for_personal_dm_target(&target).map(Some)
+    }
+}
+
+#[async_trait::async_trait]
+impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
+    async fn list_outbound_delivery_targets(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+    ) -> Result<Vec<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if caller.tenant_id != self.tenant_id {
+            return Ok(Vec::new());
+        }
+        let mut routes = self
+            .shared_channel_routes()
+            .await?
+            .into_iter()
+            .filter(|route| route.subject_user_id == caller.user_id)
+            .collect::<Vec<_>>();
+        routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
+        let mut targets = routes
+            .into_iter()
+            .map(|route| self.entry_for_shared_channel_route(&route))
+            .collect::<Result<Vec<_>, _>>()?;
+        let key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        )
+        .map_err(map_slack_personal_dm_target_error)?;
+        match self
+            .personal_dm_target_store
+            .load_personal_dm_target(&key)
+            .await
+        {
+            Ok(Some(target)) => match self.entry_for_personal_dm_target(&target) {
+                Ok(target) => targets.push(target),
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        "Slack personal DM target was skipped while listing outbound targets"
+                    );
+                }
+            },
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "Slack personal DM target lookup failed while listing outbound targets"
+                );
+            }
+        }
+        Ok(targets)
+    }
+
+    async fn resolve_outbound_delivery_target(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target_id: &RebornOutboundDeliveryTargetId,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        if let Some(channel_id) = self.channel_id_for_target_id(target_id) {
+            return self.resolve_for_channel_id(caller, channel_id).await;
+        }
+        let Some(user_id) = self.user_id_for_personal_target_id(target_id) else {
+            return Ok(None);
+        };
+        self.resolve_personal_dm_for_user(caller, &user_id).await
+    }
+
+    async fn resolve_reply_target_binding(
+        &self,
+        caller: &WebUiAuthenticatedCaller,
+        target: &ReplyTargetBindingRef,
+    ) -> Result<Option<OutboundDeliveryTargetEntry>, RebornServicesError> {
+        match self.route_for_reply_target_binding_ref(target) {
+            Some(ParsedSlackReplyTarget::SharedChannel { channel_id }) => {
+                self.resolve_for_channel_id(caller, &channel_id).await
+            }
+            Some(ParsedSlackReplyTarget::PersonalDm {
+                dm_channel_id,
+                slack_user_id,
+            }) => {
+                self.resolve_personal_dm_for_binding(caller, &dm_channel_id, &slack_user_id)
+                    .await
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+enum ParsedSlackReplyTarget {
+    SharedChannel {
+        channel_id: String,
+    },
+    PersonalDm {
+        dm_channel_id: String,
+        slack_user_id: SlackUserId,
+    },
+}
+
+pub(crate) fn slack_shared_channel_reply_target_binding_ref(
+    installation_id: &AdapterInstallationId,
+    agent_id: &AgentId,
+    project_id: Option<&ProjectId>,
+    team_id: &SlackTeamId,
+    channel_id: &str,
+) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    let conversation = ExternalConversationRef::new(Some(team_id.as_str()), channel_id, None, None)
+        .map_err(|_| slack_target_backend_error())?;
+    let raw = format!(
+        "{}{}{}{}{}",
+        product_binding_segment("adapter", SLACK_V2_ADAPTER_ID),
+        product_binding_segment("installation", installation_id.as_str()),
+        product_binding_segment("agent", agent_id.as_str()),
+        product_binding_segment("project", project_id.map_or("", |id| id.as_str())),
+        conversation.conversation_fingerprint()
+    );
+    slack_reply_target_binding_ref_from_raw(raw)
+}
+
+fn slack_personal_dm_reply_target_binding_ref(
+    installation_id: &AdapterInstallationId,
+    agent_id: &AgentId,
+    project_id: Option<&ProjectId>,
+    team_id: &SlackTeamId,
+    dm_channel_id: &str,
+    slack_user_id: &SlackUserId,
+) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    let conversation =
+        ExternalConversationRef::new(Some(team_id.as_str()), dm_channel_id, None, None)
+            .map_err(|_| slack_target_backend_error())?;
+    let actor = ExternalActorRef::new(SLACK_USER_ACTOR_KIND, slack_user_id.as_str(), None::<&str>)
+        .map_err(|_| slack_target_backend_error())?;
+    let raw = format!(
+        "{}{}{}{}{}{}{}",
+        product_binding_segment("adapter", SLACK_V2_ADAPTER_ID),
+        product_binding_segment("installation", installation_id.as_str()),
+        product_binding_segment("agent", agent_id.as_str()),
+        product_binding_segment("project", project_id.map_or("", |id| id.as_str())),
+        conversation.conversation_fingerprint(),
+        product_binding_segment("actor_kind", actor.kind()),
+        product_binding_segment("actor", actor.id())
+    );
+    slack_reply_target_binding_ref_from_raw(raw)
+}
+
+pub(crate) fn slack_reply_target_binding_ref_from_raw(
+    raw: String,
+) -> Result<ReplyTargetBindingRef, RebornServicesError> {
+    ReplyTargetBindingRef::new(format!("reply:{raw}")).map_err(|_| slack_target_backend_error())
+}
+
+// Keep this segment format in parity with
+// `ExternalConversationRef::conversation_fingerprint`.
+fn product_binding_segment(name: &str, value: &str) -> String {
+    format!("{name}:{}:{value};", value.len())
+}
+
+fn take_product_binding_segment<'a>(raw: &'a str, name: &str) -> Option<(&'a str, &'a str)> {
+    let raw = raw.strip_prefix(name)?.strip_prefix(':')?;
+    let (length, raw) = raw.split_once(':')?;
+    let length = length.parse::<usize>().ok()?;
+    let value = raw.get(..length)?;
+    let raw = raw.get(length..)?.strip_prefix(';')?;
+    Some((value, raw))
+}
+
+fn map_slack_target_route_error(error: SlackChannelRouteError) -> RebornServicesError {
+    match error {
+        SlackChannelRouteError::InvalidRoute => slack_target_not_found_error(),
+        SlackChannelRouteError::StoreUnavailable => slack_target_backend_error(),
+    }
+}
+
+fn map_slack_personal_dm_target_error(error: SlackPersonalDmTargetError) -> RebornServicesError {
+    match error {
+        SlackPersonalDmTargetError::InvalidTarget => slack_target_not_found_error(),
+        SlackPersonalDmTargetError::StoreUnavailable
+        | SlackPersonalDmTargetError::ProvisioningFailed(_) => slack_target_backend_error(),
+    }
+}
+
+fn slack_target_not_found_error() -> RebornServicesError {
+    RebornServicesError {
+        code: RebornServicesErrorCode::NotFound,
+        kind: RebornServicesErrorKind::NotFound,
+        status_code: 404,
+        retryable: false,
+        field: None,
+        validation_code: None,
+    }
+}
+
+fn slack_target_backend_error() -> RebornServicesError {
+    RebornServicesError {
+        code: RebornServicesErrorCode::Unavailable,
+        kind: RebornServicesErrorKind::ServiceUnavailable,
+        status_code: 503,
+        retryable: true,
+        field: None,
+        validation_code: None,
+    }
+}
+
+fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPersonalDmTargetError> {
+    if value.is_empty()
+        || value.len() > 128
+        || value.chars().any(|c| {
+            c == '\0' || c.is_control() || c.is_whitespace() || matches!(c, '/' | '\\' | ':' | ';')
+        })
+    {
+        tracing::debug!(field, "invalid Slack id for personal DM target");
+        return Err(SlackPersonalDmTargetError::InvalidTarget);
+    }
+    Ok(())
+}
+
+fn validate_slack_dm_channel_id(value: &str) -> Result<(), SlackPersonalDmTargetError> {
+    validate_slack_id("slack dm channel", value)?;
+    if !value.starts_with('D') {
+        return Err(SlackPersonalDmTargetError::InvalidTarget);
+    }
+    Ok(())
+}

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -435,62 +435,6 @@ impl SlackHostBetaOutboundTargetProvider {
             .cloned())
     }
 
-    async fn shared_channel_routes(
-        &self,
-    ) -> Result<Vec<SlackConfiguredChannelRoute>, RebornServicesError> {
-        let mut cursor = 0;
-        let mut stored_channel_ids = HashSet::new();
-        let mut routes = Vec::new();
-        loop {
-            let stored = self
-                .channel_route_store
-                .list_routes(
-                    &self.tenant_id,
-                    &self.installation_id,
-                    self.team_id.as_str(),
-                    cursor,
-                    SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
-                )
-                .await
-                .map_err(map_slack_target_route_error)?;
-            if routes.len() + stored.routes.len() > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES {
-                return Err(map_slack_target_route_error(
-                    SlackChannelRouteError::StoreUnavailable,
-                ));
-            }
-            for route in stored.routes {
-                stored_channel_ids.insert(route.channel_id.clone());
-                routes.push(SlackConfiguredChannelRoute::new(
-                    route.channel_id,
-                    UserId::new(route.subject_user_id).map_err(|_| slack_target_backend_error())?,
-                ));
-            }
-            let Some(next_cursor) = stored.next_cursor else {
-                break;
-            };
-            if next_cursor <= cursor {
-                return Err(map_slack_target_route_error(
-                    SlackChannelRouteError::StoreUnavailable,
-                ));
-            }
-            cursor = next_cursor;
-        }
-        if routes.len() + self.configured_channel_routes.len()
-            > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES
-        {
-            return Err(map_slack_target_route_error(
-                SlackChannelRouteError::StoreUnavailable,
-            ));
-        }
-        routes.extend(
-            self.configured_channel_routes
-                .iter()
-                .filter(|route| !stored_channel_ids.contains(&route.channel_id))
-                .cloned(),
-        );
-        Ok(routes)
-    }
-
     fn entry_for_shared_channel_route(
         &self,
         route: &SlackConfiguredChannelRoute,
@@ -658,12 +602,67 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
                 }
             }
         };
-        let (routes, personal_dm_target) =
-            tokio::join!(self.shared_channel_routes(), personal_dm_target);
-        let mut routes = routes?
+        let subject_routes = self.channel_route_store.list_routes_for_subject(
+            &self.tenant_id,
+            &self.installation_id,
+            self.team_id.as_str(),
+            &caller.user_id,
+            SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+            SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+        );
+        let (stored_routes, personal_dm_target) = tokio::join!(subject_routes, personal_dm_target);
+        let stored_routes = stored_routes.map_err(map_slack_target_route_error)?;
+        // Collect the channel ids returned for this subject so we can skip
+        // static configured routes that the store has already overridden with
+        // any subject (including a different one).  Collect as owned Strings so
+        // `stored_routes` can be moved into the route vec below.
+        let stored_channel_ids: HashSet<String> =
+            stored_routes.iter().map(|r| r.channel_id.clone()).collect();
+        let mut routes: Vec<SlackConfiguredChannelRoute> = stored_routes
             .into_iter()
-            .filter(|route| route.subject_user_id == caller.user_id)
-            .collect::<Vec<_>>();
+            .map(|r| {
+                UserId::new(r.subject_user_id)
+                    .map_err(|_| slack_target_backend_error())
+                    .map(|uid| SlackConfiguredChannelRoute::new(r.channel_id, uid))
+            })
+            .collect::<Result<_, _>>()?;
+        // For each static configured route belonging to this caller that is not
+        // already in the subject-scoped store results, check whether the store
+        // has ANY entry for that channel (even under a different subject).  If
+        // the store has overridden the channel, omit the stale static entry so
+        // the admin-assigned subject wins.  A true subject index remains a
+        // tracked follow-up; for now the N point-lookups over the (typically
+        // small) static route list are cheaper than a full-inventory scan.
+        for static_route in self
+            .configured_channel_routes
+            .iter()
+            .filter(|r| r.subject_user_id == caller.user_id)
+        {
+            if stored_channel_ids.contains(&static_route.channel_id) {
+                // Already present from the subject-scoped store results.
+                continue;
+            }
+            let key = match SlackChannelRouteKey::new(
+                self.tenant_id.clone(),
+                self.installation_id.clone(),
+                self.team_id.as_str().to_string(),
+                static_route.channel_id.clone(),
+            ) {
+                Ok(key) => key,
+                Err(_) => continue,
+            };
+            let store_override = self
+                .channel_route_store
+                .resolve_subject_user_id(&key)
+                .await
+                .map_err(map_slack_target_route_error)?;
+            if store_override.is_none() {
+                // No store entry for this channel — static route is active.
+                routes.push(static_route.clone());
+            }
+            // If the store has an entry for another subject, the static route
+            // is suppressed (admin override takes precedence).
+        }
         routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
         let mut targets = routes
             .into_iter()
@@ -1282,6 +1281,101 @@ mod tests {
         assert_eq!(error.kind, RebornServicesErrorKind::ServiceUnavailable);
         assert_eq!(error.status_code, 503);
         assert!(error.retryable);
+    }
+
+    // ── list_routes_for_subject ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_routes_for_subject_returns_only_callers_routes_across_multiple_subjects() {
+        let store = Arc::new(InMemorySlackChannelRouteStore::new());
+        let tenant_id = TenantId::new(TENANT).expect("tenant");
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let alice = UserId::new(USER).expect("alice");
+        let bob = UserId::new(OTHER_USER).expect("bob");
+
+        // Seed: two channels for alice, one for bob.
+        for (channel_id, subject) in [
+            ("C0ALICE1", alice.clone()),
+            ("C0ALICE2", alice.clone()),
+            ("C0BOB1", bob.clone()),
+        ] {
+            let key = SlackChannelRouteKey::new(
+                tenant_id.clone(),
+                installation_id.clone(),
+                TEAM.to_string(),
+                channel_id.to_string(),
+            )
+            .expect("key");
+            store.upsert_route(key, subject).await.expect("upsert");
+        }
+
+        // Alice's scoped listing must return exactly her two routes.
+        let alice_routes = store
+            .list_routes_for_subject(
+                &tenant_id,
+                &installation_id,
+                TEAM,
+                &alice,
+                100,
+                SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+            )
+            .await
+            .expect("listing succeeds");
+        assert_eq!(alice_routes.len(), 2, "alice must see exactly 2 routes");
+        assert!(
+            alice_routes
+                .iter()
+                .all(|r| r.subject_user_id == alice.as_str()),
+            "all returned routes must belong to alice"
+        );
+        assert!(
+            alice_routes.iter().any(|r| r.channel_id == "C0ALICE1"),
+            "C0ALICE1 must be present"
+        );
+        assert!(
+            alice_routes.iter().any(|r| r.channel_id == "C0ALICE2"),
+            "C0ALICE2 must be present"
+        );
+
+        // Bob's listing must return only his route — not alice's.
+        let bob_routes = store
+            .list_routes_for_subject(
+                &tenant_id,
+                &installation_id,
+                TEAM,
+                &bob,
+                100,
+                SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+            )
+            .await
+            .expect("listing succeeds");
+        assert_eq!(bob_routes.len(), 1, "bob must see exactly 1 route");
+        assert_eq!(bob_routes[0].channel_id, "C0BOB1");
+    }
+
+    #[tokio::test]
+    async fn list_routes_for_subject_enforces_cap_on_subject_matching_routes() {
+        // Reuse OversizedPageRouteStore: every route belongs to USER, so the
+        // subject filter won't reduce the count and the cap must still fire.
+        let store = Arc::new(OversizedPageRouteStore);
+        let tenant_id = TenantId::new(TENANT).expect("tenant");
+        let installation_id = AdapterInstallationId::new(INSTALLATION).expect("installation");
+        let alice = UserId::new(USER).expect("alice");
+
+        let result = store
+            .list_routes_for_subject(
+                &tenant_id,
+                &installation_id,
+                TEAM,
+                &alice,
+                SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+                SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(SlackChannelRouteError::StoreUnavailable)),
+            "cap guard must fire when subject routes exceed the maximum: {result:?}"
+        );
     }
 
     // ── cross-tenant personal-DM resolve ─────────────────────────────────────

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -33,6 +33,7 @@ use crate::slack_dm_open::{SlackDmOpenError, open_slack_dm_channel};
 use crate::slack_serve::{SlackTeamId, SlackUserId};
 
 pub(crate) const SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE: usize = 500;
+const SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES: usize = 10_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SlackConfiguredChannelRoute {
@@ -452,6 +453,11 @@ impl SlackHostBetaOutboundTargetProvider {
                 )
                 .await
                 .map_err(map_slack_target_route_error)?;
+            if routes.len() + stored.routes.len() > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES {
+                return Err(map_slack_target_route_error(
+                    SlackChannelRouteError::StoreUnavailable,
+                ));
+            }
             for route in stored.routes {
                 stored_channel_ids.insert(route.channel_id.clone());
                 routes.push(SlackConfiguredChannelRoute::new(
@@ -468,6 +474,13 @@ impl SlackHostBetaOutboundTargetProvider {
                 ));
             }
             cursor = next_cursor;
+        }
+        if routes.len() + self.configured_channel_routes.len()
+            > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES
+        {
+            return Err(map_slack_target_route_error(
+                SlackChannelRouteError::StoreUnavailable,
+            ));
         }
         routes.extend(
             self.configured_channel_routes
@@ -623,9 +636,31 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
         if caller.tenant_id != self.tenant_id {
             return Ok(Vec::new());
         }
-        let mut routes = self
-            .shared_channel_routes()
-            .await?
+        let personal_dm_key = SlackPersonalDmTargetKey::new(
+            self.tenant_id.clone(),
+            self.installation_id.clone(),
+            self.team_id.as_str().to_string(),
+            caller.user_id.clone(),
+        );
+        let personal_dm_target = async {
+            match personal_dm_key {
+                Ok(key) => Some(
+                    self.personal_dm_target_store
+                        .load_personal_dm_target(&key)
+                        .await,
+                ),
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "Slack personal DM target key could not be built while listing outbound targets"
+                    );
+                    None
+                }
+            }
+        };
+        let (routes, personal_dm_target) =
+            tokio::join!(self.shared_channel_routes(), personal_dm_target);
+        let mut routes = routes?
             .into_iter()
             .filter(|route| route.subject_user_id == caller.user_id)
             .collect::<Vec<_>>();
@@ -634,27 +669,8 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
             .into_iter()
             .map(|route| self.entry_for_shared_channel_route(&route))
             .collect::<Result<Vec<_>, _>>()?;
-        let key = match SlackPersonalDmTargetKey::new(
-            self.tenant_id.clone(),
-            self.installation_id.clone(),
-            self.team_id.as_str().to_string(),
-            caller.user_id.clone(),
-        ) {
-            Ok(key) => key,
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    "Slack personal DM target key could not be built while listing outbound targets"
-                );
-                return Ok(targets);
-            }
-        };
-        match self
-            .personal_dm_target_store
-            .load_personal_dm_target(&key)
-            .await
-        {
-            Ok(Some(target)) => match self.entry_for_personal_dm_target(&target) {
+        match personal_dm_target {
+            Some(Ok(Some(target))) => match self.entry_for_personal_dm_target(&target) {
                 Ok(target) => targets.push(target),
                 Err(error) => {
                     tracing::warn!(
@@ -663,13 +679,14 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
                     );
                 }
             },
-            Ok(None) => {}
-            Err(error) => {
+            Some(Ok(None)) => {}
+            Some(Err(error)) => {
                 tracing::warn!(
                     %error,
                     "Slack personal DM target lookup failed while listing outbound targets"
                 );
             }
+            None => {}
         }
         Ok(targets)
     }
@@ -834,4 +851,46 @@ fn validate_slack_id(field: &'static str, value: &str) -> Result<(), SlackPerson
         return Err(SlackPersonalDmTargetError::InvalidTarget);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_slack_id_accepts_128_char_id_and_rejects_129_char_id() {
+        validate_slack_id("slack id", &"A".repeat(128)).expect("128 chars is valid");
+        assert!(matches!(
+            validate_slack_id("slack id", &"A".repeat(129)),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+    }
+
+    #[test]
+    fn validate_slack_id_rejects_whitespace_and_special_chars() {
+        for value in ["", "A B", "A\0B", "A/B", "A\\B", "A:B", "A;B", "A\nB"] {
+            assert!(matches!(
+                validate_slack_id("slack id", value),
+                Err(SlackPersonalDmTargetError::InvalidTarget)
+            ));
+        }
+    }
+
+    #[test]
+    fn slack_personal_dm_target_rejects_non_d_prefixed_channel_id() {
+        let key = SlackPersonalDmTargetKey::new(
+            TenantId::new("tenant-alpha").expect("tenant"),
+            AdapterInstallationId::new("install-alpha").expect("installation"),
+            "T123".to_string(),
+            UserId::new("user:alice").expect("user"),
+        )
+        .expect("personal target key");
+
+        assert!(matches!(
+            SlackPersonalDmTarget::new(key.clone(), SlackUserId::new("U123"), "C123".to_string()),
+            Err(SlackPersonalDmTargetError::InvalidTarget)
+        ));
+        SlackPersonalDmTarget::new(key, SlackUserId::new("U123"), "D123".to_string())
+            .expect("DM-prefixed channel is valid");
+    }
 }

--- a/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_outbound_targets.rs
@@ -829,11 +829,45 @@ impl OutboundDeliveryTargetProvider for SlackHostBetaOutboundTargetProvider {
         if caller.tenant_id != self.tenant_id {
             return Ok(Vec::new());
         }
-        let mut routes = self
-            .shared_channel_routes()
-            .await?
-            .into_iter()
-            .collect::<Vec<_>>();
+        // Paginate through all shared-channel routes (all subjects) for this
+        // installation so that project-level listings show every configured
+        // channel regardless of which user the store assigned it to.
+        let mut cursor = 0;
+        let mut routes: Vec<SlackConfiguredChannelRoute> = Vec::new();
+        loop {
+            let page = self
+                .channel_route_store
+                .list_routes(
+                    &self.tenant_id,
+                    &self.installation_id,
+                    self.team_id.as_str(),
+                    cursor,
+                    SLACK_OUTBOUND_TARGET_LIST_PAGE_SIZE,
+                )
+                .await
+                .map_err(map_slack_target_route_error)?;
+            if routes.len() + page.routes.len() > SLACK_OUTBOUND_TARGET_LIST_MAX_TOTAL_ROUTES {
+                return Err(map_slack_target_route_error(
+                    SlackChannelRouteError::StoreUnavailable,
+                ));
+            }
+            for route in page.routes {
+                routes.push(
+                    UserId::new(route.subject_user_id)
+                        .map_err(|_| slack_target_backend_error())
+                        .map(|uid| SlackConfiguredChannelRoute::new(route.channel_id, uid))?,
+                );
+            }
+            let Some(next_cursor) = page.next_cursor else {
+                break;
+            };
+            if next_cursor <= cursor {
+                return Err(map_slack_target_route_error(
+                    SlackChannelRouteError::StoreUnavailable,
+                ));
+            }
+            cursor = next_cursor;
+        }
         routes.sort_by(|left, right| left.channel_id.cmp(&right.channel_id));
         routes
             .into_iter()

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -113,6 +113,7 @@ struct SlackApiResponse {
     error: Option<String>,
 }
 
+// TODO: consolidate slack_api_request/slack_json_response with slack_dm_open once error types are unified
 fn slack_api_request(
     path: &'static str,
     body: Vec<u8>,

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -9,14 +9,15 @@ use ironclaw_product_adapters::{
 use ironclaw_slack_v2_adapter::SLACK_API_HOST;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::slack_dm_open::open_slack_dm_channel;
+use crate::slack_dm_open::{
+    SLACK_API_RESPONSE_LIMIT, open_slack_dm_channel, validate_slack_dm_channel_id,
+};
 use crate::slack_personal_binding_pairing::{
     SlackPersonalBindingPairingError, SlackPersonalBindingPairingNotification,
     SlackPersonalBindingPairingNotifier,
 };
 
 const SLACK_POST_MESSAGE_PATH: &str = "/api/chat.postMessage";
-const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
 
 pub(crate) struct SlackPairingChallengeHttpNotifier {
     egress: Arc<dyn ProtocolHttpEgress>,
@@ -66,13 +67,16 @@ impl SlackPairingChallengeHttpNotifier {
         &self,
         slack_user_id: &str,
     ) -> Result<String, SlackPersonalBindingPairingError> {
-        open_slack_dm_channel(
+        let channel_id = open_slack_dm_channel(
             self.egress.as_ref(),
             self.credential_handle.clone(),
             slack_user_id,
         )
         .await
-        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        validate_slack_dm_channel_id(&channel_id)
+            .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
+        Ok(channel_id)
     }
 
     async fn send_slack_request(
@@ -241,6 +245,22 @@ mod tests {
                 Err(SlackPersonalBindingPairingError::Backend(_))
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn slack_pairing_notifier_rejects_non_dm_channel_from_open_response() {
+        let notifier = SlackPairingChallengeHttpNotifier::new(
+            Arc::new(ScriptedEgress::new([EgressResponse::new(
+                200,
+                br#"{"ok":true,"channel":{"id":"G123"}}"#.to_vec(),
+            )])),
+            EgressCredentialHandle::new("slack_bot_token").unwrap(),
+        );
+
+        assert!(matches!(
+            notifier.send_pairing_challenge(notification()).await,
+            Err(SlackPersonalBindingPairingError::Backend(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
+++ b/crates/ironclaw_reborn_composition/src/slack_pairing_notifier.rs
@@ -9,12 +9,12 @@ use ironclaw_product_adapters::{
 use ironclaw_slack_v2_adapter::SLACK_API_HOST;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+use crate::slack_dm_open::open_slack_dm_channel;
 use crate::slack_personal_binding_pairing::{
     SlackPersonalBindingPairingError, SlackPersonalBindingPairingNotification,
     SlackPersonalBindingPairingNotifier,
 };
 
-const SLACK_CONVERSATIONS_OPEN_PATH: &str = "/api/conversations.open";
 const SLACK_POST_MESSAGE_PATH: &str = "/api/chat.postMessage";
 const SLACK_API_RESPONSE_LIMIT: usize = 64 * 1024;
 
@@ -66,30 +66,13 @@ impl SlackPairingChallengeHttpNotifier {
         &self,
         slack_user_id: &str,
     ) -> Result<String, SlackPersonalBindingPairingError> {
-        let body = serde_json::to_vec(&SlackConversationsOpenRequest {
-            users: slack_user_id.to_string(),
-        })
-        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))?;
-        let response = self
-            .send_slack_request(SLACK_CONVERSATIONS_OPEN_PATH, body)
-            .await?;
-        let opened: SlackConversationsOpenResponse =
-            slack_json_response("Slack conversations.open", response.body())?;
-        if !opened.ok {
-            return Err(SlackPersonalBindingPairingError::Backend(format!(
-                "Slack rejected conversations.open ({})",
-                opened.error.unwrap_or_else(|| "unknown_error".into())
-            )));
-        }
-        opened
-            .channel
-            .map(|channel| channel.id)
-            .filter(|id| !id.is_empty())
-            .ok_or_else(|| {
-                SlackPersonalBindingPairingError::Backend(
-                    "Slack conversations.open response did not include a channel id".into(),
-                )
-            })
+        open_slack_dm_channel(
+            self.egress.as_ref(),
+            self.credential_handle.clone(),
+            slack_user_id,
+        )
+        .await
+        .map_err(|error| SlackPersonalBindingPairingError::Backend(error.to_string()))
     }
 
     async fn send_slack_request(
@@ -111,23 +94,6 @@ impl SlackPairingChallengeHttpNotifier {
         }
         Ok(response)
     }
-}
-
-#[derive(Debug, Serialize)]
-struct SlackConversationsOpenRequest {
-    users: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct SlackConversationsOpenResponse {
-    ok: bool,
-    error: Option<String>,
-    channel: Option<SlackConversationsOpenChannel>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SlackConversationsOpenChannel {
-    id: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -223,7 +189,7 @@ mod tests {
 
         let calls = egress.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].path().as_str(), SLACK_CONVERSATIONS_OPEN_PATH);
+        assert_eq!(calls[0].path().as_str(), "/api/conversations.open");
         let open_body: serde_json::Value = serde_json::from_slice(calls[0].body()).unwrap();
         assert_eq!(open_body["users"], "U123");
         assert_eq!(calls[1].path().as_str(), SLACK_POST_MESSAGE_PATH);
@@ -337,7 +303,7 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(request);
             let response = match self.calls().last().map(|request| request.path().as_str()) {
-                Some(SLACK_CONVERSATIONS_OPEN_PATH) => {
+                Some("/api/conversations.open") => {
                     br#"{"ok":true,"channel":{"id":"D123"}}"#.to_vec()
                 }
                 _ => br#"{"ok":true}"#.to_vec(),

--- a/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
+++ b/crates/ironclaw_reborn_composition/src/trigger_poller_trusted_submit.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use ironclaw_conversations::{
     AcceptedInboundMessage, AdapterInstallationId, AdapterKind, ConversationBindingResolution,
     ConversationBindingService, ConversationRouteKind, ExternalActorRef, ExternalConversationRef,
-    ExternalEventId, InboundTurnError, ResolveConversationRequest,
+    ExternalEventId, InboundTurnError, ResolveConversationRequest, TrustedOwnerScope,
 };
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_product_workflow::automation_trigger_thread_metadata_json;
@@ -16,8 +16,8 @@ use ironclaw_threads::{
     MessageContent, SessionThreadService as CanonicalSessionThreadService, ThreadScope,
 };
 use ironclaw_triggers::{
-    TriggerError, TriggerFire, TriggerId, TriggerMaterializedPrompt, TriggerPromptMaterializer,
-    TriggerTrustedInboundBinding,
+    TriggerError, TriggerFire, TriggerId, TriggerMaterializedPrompt, TriggerOwnershipScope,
+    TriggerPromptMaterializer, TriggerTrustedInboundBinding,
 };
 use ironclaw_turns::{AdmissionRejectionReason, TurnError};
 
@@ -181,24 +181,28 @@ where
             .map_err(trigger_prompt_safety_rejection)?;
         let trusted_inbound_binding = TriggerTrustedInboundBinding::for_fire(&fire);
         let resolve_request = trigger_resolve_request(&fire, &trusted_inbound_binding)?;
+        let trusted_owner = trusted_owner_scope_for_trigger_fire(&fire);
         let resolution = self
             .binding_service
             .resolve_or_create_binding_with_trusted_scope(
                 resolve_request,
                 fire.agent_id.clone(),
                 fire.project_id.clone(),
-                None,
+                trusted_owner,
             )
             .await
             .map_err(classify_materializer_inbound_error)?;
         let accepted = record_trigger_prompt(
             Arc::clone(&self.thread_service),
             &resolution,
-            fire.identity.trigger_id(),
-            &fire.prompt,
-            fire.identity.external_event_id().as_str(),
-            &self.default_agent_id,
-            None,
+            TriggerPromptRecording {
+                owner_user_id: owner_user_id_for_trigger_fire(&fire),
+                trigger_id: fire.identity.trigger_id(),
+                prompt: &fire.prompt,
+                external_event_id: fire.identity.external_event_id().as_str(),
+                default_agent_id: &self.default_agent_id,
+                accepted_message: None,
+            },
         )
         .await
         .map_err(classify_materializer_inbound_error)?;
@@ -268,15 +272,28 @@ fn trigger_resolve_request(
     })
 }
 
+struct TriggerPromptRecording<'a> {
+    owner_user_id: Option<UserId>,
+    trigger_id: TriggerId,
+    prompt: &'a str,
+    external_event_id: &'a str,
+    default_agent_id: &'a AgentId,
+    accepted_message: Option<&'a AcceptedInboundMessage>,
+}
+
 async fn record_trigger_prompt(
     thread_service: Arc<dyn CanonicalSessionThreadService>,
     resolution: &ConversationBindingResolution,
-    trigger_id: TriggerId,
-    prompt: &str,
-    external_event_id: &str,
-    default_agent_id: &AgentId,
-    accepted_message: Option<&AcceptedInboundMessage>,
+    recording: TriggerPromptRecording<'_>,
 ) -> Result<ironclaw_threads::AcceptedInboundMessage, InboundTurnError> {
+    let TriggerPromptRecording {
+        owner_user_id,
+        trigger_id,
+        prompt,
+        external_event_id,
+        default_agent_id,
+        accepted_message,
+    } = recording;
     let agent_id = resolution
         .turn_scope
         .agent_id
@@ -286,7 +303,7 @@ async fn record_trigger_prompt(
         tenant_id: resolution.turn_scope.tenant_id.clone(),
         agent_id,
         project_id: resolution.turn_scope.project_id.clone(),
-        owner_user_id: Some(resolution.actor.user_id.clone()),
+        owner_user_id,
         mission_id: None,
     };
     thread_service
@@ -325,6 +342,20 @@ async fn record_trigger_prompt(
         .map_err(|error| InboundTurnError::DurableState {
             reason: format!("trigger prompt thread record failed: {error}"),
         })
+}
+
+fn owner_user_id_for_trigger_fire(fire: &TriggerFire) -> Option<UserId> {
+    match fire.ownership_scope {
+        TriggerOwnershipScope::Personal => Some(fire.creator_user_id.clone()),
+        TriggerOwnershipScope::Project => None,
+    }
+}
+
+fn trusted_owner_scope_for_trigger_fire(fire: &TriggerFire) -> TrustedOwnerScope {
+    match fire.ownership_scope {
+        TriggerOwnershipScope::Personal => TrustedOwnerScope::User(fire.creator_user_id.clone()),
+        TriggerOwnershipScope::Project => TrustedOwnerScope::Project,
+    }
 }
 
 fn trigger_authorization_error(error: TriggerFireAuthError) -> TriggerError {
@@ -521,6 +552,7 @@ mod tests {
             creator_user_id: creator_user_id.clone(),
             agent_id: Some(agent_id.clone()),
             project_id: Some(project_id.clone()),
+            ownership_scope: TriggerOwnershipScope::Personal,
             prompt: "summarize unread mail".to_string(),
         };
         let auth_request = TriggerFireAuthRequest::for_fire(&fire);
@@ -605,7 +637,7 @@ mod tests {
             _request: ResolveConversationRequest,
             _trusted_agent_id: Option<AgentId>,
             _trusted_project_id: Option<ProjectId>,
-            _trusted_owner_user_id: Option<UserId>,
+            _trusted_owner: TrustedOwnerScope,
         ) -> Result<ConversationBindingResolution, InboundTurnError> {
             panic!("foreign-tenant materialization must reject before trusted binding resolution")
         }
@@ -649,6 +681,7 @@ mod tests {
             creator_user_id: input.creator_user_id,
             agent_id: input.agent_id,
             project_id: input.project_id,
+            ownership_scope: TriggerOwnershipScope::Personal,
             name: "worker test".to_string(),
             source: TriggerSourceKind::Schedule,
             schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),
@@ -678,6 +711,7 @@ mod tests {
             creator_user_id: creator_user_id.clone(),
             agent_id: Some(agent_id.clone()),
             project_id: Some(project_id.clone()),
+            ownership_scope: TriggerOwnershipScope::Personal,
             prompt: "summarize unread mail".to_string(),
         };
 
@@ -702,6 +736,7 @@ mod tests {
             creator_user_id,
             agent_id: None,
             project_id: None,
+            ownership_scope: TriggerOwnershipScope::Personal,
             prompt: "summarize unread mail".to_string(),
         };
 
@@ -722,6 +757,7 @@ mod tests {
             creator_user_id,
             agent_id: Some(agent_id),
             project_id: Some(project_id),
+            ownership_scope: TriggerOwnershipScope::Personal,
             prompt: "summarize unread mail".to_string(),
         };
         let request = TriggerFireAuthRequest::for_fire(&fire);
@@ -742,6 +778,7 @@ mod tests {
             creator_user_id,
             agent_id: None,
             project_id: None,
+            ownership_scope: TriggerOwnershipScope::Personal,
             prompt: "summarize unread mail".to_string(),
         };
         let request = TriggerFireAuthRequest::for_fire(&fire);
@@ -1509,22 +1546,28 @@ mod tests {
         record_trigger_prompt(
             thread_service.clone(),
             &resolution,
-            TriggerId::new(),
-            "summarize unread mail",
-            "event-trigger-hook",
-            &agent_id,
-            Some(&accepted_message),
+            TriggerPromptRecording {
+                owner_user_id: Some(resolution.actor.user_id.clone()),
+                trigger_id: TriggerId::new(),
+                prompt: "summarize unread mail",
+                external_event_id: "event-trigger-hook",
+                default_agent_id: &agent_id,
+                accepted_message: Some(&accepted_message),
+            },
         )
         .await
         .expect("prompt is recorded");
         record_trigger_prompt(
             thread_service.clone(),
             &resolution,
-            TriggerId::new(),
-            "summarize unread mail",
-            "event-trigger-hook",
-            &agent_id,
-            Some(&accepted_message),
+            TriggerPromptRecording {
+                owner_user_id: Some(resolution.actor.user_id.clone()),
+                trigger_id: TriggerId::new(),
+                prompt: "summarize unread mail",
+                external_event_id: "event-trigger-hook",
+                default_agent_id: &agent_id,
+                accepted_message: Some(&accepted_message),
+            },
         )
         .await
         .expect("prompt replay is idempotent");
@@ -1547,6 +1590,70 @@ mod tests {
         assert_eq!(
             history.messages[0].content.as_deref(),
             Some("summarize unread mail")
+        );
+    }
+
+    #[tokio::test]
+    async fn record_trigger_prompt_can_preserve_ownerless_project_scope() {
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let tenant_id = TenantId::new("trigger-shared-hook-tenant").expect("tenant id");
+        let agent_id = AgentId::new("trigger-shared-hook-agent").expect("agent id");
+        let project_id = ProjectId::new("trigger-shared-hook-project").expect("project id");
+        let actor_user_id = UserId::new("trigger-shared-hook-user").expect("user id");
+        let thread_id = ThreadId::new("trigger-shared-hook-thread").expect("thread id");
+        let source_binding_ref =
+            SourceBindingRef::new("trigger-shared-hook-source").expect("source binding");
+        let reply_target_binding_ref =
+            ReplyTargetBindingRef::new("trigger-shared-hook-reply").expect("reply binding");
+        let turn_scope = TurnScope::new_with_owner(
+            tenant_id.clone(),
+            Some(agent_id.clone()),
+            Some(project_id.clone()),
+            thread_id.clone(),
+            None,
+        );
+        let resolution = ConversationBindingResolution {
+            tenant_id: tenant_id.clone(),
+            actor: TurnActor::new(actor_user_id),
+            turn_scope,
+            source_binding_ref,
+            reply_target_binding_ref,
+            access: ThreadAccessDecision::Allowed,
+        };
+
+        record_trigger_prompt(
+            thread_service.clone(),
+            &resolution,
+            TriggerPromptRecording {
+                owner_user_id: None,
+                trigger_id: TriggerId::new(),
+                prompt: "summarize shared channel",
+                external_event_id: "event-trigger-shared-hook",
+                default_agent_id: &agent_id,
+                accepted_message: None,
+            },
+        )
+        .await
+        .expect("project-scoped prompt is recorded ownerless");
+
+        let history = thread_service
+            .list_thread_history(ThreadHistoryRequest {
+                scope: ThreadScope {
+                    tenant_id,
+                    agent_id,
+                    project_id: Some(project_id),
+                    owner_user_id: None,
+                    mission_id: None,
+                },
+                thread_id,
+            })
+            .await
+            .expect("ownerless shared-agent history loads");
+
+        assert_eq!(history.messages.len(), 1);
+        assert_eq!(
+            history.messages[0].content.as_deref(),
+            Some("summarize shared channel")
         );
     }
 
@@ -1583,6 +1690,7 @@ mod tests {
             creator_user_id: creator_user_id.clone(),
             agent_id: Some(agent_id.clone()),
             project_id: Some(project_id.clone()),
+            ownership_scope: TriggerOwnershipScope::Personal,
             name: "worker e2e".to_string(),
             source: TriggerSourceKind::Schedule,
             schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),
@@ -1715,6 +1823,7 @@ mod tests {
                 creator_user_id,
                 agent_id: Some(agent_id.clone()),
                 project_id: None,
+                ownership_scope: TriggerOwnershipScope::Personal,
                 prompt: "summarize unread mail".to_string(),
             })
             .await
@@ -1785,6 +1894,7 @@ mod tests {
                 creator_user_id,
                 agent_id: Some(agent_id.clone()),
                 project_id: None,
+                ownership_scope: TriggerOwnershipScope::Personal,
                 prompt: "summarize unread mail".to_string(),
             })
             .await

--- a/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
+++ b/crates/ironclaw_reborn_composition/tests/trigger_poller_e2e.rs
@@ -36,8 +36,8 @@ use ironclaw_reborn_composition::{
 use ironclaw_triggers::{
     TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
     TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerCompletionPolicy, TriggerId,
-    TriggerPollerWorkerConfig, TriggerRecord, TriggerRepository, TriggerRunStatus, TriggerSchedule,
-    TriggerSourceKind, TriggerState,
+    TriggerOwnershipScope, TriggerPollerWorkerConfig, TriggerRecord, TriggerRepository,
+    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use serde_json::{Value, json};
@@ -286,6 +286,7 @@ async fn trigger_poller_drives_trusted_ingress_for_due_scheduled_trigger() {
         creator_user_id: user_id,
         agent_id: Some(agent_id),
         project_id: None,
+        ownership_scope: TriggerOwnershipScope::Personal,
         name: "trigger-e2e-test".to_string(),
         source: TriggerSourceKind::Schedule,
         schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
@@ -594,6 +595,7 @@ async fn trigger_poller_does_not_fire_trigger_with_future_next_run_at() {
         creator_user_id: user_id,
         agent_id: Some(agent_id),
         project_id: None,
+        ownership_scope: TriggerOwnershipScope::Personal,
         name: "trigger-e2e-future".to_string(),
         source: TriggerSourceKind::Schedule,
         schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
@@ -701,6 +703,7 @@ async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
         creator_user_id: user_id,
         agent_id: Some(agent_id),
         project_id: None,
+        ownership_scope: TriggerOwnershipScope::Personal,
         name: "trigger-e2e-unpaired".to_string(),
         source: TriggerSourceKind::Schedule,
         schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
@@ -757,6 +760,206 @@ async fn trigger_poller_does_not_submit_turn_for_unpaired_actor() {
     );
 }
 
+/// A `Project`-scoped trigger must fire the full poller pipeline and
+/// produce a turn whose thread scope carries `owner_user_id = None`
+/// (explicitly project-owned, not creator-owned).
+/// `trusted_owner_scope_for_trigger_fire` in `trigger_poller_trusted_submit.rs`
+/// returns `TrustedOwnerScope::Project` for `TriggerOwnershipScope::Project`,
+/// which causes the binding to carry an explicit ownerless marker.
+/// `BindingRecord::resolution()` then emits `TurnScope::new_with_owner(..., None)`
+/// so the run-side `ThreadScopeResolver` reads the project thread, not the
+/// creator's personal subtree. This is the acceptance test for the blocking
+/// ownership-propagation fix described in the ownership-scope section of
+/// docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md.
+#[tokio::test]
+async fn trigger_poller_submits_project_turn_with_project_owned_scope() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let recording_gateway = Arc::new(RecordingGateway {
+        requests: Arc::new(TokioMutex::new(Vec::new())),
+    });
+
+    let runtime = build_runtime_with(
+        &root,
+        Arc::clone(&recording_gateway),
+        TriggerPollerSettings::enabled_with_tenant_scoped_authorizer_for_test().with_worker_config(
+            TriggerPollerWorkerConfig {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+
+    let repo = runtime
+        .trigger_repository()
+        .expect("local-dev runtime exposes trigger repository");
+    let pairing = runtime
+        .trigger_conversation_pairing()
+        .expect("trigger poller runtime exposes conversation pairing service");
+
+    let tenant_id = TenantId::new(TENANT).expect("tenant id");
+    let user_id = UserId::new(USER).expect("user id");
+    let agent_id = AgentId::new(AGENT).expect("agent id");
+    let trigger_id = TriggerId::new();
+
+    // Pair the external actor for the creator — the trusted trigger submission
+    // path still routes the conversation through the creator's external actor
+    // ref even for Project-scoped triggers. The difference is that the
+    // *binding ownership* produced by `trusted_owner_scope_for_trigger_fire`
+    // is `TrustedOwnerScope::Project` for `TriggerOwnershipScope::Project`,
+    // causing the binding and thread scope to be explicitly ownerless (project-owned).
+    pairing
+        .pair_external_actor(
+            tenant_id.clone(),
+            AdapterKind::new(TRIGGER_TRUSTED_ADAPTER_KIND).expect("adapter kind"),
+            AdapterInstallationId::new(TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID)
+                .expect("installation id"),
+            ExternalActorRef::new(TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, user_id.as_str())
+                .expect("actor ref"),
+            user_id.clone(),
+        )
+        .await
+        .expect("pair external actor for project trigger creator");
+
+    let project_id = ironclaw_host_api::ProjectId::new("trigger-e2e-project").expect("project id");
+
+    // Project scope requires a project_id. trusted_owner_scope_for_trigger_fire
+    // returns TrustedOwnerScope::Project for this scope, producing an explicitly
+    // ownerless (project-owned) ThreadScope.
+    let record = TriggerRecord {
+        trigger_id,
+        tenant_id: tenant_id.clone(),
+        creator_user_id: user_id,
+        agent_id: Some(agent_id),
+        project_id: Some(project_id),
+        ownership_scope: TriggerOwnershipScope::Project,
+        name: "trigger-e2e-project".to_string(),
+        source: TriggerSourceKind::Schedule,
+        schedule: TriggerSchedule::cron("* * * * *").expect("valid cron expression"),
+        completion_policy: TriggerCompletionPolicy::CompleteAfterFirstFire,
+        prompt: TRIGGER_PROMPT.to_string(),
+        state: TriggerState::Scheduled,
+        next_run_at: Utc::now() - chrono::Duration::seconds(120),
+        last_run_at: None,
+        last_fired_slot: None,
+        last_status: None,
+        active_fire_slot: None,
+        active_run_ref: None,
+        created_at: Utc::now(),
+    };
+
+    // Confirm the seeded record carries the Project scope before the
+    // poller fires it — the ownership_scope field is what drives
+    // trusted_owner_scope_for_trigger_fire to return TrustedOwnerScope::Project.
+    assert_eq!(
+        record.ownership_scope,
+        TriggerOwnershipScope::Project,
+        "seeded trigger must carry Project scope to exercise the project-owned path"
+    );
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("upsert trigger record");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut record_was_mutated = false;
+    let mut prompt_seen = false;
+
+    while Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let current = repo
+            .get_trigger(tenant_id.clone(), record.trigger_id)
+            .await
+            .expect("get_trigger")
+            .expect("record present");
+
+        let mutated = current.last_fired_slot.is_some()
+            || current.last_run_at.is_some()
+            || current.last_status.is_some()
+            || current.active_fire_slot.is_some()
+            || current.state == TriggerState::Completed;
+
+        if mutated {
+            record_was_mutated = true;
+            let contents = recording_gateway.captured_message_contents().await;
+            if contents
+                .iter()
+                .any(|content| content.contains(TRIGGER_PROMPT))
+            {
+                prompt_seen = true;
+            }
+        }
+
+        if record_was_mutated && prompt_seen {
+            break;
+        }
+    }
+
+    // Wait for the settle writes to become visible before inspecting the
+    // final record (mirrors the pattern used in the happy-path test).
+    let final_record = wait_for_settled(
+        &repo,
+        &tenant_id,
+        record.trigger_id,
+        Duration::from_secs(5),
+        |r| r.last_fired_slot.is_some() && r.last_run_at.is_some(),
+    )
+    .await;
+
+    runtime.shutdown().await.expect("runtime shutdown");
+
+    let captured_contents = recording_gateway.captured_message_contents().await;
+
+    // The poller must have processed the record — project-owned scope must
+    // not cause a panic or unrecovered error before the turn is submitted.
+    assert!(
+        record_was_mutated,
+        "poller did not mutate Project-scoped trigger record within 15s \
+         — record: {final_record:?}"
+    );
+
+    // The LLM gateway must have received the trigger prompt, proving the
+    // full project-owned-scope thread-creation path ran: the binding was
+    // resolved with TrustedOwnerScope::Project, the thread was created with
+    // owner_user_id = None, and a turn was submitted against that project thread.
+    assert!(
+        prompt_seen,
+        "LLM gateway never received a request containing the trigger prompt for \
+         Project-scoped trigger — captured_messages: {captured_contents:?}, \
+         record: {final_record:?}"
+    );
+
+    // The settle writes must be visible, confirming the full fire path ran
+    // to completion under the project-owned scope.
+    assert!(
+        final_record.last_fired_slot.is_some(),
+        "Project scope: last_fired_slot should be set after fire \
+         — record: {final_record:?}",
+    );
+    assert!(
+        final_record.last_run_at.is_some(),
+        "Project scope: last_run_at should be set after fire \
+         — record: {final_record:?}",
+    );
+    assert_eq!(
+        final_record.last_status,
+        Some(TriggerRunStatus::Ok),
+        "Project scope: last_status should be Ok — the project-owned thread scope \
+         must be accepted by the full turn-submission stack \
+         — record: {final_record:?}",
+    );
+
+    // The persisted record must retain Project scope — not quietly
+    // rewritten to Personal — confirming the ownership field survives the
+    // full fire-and-settle round-trip.
+    assert_eq!(
+        final_record.ownership_scope,
+        TriggerOwnershipScope::Project,
+        "ownership_scope must remain Project after fire — record: {final_record:?}"
+    );
+}
+
 #[tokio::test]
 async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
     let root = tempfile::tempdir().expect("tempdir");
@@ -810,6 +1013,7 @@ async fn trigger_poller_fires_recurring_trigger_and_leaves_it_scheduled() {
         creator_user_id: user_id,
         agent_id: Some(agent_id),
         project_id: None,
+        ownership_scope: TriggerOwnershipScope::Personal,
         name: "trigger-e2e-recurring".to_string(),
         source: TriggerSourceKind::Schedule,
         // Every minute — already at MIN_FIRE_CADENCE.

--- a/crates/ironclaw_triggers/src/lib.rs
+++ b/crates/ironclaw_triggers/src/lib.rs
@@ -274,6 +274,37 @@ impl<'de> Deserialize<'de> for TriggerExternalEventId {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerOwnershipScope {
+    #[default]
+    Personal,
+    Project,
+}
+
+impl TriggerOwnershipScope {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Personal => "personal",
+            Self::Project => "project",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, TriggerError> {
+        match value {
+            "personal" => Ok(Self::Personal),
+            "project" => Ok(Self::Project),
+            _ => Err(TriggerError::InvalidRecord {
+                reason: format!("unknown trigger ownership scope: {value}"),
+            }),
+        }
+    }
+
+    pub fn is_project(&self) -> bool {
+        matches!(self, Self::Project)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TriggerRecord {
     pub trigger_id: TriggerId,
@@ -281,6 +312,8 @@ pub struct TriggerRecord {
     pub creator_user_id: UserId,
     pub agent_id: Option<AgentId>,
     pub project_id: Option<ProjectId>,
+    #[serde(default)]
+    pub ownership_scope: TriggerOwnershipScope,
     pub name: String,
     pub source: TriggerSourceKind,
     pub schedule: TriggerSchedule,
@@ -321,6 +354,11 @@ impl TriggerRecord {
         if self.active_run_ref.is_some() && self.active_fire_slot.is_none() {
             return Err(TriggerError::InvalidRecord {
                 reason: "active_run_ref requires active_fire_slot".to_string(),
+            });
+        }
+        if self.ownership_scope.is_project() && self.project_id.is_none() {
+            return Err(TriggerError::InvalidRecord {
+                reason: "project trigger ownership requires project_id".to_string(),
             });
         }
         self.schedule.validate()?;
@@ -505,6 +543,7 @@ pub struct TriggerFire {
     pub creator_user_id: UserId,
     pub agent_id: Option<AgentId>,
     pub project_id: Option<ProjectId>,
+    pub ownership_scope: TriggerOwnershipScope,
     pub prompt: String,
 }
 
@@ -656,6 +695,7 @@ impl TriggerSourceProvider for ScheduleTriggerSourceProvider {
             creator_user_id: record.creator_user_id.clone(),
             agent_id: record.agent_id.clone(),
             project_id: record.project_id.clone(),
+            ownership_scope: record.ownership_scope.clone(),
             prompt: record.prompt.clone(),
         }))
     }
@@ -1706,6 +1746,7 @@ mod tests {
             creator_user_id: user("user-a"),
             agent_id: Some(AgentId::new("agent-a").expect("valid agent")),
             project_id: Some(ProjectId::new("project-a").expect("valid project")),
+            ownership_scope: TriggerOwnershipScope::Personal,
             name: "daily summary".to_string(),
             source: TriggerSourceKind::Schedule,
             schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),
@@ -2425,5 +2466,60 @@ mod tests {
             .await
             .expect_err("poisoned mutex maps to backend through permanent-failure API");
         assert!(matches!(error, TriggerError::Backend { .. }));
+    }
+
+    // f-tst-4: validate() rejects Project without project_id, accepts it with project_id
+    #[test]
+    fn validate_rejects_project_scope_without_project_id() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), ts(1_704_067_200));
+        record.ownership_scope = TriggerOwnershipScope::Project;
+        record.project_id = None;
+
+        let error = record
+            .validate()
+            .expect_err("project scope without project_id must fail");
+        assert!(
+            matches!(error, TriggerError::InvalidRecord { ref reason } if reason.contains("project_id")),
+            "expected InvalidRecord mentioning project_id, got {error}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_project_scope_with_project_id() {
+        let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+        let mut record = sample_record(trigger_id, tenant("tenant-a"), ts(1_704_067_200));
+        record.ownership_scope = TriggerOwnershipScope::Project;
+        record.project_id = Some(ProjectId::new("project-a").expect("valid project"));
+
+        record
+            .validate()
+            .expect("project scope with project_id must pass validation");
+    }
+
+    // f-tst-6: parse("bogus") returns Err with unknown-scope reason; round-trips for personal and project
+    #[test]
+    fn ownership_scope_parse_rejects_unknown_value() {
+        let error = TriggerOwnershipScope::parse("bogus").expect_err("unknown scope must fail");
+        assert!(
+            matches!(error, TriggerError::InvalidRecord { ref reason } if reason.contains("unknown trigger ownership scope")),
+            "expected InvalidRecord mentioning unknown scope, got {error}"
+        );
+    }
+
+    #[test]
+    fn ownership_scope_parse_and_as_str_round_trip_for_personal() {
+        let scope = TriggerOwnershipScope::parse("personal").expect("personal must parse");
+        assert_eq!(scope, TriggerOwnershipScope::Personal);
+        assert_eq!(scope.as_str(), "personal");
+        assert_eq!(TriggerOwnershipScope::Personal.as_str(), "personal");
+    }
+
+    #[test]
+    fn ownership_scope_parse_and_as_str_round_trip_for_project() {
+        let scope = TriggerOwnershipScope::parse("project").expect("project must parse");
+        assert_eq!(scope, TriggerOwnershipScope::Project);
+        assert_eq!(scope.as_str(), "project");
+        assert_eq!(TriggerOwnershipScope::Project.as_str(), "project");
     }
 }

--- a/crates/ironclaw_triggers/src/libsql.rs
+++ b/crates/ironclaw_triggers/src/libsql.rs
@@ -17,10 +17,10 @@ use crate::{
     ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire,
     ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
     FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerCompletionPolicy, TriggerError,
-    TriggerId, TriggerRecord, TriggerRepository, TriggerRouteThreadId, TriggerRunHistoryStatus,
-    TriggerRunRecord, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
-    reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
-    trigger_run_history_status_text,
+    TriggerId, TriggerOwnershipScope, TriggerRecord, TriggerRepository, TriggerRouteThreadId,
+    TriggerRunHistoryStatus, TriggerRunRecord, TriggerRunStatus, TriggerSchedule,
+    TriggerSourceKind, TriggerState, reject_failed_result_after_active_run,
+    reject_non_future_next_run_at, reject_run_ref_rewrite, trigger_run_history_status_text,
 };
 
 #[cfg(feature = "libsql")]
@@ -30,7 +30,7 @@ const TRIGGER_RUN_TABLE: &str = "trigger_run_history";
 
 #[cfg(feature = "libsql")]
 const TRIGGER_COLUMNS: &str = "\
-    trigger_id, tenant_id, creator_user_id, agent_id, project_id, \
+    trigger_id, tenant_id, creator_user_id, agent_id, project_id, ownership_scope, \
     name, source, schedule_expression, completion_policy, prompt, \
     state, next_run_at, last_run_at, last_fired_slot, last_status, \
     active_fire_slot, active_run_ref, created_at";
@@ -46,31 +46,33 @@ const AGENT_ID_COL: usize = 3;
 #[cfg(feature = "libsql")]
 const PROJECT_ID_COL: usize = 4;
 #[cfg(feature = "libsql")]
-const NAME_COL: usize = 5;
+const OWNERSHIP_SCOPE_COL: usize = 5;
 #[cfg(feature = "libsql")]
-const SOURCE_COL: usize = 6;
+const NAME_COL: usize = 6;
 #[cfg(feature = "libsql")]
-const SCHEDULE_EXPRESSION_COL: usize = 7;
+const SOURCE_COL: usize = 7;
 #[cfg(feature = "libsql")]
-const COMPLETION_POLICY_COL: usize = 8;
+const SCHEDULE_EXPRESSION_COL: usize = 8;
 #[cfg(feature = "libsql")]
-const PROMPT_COL: usize = 9;
+const COMPLETION_POLICY_COL: usize = 9;
 #[cfg(feature = "libsql")]
-const STATE_COL: usize = 10;
+const PROMPT_COL: usize = 10;
 #[cfg(feature = "libsql")]
-const NEXT_RUN_AT_COL: usize = 11;
+const STATE_COL: usize = 11;
 #[cfg(feature = "libsql")]
-const LAST_RUN_AT_COL: usize = 12;
+const NEXT_RUN_AT_COL: usize = 12;
 #[cfg(feature = "libsql")]
-const LAST_FIRED_SLOT_COL: usize = 13;
+const LAST_RUN_AT_COL: usize = 13;
 #[cfg(feature = "libsql")]
-const LAST_STATUS_COL: usize = 14;
+const LAST_FIRED_SLOT_COL: usize = 14;
 #[cfg(feature = "libsql")]
-const ACTIVE_FIRE_SLOT_COL: usize = 15;
+const LAST_STATUS_COL: usize = 15;
 #[cfg(feature = "libsql")]
-const ACTIVE_RUN_REF_COL: usize = 16;
+const ACTIVE_FIRE_SLOT_COL: usize = 16;
 #[cfg(feature = "libsql")]
-const CREATED_AT_COL: usize = 17;
+const ACTIVE_RUN_REF_COL: usize = 17;
+#[cfg(feature = "libsql")]
+const CREATED_AT_COL: usize = 18;
 
 #[cfg(feature = "libsql")]
 const TRIGGER_RUN_COLUMNS: &str = "\
@@ -119,6 +121,7 @@ impl LibSqlTriggerRepository {
                         creator_user_id TEXT NOT NULL,
                         agent_id TEXT,
                         project_id TEXT,
+                        ownership_scope TEXT NOT NULL DEFAULT 'personal',
                         name TEXT NOT NULL,
                         source TEXT NOT NULL,
                         schedule_expression TEXT NOT NULL,
@@ -139,6 +142,7 @@ impl LibSqlTriggerRepository {
             )
             .await
             .map_err(|error| backend_error("create trigger_records table", error))?;
+            ensure_trigger_ownership_scope_column(&conn).await?;
             conn.execute(
                 &format!(
                     "CREATE INDEX IF NOT EXISTS trigger_records_state_next_run_at_idx
@@ -238,6 +242,38 @@ impl LibSqlTriggerRepository {
             .map_err(|error| backend_error("set trigger repository busy_timeout", error))?;
         Ok(conn)
     }
+}
+
+#[cfg(feature = "libsql")]
+async fn ensure_trigger_ownership_scope_column(
+    conn: &libsql::Connection,
+) -> Result<(), TriggerError> {
+    let mut rows = conn
+        .query(&format!("PRAGMA table_info({TRIGGER_TABLE})"), ())
+        .await
+        .map_err(|error| backend_error("inspect trigger ownership_scope column", error))?;
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| backend_error("read trigger table_info row", error))?
+    {
+        let name: String = row
+            .get(1)
+            .map_err(|error| backend_error("read trigger table_info column name", error))?;
+        if name == "ownership_scope" {
+            return Ok(());
+        }
+    }
+    conn.execute(
+        &format!(
+            "ALTER TABLE {TRIGGER_TABLE}
+             ADD COLUMN ownership_scope TEXT NOT NULL DEFAULT 'personal'"
+        ),
+        (),
+    )
+    .await
+    .map_err(|error| backend_error("add trigger ownership_scope column", error))?;
+    Ok(())
 }
 
 #[cfg(feature = "libsql")]
@@ -1046,6 +1082,8 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
             ProjectId::new(value).map_err(|error| invalid_record("project_id", error.to_string()))
         })
         .transpose()?;
+    let ownership_scope =
+        TriggerOwnershipScope::parse(&required_text(row, OWNERSHIP_SCOPE_COL, "ownership_scope")?)?;
     let schedule = TriggerSchedule::cron(required_text(
         row,
         SCHEDULE_EXPRESSION_COL,
@@ -1073,6 +1111,7 @@ fn row_to_record(row: &libsql::Row) -> Result<TriggerRecord, TriggerError> {
         creator_user_id,
         agent_id,
         project_id,
+        ownership_scope,
         name: required_text(row, NAME_COL, "name")?,
         source: parse_source_kind(&required_text(row, SOURCE_COL, "source")?)?,
         schedule,
@@ -1170,15 +1209,16 @@ async fn write_record(
     conn.execute(
         &format!(
             "INSERT INTO {TRIGGER_TABLE} (
-                trigger_id, tenant_id, creator_user_id, agent_id, project_id,
+                trigger_id, tenant_id, creator_user_id, agent_id, project_id, ownership_scope,
                 name, source, schedule_expression, completion_policy, prompt,
                 state, next_run_at, last_run_at, last_fired_slot, last_status,
                 active_fire_slot, active_run_ref, created_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
             ON CONFLICT (tenant_id, trigger_id) DO UPDATE SET
                 creator_user_id = excluded.creator_user_id,
                 agent_id = excluded.agent_id,
                 project_id = excluded.project_id,
+                ownership_scope = excluded.ownership_scope,
                 name = excluded.name,
                 source = excluded.source,
                 schedule_expression = excluded.schedule_expression,
@@ -1198,6 +1238,7 @@ async fn write_record(
             record.creator_user_id.as_str(),
             opt_text(record.agent_id.as_ref().map(AgentId::as_str)),
             opt_text(record.project_id.as_ref().map(ProjectId::as_str)),
+            record.ownership_scope.as_str(),
             record.name.clone(),
             source_kind_text(record.source),
             schedule_expression_text(&record.schedule),

--- a/crates/ironclaw_triggers/src/postgres.rs
+++ b/crates/ironclaw_triggers/src/postgres.rs
@@ -11,16 +11,16 @@ use crate::{
     ActiveTriggerScanCursor, ClaimDueFireOutcome, ClaimDueFireRequest, ClaimedTriggerFire,
     ClearActiveFireRequest, FireAcceptedRequest, FirePermanentFailedRequest, FireReplayedRequest,
     FireRetryableFailedRequest, FireTerminalFailedRequest, TriggerCompletionPolicy, TriggerError,
-    TriggerId, TriggerRecord, TriggerRepository, TriggerRouteThreadId, TriggerRunHistoryStatus,
-    TriggerRunRecord, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
-    reject_failed_result_after_active_run, reject_non_future_next_run_at, reject_run_ref_rewrite,
-    trigger_run_history_status_text,
+    TriggerId, TriggerOwnershipScope, TriggerRecord, TriggerRepository, TriggerRouteThreadId,
+    TriggerRunHistoryStatus, TriggerRunRecord, TriggerRunStatus, TriggerSchedule,
+    TriggerSourceKind, TriggerState, reject_failed_result_after_active_run,
+    reject_non_future_next_run_at, reject_run_ref_rewrite, trigger_run_history_status_text,
 };
 
 const TRIGGER_TABLE: &str = "trigger_records";
 const TRIGGER_RUN_TABLE: &str = "trigger_run_history";
 const TRIGGER_COLUMNS: &str = "\
-    trigger_id, tenant_id, creator_user_id, agent_id, project_id, \
+    trigger_id, tenant_id, creator_user_id, agent_id, project_id, ownership_scope, \
     name, source, schedule_expression, completion_policy, prompt, \
     state, next_run_at, last_run_at, last_fired_slot, last_status, \
     active_fire_slot, active_run_ref, created_at";
@@ -76,6 +76,7 @@ impl TriggerRepository for PostgresTriggerRepository {
         let creator_user_id = record.creator_user_id.as_str();
         let agent_id = record.agent_id.as_ref().map(AgentId::as_str);
         let project_id = record.project_id.as_ref().map(ProjectId::as_str);
+        let ownership_scope = record.ownership_scope.as_str();
         let source = source_kind_text(record.source);
         let schedule_expression = schedule_expression_text(&record.schedule);
         let completion_policy = completion_policy_text(record.completion_policy);
@@ -92,20 +93,21 @@ impl TriggerRepository for PostgresTriggerRepository {
             .execute(
                 r#"
                 INSERT INTO trigger_records (
-                    trigger_id, tenant_id, creator_user_id, agent_id, project_id,
+                    trigger_id, tenant_id, creator_user_id, agent_id, project_id, ownership_scope,
                     name, source, schedule_expression, completion_policy, prompt,
                     state, next_run_at, last_run_at, last_fired_slot, last_status,
                     active_fire_slot, active_run_ref, created_at
                 ) VALUES (
-                    $1, $2, $3, $4, $5,
-                    $6, $7, $8, $9, $10,
-                    $11, $12, $13, $14, $15,
-                    $16, $17, $18
+                    $1, $2, $3, $4, $5, $6,
+                    $7, $8, $9, $10, $11,
+                    $12, $13, $14, $15, $16,
+                    $17, $18, $19
                 )
                 ON CONFLICT (tenant_id, trigger_id) DO UPDATE SET
                     creator_user_id = EXCLUDED.creator_user_id,
                     agent_id = EXCLUDED.agent_id,
                     project_id = EXCLUDED.project_id,
+                    ownership_scope = EXCLUDED.ownership_scope,
                     name = EXCLUDED.name,
                     source = EXCLUDED.source,
                     schedule_expression = EXCLUDED.schedule_expression,
@@ -125,6 +127,7 @@ impl TriggerRepository for PostgresTriggerRepository {
                     &creator_user_id,
                     &agent_id,
                     &project_id,
+                    &ownership_scope,
                     &record.name,
                     &source,
                     &schedule_expression,
@@ -1111,6 +1114,7 @@ fn row_to_record(row: &Row) -> Result<TriggerRecord, TriggerError> {
             ProjectId::new(value).map_err(|error| invalid_record("project_id", error.to_string()))
         })
         .transpose()?;
+    let ownership_scope = TriggerOwnershipScope::parse(&required_text(row, "ownership_scope")?)?;
     let schedule = TriggerSchedule::cron(required_text(row, "schedule_expression")?)?;
     let last_run_at = optional_text(row, "last_run_at")?
         .map(|value| parse_timestamp(&value, "last_run_at"))
@@ -1134,6 +1138,7 @@ fn row_to_record(row: &Row) -> Result<TriggerRecord, TriggerError> {
         creator_user_id,
         agent_id,
         project_id,
+        ownership_scope,
         name: required_text(row, "name")?,
         source: parse_source_kind(&required_text(row, "source")?)?,
         schedule,
@@ -1289,6 +1294,7 @@ CREATE TABLE IF NOT EXISTS trigger_records (
     creator_user_id TEXT NOT NULL,
     agent_id TEXT,
     project_id TEXT,
+    ownership_scope TEXT NOT NULL DEFAULT 'personal',
     name TEXT NOT NULL,
     source TEXT NOT NULL,
     schedule_expression TEXT NOT NULL,
@@ -1304,6 +1310,9 @@ CREATE TABLE IF NOT EXISTS trigger_records (
     created_at TEXT NOT NULL,
     PRIMARY KEY (tenant_id, trigger_id)
 );
+
+ALTER TABLE trigger_records
+    ADD COLUMN IF NOT EXISTS ownership_scope TEXT NOT NULL DEFAULT 'personal';
 
 CREATE INDEX IF NOT EXISTS trigger_records_state_next_run_at_idx
     ON trigger_records (state, next_run_at, tenant_id, trigger_id);

--- a/crates/ironclaw_triggers/src/worker/tests.rs
+++ b/crates/ironclaw_triggers/src/worker/tests.rs
@@ -15,9 +15,9 @@ use crate::{
     FireRetryableFailedRequest, FireTerminalFailedRequest, InMemoryTriggerRepository,
     TRIGGER_TRUSTED_ADAPTER_INSTALLATION_ID, TRIGGER_TRUSTED_ADAPTER_KIND,
     TRIGGER_TRUSTED_EXTERNAL_ACTOR_NAMESPACE, TriggerCompletionPolicy, TriggerError, TriggerFire,
-    TriggerId, TriggerInboundContentRef, TriggerMaterializedPrompt, TriggerPromptMaterializer,
-    TriggerRecord, TriggerRepository, TriggerRunHistoryStatus, TriggerRunStatus, TriggerSchedule,
-    TriggerSourceKind, TriggerSourceProvider, TriggerState,
+    TriggerId, TriggerInboundContentRef, TriggerMaterializedPrompt, TriggerOwnershipScope,
+    TriggerPromptMaterializer, TriggerRecord, TriggerRepository, TriggerRunHistoryStatus,
+    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerSourceProvider, TriggerState,
 };
 
 fn ts(seconds: i64) -> Timestamp {
@@ -49,6 +49,7 @@ fn sample_record(
         creator_user_id: user("user-a"),
         agent_id: Some(AgentId::new("agent-a").expect("valid agent")),
         project_id: Some(ProjectId::new("project-a").expect("valid project")),
+        ownership_scope: TriggerOwnershipScope::Personal,
         name: "daily summary".to_string(),
         source: TriggerSourceKind::Schedule,
         schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),

--- a/crates/ironclaw_triggers/tests/repository_contract.rs
+++ b/crates/ironclaw_triggers/tests/repository_contract.rs
@@ -4,8 +4,8 @@ use chrono::{TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, Timestamp, UserId};
 use ironclaw_triggers::{
     ActiveTriggerScanCursor, ClearActiveFireRequest, InMemoryTriggerRepository,
-    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerRecord, TriggerRepository,
-    TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
+    TriggerCompletionPolicy, TriggerError, TriggerId, TriggerOwnershipScope, TriggerRecord,
+    TriggerRepository, TriggerRunStatus, TriggerSchedule, TriggerSourceKind, TriggerState,
 };
 use ironclaw_turns::TurnRunId;
 
@@ -40,6 +40,7 @@ fn sample_record(
         creator_user_id: user("user-a"),
         agent_id: Some(AgentId::new("agent-a").expect("valid agent")),
         project_id: Some(ProjectId::new("project-a").expect("valid project")),
+        ownership_scope: TriggerOwnershipScope::Personal,
         name: "daily summary".to_string(),
         source: TriggerSourceKind::Schedule,
         schedule: TriggerSchedule::cron("0 8 * * *").expect("valid cron"),
@@ -932,6 +933,30 @@ async fn assert_persists_trigger_state_fire_gate(repo: &impl TriggerRepository) 
     assert_eq!(due_records[0].trigger_id, trigger_id);
 }
 
+// f-tst-3: shared contract helper — Project ownership_scope survives persist and reload
+async fn assert_project_ownership_scope_survives_persist_and_reload(repo: &impl TriggerRepository) {
+    let trigger_id = TriggerId::parse("01HZZZZZZZZZZZZZZZZZZZZZZZ").expect("ulid");
+    let tenant_id = tenant("tenant-project");
+    let mut record = sample_record(trigger_id, tenant_id.clone(), ts(1_704_067_260));
+    record.ownership_scope = TriggerOwnershipScope::Project;
+    // Project requires project_id to pass validation
+    record.project_id = Some(ProjectId::new("project-shared").expect("valid project"));
+
+    repo.upsert_trigger(record.clone())
+        .await
+        .expect("insert project-scoped record");
+
+    let fetched = repo
+        .get_trigger(tenant_id, trigger_id)
+        .await
+        .expect("get project-scoped trigger")
+        .expect("record present");
+
+    assert_eq!(fetched.ownership_scope, TriggerOwnershipScope::Project);
+    assert_eq!(fetched.project_id, record.project_id);
+    assert_eq!(fetched, record);
+}
+
 #[cfg(feature = "libsql")]
 async fn build_libsql_repo_with_db() -> (
     tempfile::TempDir,
@@ -955,6 +980,13 @@ async fn build_libsql_repo_with_db() -> (
 async fn build_libsql_repo() -> (tempfile::TempDir, LibSqlTriggerRepository) {
     let (dir, _db, repo) = build_libsql_repo_with_db().await;
     (dir, repo)
+}
+
+// f-tst-3: in-memory backend — runs whenever the file is compiled (libsql or postgres feature)
+#[tokio::test]
+async fn in_memory_project_ownership_scope_survives_persist_and_reload() {
+    let repo = InMemoryTriggerRepository::default();
+    assert_project_ownership_scope_survives_persist_and_reload(&repo).await;
 }
 
 #[cfg(feature = "libsql")]
@@ -986,6 +1018,10 @@ async fn libsql_repository_contract_parity() {
 
     let (_dir, repo) = build_libsql_repo().await;
     assert_persists_trigger_state_fire_gate(&repo).await;
+
+    // f-tst-3: Project ownership_scope survives libsql persist and reload
+    let (_dir, repo) = build_libsql_repo().await;
+    assert_project_ownership_scope_survives_persist_and_reload(&repo).await;
 }
 
 #[cfg(feature = "libsql")]
@@ -1081,6 +1117,10 @@ async fn postgres_repository_contract_parity() {
 
     clear_postgres_triggers(&pool).await;
     assert_persists_trigger_state_fire_gate(&repo).await;
+
+    // f-tst-3: Project ownership_scope survives postgres persist and reload
+    clear_postgres_triggers(&pool).await;
+    assert_project_ownership_scope_survives_persist_and_reload(&repo).await;
 }
 
 #[cfg(feature = "postgres")]

--- a/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
+++ b/docs/plans/2026-06-05-trigger-delivery-default-outbound-e2e-plan.md
@@ -501,28 +501,29 @@ provider and authority resolver.
 
 Current implementation status:
 
-- PR C1 is the active Phase 4 slice: shared-agent Slack channel targets backed
-  by admin-managed Slack channel routes.
+- PR C1 is merged: shared-agent Slack channel targets are backed by
+  admin-managed Slack channel routes.
 - PR C1 treats persisted admin routes as authoritative over static seeded
   Slack channel fallback when the same channel has a stored owner.
-- PR C2 remains the next Slack slice: personal Slack DM targets need durable
-  provider authority for the concrete Slack DM conversation id returned by
-  `conversations.open`.
+- PR C2 implements provider-side personal Slack DM target authority:
+  `conversations.open` provisions the concrete `D...` conversation id, the
+  Slack host-state store persists it under the Slack personal-binding mount,
+  and the outbound target provider lists a personal DM target only after that
+  durable authority exists.
 - Static seeded Slack channel deletion needs explicit tombstone/disabled-route
   state before delete can override startup fallback. PR C1 does not invent that
   persistence contract; keep it as a follow-up if static seeded routes must be
   revocable from the admin UI.
-- PR C1 keeps shared-channel target authority in the Slack host-beta composition
-  module to avoid refactor churn. Follow up by moving the provider into
-  `slack_channel_routes` or a dedicated Slack route-authority module if the
-  target-provider implementation grows beyond this first shared-channel slice.
+- PR C2 moves Slack outbound target authority into
+  `slack_outbound_targets.rs`, keeping shared-channel and personal-DM Slack
+  details out of core outbound preference logic.
 - PR C1 pages through the existing route-store API for shared-channel target
   inventory so stored routes past the first page still override static fallback.
   Follow up with a subject-scoped route-store query if route inventory scans
   become too expensive for tenants with many Slack channel routes.
-- PR C1 keeps the Slack reply-target binding formatter local. Follow up with a
-  shared bounded binding-ref helper only if another provider needs the same
-  formatter shape; do not move crate APIs just for this first Slack target.
+- PR C2 keeps the Slack reply-target binding formatter inside the Slack
+  outbound-target module. Follow up with a shared bounded binding-ref helper
+  only if another provider needs the same formatter shape.
 - Slack pairing-code redemption remains identity-only. It must not synthesize a
   personal default, write preferences, or treat a paired Slack user id as a
   deliverable DM target.
@@ -532,15 +533,18 @@ Deliverables:
 - Shared-agent Slack channel target backed by admin-managed Slack channel
   routes. Implemented in PR C1.
 - Personal Slack DM target backed by durable Slack identity/DM target authority.
-  Deferred to PR C2 until Slack-owned durable DM target state exists.
+  Implemented in PR C2 at provider/storage level; user-facing provisioning and
+  default-selection routes remain Phase 5.
 - Slack route deletion/owner-change tests. Covered in PR C1 for admin-managed
   shared-channel targets, plus persisted-owner override for static seeded
   channels. Static seeded delete-over-fallback needs tombstone state.
-- Shared-channel target provider placement, subject-scoped listing, and shared
-  binding-ref helper extraction are documented follow-ups, not PR C1 blockers.
+- Subject-scoped shared-route listing and shared binding-ref helper extraction
+  remain follow-ups, not Phase 4 blockers.
 - Pairing-code redemption tests proving it remains identity-only.
 - First-inbound/DM target tests proving only a concrete target can become a
-  personal default. Deferred to PR C2 with durable DM target state.
+  personal default. PR C2 covers explicit DM provisioning plus "no provisioned
+  authority means no personal target"; first-inbound prompt routing remains
+  Phase 5.
 
 Exit criteria:
 
@@ -548,7 +552,8 @@ Exit criteria:
   covers listing, preference selection, deletion revocation, and owner-change
   authority movement.
 - Personal agents can target the owner's Slack DM after DM authority exists.
-  Deferred to PR C2.
+  PR C2 implements provider-side target inventory after authority exists;
+  selecting it as a default through user-facing routes remains Phase 5.
 - No target is synthesized from arbitrary client input.
 - Slack final reply delivery still uses `chat.postMessage`.
 


### PR DESCRIPTION
## Summary

Core model for project-scoped automation ownership (design in #4662):

- `CommunicationPreferenceKey::project(tenant, project)` replaces the agent-keyed shared scope; triggered resolution derives personal/project keys from explicit thread ownership and **fails closed on ambiguous ownership** instead of falling back to the turn actor.
- Approval/auth gate prompts on triggered runs **fall back to the final-reply target** when their slots are unset — background automations no longer stall silently on gates.
- `TriggerOwnershipScope::Project` (requires `project_id`) with a **host-derived authority gate** on `builtin.trigger_create`: model tool input cannot mint project-owned triggers; every production call site ships with the gate closed.
- `TrustedOwnerScope` tri-state on the sealed conversation-binding contract propagates explicit ownership into the turn scope — **fixes the bug where project trigger fires read the creator's thread subtree and died with "unknown thread"** before reaching the model (while the poller recorded `last_status: Ok`).
- The durable milestone sink follows the run's scope (tenant stays pinned) instead of rejecting legitimate cross-project runs; events now record the run's actual agent/project/owner.

## Verification

- New e2e acceptance test: a project-scoped trigger fire reaches the model with a project-owned turn scope (`trigger_poller_submits_project_turn_with_project_owned_scope`).
- `cargo clippy --all --benches --tests --examples --all-features` — zero warnings.
- Full test suites green for outbound, triggers, host_runtime, conversations, reborn, product_workflow, composition (3 pre-existing docker-socket-dependent sandbox tests excluded).
- Boundary-checked standalone: workspace compiles and tests pass with the surface-rename PR's changes absent.

Stacked on #4600; the surface rename follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
