### PR TITLE
feat(reborn): extra-capabilities seam — register host-supplied tools as reborn capabilities

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -51,6 +51,25 @@ use self::surface_snapshot::{
 // existing adapter boundary.
 const PROVIDER_TOOL_NAME_DIGEST_BYTES: usize = 32;
 const PROVIDER_TOOL_CALL_INPUT_REF_PREFIX: &str = "input:provider-tool-";
+
+/// Observes a capability invocation's resolved input (arguments) and result
+/// (output) as the host loop executes it, for trajectory capture by downstream
+/// consumers (benchmark harnesses, debuggers, UI). `call_id` is the capability
+/// input ref and correlates the two callbacks. Best-effort and side-effect-free:
+/// implementations must never block or fail the run.
+pub trait CapabilityTrajectoryObserver: std::fmt::Debug + Send + Sync {
+    /// A model tool call resolved to a capability invocation: `capability_id` is
+    /// the resolved capability (e.g. `builtin.shell`), `arguments` the resolved
+    /// input JSON the capability runs with.
+    fn on_capability_input(
+        &self,
+        call_id: &str,
+        capability_id: &str,
+        arguments: &serde_json::Value,
+    );
+    /// The capability completed; `output` is the result JSON staged for the model.
+    fn on_capability_result(&self, call_id: &str, capability_id: &str, output: &serde_json::Value);
+}
 const MAX_IN_MEMORY_PROVIDER_TOOL_CALL_EFFECTIVE_CAPABILITY_IDS: usize = 128;
 
 #[async_trait]
@@ -239,6 +258,7 @@ pub struct HostRuntimeLoopCapabilityPortFactory {
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     execution_mounts: MountView,
     capability_execution_mounts: HashMap<CapabilityId, MountView>,
+    trajectory_observer: Option<Arc<dyn CapabilityTrajectoryObserver>>,
 }
 
 impl HostRuntimeLoopCapabilityPortFactory {
@@ -257,7 +277,18 @@ impl HostRuntimeLoopCapabilityPortFactory {
             milestone_sink,
             execution_mounts: MountView::default(),
             capability_execution_mounts: HashMap::new(),
+            trajectory_observer: None,
         }
+    }
+
+    /// Attach a [`CapabilityTrajectoryObserver`] that every port built by this
+    /// factory forwards capability inputs to. No-op when unset.
+    pub fn with_trajectory_observer(
+        mut self,
+        observer: Option<Arc<dyn CapabilityTrajectoryObserver>>,
+    ) -> Self {
+        self.trajectory_observer = observer;
+        self
     }
 
     pub fn with_execution_mounts(mut self, mounts: MountView) -> Self {
@@ -290,6 +321,7 @@ impl HostRuntimeLoopCapabilityPortFactory {
         )
         .with_execution_mounts(self.execution_mounts.clone())
         .with_capability_execution_mounts(self.capability_execution_mounts.clone())
+        .with_trajectory_observer(self.trajectory_observer.clone())
     }
 }
 
@@ -558,6 +590,7 @@ pub struct HostRuntimeLoopCapabilityPort {
     current_surface_version: Mutex<Option<String>>,
     dispatch_records: Mutex<DispatchRecordStore>,
     provider_tool_call_effective_capability_ids: Mutex<ProviderToolCallEffectiveCapabilityIdStore>,
+    trajectory_observer: Option<Arc<dyn CapabilityTrajectoryObserver>>,
 }
 
 /// Lock a poisoned-aware `Mutex` and wrap a poison error as the canonical
@@ -602,7 +635,18 @@ impl HostRuntimeLoopCapabilityPort {
             provider_tool_call_effective_capability_ids: Mutex::new(
                 ProviderToolCallEffectiveCapabilityIdStore::default(),
             ),
+            trajectory_observer: None,
         }
+    }
+
+    /// Attach a [`CapabilityTrajectoryObserver`] notified of each capability's
+    /// resolved input as this port executes it. No-op when unset.
+    pub fn with_trajectory_observer(
+        mut self,
+        observer: Option<Arc<dyn CapabilityTrajectoryObserver>>,
+    ) -> Self {
+        self.trajectory_observer = observer;
+        self
     }
 
     pub fn with_execution_mounts(mut self, mounts: MountView) -> Self {
@@ -1222,6 +1266,16 @@ impl LoopCapabilityPort for HostRuntimeLoopCapabilityPort {
             .input_resolver
             .resolve_capability_input(&self.run_context, &request.input_ref)
             .await?;
+        // Trajectory capture: the resolved input is the model's tool arguments,
+        // and this is the one place they are visible (the provider tool-call
+        // decorator stages them upstream and bypasses the input resolver hook).
+        if let Some(observer) = &self.trajectory_observer {
+            observer.on_capability_input(
+                request.input_ref.as_str(),
+                request.capability_id.as_str(),
+                &input,
+            );
+        }
         let input = match prepare_provider_arguments_with_detail(
             &input,
             &capability.parameters_schema,

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -53,9 +53,10 @@ pub use capability_allow_set::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
 };
 pub use capability_port::{
-    CapabilityResultWrite, DecoratingLoopCapabilityPortFactory, HostRuntimeLoopCapabilityPort,
-    HostRuntimeLoopCapabilityPortFactory, LoopCapabilityInputResolver, LoopCapabilityPortDecorator,
-    LoopCapabilityPortFactory, LoopCapabilityResultWriter, concurrency_hint_from_effects,
+    CapabilityResultWrite, CapabilityTrajectoryObserver, DecoratingLoopCapabilityPortFactory,
+    HostRuntimeLoopCapabilityPort, HostRuntimeLoopCapabilityPortFactory,
+    LoopCapabilityInputResolver, LoopCapabilityPortDecorator, LoopCapabilityPortFactory,
+    LoopCapabilityResultWriter, concurrency_hint_from_effects,
     loop_driver_execution_extension_id,
 };
 pub use capability_surface_filter::{

--- a/crates/ironclaw_reborn_composition/src/legacy_tools.rs
+++ b/crates/ironclaw_reborn_composition/src/legacy_tools.rs
@@ -1,0 +1,304 @@
+//! Bench-only seam: expose externally-supplied tools (e.g. the nearai-bench
+//! legacy `ironclaw::tools::Tool` service mocks — gmail/slack/calendar/sheets/
+//! notion) to the reborn agent without authoring first-party extensions.
+//!
+//! The caller supplies (1) tool specs (name/description/JSON-params) and (2) a
+//! dead-simple async `ExtraCapabilityDispatch::invoke(capability_id, args) ->
+//! json`. We wrap the local-dev capability port in a decorator that advertises
+//! those tools on the visible surface + in `tool_definitions`, and on invocation
+//! resolves the staged input (via the shared `capability_io`), calls the
+//! dispatch, and writes the result back through the same `capability_io` (so the
+//! trajectory observer + transcript see it). Everything else delegates to the
+//! inner local-dev port.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{CapabilityId, InvocationId, RuntimeKind};
+use ironclaw_loop_support::{
+    CapabilityResultWrite, LoopCapabilityInputResolver, LoopCapabilityPortDecorator,
+    LoopCapabilityResultWriter,
+};
+use ironclaw_turns::run_profile::{
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilityBatchInvocation, CapabilityBatchOutcome,
+    CapabilityCallCandidate, CapabilityDescriptorView, CapabilityFailure, CapabilityFailureKind,
+    CapabilityInvocation, CapabilityOutcome, CapabilityProgress, CapabilityResultMessage,
+    ConcurrencyHint, LoopCapabilityPort, LoopRunContext, ProviderToolCall,
+    ProviderToolCallCapabilityIds, ProviderToolCallReplay, ProviderToolDefinition,
+    VisibleCapabilityRequest, VisibleCapabilitySurface,
+};
+
+/// One externally-supplied tool advertised to the reborn agent.
+#[derive(Debug, Clone)]
+pub struct ExtraToolSpec {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+}
+
+/// Caller-provided execution of an extra tool: run `capability_id` with `input`
+/// (the model's JSON arguments) and return the JSON result the model sees.
+#[async_trait]
+pub trait ExtraCapabilityDispatch: Send + Sync + std::fmt::Debug {
+    async fn invoke(
+        &self,
+        capability_id: &str,
+        input: serde_json::Value,
+    ) -> Result<serde_json::Value, String>;
+}
+
+/// Decorator factory: installed on `RebornRuntimeInput`, applied over the
+/// local-dev port inside `capability_wiring` (which supplies the shared
+/// resolver/writer).
+#[derive(Clone)]
+pub(crate) struct ExtraCapabilitiesDecorator {
+    specs: Arc<Vec<ExtraToolSpec>>,
+    dispatch: Arc<dyn ExtraCapabilityDispatch>,
+    input_resolver: Arc<dyn LoopCapabilityInputResolver>,
+    result_writer: Arc<dyn LoopCapabilityResultWriter>,
+}
+
+impl ExtraCapabilitiesDecorator {
+    pub(crate) fn new(
+        specs: Vec<ExtraToolSpec>,
+        dispatch: Arc<dyn ExtraCapabilityDispatch>,
+        input_resolver: Arc<dyn LoopCapabilityInputResolver>,
+        result_writer: Arc<dyn LoopCapabilityResultWriter>,
+    ) -> Self {
+        Self {
+            specs: Arc::new(specs),
+            dispatch,
+            input_resolver,
+            result_writer,
+        }
+    }
+}
+
+impl LoopCapabilityPortDecorator for ExtraCapabilitiesDecorator {
+    fn decorate(
+        &self,
+        run_context: &LoopRunContext,
+        inner: Arc<dyn LoopCapabilityPort>,
+    ) -> Arc<dyn LoopCapabilityPort> {
+        Arc::new(ExtraCapabilitiesPort {
+            inner,
+            specs: Arc::clone(&self.specs),
+            dispatch: Arc::clone(&self.dispatch),
+            input_resolver: Arc::clone(&self.input_resolver),
+            result_writer: Arc::clone(&self.result_writer),
+            run_context: run_context.clone(),
+        })
+    }
+}
+
+struct ExtraCapabilitiesPort {
+    inner: Arc<dyn LoopCapabilityPort>,
+    specs: Arc<Vec<ExtraToolSpec>>,
+    dispatch: Arc<dyn ExtraCapabilityDispatch>,
+    input_resolver: Arc<dyn LoopCapabilityInputResolver>,
+    result_writer: Arc<dyn LoopCapabilityResultWriter>,
+    run_context: LoopRunContext,
+}
+
+/// Bench tool names (gmail, notion_*, …) aren't valid dotted capability ids, so
+/// we route them under a `bench.<name>` id (the model still sees the raw name).
+fn cap_id(name: &str) -> CapabilityId {
+    CapabilityId::new(format!("bench.{name}")).expect("bench.<name> is a valid capability id")
+}
+
+/// A capability result/failure `safe_summary` must be ≤512 bytes, contain no
+/// control chars, and none of `{}[]`<>/\` (payload/path delimiters) — otherwise
+/// the executor rejects it as an "unsafe strategy summary" and kills the whole
+/// turn. Tool error strings routinely contain those, so sanitize.
+fn safe_summary(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| {
+            if c.is_control() || matches!(c, '{' | '}' | '[' | ']' | '`' | '<' | '>' | '/' | '\\') {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect();
+    let collapsed = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    let truncated: String = collapsed.chars().take(480).collect();
+    if truncated.is_empty() {
+        "tool call".to_string()
+    } else {
+        truncated
+    }
+}
+
+impl ExtraCapabilitiesPort {
+    /// True if `name` (the model-facing tool name) is one of ours.
+    fn is_mine_name(&self, name: &str) -> bool {
+        self.specs.iter().any(|s| s.name == name)
+    }
+
+    /// Map a `bench.<name>` capability id back to its tool name, if it's ours.
+    fn bench_name<'a>(&self, capability_id: &'a str) -> Option<&'a str> {
+        capability_id
+            .strip_prefix("bench.")
+            .filter(|n| self.is_mine_name(n))
+    }
+
+    fn my_definitions(&self) -> Vec<ProviderToolDefinition> {
+        self.specs
+            .iter()
+            .map(|s| ProviderToolDefinition {
+                capability_id: cap_id(&s.name),
+                name: s.name.clone(),
+                description: s.description.clone(),
+                parameters: s.parameters.clone(),
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for ExtraCapabilitiesPort {
+    fn tool_definitions(&self) -> Result<Vec<ProviderToolDefinition>, AgentLoopHostError> {
+        let mut defs = self.inner.tool_definitions()?;
+        defs.extend(self.my_definitions());
+        Ok(defs)
+    }
+
+    fn provider_tool_call_capability_ids(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<ProviderToolCallCapabilityIds, AgentLoopHostError> {
+        if self.is_mine_name(&tool_call.name) {
+            return Ok(ProviderToolCallCapabilityIds::single(cap_id(&tool_call.name)));
+        }
+        self.inner.provider_tool_call_capability_ids(tool_call)
+    }
+
+    fn validate_provider_tool_call(
+        &self,
+        tool_call: &ProviderToolCall,
+    ) -> Result<(), AgentLoopHostError> {
+        if self.is_mine_name(&tool_call.name) {
+            return Ok(());
+        }
+        self.inner.validate_provider_tool_call(tool_call)
+    }
+
+    async fn register_provider_tool_call(
+        &self,
+        tool_call: ProviderToolCall,
+    ) -> Result<CapabilityCallCandidate, AgentLoopHostError> {
+        if !self.is_mine_name(&tool_call.name) {
+            return self.inner.register_provider_tool_call(tool_call).await;
+        }
+        let capability_id = cap_id(&tool_call.name);
+        let surface_version = self
+            .visible_capabilities(VisibleCapabilityRequest)
+            .await?
+            .version;
+        let input_ref = self
+            .input_resolver
+            .register_provider_tool_call_input(&self.run_context, &tool_call)
+            .await?;
+        Ok(CapabilityCallCandidate {
+            surface_version,
+            capability_id: capability_id.clone(),
+            input_ref,
+            effective_capability_ids: vec![capability_id],
+            provider_replay: Some(ProviderToolCallReplay {
+                provider_id: tool_call.provider_id,
+                provider_model_id: tool_call.provider_model_id,
+                provider_turn_id: tool_call.turn_id.unwrap_or_default(),
+                provider_call_id: tool_call.id,
+                provider_tool_name: tool_call.name,
+                arguments: tool_call.arguments,
+                response_reasoning: tool_call.response_reasoning,
+                reasoning: tool_call.reasoning,
+                signature: tool_call.signature,
+            }),
+        })
+    }
+
+    async fn visible_capabilities(
+        &self,
+        request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        let mut surface = self.inner.visible_capabilities(request).await?;
+        for spec in self.specs.iter() {
+            surface.descriptors.push(CapabilityDescriptorView {
+                capability_id: cap_id(&spec.name),
+                provider: None,
+                runtime: RuntimeKind::System,
+                safe_name: spec.name.clone(),
+                safe_description: spec.description.clone(),
+                // Service mocks mutate shared state — serialize them.
+                concurrency_hint: ConcurrencyHint::Exclusive,
+                parameters_schema: spec.parameters.clone(),
+            });
+        }
+        Ok(surface)
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        let Some(tool_name) = self.bench_name(request.capability_id.as_str()).map(str::to_string)
+        else {
+            return self.inner.invoke_capability(request).await;
+        };
+        let input = self
+            .input_resolver
+            .resolve_capability_input(&self.run_context, &request.input_ref)
+            .await?;
+        let output = match self.dispatch.invoke(&tool_name, input).await {
+            Ok(output) => output,
+            Err(message) => {
+                return Ok(CapabilityOutcome::Failed(CapabilityFailure {
+                    error_kind: CapabilityFailureKind::OperationFailed,
+                    safe_summary: safe_summary(&format!("{tool_name} failed: {message}")),
+                    detail: None,
+                }));
+            }
+        };
+        let (result_ref, byte_len) = self
+            .result_writer
+            .write_capability_result(CapabilityResultWrite {
+                run_context: &self.run_context,
+                input_ref: &request.input_ref,
+                invocation_id: InvocationId::new(),
+                capability_id: &request.capability_id,
+                output,
+                display_preview: None,
+            })
+            .await?;
+        Ok(CapabilityOutcome::Completed(CapabilityResultMessage {
+            result_ref,
+            safe_summary: safe_summary(&format!("{tool_name} returned")),
+            progress: CapabilityProgress::MadeProgress,
+            terminate_hint: false,
+            byte_len,
+        }))
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        let mut outcomes = Vec::new();
+        let mut stopped_on_suspension = false;
+        for invocation in request.invocations {
+            let outcome = self.invoke_capability(invocation).await?;
+            let is_suspension = outcome.is_suspension();
+            outcomes.push(outcome);
+            if request.stop_on_first_suspension && is_suspension {
+                stopped_on_suspension = true;
+                break;
+            }
+        }
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension,
+        })
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -41,6 +41,7 @@ mod gsuite;
 mod hooks;
 mod input;
 mod lifecycle;
+mod trajectory_observer;
 #[cfg(feature = "root-llm-provider")]
 mod llm_catalog;
 #[cfg(feature = "root-llm-provider")]
@@ -206,6 +207,7 @@ pub use runtime::{
     RebornSkillActivationMode, RebornSkillAsset, RebornSkillBundle, RebornSkillExecutionPlan,
     RebornSkillExecutionResult, RebornSkillSourceKind, build_reborn_runtime,
 };
+pub use trajectory_observer::RebornTrajectoryObserver;
 #[cfg(feature = "root-llm-provider")]
 pub use runtime_input::ResolvedRebornLlm;
 pub use runtime_input::{

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -83,6 +83,7 @@ mod provider_admin_product_command;
 #[cfg(feature = "root-llm-provider")]
 mod provider_repo;
 mod readiness;
+mod legacy_tools;
 mod runtime;
 mod runtime_input;
 mod skill_listing;
@@ -208,6 +209,7 @@ pub use runtime::{
     RebornSkillExecutionResult, RebornSkillSourceKind, build_reborn_runtime,
 };
 pub use trajectory_observer::RebornTrajectoryObserver;
+pub use legacy_tools::{ExtraCapabilityDispatch, ExtraToolSpec};
 #[cfg(feature = "root-llm-provider")]
 pub use runtime_input::ResolvedRebornLlm;
 pub use runtime_input::{

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1515,6 +1515,7 @@ pub async fn build_reborn_runtime(
         hooks: hooks_config,
         budget_defaults,
         budget_event_observer,
+        trajectory_observer,
         #[cfg(any(test, feature = "test-support"))]
         model_gateway_override,
         #[cfg(any(test, feature = "test-support"))]
@@ -1774,6 +1775,7 @@ pub async fn build_reborn_runtime(
         model_gateway,
         milestone_sink.clone(),
         skill_activation_source.clone(),
+        trajectory_observer,
     )
     .ok_or(RebornRuntimeError::HostRuntimeUnavailable)?;
     let capability_factory = local_dev_capabilities.capability_factory;

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -1516,6 +1516,7 @@ pub async fn build_reborn_runtime(
         budget_defaults,
         budget_event_observer,
         trajectory_observer,
+        extra_tools,
         #[cfg(any(test, feature = "test-support"))]
         model_gateway_override,
         #[cfg(any(test, feature = "test-support"))]
@@ -1778,9 +1779,25 @@ pub async fn build_reborn_runtime(
         trajectory_observer,
     )
     .ok_or(RebornRuntimeError::HostRuntimeUnavailable)?;
-    let capability_factory = local_dev_capabilities.capability_factory;
     let capability_input_resolver = local_dev_capabilities.capability_input_resolver;
     let capability_result_writer = local_dev_capabilities.capability_result_writer;
+    // Bench-only: expose extra (legacy service-mock) tools alongside the
+    // built-in capabilities by decorating the local-dev port.
+    let capability_factory: Arc<dyn ironclaw_loop_support::LoopCapabilityPortFactory> =
+        match extra_tools {
+            Some((specs, dispatch)) => Arc::new(
+                ironclaw_loop_support::DecoratingLoopCapabilityPortFactory::new(
+                    local_dev_capabilities.capability_factory,
+                )
+                .with_decorator(Arc::new(crate::legacy_tools::ExtraCapabilitiesDecorator::new(
+                    specs,
+                    dispatch,
+                    Arc::clone(&capability_input_resolver),
+                    Arc::clone(&capability_result_writer),
+                ))),
+            ),
+            None => local_dev_capabilities.capability_factory,
+        };
     let model_gateway = local_dev_capabilities.model_gateway;
     // Hook framework activation (#3934 + third-party projection), gated behind
     // the typed `HooksActivationConfig` carried in `RebornRuntimeInput` (master

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -2335,9 +2335,14 @@ pub(crate) struct RebornLlmReloadParts {
 #[cfg(feature = "root-llm-provider")]
 async fn build_llm_gateway(llm: ResolvedRebornLlm) -> Result<LlmGatewayBundle, RebornRuntimeError> {
     let session = ironclaw_llm::create_session_manager(llm.config.session.clone()).await;
-    let raw = ironclaw_llm::build_static_provider_chain(&llm.config, Arc::clone(&session))
-        .await
-        .map_err(|error| RebornRuntimeError::LlmProvider(error.to_string()))?;
+    // A caller-supplied provider (e.g. an instrumented wrapper) takes precedence
+    // over building one from config; only the construction is bypassed.
+    let raw = match llm.provider_override.clone() {
+        Some(provider) => provider,
+        None => ironclaw_llm::build_static_provider_chain(&llm.config, Arc::clone(&session))
+            .await
+            .map_err(|error| RebornRuntimeError::LlmProvider(error.to_string()))?,
+    };
     wrap_swappable_gateway(raw, session)
 }
 

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -90,7 +90,7 @@ pub(super) fn capability_wiring(
             thread_service,
             thread_scope,
         )
-        .with_observer(trajectory_observer),
+        .with_observer(trajectory_observer.clone()),
     );
     let capability_input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
     let capability_result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
@@ -106,6 +106,7 @@ pub(super) fn capability_wiring(
             result_writer: Arc::clone(&capability_result_writer),
             milestone_sink,
             skill_activation_source,
+            trajectory_observer,
         });
     let model_gateway: Arc<dyn HostManagedModelGateway> = Arc::new(
         LocalDevResultHydratingModelGateway::new(model_gateway, capability_io),
@@ -132,6 +133,7 @@ struct LocalDevLoopCapabilityPortFactory {
     result_writer: Arc<dyn LoopCapabilityResultWriter>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     skill_activation_source: Option<Arc<LocalDevSelectableSkillContextSource>>,
+    trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
 }
 
 #[async_trait::async_trait]
@@ -169,7 +171,8 @@ impl LoopCapabilityPortFactory for LocalDevLoopCapabilityPortFactory {
             Arc::clone(&self.result_writer),
             Arc::clone(&self.milestone_sink),
         )
-        .with_execution_mounts(workspace_mounts);
+        .with_execution_mounts(workspace_mounts)
+        .with_trajectory_observer(self.trajectory_observer.clone());
         for capability_id in self.policy.skill_management_capability_ids() {
             factory = factory
                 .with_capability_execution_mount(capability_id.clone(), skill_mounts.clone());

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -90,11 +90,7 @@ pub(super) fn capability_wiring(
             thread_service,
             thread_scope,
         )
-        .with_observer(trajectory_observer.clone()),
-    );
-    eprintln!(
-        "[OBS-DEBUG] capability_wiring: observer set = {}",
-        trajectory_observer.is_some()
+        .with_observer(trajectory_observer),
     );
     let capability_input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
     let capability_result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
@@ -483,12 +479,10 @@ impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
             &tool_call.name,
             &tool_call.arguments,
         );
-        eprintln!(
-            "[OBS-DEBUG] register_provider_tool_call_input: name={} ref={} observer={}",
-            tool_call.name,
-            input_ref.as_str(),
-            self.observer.is_some()
-        );
+        // NOTE: provider tool calls are staged by a lower decorator
+        // (`ProviderToolCallInputResolver`) that does not delegate here, so this
+        // path does not fire for them. Input args capture is a follow-up; the
+        // reliable spine is `on_capability_result`. Kept for non-provider inputs.
         if let Some(observer) = &self.observer {
             observer.on_capability_input(
                 input_ref.as_str(),
@@ -539,14 +533,8 @@ impl LoopCapabilityResultWriter for LocalDevCapabilityIo {
             },
             display_preview.as_ref(),
         );
-        eprintln!(
-            "[OBS-DEBUG] write_capability_result: cap={:?} ref={} observer={}",
-            capability_id,
-            input_ref.as_str(),
-            self.observer.is_some()
-        );
         if let Some(observer) = &self.observer {
-            observer.on_capability_result(input_ref.as_str(), &output);
+            observer.on_capability_result(input_ref.as_str(), capability_id.as_str(), &output);
         }
         if let Some(message_id) = self
             .try_append_durable_display_preview(run_context, invocation_id, capability_id)

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -75,6 +75,7 @@ pub(super) fn capability_wiring(
     model_gateway: Arc<dyn HostManagedModelGateway>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     skill_activation_source: Option<Arc<LocalDevSelectableSkillContextSource>>,
+    trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
 ) -> Option<LocalDevCapabilityWiring> {
     let runtime = services.host_runtime.clone()?;
     let local_runtime = services.local_runtime.as_ref()?;
@@ -83,11 +84,14 @@ pub(super) fn capability_wiring(
     let extension_surface_source =
         LocalDevExtensionSurfaceSource::new(local_runtime.extension_management.clone());
     let display_previews = Arc::new(CapabilityDisplayPreviewStore::default());
-    let capability_io = Arc::new(LocalDevCapabilityIo::new_with_durable_previews(
-        Arc::clone(&display_previews),
-        thread_service,
-        thread_scope,
-    ));
+    let capability_io = Arc::new(
+        LocalDevCapabilityIo::new_with_durable_previews(
+            Arc::clone(&display_previews),
+            thread_service,
+            thread_scope,
+        )
+        .with_observer(trajectory_observer),
+    );
     let capability_input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
     let capability_result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
     let capability_factory: Arc<dyn LoopCapabilityPortFactory> =
@@ -205,6 +209,8 @@ struct LocalDevCapabilityIo {
     results: StdMutex<StagedValueStore>,
     display_previews: Arc<CapabilityDisplayPreviewStore>,
     durable_previews: Option<DurableCapabilityDisplayPreviewSink>,
+    /// Optional consumer hook: receives each tool call's name/args + result.
+    observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
 }
 
 #[derive(Clone)]
@@ -226,6 +232,7 @@ impl LocalDevCapabilityIo {
             results: StdMutex::new(StagedValueStore::default()),
             display_previews,
             durable_previews: None,
+            observer: None,
         }
     }
 
@@ -242,7 +249,17 @@ impl LocalDevCapabilityIo {
                 thread_service,
                 thread_scope,
             }),
+            observer: None,
         }
+    }
+
+    /// Attach a trajectory observer (no-op when `None`).
+    fn with_observer(
+        mut self,
+        observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
+    ) -> Self {
+        self.observer = observer;
+        self
     }
 
     fn result_output(
@@ -462,6 +479,13 @@ impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
             &tool_call.name,
             &tool_call.arguments,
         );
+        if let Some(observer) = &self.observer {
+            observer.on_capability_input(
+                input_ref.as_str(),
+                &tool_call.name,
+                &tool_call.arguments,
+            );
+        }
         Ok(input_ref)
     }
 }
@@ -505,6 +529,9 @@ impl LoopCapabilityResultWriter for LocalDevCapabilityIo {
             },
             display_preview.as_ref(),
         );
+        if let Some(observer) = &self.observer {
+            observer.on_capability_result(input_ref.as_str(), &output);
+        }
         if let Some(message_id) = self
             .try_append_durable_display_preview(run_context, invocation_id, capability_id)
             .await

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev.rs
@@ -90,7 +90,11 @@ pub(super) fn capability_wiring(
             thread_service,
             thread_scope,
         )
-        .with_observer(trajectory_observer),
+        .with_observer(trajectory_observer.clone()),
+    );
+    eprintln!(
+        "[OBS-DEBUG] capability_wiring: observer set = {}",
+        trajectory_observer.is_some()
     );
     let capability_input_resolver: Arc<dyn LoopCapabilityInputResolver> = capability_io.clone();
     let capability_result_writer: Arc<dyn LoopCapabilityResultWriter> = capability_io.clone();
@@ -479,6 +483,12 @@ impl LoopCapabilityInputResolver for LocalDevCapabilityIo {
             &tool_call.name,
             &tool_call.arguments,
         );
+        eprintln!(
+            "[OBS-DEBUG] register_provider_tool_call_input: name={} ref={} observer={}",
+            tool_call.name,
+            input_ref.as_str(),
+            self.observer.is_some()
+        );
         if let Some(observer) = &self.observer {
             observer.on_capability_input(
                 input_ref.as_str(),
@@ -528,6 +538,12 @@ impl LoopCapabilityResultWriter for LocalDevCapabilityIo {
                 output_bytes,
             },
             display_preview.as_ref(),
+        );
+        eprintln!(
+            "[OBS-DEBUG] write_capability_result: cap={:?} ref={} observer={}",
+            capability_id,
+            input_ref.as_str(),
+            self.observer.is_some()
         );
         if let Some(observer) = &self.observer {
             observer.on_capability_result(input_ref.as_str(), &output);

--- a/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime/local_dev/tests.rs
@@ -353,6 +353,7 @@ mod tests {
             Arc::new(UnavailableModelGateway),
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
             None,
+            None,
         )
         .expect("local-dev capability wiring");
 
@@ -1005,6 +1006,7 @@ mod tests {
             Arc::new(UnavailableModelGateway),
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
             Some(skill_context.activation_source),
+            None,
         )
         .expect("capability wiring");
         let port = wiring
@@ -1546,6 +1548,7 @@ mod tests {
             Arc::new(UnavailableModelGateway),
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
             None,
+            None,
         )
         .expect("local-dev capability wiring");
         assert_github_capabilities_visible(&wiring, &run_context).await;
@@ -1580,6 +1583,7 @@ mod tests {
             ),
             Arc::new(UnavailableModelGateway),
             Arc::new(InMemoryLoopHostMilestoneSink::default()),
+            None,
             None,
         )
         .expect("local-dev capability wiring");

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -282,6 +282,10 @@ pub struct RebornRuntimeInput {
     /// supply their own observer (SSE projection, WS fan-out,
     /// telemetry export) here.
     pub budget_event_observer: Option<Arc<dyn crate::BudgetEventObserver>>,
+    /// Observer that receives each capability/tool invocation + result during a
+    /// run, so a downstream caller can reconstruct the full step-by-step
+    /// trajectory (the sealed runtime otherwise exposes only the final reply).
+    pub trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) model_gateway_override: Option<Arc<dyn HostManagedModelGateway>>,
     /// Cost table to pair with the model-gateway override. Without this,
@@ -316,6 +320,7 @@ impl RebornRuntimeInput {
             hooks: HooksActivationConfig::default(),
             budget_defaults: None,
             budget_event_observer: None,
+            trajectory_observer: None,
             #[cfg(any(test, feature = "test-support"))]
             model_gateway_override: None,
             #[cfg(any(test, feature = "test-support"))]
@@ -344,6 +349,16 @@ impl RebornRuntimeInput {
         observer: Arc<dyn crate::BudgetEventObserver>,
     ) -> Self {
         self.budget_event_observer = Some(observer);
+        self
+    }
+
+    /// Install a trajectory observer that receives each capability/tool call +
+    /// result during a run (for downstream step-by-step trajectory capture).
+    pub fn with_trajectory_observer(
+        mut self,
+        observer: Arc<dyn crate::RebornTrajectoryObserver>,
+    ) -> Self {
+        self.trajectory_observer = Some(observer);
         self
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -312,6 +312,12 @@ pub struct RebornRuntimeInput {
     /// run, so a downstream caller can reconstruct the full step-by-step
     /// trajectory (the sealed runtime otherwise exposes only the final reply).
     pub trajectory_observer: Option<Arc<dyn crate::RebornTrajectoryObserver>>,
+    /// Bench-only: extra tools (name/description/params) exposed to the agent,
+    /// dispatched via the supplied [`crate::ExtraCapabilityDispatch`]. Used by
+    /// nearai-bench to port its legacy service-mock tools onto reborn without
+    /// authoring first-party extensions.
+    pub extra_tools:
+        Option<(Vec<crate::ExtraToolSpec>, Arc<dyn crate::ExtraCapabilityDispatch>)>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) model_gateway_override: Option<Arc<dyn HostManagedModelGateway>>,
     /// Cost table to pair with the model-gateway override. Without this,
@@ -347,6 +353,7 @@ impl RebornRuntimeInput {
             budget_defaults: None,
             budget_event_observer: None,
             trajectory_observer: None,
+            extra_tools: None,
             #[cfg(any(test, feature = "test-support"))]
             model_gateway_override: None,
             #[cfg(any(test, feature = "test-support"))]
@@ -385,6 +392,17 @@ impl RebornRuntimeInput {
         observer: Arc<dyn crate::RebornTrajectoryObserver>,
     ) -> Self {
         self.trajectory_observer = Some(observer);
+        self
+    }
+
+    /// Install extra tools (bench-only) exposed to the agent alongside the
+    /// built-in capabilities, dispatched via `dispatch`.
+    pub fn with_extra_tools(
+        mut self,
+        specs: Vec<crate::ExtraToolSpec>,
+        dispatch: Arc<dyn crate::ExtraCapabilityDispatch>,
+    ) -> Self {
+        self.extra_tools = Some((specs, dispatch));
         self
     }
 

--- a/crates/ironclaw_reborn_composition/src/runtime_input.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime_input.rs
@@ -123,11 +123,28 @@ pub trait TriggerFireAccessChecker: Send + Sync {
 }
 
 #[cfg(feature = "root-llm-provider")]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ResolvedRebornLlm {
     provider_id: String,
     model: String,
     pub(crate) config: ironclaw_llm::LlmConfig,
+    /// Optional pre-built provider to use *instead of* building one from
+    /// `config`. Lets a caller wrap the real provider (e.g. for token /
+    /// reasoning instrumentation) and have the runtime drive it. When `None`
+    /// the gateway builds the static provider chain from `config` as usual.
+    pub(crate) provider_override: Option<Arc<dyn ironclaw_llm::LlmProvider>>,
+}
+
+// `LlmProvider` is not `Debug`, so derive can't see through `provider_override`.
+#[cfg(feature = "root-llm-provider")]
+impl std::fmt::Debug for ResolvedRebornLlm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedRebornLlm")
+            .field("provider_id", &self.provider_id)
+            .field("model", &self.model)
+            .field("provider_override", &self.provider_override.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 #[cfg(feature = "root-llm-provider")]
@@ -145,7 +162,16 @@ impl ResolvedRebornLlm {
             provider_id: config.active_provider_id(),
             model: config.active_model_name(),
             config,
+            provider_override: None,
         }
+    }
+
+    /// Drive the runtime with `provider` instead of building one from the
+    /// config. The provider must already speak the same model the config
+    /// names; only the construction is bypassed.
+    pub fn with_provider(mut self, provider: Arc<dyn ironclaw_llm::LlmProvider>) -> Self {
+        self.provider_override = Some(provider);
+        self
     }
 }
 

--- a/crates/ironclaw_reborn_composition/src/trajectory_observer.rs
+++ b/crates/ironclaw_reborn_composition/src/trajectory_observer.rs
@@ -18,9 +18,14 @@ use serde_json::Value;
 /// be cheap and non-blocking; this is best-effort observation and must not affect
 /// the run outcome.
 pub trait RebornTrajectoryObserver: std::fmt::Debug + Send + Sync {
-    /// A capability/tool was invoked with `tool_name` and `arguments`.
+    /// A capability/tool was invoked with `tool_name` and `arguments`. Not every
+    /// runtime staging path surfaces inputs here (provider tool calls are staged
+    /// by a lower decorator), so consumers must also handle a result arriving for
+    /// a `call_id` they never saw an input for — see [`Self::on_capability_result`].
     fn on_capability_input(&self, call_id: &str, tool_name: &str, arguments: &Value);
 
-    /// The capability/tool keyed by `call_id` produced `output`.
-    fn on_capability_result(&self, call_id: &str, output: &Value);
+    /// The capability keyed by `call_id` (capability id `capability_id`, e.g.
+    /// `builtin.shell`) produced `output`. This fires for every completed
+    /// capability, so it is the reliable spine of the trajectory.
+    fn on_capability_result(&self, call_id: &str, capability_id: &str, output: &Value);
 }

--- a/crates/ironclaw_reborn_composition/src/trajectory_observer.rs
+++ b/crates/ironclaw_reborn_composition/src/trajectory_observer.rs
@@ -8,24 +8,10 @@
 //! [`RebornTrajectoryObserver`] via
 //! [`RebornRuntimeInput::with_trajectory_observer`](crate::RebornRuntimeInput::with_trajectory_observer)
 //! to receive those events live.
+//!
+//! The observer trait itself lives in `ironclaw_loop_support` (next to the
+//! capability port that drives it, so both the input hook on the host port and
+//! the result hook on the local-dev capability IO can reference one type). It is
+//! re-exported here under the reborn-facing name for the composition's API.
 
-use serde_json::Value;
-
-/// Receives capability/tool invocations and their results during a run.
-///
-/// `call_id` correlates an `on_capability_input` with its matching
-/// `on_capability_result` (it is the capability input ref). Implementations must
-/// be cheap and non-blocking; this is best-effort observation and must not affect
-/// the run outcome.
-pub trait RebornTrajectoryObserver: std::fmt::Debug + Send + Sync {
-    /// A capability/tool was invoked with `tool_name` and `arguments`. Not every
-    /// runtime staging path surfaces inputs here (provider tool calls are staged
-    /// by a lower decorator), so consumers must also handle a result arriving for
-    /// a `call_id` they never saw an input for — see [`Self::on_capability_result`].
-    fn on_capability_input(&self, call_id: &str, tool_name: &str, arguments: &Value);
-
-    /// The capability keyed by `call_id` (capability id `capability_id`, e.g.
-    /// `builtin.shell`) produced `output`. This fires for every completed
-    /// capability, so it is the reliable spine of the trajectory.
-    fn on_capability_result(&self, call_id: &str, capability_id: &str, output: &Value);
-}
+pub use ironclaw_loop_support::CapabilityTrajectoryObserver as RebornTrajectoryObserver;

--- a/crates/ironclaw_reborn_composition/src/trajectory_observer.rs
+++ b/crates/ironclaw_reborn_composition/src/trajectory_observer.rs
@@ -1,0 +1,26 @@
+//! Consumer hook to observe an agent run's trajectory as it happens.
+//!
+//! The reborn runtime is intentionally sealed — the high-level
+//! [`crate::RebornRuntime`] hands back only the final assistant reply, and the
+//! per-step capability (tool) calls + their results live in internal stores not
+//! otherwise exposed. A downstream caller (e.g. a benchmark harness that wants
+//! to render a full step-by-step trajectory, or a UI/debugger) can install a
+//! [`RebornTrajectoryObserver`] via
+//! [`RebornRuntimeInput::with_trajectory_observer`](crate::RebornRuntimeInput::with_trajectory_observer)
+//! to receive those events live.
+
+use serde_json::Value;
+
+/// Receives capability/tool invocations and their results during a run.
+///
+/// `call_id` correlates an `on_capability_input` with its matching
+/// `on_capability_result` (it is the capability input ref). Implementations must
+/// be cheap and non-blocking; this is best-effort observation and must not affect
+/// the run outcome.
+pub trait RebornTrajectoryObserver: std::fmt::Debug + Send + Sync {
+    /// A capability/tool was invoked with `tool_name` and `arguments`.
+    fn on_capability_input(&self, call_id: &str, tool_name: &str, arguments: &Value);
+
+    /// The capability/tool keyed by `call_id` produced `output`.
+    fn on_capability_result(&self, call_id: &str, output: &Value);
+}


### PR DESCRIPTION
**Stacked on #4588** (base branch `reborn-trajectory-observer`) — review that one first; the diff here is the extra-capabilities seam only.

## What
`ExtraCapabilitiesPort` decorator + `ExtraToolSpec` / `ExtraCapabilityDispatch` trait + `RebornRuntimeInput::with_extra_tools(...)`. Lets a host register externally-supplied tools as reborn capabilities:
- advertised on the visible capability surface + in `tool_definitions`
- invoked through the shared capability IO, so the trajectory observer (#4588) and the transcript both see them
- capability ids mapped under `bench.<name>` (raw tool names aren't valid dotted ids)
- result/failure summaries run through a `LoopSafeSummary`-safe sanitizer, so arbitrary host-tool output (control chars, payload delimiters) can't trip the executor

## Why / consumer
nearai-bench uses this to expose its mock gmail/slack/calendar/sheets/notion backends to the reborn agent — running its trajectory suite against reborn with the same service tools the legacy agent path has. The actual dispatch impl lives bench-side; only the generic seam is here.

## Notes
- Depends on #4588 (provider-injection seam) — once that lands/rebases, this rebases on top.
- Both this and #4588 need a rebase onto `main`.
- 🤖 Generated with [Claude Code](https://claude.com/claude-code)
