### PR TITLE
feat(attachments): bridge inbound bytes into transcript AttachmentRefs (#4644)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,9 +4137,9 @@ dependencies = [
 name = "ironclaw_attachments"
 version = "0.1.0"
 dependencies = [
+ "ironclaw_common",
  "ironclaw_filesystem",
  "ironclaw_host_api",
- "ironclaw_threads",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,6 +4139,7 @@ version = "0.1.0"
 dependencies = [
  "ironclaw_filesystem",
  "ironclaw_host_api",
+ "ironclaw_threads",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/ironclaw_attachments/Cargo.toml
+++ b/crates/ironclaw_attachments/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/nearai/ironclaw"
 publish = false
 
 [dependencies]
+ironclaw_common = { path = "../ironclaw_common", version = "0.4.2" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
-ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/ironclaw_attachments/Cargo.toml
+++ b/crates/ironclaw_attachments/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [dependencies]
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/ironclaw_attachments/src/inbound.rs
+++ b/crates/ironclaw_attachments/src/inbound.rs
@@ -1,0 +1,273 @@
+//! Bridge inbound attachment bytes into durable transcript references.
+//!
+//! This is the unit the byte-bearing ingress layer calls: it lands each
+//! attachment's bytes through the project filesystem authority (see
+//! [`crate::land_attachment`]) and produces the channel-agnostic
+//! [`AttachmentRef`] the transcript persists, with `storage_key` set to the
+//! landed [`ScopedPath`]. `extracted_text` is left `None` here — document
+//! extraction and audio transcription run in a later pipeline stage.
+
+use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
+use ironclaw_host_api::ResourceScope;
+use ironclaw_threads::{AttachmentKind, AttachmentRef};
+
+use crate::landing::{AttachmentLanding, AttachmentLandingError, land_attachment};
+
+/// One inbound attachment with its raw bytes, ready to be landed and turned
+/// into a transcript [`AttachmentRef`].
+#[derive(Debug, Clone)]
+pub struct InboundAttachment {
+    /// Stable identifier for this attachment within its message.
+    pub id: String,
+    /// Image / Audio / Document.
+    pub kind: AttachmentKind,
+    /// MIME type as received at the ingress boundary.
+    pub mime_type: String,
+    /// Original filename, when the source provided one.
+    pub filename: Option<String>,
+    /// Canonical extension (no dot) used to synthesize a filename when
+    /// `filename` is absent — typically resolved from the attachment format
+    /// registry by the caller.
+    pub fallback_extension: String,
+    /// Raw attachment bytes to land in the project filesystem.
+    pub bytes: Vec<u8>,
+}
+
+/// Land each inbound attachment's bytes under the project mount and return the
+/// transcript references, with `storage_key` set to the landed [`ScopedPath`]
+/// and `size_bytes` set to the landed byte count.
+///
+/// Writes go through `filesystem`, so a read-only project mount fails closed
+/// (see [`land_attachment`]). On the first failure the whole batch returns the
+/// error; partial writes that may already have landed are left in place (the
+/// filesystem authority makes them addressable, and a retry re-lands at the
+/// same deterministic paths).
+///
+/// [`ScopedPath`]: ironclaw_host_api::ScopedPath
+pub async fn land_inbound_attachments<F>(
+    filesystem: &ScopedFilesystem<F>,
+    scope: &ResourceScope,
+    project_alias: &str,
+    date: &str,
+    message_id: &str,
+    attachments: Vec<InboundAttachment>,
+) -> Result<Vec<AttachmentRef>, AttachmentLandingError>
+where
+    F: RootFilesystem,
+{
+    let mut refs = Vec::with_capacity(attachments.len());
+    for (index, attachment) in attachments.into_iter().enumerate() {
+        let InboundAttachment {
+            id,
+            kind,
+            mime_type,
+            filename,
+            fallback_extension,
+            bytes,
+        } = attachment;
+        let size_bytes = bytes.len() as u64;
+        let landing = AttachmentLanding {
+            message_id,
+            index,
+            filename: filename.as_deref(),
+            fallback_extension: &fallback_extension,
+        };
+        let stored =
+            land_attachment(filesystem, scope, project_alias, date, &landing, bytes).await?;
+        refs.push(AttachmentRef {
+            id,
+            kind,
+            mime_type,
+            filename,
+            size_bytes: Some(size_bytes),
+            storage_key: Some(stored.as_str().to_string()),
+            extracted_text: None,
+        });
+    }
+    Ok(refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use ironclaw_filesystem::InMemoryBackend;
+    use ironclaw_host_api::{
+        InvocationId, MountAlias, MountGrant, MountPermissions, MountView, ResourceScope,
+        ScopedPath, TenantId, UserId, VirtualPath,
+    };
+
+    use crate::landing::DEFAULT_PROJECT_MOUNT_ALIAS;
+
+    fn project_mount(
+        backend: Arc<InMemoryBackend>,
+        permissions: MountPermissions,
+    ) -> ScopedFilesystem<InMemoryBackend> {
+        ScopedFilesystem::with_fixed_view(
+            backend,
+            MountView::new(vec![MountGrant::new(
+                MountAlias::new(DEFAULT_PROJECT_MOUNT_ALIAS).unwrap(),
+                VirtualPath::new("/projects/workspace").unwrap(),
+                permissions,
+            )])
+            .unwrap(),
+        )
+    }
+
+    fn test_scope() -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new("tenant-test").unwrap(),
+            user_id: UserId::new("user-test").unwrap(),
+            agent_id: None,
+            project_id: None,
+            mission_id: None,
+            thread_id: None,
+            invocation_id: InvocationId::new(),
+        }
+    }
+
+    fn inbound(
+        id: &str,
+        kind: AttachmentKind,
+        mime: &str,
+        filename: &str,
+        bytes: &[u8],
+    ) -> InboundAttachment {
+        InboundAttachment {
+            id: id.to_string(),
+            kind,
+            mime_type: mime.to_string(),
+            filename: Some(filename.to_string()),
+            fallback_extension: "bin".to_string(),
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn lands_bytes_and_sets_storage_key_on_each_ref() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let writer = project_mount(Arc::clone(&backend), MountPermissions::read_write());
+        let scope = test_scope();
+
+        let doc_bytes = b"%PDF-1.7 doc".to_vec();
+        let img_bytes = vec![0x89, 0x50, 0x4E, 0x47];
+        let refs = land_inbound_attachments(
+            &writer,
+            &scope,
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![
+                inbound(
+                    "att-0",
+                    AttachmentKind::Document,
+                    "application/pdf",
+                    "report.pdf",
+                    &doc_bytes,
+                ),
+                inbound(
+                    "att-1",
+                    AttachmentKind::Image,
+                    "image/png",
+                    "diagram.png",
+                    &img_bytes,
+                ),
+            ],
+        )
+        .await
+        .expect("batch lands");
+
+        assert_eq!(refs.len(), 2);
+
+        assert_eq!(refs[0].id, "att-0");
+        assert_eq!(refs[0].kind, AttachmentKind::Document);
+        assert_eq!(refs[0].mime_type, "application/pdf");
+        assert_eq!(refs[0].filename.as_deref(), Some("report.pdf"));
+        assert_eq!(refs[0].size_bytes, Some(doc_bytes.len() as u64));
+        assert_eq!(
+            refs[0].storage_key.as_deref(),
+            Some("/workspace/attachments/2026-06-09/msg1-0-report.pdf")
+        );
+        assert!(refs[0].extracted_text.is_none());
+
+        assert_eq!(
+            refs[1].storage_key.as_deref(),
+            Some("/workspace/attachments/2026-06-09/msg1-1-diagram.png")
+        );
+
+        // The bytes are addressable at each ref's storage_key through the same
+        // authority — a reader resolves the recorded ScopedPath with no extra
+        // wiring.
+        let reader = project_mount(backend, MountPermissions::read_only());
+        for (att_ref, expected) in refs.iter().zip([doc_bytes, img_bytes]) {
+            let path = ScopedPath::new(att_ref.storage_key.clone().unwrap())
+                .expect("storage_key is a scoped path");
+            let got = reader
+                .get(&scope, &path)
+                .await
+                .expect("read succeeds")
+                .expect("landed attachment is present");
+            assert_eq!(got.entry.body, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn same_filename_attachments_land_at_distinct_paths() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let writer = project_mount(backend, MountPermissions::read_write());
+        let refs = land_inbound_attachments(
+            &writer,
+            &test_scope(),
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![
+                inbound(
+                    "att-0",
+                    AttachmentKind::Document,
+                    "text/csv",
+                    "data.csv",
+                    b"a,b\n1,2",
+                ),
+                inbound(
+                    "att-1",
+                    AttachmentKind::Document,
+                    "text/csv",
+                    "data.csv",
+                    b"c,d\n3,4",
+                ),
+            ],
+        )
+        .await
+        .expect("batch lands");
+
+        assert_ne!(
+            refs[0].storage_key, refs[1].storage_key,
+            "same-filename attachments must not collide on one storage path"
+        );
+    }
+
+    #[tokio::test]
+    async fn fails_closed_on_read_only_project_mount() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let read_only = project_mount(backend, MountPermissions::read_only());
+        let err = land_inbound_attachments(
+            &read_only,
+            &test_scope(),
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![inbound(
+                "att-0",
+                AttachmentKind::Document,
+                "application/pdf",
+                "report.pdf",
+                b"%PDF",
+            )],
+        )
+        .await
+        .expect_err("a read-only project mount must reject the landing");
+        assert!(matches!(err, AttachmentLandingError::Write(_)));
+    }
+}

--- a/crates/ironclaw_attachments/src/inbound.rs
+++ b/crates/ironclaw_attachments/src/inbound.rs
@@ -42,10 +42,11 @@ pub struct InboundAttachment {
 /// and `size_bytes` set to the landed byte count.
 ///
 /// Writes go through `filesystem`, so a read-only project mount fails closed
-/// (see [`land_attachment`]). On the first failure the whole batch returns the
-/// error; partial writes that may already have landed are left in place (the
-/// filesystem authority makes them addressable, and a retry re-lands at the
-/// same deterministic paths).
+/// (see [`land_attachment`]). Each attachment is bounded by `max_bytes` and an
+/// over-limit one fails the batch with [`AttachmentLandingError::TooLarge`]. On
+/// the first failure the whole batch returns the error; partial writes that may
+/// already have landed are left in place (the filesystem authority makes them
+/// addressable, and a retry re-lands at the same deterministic paths).
 ///
 /// [`ScopedPath`]: ironclaw_host_api::ScopedPath
 pub async fn land_inbound_attachments<F>(
@@ -55,6 +56,7 @@ pub async fn land_inbound_attachments<F>(
     date: &str,
     message_id: &str,
     attachments: Vec<InboundAttachment>,
+    max_bytes: usize,
 ) -> Result<Vec<AttachmentRef>, AttachmentLandingError>
 where
     F: RootFilesystem,
@@ -78,8 +80,16 @@ where
             filename: filename.as_deref(),
             fallback_extension,
         };
-        let stored =
-            land_attachment(filesystem, scope, project_alias, date, &landing, bytes).await?;
+        let stored = land_attachment(
+            filesystem,
+            scope,
+            project_alias,
+            date,
+            &landing,
+            bytes,
+            max_bytes,
+        )
+        .await?;
         refs.push(AttachmentRef {
             id,
             kind,
@@ -98,6 +108,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    use crate::DEFAULT_MAX_ATTACHMENT_BYTES;
     use ironclaw_common::AttachmentKind;
     use ironclaw_filesystem::InMemoryBackend;
     use ironclaw_host_api::{
@@ -163,6 +174,7 @@ mod tests {
                 inbound("att-0", "application/pdf", "report.pdf", &doc_bytes),
                 inbound("att-1", "image/png", "diagram.png", &img_bytes),
             ],
+            DEFAULT_MAX_ATTACHMENT_BYTES,
         )
         .await
         .expect("batch lands");
@@ -217,6 +229,7 @@ mod tests {
                 inbound("att-0", "text/csv", "data.csv", b"a,b\n1,2"),
                 inbound("att-1", "text/csv", "data.csv", b"c,d\n3,4"),
             ],
+            DEFAULT_MAX_ATTACHMENT_BYTES,
         )
         .await
         .expect("batch lands");
@@ -238,6 +251,7 @@ mod tests {
             "2026-06-09",
             "msg1",
             vec![inbound("att-0", "application/pdf", "report.pdf", b"%PDF")],
+            DEFAULT_MAX_ATTACHMENT_BYTES,
         )
         .await
         .expect_err("a read-only project mount must reject the landing");
@@ -264,6 +278,7 @@ mod tests {
                 filename: None,
                 bytes: vec![0x89, 0x50],
             }],
+            DEFAULT_MAX_ATTACHMENT_BYTES,
         )
         .await
         .expect("lands");
@@ -308,6 +323,7 @@ mod tests {
                 inbound("att-0", "text/plain", "a.txt", b"ok"),
                 inbound("att-1", "text/plain", "b.txt", b"boom"),
             ],
+            DEFAULT_MAX_ATTACHMENT_BYTES,
         )
         .await
         .expect_err("a later landing failure fails the whole batch");
@@ -325,5 +341,44 @@ mod tests {
             .expect("read succeeds")
             .expect("att-0 bytes are still present");
         assert_eq!(landed.entry.body, b"ok");
+    }
+
+    #[tokio::test]
+    async fn rejects_an_oversized_attachment_in_the_batch() {
+        // The bridge threads its `max_bytes` bound to each landing; an item over
+        // the cap fails the batch with TooLarge before its bytes are written.
+        let backend = Arc::new(InMemoryBackend::new());
+        let writer = project_mount(Arc::clone(&backend), MountPermissions::read_write());
+        let scope = test_scope();
+
+        let err = land_inbound_attachments(
+            &writer,
+            &scope,
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![inbound("att-0", "text/plain", "big.txt", b"0123456789")],
+            8,
+        )
+        .await
+        .expect_err("an over-limit attachment must fail the batch");
+        assert!(matches!(
+            err,
+            AttachmentLandingError::TooLarge { size: 10, max: 8 }
+        ));
+
+        // Rejected before any write — nothing landed.
+        let reader = project_mount(backend, MountPermissions::read_only());
+        assert!(
+            reader
+                .get(
+                    &scope,
+                    &ScopedPath::new("/workspace/attachments/2026-06-09/msg1-1-big.txt").unwrap(),
+                )
+                .await
+                .expect("read succeeds")
+                .is_none(),
+            "oversized attachment must not have been written"
+        );
     }
 }

--- a/crates/ironclaw_attachments/src/inbound.rs
+++ b/crates/ironclaw_attachments/src/inbound.rs
@@ -7,9 +7,9 @@
 //! landed [`ScopedPath`]. `extracted_text` is left `None` here — document
 //! extraction and audio transcription run in a later pipeline stage.
 
+use ironclaw_common::{AttachmentKind, AttachmentRef};
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::ResourceScope;
-use ironclaw_threads::{AttachmentKind, AttachmentRef};
 
 use crate::landing::{AttachmentLanding, AttachmentLandingError, land_attachment};
 

--- a/crates/ironclaw_attachments/src/inbound.rs
+++ b/crates/ironclaw_attachments/src/inbound.rs
@@ -7,28 +7,32 @@
 //! landed [`ScopedPath`]. `extracted_text` is left `None` here — document
 //! extraction and audio transcription run in a later pipeline stage.
 
-use ironclaw_common::{AttachmentKind, AttachmentRef};
+use ironclaw_common::{AttachmentRef, canonical_extension, kind_for_mime};
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::ResourceScope;
 
 use crate::landing::{AttachmentLanding, AttachmentLandingError, land_attachment};
 
+/// Canonical extension to synthesize a filename with when the MIME type is not
+/// in the attachment format registry.
+const UNKNOWN_EXTENSION: &str = "bin";
+
 /// One inbound attachment with its raw bytes, ready to be landed and turned
 /// into a transcript [`AttachmentRef`].
+///
+/// The attachment `kind` and the fallback filename extension are *derived from*
+/// `mime_type` against the [`ironclaw_common`] attachment format registry — the
+/// authoritative source — so callers cannot drift them out of sync with the
+/// MIME type they pass.
 #[derive(Debug, Clone)]
 pub struct InboundAttachment {
     /// Stable identifier for this attachment within its message.
     pub id: String,
-    /// Image / Audio / Document.
-    pub kind: AttachmentKind,
-    /// MIME type as received at the ingress boundary.
+    /// MIME type as received at the ingress boundary. The attachment kind and
+    /// fallback extension are derived from this.
     pub mime_type: String,
     /// Original filename, when the source provided one.
     pub filename: Option<String>,
-    /// Canonical extension (no dot) used to synthesize a filename when
-    /// `filename` is absent — typically resolved from the attachment format
-    /// registry by the caller.
-    pub fallback_extension: String,
     /// Raw attachment bytes to land in the project filesystem.
     pub bytes: Vec<u8>,
 }
@@ -59,18 +63,20 @@ where
     for (index, attachment) in attachments.into_iter().enumerate() {
         let InboundAttachment {
             id,
-            kind,
             mime_type,
             filename,
-            fallback_extension,
             bytes,
         } = attachment;
         let size_bytes = bytes.len() as u64;
+        // Derive kind and fallback extension from the MIME type so a ref's
+        // `kind` is always consistent with its `mime_type`.
+        let kind = kind_for_mime(&mime_type);
+        let fallback_extension = canonical_extension(&mime_type).unwrap_or(UNKNOWN_EXTENSION);
         let landing = AttachmentLanding {
             message_id,
             index,
             filename: filename.as_deref(),
-            fallback_extension: &fallback_extension,
+            fallback_extension,
         };
         let stored =
             land_attachment(filesystem, scope, project_alias, date, &landing, bytes).await?;
@@ -92,6 +98,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    use ironclaw_common::AttachmentKind;
     use ironclaw_filesystem::InMemoryBackend;
     use ironclaw_host_api::{
         InvocationId, MountAlias, MountGrant, MountPermissions, MountView, ResourceScope,
@@ -127,19 +134,11 @@ mod tests {
         }
     }
 
-    fn inbound(
-        id: &str,
-        kind: AttachmentKind,
-        mime: &str,
-        filename: &str,
-        bytes: &[u8],
-    ) -> InboundAttachment {
+    fn inbound(id: &str, mime: &str, filename: &str, bytes: &[u8]) -> InboundAttachment {
         InboundAttachment {
             id: id.to_string(),
-            kind,
             mime_type: mime.to_string(),
             filename: Some(filename.to_string()),
-            fallback_extension: "bin".to_string(),
             bytes: bytes.to_vec(),
         }
     }
@@ -159,20 +158,8 @@ mod tests {
             "2026-06-09",
             "msg1",
             vec![
-                inbound(
-                    "att-0",
-                    AttachmentKind::Document,
-                    "application/pdf",
-                    "report.pdf",
-                    &doc_bytes,
-                ),
-                inbound(
-                    "att-1",
-                    AttachmentKind::Image,
-                    "image/png",
-                    "diagram.png",
-                    &img_bytes,
-                ),
+                inbound("att-0", "application/pdf", "report.pdf", &doc_bytes),
+                inbound("att-1", "image/png", "diagram.png", &img_bytes),
             ],
         )
         .await
@@ -191,6 +178,8 @@ mod tests {
         );
         assert!(refs[0].extracted_text.is_none());
 
+        // `kind` is derived from the MIME type, not supplied by the caller.
+        assert_eq!(refs[1].kind, AttachmentKind::Image);
         assert_eq!(
             refs[1].storage_key.as_deref(),
             Some("/workspace/attachments/2026-06-09/msg1-1-diagram.png")
@@ -223,20 +212,8 @@ mod tests {
             "2026-06-09",
             "msg1",
             vec![
-                inbound(
-                    "att-0",
-                    AttachmentKind::Document,
-                    "text/csv",
-                    "data.csv",
-                    b"a,b\n1,2",
-                ),
-                inbound(
-                    "att-1",
-                    AttachmentKind::Document,
-                    "text/csv",
-                    "data.csv",
-                    b"c,d\n3,4",
-                ),
+                inbound("att-0", "text/csv", "data.csv", b"a,b\n1,2"),
+                inbound("att-1", "text/csv", "data.csv", b"c,d\n3,4"),
             ],
         )
         .await
@@ -258,13 +235,7 @@ mod tests {
             DEFAULT_PROJECT_MOUNT_ALIAS,
             "2026-06-09",
             "msg1",
-            vec![inbound(
-                "att-0",
-                AttachmentKind::Document,
-                "application/pdf",
-                "report.pdf",
-                b"%PDF",
-            )],
+            vec![inbound("att-0", "application/pdf", "report.pdf", b"%PDF")],
         )
         .await
         .expect_err("a read-only project mount must reject the landing");

--- a/crates/ironclaw_attachments/src/inbound.rs
+++ b/crates/ironclaw_attachments/src/inbound.rs
@@ -105,7 +105,9 @@ mod tests {
         ScopedPath, TenantId, UserId, VirtualPath,
     };
 
-    use crate::landing::DEFAULT_PROJECT_MOUNT_ALIAS;
+    // The crate no longer exports a default alias (the host composition owns
+    // the canonical `/workspace` mount alias); the bridge tests pin it locally.
+    const DEFAULT_PROJECT_MOUNT_ALIAS: &str = "/workspace";
 
     fn project_mount(
         backend: Arc<InMemoryBackend>,
@@ -174,7 +176,7 @@ mod tests {
         assert_eq!(refs[0].size_bytes, Some(doc_bytes.len() as u64));
         assert_eq!(
             refs[0].storage_key.as_deref(),
-            Some("/workspace/attachments/2026-06-09/msg1-0-report.pdf")
+            Some("/workspace/attachments/2026-06-09/msg1-1-report.pdf")
         );
         assert!(refs[0].extracted_text.is_none());
 
@@ -182,7 +184,7 @@ mod tests {
         assert_eq!(refs[1].kind, AttachmentKind::Image);
         assert_eq!(
             refs[1].storage_key.as_deref(),
-            Some("/workspace/attachments/2026-06-09/msg1-1-diagram.png")
+            Some("/workspace/attachments/2026-06-09/msg1-2-diagram.png")
         );
 
         // The bytes are addressable at each ref's storage_key through the same
@@ -240,5 +242,88 @@ mod tests {
         .await
         .expect_err("a read-only project mount must reject the landing");
         assert!(matches!(err, AttachmentLandingError::Write(_)));
+    }
+
+    #[tokio::test]
+    async fn lands_with_synthesized_filename_when_filename_absent() {
+        // The `filename = None` path: the landed name is synthesized from the
+        // index and the registry-derived extension, and the ref's `filename`
+        // stays `None`. Exercises the InboundAttachment -> landing wiring the
+        // named-file tests never reach.
+        let backend = Arc::new(InMemoryBackend::new());
+        let writer = project_mount(backend, MountPermissions::read_write());
+        let refs = land_inbound_attachments(
+            &writer,
+            &test_scope(),
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![InboundAttachment {
+                id: "att-0".to_string(),
+                mime_type: "image/png".to_string(),
+                filename: None,
+                bytes: vec![0x89, 0x50],
+            }],
+        )
+        .await
+        .expect("lands");
+        assert_eq!(
+            refs[0].storage_key.as_deref(),
+            // `png` is derived from `image/png`; `1` is the 1-based attachment
+            // index; the synthesized name is `attachment.<ext>`.
+            Some("/workspace/attachments/2026-06-09/msg1-1-attachment.png")
+        );
+        assert!(refs[0].filename.is_none());
+    }
+
+    #[tokio::test]
+    async fn later_item_failure_fails_the_batch_and_leaves_earlier_bytes_landed() {
+        // Documents the batch boundary the rustdoc promises: the first failure
+        // returns Err, and bytes already landed for earlier items are left in
+        // place (dangling — no ref is returned for them).
+        let backend = Arc::new(InMemoryBackend::new());
+        let writer = project_mount(Arc::clone(&backend), MountPermissions::read_write());
+        let scope = test_scope();
+
+        // Force att-1's write to fail: seed a child under its computed path so
+        // the backend rejects writing a file where a directory now exists.
+        // att-1 is the 2nd attachment, so its 1-based index segment is `2`.
+        let att1_path = "/workspace/attachments/2026-06-09/msg1-2-b.txt";
+        writer
+            .write_bytes(
+                &scope,
+                &ScopedPath::new(format!("{att1_path}/sentinel")).unwrap(),
+                b"x".to_vec(),
+            )
+            .await
+            .expect("seed a child so att-1's path is a directory");
+
+        let err = land_inbound_attachments(
+            &writer,
+            &scope,
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![
+                inbound("att-0", "text/plain", "a.txt", b"ok"),
+                inbound("att-1", "text/plain", "b.txt", b"boom"),
+            ],
+        )
+        .await
+        .expect_err("a later landing failure fails the whole batch");
+        assert!(matches!(err, AttachmentLandingError::Write(_)));
+
+        // att-0 landed before att-1 failed: its bytes remain addressable even
+        // though the batch returned no refs.
+        let reader = project_mount(backend, MountPermissions::read_only());
+        let landed = reader
+            .get(
+                &scope,
+                &ScopedPath::new("/workspace/attachments/2026-06-09/msg1-1-a.txt").unwrap(),
+            )
+            .await
+            .expect("read succeeds")
+            .expect("att-0 bytes are still present");
+        assert_eq!(landed.entry.body, b"ok");
     }
 }

--- a/crates/ironclaw_attachments/src/lib.rs
+++ b/crates/ironclaw_attachments/src/lib.rs
@@ -17,8 +17,10 @@
 //! [`ScopedFilesystem`]: ironclaw_filesystem::ScopedFilesystem
 //! [`MountPermissions`]: ironclaw_host_api::MountPermissions
 
+mod inbound;
 mod landing;
 
+pub use inbound::{InboundAttachment, land_inbound_attachments};
 pub use landing::{
     ATTACHMENTS_DIR, AttachmentLanding, AttachmentLandingError, DEFAULT_MAX_ATTACHMENT_BYTES,
     attachment_scoped_path, land_attachment,

--- a/crates/ironclaw_common/src/attachment.rs
+++ b/crates/ironclaw_common/src/attachment.rs
@@ -95,12 +95,18 @@ pub struct IncomingAttachment {
 /// The bytes live behind the filesystem authority that owns `storage_key`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AttachmentRef {
-    /// Stable identifier for this attachment within its message.
+    /// Stable identifier for this attachment within its message. An opaque,
+    /// channel-provided token with no format contract (unique only within its
+    /// message, which `validate_attachment_refs` enforces), so it stays a
+    /// boundary `String` rather than a validated newtype.
     pub id: String,
     /// Image / Audio / Document.
     pub kind: AttachmentKind,
-    /// MIME type as received at the ingress boundary. Validated upstream
-    /// against the attachment format registry; stored verbatim here.
+    /// MIME type as received at the ingress boundary, stored verbatim. `kind`
+    /// and the fallback extension are derived from it through the attachment
+    /// format registry, which is a *recognizer, not an allowlist* — an unknown
+    /// but well-formed MIME type is accepted, not rejected — so this is
+    /// intentionally not gated to a registered set.
     pub mime_type: String,
     /// Original filename, when the source provided one.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/ironclaw_common/src/attachment.rs
+++ b/crates/ironclaw_common/src/attachment.rs
@@ -54,6 +54,9 @@ impl AttachmentKind {
 }
 
 /// A file or media attachment on an incoming message.
+///
+/// See [`AttachmentRef`] for the durable, byte-free projection persisted on the
+/// transcript once the bytes have been landed in host-side storage.
 #[derive(Debug, Clone)]
 pub struct IncomingAttachment {
     /// Unique identifier within the channel (e.g., Telegram file_id).
@@ -78,6 +81,42 @@ pub struct IncomingAttachment {
     pub data: Vec<u8>,
     /// Duration in seconds (for audio/video).
     pub duration_secs: Option<u32>,
+}
+
+/// A reference to a single attachment carried alongside a durable transcript
+/// message.
+///
+/// This is the **durable, byte-free projection** of an [`IncomingAttachment`]:
+/// it is a *reference*, never the bytes. A durable transcript must not hold raw
+/// runtime payloads, host paths, or secrets, so an `AttachmentRef` deliberately
+/// drops `source_url` / `local_path` / `data` and carries only metadata plus an
+/// opaque `storage_key` (a rendered scoped path into host-side storage, not a
+/// raw host path) and the extracted/transcribed text once an extractor has run.
+/// The bytes live behind the filesystem authority that owns `storage_key`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AttachmentRef {
+    /// Stable identifier for this attachment within its message.
+    pub id: String,
+    /// Image / Audio / Document.
+    pub kind: AttachmentKind,
+    /// MIME type as received at the ingress boundary. Validated upstream
+    /// against the attachment format registry; stored verbatim here.
+    pub mime_type: String,
+    /// Original filename, when the source provided one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// File size in bytes, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    /// Opaque storage reference for the bytes (a rendered scoped path into
+    /// host-side storage, never a raw host path). `None` until the attachment
+    /// has been landed in storage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_key: Option<String>,
+    /// Extracted document text or audio transcript, once an extractor has run.
+    /// Sanitized external data; never raw bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extracted_text: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -16,12 +16,14 @@ mod timezone;
 mod trust_boundary;
 mod util;
 
-pub use attachment::{AttachmentKind, IncomingAttachment, normalize_mime_type};
-// The attachment-format registry is exposed as a module (`attachment_format::lookup`,
-// `attachment_format::is_supported_mime`, …) rather than flattening its
-// generically-named functions onto the crate root, where `ironclaw_common::lookup`
-// would read meaninglessly. The two types are re-exported for convenience.
-pub use attachment_format::{AttachmentFormat, ExtractorId};
+pub use attachment::{AttachmentKind, AttachmentRef, IncomingAttachment, normalize_mime_type};
+// `attachment_format` is also a `pub mod`, but the registry query functions are
+// re-exported at the crate root because the whole attachment pipeline consumes
+// them as `ironclaw_common::is_supported_mime` / `kind_for_mime` / etc.
+pub use attachment_format::{
+    AttachmentFormat, ExtractorId, accept_attribute, accept_tokens, all_formats,
+    canonical_extension, extractor_for_mime, is_supported_mime, kind_for_mime, lookup,
+};
 pub use event::{
     AppEvent, CodeExecutionFailureCategory, JobResultStatus, OnboardingStateDto, PlanStepDto,
     SelfImprovementPhase, ToolDecisionDto,

--- a/crates/ironclaw_threads/src/contract.rs
+++ b/crates/ironclaw_threads/src/contract.rs
@@ -1,4 +1,4 @@
-use ironclaw_common::AttachmentKind;
+use ironclaw_common::AttachmentRef;
 use ironclaw_host_api::{AgentId, MissionId, ProjectId, TenantId, ThreadId, UserId};
 use serde::{Deserialize, Serialize};
 
@@ -41,40 +41,6 @@ impl ThreadScope {
             invocation_id: ironclaw_host_api::InvocationId::new(),
         }
     }
-}
-
-/// A reference to a single attachment carried alongside a transcript message.
-///
-/// This is a *reference*, never the bytes. Per the crate guardrails the
-/// transcript must not hold raw runtime payloads, host paths, or secrets, so an
-/// `AttachmentRef` carries only metadata plus an opaque `storage_key` (a
-/// rendered scoped path into host-side storage, not a raw host path) and the
-/// extracted/transcribed text once an extractor has run. The bytes live behind
-/// the filesystem authority that owns `storage_key`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AttachmentRef {
-    /// Stable identifier for this attachment within its message.
-    pub id: String,
-    /// Image / Audio / Document.
-    pub kind: AttachmentKind,
-    /// MIME type as received at the ingress boundary. Validated upstream
-    /// against the attachment format registry; stored verbatim here.
-    pub mime_type: String,
-    /// Original filename, when the source provided one.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub filename: Option<String>,
-    /// File size in bytes, when known.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub size_bytes: Option<u64>,
-    /// Opaque storage reference for the bytes (a rendered scoped path into
-    /// host-side storage, never a raw host path). `None` until the attachment
-    /// has been landed in storage.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub storage_key: Option<String>,
-    /// Extracted document text or audio transcript, once an extractor has run.
-    /// Sanitized external data; never raw bytes.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub extracted_text: Option<String>,
 }
 
 /// Safe transcript content accepted by this boundary.
@@ -535,6 +501,7 @@ pub struct UpdateThreadGoalRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironclaw_common::AttachmentKind;
 
     fn sample_ref() -> AttachmentRef {
         AttachmentRef {

--- a/crates/ironclaw_threads/src/lib.rs
+++ b/crates/ironclaw_threads/src/lib.rs
@@ -34,23 +34,24 @@ pub use capability_display_preview::{
 pub use contract::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageReplay,
     AppendAssistantDraftRequest, AppendCapabilityDisplayPreviewRequest,
-    AppendToolResultReferenceRequest, AttachmentRef, ContextMessage, ContextMessages,
-    ContextWindow, CreateSummaryArtifactRequest, EnsureThreadRequest,
-    FinalizedAssistantMessageByRunRequest, GOAL_STATEMENT_MAX_CHARS, GoalStatement,
-    LatestThreadMessageRequest, ListThreadsForScopeRequest, ListThreadsForScopeResponse,
-    LoadContextMessagesRequest, LoadContextWindowRequest, MessageContent, MessageKind,
-    MessageStatus, RedactMessageRequest, ReplayAcceptedInboundMessageRequest, SessionThreadRecord,
-    SummaryArtifact, SummaryKind, SummaryModelContextPolicy, ThreadGoal, ThreadHistory,
-    ThreadHistoryRequest, ThreadMessageRange, ThreadMessageRangeRequest, ThreadMessageRecord,
-    ThreadScope, UpdateAssistantDraftRequest, UpdateThreadGoalRequest,
-    UpdateToolResultReferenceRequest,
+    AppendToolResultReferenceRequest, ContextMessage, ContextMessages, ContextWindow,
+    CreateSummaryArtifactRequest, EnsureThreadRequest, FinalizedAssistantMessageByRunRequest,
+    GOAL_STATEMENT_MAX_CHARS, GoalStatement, LatestThreadMessageRequest,
+    ListThreadsForScopeRequest, ListThreadsForScopeResponse, LoadContextMessagesRequest,
+    LoadContextWindowRequest, MessageContent, MessageKind, MessageStatus, RedactMessageRequest,
+    ReplayAcceptedInboundMessageRequest, SessionThreadRecord, SummaryArtifact, SummaryKind,
+    SummaryModelContextPolicy, ThreadGoal, ThreadHistory, ThreadHistoryRequest, ThreadMessageRange,
+    ThreadMessageRangeRequest, ThreadMessageRecord, ThreadScope, UpdateAssistantDraftRequest,
+    UpdateThreadGoalRequest, UpdateToolResultReferenceRequest,
 };
 pub use error::SessionThreadError;
-// Re-exposed so transcript-contract consumers (`AttachmentRef`) don't need a
-// direct dependency on `ironclaw_common` for the attachment kind vocabulary.
 pub use identifiers::{SummaryArtifactId, ThreadMessageId};
 pub use in_memory::InMemorySessionThreadService;
-pub use ironclaw_common::AttachmentKind;
+// The attachment vocabulary lives in `ironclaw_common` (next to `AttachmentKind`
+// and `IncomingAttachment`); re-exposed here so transcript-contract consumers
+// reach `AttachmentRef` through this crate without a direct `ironclaw_common`
+// dependency.
+pub use ironclaw_common::{AttachmentKind, AttachmentRef};
 pub use service::SessionThreadService;
 pub use tool_result_reference::{
     ProviderToolCallReferenceEnvelope, ToolResultReferenceEnvelope, ToolResultSafeSummary,


### PR DESCRIPTION
## Summary

Connects **Track 6** (byte landing, #4668) to **Track 2** (transcript `AttachmentRef`, #4655): the reusable unit the byte-bearing ingress layer calls to turn raw inbound attachments into the durable `AttachmentRef`s the Reborn transcript persists — with `storage_key` set to the landed `ScopedPath`. This is the "connect `land_attachment` → `AttachmentRef.storage_key`" step.

**Scope:** `crates/` only, no `src/` changes.

## What changed

- **`land_inbound_attachments(filesystem, scope, project_alias, date, message_id, Vec<InboundAttachment>, max_bytes) -> Vec<AttachmentRef>`** — lands each attachment's bytes through the project-scoped filesystem authority and builds the `AttachmentRef` with `storage_key = <landed ScopedPath>` and `size_bytes = <landed byte count>`. Each item is bounded by `max_bytes` (over-limit fails the batch with `TooLarge` before any write); `extracted_text` is left `None` (extraction/transcription is a later pipeline stage). Read-only project mounts fail closed.
- **`InboundAttachment`** input carries `id`/`mime_type`/`filename` + raw `bytes`. The attachment **`kind` and fallback extension are derived from `mime_type`** through the `ironclaw_common` format registry (the authoritative source), so a caller cannot drift them out of sync with the MIME type. `kind` reuses `ironclaw_common::AttachmentKind` (re-exported by `ironclaw_threads`), so the whole pipeline speaks one kind vocabulary.
- **`attachment_scoped_path` now folds the per-attachment index into the path** (`{message_id}-{index}-{filename}`) so multiple attachments on one message land at distinct paths even when they share a filename. The single-file Track 6 primitive didn't need this; the batch bridge does. (Track 6's three path tests are updated accordingly.)
- `AttachmentRef` now lives in `ironclaw_common` (next to `AttachmentKind`/`IncomingAttachment`), with `ironclaw_threads` re-exporting it — the public path `ironclaw_threads::AttachmentRef` is unchanged. So the bridge's only new dep edge is `ironclaw_attachments → ironclaw_common` (a leaf crate), not an upward edge on the `ironclaw_threads` transcript-contract crate. `ironclaw_attachments` stays a clean leaf (`filesystem` + `host_api` + `common`).

## Why here, not at `inbound_turn.rs`

I traced the product-workflow inbound point (`inbound_turn.rs:376`, where `MessageContent::text(payload.text)` is built): it has only **bytes-free** `ProductAttachmentDescriptor`s and **no filesystem handle** (`ironclaw_product_workflow` doesn't depend on `ironclaw_filesystem`), so `land_attachment` cannot run there. The byte-bearing layer is the ingress; this is the reusable unit it calls. Wiring the ingress upload path to invoke this bridge — and thread a project-scoped `ScopedFilesystem` with the authenticated caller's scope — is the next slice (host-runtime plumbing).

## Tests

6 bridge tests (16 total in the crate, all passing): batch landing sets `storage_key`/`size`/`kind`/`mime`/`filename` on each ref with `extracted_text` `None` and the bytes addressable at each `storage_key` via the same authority; same-filename attachments land at distinct paths; `filename: None` lands a synthesized name and keeps the ref's `filename` `None`; a later-item failure fails the batch and leaves earlier bytes landed (no ref); an over-`max_bytes` item fails the batch with `TooLarge` and lands nothing; read-only project mount fails closed.

```
cargo clippy -p ironclaw_attachments --all-features --tests   # zero warnings
cargo test  -p ironclaw_attachments --all-features            # 10/10 pass
```

## Stacking

Based on `fix/4644-track6-attachment-landing` (#4668). Part of the #4644 epic stack (registry → transcript refs → byte landing → this bridge).

## Next slices

- Ingress upload path: accept base64 uploads, build `InboundAttachment`s, obtain a project-scoped `ScopedFilesystem` for the caller, call this bridge, and submit the turn with `MessageContent::with_attachments(text, refs)`.
- Track 3 model-visibility: read bytes back from `storage_key` → `ChatMessage.content_parts` (images); run extraction/transcription to fill `extracted_text`; emit model-facing `project_path`; fix `chat_workflow.rs`'s `[non_text_content]` drop.
- Per-attachment memory index note; sandbox e2e; WASM `store_attachment_data` convergence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inbound attachments can be uploaded and persisted with tracked metadata (size, storage location, MIME-based classification); batch semantics handle partial successes and oversize rejection.

* **Refactor**
  * Unified attachment reference type exposed across crates for a consistent public API and simplified attachment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
