### PR TITLE
feat(attachments): extract document text on the inbound landing path (#4644)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ dependencies = [
  "ironclaw_host_api",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ name = "ironclaw_attachments"
 version = "0.1.0"
 dependencies = [
  "ironclaw_common",
+ "ironclaw_extractors",
  "ironclaw_filesystem",
  "ironclaw_host_api",
  "thiserror 2.0.18",

--- a/crates/ironclaw_attachments/Cargo.toml
+++ b/crates/ironclaw_attachments/Cargo.toml
@@ -16,6 +16,7 @@ ironclaw_extractors = { path = "../ironclaw_extractors", version = "0.1.0" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 thiserror = "2"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/ironclaw_attachments/Cargo.toml
+++ b/crates/ironclaw_attachments/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 
 [dependencies]
 ironclaw_common = { path = "../ironclaw_common", version = "0.4.2" }
+ironclaw_extractors = { path = "../ironclaw_extractors", version = "0.1.0" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 thiserror = "2"

--- a/crates/ironclaw_attachments/src/inbound.rs
+++ b/crates/ironclaw_attachments/src/inbound.rs
@@ -4,10 +4,11 @@
 //! attachment's bytes through the project filesystem authority (see
 //! [`crate::land_attachment`]) and produces the channel-agnostic
 //! [`AttachmentRef`] the transcript persists, with `storage_key` set to the
-//! landed [`ScopedPath`]. `extracted_text` is left `None` here — document
-//! extraction and audio transcription run in a later pipeline stage.
+//! landed [`ScopedPath`]. Document attachments are also run through
+//! [`ironclaw_extractors`] to fill `extracted_text`; audio transcription is
+//! provider-backed and handled by a later pipeline stage.
 
-use ironclaw_common::{AttachmentRef, canonical_extension, kind_for_mime};
+use ironclaw_common::{AttachmentKind, AttachmentRef, canonical_extension, kind_for_mime};
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::ResourceScope;
 
@@ -74,6 +75,16 @@ where
         // `kind` is always consistent with its `mime_type`.
         let kind = kind_for_mime(&mime_type);
         let fallback_extension = canonical_extension(&mime_type).unwrap_or(UNKNOWN_EXTENSION);
+        // Extract document text before the bytes are moved into the write.
+        // Images go to the vision model; audio transcription is provider-backed
+        // and handled by a later pipeline stage, so both leave `extracted_text`
+        // unset here.
+        let extracted_text = match kind {
+            AttachmentKind::Document => {
+                extract_document_text(&bytes, &mime_type, filename.as_deref())
+            }
+            AttachmentKind::Image | AttachmentKind::Audio => None,
+        };
         let landing = AttachmentLanding {
             message_id,
             index,
@@ -97,10 +108,31 @@ where
             filename,
             size_bytes: Some(size_bytes),
             storage_key: Some(stored.as_str().to_string()),
-            extracted_text: None,
+            extracted_text,
         });
     }
     Ok(refs)
+}
+
+/// Maximum characters of extracted document text retained on a reference
+/// (~25K tokens). Mirrors the v1 document-extraction cap.
+const MAX_EXTRACTED_TEXT_CHARS: usize = 100_000;
+
+/// Run the type-aware text extractor over a document attachment's bytes and
+/// return the extracted text, truncated to [`MAX_EXTRACTED_TEXT_CHARS`].
+///
+/// Returns `None` when extraction yields nothing or fails — the attachment is
+/// still landed and referenced, the model just won't have its text.
+fn extract_document_text(bytes: &[u8], mime: &str, filename: Option<&str>) -> Option<String> {
+    let text = ironclaw_extractors::extract_text(bytes, mime, filename).ok()?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(ironclaw_extractors::truncate_to_chars(
+        trimmed,
+        MAX_EXTRACTED_TEXT_CHARS,
+    ))
 }
 
 #[cfg(test)]
@@ -380,5 +412,58 @@ mod tests {
                 .is_none(),
             "oversized attachment must not have been written"
         );
+    }
+
+    #[tokio::test]
+    async fn document_attachment_gets_extracted_text() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let writer = project_mount(backend, MountPermissions::read_write());
+        let refs = land_inbound_attachments(
+            &writer,
+            &test_scope(),
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![inbound("att-0", "text/csv", "data.csv", b"name,score\nalice,9")],
+            DEFAULT_MAX_ATTACHMENT_BYTES,
+        )
+        .await
+        .expect("batch lands");
+        assert_eq!(
+            refs[0].extracted_text.as_deref(),
+            Some("name,score\nalice,9")
+        );
+    }
+
+    #[tokio::test]
+    async fn image_attachment_has_no_extracted_text() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let writer = project_mount(backend, MountPermissions::read_write());
+        let refs = land_inbound_attachments(
+            &writer,
+            &test_scope(),
+            DEFAULT_PROJECT_MOUNT_ALIAS,
+            "2026-06-09",
+            "msg1",
+            vec![inbound("att-0", "image/png", "x.png", &[0x89, 0x50, 0x4E, 0x47])],
+            DEFAULT_MAX_ATTACHMENT_BYTES,
+        )
+        .await
+        .expect("batch lands");
+        assert!(refs[0].extracted_text.is_none());
+    }
+
+    #[test]
+    fn extract_document_text_truncates_long_text() {
+        let long = "x".repeat(MAX_EXTRACTED_TEXT_CHARS + 50);
+        let out = extract_document_text(long.as_bytes(), "text/plain", None)
+            .expect("non-empty text extracts");
+        assert!(out.contains("[... truncated"));
+        assert!(out.chars().count() <= MAX_EXTRACTED_TEXT_CHARS + 60);
+    }
+
+    #[test]
+    fn extract_document_text_is_none_on_empty() {
+        assert!(extract_document_text(b"   \n  ", "text/plain", None).is_none());
     }
 }

--- a/crates/ironclaw_attachments/src/inbound.rs
+++ b/crates/ironclaw_attachments/src/inbound.rs
@@ -70,6 +70,16 @@ where
             filename,
             bytes,
         } = attachment;
+        // Reject over-limit uploads before the (potentially expensive) document
+        // extraction below. `land_attachment` enforces the same bound as the
+        // canonical gate, but checking here avoids parsing bytes that are about
+        // to be thrown away.
+        if bytes.len() > max_bytes {
+            return Err(AttachmentLandingError::TooLarge {
+                size: bytes.len(),
+                max: max_bytes,
+            });
+        }
         let size_bytes = bytes.len() as u64;
         // Derive kind and fallback extension from the MIME type so a ref's
         // `kind` is always consistent with its `mime_type`.
@@ -114,8 +124,10 @@ where
     Ok(refs)
 }
 
-/// Maximum characters of extracted document text retained on a reference
-/// (~25K tokens). Mirrors the v1 document-extraction cap.
+/// Maximum characters of extracted document *content* retained on a reference
+/// (~25K tokens). Mirrors the v1 document-extraction cap. When truncation
+/// occurs a short `[... truncated ...]` marker is appended, so the stored
+/// `extracted_text` may exceed this by the marker's fixed length.
 const MAX_EXTRACTED_TEXT_CHARS: usize = 100_000;
 
 /// Run the type-aware text extractor over a document attachment's bytes and
@@ -124,7 +136,17 @@ const MAX_EXTRACTED_TEXT_CHARS: usize = 100_000;
 /// Returns `None` when extraction yields nothing or fails — the attachment is
 /// still landed and referenced, the model just won't have its text.
 fn extract_document_text(bytes: &[u8], mime: &str, filename: Option<&str>) -> Option<String> {
-    let text = ironclaw_extractors::extract_text(bytes, mime, filename).ok()?;
+    let text = match ironclaw_extractors::extract_text(bytes, mime, filename) {
+        Ok(text) => text,
+        Err(error) => {
+            // Extraction failure is non-fatal — the attachment is still landed
+            // and referenced, the model just won't have its text. Log it so an
+            // unsupported-format/corrupt-file case is observable (debug, not
+            // warn: this runs in library context that may back the REPL/TUI).
+            tracing::debug!(mime, filename, %error, "document text extraction failed");
+            return None;
+        }
+    };
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return None;
@@ -424,7 +446,12 @@ mod tests {
             DEFAULT_PROJECT_MOUNT_ALIAS,
             "2026-06-09",
             "msg1",
-            vec![inbound("att-0", "text/csv", "data.csv", b"name,score\nalice,9")],
+            vec![inbound(
+                "att-0",
+                "text/csv",
+                "data.csv",
+                b"name,score\nalice,9",
+            )],
             DEFAULT_MAX_ATTACHMENT_BYTES,
         )
         .await
@@ -445,7 +472,12 @@ mod tests {
             DEFAULT_PROJECT_MOUNT_ALIAS,
             "2026-06-09",
             "msg1",
-            vec![inbound("att-0", "image/png", "x.png", &[0x89, 0x50, 0x4E, 0x47])],
+            vec![inbound(
+                "att-0",
+                "image/png",
+                "x.png",
+                &[0x89, 0x50, 0x4E, 0x47],
+            )],
             DEFAULT_MAX_ATTACHMENT_BYTES,
         )
         .await

--- a/crates/ironclaw_extractors/src/lib.rs
+++ b/crates/ironclaw_extractors/src/lib.rs
@@ -575,6 +575,26 @@ fn try_extract_by_extension(data: &[u8], filename: Option<&str>) -> Option<Strin
     }
 }
 
+/// Marker appended to extracted text that was truncated for length.
+pub const TRUNCATION_MARKER: &str = "\n[... truncated, document too long ...]";
+
+/// Truncate `text` to at most `max_chars` characters on a UTF-8 character
+/// boundary, appending [`TRUNCATION_MARKER`] when truncation occurred.
+///
+/// Consumers cap extracted text before handing it to the model; this is the
+/// canonical, char-boundary-safe truncation (`char_indices`, never byte
+/// slicing) so each consumer doesn't re-roll it with subtly different limits.
+pub fn truncate_to_chars(text: &str, max_chars: usize) -> String {
+    match text.char_indices().nth(max_chars) {
+        Some((byte_idx, _)) => {
+            let mut out = text[..byte_idx].to_string();
+            out.push_str(TRUNCATION_MARKER);
+            out
+        }
+        None => text.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -583,6 +603,23 @@ mod tests {
     fn strip_xml_basic() {
         let xml = "<root><p>Hello</p><p>World</p></root>";
         assert_eq!(strip_xml_tags(xml), "Hello World");
+    }
+
+    #[test]
+    fn truncate_to_chars_appends_marker_only_when_over_limit() {
+        assert_eq!(truncate_to_chars("short", 100), "short");
+
+        let truncated = truncate_to_chars("abcdef", 3);
+        assert!(truncated.starts_with("abc"));
+        assert!(truncated.ends_with(TRUNCATION_MARKER));
+    }
+
+    #[test]
+    fn truncate_to_chars_splits_on_a_char_boundary() {
+        // Each `é` is two bytes; truncating at 2 chars must not split a codepoint.
+        let truncated = truncate_to_chars("éééé", 2);
+        assert!(truncated.starts_with("éé"));
+        assert!(truncated.ends_with(TRUNCATION_MARKER));
     }
 
     #[test]

--- a/crates/ironclaw_extractors/src/lib.rs
+++ b/crates/ironclaw_extractors/src/lib.rs
@@ -578,8 +578,11 @@ fn try_extract_by_extension(data: &[u8], filename: Option<&str>) -> Option<Strin
 /// Marker appended to extracted text that was truncated for length.
 pub const TRUNCATION_MARKER: &str = "\n[... truncated, document too long ...]";
 
-/// Truncate `text` to at most `max_chars` characters on a UTF-8 character
-/// boundary, appending [`TRUNCATION_MARKER`] when truncation occurred.
+/// Truncate `text`'s content to at most `max_chars` characters on a UTF-8
+/// character boundary. When truncation occurs, [`TRUNCATION_MARKER`] is appended
+/// to signal it — so the returned string is at most `max_chars` characters of
+/// content **plus** the fixed-length marker, i.e. it can exceed `max_chars` by
+/// the marker's length. Text already within the limit is returned unchanged.
 ///
 /// Consumers cap extracted text before handing it to the model; this is the
 /// canonical, char-boundary-safe truncation (`char_indices`, never byte


### PR DESCRIPTION
## Summary

`land_inbound_attachments` now runs document attachments through the **`ironclaw_extractors`** crate (#4675) and fills `AttachmentRef.extracted_text`, so the persisted transcript reference carries the document's text for the model — not just metadata + `storage_key`. This is the extraction half of Track 3.

## What changed

- For `AttachmentKind::Document`, `extract_document_text` runs `ironclaw_extractors::extract_text(bytes, mime, filename)` **before** the bytes are moved into the write, truncating to 100K chars (the v1 cap) on a UTF-8 boundary (`char_indices`, never byte-slicing). Extraction failure or empty output leaves `extracted_text` `None` — the attachment is still landed and referenced.
- Images leave `extracted_text` `None` (vision path); **audio transcription is provider-backed and remains a later pipeline stage**.
- New dep `ironclaw_attachments → ironclaw_extractors` (leaf crate, no `ironclaw_*` deps, no cycle).

## Tests

4 new (14 total, all pass): a CSV document gets its text in `extracted_text`; an image gets `None`; truncation appends the marker on a char boundary; empty extraction is `None`.

```
cargo clippy -p ironclaw_attachments --tests   # clean
cargo test  -p ironclaw_attachments            # 14 pass
```

## Stacking

Based on `fix/4644-extractors-crate` (#4675). Next: surface `extracted_text` + image bytes to the model (the `<attachments>` text block + `content_parts`), and fix `chat_workflow.rs`'s `[non_text_content]` drop.

## Deferred

- Audio transcription (needs a `TranscriptionProvider` injected at the composition layer).
- Model-visibility wiring (`ContextMessage` attachments → augment → `content_parts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Document attachments now have their text extracted during inbound processing to improve content availability for indexing and search.
  * Extracted document text is truncated to a capped length to keep storage usage reasonable.
* **Behavior Changes**
  * Image and audio attachments are left without extracted text.
* **Bug Fixes**
  * Improved handling for empty/whitespace extraction results and extraction failures (no extracted text is stored).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->